### PR TITLE
fix: remove extra dot in codemod next-lint-to-eslint-cli

### DIFF
--- a/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
+++ b/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
@@ -918,14 +918,8 @@ function updatePackageJsonScripts(packageJsonContent: string): {
                 // Skip ext and its value
                 i++
               } else if (token.startsWith('--')) {
-                // Keep other flags and their values
+                // Keep other flags (boolean flags like --fix don't consume next arg)
                 eslintArgs.push(token)
-                if (
-                  i + 1 < argTokens.length &&
-                  !argTokens[i + 1].startsWith('--')
-                ) {
-                  eslintArgs.push(argTokens[++i])
-                }
               } else {
                 // Positional arguments (paths)
                 paths.push(token)


### PR DESCRIPTION
When the original lint script includes \--fix\ followed by a path (e.g. \
ext lint --fix .\), the codemod was incorrectly consuming the path as the value of \--fix\, then appending another \.\ for the missing path — resulting in \eslint --fix . .\.

The known value-taking flags (\--dir\, \--file\, \--rulesdir\, \--ext\) are already handled in separate branches. The generic \--\ branch should just pass the flag through without consuming the next token.

Closes #84616

<!-- NEXT_JS_LLM_PR -->