### PR TITLE
output export fallbacks: resolve fallback artifacts from route manifests (17/21)

### DIFF
--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -1,0 +1,412 @@
+import {
+  addOutputExportDataSuffix,
+  clearOutputExportFallbackRouteManifestCache,
+  fetchOutputExportFallbackResponse,
+  getOutputExportFallbackCandidates,
+} from './output-export-fallback'
+
+describe('output export fallback helpers', () => {
+  const originalFetch = global.fetch
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
+  const originalTrailingSlash = process.env.__NEXT_TRAILING_SLASH
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    if (originalBasePath === undefined) {
+      delete process.env.__NEXT_ROUTER_BASEPATH
+    } else {
+      process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
+    }
+    if (originalTrailingSlash === undefined) {
+      delete process.env.__NEXT_TRAILING_SLASH
+    } else {
+      process.env.__NEXT_TRAILING_SLASH = originalTrailingSlash
+    }
+    clearOutputExportFallbackRouteManifestCache()
+    jest.restoreAllMocks()
+  })
+
+  it('discovers fallback candidates from deepest static prefix to root', () => {
+    expect(getOutputExportFallbackCandidates('/org/acme/chat/123')).toEqual([
+      '/org/acme/chat/123/__fallback',
+      '/org/acme/chat/__fallback',
+      '/org/acme/__fallback',
+      '/org/__fallback',
+      '/__fallback',
+    ])
+  })
+
+  it('includes the current pathname for optional catch-all root matches', () => {
+    expect(getOutputExportFallbackCandidates('/optional/')).toEqual([
+      '/optional/__fallback',
+      '/__fallback',
+    ])
+  })
+
+  it('adds the export data suffix for flat and trailing slash routes', () => {
+    expect(
+      addOutputExportDataSuffix(new URL('https://example.com/blog/post')).href
+    ).toBe('https://example.com/blog/post.txt')
+
+    expect(
+      addOutputExportDataSuffix(new URL('https://example.com/blog/post/')).href
+    ).toBe('https://example.com/blog/post/index.txt')
+  })
+
+  it('tries the direct fallback artifact before manifest lookups', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/org/acme/chat/123/__fallback.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/org/acme/chat/123')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/org/acme/chat/123/__fallback.txt',
+      'https://example.com/org/acme/chat/123/__fallback.meta.json',
+    ])
+  })
+
+  it('uses route manifest pathnames even when the direct artifact already exists', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/hydrated/second/__fallback/index.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      if (url.endsWith('/hydrated/second/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/hydrated/[thread]',
+                fallbackPath: '/hydrated/__fallback',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/hydrated/second/')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/hydrated/__fallback')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/hydrated/second/__fallback/index.txt',
+      'https://example.com/hydrated/second/__fallback.meta.json',
+    ])
+  })
+
+  it('falls through deeper prefixes before using a shallower fallback artifact', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/guides/export/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/export/__fallback.meta.json')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/__fallback.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/guides/export')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(result?.fallbackUrl.pathname).toBe('/docs/guides/__fallback')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/guides/export/__fallback.txt',
+      'https://example.com/docs/guides/export/__fallback.meta.json',
+      'https://example.com/docs/guides/__fallback.txt',
+      'https://example.com/docs/guides/__fallback.meta.json',
+    ])
+  })
+
+  it('prefers the trailing-slash fallback artifact when the request URL ends with /', async () => {
+    delete process.env.__NEXT_TRAILING_SLASH
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/org/umbrella/chat/thread-789/__fallback/index.txt')) {
+        return new Response('flight', {
+          status: 200,
+          headers: { 'content-type': 'text/x-component' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL(
+      'https://example.com/org/umbrella/chat/thread-789/'
+    )
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/org/umbrella/chat/thread-789/__fallback/index.txt',
+      'https://example.com/org/umbrella/chat/thread-789/__fallback.meta.json',
+    ])
+  })
+
+  it('uses route manifest to select the most specific conflicting route', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/api/reference/__fallback.txt',
+      'https://example.com/docs/api/reference/__fallback.meta.json',
+      'https://example.com/docs/api/__fallback.txt',
+      'https://example.com/docs/api/__fallback.meta.json',
+      'https://example.com/docs/__fallback.txt',
+      'https://example.com/docs/__fallback.meta.json',
+      'https://example.com/docs/__fallback/__route_0.txt',
+    ])
+  })
+
+  it('matches and fetches conflicting fallback branches under basePath via shallower metadata', async () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/base/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/base/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/base/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/base/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/base/docs/api/reference/__fallback.txt',
+      'https://example.com/base/docs/api/reference/__fallback.meta.json',
+      'https://example.com/base/docs/api/__fallback.txt',
+      'https://example.com/base/docs/api/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback.txt',
+      'https://example.com/base/docs/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback/__route_0.txt',
+    ])
+  })
+
+  it('dedupes route manifest across sibling routes', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    await fetchOutputExportFallbackResponse(
+      new URL('https://example.com/docs/api/reference')
+    )
+    await fetchOutputExportFallbackResponse(
+      new URL('https://example.com/docs/api/guide')
+    )
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/api/reference/__fallback.txt',
+      'https://example.com/docs/api/reference/__fallback.meta.json',
+      'https://example.com/docs/api/__fallback.txt',
+      'https://example.com/docs/api/__fallback.meta.json',
+      'https://example.com/docs/__fallback.txt',
+      'https://example.com/docs/__fallback.meta.json',
+      'https://example.com/docs/__fallback/__route_0.txt',
+      'https://example.com/docs/api/guide/__fallback.txt',
+      'https://example.com/docs/api/guide/__fallback.meta.json',
+      'https://example.com/docs/api/__fallback.txt',
+      'https://example.com/docs/__fallback.txt',
+      'https://example.com/docs/__fallback/__route_0.txt',
+    ])
+  })
+})

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -1,5 +1,52 @@
-import { getOutputExportFallbackPath } from '../lib/output-export-dynamic-fallback'
+import {
+  getOutputExportFallbackRouteManifestPath,
+  getOutputExportFallbackPath,
+  type OutputExportFallbackRouteManifestEntry,
+} from '../lib/output-export-dynamic-fallback'
+import { addPathPrefix } from '../shared/lib/router/utils/add-path-prefix'
+import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
+import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
+import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
+
+type OutputExportFallbackRouteManifest = {
+  version: 1
+  routes: OutputExportFallbackRouteManifestEntry[]
+}
+
+type OutputExportFallbackCacheStore = {
+  routeManifests: Map<string, Promise<OutputExportFallbackRouteManifest | null>>
+  // Only dedupe while the static asset request is in flight. Once the response
+  // has been decoded, the segment cache owns the fulfilled route data.
+  inFlightDataResponses: Map<
+    string,
+    Promise<OutputExportInFlightResponse | null>
+  >
+}
+
+type OutputExportInFlightResponse = {
+  body: ArrayBuffer
+  headers: Array<[string, string]>
+  status: number
+  statusText: string
+}
+
+type OutputExportFallbackResponseResult = {
+  response: Response
+  renderedUrl: URL
+  fallbackUrl: URL
+}
+
+const outputExportFallbackCacheStore: OutputExportFallbackCacheStore = {
+  routeManifests: new Map<
+    string,
+    Promise<OutputExportFallbackRouteManifest | null>
+  >(),
+  inFlightDataResponses: new Map<
+    string,
+    Promise<OutputExportInFlightResponse | null>
+  >(),
+}
 
 function getOutputExportCandidatePrefixes(pathname: string): string[] {
   const segments = pathname.split('/').filter(Boolean)
@@ -38,6 +85,64 @@ export function isOutputExportFlightContentType(contentType: string): boolean {
   )
 }
 
+export function clearOutputExportFallbackRouteManifestCache(): void {
+  outputExportFallbackCacheStore.routeManifests.clear()
+  outputExportFallbackCacheStore.inFlightDataResponses.clear()
+}
+
+function getOutputExportFallbackRouteManifestUrl(url: URL): URL {
+  const nextUrl = new URL(url)
+  nextUrl.pathname = getOutputExportFallbackRouteManifestPath(nextUrl.pathname)
+  return nextUrl
+}
+
+function matchOutputExportFallbackRouteManifestEntry(
+  entry: OutputExportFallbackRouteManifestEntry,
+  pathname: string
+): boolean {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  const matcher = getRouteMatcher(getRouteRegex(entry.route))
+  return matcher(removePathPrefix(pathname, basePath)) !== false
+}
+
+async function fetchOutputExportFallbackRouteManifest(
+  fallbackUrl: URL,
+  init?: RequestInit
+): Promise<OutputExportFallbackRouteManifest | null> {
+  const routeManifestUrl = getOutputExportFallbackRouteManifestUrl(fallbackUrl)
+  const cacheKey = routeManifestUrl.href
+  const routeManifestCache = outputExportFallbackCacheStore.routeManifests
+  const cached = routeManifestCache.get(cacheKey)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const routeManifestPromise = fetch(routeManifestUrl, init)
+    .then(async (routeManifestResponse) => {
+      if (!routeManifestResponse.ok) {
+        return null
+      }
+
+      const contentType =
+        routeManifestResponse.headers.get('content-type') || ''
+      if (
+        !contentType.startsWith('application/json') &&
+        !contentType.startsWith('text/json')
+      ) {
+        return null
+      }
+
+      return routeManifestResponse.json()
+    })
+    .catch((error) => {
+      routeManifestCache.delete(cacheKey)
+      throw error
+    })
+
+  routeManifestCache.set(cacheKey, routeManifestPromise)
+  return routeManifestPromise
+}
+
 function getConfiguredOutputExportDataUrl(
   url: URL,
   prefersTrailingSlash: boolean
@@ -64,23 +169,58 @@ async function fetchConfiguredOutputExportDataResult(
     prefersTrailingSlash
   )
 
-  const response = await fetch(configuredDataUrl, init)
-  const contentType = response.headers.get('content-type') || ''
-  if (
-    !response.ok ||
-    !response.body ||
-    !isOutputExportFlightContentType(contentType)
-  ) {
+  return fetchOutputExportDataResponseByUrl(configuredDataUrl, init)
+}
+
+async function fetchOutputExportDataResponseByUrl(
+  dataUrl: URL,
+  init?: RequestInit
+): Promise<Response | null> {
+  const cacheKey = dataUrl.href
+  const inFlightDataResponses =
+    outputExportFallbackCacheStore.inFlightDataResponses
+  let inFlightResponse = inFlightDataResponses.get(cacheKey)
+  if (inFlightResponse === undefined) {
+    inFlightResponse = fetch(dataUrl, init)
+      .then(async (response) => {
+        const contentType = response.headers.get('content-type') || ''
+        if (
+          !response.ok ||
+          !response.body ||
+          !isOutputExportFlightContentType(contentType)
+        ) {
+          return null
+        }
+
+        return {
+          body: await response.arrayBuffer(),
+          headers: Array.from(response.headers.entries()),
+          status: response.status,
+          statusText: response.statusText,
+        }
+      })
+      .finally(() => {
+        inFlightDataResponses.delete(cacheKey)
+      })
+    inFlightDataResponses.set(cacheKey, inFlightResponse)
+  }
+
+  const response = await inFlightResponse
+  if (response === null) {
     return null
   }
 
-  return response
+  return new Response(response.body.slice(0), {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
 }
 
 export async function fetchOutputExportFallbackResponse(
   renderedUrl: URL,
   init?: RequestInit
-): Promise<{ response: Response; renderedUrl: URL; fallbackUrl: URL } | null> {
+): Promise<OutputExportFallbackResponseResult | null> {
   const prefersTrailingSlash = renderedUrl.pathname.endsWith('/')
 
   for (const candidate of getOutputExportFallbackCandidates(
@@ -89,14 +229,65 @@ export async function fetchOutputExportFallbackResponse(
     const candidateUrl = new URL(renderedUrl)
     candidateUrl.pathname = candidate
 
-    const response = await fetchConfiguredOutputExportDataResult(
+    const directResult = await fetchConfiguredOutputExportDataResult(
       candidateUrl,
       prefersTrailingSlash,
       init
     )
-    if (response) {
+    const fallbackRouteManifest = await fetchOutputExportFallbackRouteManifest(
+      candidateUrl,
+      init
+    )
+    if (fallbackRouteManifest !== null) {
+      // A single-route manifest may still point at the public candidate path,
+      // in which case the direct result is the right response. When several
+      // routes share a prefix, each entry points at a private `__route_*`
+      // variant and we fetch that branch-specific asset below.
+      for (const entry of fallbackRouteManifest.routes) {
+        if (
+          !matchOutputExportFallbackRouteManifestEntry(
+            entry,
+            renderedUrl.pathname
+          )
+        ) {
+          continue
+        }
+
+        const branchFallbackUrl = new URL(renderedUrl)
+        const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+        branchFallbackUrl.pathname = addPathPrefix(
+          removePathPrefix(entry.fallbackPath, basePath),
+          basePath
+        )
+
+        if (directResult) {
+          return {
+            response: directResult,
+            renderedUrl,
+            fallbackUrl: branchFallbackUrl,
+          }
+        }
+
+        const result = await fetchConfiguredOutputExportDataResult(
+          branchFallbackUrl,
+          prefersTrailingSlash,
+          init
+        )
+        if (result) {
+          return {
+            response: result,
+            renderedUrl,
+            fallbackUrl: branchFallbackUrl,
+          }
+        }
+      }
+
+      continue
+    }
+
+    if (directResult) {
       return {
-        response,
+        response: directResult,
         renderedUrl,
         fallbackUrl: candidateUrl,
       }


### PR DESCRIPTION
This is PR 17 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after soft navigations know how to probe static fallback artifacts.
Previous PR: #93749 `output export fallbacks: resolve soft navigations through cached routes (16/21)`.
Next PR: #93750 `output export fallbacks: validate fallback Flight responses (18/21)`.

## What Changes
- Resolves the fallback RSC artifact for a requested URL by walking fallback candidate prefixes from deepest to root.
- Fetches route manifests for ambiguous fallback paths and selects the branch-specific fallback artifact whose route pattern matches the requested URL.
- Preserves direct fallback artifacts, trailing-slash handling, basePath handling, manifest dedupe, and in-flight static response dedupe inside the resolver helper.

## Reviewer Focus
- This PR should answer only: given a URL, which static fallback artifact should the client fetch?
- The resolver should prefer the configured direct artifact when it is enough, and use manifest entries only to disambiguate shared fallback prefixes.
- The resolver should not decide whether the decoded Flight payload is safe to hydrate.

## Proof In This PR
- `output-export-fallback` unit tests cover direct fallback lookup, manifest lookup, conflicting route selection, basePath, trailing slash, and manifest dedupe.
- I also ran this PR standalone with `pnpm test-unit packages/next/src/client/output-export-fallback.test.ts`; the repo script broadened to the unit suite and passed.

## Deferred Coverage
Flight payload validation, build-id policy, not-found replay, and Segment Cache storage are intentionally deferred to later PRs.

## Disabled-Flag Posture
The resolver remains reached through the output-export fallback feature path introduced earlier in the stack. Regular apps should not invoke this static-export fallback discovery.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. **Current PR:** [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
