### PR TITLE
docs: clarify cacheTag limit - it is per call

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
@@ -98,7 +98,7 @@ export default async function submit() {
 cacheTag('tag-one', 'tag-two')
 ```
 
-- **Limits**: A single `cacheTag()` call accepts up to 128 tags, each up to 256 characters. Tags longer than 256 characters are skipped, and any tags past the 128th in one call are dropped. Both cases log a console warning.
+- **Limits**: A single `cacheTag()` call accepts up to 128 tags, each with a maximum length of 256 characters. Tags longer than 256 characters are skipped, and any tags past the 128th in one call are dropped. Both cases log a console warning.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
@@ -98,7 +98,7 @@ export default async function submit() {
 cacheTag('tag-one', 'tag-two')
 ```
 
-- **Limits**: A single `cacheTag()` call accepts up to 128 tags, and each tag can be up to 256 characters. Tags beyond 128 in one call are dropped with a console warning.
+- **Limits**: A single `cacheTag()` call accepts up to 128 tags, each up to 256 characters. Tags longer than 256 characters are skipped, and any tags past the 128th in one call are dropped. Both cases log a console warning.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
@@ -98,7 +98,7 @@ export default async function submit() {
 cacheTag('tag-one', 'tag-two')
 ```
 
-- **Limits**: The max length for a custom tag is 256 characters and the max tag items is 128.
+- **Limits**: A single `cacheTag()` call accepts up to 128 tags, and each tag can be up to 256 characters. Tags beyond 128 in one call are dropped with a console warning.
 
 ## Examples
 


### PR DESCRIPTION
x-ref: https://vercel.slack.com/archives/C03S8ED1DKM/p1778515581719889