### PR TITLE
feat(eslint-plugin): add no-invalid-html-tags-in-head rule; add runtime warning in head.tsx

### DIFF
--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -14,6 +14,7 @@ import noHeadElement from './rules/no-head-element'
 import noHeadImportInDocument from './rules/no-head-import-in-document'
 import noHtmlLinkForPages from './rules/no-html-link-for-pages'
 import noImgElement from './rules/no-img-element'
+import noInvalidHtmlTagsInHead from './rules/no-invalid-html-tags-in-head'
 import noLocationAssign from './rules/no-location-assign-relative-destination'
 import noPageCustomFont from './rules/no-page-custom-font'
 import noScriptComponentInHead from './rules/no-script-component-in-head'
@@ -33,6 +34,7 @@ const recommendedRules = {
   '@next/next/no-css-tags': 'warn',
   '@next/next/no-head-element': 'warn',
   '@next/next/no-html-link-for-pages': 'warn',
+  '@next/next/no-invalid-html-tags-in-head': 'warn',
   '@next/next/no-img-element': 'warn',
   '@next/next/no-location-assign-relative-destination': 'warn',
   '@next/next/no-page-custom-font': 'warn',
@@ -75,6 +77,7 @@ const plugin = {
     'no-head-import-in-document': noHeadImportInDocument,
     'no-html-link-for-pages': noHtmlLinkForPages,
     'no-img-element': noImgElement,
+    'no-invalid-html-tags-in-head': noInvalidHtmlTagsInHead,
     'no-location-assign-relative-destination': noLocationAssign,
     'no-page-custom-font': noPageCustomFont,
     'no-script-component-in-head': noScriptComponentInHead,

--- a/packages/eslint-plugin-next/src/rules/no-invalid-html-tags-in-head.ts
+++ b/packages/eslint-plugin-next/src/rules/no-invalid-html-tags-in-head.ts
@@ -1,0 +1,78 @@
+import { defineRule } from '../utils/define-rule'
+
+const VALID_HEAD_TAGS = new Set([
+  'title',
+  'base',
+  'link',
+  'meta',
+  'script',
+  'style',
+  'noscript',
+  'template',
+])
+
+const url = 'https://nextjs.org/docs/messages/no-invalid-html-tags-in-head'
+
+export default defineRule({
+  meta: {
+    docs: {
+      description:
+        'Prevent use of invalid HTML elements inside the `next/head` component.',
+      recommended: true,
+      url,
+    },
+    type: 'problem',
+    schema: [],
+  },
+  create(context) {
+    let headImportName: string | null = null
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'next/head') {
+          return
+        }
+        const defaultImport = node.specifiers.find(
+          (s) => s.type === 'ImportDefaultSpecifier'
+        )
+        if (defaultImport) {
+          headImportName = defaultImport.local.name
+        }
+      },
+      JSXElement(node) {
+        if (!headImportName) {
+          return
+        }
+
+        const { openingElement } = node
+        if (
+          openingElement.name.type !== 'JSXIdentifier' ||
+          openingElement.name.name !== headImportName
+        ) {
+          return
+        }
+
+        for (const child of node.children) {
+          if (
+            child.type !== 'JSXElement' ||
+            child.openingElement.name.type !== 'JSXIdentifier'
+          ) {
+            continue
+          }
+
+          const tagName = child.openingElement.name.name
+          // Only lint lowercase names (native HTML elements); skip React components.
+          if (tagName !== tagName.toLowerCase()) {
+            continue
+          }
+          if (!VALID_HEAD_TAGS.has(tagName)) {
+            context.report({
+              node: child,
+              message: `\`<${tagName}>\` is not a valid element inside \`<Head>\` from \`next/head\`. Only elements valid inside \`<head>\` are allowed (title, base, link, meta, script, style, noscript, template). See: ${url}`,
+            })
+          }
+        }
+      },
+    }
+  },
+})

--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -116,6 +116,17 @@ function unique() {
  *
  * @param headChildrenElements List of children of <Head>
  */
+const VALID_HEAD_TAGS = new Set([
+  'title',
+  'base',
+  'link',
+  'meta',
+  'script',
+  'style',
+  'noscript',
+  'template',
+])
+
 function reduceComponents(
   headChildrenElements: Array<React.ReactElement<any>>
 ) {
@@ -139,6 +150,13 @@ function reduceComponents(
         } else if (c.type === 'link' && c.props['rel'] === 'stylesheet') {
           warnOnce(
             `Do not add stylesheets using next/head (see <link rel="stylesheet"> tag with href="${c.props['href']}"). Use Document instead. \nSee more info here: https://nextjs.org/docs/messages/no-stylesheets-in-head-component`
+          )
+        } else if (
+          typeof c.type === 'string' &&
+          !VALID_HEAD_TAGS.has(c.type)
+        ) {
+          warnOnce(
+            `\`<${c.type}>\` is not a valid element inside \`<Head>\` from \`next/head\`. Only elements valid inside \`<head>\` are allowed (title, base, link, meta, script, style, noscript, template). See: https://nextjs.org/docs/messages/no-invalid-html-tags-in-head`
           )
         }
       }

--- a/test/unit/eslint-plugin-next/no-invalid-html-tags-in-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-invalid-html-tags-in-head.test.ts
@@ -1,0 +1,137 @@
+import { RuleTester } from 'eslint'
+import { rules } from '@next/eslint-plugin-next'
+
+const NextESLintRule = rules['no-invalid-html-tags-in-head']
+
+const url = 'https://nextjs.org/docs/messages/no-invalid-html-tags-in-head'
+
+const tests = {
+  valid: [
+    // Valid HTML head elements should be allowed
+    `import Head from "next/head";
+     export default function Index() {
+       return (
+         <Head>
+           <title>My Page</title>
+           <meta name="description" content="Test" />
+           <link rel="canonical" href="https://example.com" />
+           <script src="/script.js" />
+           <style>{'body { margin: 0; }'}</style>
+           <base href="/" />
+           <noscript>Please enable JS</noscript>
+         </Head>
+       );
+     }`,
+    // Non-next/head Head component should not be linted
+    `const Head = ({ children }) => <div>{children}</div>;
+     export default function Index() {
+       return (
+         <Head>
+           <html lang="en" />
+         </Head>
+       );
+     }`,
+    // No next/head import — no lint
+    `export default function Index() {
+       return (
+         <Head>
+           <div>invalid</div>
+         </Head>
+       );
+     }`,
+    // React components (capitalized) inside Head are allowed
+    `import Head from "next/head";
+     export default function Index() {
+       return (
+         <Head>
+           <MyMeta />
+           <title>Page</title>
+         </Head>
+       );
+     }`,
+  ],
+
+  invalid: [
+    {
+      code: `
+        import Head from "next/head";
+        export default function Index() {
+          return (
+            <Head>
+              <html lang="en" />
+            </Head>
+          );
+        }`,
+      errors: [
+        {
+          message: `\`<html>\` is not a valid element inside \`<Head>\` from \`next/head\`. Only elements valid inside \`<head>\` are allowed (title, base, link, meta, script, style, noscript, template). See: ${url}`,
+        },
+      ],
+    },
+    {
+      code: `
+        import Head from "next/head";
+        export default function Index() {
+          return (
+            <Head>
+              <body class="dark" />
+            </Head>
+          );
+        }`,
+      errors: [
+        {
+          message: `\`<body>\` is not a valid element inside \`<Head>\` from \`next/head\`. Only elements valid inside \`<head>\` are allowed (title, base, link, meta, script, style, noscript, template). See: ${url}`,
+        },
+      ],
+    },
+    {
+      code: `
+        import Head from "next/head";
+        export default function Index() {
+          return (
+            <Head>
+              <div className="meta-group">
+                <meta name="foo" content="bar" />
+              </div>
+            </Head>
+          );
+        }`,
+      errors: [
+        {
+          message: `\`<div>\` is not a valid element inside \`<Head>\` from \`next/head\`. Only elements valid inside \`<head>\` are allowed (title, base, link, meta, script, style, noscript, template). See: ${url}`,
+        },
+      ],
+    },
+    {
+      code: `
+        import NextHead from "next/head";
+        export default function Index() {
+          return (
+            <NextHead>
+              <span>invalid</span>
+            </NextHead>
+          );
+        }`,
+      errors: [
+        {
+          message: `\`<span>\` is not a valid element inside \`<Head>\` from \`next/head\`. Only elements valid inside \`<head>\` are allowed (title, base, link, meta, script, style, noscript, template). See: ${url}`,
+        },
+      ],
+    },
+  ],
+}
+
+describe('no-invalid-html-tags-in-head', () => {
+  new RuleTester({
+    languageOptions: {
+      ecmaVersion: 2018,
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          modules: true,
+          jsx: true,
+        },
+      },
+    },
+  }).run('eslint', NextESLintRule, tests)
+})


### PR DESCRIPTION
## Summary

Fixes #20924. When invalid HTML elements (e.g. `<html>`, `<body>`, `<div>`) are placed inside `<Head>` from `next/head`, the browser silently moves them out of `<head>` which can cause React hydration mismatches — previously surfaced as the confusing `next-head-count is missing` error (that message no longer exists, but the underlying problem remains).

This PR adds two complementary guards:

- **New ESLint rule `@next/next/no-invalid-html-tags-in-head`** — reports at lint time when a direct child of `<Head>` is a native HTML element not in the set `{title, base, link, meta, script, style, noscript, template}`. React components (capitalized names) are intentionally skipped. Rule is added to the recommended config as `"warn"`.
- **Runtime dev-mode warning in `head.tsx`** — uses the existing `warnOnce` pattern to print a console warning when `reduceComponents` encounters an element whose type string is not in the valid set.

### Files changed
- `packages/eslint-plugin-next/src/rules/no-invalid-html-tags-in-head.ts` — new rule
- `packages/eslint-plugin-next/src/index.ts` — register rule + add to `recommendedRules`
- `packages/next/src/shared/lib/head.tsx` — `VALID_HEAD_TAGS` set + `warnOnce` check
- `test/unit/eslint-plugin-next/no-invalid-html-tags-in-head.test.ts` — unit tests (4 valid, 4 invalid cases)

### Docs
A new docs page at `https://nextjs.org/docs/messages/no-invalid-html-tags-in-head` should be added (similar to the existing `no-script-tags-in-head-component` page) — happy to add it or leave it to the Next.js docs team.

## Test plan

- [ ] `pnpm jest test/unit/eslint-plugin-next/no-invalid-html-tags-in-head.test.ts` — all cases pass
- [ ] Place `<html>` or `<div>` inside `<Head>` in a pages-router app and verify the ESLint rule fires and the dev console warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)