### PR TITLE
fix(head): improve warning for unsupported tags in next/head

### DIFF
--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -119,13 +119,15 @@ function unique() {
 function reduceComponents(
   headChildrenElements: Array<React.ReactElement<any>>
 ) {
-  return headChildrenElements
+  const resolved = headChildrenElements
     .reduce(onlyReactElement, [])
     .reverse()
     .concat(defaultHead().reverse())
     .filter(unique())
     .reverse()
-    .map((c: React.ReactElement<any>, i: number) => {
+
+  const mapAndWarn = (items: Array<React.ReactElement<any>>) =>
+    items.map((c: React.ReactElement<any>, i: number) => {
       const key = c.key || i
       if (process.env.NODE_ENV === 'development') {
         // omit JSON-LD structured data snippets from the warning
@@ -144,6 +146,34 @@ function reduceComponents(
       }
       return React.cloneElement(c, { key })
     })
+
+  const allowedTags = new Set(['title', 'meta', 'link', 'script', 'style', 'base'])
+
+  const filtered = resolved.filter((c) => {
+    const t = c.type
+    if (typeof t === 'string') {
+      if (!allowedTags.has(t)) {
+        if (process.env.NODE_ENV === 'development') {
+          warnOnce(
+            `Unsupported tag <${t}> found in next/head — it will be ignored. Use Document for document-level tags. See https://nextjs.org/docs/messages/no-head-element`
+          )
+        }
+        return false
+      }
+      return true
+    }
+
+    // If it's not a string (component/class/function), warn and ignore it in development
+    if (process.env.NODE_ENV === 'development') {
+      const displayName = (t as any).displayName || (t as any).name || String(t)
+      warnOnce(
+        `Unsupported child type in next/head: ${displayName} — only plain HTML elements are supported. The element will be ignored.`
+      )
+    }
+    return false
+  })
+
+  return mapAndWarn(filtered)
 }
 
 /**

--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -147,7 +147,7 @@ function reduceComponents(
       return React.cloneElement(c, { key })
     })
 
-  const allowedTags = new Set(['title', 'meta', 'link', 'script', 'style', 'base'])
+  const allowedTags = new Set(['title', 'meta', 'link', 'script', 'style', 'base', 'noscript'])
 
   const filtered = resolved.filter((c) => {
     const t = c.type

--- a/test/unit/next-head-invalid-tags.test.ts
+++ b/test/unit/next-head-invalid-tags.test.ts
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import Head from 'next/head'
+import React from 'react'
+import ReactDOM from 'react-dom/server'
+
+describe('next/head invalid tags', () => {
+  it('ignores unsupported HTML tags inside Head without throwing', () => {
+    const html = ReactDOM.renderToString(
+      React.createElement(
+        React.Fragment,
+        {},
+        React.createElement(
+          Head,
+          {},
+          React.createElement('html', {}, 'bad-element'),
+          React.createElement('title', {}, 'my-title')
+        ),
+        React.createElement('p', {}, 'hello world')
+      )
+    )
+    expect(html).toContain('hello world')
+    // unsupported <html> should not be rendered inside head flow server-side
+    expect(html).not.toContain('bad-element')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Improves error handling for unsupported tags inside `next/head`.

Previously, invalid tags such as `<html>` triggered a misleading `next-head-count is missing` error and could result in incorrect DOM behavior.

## Changes made

* added validation for unsupported tags in `next/head`
* improved developer-facing warning message
* prevented unsupported tags from affecting rendering flow

## Why

This improves developer experience by surfacing a clearer and more actionable warning for unsupported tags used inside `next/head`.

Fixes #20924
