### PR TITLE
fix(next): duplicated "to" in build template route comments

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -211,7 +211,7 @@ export async function handler(
   let srcPage = 'VAR_DEFINITION_PAGE'
 
   // turbopack doesn't normalize `/index` in the page name
-  // so we need to to process dynamic routes properly
+  // so we need to process dynamic routes properly
   // TODO: fix turbopack providing differing value from webpack
   if (process.env.TURBOPACK) {
     srcPage = srcPage.replace(/\/index$/, '') || '/'

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -116,7 +116,7 @@ export async function handler(
   let srcPage = 'VAR_DEFINITION_PAGE'
 
   // turbopack doesn't normalize `/index` in the page name
-  // so we need to to process dynamic routes properly
+  // so we need to process dynamic routes properly
   // TODO: fix turbopack providing differing value from webpack
   if (process.env.TURBOPACK) {
     srcPage = srcPage.replace(/\/index$/, '') || '/'

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -57,7 +57,7 @@ export async function handler(
   let srcPage = 'VAR_DEFINITION_PAGE'
 
   // turbopack doesn't normalize `/index` in the page name
-  // so we need to to process dynamic routes properly
+  // so we need to process dynamic routes properly
   // TODO: fix turbopack providing differing value from webpack
   if (process.env.TURBOPACK) {
     srcPage = srcPage.replace(/\/index$/, '') || '/'


### PR DESCRIPTION
Three identical one-line typo fixes in build templates under `packages/next/src/build/templates/`:
- `pages-api.ts` — "// so we need to to process dynamic routes properly" → "// so we need to process dynamic routes properly"
- `app-page.ts` — same fix
- `app-route.ts` — same fix

No code/behavior change.