### PR TITLE
Fix errors.json merge driver to handle gaps in error codes

### DIFF
--- a/scripts/merge-errors-json/merge.mjs
+++ b/scripts/merge-errors-json/merge.mjs
@@ -82,7 +82,7 @@ function mergeErrors(base, current, other) {
   /** @type {Set<string>} */
   const existingMessages = new Set(Object.values(result))
 
-  let nextKey = Object.keys(result).length + 1
+  let nextKey = getMaxNumericKey(result) + 1
 
   for (const message of getNewMessages(base, other)) {
     if (existingMessages.has(message)) {
@@ -95,6 +95,23 @@ function mergeErrors(base, current, other) {
   }
 
   return result
+}
+
+/**
+ * Returns the largest numeric key in the map, or 0 if there are no numeric
+ * keys. Existing entries may have gaps (e.g. when error codes were retired),
+ * so we can't rely on `Object.keys(result).length` to derive the next id.
+ * @param {ErrorsMap} map
+ */
+function getMaxNumericKey(map) {
+  let max = 0
+  for (const key of Object.keys(map)) {
+    const n = Number(key)
+    if (Number.isInteger(n) && n > max) {
+      max = n
+    }
+  }
+  return max
 }
 
 function getNewMessages(


### PR DESCRIPTION
### What?

Fixes the `errors.json` git merge driver (`scripts/merge-errors-json/merge.mjs`) so that it allocates new error ids based on the largest existing numeric key rather than the entry count. When the current file has gaps in its numeric keys (e.g. retired error codes), the previous logic produced ids that collided with existing entries and silently overwrote them during a rebase/merge.

### Why?

The driver computed the next id with:

```js
let nextKey = Object.keys(result).length + 1
```

This only works when ids are dense (`1..N` with no holes). `packages/next/errors.json` has accumulated gaps over time — for example missing ids around 1232–1234 and 1246 on `canary`. When a branch was rebased onto `canary` and the driver replayed a commit that added new entries, the computed `nextKey` (`length + 1`) pointed at an id that was already in use higher up in the map. The replayed entries then clobbered existing canary messages (e.g. "Route encountered %s during the initial render" and "in a Client Component" at 1244/1245), corrupting `errors.json` without raising a conflict.

Because the driver writes the result directly and exits 0, this kind of corruption is invisible at rebase time and only surfaces later when the displaced messages start producing wrong/duplicate codes at runtime.

### How?

- Introduce a `getMaxNumericKey(map)` helper that scans the keys of the merged map, parses each as an integer, and returns the largest value (or `0` if there are no numeric keys).
- Use `getMaxNumericKey(result) + 1` as the starting `nextKey` in `mergeErrors`, so newly added messages are always appended above the highest currently-used id, regardless of gaps.

Behavior for the dense / no-gap case is unchanged: `max + 1 === length + 1` when ids are `1..N` contiguous, so all three existing scenarios in `test/scripts/merge-errors-json/merge-errors-json.test.ts` (basic conflict, empty base, stacked PRs) continue to pass.

No changes to `errors.json` itself are included here; this PR only fixes the driver going forward.

<!-- NEXT_JS_LLM_PR -->
