### PR TITLE
Convert tests using createNext -> nextTestSetup

### DIFF
--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { createSandbox } from 'development-sandbox'
-import { FileRef, nextTestSetup } from 'e2e-utils'
+import { FileRef, isReact18, nextTestSetup } from 'e2e-utils'
 import {
   getRedboxTotalErrorCount,
   getRedboxCallStack,
@@ -9,8 +9,6 @@ import {
 } from 'next-test-utils'
 import path from 'path'
 import { outdent } from 'outdent'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('ReactRefreshLogBox', () => {
   const { isTurbopack, next, isRspack } = nextTestSetup({

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -1,11 +1,9 @@
 /* eslint-env jest */
 import { createSandbox } from 'development-sandbox'
-import { FileRef, nextTestSetup } from 'e2e-utils'
+import { FileRef, isReact18, nextTestSetup } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 import path from 'path'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('pages/ error recovery', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -1,10 +1,9 @@
 import { createSandbox } from 'development-sandbox'
-import { FileRef, nextTestSetup } from 'e2e-utils'
+import { FileRef, isReact18, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
 import { getRedboxTotalErrorCount, retry } from 'next-test-utils'
 
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
 describe('Error overlay for hydration errors in Pages router', () => {

--- a/test/development/api-cors-with-rewrite/index.test.ts
+++ b/test/development/api-cors-with-rewrite/index.test.ts
@@ -1,37 +1,31 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Rewritten API Requests should pass OPTIONS requests to the api function', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/some-endpoint.js': `
-          export default (req, res) => {
-            res.end("successfully hit some-endpoint!")
-          } 
-        `,
-      },
-      nextConfig: {
-        rewrites: () =>
-          Promise.resolve({
-            beforeFiles: [
-              // Nextjs by default requires a /api prefix, let's remove that
-              {
-                source: '/:path*',
-                destination: '/api/:path*',
-              },
-            ],
-            afterFiles: [],
-            fallback: [],
-          }),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/some-endpoint.js': `
+        export default (req, res) => {
+          res.end("successfully hit some-endpoint!")
+        } 
+      `,
+    },
+    nextConfig: {
+      rewrites: () =>
+        Promise.resolve({
+          beforeFiles: [
+            // Nextjs by default requires a /api prefix, let's remove that
+            {
+              source: '/:path*',
+              destination: '/api/:path*',
+            },
+          ],
+          afterFiles: [],
+          fallback: [],
+        }),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should pass OPTIONS requests to the api function', async () => {
     const res = await fetchViaHTTP(next.url, '/some-endpoint', null, {

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -1,12 +1,10 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 import {
   waitForRedbox,
   waitForNoRedbox,
   getRedboxDescription,
   getRedboxSource,
 } from 'next-test-utils'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 const isRspack = process.env.NEXT_RSPACK !== undefined
 

--- a/test/development/basic/allowed-dev-origins.test.ts
+++ b/test/development/basic/allowed-dev-origins.test.ts
@@ -1,8 +1,7 @@
 import http from 'http'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, NextInstance, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, findPort, retry } from 'next-test-utils'
 
 async function createHostServer() {
@@ -123,20 +122,18 @@ async function expectBlockedDevResourceMessage(
 describe.each(['', '/docs'])(
   'allowed-dev-origins, basePath: %p',
   (basePath: string) => {
-    let next: NextInstance
-
     describe('default blocking', () => {
-      beforeAll(async () => {
-        next = await createNext({
-          files: {
-            pages: new FileRef(join(__dirname, 'misc/pages')),
-            public: new FileRef(join(__dirname, 'misc/public')),
-          },
-          nextConfig: {
-            basePath,
-          },
-        })
+      const { next } = nextTestSetup({
+        files: {
+          pages: new FileRef(join(__dirname, 'misc/pages')),
+          public: new FileRef(join(__dirname, 'misc/public')),
+        },
+        nextConfig: {
+          basePath,
+        },
+      })
 
+      beforeAll(async () => {
         // render 404 page to generate
         // "/_next/static/chunks/pages/_app.js"
         // we need this because not found static assets
@@ -152,7 +149,6 @@ describe.each(['', '/docs'])(
           expect(res.status).toBe(200)
         })
       })
-      afterAll(() => next.destroy())
 
       it('should block WebSocket from cross-site', async () => {
         const { server, port } = await createHostServer()
@@ -266,18 +262,18 @@ describe.each(['', '/docs'])(
     })
 
     describe('configured but not allowlisted origins', () => {
-      beforeAll(async () => {
-        next = await createNext({
-          files: {
-            pages: new FileRef(join(__dirname, 'misc/pages')),
-            public: new FileRef(join(__dirname, 'misc/public')),
-          },
-          nextConfig: {
-            basePath,
-            allowedDevOrigins: ['127.0.0.1'],
-          },
-        })
+      const { next } = nextTestSetup({
+        files: {
+          pages: new FileRef(join(__dirname, 'misc/pages')),
+          public: new FileRef(join(__dirname, 'misc/public')),
+        },
+        nextConfig: {
+          basePath,
+          allowedDevOrigins: ['127.0.0.1'],
+        },
+      })
 
+      beforeAll(async () => {
         await next.render(withBasePath(basePath, '/404'))
 
         await retry(async () => {
@@ -288,7 +284,6 @@ describe.each(['', '/docs'])(
           expect(res.status).toBe(200)
         })
       })
-      afterAll(() => next.destroy())
 
       it('should block websocket requests from configured but non-allowlisted hosts', async () => {
         const { server, port } = await createHostServer()
@@ -328,18 +323,18 @@ describe.each(['', '/docs'])(
     })
 
     describe('configured allowed origins', () => {
-      beforeAll(async () => {
-        next = await createNext({
-          files: {
-            pages: new FileRef(join(__dirname, 'misc/pages')),
-            public: new FileRef(join(__dirname, 'misc/public')),
-          },
-          nextConfig: {
-            basePath,
-            allowedDevOrigins: ['127.0.0.1', 'example.vercel.sh'],
-          },
-        })
+      const { next } = nextTestSetup({
+        files: {
+          pages: new FileRef(join(__dirname, 'misc/pages')),
+          public: new FileRef(join(__dirname, 'misc/public')),
+        },
+        nextConfig: {
+          basePath,
+          allowedDevOrigins: ['127.0.0.1', 'example.vercel.sh'],
+        },
+      })
 
+      beforeAll(async () => {
         // render 404 page to generate
         // "/_next/static/chunks/pages/_app.js"
         // since we haven't built any paths by this point
@@ -355,7 +350,6 @@ describe.each(['', '/docs'])(
           expect(res.status).toBe(200)
         })
       })
-      afterAll(() => next.destroy())
 
       it('should allow dev WebSocket from configured cross-site', async () => {
         const { server, port } = await createHostServer()

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -2,9 +2,8 @@
 
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox, check } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
 
 const installCheckVisible = (browser) => {
   return browser.eval(`(function() {
@@ -24,17 +23,12 @@ const installCheckVisible = (browser) => {
 }
 
 describe('GS(S)P Server-Side Change Reloading', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../pages')),
-        lib: new FileRef(join(__dirname, '../lib')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../pages')),
+      lib: new FileRef(join(__dirname, '../lib')),
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should not reload page when client-side is changed too GSP', async () => {
     const browser = await webdriver(next.url, '/gsp-blog/first')

--- a/test/development/basic/legacy-decorators.test.ts
+++ b/test/development/basic/legacy-decorators.test.ts
@@ -1,31 +1,25 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('Legacy decorators SWC option', () => {
   describe('with extended tsconfig', () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'tsconfig.json': new FileRef(
-            join(__dirname, 'legacy-decorators/tsconfig-extended.json')
-          ),
-          'tsconfig-base.json': new FileRef(
-            join(__dirname, 'legacy-decorators/jsconfig.json')
-          ),
-          pages: new FileRef(join(__dirname, 'legacy-decorators/pages')),
-        },
-        dependencies: {
-          mobx: '6.3.7',
-          'mobx-react': '7.2.1',
-        },
-      })
+    const { next } = nextTestSetup({
+      files: {
+        'tsconfig.json': new FileRef(
+          join(__dirname, 'legacy-decorators/tsconfig-extended.json')
+        ),
+        'tsconfig-base.json': new FileRef(
+          join(__dirname, 'legacy-decorators/jsconfig.json')
+        ),
+        pages: new FileRef(join(__dirname, 'legacy-decorators/pages')),
+      },
+      dependencies: {
+        mobx: '6.3.7',
+        'mobx-react': '7.2.1',
+      },
     })
-    afterAll(() => next.destroy())
 
     it('should compile with legacy decorators enabled from extended config', async () => {
       let browser
@@ -47,22 +41,18 @@ describe('Legacy decorators SWC option', () => {
   })
 
   describe('with base config', () => {
-    let next: NextInstance
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'jsconfig.json': new FileRef(
-            join(__dirname, 'legacy-decorators/jsconfig.json')
-          ),
-          pages: new FileRef(join(__dirname, 'legacy-decorators/pages')),
-        },
-        dependencies: {
-          mobx: '6.3.7',
-          'mobx-react': '7.2.1',
-        },
-      })
+    const { next } = nextTestSetup({
+      files: {
+        'jsconfig.json': new FileRef(
+          join(__dirname, 'legacy-decorators/jsconfig.json')
+        ),
+        pages: new FileRef(join(__dirname, 'legacy-decorators/pages')),
+      },
+      dependencies: {
+        mobx: '6.3.7',
+        'mobx-react': '7.2.1',
+      },
     })
-    afterAll(() => next.destroy())
 
     it('should compile with legacy decorators enabled', async () => {
       let browser

--- a/test/development/basic/misc.test.ts
+++ b/test/development/basic/misc.test.ts
@@ -1,26 +1,20 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 
 describe.each([[''], ['/docs']])(
   'misc basic dev tests, basePath: %p',
   (basePath: string) => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          pages: new FileRef(join(__dirname, 'misc/pages')),
-          public: new FileRef(join(__dirname, 'misc/public')),
-        },
-        nextConfig: {
-          basePath,
-        },
-      })
+    const { next } = nextTestSetup({
+      files: {
+        pages: new FileRef(join(__dirname, 'misc/pages')),
+        public: new FileRef(join(__dirname, 'misc/public')),
+      },
+      nextConfig: {
+        basePath,
+      },
     })
-    afterAll(() => next.destroy())
 
     it('should set process.env.NODE_ENV in development', async () => {
       const browser = await webdriver(next.url, basePath + '/process-env')

--- a/test/development/basic/next-dynamic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic/next-dynamic.test.ts
@@ -1,9 +1,8 @@
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox, renderViaHTTP, check } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
 
 const customDocumentGipContent = `\
 import { Html, Main, NextScript, Head } from 'next/document'
@@ -29,28 +28,23 @@ const basePath = process.env.TEST_BASE_PATH || ''
 const srcPrefix = process.env.TEST_SRC_DIR ? 'src/' : ''
 
 describe('next/dynamic', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        [`${srcPrefix}/components`]: new FileRef(join(__dirname, 'components')),
-        [`${srcPrefix}/pages`]: new FileRef(join(__dirname, 'pages')),
-        ...(process.env.TEST_CUSTOMIZED_DOCUMENT === '1' && {
-          [`${srcPrefix}/pages/_document.js`]: customDocumentGipContent,
+  const { next } = nextTestSetup({
+    files: {
+      [`${srcPrefix}/components`]: new FileRef(join(__dirname, 'components')),
+      [`${srcPrefix}/pages`]: new FileRef(join(__dirname, 'pages')),
+      ...(process.env.TEST_CUSTOMIZED_DOCUMENT === '1' && {
+        [`${srcPrefix}/pages/_document.js`]: customDocumentGipContent,
+      }),
+      // When it's not turbopack and babel is enabled, we add a .babelrc file.
+      ...(!process.env.IS_TURBOPACK_TEST &&
+        process.env.TEST_BABEL === '1' && {
+          '.babelrc': `{ "presets": ["next/babel"] }`,
         }),
-        // When it's not turbopack and babel is enabled, we add a .babelrc file.
-        ...(!process.env.IS_TURBOPACK_TEST &&
-          process.env.TEST_BABEL === '1' && {
-            '.babelrc': `{ "presets": ["next/babel"] }`,
-          }),
-      },
-      nextConfig: {
-        basePath,
-      },
-    })
+    },
+    nextConfig: {
+      basePath,
+    },
   })
-  afterAll(() => next.destroy())
 
   async function get$(path, query?: any) {
     const html = await renderViaHTTP(next.url, path, query)

--- a/test/development/basic/styled-components-disabled.test.ts
+++ b/test/development/basic/styled-components-disabled.test.ts
@@ -1,28 +1,22 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 // TODO: Somehow the warning doesn't show up with Turbopack, even though the transform is not enabled.
 // TODO: It no longer shows up with Webpack either in tests.
 describe.skip('styled-components SWC transform', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'next.config.js': new FileRef(
-          join(__dirname, 'styled-components-disabled/next.config.js')
-        ),
-        pages: new FileRef(join(__dirname, 'styled-components-disabled/pages')),
-      },
-      dependencies: {
-        'styled-components': '6.1.16',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'next.config.js': new FileRef(
+        join(__dirname, 'styled-components-disabled/next.config.js')
+      ),
+      pages: new FileRef(join(__dirname, 'styled-components-disabled/pages')),
+    },
+    dependencies: {
+      'styled-components': '6.1.16',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should have hydration mismatch with styled-components transform disabled', async () => {
     let browser

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 import stripAnsi from 'strip-ansi'
@@ -46,28 +45,26 @@ function setupLogCapture() {
 
 describe(`Terminal Logging (${bundlerName})`, () => {
   describe('Pages Router', () => {
-    let next: NextInstance
     let logs: string[] = []
     let logCapture: ReturnType<typeof setupLogCapture>
     let browser = null
 
-    beforeAll(async () => {
+    beforeAll(() => {
       logCapture = setupLogCapture()
       logs = logCapture.logs
-
-      next = await createNext({
-        files: {
-          pages: new FileRef(join(__dirname, 'fixtures/pages')),
-          'next.config.js': new FileRef(
-            join(__dirname, 'fixtures/next.config.js')
-          ),
-        },
-      })
     })
 
-    afterAll(async () => {
+    const { next } = nextTestSetup({
+      files: {
+        pages: new FileRef(join(__dirname, 'fixtures/pages')),
+        'next.config.js': new FileRef(
+          join(__dirname, 'fixtures/next.config.js')
+        ),
+      },
+    })
+
+    afterAll(() => {
       logCapture.restore()
-      await next.destroy()
     })
 
     beforeEach(() => {
@@ -152,27 +149,25 @@ describe(`Terminal Logging (${bundlerName})`, () => {
   })
 
   describe('App Router - Server Components', () => {
-    let next: NextInstance
     let logs: string[] = []
     let logCapture: ReturnType<typeof setupLogCapture>
 
-    beforeAll(async () => {
+    beforeAll(() => {
       logCapture = setupLogCapture()
       logs = logCapture.logs
-
-      next = await createNext({
-        files: {
-          app: new FileRef(join(__dirname, 'fixtures/app')),
-          'next.config.js': new FileRef(
-            join(__dirname, 'fixtures/next.config.js')
-          ),
-        },
-      })
     })
 
-    afterAll(async () => {
+    const { next } = nextTestSetup({
+      files: {
+        app: new FileRef(join(__dirname, 'fixtures/app')),
+        'next.config.js': new FileRef(
+          join(__dirname, 'fixtures/next.config.js')
+        ),
+      },
+    })
+
+    afterAll(() => {
       logCapture.restore()
-      await next.destroy()
     })
 
     beforeEach(() => {
@@ -212,27 +207,25 @@ describe(`Terminal Logging (${bundlerName})`, () => {
   })
 
   describe('App Router - Client Components', () => {
-    let next: NextInstance
     let logs: string[] = []
     let logCapture: ReturnType<typeof setupLogCapture>
 
-    beforeAll(async () => {
+    beforeAll(() => {
       logCapture = setupLogCapture()
       logs = logCapture.logs
-
-      next = await createNext({
-        files: {
-          app: new FileRef(join(__dirname, 'fixtures/app')),
-          'next.config.js': new FileRef(
-            join(__dirname, 'fixtures/next.config.js')
-          ),
-        },
-      })
     })
 
-    afterAll(async () => {
+    const { next } = nextTestSetup({
+      files: {
+        app: new FileRef(join(__dirname, 'fixtures/app')),
+        'next.config.js': new FileRef(
+          join(__dirname, 'fixtures/next.config.js')
+        ),
+      },
+    })
+
+    afterAll(() => {
       logCapture.restore()
-      await next.destroy()
     })
 
     beforeEach(() => {
@@ -274,27 +267,25 @@ describe(`Terminal Logging (${bundlerName})`, () => {
   })
 
   describe('App Router - Hydration Errors', () => {
-    let next: NextInstance
     let logs: string[] = []
     let logCapture: ReturnType<typeof setupLogCapture>
 
-    beforeAll(async () => {
+    beforeAll(() => {
       logCapture = setupLogCapture()
       logs = logCapture.logs
-
-      next = await createNext({
-        files: {
-          app: new FileRef(join(__dirname, 'fixtures/app')),
-          'next.config.js': new FileRef(
-            join(__dirname, 'fixtures/next.config.js')
-          ),
-        },
-      })
     })
 
-    afterAll(async () => {
+    const { next } = nextTestSetup({
+      files: {
+        app: new FileRef(join(__dirname, 'fixtures/app')),
+        'next.config.js': new FileRef(
+          join(__dirname, 'fixtures/next.config.js')
+        ),
+      },
+    })
+
+    afterAll(() => {
       logCapture.restore()
-      await next.destroy()
     })
 
     beforeEach(() => {
@@ -374,27 +365,25 @@ describe(`Terminal Logging (${bundlerName})`, () => {
   })
 
   describe('App Router - Edge Runtime', () => {
-    let next: NextInstance
     let logs: string[] = []
     let logCapture: ReturnType<typeof setupLogCapture>
 
-    beforeAll(async () => {
+    beforeAll(() => {
       logCapture = setupLogCapture()
       logs = logCapture.logs
-
-      next = await createNext({
-        files: {
-          app: new FileRef(join(__dirname, 'fixtures/app')),
-          'next.config.js': new FileRef(
-            join(__dirname, 'fixtures/next.config.js')
-          ),
-        },
-      })
     })
 
-    afterAll(async () => {
+    const { next } = nextTestSetup({
+      files: {
+        app: new FileRef(join(__dirname, 'fixtures/app')),
+        'next.config.js': new FileRef(
+          join(__dirname, 'fixtures/next.config.js')
+        ),
+      },
+    })
+
+    afterAll(() => {
       logCapture.restore()
-      await next.destroy()
     })
 
     beforeEach(() => {

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -1,24 +1,18 @@
-import { createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
 
 describe('correct tsconfig.json defaults', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.tsx': 'export default function Page() {}',
-      },
-      skipStart: true,
-      dependencies: {
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.tsx': 'export default function Page() {}',
+    },
+    skipStart: true,
+    dependencies: {
+      typescript: 'latest',
+      '@types/react': 'latest',
+      '@types/node': 'latest',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should add `moduleResolution` when generating tsconfig.json in dev', async () => {
     try {

--- a/test/development/dotenv-default-expansion/index.test.ts
+++ b/test/development/dotenv-default-expansion/index.test.ts
@@ -1,26 +1,20 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 describe('Dotenv default expansion', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() { 
-            return <p>{process.env.NEXT_PUBLIC_TEST}</p>
-          } 
-        `,
-        '.env': `
-          NEXT_PUBLIC_TEST=\${MISSING_KEY:-default}
-        `,
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() { 
+          return <p>{process.env.NEXT_PUBLIC_TEST}</p>
+        } 
+      `,
+      '.env': `
+        NEXT_PUBLIC_TEST=\${MISSING_KEY:-default}
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/development/gssp-notfound/index.test.ts
+++ b/test/development/gssp-notfound/index.test.ts
@@ -1,28 +1,22 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
 describe('getServerSideProps returns notFound: true', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-        const Home = () => null
-        export default Home
-        
-        export function getServerSideProps() {
-          console.log("gssp called")
-          return { notFound: true }
-        }
-        `,
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+      const Home = () => null
+      export default Home
+      
+      export function getServerSideProps() {
+        console.log("gssp called")
+        return { notFound: true }
+      }
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should not poll indefinitely', async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
   waitForRedbox,
   waitForNoRedbox,
@@ -13,40 +12,38 @@ import webdriver from 'next-webdriver'
 import fs from 'fs-extra'
 
 describe('jsconfig-path-reloading', () => {
-  let next: NextInstance
   const tsConfigFile = 'jsconfig.json'
   const indexPage = 'pages/index.js'
 
+  const tsConfigContent = fs.readFileSync(
+    join(__dirname, 'app/jsconfig.json'),
+    'utf8'
+  )
+
   function runTests({ addAfterStart }: { addAfterStart?: boolean }) {
-    beforeAll(async () => {
-      let tsConfigContent = await fs.readFile(
-        join(__dirname, 'app/jsconfig.json'),
-        'utf8'
-      )
-
-      next = await createNext({
-        files: {
-          components: new FileRef(join(__dirname, 'app/components')),
-          pages: new FileRef(join(__dirname, 'app/pages')),
-          lib: new FileRef(join(__dirname, 'app/lib')),
-          ...(addAfterStart
-            ? {}
-            : {
-                [tsConfigFile]: tsConfigContent,
-              }),
-        },
-        dependencies: {
-          typescript: 'latest',
-          '@types/react': 'latest',
-          '@types/node': 'latest',
-        },
-      })
-
-      if (addAfterStart) {
-        await next.patchFile(tsConfigFile, tsConfigContent)
-      }
+    const { next } = nextTestSetup({
+      files: {
+        components: new FileRef(join(__dirname, 'app/components')),
+        pages: new FileRef(join(__dirname, 'app/pages')),
+        lib: new FileRef(join(__dirname, 'app/lib')),
+        ...(addAfterStart
+          ? {}
+          : {
+              [tsConfigFile]: tsConfigContent,
+            }),
+      },
+      dependencies: {
+        typescript: 'latest',
+        '@types/react': 'latest',
+        '@types/node': 'latest',
+      },
     })
-    afterAll(() => next.destroy())
+
+    if (addAfterStart) {
+      beforeAll(async () => {
+        await next.patchFile(tsConfigFile, tsConfigContent)
+      })
+    }
 
     it('should load with initial paths config correctly', async () => {
       const html = await renderViaHTTP(next.url, '/')

--- a/test/development/next-font/build-errors.test.ts
+++ b/test/development/next-font/build-errors.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import {
@@ -10,14 +9,9 @@ import {
 
 // TODO: The error overlay is not closed when restoring the working code.
 describe.skip('next/font build-errors', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, 'build-errors')),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'build-errors')),
   })
-  afterAll(() => next.destroy())
 
   it('should show a next/font error when input is wrong', async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/development/next-font/font-loader-in-document-error.test.ts
+++ b/test/development/next-font/font-loader-in-document-error.test.ts
@@ -1,20 +1,14 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
 describe('font-loader-in-document-error', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'font-loader-in-document/pages')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'font-loader-in-document/pages')),
+    },
   })
-  afterAll(() => next.destroy())
 
   test('next/font inside _document', async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -7,7 +7,7 @@ import {
   getRedboxTotalErrorCount,
 } from 'next-test-utils'
 import path from 'path'
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 describe('Client Navigation', () => {
   const { isTurbopack, next, isRspack } = nextTestSetup({
@@ -258,7 +258,6 @@ describe('Client Navigation', () => {
 
   describe('runtime errors', () => {
     it('should show redbox when a client side error is thrown inside a component', async () => {
-      const isReact18 = process.env.NEXT_TEST_REACT_VERSION?.startsWith('18')
       const pageErrors: unknown[] = []
       const browser = await next.browser('/error-inside-browser-page', {
         beforePageLoad: (page) => {

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -64,7 +64,7 @@ describe('Client Navigation', () => {
     it('should always replace the state', async () => {
       const browser = await next.browser('/nav')
 
-      const countAfterClicked = await browser
+      await browser
         .elementByCss('#self-reload-link')
         .click()
         .waitForElementByCss('#self-reload-page')
@@ -72,11 +72,12 @@ describe('Client Navigation', () => {
         .click()
         .elementByCss('#self-reload-link')
         .click()
-        .elementByCss('p')
-        .text()
 
-      // counts (page change + two clicks)
-      expect(countAfterClicked).toBe('COUNT: 3')
+      // counts (page change + two clicks). Use `retry()` because the third
+      // click's state update may not have flushed when we read the text.
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe('COUNT: 3')
+      })
 
       // Since we replace the state, back button would simply go us back to /nav
       await browser.back().waitForElementByCss('.nav-home')

--- a/test/development/pages-dir/client-navigation/rendering-head.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering-head.test.ts
@@ -1,11 +1,9 @@
 /* eslint-env jest */
 
 import cheerio from 'cheerio'
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import path from 'path'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('Client Navigation rendering <Head />', () => {
   const { next } = nextTestSetup({

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -1,13 +1,11 @@
 /* eslint-env jest */
 
 import cheerio from 'cheerio'
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, getDistDir, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
 import path from 'path'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('Client Navigation rendering', () => {
   const { isTurbopack, next, isRspack } = nextTestSetup({

--- a/test/development/project-directory-with-styled-jsx-suffix/index.test.ts
+++ b/test/development/project-directory-with-styled-jsx-suffix/index.test.ts
@@ -1,23 +1,17 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('project directory with styled-jsx suffix', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() { 
-            return <p>hello world</p>
-          } 
-        `,
-      },
-      subDir: 'test-styled-jsx',
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() { 
+          return <p>hello world</p>
+        } 
+      `,
+    },
+    subDir: 'test-styled-jsx',
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
   waitForRedbox,
   waitForNoRedbox,
@@ -13,9 +12,13 @@ import webdriver from 'next-webdriver'
 import fs from 'fs-extra'
 
 describe('tsconfig-path-reloading', () => {
-  let next: NextInstance
   const tsConfigFile = 'tsconfig.json'
   const indexPage = 'pages/index.tsx'
+
+  const tsConfigContent = fs.readFileSync(
+    join(__dirname, 'app/tsconfig.json'),
+    'utf8'
+  )
 
   function runTests({
     addAfterStart,
@@ -24,37 +27,31 @@ describe('tsconfig-path-reloading', () => {
     addAfterStart?: boolean
     testBaseUrl: boolean
   }) {
-    beforeAll(async () => {
-      let tsConfigContent = await fs.readFile(
-        join(__dirname, 'app/tsconfig.json'),
-        'utf8'
-      )
+    const typescriptVersion = testBaseUrl ? '5.9.3' : 'latest'
 
-      const typescriptVersion = testBaseUrl ? '5.9.3' : 'latest'
-
-      next = await createNext({
-        files: {
-          components: new FileRef(join(__dirname, 'app/components')),
-          pages: new FileRef(join(__dirname, 'app/pages')),
-          lib: new FileRef(join(__dirname, 'app/lib')),
-          ...(addAfterStart
-            ? {}
-            : {
-                [tsConfigFile]: tsConfigContent,
-              }),
-        },
-        dependencies: {
-          typescript: typescriptVersion,
-          '@types/react': 'latest',
-          '@types/node': 'latest',
-        },
-      })
-
-      if (addAfterStart) {
-        await next.patchFile(tsConfigFile, tsConfigContent)
-      }
+    const { next } = nextTestSetup({
+      files: {
+        components: new FileRef(join(__dirname, 'app/components')),
+        pages: new FileRef(join(__dirname, 'app/pages')),
+        lib: new FileRef(join(__dirname, 'app/lib')),
+        ...(addAfterStart
+          ? {}
+          : {
+              [tsConfigFile]: tsConfigContent,
+            }),
+      },
+      dependencies: {
+        typescript: typescriptVersion,
+        '@types/react': 'latest',
+        '@types/node': 'latest',
+      },
     })
-    afterAll(() => next.destroy())
+
+    if (addAfterStart) {
+      beforeAll(async () => {
+        await next.patchFile(tsConfigFile, tsConfigContent)
+      })
+    }
 
     it('should load with initial paths config correctly', async () => {
       const html = await renderViaHTTP(next.url, '/')

--- a/test/development/typescript-auto-install/index.test.ts
+++ b/test/development/typescript-auto-install/index.test.ts
@@ -1,35 +1,29 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { check, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'
 
 describe('typescript-auto-install', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() {
-            return <p>hello world</p>
-          }
-        `,
-      },
-      env: {
-        // unset CI env as this skips the auto-install behavior
-        // being tested
-        CI: '',
-        CIRCLECI: '',
-        GITHUB_ACTIONS: '',
-        CONTINUOUS_INTEGRATION: '',
-        RUN_ID: '',
-        BUILD_NUMBER: '',
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() {
+          return <p>hello world</p>
+        }
+      `,
+    },
+    env: {
+      // unset CI env as this skips the auto-install behavior
+      // being tested
+      CI: '',
+      CIRCLECI: '',
+      GITHUB_ACTIONS: '',
+      CONTINUOUS_INTEGRATION: '',
+      RUN_ID: '',
+      BUILD_NUMBER: '',
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/development/webpack-issuer-deprecation-warning/index.test.ts
+++ b/test/development/webpack-issuer-deprecation-warning/index.test.ts
@@ -1,26 +1,20 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 // Skip on Turbopack because it's not supported
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'webpack-issuer-deprecation-warning',
   () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'pages/index.js': `
+    const { next } = nextTestSetup({
+      files: {
+        'pages/index.js': `
           export default function Page() { 
             return <p>hello world
           } 
         `,
-        },
-        dependencies: {},
-      })
+      },
+      dependencies: {},
     })
-    afterAll(() => next.destroy())
 
     it('should not appear deprecation warning about webpack module issuer', async () => {
       const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs-extra'
-import { createNext, FileRef, type NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 
 const pathnames = {
@@ -35,16 +35,14 @@ module.exports = {
 `
 
 describe('404-page-router', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    const files = {
+  const { next } = nextTestSetup({
+    files: {
       pages: new FileRef(path.join(__dirname, 'app/pages')),
       components: new FileRef(path.join(__dirname, 'app/components')),
-    }
-    next = await createNext({ files, skipStart: true, patchFileDelay: 500 })
+    },
+    skipStart: true,
+    patchFileDelay: 500,
   })
-  afterAll(() => next.destroy())
 
   describe.each(table)(
     '404-page-router with basePath of $basePath and i18n of $i18n and middleware $middleware',

--- a/test/e2e/app-dir/app/useReportWebVitals.test.ts
+++ b/test/e2e/app-dir/app/useReportWebVitals.test.ts
@@ -1,23 +1,19 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('useReportWebVitals hook', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    env: {},
+    dependencies: {
+      nanoid: '4.0.1',
+    },
+  })
 
   beforeAll(async () => {
-    next = await createNext({
-      files: __dirname,
-      skipStart: true,
-      env: {},
-      dependencies: {
-        nanoid: '4.0.1',
-      },
-    })
-
     await next.start()
   })
-  afterAll(() => next.destroy())
 
   // Analytics events are only sent in production
   it('should send web-vitals', async () => {

--- a/test/e2e/app-dir/catch-error/catch-error-react-compiler.test.ts
+++ b/test/e2e/app-dir/catch-error/catch-error-react-compiler.test.ts
@@ -1,9 +1,8 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 // FIXME: If NEXT_TEST_REACT_VERSION is set, skip the test for now. Need to address react/compiler-runtime
 // compatibility with React below 19.
 // _describe for cleaner git history.
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 const _describe = isReact18 ? describe.skip : describe
 
 _describe('app-dir - unstable_catchError with react compiler', () => {

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -1,6 +1,5 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { createNext, FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
@@ -15,22 +14,17 @@ import stripAnsi from 'strip-ansi'
       return
     }
 
-    let next: NextInstance
-
     if (isDev) {
       describe('page.js', () => {
         describe('root layout in app', () => {
-          beforeAll(async () => {
-            next = await createNext({
-              files: {
-                app: new FileRef(path.join(__dirname, 'app')),
-                'next.config.js': new FileRef(
-                  path.join(__dirname, 'next.config.js')
-                ),
-              },
-            })
+          const { next } = nextTestSetup({
+            files: {
+              app: new FileRef(path.join(__dirname, 'app')),
+              'next.config.js': new FileRef(
+                path.join(__dirname, 'next.config.js')
+              ),
+            },
           })
-          afterAll(() => next.destroy())
 
           it('create root layout', async () => {
             const outputIndex = next.cliOutput.length
@@ -67,17 +61,14 @@ import stripAnsi from 'strip-ansi'
         })
 
         describe('root layout in route group', () => {
-          beforeAll(async () => {
-            next = await createNext({
-              files: {
-                app: new FileRef(path.join(__dirname, 'app-group-layout')),
-                'next.config.js': new FileRef(
-                  path.join(__dirname, 'next.config.js')
-                ),
-              },
-            })
+          const { next } = nextTestSetup({
+            files: {
+              app: new FileRef(path.join(__dirname, 'app-group-layout')),
+              'next.config.js': new FileRef(
+                path.join(__dirname, 'next.config.js')
+              ),
+            },
           })
-          afterAll(() => next.destroy())
 
           it('create root layout', async () => {
             const outputIndex = next.cliOutput.length
@@ -115,19 +106,14 @@ import stripAnsi from 'strip-ansi'
         })
 
         describe('find available dir', () => {
-          beforeAll(async () => {
-            next = await createNext({
-              files: {
-                app: new FileRef(
-                  path.join(__dirname, 'app-find-available-dir')
-                ),
-                'next.config.js': new FileRef(
-                  path.join(__dirname, 'next.config.js')
-                ),
-              },
-            })
+          const { next } = nextTestSetup({
+            files: {
+              app: new FileRef(path.join(__dirname, 'app-find-available-dir')),
+              'next.config.js': new FileRef(
+                path.join(__dirname, 'next.config.js')
+              ),
+            },
           })
-          afterAll(() => next.destroy())
 
           it('create root layout', async () => {
             const outputIndex = next.cliOutput.length
@@ -166,19 +152,16 @@ import stripAnsi from 'strip-ansi'
       })
 
       describe('page.tsx', () => {
-        beforeAll(async () => {
-          next = await createNext({
-            files: {
-              'app/page.tsx': new FileRef(
-                path.join(__dirname, 'app/route/page.js')
-              ),
-              'next.config.js': new FileRef(
-                path.join(__dirname, 'next.config.js')
-              ),
-            },
-          })
+        const { next } = nextTestSetup({
+          files: {
+            'app/page.tsx': new FileRef(
+              path.join(__dirname, 'app/route/page.js')
+            ),
+            'next.config.js': new FileRef(
+              path.join(__dirname, 'next.config.js')
+            ),
+          },
         })
-        afterAll(() => next.destroy())
 
         it('create root layout', async () => {
           const outputIndex = next.cliOutput.length

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -1,21 +1,15 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 describe('navigation between pages and app dir', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(__dirname),
-      dependencies: {
-        typescript: 'latest',
-        '@types/react': 'latest',
-        '@types/node': 'latest',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(__dirname),
+    dependencies: {
+      typescript: 'latest',
+      '@types/react': 'latest',
+      '@types/node': 'latest',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('It should be able to navigate app -> pages', async () => {
     const browser = await webdriver(next.url, '/app')

--- a/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+++ b/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 import {
   getRedboxDescription,
   retry,
@@ -6,8 +6,6 @@ import {
   waitForRedbox,
 } from 'next-test-utils'
 import type { Page, Request } from 'playwright'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('javascript-urls', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
@@ -1,17 +1,11 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { check } from 'next-test-utils'
 
 describe('useSelectedLayoutSegment(s)', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(__dirname),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(__dirname),
   })
-  afterAll(() => next.destroy())
 
   let browser: Awaited<ReturnType<typeof webdriver>>
   beforeEach(async () => {

--- a/test/e2e/basepath/trailing-slash.test.ts
+++ b/test/e2e/basepath/trailing-slash.test.ts
@@ -1,26 +1,21 @@
 import webdriver from 'next-webdriver'
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
 describe('basePath + trailingSlash', () => {
-  let next: NextInstance
   const basePath = '/docs'
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: __dirname,
-      nextConfig: {
-        trailingSlash: true,
-        basePath,
-        onDemandEntries: {
-          // Make sure entries are not getting disposed.
-          maxInactiveAge: 1000 * 60 * 60,
-        },
+  const { next } = nextTestSetup({
+    files: __dirname,
+    nextConfig: {
+      trailingSlash: true,
+      basePath,
+      onDemandEntries: {
+        // Make sure entries are not getting disposed.
+        maxInactiveAge: 1000 * 60 * 60,
       },
-    })
+    },
   })
-  afterAll(() => next.destroy())
 
   const runTests = (dev = false) => {
     it('should allow URL query strings without refresh', async () => {

--- a/test/e2e/browserslist-extends/index.test.ts
+++ b/test/e2e/browserslist-extends/index.test.ts
@@ -1,35 +1,29 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('browserslist-extends', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          import styles from './index.module.css'
-          
-          export default function Page() { 
-            return <p className={styles.hello}>hello world</p>
-          } 
-        `,
-        'pages/index.module.css': `
-          .hello {
-            color: pink;
-          }
-        `,
-      },
-      dependencies: {
-        'browserslist-config-google': '^3.0.1',
-      },
-      packageJson: {
-        browserslist: ['extends browserslist-config-google'],
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        import styles from './index.module.css'
+        
+        export default function Page() { 
+          return <p className={styles.hello}>hello world</p>
+        } 
+      `,
+      'pages/index.module.css': `
+        .hello {
+          color: pink;
+        }
+      `,
+    },
+    dependencies: {
+      'browserslist-config-google': '^3.0.1',
+    },
+    packageJson: {
+      browserslist: ['extends browserslist-config-google'],
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/browserslist/browserslist.test.ts
+++ b/test/e2e/browserslist/browserslist.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
@@ -7,18 +6,13 @@ const appDir = path.join(__dirname, 'app')
 
 // TODO: This test needs to check multiple files and syntax features.
 describe.skip('Browserslist', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(path.join(appDir, 'pages')),
-        // In Chrome 45 arrow functions are introduced, by
-        '.browserslistrc': 'Chrome 42',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(appDir, 'pages')),
+      // In Chrome 45 arrow functions are introduced, by
+      '.browserslistrc': 'Chrome 42',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should apply browserslist target', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/browserslist/default-target.test.ts
+++ b/test/e2e/browserslist/default-target.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'
@@ -7,16 +6,11 @@ const appDir = path.join(__dirname, 'app')
 
 // TODO: This test needs to check multiple files and syntax features.
 describe.skip('default browserslist target', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(path.join(appDir, 'pages')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(appDir, 'pages')),
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should apply default browserslist target', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/config-promise-export/async-function.test.ts
+++ b/test/e2e/config-promise-export/async-function.test.ts
@@ -1,30 +1,24 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('async export', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() { 
-            return <p>hello world</p>
-          } 
-        `,
-        'next.config.js': `
-          module.exports = async () => {
-            return {
-              basePath: '/docs'
-            }
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() { 
+          return <p>hello world</p>
+        } 
+      `,
+      'next.config.js': `
+        module.exports = async () => {
+          return {
+            basePath: '/docs'
           }
-        `,
-      },
-      dependencies: {},
-    })
+        }
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/docs')

--- a/test/e2e/config-promise-export/promise.test.ts
+++ b/test/e2e/config-promise-export/promise.test.ts
@@ -1,30 +1,24 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('promise export', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() { 
-            return <p>hello world</p>
-          } 
-        `,
-        'next.config.js': `
-          module.exports = new Promise((resolve) => {
-            resolve({
-              basePath: '/docs'
-            })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() { 
+          return <p>hello world</p>
+        } 
+      `,
+      'next.config.js': `
+        module.exports = new Promise((resolve) => {
+          resolve({
+            basePath: '/docs'
           })
-        `,
-      },
-      dependencies: {},
-    })
+        })
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/docs')

--- a/test/e2e/edge-api-endpoints-can-receive-body/index.test.ts
+++ b/test/e2e/edge-api-endpoints-can-receive-body/index.test.ts
@@ -1,25 +1,19 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 
 describe('Edge API endpoints can receive body', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/edge.js': new FileRef(
-          path.resolve(__dirname, './app/pages/api/edge.js')
-        ),
-        'pages/api/index.js': new FileRef(
-          path.resolve(__dirname, './app/pages/api/index.js')
-        ),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/edge.js': new FileRef(
+        path.resolve(__dirname, './app/pages/api/edge.js')
+      ),
+      'pages/api/index.js': new FileRef(
+        path.resolve(__dirname, './app/pages/api/index.js')
+      ),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('reads the body as text', async () => {
     const res = await fetchViaHTTP(

--- a/test/e2e/edge-can-read-request-body/index.test.ts
+++ b/test/e2e/edge-can-read-request-body/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import type { Response } from 'node-fetch'
@@ -13,15 +12,10 @@ async function serialize(response: Response) {
 }
 
 describe('Edge can read request body', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.resolve(__dirname, './app')),
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(path.resolve(__dirname, './app')),
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('renders the static page', async () => {
     const html = await renderViaHTTP(next.url, '/api/nothing')

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'
@@ -8,7 +7,7 @@ function extractJSON(response) {
   return JSON.parse(response.headers.get('data') ?? '{}')
 }
 
-function baseNextConfig(): Parameters<typeof createNext>[0] {
+function baseNextConfig(): Parameters<typeof nextTestSetup>[0] {
   return {
     files: {
       'src/add.wasm': new FileRef(path.join(__dirname, './add.wasm')),
@@ -37,34 +36,30 @@ function baseNextConfig(): Parameters<typeof createNext>[0] {
 }
 
 describe('edge api endpoints can use wasm files', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/add.js': `
+        import { increment } from '../../src/add.js'
+        export default async (request) => {
+          const input = Number(request.nextUrl.searchParams.get('input')) || 1;
+          const value = await increment(input);
+          return new Response(null, { headers: { data: JSON.stringify({ input, value }) } });
+        }
+        export const config = { runtime: 'edge' };
+      `,
+      'src/add.wasm': new FileRef(path.join(__dirname, './add.wasm')),
+      'src/add.js': `
+        import wasm from './add.wasm?module'
+        const instance$ = WebAssembly.instantiate(wasm);
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/add.js': `
-          import { increment } from '../../src/add.js'
-          export default async (request) => {
-            const input = Number(request.nextUrl.searchParams.get('input')) || 1;
-            const value = await increment(input);
-            return new Response(null, { headers: { data: JSON.stringify({ input, value }) } });
-          }
-          export const config = { runtime: 'edge' };
-        `,
-        'src/add.wasm': new FileRef(path.join(__dirname, './add.wasm')),
-        'src/add.js': `
-          import wasm from './add.wasm?module'
-          const instance$ = WebAssembly.instantiate(wasm);
-
-          export async function increment(a) {
-            const { exports } = await instance$;
-            return exports.add_one(a);
-          }
-        `,
-      },
-    })
+        export async function increment(a) {
+          const { exports } = await instance$;
+          return exports.add_one(a);
+        }
+      `,
+    },
   })
-  afterAll(() => next.destroy())
+
   it('uses the wasm file', async () => {
     const response = await fetchViaHTTP(next.url, '/api/add', { input: 10 })
     expect(extractJSON(response)).toEqual({
@@ -75,13 +70,7 @@ describe('edge api endpoints can use wasm files', () => {
 })
 
 describe('middleware can use wasm files', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    const config = baseNextConfig()
-    next = await createNext(config)
-  })
-  afterAll(() => next.destroy())
+  const { next } = nextTestSetup(baseNextConfig())
 
   it('uses the wasm file', async () => {
     const response = await fetchViaHTTP(next.url, '/')
@@ -134,25 +123,20 @@ describe('middleware can use wasm files', () => {
 })
 
 describe('middleware can use wasm files with the experimental modes on', () => {
-  let next: NextInstance
+  const config = baseNextConfig()
+  ;(config.files as Record<string, string>)['next.config.js'] = `
+    module.exports = {
+      webpack(config) {
+        config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
 
-  beforeAll(async () => {
-    const config = baseNextConfig()
-    config.files['next.config.js'] = `
-      module.exports = {
-        webpack(config) {
-          config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
+        // Since Webpack 5 doesn't enable WebAssembly by default, we should do it manually
+        config.experiments = { ...config.experiments, asyncWebAssembly: true }
 
-          // Since Webpack 5 doesn't enable WebAssembly by default, we should do it manually
-          config.experiments = { ...config.experiments, asyncWebAssembly: true }
-
-          return config
-        },
-      }
-    `
-    next = await createNext(config)
-  })
-  afterAll(() => next.destroy())
+        return config
+      },
+    }
+  `
+  const { next } = nextTestSetup(config)
 
   it('uses the wasm file', async () => {
     const response = await fetchViaHTTP(next.url, '/')

--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -1,10 +1,7 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Edge compiler module exports preference', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     // this test is skipped when deployed because it manually creates a package in the node_modules directory
     // which is unsupported
@@ -12,49 +9,46 @@ describe('Edge compiler module exports preference', () => {
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() {
-            return <p>hello world</p>
-          }
-        `,
-        'middleware.js': `
-          import { NextResponse } from 'next/server';
-          import lib from 'my-lib';
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() {
+          return <p>hello world</p>
+        }
+      `,
+      'middleware.js': `
+        import { NextResponse } from 'next/server';
+        import lib from 'my-lib';
 
-          export default (req) => {
-            return NextResponse.next({
-              headers: {
-                'x-imported': lib
-              }
-            })
-          }
-        `,
-        'node_modules/my-lib/package.json': JSON.stringify({
-          name: 'my-lib',
-          version: '1.0.0',
-          main: 'index.js',
-          browser: 'browser.js',
-        }),
-        'node_modules/my-lib/index.js': `module.exports = "Node.js"`,
-        'node_modules/my-lib/browser.js': `module.exports = "Browser"`,
+        export default (req) => {
+          return NextResponse.next({
+            headers: {
+              'x-imported': lib
+            }
+          })
+        }
+      `,
+      'node_modules/my-lib/package.json': JSON.stringify({
+        name: 'my-lib',
+        version: '1.0.0',
+        main: 'index.js',
+        browser: 'browser.js',
+      }),
+      'node_modules/my-lib/index.js': `module.exports = "Node.js"`,
+      'node_modules/my-lib/browser.js': `module.exports = "Browser"`,
+    },
+    packageJson: {
+      scripts: {
+        build: 'next build',
+        dev: 'next dev',
+        start: 'next start',
       },
-      packageJson: {
-        scripts: {
-          build: 'next build',
-          dev: 'next dev',
-          start: 'next start',
-        },
-      },
-      installCommand: 'pnpm i',
-      startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
-      buildCommand: 'pnpm run build',
-      dependencies: {},
-    })
+    },
+    installCommand: 'pnpm i',
+    startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    buildCommand: 'pnpm run build',
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('favors the browser export', async () => {
     const response = await fetchViaHTTP(next.url, '/')

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import escapeRegex from 'escape-string-regexp'
 import {
   check,
@@ -16,12 +16,10 @@ import {
 } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'e2e-utils'
 
 const appDir = join(__dirname, '../app')
 
 let buildId
-let next: NextInstance
 
 const expectedManifestRoutes = () => [
   {
@@ -203,7 +201,7 @@ const expectedManifestRoutes = () => [
   },
 ]
 
-const navigateTest = () => {
+const navigateTest = (next: ReturnType<typeof nextTestSetup>['next']) => {
   it('should navigate between pages successfully', async () => {
     const toBuild = [
       '/',
@@ -289,8 +287,12 @@ const navigateTest = () => {
   })
 }
 
-const runTests = (isDev = false, isDeploy = false) => {
-  navigateTest()
+const runTests = (
+  next: ReturnType<typeof nextTestSetup>['next'],
+  isDev = false,
+  isDeploy = false
+) => {
+  navigateTest(next)
 
   it('should work with early request ending', async () => {
     const res = await fetchViaHTTP(next.url, '/early-request-end')
@@ -869,19 +871,18 @@ const runTests = (isDev = false, isDeploy = false) => {
 }
 
 describe('getServerSideProps', () => {
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(appDir, 'pages')),
-        public: new FileRef(join(appDir, 'public')),
-        'world.txt': new FileRef(join(appDir, 'world.txt')),
-        'next.config.js': new FileRef(join(appDir, 'next.config.js')),
-      },
-      patchFileDelay: 500,
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(appDir, 'pages')),
+      public: new FileRef(join(appDir, 'public')),
+      'world.txt': new FileRef(join(appDir, 'world.txt')),
+      'next.config.js': new FileRef(join(appDir, 'next.config.js')),
+    },
+    patchFileDelay: 500,
+  })
+  beforeAll(() => {
     buildId = next.buildId
   })
-  afterAll(() => next.destroy())
 
-  runTests((global as any).isNextDev, (global as any).isNextDeploy)
+  runTests(next, (global as any).isNextDev, (global as any).isNextDeploy)
 })

--- a/test/e2e/handle-non-hoisted-swc-helpers/index.test.ts
+++ b/test/e2e/handle-non-hoisted-swc-helpers/index.test.ts
@@ -1,45 +1,39 @@
-import { createNext, isNextDev } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('handle-non-hoisted-swc-helpers', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() {
+          return <p>hello world</p>
+        }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() {
-            return <p>hello world</p>
-          }
-
-          export function getServerSideProps() {
-            const helper = require('@swc/helpers/_/_object_spread')
-            console.log(helper)
-            return {
-              props: {
-                now: Date.now()
-              }
+        export function getServerSideProps() {
+          const helper = require('@swc/helpers/_/_object_spread')
+          console.log(helper)
+          return {
+            props: {
+              now: Date.now()
             }
           }
-        `,
+        }
+      `,
+    },
+    packageJson: {
+      packageManager: 'npm@10.9.2',
+      scripts: {
+        build: 'next build',
+        dev: 'next dev',
+        start: 'next start',
       },
-      packageJson: {
-        packageManager: 'npm@10.9.2',
-        scripts: {
-          build: 'next build',
-          dev: 'next dev',
-          start: 'next start',
-        },
-      },
-      installCommand:
-        'npm install; mkdir -p node_modules/next/node_modules/@swc; mv node_modules/@swc/helpers node_modules/next/node_modules/@swc/',
-      buildCommand: 'npm run build',
-      startCommand: isNextDev ? 'npm run dev' : 'npm run start',
-      dependencies: {},
-    })
+    },
+    installCommand:
+      'npm install; mkdir -p node_modules/next/node_modules/@swc; mv node_modules/@swc/helpers node_modules/next/node_modules/@swc/',
+    buildCommand: 'npm run build',
+    startCommand: isNextDev ? 'npm run dev' : 'npm run start',
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/i18n-api-support/index.test.ts
+++ b/test/e2e/i18n-api-support/index.test.ts
@@ -1,46 +1,40 @@
-import { createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
 
 describe('i18n API support', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/hello.js': `
-          export default function handler(req, res) { 
-            res.end('hello world')
-          } 
-        `,
-        'pages/api/blog/[slug].js': `
-          export default function handler(req, res) {
-            res.end('blog/[slug]')
-          }
-        `,
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/hello.js': `
+        export default function handler(req, res) { 
+          res.end('hello world')
+        } 
+      `,
+      'pages/api/blog/[slug].js': `
+        export default function handler(req, res) {
+          res.end('blog/[slug]')
+        }
+      `,
+    },
+    nextConfig: {
+      i18n: {
+        locales: ['en', 'fr'],
+        defaultLocale: 'en',
       },
-      nextConfig: {
-        i18n: {
-          locales: ['en', 'fr'],
-          defaultLocale: 'en',
-        },
-        async rewrites() {
-          return {
-            beforeFiles: [],
-            afterFiles: [],
-            fallback: [
-              {
-                source: '/api/:path*',
-                destination: 'https://example.vercel.sh/',
-              },
-            ],
-          }
-        },
+      async rewrites() {
+        return {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [
+            {
+              source: '/api/:path*',
+              destination: 'https://example.vercel.sh/',
+            },
+          ],
+        }
       },
-      dependencies: {},
-    })
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should respond to normal API request', async () => {
     const res = await fetchViaHTTP(next.url, '/api/hello')

--- a/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
@@ -1,28 +1,22 @@
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
 describe('i18n-data-fetching-redirect', () => {
-  let next: NextInstance
-
   // TODO: investigate tests failures on deploy
   if ((global as any).isNextDeploy) {
     it('should skip temporarily', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   describe('Redirect to locale from context', () => {
     test.each`

--- a/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
@@ -1,28 +1,22 @@
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
 describe('i18n-data-fetching-redirect', () => {
-  let next: NextInstance
-
   // TODO: investigate tests failures on deploy
   if ((global as any).isNextDeploy) {
     it('should skip temporarily', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   describe('Redirect to another locale', () => {
     test.each`

--- a/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
@@ -7,52 +6,47 @@ import webdriver from 'next-webdriver'
 const locales = ['', '/en', '/sv', '/nl']
 
 describe('i18n-ignore-redirect-source-locale with basepath', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+    },
+    dependencies: {},
+    nextConfig: {
+      basePath: '/basepath',
+      i18n: {
+        locales: ['en', 'sv', 'nl'],
+        defaultLocale: 'en',
       },
-      dependencies: {},
-      nextConfig: {
-        basePath: '/basepath',
-        i18n: {
-          locales: ['en', 'sv', 'nl'],
-          defaultLocale: 'en',
-        },
-        async redirects() {
-          return [
-            {
-              source: '/:locale/to-sv',
-              destination: '/sv/newpage',
-              permanent: false,
-              locale: false,
-            },
-            {
-              source: '/:locale/to-en',
-              destination: '/en/newpage',
-              permanent: false,
-              locale: false,
-            },
-            {
-              source: '/:locale/to-slash',
-              destination: '/newpage',
-              permanent: false,
-              locale: false,
-            },
-            {
-              source: '/:locale/to-same',
-              destination: '/:locale/newpage',
-              permanent: false,
-              locale: false,
-            },
-          ]
-        },
+      async redirects() {
+        return [
+          {
+            source: '/:locale/to-sv',
+            destination: '/sv/newpage',
+            permanent: false,
+            locale: false,
+          },
+          {
+            source: '/:locale/to-en',
+            destination: '/en/newpage',
+            permanent: false,
+            locale: false,
+          },
+          {
+            source: '/:locale/to-slash',
+            destination: '/newpage',
+            permanent: false,
+            locale: false,
+          },
+          {
+            source: '/:locale/to-same',
+            destination: '/:locale/newpage',
+            permanent: false,
+            locale: false,
+          },
+        ]
       },
-    })
+    },
   })
-  afterAll(() => next.destroy())
 
   test.each(locales)(
     'get redirected to the new page, from: %s to: sv',

--- a/test/e2e/i18n-ignore-redirect-source-locale/redirects.test.ts
+++ b/test/e2e/i18n-ignore-redirect-source-locale/redirects.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
@@ -7,51 +6,46 @@ import webdriver from 'next-webdriver'
 const locales = ['', '/en', '/sv', '/nl']
 
 describe('i18n-ignore-redirect-source-locale', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+    },
+    dependencies: {},
+    nextConfig: {
+      i18n: {
+        locales: ['en', 'sv', 'nl'],
+        defaultLocale: 'en',
       },
-      dependencies: {},
-      nextConfig: {
-        i18n: {
-          locales: ['en', 'sv', 'nl'],
-          defaultLocale: 'en',
-        },
-        async redirects() {
-          return [
-            {
-              source: '/:locale/to-sv',
-              destination: '/sv/newpage',
-              permanent: false,
-              locale: false,
-            },
-            {
-              source: '/:locale/to-en',
-              destination: '/en/newpage',
-              permanent: false,
-              locale: false,
-            },
-            {
-              source: '/:locale/to-slash',
-              destination: '/newpage',
-              permanent: false,
-              locale: false,
-            },
-            {
-              source: '/:locale/to-same',
-              destination: '/:locale/newpage',
-              permanent: false,
-              locale: false,
-            },
-          ]
-        },
+      async redirects() {
+        return [
+          {
+            source: '/:locale/to-sv',
+            destination: '/sv/newpage',
+            permanent: false,
+            locale: false,
+          },
+          {
+            source: '/:locale/to-en',
+            destination: '/en/newpage',
+            permanent: false,
+            locale: false,
+          },
+          {
+            source: '/:locale/to-slash',
+            destination: '/newpage',
+            permanent: false,
+            locale: false,
+          },
+          {
+            source: '/:locale/to-same',
+            destination: '/:locale/newpage',
+            permanent: false,
+            locale: false,
+          },
+        ]
       },
-    })
+    },
   })
-  afterAll(() => next.destroy())
 
   test.each(locales)(
     'get redirected to the new page, from: %s to: sv',

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
@@ -1,5 +1,4 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'
@@ -7,45 +6,40 @@ import fs from 'fs-extra'
 const locales = ['', '/en', '/sv', '/nl']
 
 describe('i18n-ignore-rewrite-source-locale', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/hello.js': `
-        export default function handler(req, res) {
-          res.send('hello from api')
-        }`,
-        'public/file.txt': 'hello from file.txt',
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/hello.js': `
+      export default function handler(req, res) {
+        res.send('hello from api')
+      }`,
+      'public/file.txt': 'hello from file.txt',
+    },
+    dependencies: {},
+    nextConfig: {
+      i18n: {
+        locales: ['en', 'sv', 'nl'],
+        defaultLocale: 'en',
       },
-      dependencies: {},
-      nextConfig: {
-        i18n: {
-          locales: ['en', 'sv', 'nl'],
-          defaultLocale: 'en',
-        },
-        async rewrites() {
-          return {
-            beforeFiles: [
-              {
-                source: '/:locale/rewrite-files/:path*',
-                destination: '/:path*',
-                locale: false,
-              },
-              {
-                source: '/:locale/rewrite-api/:path*',
-                destination: '/api/:path*',
-                locale: false,
-              },
-            ],
-            afterFiles: [],
-            fallback: [],
-          }
-        },
+      async rewrites() {
+        return {
+          beforeFiles: [
+            {
+              source: '/:locale/rewrite-files/:path*',
+              destination: '/:path*',
+              locale: false,
+            },
+            {
+              source: '/:locale/rewrite-api/:path*',
+              destination: '/api/:path*',
+              locale: false,
+            },
+          ],
+          afterFiles: [],
+          fallback: [],
+        }
       },
-    })
+    },
   })
-  afterAll(() => next.destroy())
 
   test.each(locales)(
     'get public file by skipping locale in rewrite, locale: %s',

--- a/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
@@ -1,6 +1,5 @@
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import webdriver, { Playwright } from 'next-webdriver'
 
@@ -14,18 +13,13 @@ const emitPopsStateEvent = (browser: Playwright, state: HistoryState) =>
   )
 
 describe('i18n: Event with stale state - static route previously was dynamic', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   test('Ignore event without query param', async () => {
     const browser = await webdriver(next.url, '/sv/static')

--- a/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
@@ -1,6 +1,5 @@
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import webdriver, { Playwright } from 'next-webdriver'
 
@@ -14,18 +13,13 @@ const emitPopsStateEvent = (browser: Playwright, state: HistoryState) =>
   )
 
 describe('Event with stale state - static route previously was dynamic', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        // Don't use next.config.js to avoid getting i18n
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      // Don't use next.config.js to avoid getting i18n
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   test('Ignore event without query param', async () => {
     const browser = await webdriver(next.url, '/static')

--- a/test/e2e/link-with-api-rewrite/index.test.ts
+++ b/test/e2e/link-with-api-rewrite/index.test.ts
@@ -1,22 +1,16 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
 describe('link-with-api-rewrite', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should perform hard navigation for rewritten urls', async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import httpProxy from 'http-proxy'
 import { join } from 'path'
 import http from 'http'
@@ -13,20 +12,20 @@ describe('manual-client-base-path', () => {
     return
   }
 
-  let next: NextInstance
   let server: http.Server
   let appPort: string
   const basePath = '/docs-proxy'
   const responses = new Set()
 
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
+    },
+    dependencies: {},
+  })
+
   beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
-      },
-      dependencies: {},
-    })
     const getProxyTarget = (req) => {
       const destination = new URL(next.url)
       const reqUrl = new URL(req.url, 'http://localhost')
@@ -89,7 +88,6 @@ describe('manual-client-base-path', () => {
     appPort = server.address().port
   })
   afterAll(async () => {
-    await next.destroy()
     try {
       server.close()
       responses.forEach((res: any) => res.end?.() || res.close?.())

--- a/test/e2e/middleware-base-path/test/index.test.ts
+++ b/test/e2e/middleware-base-path/test/index.test.ts
@@ -3,22 +3,16 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('Middleware base tests', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../app/pages')),
-        'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
-        'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../app/pages')),
+      'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
+      'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should execute from absolute paths', async () => {
     const browser = await webdriver(next.url, '/redirect-with-basepath')

--- a/test/e2e/middleware-custom-matchers-basepath/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers-basepath/test/index.test.ts
@@ -4,22 +4,16 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 
 const isModeDeploy = process.env.NEXT_TEST_MODE === 'deploy'
 
 describe('Middleware custom matchers basePath', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, '../app')),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, '../app')),
   })
-  afterAll(() => next.destroy())
 
   // FIXME
   // See https://linear.app/vercel/issue/EC-170/middleware-rewrite-of-nextjs-with-basepath-does-not-work-on-vercel

--- a/test/e2e/middleware-custom-matchers/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers/test/index.test.ts
@@ -2,33 +2,27 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 
 const isModeDeploy = process.env.NEXT_TEST_MODE === 'deploy'
 
 describe('Middleware custom matchers', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy && process.env.TEST_NODE_MIDDLEWARE) {
     return it('should skip deploy for now', () => {})
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, '../app')),
-      overrideFiles: process.env.TEST_NODE_MIDDLEWARE
-        ? {
-            'middleware.js': new FileRef(
-              join(__dirname, '../app/middleware-node.js')
-            ),
-          }
-        : {},
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, '../app')),
+    overrideFiles: process.env.TEST_NODE_MIDDLEWARE
+      ? {
+          'middleware.js': new FileRef(
+            join(__dirname, '../app/middleware-node.js')
+          ),
+        }
+      : {},
   })
-  afterAll(() => next.destroy())
 
   const runTests = () => {
     it('should match missing header correctly', async () => {

--- a/test/e2e/middleware-dynamic-basepath-matcher/test/index.test.ts
+++ b/test/e2e/middleware-dynamic-basepath-matcher/test/index.test.ts
@@ -4,22 +4,16 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { check, fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 
 const isModeDeploy = process.env.NEXT_TEST_MODE === 'deploy'
 
 describe('Middleware custom matchers basePath', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, '../app')),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, '../app')),
   })
-  afterAll(() => next.destroy())
 
   // FIXME
   // See https://linear.app/vercel/issue/EC-170/middleware-rewrite-of-nextjs-with-basepath-does-not-work-on-vercel

--- a/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
+++ b/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
@@ -1,51 +1,45 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Middleware fetches with any HTTP method', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/ping.js': `
+        export default (req, res) => {
+          res.send(JSON.stringify({
+            method: req.method,
+            headers: {...req.headers},
+          }))
+        }
+      `,
+      'middleware.js': `
+        import { NextResponse } from 'next/server';
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/ping.js': `
-          export default (req, res) => {
-            res.send(JSON.stringify({
-              method: req.method,
-              headers: {...req.headers},
-            }))
-          }
-        `,
-        'middleware.js': `
-          import { NextResponse } from 'next/server';
+        const HTTP_ECHO_URL = 'https://next-data-api-endpoint.vercel.app/api/echo-headers';
 
-          const HTTP_ECHO_URL = 'https://next-data-api-endpoint.vercel.app/api/echo-headers';
+        export default async (req) => {
+          const kind = req.nextUrl.searchParams.get('kind')
+          const handler = handlers[kind] ?? handlers['normal-fetch'];
 
-          export default async (req) => {
-            const kind = req.nextUrl.searchParams.get('kind')
-            const handler = handlers[kind] ?? handlers['normal-fetch'];
+          const response = await handler({url: HTTP_ECHO_URL, method: req.method});
+          const json = await response.text()
 
-            const response = await handler({url: HTTP_ECHO_URL, method: req.method});
-            const json = await response.text()
+          const res = NextResponse.next();
+          res.headers.set('x-resolved', json ?? '{}');
+          return res
+        }
 
-            const res = NextResponse.next();
-            res.headers.set('x-resolved', json ?? '{}');
-            return res
-          }
+        const handlers = {
+          'new-request': ({url, method}) =>
+            fetch(new Request(url, { method, headers: { 'x-kind': 'new-request' } })),
 
-          const handlers = {
-            'new-request': ({url, method}) =>
-              fetch(new Request(url, { method, headers: { 'x-kind': 'new-request' } })),
-
-            'normal-fetch': ({url, method}) =>
-              fetch(url, { method, headers: { 'x-kind': 'normal-fetch' } })
-          }
-        `,
-      },
-      dependencies: {},
-    })
+          'normal-fetch': ({url, method}) =>
+            fetch(url, { method, headers: { 'x-kind': 'normal-fetch' } })
+        }
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('passes the method on a direct fetch request', async () => {
     const response = await fetchViaHTTP(

--- a/test/e2e/middleware-fetches-with-body/index.test.ts
+++ b/test/e2e/middleware-fetches-with-body/index.test.ts
@@ -1,52 +1,46 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Middleware fetches with body', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/default.js': `
+        export default (req, res) => res.json({ body: req.body })
+      `,
+      'pages/api/size_limit_5kb.js': `
+        export const config = { api: { bodyParser: { sizeLimit: '5kb' } } }
+        export default (req, res) => res.json({ body: req.body })
+      `,
+      'pages/api/size_limit_5mb.js': `
+        export const config = { api: { bodyParser: { sizeLimit: '5mb' } } }
+        export default (req, res) => res.json({ body: req.body })
+      `,
+      'pages/api/body_parser_false.js': `
+        export const config = { api: { bodyParser: false } }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/default.js': `
-          export default (req, res) => res.json({ body: req.body })
-        `,
-        'pages/api/size_limit_5kb.js': `
-          export const config = { api: { bodyParser: { sizeLimit: '5kb' } } }
-          export default (req, res) => res.json({ body: req.body })
-        `,
-        'pages/api/size_limit_5mb.js': `
-          export const config = { api: { bodyParser: { sizeLimit: '5mb' } } }
-          export default (req, res) => res.json({ body: req.body })
-        `,
-        'pages/api/body_parser_false.js': `
-          export const config = { api: { bodyParser: false } }
-
-          async function buffer(readable) {
-            const chunks = []
-            for await (const chunk of readable) {
-              chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
-            }
-            return Buffer.concat(chunks)
+        async function buffer(readable) {
+          const chunks = []
+          for await (const chunk of readable) {
+            chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
           }
+          return Buffer.concat(chunks)
+        }
 
-          export default async (req, res) => {
-            const buf = await buffer(req)
-            const rawBody = buf.toString('utf8');
+        export default async (req, res) => {
+          const buf = await buffer(req)
+          const rawBody = buf.toString('utf8');
 
-            res.json({ rawBody, body: req.body })
-          }
-        `,
-        'middleware.js': `
-          import { NextResponse } from 'next/server';
+          res.json({ rawBody, body: req.body })
+        }
+      `,
+      'middleware.js': `
+        import { NextResponse } from 'next/server';
 
-          export default async (req) => NextResponse.next();
-        `,
-      },
-      dependencies: {},
-    })
+        export default async (req) => NextResponse.next();
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   describe('with default bodyParser sizeLimit (1mb)', () => {
     it('should return 413 for body greater than 1mb', async () => {

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -3,95 +3,87 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { isNextStart, NextInstance } from 'e2e-utils'
+import { FileRef, isNextStart, nextTestSetup } from 'e2e-utils'
 import { check, fetchViaHTTP, waitFor } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
 
 const urlsError = 'Please use only absolute URLs'
 
 describe('Middleware Runtime', () => {
-  let next: NextInstance
-
   const isNodeMiddleware = Boolean(process.env.TEST_NODE_MIDDLEWARE)
 
   const setup = ({ i18n }: { i18n: boolean }) => {
-    afterAll(async () => {
-      await next.destroy()
-    })
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'middleware.js': new FileRef(
-            join(
-              __dirname,
-              '../app',
-              isNodeMiddleware ? 'middleware-node.js' : 'middleware.js'
-            )
-          ),
-          lib: new FileRef(join(__dirname, '../app/lib')),
-          pages: new FileRef(join(__dirname, '../app/pages')),
-          'shared-package': new FileRef(
-            join(__dirname, '../app/node_modules/shared-package')
-          ),
+    return nextTestSetup({
+      files: {
+        'middleware.js': new FileRef(
+          join(
+            __dirname,
+            '../app',
+            isNodeMiddleware ? 'middleware-node.js' : 'middleware.js'
+          )
+        ),
+        lib: new FileRef(join(__dirname, '../app/lib')),
+        pages: new FileRef(join(__dirname, '../app/pages')),
+        'shared-package': new FileRef(
+          join(__dirname, '../app/node_modules/shared-package')
+        ),
+      },
+      nextConfig: {
+        experimental: {
+          webpackBuildWorker: true,
         },
-        nextConfig: {
-          experimental: {
-            webpackBuildWorker: true,
-          },
-          ...(i18n
-            ? {
-                i18n: {
-                  locales: ['en', 'fr', 'nl'],
-                  defaultLocale: 'en',
-                },
-              }
-            : {}),
-          async redirects() {
-            return [
-              {
-                source: '/redirect-1',
-                destination: '/somewhere/else',
-                permanent: false,
+        ...(i18n
+          ? {
+              i18n: {
+                locales: ['en', 'fr', 'nl'],
+                defaultLocale: 'en',
               },
-            ]
-          },
-          async rewrites() {
-            return [
-              {
-                source: '/rewrite-1',
-                destination: '/ssr-page?from=config',
-              },
-              {
-                source: '/rewrite-2',
-                destination: '/about/a?from=next-config',
-              },
-              {
-                source: '/sha',
-                destination: '/shallow',
-              },
-              {
-                source: '/rewrite-3',
-                destination: '/blog/middleware-rewrite?hello=config',
-              },
-            ]
-          },
+            }
+          : {}),
+        async redirects() {
+          return [
+            {
+              source: '/redirect-1',
+              destination: '/somewhere/else',
+              permanent: false,
+            },
+          ]
         },
-        packageJson: {
-          scripts: {
-            setup: `cp -r ./shared-package ./node_modules`,
-            build: 'pnpm run setup && next build',
-            dev: 'pnpm run setup && next dev',
-            start: 'next start',
-          },
+        async rewrites() {
+          return [
+            {
+              source: '/rewrite-1',
+              destination: '/ssr-page?from=config',
+            },
+            {
+              source: '/rewrite-2',
+              destination: '/about/a?from=next-config',
+            },
+            {
+              source: '/sha',
+              destination: '/shallow',
+            },
+            {
+              source: '/rewrite-3',
+              destination: '/blog/middleware-rewrite?hello=config',
+            },
+          ]
         },
-        startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
-        buildCommand: 'pnpm build',
-        env: {
-          ANOTHER_MIDDLEWARE_TEST: 'asdf2',
-          STRING_ENV_VAR: 'asdf3',
-          MIDDLEWARE_TEST: 'asdf',
+      },
+      packageJson: {
+        scripts: {
+          setup: `cp -r ./shared-package ./node_modules`,
+          build: 'pnpm run setup && next build',
+          dev: 'pnpm run setup && next dev',
+          start: 'next start',
         },
-      })
+      },
+      startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+      buildCommand: 'pnpm build',
+      env: {
+        ANOTHER_MIDDLEWARE_TEST: 'asdf2',
+        STRING_ENV_VAR: 'asdf3',
+        MIDDLEWARE_TEST: 'asdf',
+      },
     })
   }
 
@@ -103,7 +95,10 @@ describe('Middleware Runtime', () => {
     return response.headers.get('error')
   }
 
-  function runTests({ i18n }: { i18n?: boolean }) {
+  function runTests(
+    next: ReturnType<typeof nextTestSetup>['next'],
+    { i18n }: { i18n?: boolean }
+  ) {
     it('should not treat as _next/data request with just header', async () => {
       const res = await next.fetch('/redirect-to-somewhere', {
         redirect: 'manual',
@@ -857,12 +852,12 @@ describe('Middleware Runtime', () => {
     })
   }
   describe('with i18n', () => {
-    setup({ i18n: true })
-    runTests({ i18n: true })
+    const { next } = setup({ i18n: true })
+    runTests(next, { i18n: true })
   })
 
   describe('without i18n', () => {
-    setup({ i18n: false })
-    runTests({ i18n: false })
+    const { next } = setup({ i18n: false })
+    runTests(next, { i18n: false })
   })
 })

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -1,19 +1,13 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, fetchViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
 describe('Middleware can set the matcher in its config', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, 'app')),
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'app')),
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('does add the header for root request', async () => {
     const response = await fetchViaHTTP(next.url, '/')
@@ -226,42 +220,38 @@ describe('Middleware can set the matcher in its config', () => {
 })
 
 describe('using a single matcher', () => {
-  let next: NextInstance
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/[...route].js': `
-          export default function Page({ message }) {
-            return <div>
-              <p>root page</p>
-              <p>{message}</p>
-            </div>
-          }
+  const { next } = nextTestSetup({
+    files: {
+      'pages/[...route].js': `
+        export default function Page({ message }) {
+          return <div>
+            <p>root page</p>
+            <p>{message}</p>
+          </div>
+        }
 
-          export const getServerSideProps = ({ params }) => {
-            return {
-              props: {
-                message: "Hello from /" + params.route.join("/")
-              }
+        export const getServerSideProps = ({ params }) => {
+          return {
+            props: {
+              message: "Hello from /" + params.route.join("/")
             }
           }
-        `,
-        'middleware.js': `
-          import { NextResponse } from 'next/server'
-          export const config = {
-            matcher: '/middleware/works'
-          };
-          export default (req) => {
-            const res = NextResponse.next();
-            res.headers.set('X-From-Middleware', 'true');
-            return res;
-          }
-        `,
-      },
-      dependencies: {},
-    })
+        }
+      `,
+      'middleware.js': `
+        import { NextResponse } from 'next/server'
+        export const config = {
+          matcher: '/middleware/works'
+        };
+        export default (req) => {
+          const res = NextResponse.next();
+          res.headers.set('X-From-Middleware', 'true');
+          return res;
+        }
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('does not add the header for root request', async () => {
     const response = await fetchViaHTTP(next.url, '/')
@@ -325,50 +315,46 @@ describe.each([
 ])(
   'using a single matcher with i18n for a non-root route$title',
   ({ trailingSlash }) => {
-    let next: NextInstance
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'pages/[...route].js': `
-            export default function Page({ message }) {
-              return <div>
-                <p>catchall page</p>
-                <p>{message}</p>
-              </div>
-            }
+    const { next } = nextTestSetup({
+      files: {
+        'pages/[...route].js': `
+          export default function Page({ message }) {
+            return <div>
+              <p>catchall page</p>
+              <p>{message}</p>
+            </div>
+          }
 
-            export const getServerSideProps = ({ params, locale }) => ({
-              props: {
-                message: \`(\${locale}) Hello from /\${params.route.join("/")}\`
-              }
-            })
-          `,
-          'middleware.js': `
-            import { NextResponse } from 'next/server'
-            export const config = {
-              matcher: '/middleware/works'
-            };
-            export default (req) => {
-              const res = NextResponse.next();
-              res.headers.set('X-From-Middleware', 'true');
-              return res;
+          export const getServerSideProps = ({ params, locale }) => ({
+            props: {
+              message: \`(\${locale}) Hello from /\${params.route.join("/")}\`
             }
-          `,
-          'next.config.js': `
-            module.exports = {
-              ${trailingSlash ? 'trailingSlash: true,' : ''}
-              i18n: {
-                localeDetection: false,
-                locales: ['es', 'en'],
-                defaultLocale: 'en',
-              }
+          })
+        `,
+        'middleware.js': `
+          import { NextResponse } from 'next/server'
+          export const config = {
+            matcher: '/middleware/works'
+          };
+          export default (req) => {
+            const res = NextResponse.next();
+            res.headers.set('X-From-Middleware', 'true');
+            return res;
+          }
+        `,
+        'next.config.js': `
+          module.exports = {
+            ${trailingSlash ? 'trailingSlash: true,' : ''}
+            i18n: {
+              localeDetection: false,
+              locales: ['es', 'en'],
+              defaultLocale: 'en',
             }
-          `,
-        },
-        dependencies: {},
-      })
+          }
+        `,
+      },
+      dependencies: {},
     })
-    afterAll(() => next.destroy())
 
     it('adds the header for matched paths', async () => {
       const res1 = await fetchViaHTTP(next.url, '/middleware/works')
@@ -426,38 +412,34 @@ describe.each([
 )
 
 describe('using root matcher', () => {
-  let next: NextInstance
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export function getStaticProps() {
-            return {
-              props: {
-                message: 'hello world'
-              }
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export function getStaticProps() {
+          return {
+            props: {
+              message: 'hello world'
             }
           }
-          
-          export default function Home({ message }) {
-            return <div>Hi there!</div>
-          }
-        `,
-        'middleware.js': `
-          import { NextResponse } from 'next/server'
-          export default (req) => {
-            const res = NextResponse.next();
-            res.headers.set('X-From-Middleware', 'true');
-            return res;
-          }
+        }
 
-          export const config = { matcher: '/' };
-        `,
-      },
-      dependencies: {},
-    })
+        export default function Home({ message }) {
+          return <div>Hi there!</div>
+        }
+      `,
+      'middleware.js': `
+        import { NextResponse } from 'next/server'
+        export default (req) => {
+          const res = NextResponse.next();
+          res.headers.set('X-From-Middleware', 'true');
+          return res;
+        }
+
+        export const config = { matcher: '/' };
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('adds the header to the /', async () => {
     const response = await fetchViaHTTP(next.url, '/')
@@ -507,55 +489,51 @@ describe.each([
   { title: '' },
   { title: ' and trailingSlash', trailingSlash: true },
 ])('using a single matcher with i18n$title', ({ trailingSlash }) => {
-  let next: NextInstance
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page({ message }) {
-            return <div>
-              <p>{message}</p>
-            </div>
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page({ message }) {
+          return <div>
+            <p>{message}</p>
+          </div>
+        }
+        export const getServerSideProps = ({ params, locale }) => ({
+          props: { message: \`(\${locale}) Hello from /\` }
+        })
+      `,
+      'pages/[...route].js': `
+        export default function Page({ message }) {
+          return <div>
+            <p>catchall page</p>
+            <p>{message}</p>
+          </div>
+        }
+        export const getServerSideProps = ({ params, locale }) => ({
+          props: { message: \`(\${locale}) Hello from /\` + params.route.join("/") }
+        })
+      `,
+      'middleware.js': `
+        import { NextResponse } from 'next/server'
+        export const config = { matcher: '/' };
+        export default (req) => {
+          const res = NextResponse.next();
+          res.headers.set('X-From-Middleware', 'true');
+          return res;
+        }
+      `,
+      'next.config.js': `
+        module.exports = {
+          ${trailingSlash ? 'trailingSlash: true,' : ''}
+          i18n: {
+            localeDetection: false,
+            locales: ['es', 'en'],
+            defaultLocale: 'en',
           }
-          export const getServerSideProps = ({ params, locale }) => ({
-            props: { message: \`(\${locale}) Hello from /\` }
-          })
-        `,
-        'pages/[...route].js': `
-          export default function Page({ message }) {
-            return <div>
-              <p>catchall page</p>
-              <p>{message}</p>
-            </div>
-          }
-          export const getServerSideProps = ({ params, locale }) => ({
-            props: { message: \`(\${locale}) Hello from /\` + params.route.join("/") }
-          })
-        `,
-        'middleware.js': `
-          import { NextResponse } from 'next/server'
-          export const config = { matcher: '/' };
-          export default (req) => {
-            const res = NextResponse.next();
-            res.headers.set('X-From-Middleware', 'true');
-            return res;
-          }
-        `,
-        'next.config.js': `
-          module.exports = {
-            ${trailingSlash ? 'trailingSlash: true,' : ''}
-            i18n: {
-              localeDetection: false,
-              locales: ['es', 'en'],
-              defaultLocale: 'en',
-            }
-          }
-        `,
-      },
-      dependencies: {},
-    })
+        }
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it(`adds the header for a matched path`, async () => {
     const res1 = await fetchViaHTTP(next.url, `/`)
@@ -610,11 +588,9 @@ describe.each([
 ])(
   'using a single matcher with i18n and basePath$title',
   ({ trailingSlash }) => {
-    let next: NextInstance
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'pages/index.js': `
+    const { next } = nextTestSetup({
+      files: {
+        'pages/index.js': `
           export default function Page({ message }) {
             return <div>
               <p>root page</p>
@@ -625,7 +601,7 @@ describe.each([
             props: { message: \`(\${locale}) Hello from /\` }
           })
         `,
-          'pages/[...route].js': `
+        'pages/[...route].js': `
           export default function Page({ message }) {
             return <div>
               <p>catchall page</p>
@@ -636,7 +612,7 @@ describe.each([
             props: { message: \`(\${locale}) Hello from /\` + params.route.join("/") }
           })
         `,
-          'middleware.js': `
+        'middleware.js': `
           import { NextResponse } from 'next/server'
           export const config = { matcher: '/' };
           export default (req) => {
@@ -645,7 +621,7 @@ describe.each([
             return res;
           }
         `,
-          'next.config.js': `
+        'next.config.js': `
           module.exports = {
             ${trailingSlash ? 'trailingSlash: true,' : ''}
             basePath: '/root',
@@ -656,11 +632,9 @@ describe.each([
             }
           }
         `,
-        },
-        dependencies: {},
-      })
+      },
+      dependencies: {},
     })
-    afterAll(() => next.destroy())
 
     it(`adds the header for a matched path`, async () => {
       const res1 = await fetchViaHTTP(next.url, `/root`)

--- a/test/e2e/middleware-redirects/test/index.test.ts
+++ b/test/e2e/middleware-redirects/test/index.test.ts
@@ -4,29 +4,23 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { check, fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('Middleware Redirect', () => {
-  let next: NextInstance
-
-  afterAll(() => next.destroy())
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../app/pages')),
-        ...(process.env.TEST_NODE_MIDDLEWARE
-          ? {
-              'proxy.js': new FileRef(join(__dirname, '../app/middleware.js')),
-            }
-          : {
-              'middleware.js': new FileRef(
-                join(__dirname, '../app/middleware.js')
-              ),
-            }),
-        'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../app/pages')),
+      ...(process.env.TEST_NODE_MIDDLEWARE
+        ? {
+            'proxy.js': new FileRef(join(__dirname, '../app/middleware.js')),
+          }
+        : {
+            'middleware.js': new FileRef(
+              join(__dirname, '../app/middleware.js')
+            ),
+          }),
+      'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
+    },
   })
   function tests() {
     it('should redirect correctly with redirect in next.config.js', async () => {

--- a/test/e2e/middleware-request-header-overrides/test/index.test.ts
+++ b/test/e2e/middleware-request-header-overrides/test/index.test.ts
@@ -1,24 +1,18 @@
 /* eslint-env jest */
 
 import { join } from 'path'
-import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 import type { Response } from 'node-fetch'
 
 describe('Middleware Request Headers Overrides', () => {
-  let next: NextInstance
-
-  afterAll(() => next.destroy())
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../app/pages')),
-        'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
-        'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../app/pages')),
+      'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
+      'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
+    },
   })
 
   describe.each([

--- a/test/e2e/middleware-responses/test/index.test.ts
+++ b/test/e2e/middleware-responses/test/index.test.ts
@@ -2,21 +2,15 @@
 
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('Middleware Responses', () => {
-  let next: NextInstance
-
-  afterAll(() => next.destroy())
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../app/pages')),
-        'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
-        'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../app/pages')),
+      'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
+      'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
+    },
   })
   function testsWithLocale(locale = '') {
     const label = locale ? `${locale} ` : ``

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -3,23 +3,17 @@
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP, retry } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import escapeStringRegexp from 'escape-string-regexp'
 
 describe('Middleware Rewrite', () => {
-  let next: NextInstance
-
-  afterAll(() => next.destroy())
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../app/pages')),
-        'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
-        'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../app/pages')),
+      'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
+      'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
+    },
   })
 
   function tests() {

--- a/test/e2e/middleware-shallow-link/index.test.ts
+++ b/test/e2e/middleware-shallow-link/index.test.ts
@@ -1,22 +1,15 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 import { check } from 'next-test-utils'
 
 describe('browser-shallow-navigation', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        'middleware.js': new FileRef(join(__dirname, 'app/middleware.js')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      'middleware.js': new FileRef(join(__dirname, 'app/middleware.js')),
+    },
   })
-
-  afterAll(() => next.destroy())
 
   it('should render the correct page', async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/e2e/middleware-static-files/index.test.ts
+++ b/test/e2e/middleware-static-files/index.test.ts
@@ -1,12 +1,13 @@
 /* eslint-env jest */
 
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { isNextStart, NextInstance } from 'e2e-utils'
+import { FileRef, isNextStart, nextTestSetup } from 'e2e-utils'
 import { listClientChunks } from 'next-test-utils'
 
 describe('Middleware Runtime', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'app')),
+  })
   let testPaths: Array<{ testPath: string }> = [
     { testPath: '/file.svg' },
     { testPath: '/vercel copy.svg' },
@@ -28,15 +29,6 @@ describe('Middleware Runtime', () => {
     { testPath: '/pages-glob%2fhello' },
     { testPath: '/pages-glob/hello' },
   ]
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, 'app')),
-    })
-  })
-  afterAll(async () => {
-    await next.destroy()
-  })
 
   it.each(testPaths)(
     'should match middleware correctly for $testPath',

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -3,24 +3,16 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, fetchViaHTTP, waitFor } from 'next-test-utils'
 
 describe('Middleware Runtime trailing slash', () => {
-  let next: NextInstance
-
-  afterAll(async () => {
-    await next.destroy()
-  })
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
-        'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
-        pages: new FileRef(join(__dirname, '../app/pages')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
+      'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
+      pages: new FileRef(join(__dirname, '../app/pages')),
+    },
   })
 
   function runTests() {

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -1,25 +1,19 @@
-import { createNext, FileRef, isNextDev } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, isNextDev, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
 
 const appDir = path.join(__dirname, 'child-a-tag-error')
 
 describe('New Link Behavior with <a> child', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(path.join(appDir, 'pages')),
-        'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
-      },
-      dependencies: {
-        next: 'latest',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(appDir, 'pages')),
+      'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
+    },
+    dependencies: {
+      next: 'latest',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should throw error with <a> child', async () => {
     const browser = await webdriver(next.url, `/`)

--- a/test/e2e/new-link-behavior/index.test.ts
+++ b/test/e2e/new-link-behavior/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'
@@ -21,18 +20,13 @@ async function matchLogs(browser, includes: string) {
 const appDir = path.join(__dirname, 'app')
 
 describe('New Link Behavior', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(path.join(appDir, 'pages')),
-        'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(appDir, 'pages')),
+      'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should render link with <a>', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/new-link-behavior/stitches.test.ts
+++ b/test/e2e/new-link-behavior/stitches.test.ts
@@ -1,30 +1,24 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
 
 const appDir = path.join(__dirname, 'stitches')
 
 describe('New Link Behavior with stitches', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(path.join(appDir, 'pages')),
-        components: new FileRef(path.join(appDir, 'components')),
-        'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
-        'stitches.config.js': new FileRef(
-          path.join(appDir, 'stitches.config.js')
-        ),
-      },
-      dependencies: {
-        '@stitches/react': '^1.2.6',
-        next: 'latest',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(appDir, 'pages')),
+      components: new FileRef(path.join(appDir, 'components')),
+      'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
+      'stitches.config.js': new FileRef(
+        path.join(appDir, 'stitches.config.js')
+      ),
+    },
+    dependencies: {
+      '@stitches/react': '^1.2.6',
+      next: 'latest',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should render <a>', async () => {
     const browser = await webdriver(next.url, `/`)

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -1,6 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 
@@ -9,27 +8,20 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google basepath', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'basepath/pages')),
-        'next.config.js': new FileRef(
-          join(__dirname, 'basepath/next.config.js')
-        ),
-      },
-      env: {
-        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'basepath/pages')),
+      'next.config.js': new FileRef(join(__dirname, 'basepath/next.config.js')),
+    },
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
   })
-  afterAll(() => next.destroy())
 
   test('preload correct files', async () => {
     const html = await renderViaHTTP(next.url, '/dashboard')

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
@@ -9,25 +8,21 @@ const mockedGoogleFontResponses = require.resolve(
 
 describe('next/font/google fetch error', () => {
   const isDev = (global as any).isNextDev
-  let next: NextInstance
 
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'google-fetch-error/pages')),
-      },
-      env: {
-        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-      },
-      skipStart: true,
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'google-fetch-error/pages')),
+    },
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
+    skipStart: true,
   })
-  afterAll(() => next.destroy())
 
   if (isDev) {
     it('should use a fallback font in dev', async () => {

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -1,6 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
@@ -38,29 +37,24 @@ function hrefMatchesFontWithoutSizeAdjust(href: string) {
 }
 
 describe('next/font', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, `app/pages`)),
-        components: new FileRef(join(__dirname, `app/components`)),
-        fonts: new FileRef(join(__dirname, `app/fonts`)),
-      },
-      dependencies: {
-        '@next/font': 'canary',
-      },
-      env: {
-        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, `app/pages`)),
+      components: new FileRef(join(__dirname, `app/components`)),
+      fonts: new FileRef(join(__dirname, `app/fonts`)),
+    },
+    dependencies: {
+      '@next/font': 'canary',
+    },
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
   })
-  afterAll(() => next.destroy())
 
   if ((global as any).isNextDev) {
     it('should use production cache control for fonts', async () => {

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -1,6 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 
@@ -11,22 +10,17 @@ const mockedGoogleFontResponses = require.resolve(
 const isDev = (global as any).isNextDev
 
 describe('next/font/google with-font-declarations-file', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: join(__dirname, 'with-font-declarations-file'),
-      env: {
-        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-      },
-    })
+  const { next } = nextTestSetup({
+    files: join(__dirname, 'with-font-declarations-file'),
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
   })
-  afterAll(() => next.destroy())
 
   test('preload correct files at /inter', async () => {
     const html = await renderViaHTTP(next.url, '/inter')

--- a/test/e2e/next-font/without-preloaded-fonts.test.ts
+++ b/test/e2e/next-font/without-preloaded-fonts.test.ts
@@ -1,6 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 
@@ -9,29 +8,24 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google without-preloaded-fonts without _app', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/no-preload.js': new FileRef(
-          join(__dirname, 'without-preloaded-fonts/pages/no-preload.js')
-        ),
-        'pages/without-fonts.js': new FileRef(
-          join(__dirname, 'without-preloaded-fonts/pages/without-fonts.js')
-        ),
-      },
-      env: {
-        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/no-preload.js': new FileRef(
+        join(__dirname, 'without-preloaded-fonts/pages/no-preload.js')
+      ),
+      'pages/without-fonts.js': new FileRef(
+        join(__dirname, 'without-preloaded-fonts/pages/without-fonts.js')
+      ),
+    },
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
   })
-  afterAll(() => next.destroy())
 
   test('without preload', async () => {
     const html = await renderViaHTTP(next.url, '/no-preload')
@@ -60,32 +54,27 @@ describe('next/font/google without-preloaded-fonts without _app', () => {
 })
 
 describe('next/font/google no preloads with _app', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/_app.js': new FileRef(
-          join(__dirname, 'without-preloaded-fonts/pages/_app.js')
-        ),
-        'pages/no-preload.js': new FileRef(
-          join(__dirname, 'without-preloaded-fonts/pages/no-preload.js')
-        ),
-        'pages/without-fonts.js': new FileRef(
-          join(__dirname, 'without-preloaded-fonts/pages/without-fonts.js')
-        ),
-      },
-      env: {
-        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/_app.js': new FileRef(
+        join(__dirname, 'without-preloaded-fonts/pages/_app.js')
+      ),
+      'pages/no-preload.js': new FileRef(
+        join(__dirname, 'without-preloaded-fonts/pages/no-preload.js')
+      ),
+      'pages/without-fonts.js': new FileRef(
+        join(__dirname, 'without-preloaded-fonts/pages/without-fonts.js')
+      ),
+    },
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
   })
-  afterAll(() => next.destroy())
 
   test('without preload', async () => {
     const html = await renderViaHTTP(next.url, '/no-preload')

--- a/test/e2e/next-form/default/shared-tests.util.ts
+++ b/test/e2e/next-form/default/shared-tests.util.ts
@@ -1,7 +1,5 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 import { Playwright } from 'next-webdriver'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 // These tests are defined here and used in `app-dir.test.ts` and
 // `pages-dir.test.ts` so that both test suites can be run in parallel.

--- a/test/e2e/next-head/index.test.ts
+++ b/test/e2e/next-head/index.test.ts
@@ -1,22 +1,16 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
 describe('next/head', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        components: new FileRef(join(__dirname, 'app/components')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      components: new FileRef(join(__dirname, 'app/components')),
+    },
   })
-  afterAll(() => next.destroy())
 
   it(`should place charset element at the top of <head>`, async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/e2e/next-image-forward-ref/index.test.ts
+++ b/test/e2e/next-image-forward-ref/index.test.ts
@@ -1,23 +1,17 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import path from 'path'
 import webdriver from 'next-webdriver'
 
 describe('next-image-forward-ref', () => {
-  let next: NextInstance
-
   const appDir = path.join(__dirname, 'app')
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(appDir),
-      dependencies: {
-        'framer-motion': '7.6.9',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(appDir),
+    dependencies: {
+      'framer-motion': '7.6.9',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('allows framer-motion to animate opacity', async () => {
     const browser = await webdriver(next.url, '/framer-motion')

--- a/test/e2e/next-image-new/default/default.test.ts
+++ b/test/e2e/next-image-new/default/default.test.ts
@@ -8,11 +8,9 @@ import {
   listClientChunks,
   getDeploymentId,
 } from 'next-test-utils'
-import { nextTestSetup, isNextDev } from 'e2e-utils'
+import { isReact18, nextTestSetup, isNextDev } from 'e2e-utils'
 import { existsSync } from 'fs'
 import { join } from 'path'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('Image Component Default Tests', () => {
   const { next, skipped } = nextTestSetup({

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -1,48 +1,43 @@
 import webdriver, { Playwright } from 'next-webdriver'
-import { createNext } from 'e2e-utils'
+import { createNext, nextTestSetup } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('beforeInteractive in document Head', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/_document.js': `
+        import { Html, Head, Main, NextScript } from 'next/document'
+        import Script from 'next/script'
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/_document.js': `
-          import { Html, Head, Main, NextScript } from 'next/document'
-          import Script from 'next/script'
-
-          export default function Document() {
-            return (
-              <Html>
-                <Head>
-                  <Script
-                    src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js"
-                    strategy="beforeInteractive"
-                  ></Script>
-                </Head>
-                <body>
-                  <Main />
-                  <NextScript />
-                </body>
-              </Html>
-            )
-          }
-        `,
-        'pages/index.js': `
-          export default function Home() {
-            return (
-              <>
-                <p>Home page</p>
-              </>
-            )
-          }
-        `,
-      },
-    })
+        export default function Document() {
+          return (
+            <Html>
+              <Head>
+                <Script
+                  src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js"
+                  strategy="beforeInteractive"
+                ></Script>
+              </Head>
+              <body>
+                <Main />
+                <NextScript />
+              </body>
+            </Html>
+          )
+        }
+      `,
+      'pages/index.js': `
+        export default function Home() {
+          return (
+            <>
+              <p>Home page</p>
+            </>
+          )
+        }
+      `,
+    },
   })
-  afterAll(() => next.destroy())
 
   it('Script is injected server-side', async () => {
     let browser: Playwright
@@ -61,44 +56,39 @@ describe('beforeInteractive in document Head', () => {
 })
 
 describe('beforeInteractive in document body', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/_document.js': `
+        import { Html, Head, Main, NextScript } from 'next/document'
+        import Script from 'next/script'
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/_document.js': `
-          import { Html, Head, Main, NextScript } from 'next/document'
-          import Script from 'next/script'
-
-          export default function Document() {
-            return (
-              <Html>
-                <Head />
-                <body>
-                  <Main />
-                  <NextScript />
-                  <Script
-                    src="https://www.google-analytics.com/analytics.js"
-                    strategy="beforeInteractive"
-                  />
-                </body>
-              </Html>
-            )
-          }
-        `,
-        'pages/index.js': `
-          export default function Home() {
-            return (
-              <>
-                <p>Home page</p>
-              </>
-            )
-          }
-        `,
-      },
-    })
+        export default function Document() {
+          return (
+            <Html>
+              <Head />
+              <body>
+                <Main />
+                <NextScript />
+                <Script
+                  src="https://www.google-analytics.com/analytics.js"
+                  strategy="beforeInteractive"
+                />
+              </body>
+            </Html>
+          )
+        }
+      `,
+      'pages/index.js': `
+        export default function Home() {
+          return (
+            <>
+              <p>Home page</p>
+            </>
+          )
+        }
+      `,
+    },
   })
-  afterAll(() => next.destroy())
 
   it('Script is injected server-side', async () => {
     let browser: Playwright
@@ -118,44 +108,39 @@ describe('beforeInteractive in document body', () => {
 })
 
 describe('empty strategy in document Head', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/_document.js': `
+        import { Html, Head, Main, NextScript } from 'next/document'
+        import Script from 'next/script'
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/_document.js': `
-          import { Html, Head, Main, NextScript } from 'next/document'
-          import Script from 'next/script'
-
-          export default function Document() {
-            return (
-              <Html>
-                <Head>
-                  <Script
-                    src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js"
-                  ></Script>
-                </Head>
-                <body>
-                  <Main />
-                  <NextScript />
-                </body>
-              </Html>
-            )
-          }
-        `,
-        'pages/index.js': `
-          export default function Home() {
-            return (
-              <>
-                <p>Home page</p>
-              </>
-            )
-          }
-        `,
-      },
-    })
+        export default function Document() {
+          return (
+            <Html>
+              <Head>
+                <Script
+                  src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js"
+                ></Script>
+              </Head>
+              <body>
+                <Main />
+                <NextScript />
+              </body>
+            </Html>
+          )
+        }
+      `,
+      'pages/index.js': `
+        export default function Home() {
+          return (
+            <>
+              <p>Home page</p>
+            </>
+          )
+        }
+      `,
+    },
   })
-  afterAll(() => next.destroy())
 
   it('Script is injected server-side', async () => {
     let browser: Playwright
@@ -174,43 +159,38 @@ describe('empty strategy in document Head', () => {
 })
 
 describe('empty strategy in document body', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/_document.js': `
+        import { Html, Head, Main, NextScript } from 'next/document'
+        import Script from 'next/script'
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/_document.js': `
-          import { Html, Head, Main, NextScript } from 'next/document'
-          import Script from 'next/script'
-
-          export default function Document() {
-            return (
-              <Html>
-                <Head/>
-                <body>
-                  <Main />
-                  <NextScript />
-                  <Script
-                    src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js"
-                  />
-                </body>
-              </Html>
-            )
-          }
-        `,
-        'pages/index.js': `
-          export default function Home() {
-            return (
-              <>
-                <p>Home page</p>
-              </>
-            )
-          }
-        `,
-      },
-    })
+        export default function Document() {
+          return (
+            <Html>
+              <Head/>
+              <body>
+                <Main />
+                <NextScript />
+                <Script
+                  src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js"
+                />
+              </body>
+            </Html>
+          )
+        }
+      `,
+      'pages/index.js': `
+        export default function Home() {
+          return (
+            <>
+              <p>Home page</p>
+            </>
+          )
+        }
+      `,
+    },
   })
-  afterAll(() => next.destroy())
 
   it('Script is injected server-side', async () => {
     let browser: Playwright
@@ -231,12 +211,9 @@ describe('empty strategy in document body', () => {
   'experimental.nextScriptWorkers',
   () => {
     describe('experimental.nextScriptWorkers: false with no Partytown dependency', () => {
-      let next: NextInstance
-
-      beforeAll(async () => {
-        next = await createNext({
-          files: {
-            'pages/index.js': `
+      const { next } = nextTestSetup({
+        files: {
+          'pages/index.js': `
           import Script from 'next/script'
 
           export default function Page() {
@@ -250,10 +227,8 @@ describe('empty strategy in document body', () => {
             )
           }
         `,
-          },
-        })
+        },
       })
-      afterAll(() => next.destroy())
 
       it('Partytown snippet is not injected to head if not enabled in configuration', async () => {
         let browser: Playwright
@@ -273,17 +248,14 @@ describe('empty strategy in document body', () => {
     })
 
     describe('experimental.nextScriptWorkers: true with required Partytown dependency for external script', () => {
-      let next: NextInstance
-
-      beforeAll(async () => {
-        next = await createNext({
-          nextConfig: {
-            experimental: {
-              nextScriptWorkers: true,
-            },
+      const { next } = nextTestSetup({
+        nextConfig: {
+          experimental: {
+            nextScriptWorkers: true,
           },
-          files: {
-            'pages/index.js': `
+        },
+        files: {
+          'pages/index.js': `
           import Script from 'next/script'
 
           export default function Page() {
@@ -297,13 +269,11 @@ describe('empty strategy in document body', () => {
             )
           }
         `,
-          },
-          dependencies: {
-            '@builder.io/partytown': '0.4.2',
-          },
-        })
+        },
+        dependencies: {
+          '@builder.io/partytown': '0.4.2',
+        },
       })
-      afterAll(() => next.destroy())
 
       it('Partytown snippets are injected to head if enabled in configuration', async () => {
         let browser: Playwright
@@ -442,17 +412,14 @@ describe('empty strategy in document body', () => {
     })
 
     describe('experimental.nextScriptWorkers: true with config override', () => {
-      let next: NextInstance
-
-      beforeAll(async () => {
-        next = await createNext({
-          nextConfig: {
-            experimental: {
-              nextScriptWorkers: true,
-            },
+      const { next } = nextTestSetup({
+        nextConfig: {
+          experimental: {
+            nextScriptWorkers: true,
           },
-          files: {
-            'pages/_document.js': `
+        },
+        files: {
+          'pages/_document.js': `
         import Document, { Html, Head, Main, NextScript } from "next/document";
 
         class MyDocument extends Document {
@@ -483,7 +450,7 @@ describe('empty strategy in document body', () => {
 
         export default MyDocument;
         `,
-            'pages/index.js': `
+          'pages/index.js': `
           import Script from 'next/script'
 
           export default function Page() {
@@ -497,13 +464,11 @@ describe('empty strategy in document body', () => {
             )
           }
         `,
-          },
-          dependencies: {
-            '@builder.io/partytown': '0.4.2',
-          },
-        })
+        },
+        dependencies: {
+          '@builder.io/partytown': '0.4.2',
+        },
       })
-      afterAll(() => next.destroy())
 
       it('Partytown config script is overwritten', async () => {
         let browser: Playwright

--- a/test/e2e/nonce-head-manager/index.test.ts
+++ b/test/e2e/nonce-head-manager/index.test.ts
@@ -1,21 +1,15 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
 describe('nonce head manager', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        public: new FileRef(join(__dirname, 'app/public')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      public: new FileRef(join(__dirname, 'app/public')),
+    },
   })
-  afterAll(() => next.destroy())
 
   async function runTests(url) {
     const browser = await webdriver(next.url, url)

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -1,18 +1,12 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import fs from 'fs-extra'
 import { join } from 'path'
 
 describe('og-api', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, 'app')),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'app')),
   })
-  afterAll(() => next.destroy())
 
   it('should respond from index', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/prerender-crawler.test.ts
+++ b/test/e2e/prerender-crawler.test.ts
@@ -1,55 +1,49 @@
-import { createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
 
 describe('Prerender crawler handling', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() { 
-            return <p>index page</p>
-          } 
-        `,
-        'pages/blog/[slug].js': `
-          import {useRouter} from 'next/router'
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() { 
+          return <p>index page</p>
+        } 
+      `,
+      'pages/blog/[slug].js': `
+        import {useRouter} from 'next/router'
+        
+        export default function Page({ slug }) { 
+          const router = useRouter()
           
-          export default function Page({ slug }) { 
-            const router = useRouter()
-            
-            if (router.isFallback) {
-              return 'Loading...'
-            }
-            
-            return (
-              <>
-                <p id='page'>slug page</p>
-                <p id='slug'>{slug}</p>
-              </>
-            )
-          } 
+          if (router.isFallback) {
+            return 'Loading...'
+          }
           
-          export async function getStaticProps({ params }) {
-            return {
-              props: {
-                slug: params.slug
-              }
-            }
-          } 
-          
-          export async function getStaticPaths() {
-            return {
-              paths: ['/blog/first'],
-              fallback: true
+          return (
+            <>
+              <p id='page'>slug page</p>
+              <p id='slug'>{slug}</p>
+            </>
+          )
+        } 
+        
+        export async function getStaticProps({ params }) {
+          return {
+            props: {
+              slug: params.slug
             }
           }
-        `,
-      },
-    })
+        } 
+        
+        export async function getStaticPaths() {
+          return {
+            paths: ['/blog/first'],
+            fallback: true
+          }
+        }
+      `,
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should return prerendered page for correctly', async () => {
     const html = await renderViaHTTP(next.url, '/blog/first')

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -1,35 +1,25 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, isReact18, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
-
 describe('prerender native module', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(
-          path.join(__dirname, 'prerender-native-module/pages')
-        ),
-        'data.sqlite': new FileRef(
-          path.join(__dirname, 'prerender-native-module/data.sqlite')
-        ),
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(__dirname, 'prerender-native-module/pages')),
+      'data.sqlite': new FileRef(
+        path.join(__dirname, 'prerender-native-module/data.sqlite')
+      ),
+    },
+    dependencies: {
+      sqlite: '4.0.22',
+      sqlite3: '5.0.2',
+    },
+    packageJson: {
+      pnpm: {
+        onlyBuiltDependencies: ['sqlite3'],
       },
-      dependencies: {
-        sqlite: '4.0.22',
-        sqlite3: '5.0.2',
-      },
-      packageJson: {
-        pnpm: {
-          onlyBuiltDependencies: ['sqlite3'],
-        },
-      },
-    })
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should render index correctly', async () => {
     const browser = await webdriver(next.url, '/')

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -3,8 +3,7 @@ import cookie from 'cookie'
 import cheerio from 'cheerio'
 import { join, sep } from 'path'
 import escapeRegex from 'escape-string-regexp'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, isReact18, nextTestSetup } from 'e2e-utils'
 import {
   waitForRedbox,
   check,
@@ -20,42 +19,35 @@ import {
 import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'
 
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
-
 describe('Prerender', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'prerender/pages')),
-        'world.txt': new FileRef(join(__dirname, 'prerender/world.txt')),
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'prerender/pages')),
+      'world.txt': new FileRef(join(__dirname, 'prerender/world.txt')),
+    },
+    dependencies: {
+      firebase: '7.14.5',
+    },
+    nextConfig: {
+      async rewrites() {
+        return [
+          {
+            source: '/some-rewrite/:item',
+            destination: '/blog/post-:item',
+          },
+          {
+            source: '/about',
+            destination: '/lang/en/about',
+          },
+          {
+            source: '/blocked-create',
+            destination: '/blocking-fallback/blocked-create',
+          },
+        ]
       },
-      dependencies: {
-        firebase: '7.14.5',
-      },
-      nextConfig: {
-        async rewrites() {
-          return [
-            {
-              source: '/some-rewrite/:item',
-              destination: '/blog/post-:item',
-            },
-            {
-              source: '/about',
-              destination: '/lang/en/about',
-            },
-            {
-              source: '/blocked-create',
-              destination: '/blocking-fallback/blocked-create',
-            },
-          ]
-        },
-      },
-      patchFileDelay: 500,
-    })
+    },
+    patchFileDelay: 500,
   })
-  afterAll(() => next.destroy())
 
   async function waitForCacheWrite(
     prerenderPath = '',
@@ -382,7 +374,7 @@ describe('Prerender', () => {
       ]
 
       for (const toBuild of toBuildBatches) {
-        // eslint-disable-next-line no-loop-func -- we're not accessing `next` after the loop was exited.
+         
         await Promise.all(toBuild.map((pg) => renderViaHTTP(next.url, pg)))
       }
 

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -374,7 +374,6 @@ describe('Prerender', () => {
       ]
 
       for (const toBuild of toBuildBatches) {
-         
         await Promise.all(toBuild.map((pg) => renderViaHTTP(next.url, pg)))
       }
 

--- a/test/e2e/proxy-request-with-middleware/test/index.test.ts
+++ b/test/e2e/proxy-request-with-middleware/test/index.test.ts
@@ -2,23 +2,17 @@
 
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('Requests not effected when middleware used', () => {
-  let next: NextInstance
-
-  afterAll(() => next.destroy())
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../app/pages')),
-        'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
-      },
-      dependencies: {
-        request: '^2.88.2',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../app/pages')),
+      'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
+    },
+    dependencies: {
+      request: '^2.88.2',
+    },
   })
 
   function sendRequest(method) {

--- a/test/e2e/react-compiler/react-compiler.test.ts
+++ b/test/e2e/react-compiler/react-compiler.test.ts
@@ -1,9 +1,7 @@
-import { nextTestSetup, FileRef } from 'e2e-utils'
+import { isReact18, nextTestSetup, FileRef } from 'e2e-utils'
 import { waitForRedbox } from 'next-test-utils'
 import { join } from 'path'
 import stripAnsi from 'strip-ansi'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 function normalizeCodeLocInfo(str) {
   return (

--- a/test/e2e/reload-scroll-backforward-restoration/index.test.ts
+++ b/test/e2e/reload-scroll-backforward-restoration/index.test.ts
@@ -1,23 +1,17 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import assert from 'assert'
 
 describe('reload-scroll-back-restoration', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'pages')),
-        'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
-      },
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'pages')),
+      'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should restore the scroll position on navigating back', async () => {
     const browser = await webdriver(next.url, '/0')

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, fetchViaHTTP } from 'next-test-utils'
 import {
   NEXT_HMR_REFRESH_HEADER,
@@ -14,15 +13,10 @@ import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 
 describe('skip-trailing-slash-redirect', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, 'app')),
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'app')),
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   // the tests below are run in both pages and app dir to ensure the behavior is the same
   // the other cases aren't added to this block since they are either testing pages-specific behavior

--- a/test/e2e/ssr-react-context/index.test.ts
+++ b/test/e2e/ssr-react-context/index.test.ts
@@ -1,20 +1,14 @@
 import { join } from 'path'
 import { renderViaHTTP, check } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('React Context', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'app/pages')),
-        'context.js': new FileRef(join(__dirname, 'app/context.js')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'app/pages')),
+      'context.js': new FileRef(join(__dirname, 'app/context.js')),
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should render a page with context', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -1,6 +1,5 @@
 import { join } from 'path'
 import { createNext, nextTestSetup } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,
@@ -122,49 +121,46 @@ if (isNextProd) {
   })
 
   describe('react 18 streaming SSR in minimal mode with node runtime', () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
+    beforeAll(() => {
       if (isNextProd) {
         process.env.NEXT_PRIVATE_MINIMAL_MODE = '1'
       }
+    })
+    afterAll(() => {
+      if (isNextProd) {
+        delete process.env.NEXT_PRIVATE_MINIMAL_MODE
+      }
+    })
 
-      next = await createNext({
-        files: {
-          'pages/index.js': `
+    const { next } = nextTestSetup({
+      files: {
+        'pages/index.js': `
           export default function Page() {
             return <p>streaming</p>
           }
           export async function getServerSideProps() {
             return { props: {} }
           }`,
+      },
+      nextConfig: {
+        webpack(config, { nextRuntime }) {
+          const path = require('path')
+          const fs = require('fs')
+
+          const runtimeFilePath = path.join(__dirname, 'runtimes.txt')
+          let runtimeContent = ''
+
+          try {
+            runtimeContent = fs.readFileSync(runtimeFilePath, 'utf8')
+            runtimeContent += '\n'
+          } catch (_) {}
+
+          runtimeContent += nextRuntime || 'client'
+
+          fs.writeFileSync(runtimeFilePath, runtimeContent)
+          return config
         },
-        nextConfig: {
-          webpack(config, { nextRuntime }) {
-            const path = require('path')
-            const fs = require('fs')
-
-            const runtimeFilePath = path.join(__dirname, 'runtimes.txt')
-            let runtimeContent = ''
-
-            try {
-              runtimeContent = fs.readFileSync(runtimeFilePath, 'utf8')
-              runtimeContent += '\n'
-            } catch (_) {}
-
-            runtimeContent += nextRuntime || 'client'
-
-            fs.writeFileSync(runtimeFilePath, runtimeContent)
-            return config
-          },
-        },
-      })
-    })
-    afterAll(() => {
-      if (isNextProd) {
-        delete process.env.NEXT_PRIVATE_MINIMAL_MODE
-      }
-      next.destroy()
+      },
     })
 
     // Relies on the custom webpack config above

--- a/test/e2e/swc-warnings/index.test.ts
+++ b/test/e2e/swc-warnings/index.test.ts
@@ -1,31 +1,25 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 // Tests Babel, not needed for Turbopack
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'swc warnings by default',
   () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'pages/index.js': `
+    const { next } = nextTestSetup({
+      files: {
+        'pages/index.js': `
           export default function Page() { 
             return <p>hello world</p>
           } 
         `,
-          '.babelrc': `
+        '.babelrc': `
           {
             "presets": ["next/babel"]
           }
         `,
-        },
-        dependencies: {},
-      })
+      },
+      dependencies: {},
     })
-    afterAll(() => next.destroy())
 
     it('should have warning', async () => {
       await renderViaHTTP(next.url, '/')
@@ -40,31 +34,26 @@ import { renderViaHTTP } from 'next-test-utils'
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'can force swc',
   () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        nextConfig: {
-          experimental: {
-            forceSwcTransforms: true,
-          },
+    const { next } = nextTestSetup({
+      nextConfig: {
+        experimental: {
+          forceSwcTransforms: true,
         },
-        files: {
-          'pages/index.js': `
+      },
+      files: {
+        'pages/index.js': `
           export default function Page() { 
             return <p>hello world</p>
           } 
         `,
-          '.babelrc': `
+        '.babelrc': `
           {
             "presets": ["next/babel"]
           }
         `,
-        },
-        dependencies: {},
-      })
+      },
+      dependencies: {},
     })
-    afterAll(() => next.destroy())
 
     it('should not have warning', async () => {
       await renderViaHTTP(next.url, '/')

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, fetchViaHTTP, renderViaHTTP, waitFor } from 'next-test-utils'
 
 function splitLines(text) {
@@ -31,7 +30,6 @@ async function testRoute(appPort, url, { isStatic, isEdge }) {
 }
 
 describe('Switchable runtime', () => {
-  let next: NextInstance
   let context
 
   if ((global as any).isNextDeploy) {
@@ -40,10 +38,11 @@ describe('Switchable runtime', () => {
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(__dirname),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(__dirname),
+  })
+
+  beforeAll(() => {
     context = {
       appPort: next.url,
       appDir: next.testDir,
@@ -51,7 +50,6 @@ describe('Switchable runtime', () => {
       stderr: '',
     }
   })
-  afterAll(() => next.destroy())
 
   if ((global as any).isNextDev) {
     describe('Switchable runtime (dev)', () => {

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -1,22 +1,16 @@
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('trailingSlash:true with rewrites and getStaticProps', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, './app')),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, './app')),
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const res = await fetchViaHTTP(next.url, '/country')

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -1,25 +1,19 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 describe('transpile packages', () => {
-  let next: NextInstance
-
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, './npm')),
-      dependencies: {
-        sass: 'latest',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(path.join(__dirname, './npm')),
+    dependencies: {
+      sass: 'latest',
+    },
   })
-  afterAll(() => next.destroy())
 
   const { isNextDeploy } = global as any
   if (isNextDeploy) {

--- a/test/e2e/type-module-interop/index.test.ts
+++ b/test/e2e/type-module-interop/index.test.ts
@@ -1,70 +1,67 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'
 
 describe('Type module interop', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        import Link from 'next/link'
+        import Head from 'next/head'
+        import Script from 'next/script'
+        import dynamic from 'next/dynamic'
+
+        const Dynamic = dynamic(() => import('../components/example'))
+
+        export default function Page() {
+          return (
+            <>
+              <Head>
+                <title>This page has a title 🤔</title>
+                <meta charSet="utf-8" />
+                <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+              </Head>
+              <Script
+                strategy="afterInteractive"
+                dangerouslySetInnerHTML={{
+                  __html: 'console.log("hello world")',
+                }}
+              />
+              <p>hello world</p>
+              <Dynamic />
+              <Link href="/modules" id="link-to-module">
+                link to module
+              </Link>
+            </>
+          )
+        } 
+      `,
+      'pages/modules.jsx': `
+        import Link from 'next/link'
+        import Image from 'next/image'
+
+        export default function Modules() {
+          return (
+            <>
+              <Link href="/" id="link-to-home">
+                link to home
+              </Link>
+              <Image src="/static/image.png" width="100" height="100" />
+            </>
+          )
+        }
+      `,
+      'components/example.jsx': `
+        export default function Example() {
+          return <p>An example components load via next/dynamic</p>
+        }
+      `,
+    },
+    dependencies: {},
+  })
 
   beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          import Link from 'next/link'
-          import Head from 'next/head'
-          import Script from 'next/script'
-          import dynamic from 'next/dynamic'
-
-          const Dynamic = dynamic(() => import('../components/example'))
-
-          export default function Page() {
-            return (
-              <>
-                <Head>
-                  <title>This page has a title 🤔</title>
-                  <meta charSet="utf-8" />
-                  <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-                </Head>
-                <Script
-                  strategy="afterInteractive"
-                  dangerouslySetInnerHTML={{
-                    __html: 'console.log("hello world")',
-                  }}
-                />
-                <p>hello world</p>
-                <Dynamic />
-                <Link href="/modules" id="link-to-module">
-                  link to module
-                </Link>
-              </>
-            )
-          } 
-        `,
-        'pages/modules.jsx': `
-          import Link from 'next/link'
-          import Image from 'next/image'
-
-          export default function Modules() {
-            return (
-              <>
-                <Link href="/" id="link-to-home">
-                  link to home
-                </Link>
-                <Image src="/static/image.png" width="100" height="100" />
-              </>
-            )
-          }
-        `,
-        'components/example.jsx': `
-          export default function Example() {
-            return <p>An example components load via next/dynamic</p>
-          }
-        `,
-      },
-      dependencies: {},
-    })
-
     // can't modify build output after deploy
     if (!(global as any).isNextDeploy) {
       const contents = await next.readFile('package.json')
@@ -78,7 +75,6 @@ describe('Type module interop', () => {
       )
     }
   })
-  afterAll(() => next.destroy())
 
   it('should render server-side', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/undici-fetch/index.test.ts
+++ b/test/e2e/undici-fetch/index.test.ts
@@ -1,51 +1,45 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('undici fetch', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/api/globalFetch.js': `
-          import { ReadableStream } from 'node:stream/web';
-          export default async function globalFetch(req, res) {
-            try {
-              const response = await fetch('https://example.vercel.sh')
-              res.json({ value: response.body instanceof ReadableStream })
-            } catch (error) {
-              console.error(error);
-              res.send(error);
-            }
+  const { next } = nextTestSetup({
+    files: {
+      'pages/api/globalFetch.js': `
+        import { ReadableStream } from 'node:stream/web';
+        export default async function globalFetch(req, res) {
+          try {
+            const response = await fetch('https://example.vercel.sh')
+            res.json({ value: response.body instanceof ReadableStream })
+          } catch (error) {
+            console.error(error);
+            res.send(error);
           }
-        `,
-        'pages/api/globalHeaders.js': `
-          export default async function globalHeaders(req, res) {
-            res.json({
-              value: (new Headers())[Symbol.iterator].name === 'entries'
-            })
-          }
-        `,
-        'pages/api/globalRequest.js': `
-          export default async function globalRequest(req, res) {
-            res.json({
-              value: (new Request('https://example.vercel.sh')).headers[Symbol.iterator].name === 'entries'
-            })
-          }
-        `,
-        'pages/api/globalResponse.js': `
-          export default async function globalResponse(req, res) {
-            res.json({
-              value: (new Response()).headers[Symbol.iterator].name === 'entries'
-            })
-          }
-        `,
-      },
-      dependencies: {},
-    })
+        }
+      `,
+      'pages/api/globalHeaders.js': `
+        export default async function globalHeaders(req, res) {
+          res.json({
+            value: (new Headers())[Symbol.iterator].name === 'entries'
+          })
+        }
+      `,
+      'pages/api/globalRequest.js': `
+        export default async function globalRequest(req, res) {
+          res.json({
+            value: (new Request('https://example.vercel.sh')).headers[Symbol.iterator].name === 'entries'
+          })
+        }
+      `,
+      'pages/api/globalResponse.js': `
+        export default async function globalResponse(req, res) {
+          res.json({
+            value: (new Response()).headers[Symbol.iterator].name === 'entries'
+          })
+        }
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   describe('undici', () => {
     it('global fetch should return true when undici is used', async () => {

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -1,8 +1,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 
 jest.setTimeout(2 * 60 * 1000)
 
@@ -22,54 +21,47 @@ export function runTests(
     versionParts[0] > 16 ||
     (versionParts[0] === 16 && versionParts[1] >= 14)
   ) {
-    let next: NextInstance
+    const srcDir = join(__dirname, '../../../../examples', example)
+    const srcFiles = fs.readdirSync(srcDir)
 
-    beforeAll(async () => {
-      const srcDir = join(__dirname, '../../../../examples', example)
-      const srcFiles = await fs.readdir(srcDir)
+    const packageJson = fs.readJsonSync(join(srcDir, 'package.json'))
+    // Use the default versions that are usually used in tests.
+    // Since we replace `next` in the install, we also need to fulfill the peerDependencies.
+    // However, the example specified latest next which may have different peerDependencies that the next that we test here i.e. the next on this commit.
+    delete packageJson.dependencies['react']
+    delete packageJson.dependencies['react-dom']
 
-      const packageJson = await fs.readJson(join(srcDir, 'package.json'))
-      // Use the default versions that are usually used in tests.
-      // Since we replace `next` in the install, we also need to fulfill the peerDependencies.
-      // However, the example specified latest next which may have different peerDependencies that the next that we test here i.e. the next on this commit.
-      delete packageJson.dependencies['react']
-      delete packageJson.dependencies['react-dom']
-
-      next = await createNext({
-        files: srcFiles.reduce(
-          (prev, file) => {
-            if (file !== 'package.json') {
-              prev[file] = new FileRef(join(srcDir, file))
-            }
-            return prev
-          },
-          {} as { [key: string]: FileRef }
-        ),
-        packageJson: {
-          // Bootstrap with classic yarn; the install command below runs
-          // `yarn set version berry` which rewrites this to the berry version.
-          packageManager: 'yarn@1.22.22',
+    const { next } = nextTestSetup({
+      files: srcFiles.reduce(
+        (prev, file) => {
+          if (file !== 'package.json') {
+            prev[file] = new FileRef(join(srcDir, file))
+          }
+          return prev
         },
-        dependencies: {
-          ...packageJson.dependencies,
-          ...packageJson.devDependencies,
-        },
-        installCommand: ({ dependencies }) => {
-          const pkgs = Object.keys(dependencies).reduce((prev, cur) => {
-            prev.push(`${cur}@${dependencies[cur]}`)
-            return prev
-          }, [] as string[])
-          return `yarn set version berry && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
-            ' '
-          )}`
-        },
-        buildCommand: `yarn next build`,
-        startCommand: (global as any).isNextDev
-          ? `yarn next`
-          : `yarn next start`,
-      })
+        {} as { [key: string]: FileRef }
+      ),
+      packageJson: {
+        // Bootstrap with classic yarn; the install command below runs
+        // `yarn set version berry` which rewrites this to the berry version.
+        packageManager: 'yarn@1.22.22',
+      },
+      dependencies: {
+        ...packageJson.dependencies,
+        ...packageJson.devDependencies,
+      },
+      installCommand: ({ dependencies }) => {
+        const pkgs = Object.keys(dependencies).reduce((prev, cur) => {
+          prev.push(`${cur}@${dependencies[cur]}`)
+          return prev
+        }, [] as string[])
+        return `yarn set version berry && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
+          ' '
+        )}`
+      },
+      buildCommand: `yarn next build`,
+      startCommand: (global as any).isNextDev ? `yarn next` : `yarn next start`,
     })
-    afterAll(() => next?.destroy())
 
     it(`should compile and serve the index page correctly ${example}`, async () => {
       const res = await fetchViaHTTP(next.url, testPath)

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -167,6 +167,15 @@ const isNextTestWasm = !!process.env.NEXT_TEST_WASM
 export const itTurbopack =
   !isNextTestWasm && shouldUseTurbopack() ? it : it.skip
 
+/**
+ * Whether the test is running against React 18 (based on
+ * `process.env.NEXT_TEST_REACT_VERSION`). When the env var is unset or empty,
+ * the test install uses the default React peer dependency version which is
+ * currently React 19, so this is `false`.
+ */
+export const isReact18 =
+  parseInt(process.env.NEXT_TEST_REACT_VERSION || '', 10) === 18
+
 if (!testMode) {
   throw new Error(
     `No 'NEXT_TEST_MODE' set in environment, this is required for e2e-utils`

--- a/test/production/app-dir-edge-runtime-with-wasm/index.test.ts
+++ b/test/production/app-dir-edge-runtime-with-wasm/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 const files = {
@@ -38,14 +37,9 @@ const files = {
 }
 
 describe('app-dir edge runtime with wasm', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files,
-    })
+  const { next } = nextTestSetup({
+    files,
   })
-  afterAll(() => next?.destroy())
 
   it('should have built', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
+++ b/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
@@ -1,20 +1,14 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
 describe('app-dir-hide-suppressed-error-during-next-export', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      skipStart: true,
-      files: {
-        'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
-        app: new FileRef(join(__dirname, 'app')),
-      },
-    })
+  const { next } = nextTestSetup({
+    skipStart: true,
+    files: {
+      'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
+      app: new FileRef(join(__dirname, 'app')),
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should not log suppressed error when exporting static page', async () => {
     await expect(next.start()).rejects.toThrow('next build failed')

--- a/test/production/app-dir-prefetch-non-iso-url/index.test.ts
+++ b/test/production/app-dir-prefetch-non-iso-url/index.test.ts
@@ -1,22 +1,16 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import { Playwright } from 'next-webdriver'
 import webdriver from 'next-webdriver'
 import { check } from 'next-test-utils'
 
 describe('app-dir-prefetch-non-iso-url', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
-        app: new FileRef(join(__dirname, 'app')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
+      app: new FileRef(join(__dirname, 'app')),
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should go to iso url', async () => {
     let browser: Playwright

--- a/test/production/app-dir-prevent-304-caching/index.test.ts
+++ b/test/production/app-dir-prevent-304-caching/index.test.ts
@@ -1,20 +1,14 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import { fetchViaHTTP, waitFor } from 'next-test-utils'
 
 describe('app-dir-prevent-304-caching', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
-        app: new FileRef(join(__dirname, 'app')),
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
+      app: new FileRef(join(__dirname, 'app')),
+    },
   })
-  afterAll(() => next.destroy())
 
   // https://github.com/vercel/next.js/issues/56580
   it('should not cache 304 status', async () => {

--- a/test/production/app-dir/global-default-cache-handler/global-default-cache-handler.test.ts
+++ b/test/production/app-dir/global-default-cache-handler/global-default-cache-handler.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { createNext, FileRef, NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
   fetchViaHTTP,
   findPort,
@@ -12,13 +12,13 @@ describe('global-default-cache-handler', () => {
   let appPort: number
   let server: any
   let output = ''
-  let next: NextInstance
+
+  const { next } = nextTestSetup({
+    files: new FileRef(__dirname),
+    skipStart: true,
+  })
 
   beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(__dirname),
-      skipStart: true,
-    })
     await next.build()
 
     const standaloneServer = '.next/standalone/server.js'
@@ -79,7 +79,6 @@ describe('global-default-cache-handler', () => {
     )
   })
   afterAll(async () => {
-    await next.destroy()
     await killApp(server)
   })
 

--- a/test/production/app-dir/image-jest-qualities/image-jest-qualities.test.ts
+++ b/test/production/app-dir/image-jest-qualities/image-jest-qualities.test.ts
@@ -1,26 +1,22 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import execa from 'execa'
 
 const appDir = path.join(__dirname, 'app')
 
 describe('next/jest image qualities config', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      skipStart: true,
-      files: {
-        'next.config.js': `
+  const { next } = nextTestSetup({
+    skipStart: true,
+    files: {
+      'next.config.js': `
 module.exports = {
   images: {
     qualities: [90, 100],
   },
 }
         `,
-        app: new FileRef(path.join(appDir, 'app')),
-        'jest.config.js': `
+      app: new FileRef(path.join(appDir, 'app')),
+      'jest.config.js': `
 const nextJest = require('next/jest')
 
 const createJestConfig = nextJest({
@@ -33,7 +29,7 @@ const customJestConfig = {
 
 module.exports = createJestConfig(customJestConfig)
         `,
-        [`tests/image.test.tsx`]: `
+      [`tests/image.test.tsx`]: `
 import Image from 'next/image'
 import { render, screen } from '@testing-library/react'
 
@@ -85,17 +81,14 @@ describe('Image quality config', () => {
   })
 })
         `,
-      },
-      dependencies: {
-        jest: '29.7.0',
-        'jest-environment-jsdom': '29.7.0',
-        '@testing-library/react': '15.0.2',
-        '@testing-library/jest-dom': '5.17.0',
-      },
-    })
+    },
+    dependencies: {
+      jest: '29.7.0',
+      'jest-environment-jsdom': '29.7.0',
+      '@testing-library/react': '15.0.2',
+      '@testing-library/jest-dom': '5.17.0',
+    },
   })
-
-  afterAll(() => next.destroy())
 
   it('should pass jest tests with custom image qualities', async () => {
     const result = await execa(

--- a/test/production/build-spinners/index.test.ts
+++ b/test/production/build-spinners/index.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import stripAnsi from 'strip-ansi'
 import resolveFrom from 'resolve-from'
-import { NextInstance, createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 type File = {
   filename: string
@@ -45,25 +45,19 @@ const pagesFiles: File[] = [
   },
 ]
 
-let next: NextInstance
-
 describe('build-spinners', () => {
-  beforeAll(async () => {
-    next = await createNext({
-      skipStart: true,
-      files: {},
-      dependencies: {
-        'node-pty': '0.10.1',
+  const { next } = nextTestSetup({
+    skipStart: true,
+    files: {},
+    dependencies: {
+      'node-pty': '0.10.1',
+    },
+    packageJson: {
+      pnpm: {
+        onlyBuiltDependencies: ['node-pty'],
       },
-      packageJson: {
-        pnpm: {
-          onlyBuiltDependencies: ['node-pty'],
-        },
-      },
-    })
+    },
   })
-
-  afterAll(() => next.destroy())
 
   beforeEach(async () => {
     await fs.remove(path.join(next.testDir, 'pages'))

--- a/test/production/custom-error-500/index.test.ts
+++ b/test/production/custom-error-500/index.test.ts
@@ -1,54 +1,48 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { check, renderViaHTTP } from 'next-test-utils'
 
 describe('custom-error-500', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export function getServerSideProps() {
-            throw new Error('custom error')
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export function getServerSideProps() {
+          throw new Error('custom error')
+        }
+        
+        export default function Page() {
+          return <p>index page</p>
+        }
+      `,
+      'pages/500.js': `
+        export default function Custom500() {
+          return (
+            <>
+              <p>pages/500</p>
+            </>
+          )
+        }
+      `,
+      'pages/_error.js': `
+        function Error({ hasError }) {
+          return (
+            <>
+              <p>/_error</p>
+            </>
+          )
+        }
+        
+        Error.getInitialProps = ({ err }) => {
+          console.log(\`called Error.getInitialProps \${!!err}\`)
+          return {
+            hasError: !!err
           }
-          
-          export default function Page() {
-            return <p>index page</p>
-          }
-        `,
-        'pages/500.js': `
-          export default function Custom500() {
-            return (
-              <>
-                <p>pages/500</p>
-              </>
-            )
-          }
-        `,
-        'pages/_error.js': `
-          function Error({ hasError }) {
-            return (
-              <>
-                <p>/_error</p>
-              </>
-            )
-          }
-          
-          Error.getInitialProps = ({ err }) => {
-            console.log(\`called Error.getInitialProps \${!!err}\`)
-            return {
-              hasError: !!err
-            }
-          }
-          
-          export default Error
-        `,
-      },
-      dependencies: {},
-    })
+        }
+        
+        export default Error
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should correctly use pages/500 and call Error.getInitialProps', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/production/custom-server/custom-server.test.ts
+++ b/test/production/custom-server/custom-server.test.ts
@@ -1,6 +1,4 @@
-import { nextTestSetup } from 'e2e-utils'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 describe('custom server', () => {
   const { next } = nextTestSetup({

--- a/test/production/dependencies-can-use-env-vars-in-middlewares/index.test.ts
+++ b/test/production/dependencies-can-use-env-vars-in-middlewares/index.test.ts
@@ -1,53 +1,47 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('dependencies can use env vars in middlewares', () => {
-  let next: NextInstance
-
   beforeAll(() => {
     process.env.MY_CUSTOM_PACKAGE_ENV_VAR = 'my-custom-package-env-var'
     process.env.ENV_VAR_USED_IN_MIDDLEWARE = 'env-var-used-in-middleware'
   })
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        // A 3rd party dependency
-        'node_modules/my-custom-package/package.json': JSON.stringify({
-          name: 'my-custom-package',
-          version: '1.0.0',
-          browser: 'index.js',
-        }),
-        'node_modules/my-custom-package/index.js': `
-          module.exports = () => process.env.MY_CUSTOM_PACKAGE_ENV_VAR;
-        `,
+  const { next } = nextTestSetup({
+    files: {
+      // A 3rd party dependency
+      'node_modules/my-custom-package/package.json': JSON.stringify({
+        name: 'my-custom-package',
+        version: '1.0.0',
+        browser: 'index.js',
+      }),
+      'node_modules/my-custom-package/index.js': `
+        module.exports = () => process.env.MY_CUSTOM_PACKAGE_ENV_VAR;
+      `,
 
-        'pages/index.js': `
-          export default function () { return <div>Hello, world!</div> }
-        `,
+      'pages/index.js': `
+        export default function () { return <div>Hello, world!</div> }
+      `,
 
-        'middleware.js': `
-          import customPackage from 'my-custom-package';
-          export default function middleware(_req) {
-            return new Response(null, { 
-              headers: { 
-                data: JSON.stringify({
-                  string: "a constant string",
-                  hello: process.env.ENV_VAR_USED_IN_MIDDLEWARE,
-                  customPackage: customPackage(),
-                })
-              }
-            })
-          }
-        `,
-        // make sure invalid package-lock doesn't error
-        'package-lock.json': '{}',
-      },
-      dependencies: {},
-    })
+      'middleware.js': `
+        import customPackage from 'my-custom-package';
+        export default function middleware(_req) {
+          return new Response(null, { 
+            headers: { 
+              data: JSON.stringify({
+                string: "a constant string",
+                hello: process.env.ENV_VAR_USED_IN_MIDDLEWARE,
+                customPackage: customPackage(),
+              })
+            }
+          })
+        }
+      `,
+      // make sure invalid package-lock doesn't error
+      'package-lock.json': '{}',
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('does not error from patching lockfile', () => {
     expect(next.cliOutput).not.toContain('patch-incorrect-lockfile')

--- a/test/production/disable-fallback-polyfills/index.test.ts
+++ b/test/production/disable-fallback-polyfills/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext } from 'e2e-utils'
-import type { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { statSync } from 'fs'
 import { join } from 'path'
 
@@ -7,8 +6,6 @@ import { join } from 'path'
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'Disable fallback polyfills',
   () => {
-    let next: NextInstance
-
     async function getIndexPageSize() {
       // Read build manifest to get chunk files for the index page
       // this only works reliably for pages router and simple examples.
@@ -33,10 +30,9 @@ import { join } from 'path'
       return totalSize / 1024
     }
 
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          'pages/index.js': `
+    const { next } = nextTestSetup({
+      files: {
+        'pages/index.js': `
           import { useEffect } from 'react'
           import crypto from 'crypto'
 
@@ -47,14 +43,15 @@ import { join } from 'path'
             return <p>hello world</p>
           } 
         `,
-        },
-        dependencies: {
-          axios: '0.27.2',
-        },
-      })
+      },
+      dependencies: {
+        axios: '0.27.2',
+      },
+    })
+
+    beforeAll(async () => {
       await next.stop()
     })
-    afterAll(() => next.destroy())
 
     it('Fallback polyfills added by default', async () => {
       const indexPageSizeKB = await getIndexPageSize()

--- a/test/production/edge-runtime-is-addressable/index.test.ts
+++ b/test/production/edge-runtime-is-addressable/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 
@@ -34,15 +33,10 @@ const files = {
 }
 
 describe('Edge Runtime is addressable', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files,
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files,
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   test('EdgeRuntime evaluates to a string', async () => {
     const resp = await fetchViaHTTP(next.url, '/')
@@ -72,18 +66,13 @@ describe('Edge Runtime is addressable', () => {
 })
 
 describe('Edge Runtime can be set to the production provider', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files,
-      dependencies: {},
-      env: {
-        NEXT_EDGE_RUNTIME_PROVIDER: 'vercel',
-      },
-    })
+  const { next } = nextTestSetup({
+    files,
+    dependencies: {},
+    env: {
+      NEXT_EDGE_RUNTIME_PROVIDER: 'vercel',
+    },
   })
-  afterAll(() => next.destroy())
 
   test('EdgeRuntime evaluates to a string', async () => {
     const resp = await fetchViaHTTP(next.url, '/')

--- a/test/production/emit-decorator-metadata/index.test.ts
+++ b/test/production/emit-decorator-metadata/index.test.ts
@@ -1,24 +1,17 @@
 import { join } from 'path'
 import webdriver, { Playwright } from 'next-webdriver'
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('emitDecoratorMetadata SWC option', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: join(__dirname, 'app'),
-      dependencies: {
-        'reflect-metadata': '0.1.13',
-        'path-to-regexp': '6.2.0',
-        tsyringe: '4.6.0',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: join(__dirname, 'app'),
+    dependencies: {
+      'reflect-metadata': '0.1.13',
+      'path-to-regexp': '6.2.0',
+      tsyringe: '4.6.0',
+    },
   })
-
-  afterAll(() => next.destroy())
 
   it('should compile with emitDecoratorMetadata enabled', async () => {
     let browser: Playwright

--- a/test/production/enoent-during-require/index.test.ts
+++ b/test/production/enoent-during-require/index.test.ts
@@ -1,44 +1,38 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { check, renderViaHTTP } from 'next-test-utils'
 
 describe('ENOENT during require', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/_app.js': `
-          import App from 'next/app'
-          
-          if (typeof window === 'undefined') {
-            if (process.env.NEXT_PHASE !== 'phase-production-build') {
-              require('fs').readdirSync('non-existent-folder')
-            }
+  const { next } = nextTestSetup({
+    files: {
+      'pages/_app.js': `
+        import App from 'next/app'
+        
+        if (typeof window === 'undefined') {
+          if (process.env.NEXT_PHASE !== 'phase-production-build') {
+            require('fs').readdirSync('non-existent-folder')
           }
-          export default App
-        `,
-        'pages/index.js': `
-          export function getStaticProps() {
-            console.log('revalidate /')
-            
-            return {
-              props: {
-                now: Date.now()
-              },
-              revalidate: 1
-            }
-          }
+        }
+        export default App
+      `,
+      'pages/index.js': `
+        export function getStaticProps() {
+          console.log('revalidate /')
           
-          export default function Page() { 
-            return <p>hello world</p>
-          } 
-        `,
-      },
-      dependencies: {},
-    })
+          return {
+            props: {
+              now: Date.now()
+            },
+            revalidate: 1
+          }
+        }
+        
+        export default function Page() { 
+          return <p>hello world</p>
+        } 
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should show ENOENT error correctly', async () => {
     await check(async () => {

--- a/test/production/fallback-export-error/index.test.ts
+++ b/test/production/fallback-export-error/index.test.ts
@@ -1,22 +1,16 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
 describe('fallback export error', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'pages')),
-      },
-      nextConfig: {
-        output: 'export',
-      },
-      skipStart: true,
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'pages')),
+    },
+    nextConfig: {
+      output: 'export',
+    },
+    skipStart: true,
   })
-  afterAll(() => next.destroy())
 
   it('should have built', async () => {
     const result = await next.build()

--- a/test/production/fatal-render-error/index.test.ts
+++ b/test/production/fatal-render-error/index.test.ts
@@ -1,19 +1,13 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
 describe('fatal-render-error', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, 'app')),
-      dependencies: {},
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'app')),
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('should render page without error correctly', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -1,23 +1,19 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'node:path'
 
 describe('next/jest', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'public/vercel.svg':
-          '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"/>',
-        'components/comp.js': `
+  const { next } = nextTestSetup({
+    files: {
+      'public/vercel.svg':
+        '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"/>',
+      'components/comp.js': `
           export default function Comp() {
             return <h1>Hello Dynamic</h1>;
           }
         `,
-        'styles/index.module.css': '.home { color: orange }',
-        'pages/index.js': `
+      'styles/index.module.css': '.home { color: orange }',
+      'pages/index.js': `
           import dynamic from "next/dynamic";
           import Image from "next/image";
           import img from "../public/vercel.svg";
@@ -42,7 +38,7 @@ describe('next/jest', () => {
             </>
           }
         `,
-        'jest.config.js': `
+      'jest.config.js': `
           // jest.config.js
           const nextJest = require('next/jest')
 
@@ -67,11 +63,11 @@ describe('next/jest', () => {
           // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
           module.exports = createJestConfig(customJestConfig)
         `,
-        'jest.setup.js': `
+      'jest.setup.js': `
           // Learn more: https://github.com/testing-library/jest-dom
           import '@testing-library/jest-dom/extend-expect'
         `,
-        'test/dynamic.test.js': `
+      'test/dynamic.test.js': `
           import { render, screen, act } from "@testing-library/react";
           import Home from "../pages/index";
           
@@ -90,14 +86,14 @@ describe('next/jest', () => {
           });
         
         `,
-        'lib/hello.mjs': `
+      'lib/hello.mjs': `
           import path from 'path'
 
           export default function hello() {
             return path.join('hello', 'world')
           }
         `,
-        'test/mjs-support.test.js': `
+      'test/mjs-support.test.js': `
           import path from 'path'
           import hello from '../lib/hello.mjs'
           
@@ -105,7 +101,7 @@ describe('next/jest', () => {
             expect(hello()).toBe(path.join('hello', 'world'))
           })
         `,
-        'test/mock.test.js': `
+      'test/mock.test.js': `
           import router from 'next/router'
 
           jest.mock('next/router', () => ({
@@ -126,29 +122,27 @@ describe('next/jest', () => {
             expect(router.push._isMockFunction).toBeTruthy()
           })
         `,
-        'pages/my-font.woff2': new FileRef(
-          join(__dirname, 'basic', 'my-font.woff2')
-        ),
+      'pages/my-font.woff2': new FileRef(
+        join(__dirname, 'basic', 'my-font.woff2')
+      ),
+    },
+    dependencies: {
+      '@next/font': 'canary',
+      jest: '29.7.0',
+      'jest-environment-jsdom': '29.7.0',
+      '@testing-library/jest-dom': '5.16.1',
+      '@testing-library/react': '15.0.2',
+      '@testing-library/user-event': '14.5.2',
+    },
+    packageJson: {
+      scripts: {
+        // Runs jest and bails if jest fails
+        build: 'next build && jest test/mock.test.js test/dynamic.test.js',
       },
-      dependencies: {
-        '@next/font': 'canary',
-        jest: '29.7.0',
-        'jest-environment-jsdom': '29.7.0',
-        '@testing-library/jest-dom': '5.16.1',
-        '@testing-library/react': '15.0.2',
-        '@testing-library/user-event': '14.5.2',
-      },
-      packageJson: {
-        scripts: {
-          // Runs jest and bails if jest fails
-          build: 'next build && jest test/mock.test.js test/dynamic.test.js',
-        },
-      },
-      installCommand: 'pnpm i',
-      buildCommand: `pnpm build`,
-    })
+    },
+    installCommand: 'pnpm i',
+    buildCommand: `pnpm build`,
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/production/jest/new-link-behavior.test.ts
+++ b/test/production/jest/new-link-behavior.test.ts
@@ -1,55 +1,48 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('next/jest newLinkBehavior', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.jsx': `
+        import Link from 'next/link'
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.jsx': `
-          import Link from 'next/link'
+        export default function Page() {
+          return <Link href='https://example.com'><div>Hello World!</div></Link>
+        }
+      `,
+      'test/index.test.jsx': `
+        import { render, screen, act } from '@testing-library/react'
+        import Page from '../pages/index'
 
-          export default function Page() {
-            return <Link href='https://example.com'><div>Hello World!</div></Link>
-          }
-        `,
-        'test/index.test.jsx': `
-          import { render, screen, act } from '@testing-library/react'
-          import Page from '../pages/index'
+        it('Link', () => {
+          render(<Page />)
 
-          it('Link', () => {
-            render(<Page />)
-
-            const link = screen.getByRole('link', { name: 'Hello World!' })
-            expect(link.getAttribute('href')).toBe('https://example.com')
-          })
-        `,
-        'jest.config.js': `
-          const nextJest = require('next/jest')
-          const createJestConfig = nextJest({ dir: './' })
-          module.exports = createJestConfig({
-            testEnvironment: 'jest-environment-jsdom',
-          })
-        `,
+          const link = screen.getByRole('link', { name: 'Hello World!' })
+          expect(link.getAttribute('href')).toBe('https://example.com')
+        })
+      `,
+      'jest.config.js': `
+        const nextJest = require('next/jest')
+        const createJestConfig = nextJest({ dir: './' })
+        module.exports = createJestConfig({
+          testEnvironment: 'jest-environment-jsdom',
+        })
+      `,
+    },
+    dependencies: {
+      jest: '29.7.0',
+      'jest-environment-jsdom': '29.7.0',
+      '@testing-library/react': '15.0.2',
+    },
+    packageJson: {
+      scripts: {
+        build: 'next build && jest --forceExit test/index.test.jsx',
       },
-      dependencies: {
-        jest: '29.7.0',
-        'jest-environment-jsdom': '29.7.0',
-        '@testing-library/react': '15.0.2',
-      },
-      packageJson: {
-        scripts: {
-          build: 'next build && jest --forceExit test/index.test.jsx',
-        },
-      },
-      installCommand: 'pnpm i',
-      skipStart: true,
-      buildCommand: `pnpm build`,
-    })
+    },
+    installCommand: 'pnpm i',
+    skipStart: true,
+    buildCommand: `pnpm build`,
   })
-
-  afterAll(() => next.destroy())
 
   it(`should use new link behavior`, async () => {
     await next.start()

--- a/test/production/jest/next-image-preload/next-image-preload.test.ts
+++ b/test/production/jest/next-image-preload/next-image-preload.test.ts
@@ -1,39 +1,33 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import execa from 'execa'
 
 const appDir = path.join(__dirname, 'app')
 
 describe('next/jest', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    skipStart: true,
+    files: {
+      app: new FileRef(path.join(appDir, 'app')),
+      [`tests/index.test.tsx`]: `
+      import { render, screen } from '@testing-library/react'
+      import Page from '../app/page'
 
-  beforeAll(async () => {
-    next = await createNext({
-      skipStart: true,
-      files: {
-        app: new FileRef(path.join(appDir, 'app')),
-        [`tests/index.test.tsx`]: `
-        import { render, screen } from '@testing-library/react'
-        import Page from '../app/page'
-
-        it('<Page /> renders', () => {
-          render(<Page />)
-          const logo = screen.getByRole('img')
-          expect(logo).toBeDefined()
-        })
-        `,
-        'jest.config.js': new FileRef(path.join(appDir, 'jest.config.js')),
-      },
-      dependencies: {
-        jest: '29.7.0',
-        'jest-environment-jsdom': '29.7.0',
-        '@testing-library/react': '15.0.2',
-        '@testing-library/jest-dom': '5.17.0',
-      },
-    })
+      it('<Page /> renders', () => {
+        render(<Page />)
+        const logo = screen.getByRole('img')
+        expect(logo).toBeDefined()
+      })
+      `,
+      'jest.config.js': new FileRef(path.join(appDir, 'jest.config.js')),
+    },
+    dependencies: {
+      jest: '29.7.0',
+      'jest-environment-jsdom': '29.7.0',
+      '@testing-library/react': '15.0.2',
+      '@testing-library/jest-dom': '5.17.0',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('Should not throw preload is undefined error', async () => {
     const { stdout, stderr } = await execa(

--- a/test/production/jest/relay/relay-jest.test.ts
+++ b/test/production/jest/relay/relay-jest.test.ts
@@ -1,76 +1,70 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
 const appDir = path.join(__dirname, 'app')
 
 // react-relay is not compatible with React 19 and therefore Next.js 15
 describe.skip('next/jest', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        components: new FileRef(path.join(appDir, 'components')),
-        pages: new FileRef(path.join(appDir, 'pages')),
-        'tests/entry.test.tsx': `
-        import { render, waitFor } from '@testing-library/react'
-        import { RelayEnvironmentProvider } from 'react-relay'
-        import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils'
-        
-        import Page from '@/pages'
-        
-        describe('test graphql tag transformation', () => {
-          it('should work', async () => {
-            let environment = createMockEnvironment()
-        
-            const { getByText } = render(
-              <RelayEnvironmentProvider environment={environment}>
-                <Page />
-              </RelayEnvironmentProvider>
-            )
-        
-            environment.mock.resolveMostRecentOperation((operation) => {
-              return MockPayloadGenerator.generate(operation)
-            })
-        
-            await waitFor(() => getByText('Data requested:'))
-        
-            expect(getByText('Data requested:')).not.toBe(null)
+  nextTestSetup({
+    files: {
+      components: new FileRef(path.join(appDir, 'components')),
+      pages: new FileRef(path.join(appDir, 'pages')),
+      'tests/entry.test.tsx': `
+      import { render, waitFor } from '@testing-library/react'
+      import { RelayEnvironmentProvider } from 'react-relay'
+      import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils'
+      
+      import Page from '@/pages'
+      
+      describe('test graphql tag transformation', () => {
+        it('should work', async () => {
+          let environment = createMockEnvironment()
+      
+          const { getByText } = render(
+            <RelayEnvironmentProvider environment={environment}>
+              <Page />
+            </RelayEnvironmentProvider>
+          )
+      
+          environment.mock.resolveMostRecentOperation((operation) => {
+            return MockPayloadGenerator.generate(operation)
           })
+      
+          await waitFor(() => getByText('Data requested:'))
+      
+          expect(getByText('Data requested:')).not.toBe(null)
         })
-        
-        `,
-        types: new FileRef(path.join(appDir, 'types')),
-        'jest.config.js': new FileRef(path.join(appDir, 'jest.config.js')),
-        'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
-        'tsconfig.json': new FileRef(path.join(appDir, 'tsconfig.json')),
-        'main.graphql': new FileRef(path.join(appDir, 'main.graphql')),
+      })
+      
+      `,
+      types: new FileRef(path.join(appDir, 'types')),
+      'jest.config.js': new FileRef(path.join(appDir, 'jest.config.js')),
+      'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
+      'tsconfig.json': new FileRef(path.join(appDir, 'tsconfig.json')),
+      'main.graphql': new FileRef(path.join(appDir, 'main.graphql')),
+    },
+    dependencies: {
+      jest: '27.4.7',
+      'react-relay': '13.2.0',
+      '@testing-library/react': '15.0.2',
+      '@types/jest': '27.4.1',
+      'babel-jest': '27.5.1',
+      'babel-plugin-relay': '13.2.0',
+      jsdom: '19.0.0',
+      'relay-compiler': '13.0.1',
+      'relay-runtime': '13.0.2',
+      'relay-test-utils': '13.0.2',
+      typescript: '5.2.2',
+    },
+    packageJson: {
+      scripts: {
+        // Runs jest and bails if jest fails
+        build: 'jest --forceExit tests/entry.test.tsx && next build',
       },
-      dependencies: {
-        jest: '27.4.7',
-        'react-relay': '13.2.0',
-        '@testing-library/react': '15.0.2',
-        '@types/jest': '27.4.1',
-        'babel-jest': '27.5.1',
-        'babel-plugin-relay': '13.2.0',
-        jsdom: '19.0.0',
-        'relay-compiler': '13.0.1',
-        'relay-runtime': '13.0.2',
-        'relay-test-utils': '13.0.2',
-        typescript: '5.2.2',
-      },
-      packageJson: {
-        scripts: {
-          // Runs jest and bails if jest fails
-          build: 'jest --forceExit tests/entry.test.tsx && next build',
-        },
-      },
-      installCommand: 'pnpm i',
-      buildCommand: `pnpm build`,
-    })
+    },
+    installCommand: 'pnpm i',
+    buildCommand: `pnpm build`,
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     // Suite fails if `jest` fails during `build`

--- a/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
+++ b/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
@@ -1,54 +1,48 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 
 const appDir = path.join(__dirname, 'app')
 
 describe('next/jest', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(appDir, 'pages')),
+      'tests/index.test.tsx': `
+      import { render, waitFor } from '@testing-library/react'
+      import '@testing-library/jest-dom/extend-expect';
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(path.join(appDir, 'pages')),
-        'tests/index.test.tsx': `
-        import { render, waitFor } from '@testing-library/react'
-        import '@testing-library/jest-dom/extend-expect';
+      import Page from '@/pages'
 
-        import Page from '@/pages'
-
-        describe('testid', () => {
-          it('data-testid should be available in the test', async () => {
-            const { getByTestId } = render(
-              <Page />
-            )
-            expect(getByTestId('main-text')).toHaveTextContent('Hello World')
-          })
+      describe('testid', () => {
+        it('data-testid should be available in the test', async () => {
+          const { getByTestId } = render(
+            <Page />
+          )
+          expect(getByTestId('main-text')).toHaveTextContent('Hello World')
         })
-        
-        `,
-        'jest.config.js': new FileRef(path.join(appDir, 'jest.config.js')),
-        'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
-        'tsconfig.json': new FileRef(path.join(appDir, 'tsconfig.json')),
+      })
+      
+      `,
+      'jest.config.js': new FileRef(path.join(appDir, 'jest.config.js')),
+      'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
+      'tsconfig.json': new FileRef(path.join(appDir, 'tsconfig.json')),
+    },
+    dependencies: {
+      jest: '29.7.0',
+      'jest-environment-jsdom': '29.7.0',
+      '@testing-library/react': '15.0.2',
+      '@testing-library/jest-dom': '5.16.4',
+    },
+    packageJson: {
+      scripts: {
+        // Runs jest and bails if jest fails
+        build: 'jest --forceExit tests/index.test.tsx && next build',
       },
-      dependencies: {
-        jest: '29.7.0',
-        'jest-environment-jsdom': '29.7.0',
-        '@testing-library/react': '15.0.2',
-        '@testing-library/jest-dom': '5.16.4',
-      },
-      packageJson: {
-        scripts: {
-          // Runs jest and bails if jest fails
-          build: 'jest --forceExit tests/index.test.tsx && next build',
-        },
-      },
-      installCommand: 'pnpm i',
-      buildCommand: `pnpm build`,
-    })
+    },
+    installCommand: 'pnpm i',
+    buildCommand: `pnpm build`,
   })
-  afterAll(() => next.destroy())
 
   it('data-testid should be removed in production', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/production/jest/transpile-packages.test.ts
+++ b/test/production/jest/transpile-packages.test.ts
@@ -1,41 +1,35 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 describe('next/jest', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `import capitalize from '@hashicorp/platform-util/text/capitalize'
-        export default function Home() {
-          return capitalize('test')
-        }`,
-        'index.test.ts': `import capitalize from '@hashicorp/platform-util/text/capitalize'
-        it('should work', () => {
-          expect(capitalize('test')).toEqual('Test')
-        })`,
-        'jest.config.js': `module.exports = require('next/jest')({ dir: './' })()`,
-        'next.config.js': `module.exports = {
-          transpilePackages: ['@hashicorp/platform-util'],
-        }`,
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `import capitalize from '@hashicorp/platform-util/text/capitalize'
+      export default function Home() {
+        return capitalize('test')
+      }`,
+      'index.test.ts': `import capitalize from '@hashicorp/platform-util/text/capitalize'
+      it('should work', () => {
+        expect(capitalize('test')).toEqual('Test')
+      })`,
+      'jest.config.js': `module.exports = require('next/jest')({ dir: './' })()`,
+      'next.config.js': `module.exports = {
+        transpilePackages: ['@hashicorp/platform-util'],
+      }`,
+    },
+    packageJson: {
+      scripts: {
+        // Runs jest and bails if jest fails
+        build: 'next build && jest',
       },
-      packageJson: {
-        scripts: {
-          // Runs jest and bails if jest fails
-          build: 'next build && jest',
-        },
-      },
-      installCommand: 'pnpm i',
-      buildCommand: `pnpm build`,
-      dependencies: {
-        '@hashicorp/platform-util': '0.2.0',
-        '@types/react': 'latest',
-        jest: '27.4.7',
-      },
-    })
+    },
+    installCommand: 'pnpm i',
+    buildCommand: `pnpm build`,
+    dependencies: {
+      '@hashicorp/platform-util': '0.2.0',
+      '@types/react': 'latest',
+      jest: '27.4.7',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/production/next-font/babel-unsupported.test.ts
+++ b/test/production/next-font/babel-unsupported.test.ts
@@ -1,20 +1,14 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
 // Turbopack does not support `.babelrc`. So this test is not relevant for Turbopack.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   '@next/font babel unsupported',
   () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        skipStart: true,
-        files: new FileRef(join(__dirname, 'babel-unsupported')),
-      })
+    const { next } = nextTestSetup({
+      skipStart: true,
+      files: new FileRef(join(__dirname, 'babel-unsupported')),
     })
-    afterAll(() => next.destroy())
 
     test('Build error when using babel', async () => {
       await expect(next.start()).rejects.toThrow(

--- a/test/production/next-font/telemetry.test.ts
+++ b/test/production/next-font/telemetry.test.ts
@@ -1,5 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { findAllTelemetryEvents } from 'next-test-utils'
 import { join } from 'path'
 
@@ -11,20 +10,15 @@ const mockedGoogleFontResponses = require.resolve(
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'next/font used telemetry',
   () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          pages: new FileRef(join(__dirname, 'telemetry/pages')),
-        },
-        env: {
-          NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-          NEXT_TELEMETRY_DEBUG: '1',
-        },
-      })
+    const { next } = nextTestSetup({
+      files: {
+        pages: new FileRef(join(__dirname, 'telemetry/pages')),
+      },
+      env: {
+        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+        NEXT_TELEMETRY_DEBUG: '1',
+      },
     })
-    afterAll(() => next.destroy())
 
     it('should send next/font/google and next/font/local usage event', async () => {
       const events = findAllTelemetryEvents(
@@ -47,20 +41,15 @@ const mockedGoogleFontResponses = require.resolve(
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'next/font unused telemetry',
   () => {
-    let next: NextInstance
-
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          pages: new FileRef(join(__dirname, 'telemetry/pages-unused')),
-        },
-        env: {
-          NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
-          NEXT_TELEMETRY_DEBUG: '1',
-        },
-      })
+    const { next } = nextTestSetup({
+      files: {
+        pages: new FileRef(join(__dirname, 'telemetry/pages-unused')),
+      },
+      env: {
+        NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+        NEXT_TELEMETRY_DEBUG: '1',
+      },
     })
-    afterAll(() => next.destroy())
 
     it('should not send next/font/google and next/font/local usage event', async () => {
       const events = findAllTelemetryEvents(

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -1,9 +1,7 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import fs from 'fs'
 import { NextAdapter } from 'next'
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 function normalizeNFT(base: string, files: string[]): string[] {
   const result = [

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -21,15 +21,13 @@ import dynamicImportTests from './dynamic'
 import processEnv from './process-env'
 import security from './security'
 import { promisify } from 'util'
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 const glob = promisify(globOriginal)
 
 if (process.env.NEXT_TEST_WASM || process.env.NEXT_TEST_WASM_AFTER_JEST) {
   jest.setTimeout(120 * 1000)
 }
-
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('Production Usage', () => {
   const { next } = nextTestSetup({

--- a/test/production/postcss-plugin-config-as-string/index.test.ts
+++ b/test/production/postcss-plugin-config-as-string/index.test.ts
@@ -1,51 +1,45 @@
-import { createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
 
 describe('PostCSS plugin config as string', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() {
-            return <p>hello world</p>
-          }
-        `,
-        'global.css': `
-          @import "tailwindcss/base";
-          @import "tailwindcss/components";
-          @import "tailwindcss/utilities";
-        `,
-        'pages/_app.js': `
-          import "../global.css"
-          
-          export default function MyApp({ Component, pageProps }) {
-            return <Component {...pageProps} />
-          }
-        `,
-        'postcss.config.js': `
-          module.exports = {
-            plugins: {
-              'tailwindcss/nesting': 'postcss-nesting',
-              tailwindcss: {},
-            },
-          }
-        `,
-        'tailwind.config.js': `
-          module.exports = {
-            content: ['./pages/**/*'],
-          }
-        `,
-      },
-      dependencies: {
-        'postcss-nesting': '10.1.3',
-        tailwindcss: '3.0.23',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() {
+          return <p>hello world</p>
+        }
+      `,
+      'global.css': `
+        @import "tailwindcss/base";
+        @import "tailwindcss/components";
+        @import "tailwindcss/utilities";
+      `,
+      'pages/_app.js': `
+        import "../global.css"
+        
+        export default function MyApp({ Component, pageProps }) {
+          return <Component {...pageProps} />
+        }
+      `,
+      'postcss.config.js': `
+        module.exports = {
+          plugins: {
+            'tailwindcss/nesting': 'postcss-nesting',
+            tailwindcss: {},
+          },
+        }
+      `,
+      'tailwind.config.js': `
+        module.exports = {
+          content: ['./pages/**/*'],
+        }
+      `,
+    },
+    dependencies: {
+      'postcss-nesting': '10.1.3',
+      tailwindcss: '3.0.23',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/production/prerender-prefetch/index.test.ts
+++ b/test/production/prerender-prefetch/index.test.ts
@@ -1,5 +1,4 @@
-import { NextInstance } from 'e2e-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,
@@ -12,13 +11,14 @@ import webdriver from 'next-webdriver'
 import assert from 'assert'
 
 describe('Prerender prefetch', () => {
-  let next: NextInstance
-
-  const runTests = ({
-    optimisticClientCache,
-  }: {
-    optimisticClientCache?: boolean
-  }) => {
+  const runTests = (
+    next: ReturnType<typeof nextTestSetup>['next'],
+    {
+      optimisticClientCache,
+    }: {
+      optimisticClientCache?: boolean
+    }
+  ) => {
     it('should not revalidate during prefetching', async () => {
       const cliOutputStart = next.cliOutput.length
 
@@ -294,53 +294,47 @@ describe('Prerender prefetch', () => {
   }
 
   describe('with optimisticClientCache enabled', () => {
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          pages: new FileRef(join(__dirname, 'app/pages')),
-        },
-        dependencies: {},
-        env: {
-          // Simulate that a CDN has consumed the SWR cache-control header,
-          // otherwise the browser will cache responses and which messes with
-          // the expectations in this test.
-          // See https://github.com/vercel/next.js/pull/70674 for context.
-          NEXT_PRIVATE_CDN_CONSUMED_SWR_CACHE_CONTROL: '1',
-        },
-        // relies on changing build id
-        disableAutoSkewProtection: true,
-      })
+    const { next } = nextTestSetup({
+      files: {
+        pages: new FileRef(join(__dirname, 'app/pages')),
+      },
+      dependencies: {},
+      env: {
+        // Simulate that a CDN has consumed the SWR cache-control header,
+        // otherwise the browser will cache responses and which messes with
+        // the expectations in this test.
+        // See https://github.com/vercel/next.js/pull/70674 for context.
+        NEXT_PRIVATE_CDN_CONSUMED_SWR_CACHE_CONTROL: '1',
+      },
+      // relies on changing build id
+      disableAutoSkewProtection: true,
     })
-    afterAll(() => next.destroy())
 
-    runTests({ optimisticClientCache: true })
+    runTests(next, { optimisticClientCache: true })
   })
 
   describe('with optimisticClientCache disabled', () => {
-    beforeAll(async () => {
-      next = await createNext({
-        files: {
-          pages: new FileRef(join(__dirname, 'app/pages')),
+    const { next } = nextTestSetup({
+      files: {
+        pages: new FileRef(join(__dirname, 'app/pages')),
+      },
+      nextConfig: {
+        experimental: {
+          optimisticClientCache: false,
         },
-        nextConfig: {
-          experimental: {
-            optimisticClientCache: false,
-          },
-        },
-        dependencies: {},
-        env: {
-          // Simulate that a CDN has consumed the SWR cache-control header,
-          // otherwise the browser will cache responses and which messes with
-          // the expectations in this test.
-          // See https://github.com/vercel/next.js/pull/70674 for context.
-          NEXT_PRIVATE_CDN_CONSUMED_SWR_CACHE_CONTROL: '1',
-        },
-        // relies on changing build id
-        disableAutoSkewProtection: true,
-      })
+      },
+      dependencies: {},
+      env: {
+        // Simulate that a CDN has consumed the SWR cache-control header,
+        // otherwise the browser will cache responses and which messes with
+        // the expectations in this test.
+        // See https://github.com/vercel/next.js/pull/70674 for context.
+        NEXT_PRIVATE_CDN_CONSUMED_SWR_CACHE_CONTROL: '1',
+      },
+      // relies on changing build id
+      disableAutoSkewProtection: true,
     })
-    afterAll(() => next.destroy())
 
-    runTests({ optimisticClientCache: false })
+    runTests(next, { optimisticClientCache: false })
   })
 })

--- a/test/production/reading-request-body-in-middleware/index.test.ts
+++ b/test/production/reading-request-body-in-middleware/index.test.ts
@@ -1,55 +1,49 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('reading request body in middleware', () => {
-  let next: NextInstance
+  const { next } = nextTestSetup({
+    files: {
+      'middleware.js': `
+        const { NextResponse } = require('next/server');
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'middleware.js': `
-          const { NextResponse } = require('next/server');
-
-          export default async function middleware(request) {
-            if (!request.body) {
-              return new Response(null, { status: 400 });
-            }
-
-            let json;
-
-            if (!request.nextUrl.searchParams.has("no_reading")) {
-              json = await request.json();
-            }
-
-            if (request.nextUrl.searchParams.has("next")) {
-              const res = NextResponse.next();
-              res.headers.set('x-from-root-middleware', '1');
-              return res;
-            }
-
-            return new Response(null, {
-              status: 200,
-              headers: {
-                data: JSON.stringify({ root: true, ...json }),
-              },
-            })
+        export default async function middleware(request) {
+          if (!request.body) {
+            return new Response(null, { status: 400 });
           }
-        `,
 
-        'pages/api/hi.js': `
-          export default function hi(req, res) {
-            res.json({
-              ...req.body,
-              api: true,
-            })
+          let json;
+
+          if (!request.nextUrl.searchParams.has("no_reading")) {
+            json = await request.json();
           }
-        `,
-      },
-      dependencies: {},
-    })
+
+          if (request.nextUrl.searchParams.has("next")) {
+            const res = NextResponse.next();
+            res.headers.set('x-from-root-middleware', '1');
+            return res;
+          }
+
+          return new Response(null, {
+            status: 200,
+            headers: {
+              data: JSON.stringify({ root: true, ...json }),
+            },
+          })
+        }
+      `,
+
+      'pages/api/hi.js': `
+        export default function hi(req, res) {
+          res.json({
+            ...req.body,
+            api: true,
+          })
+        }
+      `,
+    },
+    dependencies: {},
   })
-  afterAll(() => next.destroy())
 
   it('rejects with 400 for get requests', async () => {
     const response = await fetchViaHTTP(next.url, '/')

--- a/test/production/standalone-mode/ipv6/index.test.ts
+++ b/test/production/standalone-mode/ipv6/index.test.ts
@@ -1,4 +1,4 @@
-import { NextInstance, createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs-extra'
 import glob from 'glob'
 import {
@@ -10,15 +10,15 @@ import {
 import { join } from 'path'
 
 describe('standalone mode: ipv6 hostname', () => {
-  let next: NextInstance
   let server
   let appPort
   let output = ''
 
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
   beforeAll(async () => {
-    next = await createNext({
-      files: __dirname,
-    })
     await next.stop()
 
     await fs.move(
@@ -67,7 +67,6 @@ describe('standalone mode: ipv6 hostname', () => {
     )
   })
   afterAll(async () => {
-    await next.destroy()
     if (server) await killApp(server)
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs/promises'
 import { join } from 'node:path'
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
   createNowRouteMatches,
   fetchViaHTTP,
@@ -16,7 +15,6 @@ import { ChildProcess } from 'node:child_process'
 
 // TODO(NAR-423): Migrate to Cache Components.
 describe.skip('required server files app router', () => {
-  let next: NextInstance
   let server: ChildProcess
   let appPort: number | string
   let delayedPostpone: string
@@ -25,42 +23,43 @@ describe.skip('required server files app router', () => {
   let secondCookieHTML: string
   let cliOutput = ''
 
-  beforeAll(async () => {
+  beforeAll(() => {
     process.env.NOW_BUILDER = '1'
     process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
     process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS =
       './cache-entry-handlers.js'
+  })
 
-    // Setup the Next.js app and build it.
-    next = await createNext({
-      files: {
-        app: new FileRef(join(__dirname, 'app')),
-        'pages/catch-all/[[...rest]].js': new FileRef(
-          join(__dirname, 'pages', 'catch-all', '[[...rest]].js')
-        ),
-        lib: new FileRef(join(__dirname, 'lib')),
-        'cache-handler.js': new FileRef(join(__dirname, 'cache-handler.js')),
-        'middleware.js': new FileRef(join(__dirname, 'middleware.js')),
-        'data.txt': new FileRef(join(__dirname, 'data.txt')),
-        '.env': new FileRef(join(__dirname, '.env')),
-        '.env.local': new FileRef(join(__dirname, '.env.local')),
-        '.env.production': new FileRef(join(__dirname, '.env.production')),
-        'cache-entry-handlers.js': new FileRef(
-          join(__dirname, 'cache-entry-handlers.js')
-        ),
-      },
-      overrideFiles: {
-        'app/not-found.js': new FileRef(
-          join(__dirname, 'ppr', 'app', 'not-found.js')
-        ),
-      },
-      nextConfig: {
-        cacheHandler: './cache-handler.js',
-        cacheComponents: true,
-        output: 'standalone',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      app: new FileRef(join(__dirname, 'app')),
+      'pages/catch-all/[[...rest]].js': new FileRef(
+        join(__dirname, 'pages', 'catch-all', '[[...rest]].js')
+      ),
+      lib: new FileRef(join(__dirname, 'lib')),
+      'cache-handler.js': new FileRef(join(__dirname, 'cache-handler.js')),
+      'middleware.js': new FileRef(join(__dirname, 'middleware.js')),
+      'data.txt': new FileRef(join(__dirname, 'data.txt')),
+      '.env': new FileRef(join(__dirname, '.env')),
+      '.env.local': new FileRef(join(__dirname, '.env.local')),
+      '.env.production': new FileRef(join(__dirname, '.env.production')),
+      'cache-entry-handlers.js': new FileRef(
+        join(__dirname, 'cache-entry-handlers.js')
+      ),
+    },
+    overrideFiles: {
+      'app/not-found.js': new FileRef(
+        join(__dirname, 'ppr', 'app', 'not-found.js')
+      ),
+    },
+    nextConfig: {
+      cacheHandler: './cache-handler.js',
+      cacheComponents: true,
+      output: 'standalone',
+    },
+  })
 
+  beforeAll(async () => {
     // Stop the server, we're going to restart it using the standalone server
     // below after some cleanup.
     await next.stop()
@@ -126,7 +125,6 @@ describe.skip('required server files app router', () => {
     delete process.env.NOW_BUILDER
     delete process.env.NEXT_PRIVATE_TEST_HEADERS
     delete process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS
-    await next.destroy()
     if (server) await killApp(server)
   })
 

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -2,8 +2,7 @@ import glob from 'glob'
 import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
   killApp,
   findPort,
@@ -13,20 +12,22 @@ import {
 } from 'next-test-utils'
 
 describe('minimal-mode-response-cache', () => {
-  let next: NextInstance
   let server
   let port
   let appPort
   let output = ''
 
-  beforeAll(async () => {
+  beforeAll(() => {
     // test build against environment with next support
     process.env.NOW_BUILDER = '1'
     process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
+  })
 
-    next = await createNext({
-      files: new FileRef(join(__dirname, 'app')),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'app')),
+  })
+
+  beforeAll(async () => {
     await next.stop()
 
     await fs.move(
@@ -88,7 +89,6 @@ describe('minimal-mode-response-cache', () => {
   afterAll(async () => {
     delete process.env.NOW_BUILDER
     delete process.env.NEXT_PRIVATE_TEST_HEADERS
-    await next.destroy()
     if (server) await killApp(server)
   })
 

--- a/test/production/standalone-mode/runtimeServerDeploymentId/index.test.ts
+++ b/test/production/standalone-mode/runtimeServerDeploymentId/index.test.ts
@@ -1,4 +1,4 @@
-import { NextInstance, createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs-extra'
 import {
   findPort,
@@ -11,20 +11,20 @@ import { join } from 'path'
 let MY_DEPLOYMENT_ID = 'test-deployment-id'
 
 describe('standalone mode: runtimeServerDeploymentId', () => {
-  let next: NextInstance
   let server
   let appPort
   let output = ''
 
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: {
+      NEXT_DEPLOYMENT_ID: MY_DEPLOYMENT_ID,
+    },
+    skipStart: true,
+    disableAutoSkewProtection: true,
+  })
+
   beforeAll(async () => {
-    next = await createNext({
-      files: __dirname,
-      env: {
-        NEXT_DEPLOYMENT_ID: MY_DEPLOYMENT_ID,
-      },
-      skipStart: true,
-      disableAutoSkewProtection: true,
-    })
     let { exitCode } = await next.build()
     // eslint-disable-next-line jest/no-standalone-expect
     expect(exitCode).toBe(0)
@@ -66,7 +66,6 @@ describe('standalone mode: runtimeServerDeploymentId', () => {
     )
   })
   afterAll(async () => {
-    await next.destroy()
     if (server) await killApp(server)
   })
 

--- a/test/production/standalone-mode/server-actions/standalone-mode-server-actions.test.ts
+++ b/test/production/standalone-mode/server-actions/standalone-mode-server-actions.test.ts
@@ -1,20 +1,20 @@
 import { ChildProcess } from 'child_process'
-import { NextInstance, createNext } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs-extra'
 import { findPort, initNextServerScript, killApp } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
 describe('standalone mode: server actions', () => {
-  let next: NextInstance
   let server: ChildProcess
   let appPort: number
 
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
   beforeAll(async () => {
-    next = await createNext({
-      files: __dirname,
-      skipStart: true,
-    })
     await next.build()
 
     await fs.move(
@@ -50,8 +50,6 @@ describe('standalone mode: server actions', () => {
   })
 
   afterAll(async () => {
-    await next.destroy()
-
     if (server) {
       await killApp(server)
     }

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -1,24 +1,18 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'e2e-utils'
 
 describe('TypeScript basic', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(path.join(__dirname, 'app')),
-      dependencies: {
-        '@next/bundle-analyzer': 'canary',
-        typescript: 'latest',
-        '@types/node': 'latest',
-        '@types/react': 'latest',
-        '@types/react-dom': 'latest',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(path.join(__dirname, 'app')),
+    dependencies: {
+      '@next/bundle-analyzer': 'canary',
+      typescript: 'latest',
+      '@types/node': 'latest',
+      '@types/react': 'latest',
+      '@types/react-dom': 'latest',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should not have eslint setup started', async () => {
     expect(next.cliOutput).not.toContain(


### PR DESCRIPTION
## What?

Converts existing `createNext()` usage into `nextTestSetup()`. 

`createNext()` was the setup step we had before `nextTestSetup()` was added.

This PR focused on the simple conversion cases. There will be a follow-up to complete the last few.