### PR TITLE
Fix warning in new apps caused by incorrect image dimensions

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -46,7 +46,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>

--- a/packages/create-next-app/templates/app/js/app/page.js
+++ b/packages/create-next-app/templates/app/js/app/page.js
@@ -47,7 +47,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>

--- a/packages/create-next-app/templates/app/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app/ts/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>

--- a/packages/create-next-app/templates/default-tw/js/pages/index.js
+++ b/packages/create-next-app/templates/default-tw/js/pages/index.js
@@ -59,7 +59,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>

--- a/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
@@ -59,7 +59,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>

--- a/packages/create-next-app/templates/default/js/pages/index.js
+++ b/packages/create-next-app/templates/default/js/pages/index.js
@@ -68,7 +68,7 @@ export default function Home() {
                 src="/vercel.svg"
                 alt="Vercel logomark"
                 width={16}
-                height={16}
+                height={14}
               />
               Deploy Now
             </a>

--- a/packages/create-next-app/templates/default/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default/ts/pages/index.tsx
@@ -68,7 +68,7 @@ export default function Home() {
                 src="/vercel.svg"
                 alt="Vercel logomark"
                 width={16}
-                height={16}
+                height={14}
               />
               Deploy Now
             </a>

--- a/test/development/app-dir/create-next-app-default/create-next-app-default.test.ts
+++ b/test/development/app-dir/create-next-app-default/create-next-app-default.test.ts
@@ -1,0 +1,74 @@
+import { createNext } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { join } from 'path'
+import {
+  resolveNextTgzFilename,
+  run,
+  useTempDir,
+} from '../../../production/create-next-app/utils'
+
+const TEST_TIMEOUT_MS = 5 * 60 * 1000
+
+describe('create-next-app default template', () => {
+  let nextTgzFilename: string
+
+  beforeAll(() => {
+    nextTgzFilename = resolveNextTgzFilename()
+  })
+
+  it(
+    'should create and run without browser warnings or errors',
+    async () => {
+      await useTempDir(async (cwd) => {
+        const projectName = 'default-app'
+        const { exitCode } = await run(
+          [
+            projectName,
+            '--yes',
+            ...(process.env.NEXT_RSPACK ? ['--rspack'] : []),
+          ],
+          nextTgzFilename,
+          {
+            cwd,
+          }
+        )
+
+        expect(exitCode).toBe(0)
+
+        const nextBin = 'node_modules/next/dist/bin/next'
+        const next = await createNext({
+          files: join(cwd, projectName),
+          installCommand: 'true',
+          skipStart: false,
+          startCommand: `node ${nextBin} dev`,
+          startServerTimeout: 60_000,
+        })
+        let browser: Awaited<ReturnType<typeof next.browser>> | undefined
+
+        try {
+          browser = await next.browser('/')
+          const page = browser
+          expect(await page.elementByCss('body').text()).toContain('Deploy Now')
+
+          await retry(async () => {
+            const imagesReady = await page.eval(`
+              Array.from(document.images).every(
+                (img) => img.complete && img.naturalWidth > 0
+              )
+            `)
+            expect(imagesReady).toBe(true)
+          })
+
+          const messages = (await page.log()).filter(
+            (log) => log.source === 'warning' || log.source === 'error'
+          )
+          expect(messages).toEqual([])
+        } finally {
+          await browser?.close()
+          await next.destroy()
+        }
+      })
+    },
+    TEST_TIMEOUT_MS
+  )
+})

--- a/test/e2e/app-dir/middleware-rewrite-dynamic/app/page.tsx
+++ b/test/e2e/app-dir/middleware-rewrite-dynamic/app/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>

--- a/test/e2e/middleware-static-files/app/app/page.tsx
+++ b/test/e2e/middleware-static-files/app/app/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
-              height={16}
+              height={14}
             />
             Deploy Now
           </a>


### PR DESCRIPTION
Fixes the default create-next-app templates so the Vercel SVG logomark uses dimensions that match its intrinsic aspect ratio, avoiding the next/image development warning on freshly generated apps. Adds a regression test that creates the default app, runs it in dev mode, loads it in a browser, and asserts there are no browser warnings or errors.