### PR TITLE
Revert "[test] Skip flaky `cached-navigations` tests"

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,7 +345,8 @@
       "@rspack/core@1.6.7": "patches/@rspack__core@1.6.7.patch",
       "@modelcontextprotocol/sdk": "patches/@modelcontextprotocol__sdk.patch",
       "@vercel/blob": "patches/@vercel__blob.patch",
-      "postcss-scss": "patches/postcss-scss.patch"
+      "postcss-scss": "patches/postcss-scss.patch",
+      "playwright-core@1.58.2": "patches/playwright-core@1.58.2.patch"
     }
   }
 }

--- a/patches/playwright-core@1.58.2.patch
+++ b/patches/playwright-core@1.58.2.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/client/browserContext.js b/lib/client/browserContext.js
+index 0b5cb3356cdc4917d9198a184f1a2cb391924453..3ad3d86bebde7a7e25af4f94b964d003e10d40a0 100644
+--- a/lib/client/browserContext.js
++++ b/lib/client/browserContext.js
+@@ -183,6 +183,19 @@ class BrowserContext extends import_channelOwner.ChannelOwner {
+   _onRequestFailed(request, responseEndTiming, failureText, page) {
+     request._failureText = failureText || null;
+     request._setResponseEndTiming(responseEndTiming);
++    // PATCH (next.js): mirror what `_onRequestFinished` does for the
++    // response, so callers awaiting `response.finished()` don't hang on
++    // failed/canceled requests. The server side already resolves the
++    // server-side `_finishedPromise` from `_onLoadingFailed` (see
++    // chromium/crNetworkManager.js), but only the `requestFinished` IPC
++    // carries a response payload — `requestFailed` does not, so the
++    // client-side Response's `_finishedPromise` is otherwise never
++    // resolved. We look up the response via the existing async RPC and
++    // resolve it fire-and-forget; catch is a no-op so we never produce
++    // an unhandled rejection if the context tears down concurrently.
++    request.response().then((response) => {
++      if (response !== null) response._finishedPromise.resolve(null);
++    }).catch(() => {});
+     this.emit(import_events.Events.BrowserContext.RequestFailed, request);
+     if (page)
+       page.emit(import_events.Events.Page.RequestFailed, request);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ patchedDependencies:
   minizlib@3.1.0:
     hash: 587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67
     path: patches/minizlib@3.1.0.patch
+  playwright-core@1.58.2:
+    hash: 064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886
+    path: patches/playwright-core@1.58.2.patch
   postcss-scss:
     hash: 88893e632b3e099730dc0ffcc93cf3654b31c277da9e2796e822f6b5aeedc093
     path: patches/postcss-scss.patch
@@ -33734,15 +33737,15 @@ snapshots:
 
   playwright-chromium@1.58.2:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.58.2(patch_hash=064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886)
 
   playwright-core@1.51.1: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.58.2(patch_hash=064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886): {}
 
   playwright@1.58.2:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.58.2(patch_hash=064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886)
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -13,8 +13,7 @@ describe('cached navigations', () => {
     return
   }
 
-  // TODO: flaky
-  it.skip('serves cached static segments instantly on the second navigation', async () => {
+  it('serves cached static segments instantly on the second navigation', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -182,8 +181,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('caches static segments when navigating to a known route without a prefetch', async () => {
+  it('caches static segments when navigating to a known route without a prefetch', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -276,8 +274,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('includes static params in the cached static stage', async () => {
+  it('includes static params in the cached static stage', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -337,8 +334,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('defers fallback params to the runtime stage', async () => {
+  it('defers fallback params to the runtime stage', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -407,8 +403,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('caches runtime-prefetchable content from a navigation for instant second visit', async () => {
+  it('caches runtime-prefetchable content from a navigation for instant second visit', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -562,8 +557,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('caches runtime-prefetchable content from the initial HTML for subsequent navigations', async () => {
+  it('caches runtime-prefetchable content from the initial HTML for subsequent navigations', async () => {
     let page: Playwright.Page
     // Start directly at /runtime-prefetchable — full HTML load, not a
     // client-side navigation. The RSC payload is inlined in the HTML and
@@ -757,8 +751,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('caches a partially static page from the initial HTML for subsequent navigations', async () => {
+  it('caches a partially static page from the initial HTML for subsequent navigations', async () => {
     let page: Playwright.Page
     // Start directly at /partially-static — full HTML load. The RSC payload
     // inlined in the HTML contains both cached and dynamic content.
@@ -824,8 +817,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('reuses cached page segment across different fallback params after navigation', async () => {
+  it('reuses cached page segment across different fallback params after navigation', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -886,8 +878,7 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: flaky
-  it.skip('reuses cached page segment across different fallback params after initial HTML load', async () => {
+  it('reuses cached page segment across different fallback params after initial HTML load', async () => {
     let page: Playwright.Page
     // Start directly at /with-fallback-params/foo — full HTML load. The RSC
     // payload inlined in the HTML seeds the segment cache with the page


### PR DESCRIPTION
Reverts vercel/next.js#92199.

Depends on #93802, which patches `playwright-core` to fix the root cause: the client-side `Response._finishedPromise` was never resolved on `requestFailed`, causing `response.finished()` to hang indefinitely and surface as opaque 60s Jest timeouts in router-act-using tests.

With that patch in place, the cached-navigations tests can be reinstated. This PR's CI is part of the verification path — the previously-flaky tests now run cleanly through the 3× flake-detection job.

<!-- NEXT_JS_LLM_PR -->