### PR TITLE
fix: GNU xargs warns about incompatible --replace/--max-args

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lint-ast-grep": "ast-grep scan",
     "lint-no-typescript": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" run-p prettier-check \"lint-eslint .\" lint-language",
     "types-and-precompiled": "run-p \"lint-typescript --log-order=stream\" check-compiler-fixtures types:test-lib && pnpm check-precompiled",
-    "check-compiler-fixtures": "find crates/next-custom-transforms/tests/fixture -type f -name 'tsconfig.json' -print0 | xargs --null -n1 -I'{}' pnpm tsc --noEmit --project '{}'",
+    "check-compiler-fixtures": "find crates/next-custom-transforms/tests/fixture -type f -name 'tsconfig.json' -print0 | xargs --null -I'{}' pnpm tsc --noEmit --project '{}'",
     "validate-externals-doc": "node ./scripts/validate-externals-doc.js",
     "check-unused-turbo-tasks": "node scripts/check-unused-turbo-tasks.mjs",
     "lint": "run-p test-types lint-typescript prettier-check \"lint-eslint .\" lint-ast-grep lint-language check-unused-turbo-tasks",


### PR DESCRIPTION
we were invoking

```
xargs --null -n1 -I'{}' ...
```
to tell xargs that we want to:
- use 1 argument per invocation (`-n1`)
- `{}` is the placeholder (`-I'{}'`)

but it seems like `-I'{}'` already implies `-n1`. BSD xargs doesn't care, but GNU xargs warns about it, so we get this in CI (e.g. [here](https://github.com/vercel/next.js/actions/runs/25789455488/job/75751231855?pr=93801#step:36:54)):
```
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
```

seems like both GNU and BSD xargs are happy if we just drop the `-n1` and only use `-I{}`.