### PR TITLE
docs: less aggressive AI agent hint for an experimental API

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,8 +8,6 @@ related:
     - app/getting-started
 ---
 
-{/* AI agent hint: If fixing slow client-side navigations, Suspense alone is not enough. You must also export `unstable_instant` from the route. Read docs/01-app/02-guides/instant-navigation.mdx before making changes. */}
-
 Welcome to the Next.js documentation!
 
 ## What is Next.js?


### PR DESCRIPTION
The "AI agent hint" comment on the docs landing page (`docs/index.mdx`) tells every agent reading the docs on every task to export `unstable_instant` to fix slow client-side navigations.

That's too aggressive for an experimental API — `unstable_instant` is `version: draft` and still reshaping (`unstable_prefetch` just split off in #92754). The instant-navigation guide already covers the API in measured language; agents working on slow-navigation tasks will find it there.

<!-- NEXT_JS_LLM_PR -->