### PR TITLE
output export fallbacks: store fallback data in Segment Cache (19/21)

### DIFF
--- a/packages/next/src/client/app-globals.ts
+++ b/packages/next/src/client/app-globals.ts
@@ -1,6 +1,12 @@
 // imports polyfill from `@next/polyfill-module` after build.
 import '../build/polyfills/polyfill-module'
 
+declare global {
+  interface Window {
+    __NEXT_ARM_INSTANT_NAVIGATION_LOCK?: () => void
+  }
+}
+
 // Only set up devtools for the dev server.
 if (process.env.__NEXT_DEV_SERVER) {
   require('../next-devtools/userspace/app/app-dev-overlay-setup') as typeof import('../next-devtools/userspace/app/app-dev-overlay-setup')
@@ -10,7 +16,11 @@ if (process.env.__NEXT_DEV_SERVER) {
 // (e.g. Playwright) sets/clears this cookie to control the navigation lock.
 // Browser-only.
 if (process.env.__NEXT_EXPOSE_TESTING_API && typeof window !== 'undefined') {
-  const { startListeningForInstantNavigationCookie } =
+  const {
+    startListeningForInstantNavigationCookie,
+    armNavigationLockForTesting,
+  } =
     require('./components/segment-cache/navigation-testing-lock') as typeof import('./components/segment-cache/navigation-testing-lock')
   startListeningForInstantNavigationCookie()
+  window.__NEXT_ARM_INSTANT_NAVIGATION_LOCK = armNavigationLockForTesting
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -54,7 +54,7 @@ let offlineNavigationFallbackBootstrap: ReturnType<
 >
 if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
   offlineNavigationBootstrap =
-    (require('./offline-navigation-bootstrap') as typeof import('./offline-navigation-bootstrap'))
+    require('./offline-navigation-bootstrap') as typeof import('./offline-navigation-bootstrap')
   offlineNavigationFallbackBootstrap =
     offlineNavigationBootstrap.createOfflineNavigationFallbackBootstrap()
 } else {
@@ -285,6 +285,7 @@ if (
 }
 
 let initialServerResponse: Promise<InitialRSCPayload>
+let initialStaticExportFallbackPathname: string | null = null
 if (instantTestStaticFetch) {
   // Instant Navigation Testing API: hydrate from the static RSC payload
   // fetch kicked off by an injected <script> tag, instead of the inline
@@ -314,10 +315,14 @@ if (instantTestStaticFetch) {
   // This must be checked before __NEXT_CLIENT_RESUME because _fallback.html may
   // be based on a PPR shell that also sets __NEXT_CLIENT_RESUME. Export fallback
   // boot always fetches the RSC payload for the requested route.
-  initialServerResponse =
-    outputExportFallbackBootstrap.createOutputExportFallbackInitialResponse({
+  initialServerResponse = outputExportFallbackBootstrap
+    .createOutputExportFallbackInitialResponse({
       createFromFetch,
       debugChannel,
+    })
+    .then(({ initialRSCPayload, staticExportFallbackPathname }) => {
+      initialStaticExportFallbackPathname = staticExportFallbackPathname
+      return initialRSCPayload
     })
 } else if (offlineNavigationFallbackBootstrap) {
   initialServerResponse =
@@ -460,6 +465,7 @@ export async function hydrate(
       initialRSCPayload,
       initialFlightStreamForCache,
       location: window.location,
+      staticExportFallbackPathname: initialStaticExportFallbackPathname,
     }),
     instrumentationHooks
   )

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
@@ -1,0 +1,167 @@
+import type { InitialRSCPayload } from '../../../shared/lib/app-router-types'
+import { createInitialRouterState } from './create-initial-router-state'
+
+const mockGetFlightDataPartsFromPath = jest.fn()
+const mockCreateInitialCacheNodeForHydration = jest.fn()
+const mockConvertRootFlightRouterStateToRouteTree = jest.fn()
+const mockDiscoverKnownRoute = jest.fn()
+const mockProcessRuntimePrefetchStream = jest.fn()
+const mockWriteDynamicRenderResponseIntoCache = jest.fn()
+
+jest.mock('../../flight-data-helpers', () => ({
+  getFlightDataPartsFromPath: (...args: Array<unknown>) =>
+    mockGetFlightDataPartsFromPath(...args),
+}))
+
+jest.mock('./ppr-navigations', () => ({
+  createInitialCacheNodeForHydration: (...args: Array<unknown>) =>
+    mockCreateInitialCacheNodeForHydration(...args),
+}))
+
+jest.mock('../segment-cache/cache', () => ({
+  convertRootFlightRouterStateToRouteTree: (...args: Array<unknown>) =>
+    mockConvertRootFlightRouterStateToRouteTree(...args),
+  getStaleTimeMs: jest.fn((staleTime: number) => staleTime),
+  getStaleAt: jest.fn(),
+  processRuntimePrefetchStream: (...args: Array<unknown>) =>
+    mockProcessRuntimePrefetchStream(...args),
+  writeDynamicRenderResponseIntoCache: (...args: Array<unknown>) =>
+    mockWriteDynamicRenderResponseIntoCache(...args),
+  writeStaticStageResponseIntoCache: jest.fn(),
+}))
+
+jest.mock('../segment-cache/optimistic-routes', () => ({
+  discoverKnownRoute: (...args: Array<unknown>) =>
+    mockDiscoverKnownRoute(...args),
+}))
+
+describe('createInitialRouterState output export fallback', () => {
+  const discoveredRouteEntry = {
+    staticExportFallbackPathname: null as string | null,
+  }
+
+  const initialRSCPayload: InitialRSCPayload = {
+    c: ['', 'hydrated', 'first'],
+    q: '',
+    i: false,
+    f: [[] as any],
+    m: new Set(),
+    G: [(() => null) as any, undefined],
+    S: false,
+    h: null,
+  }
+
+  beforeEach(() => {
+    mockGetFlightDataPartsFromPath.mockReset()
+    mockCreateInitialCacheNodeForHydration.mockReset()
+    mockConvertRootFlightRouterStateToRouteTree.mockReset()
+    mockDiscoverKnownRoute.mockReset()
+    mockProcessRuntimePrefetchStream.mockReset()
+    mockWriteDynamicRenderResponseIntoCache.mockReset()
+
+    discoveredRouteEntry.staticExportFallbackPathname = null
+
+    mockGetFlightDataPartsFromPath.mockReturnValue({
+      tree: ['', {}],
+      seedData: null,
+      head: null,
+    })
+    mockCreateInitialCacheNodeForHydration.mockReturnValue({
+      rsc: null,
+      prefetchRsc: null,
+      prefetchHead: null,
+      head: null,
+      slots: null,
+      scrollRef: null,
+    })
+    mockConvertRootFlightRouterStateToRouteTree.mockImplementation(
+      (_tree, _renderedSearch, acc) => {
+        acc.metadataVaryPath = '__PAGE__'
+        return { path: '/hydrated/[thread]' }
+      }
+    )
+    mockDiscoverKnownRoute.mockReturnValue(discoveredRouteEntry)
+  })
+
+  it('passes the learned fallback artifact base path into route discovery', () => {
+    createInitialRouterState({
+      navigatedAt: Date.now(),
+      initialRSCPayload,
+      location: new URL(
+        'https://example.com/hydrated/first/'
+      ) as unknown as Location,
+      staticExportFallbackPathname: '/hydrated/__fallback',
+    })
+
+    expect(mockDiscoverKnownRoute).toHaveBeenCalledWith(
+      expect.any(Number),
+      '/hydrated/first/',
+      null,
+      null,
+      { path: '/hydrated/[thread]' },
+      '__PAGE__',
+      false,
+      '/hydrated/first/',
+      false,
+      false,
+      { staticExportFallbackPathname: '/hydrated/__fallback' }
+    )
+  })
+
+  it('passes the learned fallback artifact base path into runtime-prefetch cache writes', async () => {
+    const processedNavigationSeed = {
+      renderedSearch: '',
+      routeTree: { path: '/hydrated/[thread]' },
+      metadataVaryPath: null,
+      data: null,
+      head: null,
+      dynamicStaleAt: Date.now() + 30_000,
+      staticExportFallbackPathname: '/hydrated/__fallback' as string | null,
+    }
+
+    mockProcessRuntimePrefetchStream.mockResolvedValue({
+      flightDatas: [],
+      navigationSeed: processedNavigationSeed,
+      buildId: undefined,
+      isResponsePartial: false,
+      headVaryParams: null,
+      staleAt: Date.now() + 30_000,
+    })
+
+    createInitialRouterState({
+      navigatedAt: Date.now(),
+      initialRSCPayload: {
+        ...initialRSCPayload,
+        p: new ReadableStream<Uint8Array>(),
+      },
+      location: new URL(
+        'https://example.com/hydrated/first/'
+      ) as unknown as Location,
+      staticExportFallbackPathname: '/hydrated/__fallback',
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockProcessRuntimePrefetchStream).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(ReadableStream),
+      ['', {}],
+      '',
+      '/hydrated/__fallback'
+    )
+    expect(mockWriteDynamicRenderResponseIntoCache).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.anything(),
+      expect.any(Array),
+      undefined,
+      false,
+      null,
+      expect.any(Number),
+      expect.objectContaining({
+        staticExportFallbackPathname: '/hydrated/__fallback',
+      }),
+      null
+    )
+  })
+})

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -27,6 +27,7 @@ export interface InitialRouterStateParameters {
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
   location: Location | null
+  staticExportFallbackPathname?: string | null
 }
 
 export function createInitialRouterState({
@@ -34,6 +35,7 @@ export function createInitialRouterState({
   initialRSCPayload,
   initialFlightStreamForCache,
   location,
+  staticExportFallbackPathname = null,
 }: InitialRouterStateParameters): AppRouterState {
   const {
     c: initialCanonicalUrlParts,
@@ -119,7 +121,8 @@ export function createInitialRouterState({
       initialCouldBeIntercepted,
       canonicalUrl,
       initialSupportsPerSegmentPrefetching,
-      false // hasDynamicRewrite
+      false, // hasDynamicRewrite
+      { staticExportFallbackPathname }
     )
 
     // Write the initial seed data into the segment cache so subsequent
@@ -148,7 +151,8 @@ export function createInitialRouterState({
               staleAt,
               initialTree,
               initialRenderedSearch,
-              true // isResponsePartial
+              true, // isResponsePartial
+              staticExportFallbackPathname
             )
           })
           .catch(() => {
@@ -173,7 +177,8 @@ export function createInitialRouterState({
               staleAt,
               initialTree,
               initialRenderedSearch,
-              false // isResponsePartial
+              false, // isResponsePartial
+              staticExportFallbackPathname
             )
           })
           .catch(() => {
@@ -198,7 +203,8 @@ export function createInitialRouterState({
         Date.now(),
         initialRuntimePrefetchStream,
         initialTree,
-        initialRenderedSearch
+        initialRenderedSearch,
+        staticExportFallbackPathname
       )
         .then((processed) => {
           if (processed !== null) {

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
@@ -182,6 +182,7 @@ describe('fetchServerResponse output export fallback', () => {
     expect(typeof result).not.toBe('string')
     if (typeof result !== 'string') {
       expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+      expect(result.staticExportFallbackPathname).toBe('/another/__fallback')
     }
     expect(global.fetch).toHaveBeenCalledTimes(1)
     expect(mockFetchOutputExportFallbackResponse).toHaveBeenCalledTimes(1)
@@ -226,6 +227,7 @@ describe('fetchServerResponse output export fallback', () => {
     expect(typeof result).not.toBe('string')
     if (typeof result !== 'string') {
       expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+      expect(result.staticExportFallbackPathname).toBe('/another/__fallback')
     }
   })
 
@@ -317,6 +319,7 @@ describe('fetchServerResponse output export fallback', () => {
     expect(typeof result).not.toBe('string')
     if (typeof result !== 'string') {
       expect(result.canonicalUrl.href).toBe(`${origin}/another/third/extra`)
+      expect(result.staticExportFallbackPathname).toBe('/_not-found')
     }
     expect(mockFetchOutputExportNotFoundDataResponse).toHaveBeenCalledTimes(1)
   })

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -105,6 +105,7 @@ type SpaFetchServerResponseResult = {
   flightData: NormalizedFlightData[]
   canonicalUrl: URL
   renderedSearch: NormalizedSearch
+  staticExportFallbackPathname: string | null
   couldBeIntercepted: boolean
   supportsPerSegmentPrefetching: boolean
   postponed: boolean
@@ -192,7 +193,7 @@ export async function fetchServerResponse(
   const originalUrl = url
 
   try {
-    let outputExportFallbackFetchKind: OutputExportFallbackFetchKind = 'none'
+    let staticExportFallbackPathname: string | null = null
     let outputExportFallbackFetchResult: OutputExportFallbackFetchResult | null =
       null
     if (
@@ -237,7 +238,7 @@ export async function fetchServerResponse(
     let responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
     let canonicalUrl = res.redirected ? responseUrl : originalUrl
 
-    let contentType = res.headers.get('content-type') || ''
+    const contentType = res.headers.get('content-type') || ''
     let interception = !!res.headers.get('vary')?.includes(NEXT_URL)
     let postponed = !!res.headers.get(NEXT_DID_POSTPONE_HEADER)
     let isFlightResponse = contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
@@ -251,30 +252,28 @@ export async function fetchServerResponse(
       }
 
       if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
-        if (!isFlightResponse || !res.ok || !res.body) {
-          const outputExportFallback =
-            require('../../output-export-fallback') as typeof import('../../output-export-fallback')
-          const fallbackResult = await fetchOutputExportFallbackFetchResult(
-            outputExportFallback,
-            originalUrl,
-            headers
-          )
+        outputExportFallbackFetchResult =
+          await fetchOutputExportFallbackFetchResultIfNeeded({
+            response: res,
+            isFlightResponse,
+            renderedUrl: originalUrl,
+            headers,
+          })
 
-          if (fallbackResult !== null) {
-            outputExportFallbackFetchKind = 'discovered'
-            outputExportFallbackFetchResult = fallbackResult
-            res = fallbackResult.response
-            responseUrl = originalUrl
-            canonicalUrl = originalUrl
-            contentType = res.headers.get('content-type') || ''
-            interception = !!res.headers.get('vary')?.includes(NEXT_URL)
-            // Static export fallback payloads are partial-by-construction, but
-            // static hosts cannot attach the normal postpone header. Treat them as
-            // partial so Flight decoding accepts the closed stream and the router
-            // keeps the fallback shell suspended until dynamic holes resolve.
-            postponed = true
-            isFlightResponse = true
-          }
+        if (outputExportFallbackFetchResult !== null) {
+          staticExportFallbackPathname =
+            outputExportFallbackFetchResult.staticExportFallbackPathname
+          const appliedFallbackResponse =
+            getAppliedOutputExportFallbackResponse(
+              outputExportFallbackFetchResult,
+              originalUrl
+            )
+          res = appliedFallbackResponse.response
+          responseUrl = appliedFallbackResponse.responseUrl
+          canonicalUrl = appliedFallbackResponse.canonicalUrl
+          interception = appliedFallbackResponse.interception
+          postponed = appliedFallbackResponse.postponed
+          isFlightResponse = true
         }
       } else {
         // Static export fallback discovery is erased when the feature is off.
@@ -336,7 +335,7 @@ export async function fetchServerResponse(
     const missingBuildIdFromOutputExportFallback =
       responseBuildId === undefined &&
       process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS &&
-      outputExportFallbackFetchKind !== 'none'
+      outputExportFallbackFetchResult !== null
     if (
       !missingBuildIdFromOutputExportFallback &&
       responseBuildId !== getNavigationBuildId()
@@ -348,35 +347,29 @@ export async function fetchServerResponse(
     let fallbackFlightData: NavigationFlightResponse['f'] | null =
       outputExportFallbackFetchResult?.fallbackFlightData ?? null
     let shouldFetchOutputExportNotFound =
-      outputExportFallbackFetchKind === 'discovered' &&
       outputExportFallbackFetchResult !== null &&
       !outputExportFallbackFetchResult.matchesRenderedPathname
     if (
       fallbackFlightData === null &&
-      outputExportFallbackFetchKind !== 'none'
+      outputExportFallbackFetchResult !== null &&
+      process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS
     ) {
-      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
-        fallbackFlightData = fillInAndValidateFallbackFlightData(
-          flightResponse.f,
-          originalUrl.pathname,
-          originalUrl.search as NormalizedSearch
-        )
-        if (fallbackFlightData === null) {
-          shouldFetchOutputExportNotFound = true
-        }
-      } else {
-        fallbackFlightData = fillInFallbackFlightData(
-          flightResponse.f,
-          originalUrl.pathname,
-          originalUrl.search as NormalizedSearch
-        )
+      fallbackFlightData = fillInAndValidateFallbackFlightData(
+        flightResponse.f,
+        originalUrl.pathname,
+        originalUrl.search as NormalizedSearch
+      )
+      if (fallbackFlightData === null) {
+        shouldFetchOutputExportNotFound = true
       }
     }
 
     if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
       if (shouldFetchOutputExportNotFound) {
-        const outputExportFallback =
-          require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+        const outputExportFallback = getOutputExportFallbackModule()
+        if (outputExportFallback === null) {
+          return doMpaNavigation(originalUrl.href)
+        }
         const notFoundResult = await fetchOutputExportNotFoundFetchResult(
           outputExportFallback,
           originalUrl,
@@ -387,16 +380,20 @@ export async function fetchServerResponse(
           return doMpaNavigation(originalUrl.href)
         }
 
-        res = notFoundResult.response
-        responseUrl = originalUrl
-        canonicalUrl = originalUrl
-        contentType = res.headers.get('content-type') || ''
-        interception = !!res.headers.get('vary')?.includes(NEXT_URL)
-        postponed = true
-        isFlightResponse = true
+        const appliedNotFoundResponse = getAppliedOutputExportFallbackResponse(
+          notFoundResult,
+          originalUrl
+        )
+        res = appliedNotFoundResponse.response
+        responseUrl = appliedNotFoundResponse.responseUrl
+        canonicalUrl = appliedNotFoundResponse.canonicalUrl
+        interception = appliedNotFoundResponse.interception
+        postponed = appliedNotFoundResponse.postponed
         flightResponse = notFoundResult.flightResponse
         cacheData = notFoundResult.cacheData
         fallbackFlightData = notFoundResult.fallbackFlightData
+        staticExportFallbackPathname =
+          notFoundResult.staticExportFallbackPathname
       }
     } else {
       // Static export fallback route-shape checks are erased when the feature is off.
@@ -425,6 +422,7 @@ export async function fetchServerResponse(
       // header alone. So we need to investigate why the header is sometimes
       // wrong for interception routes.
       renderedSearch: flightResponse.q as NormalizedSearch,
+      staticExportFallbackPathname,
       couldBeIntercepted: interception,
       supportsPerSegmentPrefetching: flightResponse.S,
       postponed,
@@ -501,23 +499,83 @@ type FetchResponseCacheData = {
   responseBodyClone?: ReadableStream<Uint8Array>
 }
 
-type OutputExportFallbackFetchKind = 'none' | 'discovered'
-
 type OutputExportFallbackFetchResult = {
   response: RSCResponse<NavigationFlightResponse>
   flightResponse: NavigationFlightResponse
   cacheData: FetchResponseCacheData | null
   fallbackFlightData: NavigationFlightResponse['f']
   matchesRenderedPathname: boolean
+  staticExportFallbackPathname: string
+}
+
+let outputExportFallbackModule: OutputExportFallbackModule | undefined
+
+function getOutputExportFallbackModule(): OutputExportFallbackModule | null {
+  if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+    if (outputExportFallbackModule === undefined) {
+      outputExportFallbackModule =
+        require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+    }
+    return outputExportFallbackModule
+  } else {
+    return null
+  }
+}
+
+function getAppliedOutputExportFallbackResponse(
+  fallbackResult: OutputExportFallbackFetchResult,
+  renderedUrl: URL
+) {
+  const response = fallbackResult.response
+  return {
+    response,
+    responseUrl: renderedUrl,
+    canonicalUrl: renderedUrl,
+    interception: !!response.headers.get('vary')?.includes(NEXT_URL),
+    // Static export fallback payloads are partial-by-construction, but static
+    // hosts cannot attach the normal postpone header. Treat them as partial so
+    // Flight decoding accepts the closed stream and the router keeps the
+    // fallback shell suspended until dynamic holes resolve.
+    postponed: true,
+  }
+}
+
+async function fetchOutputExportFallbackFetchResultIfNeeded({
+  response,
+  isFlightResponse,
+  renderedUrl,
+  headers,
+}: {
+  response: RSCResponse<NavigationFlightResponse>
+  isFlightResponse: boolean
+  renderedUrl: URL
+  headers: RequestHeaders
+}): Promise<OutputExportFallbackFetchResult | null> {
+  if (isFlightResponse && response.ok && response.body) {
+    return null
+  }
+
+  const outputExportFallback = getOutputExportFallbackModule()
+  if (outputExportFallback === null) {
+    return null
+  }
+
+  return fetchOutputExportFallbackFetchResult(
+    outputExportFallback,
+    renderedUrl,
+    headers
+  )
 }
 
 async function createOutputExportFallbackFetchResult({
   response,
   renderedUrl,
+  staticExportFallbackPathname,
   headers,
 }: {
   response: Response
   renderedUrl: URL
+  staticExportFallbackPathname: string
   headers: RequestHeaders
 }): Promise<OutputExportFallbackFetchResult | null> {
   const { response: processed, cacheData } = await processFetch(response)
@@ -560,6 +618,7 @@ async function createOutputExportFallbackFetchResult({
     cacheData,
     fallbackFlightData,
     matchesRenderedPathname: matchedFallbackFlightData !== null,
+    staticExportFallbackPathname,
   }
 }
 
@@ -581,6 +640,7 @@ async function fetchOutputExportFallbackFetchResult(
   return createOutputExportFallbackFetchResult({
     response: fallbackResult.response,
     renderedUrl,
+    staticExportFallbackPathname: fallbackResult.fallbackUrl.pathname,
     headers,
   })
 }
@@ -606,6 +666,7 @@ async function fetchOutputExportNotFoundFetchResult(
   return createOutputExportFallbackFetchResult({
     response: notFoundResponse.response,
     renderedUrl,
+    staticExportFallbackPathname: notFoundResponse.fallbackUrl.pathname,
     headers,
   })
 }

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1625,7 +1625,8 @@ async function fetchMissingDynamicData(
       task.route,
       result.flightData,
       result.renderedSearch,
-      result.dynamicStaleTime
+      result.dynamicStaleTime,
+      result.staticExportFallbackPathname
     )
 
     // If the navigation lock is active, wait for it to be released before
@@ -1653,7 +1654,8 @@ async function fetchMissingDynamicData(
             staleAt,
             dynamicRequestTree,
             result.renderedSearch,
-            isResponsePartial
+            isResponsePartial,
+            result.staticExportFallbackPathname
           )
         })
         .catch(() => {
@@ -1667,7 +1669,8 @@ async function fetchMissingDynamicData(
         now,
         result.runtimePrefetchStream,
         dynamicRequestTree,
-        result.renderedSearch
+        result.renderedSearch,
+        result.staticExportFallbackPathname
       )
         .then((processed) => {
           if (processed !== null) {

--- a/packages/next/src/client/components/segment-cache/cache.test.ts
+++ b/packages/next/src/client/components/segment-cache/cache.test.ts
@@ -1,0 +1,233 @@
+import {
+  HEAD_REQUEST_KEY,
+  type SegmentRequestKey,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import type { VaryParamsThenable } from '../../../shared/lib/segment-cache/vary-params-decoding'
+import { FetchStrategy } from './types'
+import { Fallback } from './cache-map'
+import {
+  EntryStatus,
+  getStaticExportSegmentRequestUrl,
+  invalidateEntirePrefetchCache,
+  readSegmentCacheEntry,
+  readOrCreateSegmentCacheEntry,
+  upgradeToPendingSegment,
+  writeDynamicRenderResponseIntoCache,
+} from './cache'
+import { convertServerPatchToFullTree } from './navigation'
+import { finalizeMetadataVaryPath, finalizePageVaryPath } from './vary-path'
+
+describe('getStaticExportSegmentRequestUrl', () => {
+  it('uses the concrete rendered route when no fallback pathname is known', () => {
+    expect(
+      getStaticExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        HEAD_REQUEST_KEY,
+        { staticExportFallbackPathname: null }
+      ).href
+    ).toBe(
+      'https://example.com/org/acme/chat/thread-456/__next._head.txt?mode=full'
+    )
+  })
+
+  it('reuses the learned fallback pathname for sibling segment requests', () => {
+    expect(
+      getStaticExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        '/t/$d$threadId' as SegmentRequestKey,
+        { staticExportFallbackPathname: '/org/__fallback' }
+      ).href
+    ).toBe(
+      'https://example.com/org/__fallback/__next.t.$d$threadId.txt?mode=full'
+    )
+  })
+
+  it('keeps the matched branch fallback pathname for conflicting routes', () => {
+    expect(
+      getStaticExportSegmentRequestUrl(
+        new URL('https://example.com/docs/api/reference'),
+        '/docs/$d$section/$d$page' as SegmentRequestKey,
+        { staticExportFallbackPathname: '/docs/__fallback/__route_0' }
+      ).href
+    ).toBe(
+      'https://example.com/docs/__fallback/__route_0/__next.docs.$d$section.$d$page.txt'
+    )
+  })
+})
+
+describe('readOrCreateSegmentCacheEntry output export fallback', () => {
+  afterEach(() => {
+    delete process.env.__NEXT_VARY_PARAMS
+    invalidateEntirePrefetchCache(null, ['', {}])
+  })
+
+  it('dedupes pending metadata entries across sibling fallback params', () => {
+    const now = Date.now()
+    const firstTree = {
+      requestKey: HEAD_REQUEST_KEY,
+      segment: HEAD_REQUEST_KEY,
+      refreshState: null,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'first' as any,
+          parent: null,
+        } as any
+      ),
+      isPage: true as const,
+      slots: null,
+      prefetchHints: 0,
+    }
+    const secondTree = {
+      ...firstTree,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'second' as any,
+          parent: null,
+        } as any
+      ),
+    }
+
+    const firstEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      firstTree,
+      '/hydrated/__fallback'
+    )
+    const secondEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      secondTree,
+      '/hydrated/__fallback'
+    )
+
+    expect(firstEntry).toBe(secondEntry)
+    const secondThreadVaryPath = secondTree.varyPath.parent?.parent
+    expect(secondThreadVaryPath).not.toBeNull()
+    if (secondThreadVaryPath === null) {
+      throw new Error('expected metadata vary path to include thread params')
+    }
+    expect(secondThreadVaryPath.value).toBe('second')
+    expect(secondThreadVaryPath.value).not.toBe(Fallback)
+  })
+
+  it('rekeys runtime-prefetched fallback segments under generic params', () => {
+    process.env.__NEXT_VARY_PARAMS = 'true'
+
+    const now = Date.now()
+    const makeTree = (thread: string) => ({
+      requestKey: '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+      segment: '/t/$d$threadId' as SegmentRequestKey,
+      refreshState: null,
+      varyPath: finalizePageVaryPath(
+        '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'threadId',
+          value: thread as any,
+          parent: null,
+        } as any
+      ),
+      isPage: true as const,
+      slots: null,
+      prefetchHints: 0,
+    })
+
+    const firstTree = makeTree('first')
+    const secondTree = makeTree('second')
+    const emptyEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPRRuntime,
+      firstTree,
+      '/t/__fallback'
+    )
+    expect(emptyEntry.status).toBe(EntryStatus.Empty)
+    if (emptyEntry.status !== EntryStatus.Empty) {
+      throw new Error('expected a new empty segment cache entry')
+    }
+    const ownedEntry = upgradeToPendingSegment(
+      emptyEntry,
+      FetchStrategy.PPRRuntime
+    )
+    const fulfilledVaryParams = new Set(['threadId'])
+    const fulfilledVaryParamsThenable: VaryParamsThenable = {
+      status: 'fulfilled',
+      value: fulfilledVaryParams,
+      then<TResult1 = Set<string>, TResult2 = never>(
+        onfulfilled?:
+          | ((value: Set<string>) => TResult1 | PromiseLike<TResult1>)
+          | null,
+        _onrejected?:
+          | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+          | null
+      ): PromiseLike<TResult1 | TResult2> {
+        if (onfulfilled) {
+          return Promise.resolve(onfulfilled(fulfilledVaryParams))
+        }
+        return Promise.resolve(fulfilledVaryParams as TResult1)
+      },
+    }
+
+    writeDynamicRenderResponseIntoCache(
+      now,
+      FetchStrategy.PPRRuntime,
+      [
+        {
+          segmentPath: [],
+          pathToSegment: [],
+          segment: '',
+          tree: ['', {}],
+          seedData: [
+            'runtime fallback data',
+            {},
+            null,
+            false,
+            fulfilledVaryParamsThenable,
+          ],
+          head: null,
+          isHeadPartial: false,
+          isRootRender: true,
+        },
+      ],
+      undefined,
+      false,
+      null,
+      now + 30_000,
+      {
+        renderedSearch: '',
+        routeTree: firstTree,
+        metadataVaryPath: null,
+        data: null,
+        head: null,
+        dynamicStaleAt: now + 30_000,
+        staticExportFallbackPathname: '/t/__fallback',
+      },
+      new Map([[firstTree.requestKey, ownedEntry]])
+    )
+
+    const secondEntry = readSegmentCacheEntry(now, secondTree.varyPath)
+
+    expect(secondEntry).toBe(ownedEntry)
+    expect(secondEntry?.status).toBe(EntryStatus.Fulfilled)
+  })
+})
+
+describe('convertServerPatchToFullTree output export fallback', () => {
+  it('records the learned fallback artifact pathname on the returned navigation seed', () => {
+    const navigationSeed = convertServerPatchToFullTree(
+      Date.now(),
+      ['', {}],
+      null,
+      '',
+      0,
+      '/docs/__fallback'
+    )
+
+    expect(navigationSeed.staticExportFallbackPathname).toBe('/docs/__fallback')
+  })
+})

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -30,6 +30,7 @@ import {
 import {
   createFetch,
   createFromNextReadableStream,
+  processFetch,
   type RSCResponse,
   type RequestHeaders,
 } from '../router-reducer/fetch-server-response'
@@ -77,10 +78,12 @@ import { createCacheKey as createPrefetchRequestKey } from './cache-key'
 import {
   doesStaticSegmentAppearInURL,
   getCacheKeyForDynamicParam,
+  getNextPathnamePartsIndexForParam,
   getRenderedPathname,
   getRenderedSearch,
   parseDynamicParamFromURLPart,
 } from '../../route-params'
+import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-prefix'
 import {
   createCacheMap,
   getFromCacheMap,
@@ -105,6 +108,7 @@ import type {
   NavigationFlightResponse,
 } from '../../../shared/lib/app-router-types'
 import {
+  fillInAndValidateFallbackFlightData,
   type NormalizedFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -144,6 +148,11 @@ function getOfflineNavigationCacheModule():
     return null
   }
 }
+
+type OutputExportFallbackModule = typeof import('../../output-export-fallback')
+type OutputExportFallbackResult = Awaited<
+  ReturnType<OutputExportFallbackModule['fetchOutputExportFallbackResponse']>
+>
 
 /**
  * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
@@ -259,12 +268,25 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
+  hasInlinedSegments: boolean
+  staticExportFallbackPathname: string | null
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
   // to a different route structure (e.g., /foo was rewritten to /bar). Since
   // rewrite behavior can vary by param value, we can't safely predict the
   // route structure for other URLs matching this pattern.
   hasDynamicRewrite: boolean
+}
+
+type StaticExportFallbackRoute = Pick<
+  FulfilledRouteCacheEntry,
+  'staticExportFallbackPathname'
+>
+
+export function usesStaticExportFallback(
+  route: StaticExportFallbackRoute
+): boolean {
+  return route.staticExportFallbackPathname !== null
 }
 
 export type RouteCacheEntry =
@@ -381,6 +403,13 @@ export const MetadataOnlyRequestTree: FlightRouterState = [
   {},
   null,
   'metadata-only',
+]
+
+const DynamicRequestTreeForEntireRoute: FlightRouterState = [
+  '',
+  {},
+  null,
+  'refetch',
 ]
 
 let routeCacheMap: CacheMap<RouteCacheEntry> = createCacheMap()
@@ -788,6 +817,10 @@ export function deprecated_requestOptimisticRouteCacheEntry(
     couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
     supportsPerSegmentPrefetching:
       routeWithNoSearchParams.supportsPerSegmentPrefetching,
+    hasInlinedSegments: routeWithNoSearchParams.hasInlinedSegments,
+    // Output export fallback always enables the new optimistic route matcher,
+    // so the deprecated search-param prediction path stays export-agnostic.
+    staticExportFallbackPathname: null,
     hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
 
     // Override the rendered search with the optimistic value.
@@ -860,7 +893,8 @@ function deprecated_createOptimisticRouteTree(
 export function readOrCreateSegmentCacheEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  staticExportFallbackPathname: string | null = null
 ): SegmentCacheEntry {
   const existingEntry = readSegmentCacheEntry(now, tree.varyPath)
   if (existingEntry !== null) {
@@ -869,7 +903,11 @@ export function readOrCreateSegmentCacheEntry(
   // Create a pending entry and add it to the cache. The stale time is set to a
   // default value; the actual stale time will be set when the entry is
   // fulfilled with data from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    staticExportFallbackPathname
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = false
   setInCacheMap(
@@ -884,7 +922,8 @@ export function readOrCreateSegmentCacheEntry(
 export function readOrCreateRevalidatingSegmentEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  staticExportFallbackPathname: string | null = null
 ): SegmentCacheEntry {
   // This function is called when we've already confirmed that a particular
   // segment is cached, but we want to perform another request anyway in case it
@@ -920,7 +959,11 @@ export function readOrCreateRevalidatingSegmentEntry(
   // Create a pending entry and add it to the cache. The stale time is set to a
   // default value; the actual stale time will be set when the entry is
   // fulfilled with data from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    staticExportFallbackPathname
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = true
   setInCacheMap(
@@ -935,14 +978,19 @@ export function readOrCreateRevalidatingSegmentEntry(
 export function overwriteRevalidatingSegmentCacheEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  staticExportFallbackPathname: string | null = null
 ) {
   // This function is called when we've already decided to replace an existing
   // revalidation entry. Create a new entry and write it into the cache,
   // overwriting the previous value. The stale time is set to a default value;
   // the actual stale time will be set when the entry is fulfilled with data
   // from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    staticExportFallbackPathname
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = true
   setInCacheMap(
@@ -1208,6 +1256,8 @@ export function fulfillRouteCacheEntry(
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
+  fulfilledEntry.hasInlinedSegments = false
+  fulfilledEntry.staticExportFallbackPathname = null
   fulfilledEntry.hasDynamicRewrite = false
   pingBlockedTasks(entry)
   return fulfilledEntry
@@ -1560,7 +1610,9 @@ export function writeOfflineNavigationRouteRecordIntoCache(
     metadata: record.metadata as RouteTree,
     couldBeIntercepted: route.couldBeIntercepted,
     supportsPerSegmentPrefetching: route.supportsPerSegmentPrefetching,
+    hasInlinedSegments: false,
     hasDynamicRewrite: route.hasDynamicRewrite,
+    staticExportFallbackPathname: null,
     ref: null,
     size: 0,
     staleAt: record.staleAt,
@@ -1740,8 +1792,13 @@ function convertRootTreePrefetchToRouteTree(
   renderedSearch: NormalizedSearch,
   acc: RouteTreeAccumulator
 ) {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  const pathname =
+    basePath === ''
+      ? renderedPathname
+      : removePathPrefix(renderedPathname, basePath)
   // Remove trailing and leading slashes
-  const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
+  const pathnameParts = pathname.split('/').filter((p) => p !== '')
   const index = 0
   const rootSegment = ROOT_SEGMENT_REQUEST_KEY
   return convertTreePrefetchToRouteTree(
@@ -1786,7 +1843,7 @@ function convertTreePrefetchToRouteTree(
       const childSegmentName = childPrefetch.name
       const childParam = childPrefetch.param
 
-      let childDoesAppearInURL: boolean
+      let childPathnamePartsIndex: number
       let childSegment: FlightRouterStateSegment
       let childPartialVaryPath: PartialSegmentVaryPath | null
       if (childParam !== null) {
@@ -1829,20 +1886,20 @@ function convertTreePrefetchToRouteTree(
           childParam.type,
           childParam.siblings,
         ]
-        childDoesAppearInURL = true
+        childPathnamePartsIndex = getNextPathnamePartsIndexForParam(
+          childParam.type,
+          pathnameParts,
+          pathnamePartsIndex
+        )
       } else {
         // This segment does not have a param. Inherit the partial vary path of
         // the parent.
         childPartialVaryPath = partialVaryPath
         childSegment = childSegmentName
-        childDoesAppearInURL = doesStaticSegmentAppearInURL(childSegmentName)
+        childPathnamePartsIndex = doesStaticSegmentAppearInURL(childSegmentName)
+          ? pathnamePartsIndex + 1
+          : pathnamePartsIndex
       }
-
-      // Only increment the index if the segment appears in the URL. If it's a
-      // "virtual" segment, like a route group, it remains the same.
-      const childPathnamePartsIndex = childDoesAppearInURL
-        ? pathnamePartsIndex + 1
-        : pathnamePartsIndex
 
       const childRequestKeyPart = createSegmentRequestKeyPart(childSegment)
       const childRequestKey = appendSegmentRequestKeyPart(
@@ -2202,7 +2259,22 @@ export async function fetchRouteOnCacheMiss(
         response !== null && response.redirected ? new URL(response.url) : url
     }
 
-    if (!response || !response.ok || !response.body) {
+    if (
+      !response ||
+      !response.ok ||
+      // 204 is a Cache miss. Though theoretically this shouldn't happen when
+      // PPR is enabled, because we always respond to route tree requests, even
+      // if it needs to be blockingly generated on demand.
+      response.status === 204 ||
+      !response.body
+    ) {
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        return fetchRouteOnCacheMissFromOutputExportFallback(
+          entry,
+          key,
+          headers
+        )
+      }
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
@@ -2273,8 +2345,12 @@ export async function fetchRouteOnCacheMiss(
       // Get the params that were used to render the target page. These may
       // be different from the params in the request URL, if the page
       // was rewritten.
-      const renderedPathname = getRenderedPathname(response)
-      const renderedSearch = getRenderedSearch(response)
+      const renderedPathname = isOutputExportMode
+        ? (urlAfterRedirects.pathname as NormalizedPathname)
+        : getRenderedPathname(response)
+      const renderedSearch = isOutputExportMode
+        ? (urlAfterRedirects.search as NormalizedSearch)
+        : getRenderedSearch(response)
 
       // Convert the server-sent data into the RouteTree format used by the
       // client cache.
@@ -2404,6 +2480,271 @@ export async function fetchRouteOnCacheMiss(
   }
 }
 
+type OutputExportFallbackNavigationData = {
+  buildId: string | undefined
+  closed: Promise<void>
+  couldBeIntercepted: boolean
+  flightDatas: NormalizedFlightData[]
+  headVaryParams: VaryParams | null
+  staticExportFallbackPathname: string
+  responseSize: number
+  staleAt: number
+  supportsPerSegmentPrefetching: boolean
+}
+
+async function fetchOutputExportFallbackNavigationData(
+  renderedUrl: URL,
+  headers: RequestHeaders,
+  now: number
+): Promise<OutputExportFallbackNavigationData | null> {
+  let fallbackResult: OutputExportFallbackResult
+  if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+    const { fetchOutputExportFallbackResponse } =
+      require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+    fallbackResult = await fetchOutputExportFallbackResponse(renderedUrl, {
+      credentials: 'same-origin',
+      headers,
+    })
+  } else {
+    return null
+  }
+
+  if (fallbackResult === null) {
+    return null
+  }
+  // The user-visible route and the static fallback artifact can live at
+  // different paths. Keep the artifact path on the route entry so later
+  // per-segment requests are redirected to the fallback asset directory.
+  const staticExportFallbackPathname = fallbackResult.fallbackUrl.pathname
+
+  const { response } = await processFetch(fallbackResult.response)
+  if (!response.body) {
+    return null
+  }
+
+  const closed = createPromiseWithResolvers<void>()
+  const { stream: prefetchStream, size: responseSize } =
+    await createNonTaskyPrefetchResponseStream(response.body)
+  closed.resolve()
+
+  const serverData =
+    await createFromNextReadableStream<NavigationFlightResponse>(
+      prefetchStream,
+      headers,
+      { allowPartialStream: true }
+    )
+
+  const buildId =
+    response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
+  // Fallback RSC artifacts are served as static files. Some hosts cannot attach
+  // the navigation deployment header, and the serialized payload can omit `b`.
+  // Accept a missing id here, but keep rejecting explicit skew.
+  if (buildId !== undefined && buildId !== getNavigationBuildId()) {
+    return null
+  }
+
+  const renderedSearch = renderedUrl.search as NormalizedSearch
+  const headVaryParamsThenable = serverData.h
+  const headVaryParams =
+    headVaryParamsThenable !== null
+      ? readVaryParams(headVaryParamsThenable)
+      : null
+  const patchedFlightData = fillInAndValidateFallbackFlightData(
+    serverData.f,
+    renderedUrl.pathname,
+    renderedSearch
+  )
+  if (patchedFlightData === null) {
+    return null
+  }
+
+  const flightDatas = normalizeFlightData(patchedFlightData)
+
+  if (typeof flightDatas === 'string') {
+    return null
+  }
+
+  return {
+    buildId,
+    closed: closed.promise,
+    couldBeIntercepted: serverData.i,
+    flightDatas,
+    headVaryParams,
+    staticExportFallbackPathname,
+    responseSize,
+    staleAt: await getStaleAt(now, serverData.s),
+    supportsPerSegmentPrefetching: serverData.S,
+  }
+}
+
+async function fetchRouteOnCacheMissFromOutputExportFallback(
+  entry: PendingRouteCacheEntry,
+  key: RouteCacheKey,
+  headers: RequestHeaders
+): Promise<PrefetchSubtaskResult<null> | null> {
+  const now = Date.now()
+  const renderedUrl = new URL(key.pathname + key.search, location.origin)
+  const navigationData = await fetchOutputExportFallbackNavigationData(
+    renderedUrl,
+    headers,
+    now
+  )
+
+  if (navigationData === null) {
+    rejectRouteCacheEntry(entry, now + 10 * 1000)
+    return null
+  }
+
+  const {
+    buildId,
+    closed,
+    couldBeIntercepted,
+    flightDatas,
+    headVaryParams,
+    staticExportFallbackPathname,
+    responseSize,
+    staleAt,
+    supportsPerSegmentPrefetching,
+  } = navigationData
+  const renderedSearch = renderedUrl.search as NormalizedSearch
+  setSizeInCacheMap(entry, responseSize)
+
+  const navigationSeed = convertServerPatchToFullTree(
+    now,
+    DynamicRequestTreeForEntireRoute,
+    flightDatas,
+    renderedSearch,
+    UnknownDynamicStaleTime,
+    staticExportFallbackPathname
+  )
+  if (navigationSeed.metadataVaryPath === null) {
+    rejectRouteCacheEntry(entry, now + 10 * 1000)
+    return null
+  }
+
+  const fetchStrategy = supportsPerSegmentPrefetching
+    ? FetchStrategy.PPR
+    : FetchStrategy.LoadingBoundary
+  writeDynamicRenderResponseIntoCache(
+    now,
+    fetchStrategy,
+    flightDatas,
+    buildId,
+    false,
+    headVaryParams,
+    staleAt,
+    navigationSeed,
+    null
+  )
+
+  const fulfilledEntry = discoverKnownRoute(
+    now,
+    renderedUrl.pathname,
+    key.nextUrl,
+    entry,
+    navigationSeed.routeTree,
+    navigationSeed.metadataVaryPath,
+    couldBeIntercepted,
+    createHrefFromUrl(renderedUrl),
+    supportsPerSegmentPrefetching,
+    false,
+    { staticExportFallbackPathname }
+  )
+  fulfilledEntry.hasInlinedSegments = true
+
+  if (!couldBeIntercepted) {
+    const fulfilledVaryPath = getFulfilledRouteVaryPath(
+      key.pathname,
+      key.search,
+      key.nextUrl,
+      couldBeIntercepted
+    )
+    const isRevalidation = false
+    setInCacheMap(routeCacheMap, fulfilledVaryPath, entry, isRevalidation)
+  }
+
+  return { value: null, closed }
+}
+
+async function fetchSegmentsFromOutputExportFallback(
+  _route: FulfilledRouteCacheEntry,
+  routeKey: RouteCacheKey,
+  segments: SegmentBundle,
+  headers: RequestHeaders
+): Promise<PrefetchSubtaskResult<null> | null> {
+  const now = Date.now()
+  const renderedUrl = new URL(
+    routeKey.pathname + routeKey.search,
+    location.origin
+  )
+  const navigationData = await fetchOutputExportFallbackNavigationData(
+    renderedUrl,
+    headers,
+    now
+  )
+
+  if (navigationData === null) {
+    rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+    return null
+  }
+
+  const {
+    buildId,
+    closed,
+    flightDatas,
+    headVaryParams,
+    staticExportFallbackPathname,
+    staleAt,
+  } = navigationData
+  const renderedSearch = renderedUrl.search as NormalizedSearch
+
+  const spawnedEntries = new Map<SegmentRequestKey, PendingSegmentCacheEntry>()
+  let node: SegmentBundle | null = segments
+  while (node !== null) {
+    const nodeEntry = node.entry
+    const nodeTree = node.tree
+    if (
+      nodeTree !== null &&
+      nodeEntry !== null &&
+      nodeEntry.status === EntryStatus.Pending
+    ) {
+      spawnedEntries.set(nodeTree.requestKey, nodeEntry)
+    }
+    node = node.parent
+  }
+
+  const navigationSeed = convertServerPatchToFullTree(
+    now,
+    DynamicRequestTreeForEntireRoute,
+    flightDatas,
+    renderedSearch,
+    UnknownDynamicStaleTime,
+    staticExportFallbackPathname
+  )
+  if (navigationSeed.metadataVaryPath === null) {
+    rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+    return null
+  }
+
+  // Always use PPR strategy. The scheduler creates segment entries with
+  // FetchStrategy.PPR; upsertSegmentEntry rejects candidates whose strategy
+  // is "less specific" than the existing entry. Using LoadingBoundary here
+  // would cause the fallback-written segments to be silently rejected.
+  writeDynamicRenderResponseIntoCache(
+    now,
+    FetchStrategy.PPR,
+    flightDatas,
+    buildId,
+    false,
+    headVaryParams,
+    staleAt,
+    navigationSeed,
+    spawnedEntries
+  )
+
+  return { value: null, closed }
+}
+
 function rejectRemainingSegmentsInBundle(
   entries: SegmentBundle,
   staleAt: number
@@ -2463,10 +2804,14 @@ export async function fetchSegmentsOnCacheMiss(
   // Testing API. Static pre-renders don't normally happen during development.
   addInstantPrefetchHeaderIfLocked(headers)
 
-  const requestUrl = isOutputExportMode
-    ? // In output: "export" mode, we need to add the segment path to the URL.
-      addSegmentPathToUrlInOutputExportMode(url, normalizedRequestKey)
-    : url
+  let requestUrl = url
+  if (isOutputExportMode) {
+    requestUrl = getStaticExportSegmentRequestUrl(
+      url,
+      normalizedRequestKey,
+      route
+    )
+  }
   try {
     const response = await fetchPrefetchResponse(requestUrl, headers)
     if (
@@ -2484,6 +2829,17 @@ export async function fetchSegmentsOnCacheMiss(
         !isOutputExportMode) ||
       !response.body
     ) {
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        // Per-segment files don't exist for dynamic fallback routes. Try
+        // fetching the full fallback flight response instead and write its
+        // segments into the cache.
+        return fetchSegmentsFromOutputExportFallback(
+          route,
+          routeKey,
+          segments,
+          headers
+        )
+      }
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectRemainingSegmentsInBundle(segments, Date.now() + 10 * 1000)
@@ -2555,8 +2911,16 @@ export async function fetchSegmentsOnCacheMiss(
       // generic path. Otherwise use the request vary path.
       const canonicalVaryPath =
         process.env.__NEXT_VARY_PARAMS && data.varyParams !== null
-          ? getFulfilledSegmentVaryPath(node.tree.varyPath, data.varyParams)
-          : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree)
+          ? getFulfilledSegmentVaryPath(
+              node.tree.varyPath,
+              data.varyParams,
+              usesStaticExportFallback(route)
+            )
+          : getSegmentVaryPathForRequest(
+              FetchStrategy.PPR,
+              node.tree,
+              route.staticExportFallbackPathname
+            )
 
       let fulfilled: FulfilledSegmentCacheEntry | null = null
       const nodeEntry = node.entry
@@ -3023,6 +3387,7 @@ export function writeDynamicRenderResponseIntoCache(
         staleAt,
         seedData,
         isResponsePartial,
+        navigationSeed.staticExportFallbackPathname,
         spawnedEntries
       )
     }
@@ -3052,6 +3417,7 @@ export function writeDynamicRenderResponseIntoCache(
         // parameter.
         headVaryParams,
         metadataTree,
+        navigationSeed.staticExportFallbackPathname,
         spawnedEntries
       )
     }
@@ -3085,6 +3451,7 @@ function writeSeedDataIntoCache(
   staleAt: number,
   seedData: CacheNodeSeedData,
   isResponsePartial: boolean,
+  staticExportFallbackPathname: string | null,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -3108,6 +3475,7 @@ function writeSeedDataIntoCache(
     staleAt,
     varyParams,
     tree,
+    staticExportFallbackPathname,
     entriesOwnedByCurrentTask
   )
 
@@ -3127,6 +3495,7 @@ function writeSeedDataIntoCache(
           staleAt,
           childSeedData,
           isResponsePartial,
+          staticExportFallbackPathname,
           entriesOwnedByCurrentTask
         )
       }
@@ -3146,6 +3515,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   staleAt: number,
   segmentVaryParams: Set<string> | null,
   tree: RouteTree,
+  staticExportFallbackPathname: string | null,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -3169,7 +3539,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
     if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
       const fulfilledVaryPath = getFulfilledSegmentVaryPath(
         tree.varyPath,
-        segmentVaryParams
+        segmentVaryParams,
+        staticExportFallbackPathname !== null
       )
       const isRevalidation = false
       setInCacheMap(
@@ -3184,7 +3555,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
     const possiblyNewEntry = readOrCreateSegmentCacheEntry(
       now,
       fetchStrategy,
-      tree
+      tree,
+      staticExportFallbackPathname
     )
     if (possiblyNewEntry.status === EntryStatus.Empty) {
       // Confirmed this is a new entry. We can fulfill it.
@@ -3199,7 +3571,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
         const fulfilledVaryPath = getFulfilledSegmentVaryPath(
           tree.varyPath,
-          segmentVaryParams
+          segmentVaryParams,
+          staticExportFallbackPathname !== null
         )
         const isRevalidation = false
         setInCacheMap(
@@ -3225,8 +3598,16 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       // the request vary path.
       const varyPath =
         process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null
-          ? getFulfilledSegmentVaryPath(tree.varyPath, segmentVaryParams)
-          : getSegmentVaryPathForRequest(fetchStrategy, tree)
+          ? getFulfilledSegmentVaryPath(
+              tree.varyPath,
+              segmentVaryParams,
+              staticExportFallbackPathname !== null
+            )
+          : getSegmentVaryPathForRequest(
+              fetchStrategy,
+              tree,
+              staticExportFallbackPathname
+            )
       upsertSegmentEntry(now, varyPath, newEntry)
     }
   }
@@ -3253,15 +3634,22 @@ async function fetchPrefetchResponse<T>(
   }
 
   // Check the content type
+  const contentType = response.headers.get('content-type') || ''
   if (isOutputExportMode) {
-    // In output: "export" mode, we relaxed about the content type, since it's
-    // not Next.js that's serving the response. If the status is OK, assume the
-    // response is valid. If it's not a valid response, the Flight client won't
-    // be able to decode it, and we'll treat it as a miss.
+    if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+      const { isOutputExportFlightContentType } =
+        require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+      if (!isOutputExportFlightContentType(contentType)) {
+        return null
+      }
+    } else {
+      // Preserve the existing static export behavior when dynamic fallbacks are
+      // disabled: static hosts may not provide the normal RSC content type, so
+      // an OK response is allowed through and Flight decoding determines
+      // whether it was usable.
+    }
   } else {
-    const contentType = response.headers.get('content-type')
-    const isFlightResponse =
-      contentType && contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
+    const isFlightResponse = contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
     if (!isFlightResponse) {
       return null
     }
@@ -3374,6 +3762,39 @@ function createIncrementalPrefetchResponseStream(
   })
 }
 
+function getStaticExportSegmentRequestUrlForPathname(
+  url: URL,
+  segmentPath: SegmentRequestKey,
+  staticExportFallbackPathname: string | null
+): URL {
+  const staticUrl = new URL(url)
+  if (staticExportFallbackPathname !== null) {
+    // For dynamic fallback routes, the segment cache key is still based on the
+    // rendered URL, but the segment files are emitted next to the fallback RSC
+    // artifact. Request that artifact directory instead of the rendered route.
+    staticUrl.pathname = staticExportFallbackPathname
+  }
+  const routeDir = staticUrl.pathname.endsWith('/')
+    ? staticUrl.pathname.slice(0, -1)
+    : staticUrl.pathname
+  const staticExportFilename =
+    convertSegmentPathToStaticExportFilename(segmentPath)
+  staticUrl.pathname = `${routeDir}/${staticExportFilename}`
+  return staticUrl
+}
+
+export function getStaticExportSegmentRequestUrl(
+  url: URL,
+  segmentPath: SegmentRequestKey,
+  route: StaticExportFallbackRoute
+): URL {
+  return getStaticExportSegmentRequestUrlForPathname(
+    url,
+    segmentPath,
+    route.staticExportFallbackPathname
+  )
+}
+
 function addSegmentPathToUrlInOutputExportMode(
   url: URL,
   segmentPath: SegmentRequestKey
@@ -3381,14 +3802,7 @@ function addSegmentPathToUrlInOutputExportMode(
   if (isOutputExportMode) {
     // In output: "export" mode, we cannot use a header to encode the segment
     // path. Instead, we append it to the end of the pathname.
-    const staticUrl = new URL(url)
-    const routeDir = staticUrl.pathname.endsWith('/')
-      ? staticUrl.pathname.slice(0, -1)
-      : staticUrl.pathname
-    const staticExportFilename =
-      convertSegmentPathToStaticExportFilename(segmentPath)
-    staticUrl.pathname = `${routeDir}/${staticExportFilename}`
-    return staticUrl
+    return getStaticExportSegmentRequestUrlForPathname(url, segmentPath, null)
   }
   return url
 }
@@ -3557,7 +3971,8 @@ export function writeStaticStageResponseIntoCache(
   staleAt: number,
   baseTree: FlightRouterState,
   renderedSearch: string,
-  isResponsePartial: boolean
+  isResponsePartial: boolean,
+  staticExportFallbackPathname: string | null = null
 ): void {
   const fetchStrategy = isResponsePartial
     ? FetchStrategy.PPR
@@ -3577,7 +3992,8 @@ export function writeStaticStageResponseIntoCache(
     baseTree,
     flightDatas,
     renderedSearch,
-    UnknownDynamicStaleTime
+    UnknownDynamicStaleTime,
+    staticExportFallbackPathname
   )
   writeDynamicRenderResponseIntoCache(
     now,
@@ -3602,7 +4018,8 @@ export async function processRuntimePrefetchStream(
   now: number,
   runtimePrefetchStream: ReadableStream<Uint8Array>,
   baseTree: FlightRouterState,
-  renderedSearch: string
+  renderedSearch: string,
+  staticExportFallbackPathname: string | null = null
 ): Promise<{
   flightDatas: NormalizedFlightData[]
   navigationSeed: NavigationSeed
@@ -3637,7 +4054,8 @@ export async function processRuntimePrefetchStream(
     baseTree,
     flightDatas,
     renderedSearch,
-    UnknownDynamicStaleTime
+    UnknownDynamicStaleTime,
+    staticExportFallbackPathname
   )
 
   return {

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -109,6 +109,12 @@ function acquireLock(): void {
   }
 }
 
+export function armNavigationLockForTesting(): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    acquireLock()
+  }
+}
+
 function releaseLock(): void {
   if (lockState === null) {
     return

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -317,6 +317,7 @@ function navigateUsingPrefetchedRouteTree(
     data: null,
     head: null,
     dynamicStaleAt: computeDynamicStaleAt(now, UnknownDynamicStaleTime),
+    staticExportFallbackPathname: route.staticExportFallbackPathname,
   }
   return navigateToKnownRoute(
     now,
@@ -407,6 +408,7 @@ async function navigateToUnknownRoute(
     flightData,
     canonicalUrl,
     renderedSearch,
+    staticExportFallbackPathname,
     couldBeIntercepted,
     supportsPerSegmentPrefetching,
     dynamicStaleTime,
@@ -424,7 +426,8 @@ async function navigateToUnknownRoute(
     currentFlightRouterState,
     flightData,
     renderedSearch,
-    dynamicStaleTime
+    dynamicStaleTime,
+    staticExportFallbackPathname
   )
 
   // Learn the route pattern so we can predict it for future navigations.
@@ -444,7 +447,8 @@ async function navigateToUnknownRoute(
       couldBeIntercepted,
       createHrefFromUrl(canonicalUrl),
       supportsPerSegmentPrefetching,
-      false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
+      false, // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
+      { staticExportFallbackPathname }
     )
 
     if (staticStageData !== null) {
@@ -467,7 +471,8 @@ async function navigateToUnknownRoute(
             staleAt,
             currentFlightRouterState,
             renderedSearch,
-            isResponsePartial
+            isResponsePartial,
+            staticExportFallbackPathname
           )
         })
         .catch(() => {
@@ -481,7 +486,8 @@ async function navigateToUnknownRoute(
         now,
         runtimePrefetchStream,
         currentFlightRouterState,
-        renderedSearch
+        renderedSearch,
+        staticExportFallbackPathname
       )
         .then((processed) => {
           if (processed !== null) {
@@ -743,6 +749,7 @@ export type NavigationSeed = {
   data: CacheNodeSeedData | null
   head: HeadData | null
   dynamicStaleAt: number
+  staticExportFallbackPathname: string | null
 }
 
 export function convertServerPatchToFullTree(
@@ -750,7 +757,8 @@ export function convertServerPatchToFullTree(
   currentTree: FlightRouterState,
   flightData: Array<NormalizedFlightData> | null,
   renderedSearch: string,
-  dynamicStaleTimeSeconds: number
+  dynamicStaleTimeSeconds: number,
+  staticExportFallbackPathname: string | null = null
 ): NavigationSeed {
   // During a client navigation or prefetch, the server sends back only a patch
   // for the parts of the tree that have changed.
@@ -816,6 +824,7 @@ export function convertServerPatchToFullTree(
     renderedSearch,
     head,
     dynamicStaleAt: computeDynamicStaleAt(now, dynamicStaleTimeSeconds),
+    staticExportFallbackPathname,
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -166,6 +166,21 @@ type KnownRoutePart =
  */
 type ResolvedParams = Map<string, string | string[]>
 
+type DiscoverKnownRouteOptions = {
+  staticExportFallbackPathname?: string | null
+}
+
+function applyDiscoverKnownRouteOptions(
+  entry: FulfilledRouteCacheEntry,
+  options: DiscoverKnownRouteOptions | undefined
+): FulfilledRouteCacheEntry {
+  const staticExportFallbackPathname = options?.staticExportFallbackPathname
+  if (staticExportFallbackPathname != null) {
+    entry.staticExportFallbackPathname = staticExportFallbackPathname
+  }
+  return entry
+}
+
 /**
  * Read the pattern from a KnownRoutePart, evicting it if expired.
  *
@@ -182,7 +197,10 @@ function readPattern(
   if (pattern === null) {
     return null
   }
-  if (isValueExpired(now, getCurrentRouteCacheVersion(), pattern)) {
+  if (
+    pattern.staticExportFallbackPathname === null &&
+    isValueExpired(now, getCurrentRouteCacheVersion(), pattern)
+  ) {
     // The pattern is expired. Null it out so the slot can be repopulated.
     part.pattern = null
     return null
@@ -235,7 +253,8 @@ export function discoverKnownRoute(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   supportsPerSegmentPrefetching: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  options?: DiscoverKnownRouteOptions
 ): FulfilledRouteCacheEntry {
   const tree = routeTree
 
@@ -259,6 +278,7 @@ export function discoverKnownRoute(
     if (hasDynamicRewrite) {
       fulfilledEntry.hasDynamicRewrite = true
     }
+    applyDiscoverKnownRouteOptions(fulfilledEntry, options)
     // Populate the known route tree (handles rewrite detection internally).
     // The entry is already in the cache; this just stores it as a pattern
     // if the URL matches the route structure.
@@ -276,7 +296,8 @@ export function discoverKnownRoute(
       couldBeIntercepted,
       canonicalUrl,
       supportsPerSegmentPrefetching,
-      hasDynamicRewrite
+      hasDynamicRewrite,
+      options
     )
   } else {
     // No pending entry - discoverKnownRoutePart will create one and insert it
@@ -295,7 +316,8 @@ export function discoverKnownRoute(
       couldBeIntercepted,
       canonicalUrl,
       supportsPerSegmentPrefetching,
-      hasDynamicRewrite
+      hasDynamicRewrite,
+      options
     )
   }
 
@@ -380,7 +402,8 @@ export function restoreKnownRouteFromCacheEntry(
     entry.couldBeIntercepted,
     entry.canonicalUrl,
     entry.supportsPerSegmentPrefetching,
-    entry.hasDynamicRewrite
+    entry.hasDynamicRewrite,
+    undefined
   )
 }
 
@@ -436,7 +459,8 @@ function discoverKnownRoutePart(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   supportsPerSegmentPrefetching: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  options: DiscoverKnownRouteOptions | undefined
 ): FulfilledRouteCacheEntry {
   const segment = routeTree.segment
 
@@ -466,17 +490,20 @@ function discoverKnownRoutePart(
       // Don't populate the known route tree, just write the route into the
       // cache and return immediately.
       if (existingEntry !== null) {
-        return existingEntry
+        return applyDiscoverKnownRouteOptions(existingEntry, options)
       }
-      return writeRouteIntoCache(
-        now,
-        pathname as NormalizedPathname,
-        nextUrl,
-        fullTree,
-        metadataVaryPath,
-        couldBeIntercepted,
-        canonicalUrl,
-        supportsPerSegmentPrefetching
+      return applyDiscoverKnownRouteOptions(
+        writeRouteIntoCache(
+          now,
+          pathname as NormalizedPathname,
+          nextUrl,
+          fullTree,
+          metadataVaryPath,
+          couldBeIntercepted,
+          canonicalUrl,
+          supportsPerSegmentPrefetching
+        ),
+        options
       )
     }
 
@@ -495,14 +522,22 @@ function discoverKnownRoutePart(
       // - staticChildren: null = siblings unknown (can't safely match dynamic)
       // - staticChildren: Map = siblings known (even if empty)
       // This matters in dev mode where webpack may not know all siblings yet.
-      if (staticSiblings !== null) {
+      if (staticSiblings !== null || process.env.NODE_ENV === 'production') {
         // Siblings are known - ensure we have a Map (even if empty)
         if (parentKnownRoutePart.staticChildren === null) {
           parentKnownRoutePart.staticChildren = new Map()
         }
+      }
+      if (staticSiblings !== null) {
+        const staticChildren = parentKnownRoutePart.staticChildren
+        if (staticChildren === null) {
+          throw new Error(
+            'Expected staticChildren to be initialized for known dynamic siblings.'
+          )
+        }
         for (const sibling of staticSiblings) {
-          if (!parentKnownRoutePart.staticChildren.has(sibling)) {
-            parentKnownRoutePart.staticChildren.set(sibling, createEmptyPart())
+          if (!staticChildren.has(sibling)) {
+            staticChildren.set(sibling, createEmptyPart())
           }
         }
       }
@@ -556,7 +591,8 @@ function discoverKnownRoutePart(
         couldBeIntercepted,
         canonicalUrl,
         supportsPerSegmentPrefetching,
-        hasDynamicRewrite
+        hasDynamicRewrite,
+        options
       )
       // All parallel route branches share the same URL, so they should all
       // reach compatible leaf nodes. We capture any result.
@@ -568,17 +604,20 @@ function discoverKnownRoutePart(
     // Defensive fallback: no children returned a result. This shouldn't happen
     // for valid route trees, but handle it gracefully.
     if (existingEntry !== null) {
-      return existingEntry
+      return applyDiscoverKnownRouteOptions(existingEntry, options)
     }
-    return writeRouteIntoCache(
-      now,
-      pathname as NormalizedPathname,
-      nextUrl,
-      fullTree,
-      metadataVaryPath,
-      couldBeIntercepted,
-      canonicalUrl,
-      supportsPerSegmentPrefetching
+    return applyDiscoverKnownRouteOptions(
+      writeRouteIntoCache(
+        now,
+        pathname as NormalizedPathname,
+        nextUrl,
+        fullTree,
+        metadataVaryPath,
+        couldBeIntercepted,
+        canonicalUrl,
+        supportsPerSegmentPrefetching
+      ),
+      options
     )
   }
 
@@ -590,7 +629,7 @@ function discoverKnownRoutePart(
     if (hasDynamicRewrite) {
       existingPattern.hasDynamicRewrite = true
     }
-    return existingPattern
+    return applyDiscoverKnownRouteOptions(existingPattern, options)
   }
 
   // Get or create the entry
@@ -616,6 +655,7 @@ function discoverKnownRoutePart(
   if (hasDynamicRewrite) {
     entry.hasDynamicRewrite = true
   }
+  applyDiscoverKnownRouteOptions(entry, options)
 
   // Store as pattern
   knownRoutePart.pattern = entry
@@ -704,6 +744,8 @@ export function matchKnownRoute(
     metadata: reifiedMetadata,
     couldBeIntercepted: pattern.couldBeIntercepted,
     supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
+    hasInlinedSegments: pattern.hasInlinedSegments,
+    staticExportFallbackPathname: pattern.staticExportFallbackPathname,
     hasDynamicRewrite: false,
     renderedSearch: search,
     ref: null,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -615,10 +615,9 @@ function pingRoute(now: number, task: PrefetchTask): PrefetchTaskExitStatus {
     // Note that we don't need to prefetch any of the segment data. Just the
     // route tree.
     //
-    // TODO: This is a temporary solution; the plan is to replace this by adding
-    // a wildcard lookup method to the TupleMap implementation. This is
-    // non-trivial to implement because it needs to account for things like
-    // fallback route entries, hence this temporary workaround.
+    // Keep this as an explicit searchless prefetch instead of a wildcard cache
+    // lookup. Route entries are keyed by the exact URL shape, and static export
+    // fallback route entries need to participate in that same key space.
     const url = new URL(key.pathname, location.origin)
     const keyWithoutSearch = createCacheKey(url.href, key.nextUrl)
     const routeWithoutSearch = readOrCreateRouteCacheEntry(
@@ -707,6 +706,11 @@ function pingRootRouteTree(
     case EntryStatus.Fulfilled: {
       if (task.phase !== PrefetchPhase.Segments) {
         // Do not prefetch segment data until we've entered the segment phase.
+        return PrefetchTaskExitStatus.Done
+      }
+      if (route.hasInlinedSegments) {
+        // Segment data was already written into the cache during route
+        // fulfillment. Skip the per-segment fetch phase.
         return PrefetchTaskExitStatus.Done
       }
       // Recursively fill in the segment tree.
@@ -903,7 +907,8 @@ function pingStaticHead(
     entry: readOrCreateSegmentCacheEntry(
       now,
       FetchStrategy.PPR,
-      route.metadata
+      route.metadata,
+      route.staticExportFallbackPathname
     ),
     parent: null,
   }
@@ -1263,7 +1268,12 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
   let refetchMarker: 'refetch' | 'inside-shared-layout' | null =
     refetchMarkerContext === null ? 'inside-shared-layout' : null
 
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+  const segment = readOrCreateSegmentCacheEntry(
+    now,
+    task.fetchStrategy,
+    tree,
+    route.staticExportFallbackPathname
+  )
   switch (segment.status) {
     case EntryStatus.Empty: {
       // This segment is not cached. Add a refetch marker so the server knows
@@ -1373,7 +1383,8 @@ function pingRouteTreeAndIncludeDynamicData(
     // always use runtime prefetching (via `export const prefetch`), and those should check for
     // entries that include search params.
     fetchStrategy,
-    tree
+    tree,
+    route.staticExportFallbackPathname
   )
 
   let spawnedSegment: PendingSegmentCacheEntry | null = null
@@ -1422,7 +1433,12 @@ function pingRouteTreeAndIncludeDynamicData(
             break
           }
         }
-        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
+        spawnedSegment = pingFullSegmentRevalidation(
+          now,
+          route,
+          tree,
+          fetchStrategy
+        )
       }
       break
     }
@@ -1436,7 +1452,12 @@ function pingRouteTreeAndIncludeDynamicData(
           fetchStrategy
         )
       ) {
-        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
+        spawnedSegment = pingFullSegmentRevalidation(
+          now,
+          route,
+          tree,
+          fetchStrategy
+        )
       }
       break
     }
@@ -1656,7 +1677,12 @@ function accumulateSegmentBundle(
     }
   }
 
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+  const segment = readOrCreateSegmentCacheEntry(
+    now,
+    task.fetchStrategy,
+    tree,
+    route.staticExportFallbackPathname
+  )
 
   if (
     process.env.__NEXT_PREFETCH_INLINING &&
@@ -1682,7 +1708,8 @@ function accumulateSegmentBundle(
       entry: readOrCreateSegmentCacheEntry(
         now,
         FetchStrategy.PPR,
-        route.metadata
+        route.metadata,
+        route.staticExportFallbackPathname
       ),
       parent: parentBundle,
     }
@@ -1722,13 +1749,15 @@ function finishStaticBundleOnRuntimeBailout(
 
 function pingFullSegmentRevalidation(
   now: number,
+  route: FulfilledRouteCacheEntry,
   tree: RouteTree,
   fetchStrategy: FetchStrategy.Full | FetchStrategy.PPRRuntime
 ): PendingSegmentCacheEntry | null {
   const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
     now,
     fetchStrategy,
-    tree
+    tree,
+    route.staticExportFallbackPathname
   )
   if (revalidatingSegment.status === EntryStatus.Empty) {
     // During a Full/PPRRuntime prefetch, a single dynamic request is made for all the

--- a/packages/next/src/client/components/segment-cache/vary-path.test.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.test.ts
@@ -1,0 +1,105 @@
+import { Fallback } from './cache-map'
+import { FetchStrategy } from './types'
+import {
+  HEAD_REQUEST_KEY,
+  type SegmentRequestKey,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import {
+  finalizeMetadataVaryPath,
+  finalizePageVaryPath,
+  getFulfilledSegmentVaryPath,
+  getSegmentVaryPathForRequest,
+} from './vary-path'
+
+function getRequiredParent<T extends { parent: unknown | null }>(
+  path: T
+): Exclude<T['parent'], null> {
+  expect(path.parent).not.toBeNull()
+  return path.parent as Exclude<T['parent'], null>
+}
+
+describe('getSegmentVaryPathForRequest output export fallback', () => {
+  it('reuses path params for normal static prefetches', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: HEAD_REQUEST_KEY,
+        segment: HEAD_REQUEST_KEY,
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      null
+    )
+
+    expect(getRequiredParent(getRequiredParent(requestVaryPath)).value).toBe(
+      'j97358'
+    )
+  })
+
+  it('treats path params as reusable for learned output export fallback routes', () => {
+    const varyPath = finalizePageVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+        segment: '/t/$d$threadId' as SegmentRequestKey,
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      '/t/__fallback'
+    )
+
+    expect(getRequiredParent(requestVaryPath).value).toBe(Fallback)
+    expect(getRequiredParent(getRequiredParent(requestVaryPath)).value).toBe(
+      Fallback
+    )
+  })
+
+  it('keeps fulfilled fallback segment path params generic even when vary params include them', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const fulfilledVaryPath = getFulfilledSegmentVaryPath(
+      varyPath,
+      new Set(['?', 'threadId']),
+      true
+    )
+
+    expect(getRequiredParent(fulfilledVaryPath).value).toBe('')
+    expect(getRequiredParent(getRequiredParent(fulfilledVaryPath)).value).toBe(
+      Fallback
+    )
+  })
+})

--- a/packages/next/src/client/components/segment-cache/vary-path.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.ts
@@ -244,7 +244,8 @@ export function finalizeMetadataVaryPath(
 
 export function getSegmentVaryPathForRequest(
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  staticExportFallbackPathname: string | null = null
 ): SegmentVaryPath {
   // This is used for storing pending requests in the cache. We want to choose
   // the most generic vary path based on the strategy used to fetch it, i.e.
@@ -272,6 +273,15 @@ export function getSegmentVaryPathForRequest(
   // Only page segments (and the special "metadata" segment, which is treated
   // like a page segment for the purposes of caching) may contain search
   // params. There's no reason to include them in the vary path otherwise.
+  const originalPathParamsVaryPath = tree.isPage
+    ? getPartialPageVaryPath(originalVaryPath as PageVaryPath)
+    : getPartialLayoutVaryPath(originalVaryPath as LayoutVaryPath)
+
+  const pathParamsVaryPath =
+    staticExportFallbackPathname !== null
+      ? clonePathParamsVaryPathWithFallback(originalPathParamsVaryPath)
+      : originalPathParamsVaryPath
+
   if (tree.isPage) {
     // Only a runtime prefetch will include search params in the vary path.
     // Static prefetches never include search params, so they can be reused
@@ -287,8 +297,6 @@ export function getSegmentVaryPathForRequest(
       //
       // requestKey -> searchParams -> pathParams
       //               ^ This part gets replaced with Fallback
-      const searchParamsVaryPath = (originalVaryPath as PageVaryPath).parent
-      const pathParamsVaryPath = searchParamsVaryPath.parent
       const patchedVaryPath: VaryPath = {
         id: null,
         value: originalVaryPath.value,
@@ -300,10 +308,51 @@ export function getSegmentVaryPathForRequest(
       }
       return patchedVaryPath as SegmentVaryPath
     }
+
+    if (pathParamsVaryPath !== originalPathParamsVaryPath) {
+      const searchParamsVaryPath = (originalVaryPath as PageVaryPath).parent
+      const patchedVaryPath: VaryPath = {
+        id: null,
+        value: originalVaryPath.value,
+        parent: {
+          id: '?',
+          value: searchParamsVaryPath.value,
+          parent: pathParamsVaryPath,
+        },
+      }
+      return patchedVaryPath as SegmentVaryPath
+    }
+  }
+
+  if (pathParamsVaryPath !== originalPathParamsVaryPath) {
+    const patchedVaryPath: VaryPath = {
+      id: null,
+      value: originalVaryPath.value,
+      parent: pathParamsVaryPath,
+    }
+    return patchedVaryPath as SegmentVaryPath
   }
 
   // The request does vary on search params. We don't need to modify anything.
   return originalVaryPath as SegmentVaryPath
+}
+
+function clonePathParamsVaryPathWithFallback(
+  originalVaryPath: PartialSegmentVaryPath | null
+): PartialSegmentVaryPath | null {
+  if (originalVaryPath === null) {
+    return null
+  }
+
+  const clonedParent = clonePathParamsVaryPathWithFallback(
+    originalVaryPath.parent as PartialSegmentVaryPath | null
+  )
+  const clonedVaryPath: VaryPath = {
+    id: originalVaryPath.id,
+    value: originalVaryPath.id === null ? originalVaryPath.value : Fallback,
+    parent: clonedParent,
+  }
+  return clonedVaryPath as PartialSegmentVaryPath
 }
 
 export function clonePageVaryPathWithNewSearchParams(
@@ -336,7 +385,8 @@ export function getRenderedSearchFromVaryPath(
 
 export function getFulfilledSegmentVaryPath(
   original: VaryPath,
-  varyParams: Set<string>
+  varyParams: Set<string>,
+  forceFallbackPathParams: boolean = false
 ): SegmentVaryPath {
   // Re-keys a segment's vary path based on which params the segment actually
   // depends on. Params that are NOT in the varyParams set are replaced with
@@ -348,17 +398,26 @@ export function getFulfilledSegmentVaryPath(
   // accessed during rendering.
   const clone: VaryPath = {
     id: original.id,
-    // If the id is null, this node is not a param (e.g., it's a request key).
-    // If the id is in the varyParams set, keep the original value.
-    // Otherwise, replace with Fallback to make it reusable.
+    // If the id is null, this node is not a param (e.g., it's a request key),
+    // so always preserve it. For output export fallback routes, path params
+    // are always generic even if the server reports them as accessed, because
+    // the emitted fallback artifacts are shared across all param values.
     value:
-      original.id === null || varyParams.has(original.id)
+      original.id === null
         ? original.value
-        : Fallback,
+        : forceFallbackPathParams && original.id !== '?'
+          ? Fallback
+          : varyParams.has(original.id)
+            ? original.value
+            : Fallback,
     parent:
       original.parent === null
         ? null
-        : getFulfilledSegmentVaryPath(original.parent, varyParams),
+        : getFulfilledSegmentVaryPath(
+            original.parent,
+            varyParams,
+            forceFallbackPathParams
+          ),
   }
   return clone as SegmentVaryPath
 }

--- a/packages/next/src/client/output-export-fallback-bootstrap.ts
+++ b/packages/next/src/client/output-export-fallback-bootstrap.ts
@@ -30,6 +30,11 @@ type OutputExportFallbackState = {
   isFallback: boolean
 }
 
+type OutputExportFallbackInitialResponse = {
+  initialRSCPayload: InitialRSCPayload
+  staticExportFallbackPathname: string | null
+}
+
 declare global {
   interface Window {
     __NEXT_EXPORT_FALLBACK?: boolean
@@ -48,7 +53,7 @@ export async function createOutputExportFallbackInitialResponse({
 }: {
   createFromFetch: CreateFromFetch
   debugChannel: DebugChannel
-}): Promise<InitialRSCPayload> {
+}): Promise<OutputExportFallbackInitialResponse> {
   const renderedUrl = new URL(window.location.href)
   const fallbackResult = await fetchOutputExportFallbackResponse(renderedUrl, {
     credentials: 'same-origin',
@@ -68,7 +73,10 @@ export async function createOutputExportFallbackInitialResponse({
         renderedUrl.pathname
       )
     ) {
-      return fallbackPayload
+      return {
+        initialRSCPayload: fallbackPayload,
+        staticExportFallbackPathname: fallbackResult.fallbackUrl.pathname,
+      }
     }
   }
 
@@ -83,12 +91,15 @@ export async function createOutputExportFallbackInitialResponse({
       credentials: 'same-origin',
     }))
 
-  return decodeFallbackPrerenderPayload(
-    Promise.resolve(notFoundResult.response),
-    renderedUrl,
-    createFromFetch,
-    debugChannel
-  )
+  return {
+    initialRSCPayload: await decodeFallbackPrerenderPayload(
+      Promise.resolve(notFoundResult.response),
+      renderedUrl,
+      createFromFetch,
+      debugChannel
+    ),
+    staticExportFallbackPathname: notFoundResult.fallbackUrl.pathname,
+  }
 }
 
 async function decodeFallbackPrerenderPayload(

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/slug-client.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/slug-client.tsx
@@ -4,5 +4,5 @@ import { useParams } from 'next/navigation'
 
 export default function SlugClient() {
   const params = useParams()
-  return <h1>{params.slug}</h1>
+  return <h1 id="slug">{params.slug}</h1>
 }

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { createReadStream } from 'fs'
+import { createReadStream, promises as nodeFs } from 'fs'
 import fs from 'fs-extra'
 import http from 'http'
 import { join } from 'path'
@@ -15,7 +15,7 @@ describe('output-export-dynamic-fallbacks', () => {
     skipStart: true,
   })
 
-  it('writes fallback artifacts and resolves hard loads and prefetched soft navigations', async () => {
+  it('writes fallback artifacts and resolves hard loads and soft navigations', async () => {
     await next.build()
 
     const outDir = join(next.testDir, 'out')
@@ -56,7 +56,7 @@ describe('output-export-dynamic-fallbacks', () => {
       const hardLoad = await webdriver(port, '/another/alpha')
       try {
         await retry(async () => {
-          expect(await hardLoad.elementByCss('h1').text()).toBe('alpha')
+          expect(await hardLoad.elementByCss('#slug').text()).toBe('alpha')
         })
       } finally {
         await hardLoad.close()
@@ -75,11 +75,16 @@ describe('output-export-dynamic-fallbacks', () => {
 
         await act!(async () => {
           await toggle.click()
-          await softNav.elementByCss('a[href="/another/alpha"]').click()
         })
 
+        await act!(async () => {
+          await softNav.elementByCss('a[href="/another/alpha"]').click()
+        }, 'no-requests')
+
         await retry(async () => {
-          expect(await softNav.elementByCss('h1').text()).toBe('alpha')
+          expect(await softNav.eval('document.body.innerText')).toContain(
+            'alpha'
+          )
         })
       } finally {
         await softNav.close()
@@ -87,6 +92,57 @@ describe('output-export-dynamic-fallbacks', () => {
     } finally {
       await stopApp(app)
     }
+  })
+
+  it('does not ship fallback client code for regular apps when the flag is disabled', async () => {
+    await next.patchFile(
+      'next.config.js',
+      `/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: false,
+  },
+}
+
+module.exports = nextConfig
+`
+    )
+
+    await fs.remove(join(next.testDir, 'out'))
+    await next.build()
+
+    expect(
+      await fs.pathExists(join(next.testDir, 'out', '_fallback.html'))
+    ).toBe(false)
+    expect(
+      await fs.pathExists(
+        join(next.testDir, '.next', 'server', 'app', '_fallback.html')
+      )
+    ).toBe(false)
+
+    const htmlFiles = await readFilesRecursive(
+      join(next.testDir, '.next', 'server', 'app'),
+      (filename) => filename.endsWith('.html')
+    )
+    for (const htmlFile of htmlFiles) {
+      const html = await fs.readFile(htmlFile, 'utf8')
+      expect(html).not.toContain('__NEXT_EXPORT_FALLBACK')
+    }
+
+    const clientChunks = await readFilesRecursive(
+      join(next.testDir, '.next', 'static', 'chunks'),
+      (filename) => filename.endsWith('.js')
+    )
+    const clientBundle = (
+      await Promise.all(clientChunks.map((chunk) => fs.readFile(chunk, 'utf8')))
+    ).join('\n')
+
+    expect(clientBundle).not.toContain('output-export-fallback')
+    expect(clientBundle).not.toContain('__NEXT_EXPORT_FALLBACK')
+    expect(clientBundle).not.toContain('__fallback.meta.json')
   })
 })
 
@@ -124,4 +180,25 @@ async function startFallbackServer(outDir: string, port: number) {
 
   await new Promise<void>((resolve) => server.listen(port, resolve))
   return server
+}
+
+async function readFilesRecursive(
+  dir: string,
+  shouldInclude: (filename: string) => boolean
+): Promise<string[]> {
+  if (!(await fs.pathExists(dir))) {
+    return []
+  }
+
+  const files: string[] = []
+  const entries = await nodeFs.readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const absolutePath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await readFilesRecursive(absolutePath, shouldInclude)))
+    } else if (entry.isFile() && shouldInclude(absolutePath)) {
+      files.push(absolutePath)
+    }
+  }
+  return files
 }


### PR DESCRIPTION
This is PR 19 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93750 `output export fallbacks: validate fallback Flight responses (18/21)`.
Next PR: #93751 `output export fallbacks: support known params and export variants (20/21)`.

## What Changes
- Stores the learned `staticExportFallbackPathname` on existing Segment Cache route entries.
- Uses that route-entry fact to request fallback segment data without introducing a parallel fallback cache.

## Reviewer Focus
- The learned fallback pathname should live with the route entry that needs it.
- Segment Cache should dedupe pending fallback segment requests through its existing machinery.

## Proof In This PR
- `packages/next/src/client/components/segment-cache/cache.test.ts` covers fallback segment request URLs, pending-entry dedupe, and route-entry propagation.
- Output-export e2e covers no-extra-fetch behavior for fallback-fed navigation.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Known params, basePath, flat output, and conflict variants are widened in the next PR.

## Disabled-Flag Posture
Segment Cache fallback fields are only populated by the gated output-export fallback path.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. **Current PR:** [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
