### PR TITLE
Patch `playwright-core` to resolve `_finishedPromise` on `requestFailed`

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,7 +345,8 @@
       "@rspack/core@1.6.7": "patches/@rspack__core@1.6.7.patch",
       "@modelcontextprotocol/sdk": "patches/@modelcontextprotocol__sdk.patch",
       "@vercel/blob": "patches/@vercel__blob.patch",
-      "postcss-scss": "patches/postcss-scss.patch"
+      "postcss-scss": "patches/postcss-scss.patch",
+      "playwright-core@1.58.2": "patches/playwright-core@1.58.2.patch"
     }
   }
 }

--- a/patches/playwright-core@1.58.2.patch
+++ b/patches/playwright-core@1.58.2.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/client/browserContext.js b/lib/client/browserContext.js
+index 0b5cb3356cdc4917d9198a184f1a2cb391924453..3ad3d86bebde7a7e25af4f94b964d003e10d40a0 100644
+--- a/lib/client/browserContext.js
++++ b/lib/client/browserContext.js
+@@ -183,6 +183,19 @@ class BrowserContext extends import_channelOwner.ChannelOwner {
+   _onRequestFailed(request, responseEndTiming, failureText, page) {
+     request._failureText = failureText || null;
+     request._setResponseEndTiming(responseEndTiming);
++    // PATCH (next.js): mirror what `_onRequestFinished` does for the
++    // response, so callers awaiting `response.finished()` don't hang on
++    // failed/canceled requests. The server side already resolves the
++    // server-side `_finishedPromise` from `_onLoadingFailed` (see
++    // chromium/crNetworkManager.js), but only the `requestFinished` IPC
++    // carries a response payload — `requestFailed` does not, so the
++    // client-side Response's `_finishedPromise` is otherwise never
++    // resolved. We look up the response via the existing async RPC and
++    // resolve it fire-and-forget; catch is a no-op so we never produce
++    // an unhandled rejection if the context tears down concurrently.
++    request.response().then((response) => {
++      if (response !== null) response._finishedPromise.resolve(null);
++    }).catch(() => {});
+     this.emit(import_events.Events.BrowserContext.RequestFailed, request);
+     if (page)
+       page.emit(import_events.Events.Page.RequestFailed, request);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ patchedDependencies:
   minizlib@3.1.0:
     hash: 587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67
     path: patches/minizlib@3.1.0.patch
+  playwright-core@1.58.2:
+    hash: 064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886
+    path: patches/playwright-core@1.58.2.patch
   postcss-scss:
     hash: 88893e632b3e099730dc0ffcc93cf3654b31c277da9e2796e822f6b5aeedc093
     path: patches/postcss-scss.patch
@@ -33734,15 +33737,15 @@ snapshots:
 
   playwright-chromium@1.58.2:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.58.2(patch_hash=064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886)
 
   playwright-core@1.51.1: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.58.2(patch_hash=064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886): {}
 
   playwright@1.58.2:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.58.2(patch_hash=064d5ffec38700c624b4c1a08fa7a1833aecdf196702f97d61f655385d18f886)
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
The client-side `BrowserContext._onRequestFailed` handler in `playwright-core` does not resolve the corresponding `Response._finishedPromise`, while `_onRequestFinished` does. When Chromium fires `Network.loadingFailed` for a request that already received a response — e.g. an RSC response that was delivered to the response buffer but is no longer needed because a soft navigation has already committed — the server-side `_finishedPromise` is resolved correctly (in `chromium/crNetworkManager._onLoadingFailed`), but the client side is never told. Any caller of `response.finished()` on such a response hangs indefinitely, surfacing in tests as a 60s Jest timeout with no clear stack trace.

This is the root cause of intermittent timeouts in router-act-using tests.

The patch mirrors the resolve step from `_onRequestFinished`: look up the response via the existing async `request.response()` RPC and fire-and-forget `resolve(null)` on its `_finishedPromise`. `catch` is a no-op so a tearing-down context doesn't produce an unhandled rejection.

Verified empirically against workflow run https://github.com/vercel/next.js/actions/runs/25760869258, which flake-detected all 40 router-act consumers (each 3 times) with diagnostic logging enabled. One `Network.loadingFailed canceled=true` event fired during the run (the canonical bug scenario: an outer `act` releasing a child `block: true` response that Chrome canceled mid-flight; see https://github.com/vercel/next.js/actions/runs/25760869258/job/75669131568) — pre-patch this would have hung until Jest's 60s test timeout fired, post-patch `response.finished()` resolved in 1ms. Alongside ~4000 normal resolutions, with zero `wait-browser-finished` hangs and zero router-act-related test failures.

This is a stop-gap until the router-act rewrite in #90959 lands, which replaces Playwright's `route.fulfill` + `response.finished()` flow with a browser-side `fetch` interception and removes the dependency on this Playwright code path entirely. The patch can be dropped at that point.