### PR TITLE
docs: add missing word in contribution guide style section

### DIFF
--- a/docs/04-community/01-contribution-guide.mdx
+++ b/docs/04-community/01-contribution-guide.mdx
@@ -396,7 +396,7 @@ While we don't have a strict template for pages, there are page sections you'll 
 - **Overview:** The first paragraph of a page should tell the user what the feature is and what it's used for. Followed by a minimum working example or its API reference.
 - **Convention:** If the feature has a convention, it should be explained here.
 - **Examples**: Show how the feature can be used with different use cases.
-- **API Tables**: API Pages should have an overview table at the of the page with jump-to-section links (when possible).
+- **API Tables**: API Pages should have an overview table at the top of the page with jump-to-section links (when possible).
 - **Next Steps (Related Links)**: Add links to related pages to guide the user's learning journey.
 
 Feel free to add these sections as needed.


### PR DESCRIPTION
### What?

Fixes a missing word in the Docs Contribution Guide's "Page Templates" section.

### Why?

The "API Tables" bullet currently reads:

> API Pages should have an overview table **at the of the page** with jump-to-section links

The word "top" is missing between "the" and "of".

### How?

One-word insertion in `docs/04-community/01-contribution-guide.mdx`.

**Before:** `at the of the page`
**After:** `at the top of the page`