### PR TITLE
fix(image): skip and delete 0-byte cache files to prevent LRU singleton poisoning

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -70,6 +70,15 @@ async function initCacheEntries(
   for (const cacheKey of cacheKeys) {
     try {
       const { expireAt, buffer } = await readFromCacheDir(cacheDir, cacheKey)
+      if (buffer.byteLength === 0) {
+        // A 0-byte file was left by an interrupted write (e.g., process killed
+        // mid-write on Windows). Passing size=0 to LRUCache.set() would throw
+        // and permanently poison the module-level disk-LRU singleton, breaking
+        // all subsequent image optimization for the lifetime of the process.
+        // Delete the corrupt file and skip this entry.
+        await deleteFromCacheDir(cacheDir, cacheKey)
+        continue
+      }
       entries.push({
         key: cacheKey,
         size: buffer.byteLength,

--- a/packages/next/src/server/lib/disk-lru-cache.external.test.ts
+++ b/packages/next/src/server/lib/disk-lru-cache.external.test.ts
@@ -1,0 +1,106 @@
+import { getOrInitDiskLRU, resetDiskLRU } from './disk-lru-cache.external'
+
+// Helpers to build mock callbacks — no fs access needed when maxDiskSize is provided.
+const makeReadEntries =
+  (
+    entries: Array<{ key: string; size: number; expireAt: number }>
+  ): Parameters<typeof getOrInitDiskLRU>[2] =>
+  async () =>
+    entries
+
+const makeEvict = (): Parameters<typeof getOrInitDiskLRU>[3] =>
+  jest.fn().mockResolvedValue(undefined)
+
+// maxDiskSize large enough that no evictions happen during init replay.
+const MAX = 100 * 1024 * 1024 // 100 MB
+
+describe('getOrInitDiskLRU', () => {
+  beforeEach(() => {
+    resetDiskLRU()
+  })
+
+  afterEach(() => {
+    resetDiskLRU()
+    jest.restoreAllMocks()
+  })
+
+  it('initialises the LRU with valid entries', async () => {
+    const entries = [
+      { key: 'img-a', size: 1024, expireAt: Date.now() + 60_000 },
+      { key: 'img-b', size: 2048, expireAt: Date.now() + 60_000 },
+    ]
+    const lru = await getOrInitDiskLRU(
+      '/cache',
+      MAX,
+      makeReadEntries(entries),
+      makeEvict()
+    )
+
+    expect(lru.has('img-a')).toBe(true)
+    expect(lru.has('img-b')).toBe(true)
+  })
+
+  it('skips a 0-byte (size=0) entry and warns instead of poisoning the singleton', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const entries = [
+      { key: 'corrupt', size: 0, expireAt: Date.now() + 60_000 },
+      { key: 'valid', size: 512, expireAt: Date.now() + 60_000 },
+    ]
+    const lru = await getOrInitDiskLRU(
+      '/cache',
+      MAX,
+      makeReadEntries(entries),
+      makeEvict()
+    )
+
+    // Corrupt entry must be skipped — not present in the LRU.
+    expect(lru.has('corrupt')).toBe(false)
+    // Valid entry must still be loaded.
+    expect(lru.has('valid')).toBe(true)
+    // A warning must be emitted identifying the bad entry.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('corrupt')
+    )
+  })
+
+  it('leaves the singleton functional after skipping a 0-byte entry', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const lru = await getOrInitDiskLRU(
+      '/cache',
+      MAX,
+      makeReadEntries([{ key: 'zero', size: 0, expireAt: Date.now() + 60_000 }]),
+      makeEvict()
+    )
+
+    // The singleton must not be poisoned — subsequent set() calls work fine.
+    expect(() => lru.set('new-img', 4096)).not.toThrow()
+    expect(lru.has('new-img')).toBe(true)
+  })
+
+  it('returns the same singleton instance on repeated calls', async () => {
+    const readEntries = makeReadEntries([
+      { key: 'img', size: 256, expireAt: Date.now() + 60_000 },
+    ])
+    const evict = makeEvict()
+
+    const lru1 = await getOrInitDiskLRU('/cache', MAX, readEntries, evict)
+    const lru2 = await getOrInitDiskLRU('/cache', MAX, readEntries, evict)
+
+    expect(lru1).toBe(lru2)
+  })
+
+  it('handles all-corrupt entries without throwing', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const entries = [
+      { key: 'bad-1', size: 0, expireAt: Date.now() + 60_000 },
+      { key: 'bad-2', size: 0, expireAt: Date.now() + 60_000 },
+    ]
+
+    await expect(
+      getOrInitDiskLRU('/cache', MAX, makeReadEntries(entries), makeEvict())
+    ).resolves.toBeDefined()
+  })
+})

--- a/packages/next/src/server/lib/disk-lru-cache.external.ts
+++ b/packages/next/src/server/lib/disk-lru-cache.external.ts
@@ -43,7 +43,17 @@ export async function getOrInitDiskLRU(
 
       const entries = await readEntries(cacheDir)
       for (const entry of entries) {
-        lru.set(entry.key, entry.size)
+        try {
+          lru.set(entry.key, entry.size)
+        } catch (err) {
+          // A corrupt entry (e.g. size ≤ 0 from a 0-byte file) must not
+          // reject the module-level promise and poison the singleton.
+          // Warn and skip so the rest of the cache remains usable.
+          console.warn(
+            `[next/image] Skipping corrupt disk-cache entry "${entry.key}" ` +
+              `(size=${entry.size}): ${err instanceof Error ? err.message : err}`
+          )
+        }
       }
 
       return lru


### PR DESCRIPTION
## What

Fixes #93757

A 0-byte file left in `.next/cache/images/` (or `.next/dev/cache/images/` in dev mode) by an interrupted `next dev` or `next start` process permanently breaks `next/image` optimisation for the rest of the process lifetime.

## Why it happens

When `next dev` is killed mid-write (Ctrl-C, OOM, antivirus interrupt — common on Windows), `fs.promises.writeFile` creates the inode before it finishes flushing bytes, leaving a 0-byte file on disk.

On the next server start the call chain is:

```
initCacheEntries()            ← pushes { size: 0 } for the 0-byte file
  → getOrInitDiskLRU()        ← replays entries via lru.set(key, 0)
    → LRUCache.set()          ← throws: "size must be > 0"
```

That throw **rejects the module-level `_diskLRUPromise`**. Because the promise is cached at module scope, every subsequent `await getOrInitDiskLRU(...)` re-throws — the disk LRU is permanently poisoned. The error key in the log (`Failed to write image to cache <key>`) is the *current* request's key, not the corrupt entry, making the bug very hard to diagnose.

## Fix

Two-layer defence so neither layer depends on the other being in place:

### Layer 1 — root cause (`image-optimizer.ts: initCacheEntries`)

After reading a cache-dir entry, check `buffer.byteLength === 0`. If the file is empty, delete it from disk with the existing `deleteFromCacheDir` helper and `continue` to the next key. The corrupt file is removed so it cannot cause the same problem on future starts.

```diff
+ if (buffer.byteLength === 0) {
+   await deleteFromCacheDir(cacheDir, cacheKey)
+   continue
+ }
```

### Layer 2 — defence-in-depth (`disk-lru-cache.external.ts: getOrInitDiskLRU`)

Wrap the per-entry `lru.set()` during the init replay in a `try/catch`. A bad entry now emits a `console.warn` (including the entry key and error message) and is skipped; the singleton promise resolves successfully and the rest of the cache remains usable.

```diff
- lru.set(entry.key, entry.size)
+ try {
+   lru.set(entry.key, entry.size)
+ } catch (err) {
+   console.warn(`[next/image] Skipping corrupt disk-cache entry ...`)
+ }
```

## Tests

Added `packages/next/src/server/lib/disk-lru-cache.external.test.ts` with five unit tests covering:

- Normal init with valid entries
- 0-byte (size=0) entry is skipped and a warning is emitted
- Singleton remains functional (not poisoned) after skipping a 0-byte entry
- Repeated `getOrInitDiskLRU` calls return the same singleton
- All-corrupt entries don't throw

Because `getOrInitDiskLRU` accepts `readEntries` and `evictEntry` as injected callbacks, and `maxDiskSize` is provided directly (bypassing the `statfs` call), the tests require **zero filesystem mocking**.

## Reproduction

Reproduced exactly as described in the issue:

```bash
mkdir -p .next/dev/cache/images/anyKey
: > .next/dev/cache/images/anyKey/14400.1.a.b.avif
# start next dev and request an image
# Before: "LRUCache: calculateSize returned 0" on every request
# After:  silent cleanup on startup, image serves normally
```

## Workaround for affected users (unchanged)

```bash
find .next -path '*/cache/images*' -size 0 -delete
# then restart the server
```