### PR TITLE
docs: add pnpm installation step to module-not-found error page

### DIFF
--- a/errors/module-not-found.mdx
+++ b/errors/module-not-found.mdx
@@ -27,6 +27,7 @@ The `swr` module has to be installed using a package manager.
 
 - When using `npm`: `npm install swr`
 - When using `yarn`: `yarn add swr`
+- When using `pnpm`: `pnpm add swr`
 
 ### The module you're trying to import is in a different directory
 


### PR DESCRIPTION
Added missing pnpm command for installing dependencies to ensure consistency with other documentation pages.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Added the missing `pnpm` installation command to the `module-not-found` error documentation page.

### Why?
To ensure consistency across the documentation, as other error pages and guides in Next.js typically include examples for npm, yarn, and pnpm.

### How?
Added `- When using pnpm: pnpm add swr` to the "Possible Ways to Fix It" section in `errors/module-not-found.mdx`.

Closes NEXT-
Fixes #

-->
