### PR TITLE
make rcstrs on the heap/static slightly smaller

### DIFF
--- a/turbopack/crates/turbo-rcstr-macros/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr-macros/src/lib.rs
@@ -40,7 +40,7 @@ pub fn rcstr(input: TokenStream) -> TokenStream {
                 format!("::turbo_rcstr::inline_atom({lit}).unwrap()")
             } else {
                 format!(
-                    "{{ static RCSTR_STORAGE: ::turbo_rcstr::PrehashedString = \
+                    "{{ static RCSTR_STORAGE: ::turbo_rcstr::StaticPrehashedString = \
                      ::turbo_rcstr::make_const_prehashed_string({lit}); const RCSTR: \
                      ::turbo_rcstr::RcStr = ::turbo_rcstr::from_static(&RCSTR_STORAGE); \
                      ::turbo_rcstr::__rcstr_inventory_submit!( \
@@ -51,7 +51,7 @@ pub fn rcstr(input: TokenStream) -> TokenStream {
             format!(
                 "{{ const TEXT: &str = {input}; if ::turbo_rcstr::is_atom_inlineable(TEXT) {{ \
                  ::turbo_rcstr::inline_atom(TEXT).unwrap() }} else {{ static RCSTR_STORAGE: \
-                 ::turbo_rcstr::PrehashedString = \
+                 ::turbo_rcstr::StaticPrehashedString = \
                  ::turbo_rcstr::make_const_prehashed_string(TEXT); const RCSTR: \
                  ::turbo_rcstr::RcStr = ::turbo_rcstr::from_static(&RCSTR_STORAGE); \
                  ::turbo_rcstr::__rcstr_inventory_submit!( \

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -63,6 +63,8 @@ pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
     let hash = hash_bytes(text.as_bytes());
 
     let prehashed = DynamicPrehashedString {
+        // NOTE: This will capture as a Box<str> which will essentially
+        // `shrink_to_fit` the bytes.
         value: text.into(),
         hash,
     };

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -7,49 +7,41 @@ use crate::{
     is_atom_inlineable, tagged_value::TaggedValue,
 };
 
-pub enum Payload {
-    String(String),
-    Ref(&'static str),
-}
-
-impl Payload {
-    pub(crate) fn as_str(&self) -> &str {
-        match self {
-            Payload::String(s) => s,
-            Payload::Ref(s) => s,
-        }
-    }
-    pub(crate) fn into_string(self) -> String {
-        match self {
-            Payload::String(s) => s,
-            Payload::Ref(r) => r.to_string(),
-        }
-    }
-}
-impl PartialEq for Payload {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-pub struct PrehashedString {
-    pub value: Payload,
+/// Read-only header for atoms allocated in static storage by the `rcstr!`
+/// macro. The value lives for `'static`, so we store a `&'static str` rather
+/// than owning the bytes.
+pub struct StaticPrehashedString {
+    pub value: &'static str,
     /// This is not the actual `fxhash`, but rather it's a value that passed to
     /// `write_u64` of [rustc_hash::FxHasher].
     pub hash: u64,
 }
 
-pub unsafe fn cast(ptr: TaggedValue) -> *const PrehashedString {
-    ptr.get_ptr().cast()
+/// Heap-owned header for atoms held in an [`Arc`]. `Box<str>` instead of
+/// `String` because the contents are immutable — we save the `capacity` field
+/// (and a tag/padding byte vs the old `Payload` enum) per atom.
+///
+/// TODO: collapse the two allocations (this header + the boxed bytes) into a
+/// single [`triomphe::ThinArc`] so the hash and bytes share one allocation and
+/// the inline pointer in [`crate::RcStr`] is one word. That change would make
+/// `RcStr::from(String)` copy the bytes, which would invalidate the current
+/// "cheap `String -> RcStr -> String`" property — worth a separate evaluation.
+pub struct DynamicPrehashedString {
+    pub value: Box<str>,
+    pub hash: u64,
 }
 
-pub(crate) unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i PrehashedString {
-    unsafe { &*cast(ptr) }
+pub(crate) unsafe fn deref_static<'i>(ptr: TaggedValue) -> &'i StaticPrehashedString {
+    unsafe { &*(ptr.get_ptr() as *const StaticPrehashedString) }
+}
+
+pub(crate) unsafe fn deref_dynamic<'i>(ptr: TaggedValue) -> &'i DynamicPrehashedString {
+    unsafe { &*(ptr.get_ptr() as *const DynamicPrehashedString) }
 }
 
 /// Caller should call `forget` (or `clone`) on the returned `Arc`
-pub unsafe fn restore_arc(v: TaggedValue) -> Arc<PrehashedString> {
-    let ptr = v.get_ptr() as *const PrehashedString;
+pub unsafe fn restore_arc(v: TaggedValue) -> Arc<DynamicPrehashedString> {
+    let ptr = v.get_ptr() as *const DynamicPrehashedString;
     unsafe { Arc::from_raw(ptr) }
 }
 
@@ -70,20 +62,20 @@ pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
 
     let hash = hash_bytes(text.as_bytes());
 
-    let prehashed = PrehashedString {
-        value: Payload::String(text.into()),
+    let prehashed = DynamicPrehashedString {
+        value: text.into(),
         hash,
     };
     new_atom_from_prehashed(prehashed)
 }
 
-/// Construct a new dynamic RcStr from a PrehashedString
-pub(crate) fn new_atom_from_prehashed(prehashed: PrehashedString) -> RcStr {
-    let entry: Arc<PrehashedString> = Arc::new(prehashed);
+/// Construct a new dynamic RcStr from a DynamicPrehashedString
+pub(crate) fn new_atom_from_prehashed(prehashed: DynamicPrehashedString) -> RcStr {
+    let entry: Arc<DynamicPrehashedString> = Arc::new(prehashed);
     let mut entry = Arc::into_raw(entry);
     debug_assert!(0 == entry as u8 & TAG_MASK);
-    entry = ((entry as usize) | DYNAMIC_TAG as usize) as *mut PrehashedString;
-    let ptr: NonNull<PrehashedString> = unsafe {
+    entry = ((entry as usize) | DYNAMIC_TAG as usize) as *mut DynamicPrehashedString;
+    let ptr: NonNull<DynamicPrehashedString> = unsafe {
         // Safety: Arc::into_raw returns a non-null pointer
         NonNull::new_unchecked(entry as *mut _)
     };
@@ -94,15 +86,15 @@ pub(crate) fn new_atom_from_prehashed(prehashed: PrehashedString) -> RcStr {
 }
 
 #[inline(always)]
-pub(crate) const fn new_static_atom(string: &'static PrehashedString) -> RcStr {
-    let entry = string as *const PrehashedString;
+pub(crate) const fn new_static_atom(string: &'static StaticPrehashedString) -> RcStr {
+    let entry = string as *const StaticPrehashedString;
     const {
-        debug_assert!(align_of::<PrehashedString>() >= 4);
+        debug_assert!(align_of::<StaticPrehashedString>() >= 4);
         // This must be 00, so that we don't have to remove the tag, which we can't since it would
         // require pointer-integer casts in a const context.
         debug_assert!(STATIC_TAG == 0b_00);
     }
-    let ptr: NonNull<PrehashedString> = unsafe {
+    let ptr: NonNull<StaticPrehashedString> = unsafe {
         // Safety: references always return a non-null pointers
         NonNull::new_unchecked(entry as *mut _)
     };

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -32,7 +32,10 @@ use triomphe::Arc;
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
 
 use crate::{
-    dynamic::{deref_from, hash_bytes, new_atom, new_atom_from_prehashed, new_static_atom},
+    dynamic::{
+        DynamicPrehashedString, deref_dynamic, deref_static, hash_bytes, new_atom,
+        new_atom_from_prehashed, new_static_atom,
+    },
     tagged_value::{MAX_INLINE_LEN, TaggedValue},
 };
 
@@ -121,9 +124,10 @@ impl RcStr {
 
     #[inline(never)]
     pub fn as_str(&self) -> &str {
-        match self.location() {
-            PREHASHED_STRING_LOCATION => self.prehashed_string_as_str(),
-            INLINE_LOCATION => self.inline_as_str(),
+        match self.tag() {
+            STATIC_TAG => unsafe { deref_static(self.unsafe_data).value },
+            DYNAMIC_TAG => unsafe { &deref_dynamic(self.unsafe_data).value },
+            INLINE_TAG => self.inline_as_str(),
             _ => unsafe { debug_unreachable!() },
         }
     }
@@ -133,12 +137,6 @@ impl RcStr {
         let len = (self.unsafe_data.tag_byte() & LEN_MASK) >> LEN_OFFSET;
         let src = self.unsafe_data.data();
         unsafe { std::str::from_utf8_unchecked(&src[..(len as usize)]) }
-    }
-
-    // Extract the str reference from a string stored in a PrehashedString
-    fn prehashed_string_as_str(&self) -> &str {
-        debug_assert!(self.location() == PREHASHED_STRING_LOCATION);
-        unsafe { dynamic::deref_from(self.unsafe_data).value.as_str() }
     }
 
     /// Returns an owned mutable [`String`].
@@ -154,12 +152,13 @@ impl RcStr {
                 // convert `self` into `arc`
                 let arc = unsafe { dynamic::restore_arc(ManuallyDrop::new(self).unsafe_data) };
                 match Arc::try_unwrap(arc) {
-                    Ok(v) => v.value.into_string(),
-                    Err(arc) => arc.value.as_str().to_string(),
+                    // `String::from(Box<str>)` reuses the boxed allocation, so this is O(1).
+                    Ok(v) => String::from(v.value),
+                    Err(arc) => arc.value.to_string(),
                 }
             }
             INLINE_TAG => self.inline_as_str().to_string(),
-            STATIC_TAG => self.prehashed_string_as_str().to_string(),
+            STATIC_TAG => unsafe { deref_static(self.unsafe_data).value.to_string() },
             _ => unsafe { debug_unreachable!() },
         }
     }
@@ -179,13 +178,13 @@ impl RcStr {
             let hash = hash_bytes(s.as_bytes());
             // Check the static table
             if let Some(entries) = STATIC_TABLE.get(&hash)
-                && let Some(static_phs) = entries.iter().find(|phs| phs.value.as_str() == s)
+                && let Some(static_phs) = entries.iter().find(|phs| phs.value == s)
             {
                 new_static_atom(static_phs)
             } else {
-                new_atom_from_prehashed(PrehashedString {
+                new_atom_from_prehashed(DynamicPrehashedString {
                     hash,
-                    value: dynamic::Payload::String(s.into()),
+                    value: s.into(),
                 })
             }
         } else {
@@ -358,17 +357,33 @@ impl PartialEq for RcStr {
         if self.unsafe_data == other.unsafe_data {
             return true;
         }
-        // They can still be equal if they are both stored on the heap
-        match (self.location(), other.location()) {
-            (PREHASHED_STRING_LOCATION, PREHASHED_STRING_LOCATION) => {
-                let l = unsafe { deref_from(self.unsafe_data) };
-                let r = unsafe { deref_from(other.unsafe_data) };
-                l.hash == r.hash && l.value == r.value
-            }
-            // NOTE: it is never possible for an inline storage string to compare equal to a dynamic
-            // allocated string, the construction routines separate the strings based on length.
-            _ => false,
+        // They can still be equal if they are both stored on the heap (STATIC or DYNAMIC).
+        // NOTE: it is never possible for an inline storage string to compare equal to a heap
+        // allocated string, the construction routines separate the strings based on length.
+        if self.location() != PREHASHED_STRING_LOCATION
+            || other.location() != PREHASHED_STRING_LOCATION
+        {
+            return false;
         }
+        let (l_hash, l_str) = unsafe { heap_hash_and_str(self) };
+        let (r_hash, r_str) = unsafe { heap_hash_and_str(other) };
+        l_hash == r_hash && l_str == r_str
+    }
+}
+
+/// Caller must ensure `s.location() == PREHASHED_STRING_LOCATION`.
+#[inline]
+unsafe fn heap_hash_and_str(s: &RcStr) -> (u64, &str) {
+    match s.tag() {
+        STATIC_TAG => {
+            let p = unsafe { deref_static(s.unsafe_data) };
+            (p.hash, p.value)
+        }
+        DYNAMIC_TAG => {
+            let p = unsafe { deref_dynamic(s.unsafe_data) };
+            (p.hash, &p.value)
+        }
+        _ => unsafe { debug_unreachable!() },
     }
 }
 
@@ -390,8 +405,8 @@ impl Hash for RcStr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self.location() {
             PREHASHED_STRING_LOCATION => {
-                let l = unsafe { deref_from(self.unsafe_data) };
-                state.write_u64(l.hash);
+                let (h, _) = unsafe { heap_hash_and_str(self) };
+                state.write_u64(h);
                 state.write_u8(0xff); // matches the implementation of the `str` Hash impl
             }
             INLINE_LOCATION => {
@@ -497,16 +512,16 @@ pub const fn is_atom_inlineable(s: &str) -> bool {
 
 #[doc(hidden)]
 #[inline(always)]
-pub const fn from_static(s: &'static PrehashedString) -> RcStr {
+pub const fn from_static(s: &'static StaticPrehashedString) -> RcStr {
     dynamic::new_static_atom(s)
 }
 #[doc(hidden)]
-pub use dynamic::PrehashedString;
+pub use dynamic::StaticPrehashedString;
 
 #[doc(hidden)]
-pub const fn make_const_prehashed_string(text: &'static str) -> PrehashedString {
-    PrehashedString {
-        value: dynamic::Payload::Ref(text),
+pub const fn make_const_prehashed_string(text: &'static str) -> StaticPrehashedString {
+    StaticPrehashedString {
+        value: text,
         hash: hash_bytes(text.as_bytes()),
     }
 }
@@ -517,7 +532,7 @@ pub use inventory;
 
 /// Wrapper for collecting `rcstr!` static constants via `inventory`.
 #[doc(hidden)]
-pub struct StaticRcStr(pub &'static PrehashedString);
+pub struct StaticRcStr(pub &'static StaticPrehashedString);
 
 inventory::collect!(StaticRcStr);
 
@@ -535,21 +550,21 @@ macro_rules! __rcstr_inventory_submit {
     };
 }
 
-/// Read-only lookup table mapping precomputed hash -> static PrehashedString.
+/// Read-only lookup table mapping precomputed hash -> static StaticPrehashedString.
 /// Built once on first access from all `rcstr!` constants collected by `inventory`.
 ///
 /// Multiple `rcstr!` calls with the same string content will each submit to
 /// inventory, but we deduplicate by content here so only one entry per unique
 /// string is stored.
 static STATIC_TABLE: LazyLock<
-    HashMap<u64, SmallVec<[&'static PrehashedString; 1]>, FxBuildHasher>,
+    HashMap<u64, SmallVec<[&'static StaticPrehashedString; 1]>, FxBuildHasher>,
 > = LazyLock::new(|| {
-    let mut map: HashMap<u64, SmallVec<[&'static PrehashedString; 1]>, FxBuildHasher> =
+    let mut map: HashMap<u64, SmallVec<[&'static StaticPrehashedString; 1]>, FxBuildHasher> =
         HashMap::with_hasher(FxBuildHasher);
     for StaticRcStr(phs) in inventory::iter::<StaticRcStr> {
-        if phs.value.as_str().len() <= MAX_INLINE_LEN {
+        if phs.value.len() <= MAX_INLINE_LEN {
             // This is rare, but possible if our macro cannot determine the length of the string at
-            // macro time we may end up with a wasted PrehashedString submitted to inventory.
+            // macro time we may end up with a wasted StaticPrehashedString submitted to inventory.
 
             // Just skip it
             continue;
@@ -558,10 +573,7 @@ static STATIC_TABLE: LazyLock<
         // Deduplicate: skip if an entry with the same string content exists
         // Mostly linkers will merge static strings but this isn't guaranteed so we cannot just rely
         // on pointer equality.
-        if !entries
-            .iter()
-            .any(|e| e.value.as_str() == phs.value.as_str())
-        {
+        if !entries.iter().any(|e| e.value == phs.value) {
             entries.push(phs);
         }
     }

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -99,15 +99,12 @@ unsafe impl Sync for RcStr {}
 
 // Marks a payload that is stored in an Arc
 const DYNAMIC_TAG: u8 = 0b_10;
-const PREHASHED_STRING_LOCATION: u8 = 0b_0;
 // Marks a payload that has been leaked since it has a static lifetime
 const STATIC_TAG: u8 = 0b_00;
 // The payload is stored inline
 const INLINE_TAG: u8 = 0b_01; // len in upper nybble
-const INLINE_LOCATION: u8 = 0b_1;
 const INLINE_TAG_INIT: NonZeroU8 = NonZeroU8::new(INLINE_TAG).unwrap();
 const TAG_MASK: u8 = 0b_11;
-const LOCATION_MASK: u8 = 0b_1;
 // For inline tags the length is stored in the upper 4 bits of the tag byte
 const LEN_OFFSET: usize = 4;
 const LEN_MASK: u8 = 0xf0;
@@ -116,10 +113,6 @@ impl RcStr {
     #[inline(always)]
     fn tag(&self) -> u8 {
         self.unsafe_data.tag_byte() & TAG_MASK
-    }
-    #[inline(always)]
-    fn location(&self) -> u8 {
-        self.unsafe_data.tag_byte() & LOCATION_MASK
     }
 
     #[inline(never)]
@@ -133,7 +126,7 @@ impl RcStr {
     }
 
     fn inline_as_str(&self) -> &str {
-        debug_assert!(self.location() == INLINE_LOCATION);
+        debug_assert!(self.tag() == INLINE_TAG);
         let len = (self.unsafe_data.tag_byte() & LEN_MASK) >> LEN_OFFSET;
         let src = self.unsafe_data.data();
         unsafe { std::str::from_utf8_unchecked(&src[..(len as usize)]) }
@@ -329,18 +322,19 @@ impl From<RcStr> for PathBuf {
 impl Clone for RcStr {
     #[inline(always)]
     fn clone(&self) -> Self {
-        let alias = self.unsafe_data;
-        // We only need to increment the ref count for DYNAMIC_TAG values
+        // We only need to increment the ref count for DYNAMIC_TAG values.
         // For STATIC_TAG and INLINE_TAG we can just copy the value.
-        if alias.tag_byte() & TAG_MASK == DYNAMIC_TAG {
+        if self.tag() == DYNAMIC_TAG {
             unsafe {
-                let arc = dynamic::restore_arc(alias);
+                let arc = dynamic::restore_arc(self.unsafe_data);
                 forget(arc.clone());
                 forget(arc);
             }
         }
 
-        RcStr { unsafe_data: alias }
+        RcStr {
+            unsafe_data: self.unsafe_data,
+        }
     }
 }
 
@@ -357,21 +351,21 @@ impl PartialEq for RcStr {
         if self.unsafe_data == other.unsafe_data {
             return true;
         }
-        // They can still be equal if they are both stored on the heap (STATIC or DYNAMIC).
-        // NOTE: it is never possible for an inline storage string to compare equal to a heap
-        // allocated string, the construction routines separate the strings based on length.
-        if self.location() != PREHASHED_STRING_LOCATION
-            || other.location() != PREHASHED_STRING_LOCATION
-        {
+        // If either side is inline, they can't be equal: an inline string is always shorter than
+        // any heap-allocated one (construction splits on length), and two inline strings would
+        // have been caught by the `unsafe_data == unsafe_data` check above.
+        if self.tag() == INLINE_TAG || other.tag() == INLINE_TAG {
             return false;
         }
+
+        // slow path compare precomputed hashes and string refs
         let (l_hash, l_str) = unsafe { heap_hash_and_str(self) };
         let (r_hash, r_str) = unsafe { heap_hash_and_str(other) };
         l_hash == r_hash && l_str == r_str
     }
 }
 
-/// Caller must ensure `s.location() == PREHASHED_STRING_LOCATION`.
+/// Caller must ensure `s.tag()` is `STATIC_TAG` or `DYNAMIC_TAG`.
 #[inline]
 unsafe fn heap_hash_and_str(s: &RcStr) -> (u64, &str) {
     match s.tag() {
@@ -403,13 +397,16 @@ impl Ord for RcStr {
 
 impl Hash for RcStr {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        match self.location() {
-            PREHASHED_STRING_LOCATION => {
-                let (h, _) = unsafe { heap_hash_and_str(self) };
-                state.write_u64(h);
+        match self.tag() {
+            STATIC_TAG => {
+                state.write_u64(unsafe { deref_static(self.unsafe_data).hash });
                 state.write_u8(0xff); // matches the implementation of the `str` Hash impl
             }
-            INLINE_LOCATION => {
+            DYNAMIC_TAG => {
+                state.write_u64(unsafe { deref_dynamic(self.unsafe_data).hash });
+                state.write_u8(0xff); // matches the implementation of the `str` Hash impl
+            }
+            INLINE_TAG => {
                 self.inline_as_str().hash(state);
             }
             _ => unsafe { debug_unreachable!() },
@@ -487,11 +484,8 @@ impl Drop for RcStr {
     fn drop(&mut self) {
         match self.tag() {
             DYNAMIC_TAG => unsafe { drop(dynamic::restore_arc(self.unsafe_data)) },
-            STATIC_TAG => {
-                // do nothing, these are never deallocated
-            }
-            INLINE_TAG => {
-                // do nothing, these payloads need no drop logic
+            INLINE_TAG | STATIC_TAG => {
+                // no-ops
             }
             _ => unsafe { debug_unreachable!() },
         }


### PR DESCRIPTION
### What?

Splits the previously unified `PrehashedString` (which held a `Payload` enum of `String | &'static str`) into two separate types: `StaticPrehashedString { value: &'static str, hash: u64 }` for atoms produced by `rcstr!` / `make_const_prehashed_string`, and `DynamicPrehashedString { value: Box<str>, hash: u64 }` for atoms held in an `Arc`. The static and dynamic paths were already distinguished by the `STATIC_TAG` / `DYNAMIC_TAG` bits in `RcStr`, so the runtime branch on enum discriminant was redundant.

### Why?

- **16 bytes saved per heap-allocated `RcStr` value .** Dynamic atoms drop the `String::capacity` field (which was always equal to `len` since the contents are immutable) and because they are stored in a `triomphe::Arc` this drops the Arc payload to 32 bytes instead of 40 which matches a mimalloc bucket (previously we were rounded up to a 48 byte bucket) so we save 16 bytes.
- **8 bytes saved per static `RcStr` value.** The linker will optimally align our 24 byte struct.
- Removes a layer of dispatch on the hot path (`as_str`, `==`, `Hash`) — typed deref to the correct variant instead of matching on `Payload`. (i.o.w. one 'descreminent' traversal instead of 2)

### How?

- `dynamic.rs`: `Payload` enum removed; two structs replace `PrehashedString`. `deref_from` split into `deref_static` and `deref_dynamic`. `restore_arc` returns `Arc<DynamicPrehashedString>`.
- `lib.rs`: `as_str` and `into_owned` dispatch on `tag()` (STATIC vs DYNAMIC vs INLINE) rather than `location()`. New `heap_hash_and_str` helper for `PartialEq` and `Hash` to share the static/dynamic branch. `into_owned`'s `try_unwrap` arm uses `String::from(Box<str>)` which reuses the box allocation (still O(1)).
- `turbo-rcstr-macros`: emit `::turbo_rcstr::StaticPrehashedString` instead of `::turbo_rcstr::PrehashedString`.
- Added a comment on `DynamicPrehashedString` noting the future move to `triomphe::ThinArc` to fold the two heap allocations (Arc header + boxed bytes) into one. Deferred because that change would make `RcStr::from(String)` copy the bytes, invalidating the documented cheap `String -> RcStr -> String` round-trip — wants a separate evaluation.


<!-- NEXT_JS_LLM_PR -->