### PR TITLE
Fix `Date.now()` cause shadowing in sync IO error overlay

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/container/errors.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.test.ts
@@ -1,0 +1,237 @@
+import {
+  createDynamicBodyError,
+  createDynamicMetadataError,
+  createDynamicOrRuntimeBodyError,
+  createDynamicOrRuntimeMetadataError,
+  createDynamicOrRuntimeViewportError,
+  createDynamicViewportError,
+  createRuntimeBodyError,
+  createRuntimeMetadataError,
+  createRuntimeViewportError,
+} from '../../../server/app-render/blocking-route-messages'
+import {
+  createSyncIOClientError,
+  createSyncIOError,
+  createSyncIORuntimeError,
+  type SyncIOApiType,
+} from '../../../server/app-render/sync-io-messages'
+import {
+  getBlockingRouteErrorDetails,
+  isRuntimeVariant,
+  isSyncIOClientError,
+  isSyncIOError,
+} from './errors'
+
+const ROUTE = '/example'
+
+// Every detection helper in errors.tsx walks the user-facing error message
+// produced by the server-side factories in `blocking-route-messages.ts` and
+// `sync-io-messages.ts`. These tests guard the contract between the two
+// modules: if a factory's wording shifts in a way the detector can't
+// recognize, classification silently falls back to "not an instant error"
+// and the overlay shows the wrong UI. Three regressions in this exact spot
+// during the redesign motivated this test.
+
+describe('isRuntimeVariant', () => {
+  it('returns true for runtime body factory output', () => {
+    expect(isRuntimeVariant(createRuntimeBodyError(ROUTE).message)).toBe(true)
+  })
+
+  it('returns false for dynamic body factory output', () => {
+    expect(isRuntimeVariant(createDynamicBodyError(ROUTE).message)).toBe(false)
+  })
+
+  it('returns true for runtime metadata factory output', () => {
+    expect(isRuntimeVariant(createRuntimeMetadataError(ROUTE).message)).toBe(
+      true
+    )
+  })
+
+  it('returns false for dynamic metadata factory output', () => {
+    expect(isRuntimeVariant(createDynamicMetadataError(ROUTE).message)).toBe(
+      false
+    )
+  })
+
+  it('returns true for runtime viewport factory output', () => {
+    expect(isRuntimeVariant(createRuntimeViewportError(ROUTE).message)).toBe(
+      true
+    )
+  })
+
+  it('returns false for dynamic viewport factory output', () => {
+    expect(isRuntimeVariant(createDynamicViewportError(ROUTE).message)).toBe(
+      false
+    )
+  })
+})
+
+describe('isSyncIOError', () => {
+  it.each<[SyncIOApiType]>([['time'], ['random'], ['crypto']])(
+    'returns true for createSyncIOError(%s)',
+    (type) => {
+      const message = createSyncIOError(ROUTE, 'expr', type).message
+      expect(isSyncIOError(message)).toBe(true)
+    }
+  )
+
+  it.each<[SyncIOApiType]>([['time'], ['random'], ['crypto']])(
+    'returns true for createSyncIORuntimeError(%s)',
+    (type) => {
+      const message = createSyncIORuntimeError(ROUTE, 'expr', type).message
+      expect(isSyncIOError(message)).toBe(true)
+    }
+  )
+
+  it.each<[SyncIOApiType]>([['time'], ['random'], ['crypto']])(
+    'returns true for createSyncIOClientError(%s)',
+    (type) => {
+      const message = createSyncIOClientError(ROUTE, 'expr', type).message
+      expect(isSyncIOError(message)).toBe(true)
+    }
+  )
+
+  it('returns false for non sync-IO factory output', () => {
+    expect(isSyncIOError(createRuntimeBodyError(ROUTE).message)).toBe(false)
+    expect(isSyncIOError(createDynamicMetadataError(ROUTE).message)).toBe(false)
+  })
+
+  it('returns false for an unrelated error message', () => {
+    expect(isSyncIOError('Random unrelated error text')).toBe(false)
+  })
+})
+
+describe('isSyncIOClientError', () => {
+  it.each<[SyncIOApiType]>([['time'], ['random'], ['crypto']])(
+    'returns true for createSyncIOClientError(%s)',
+    (type) => {
+      const message = createSyncIOClientError(ROUTE, 'expr', type).message
+      expect(isSyncIOClientError(message)).toBe(true)
+    }
+  )
+
+  it.each<[SyncIOApiType]>([['time'], ['random'], ['crypto']])(
+    'returns false for createSyncIOError(%s)',
+    (type) => {
+      const message = createSyncIOError(ROUTE, 'expr', type).message
+      expect(isSyncIOClientError(message)).toBe(false)
+    }
+  )
+
+  it.each<[SyncIOApiType]>([['time'], ['random'], ['crypto']])(
+    'returns false for createSyncIORuntimeError(%s)',
+    (type) => {
+      const message = createSyncIORuntimeError(ROUTE, 'expr', type).message
+      expect(isSyncIOClientError(message)).toBe(false)
+    }
+  )
+})
+
+describe('getBlockingRouteErrorDetails', () => {
+  it('classifies createRuntimeBodyError as blocking-route + runtime', () => {
+    expect(getBlockingRouteErrorDetails(createRuntimeBodyError(ROUTE))).toEqual(
+      { type: 'blocking-route', variant: 'runtime' }
+    )
+  })
+
+  it('classifies createDynamicBodyError as blocking-route + navigation', () => {
+    expect(getBlockingRouteErrorDetails(createDynamicBodyError(ROUTE))).toEqual(
+      { type: 'blocking-route', variant: 'navigation' }
+    )
+  })
+
+  it('classifies createDynamicOrRuntimeBodyError as blocking-route + navigation', () => {
+    // The "either" factory has no clear runtime signal — falls into the
+    // navigation branch by `isRuntimeVariant`. Documents current behavior.
+    expect(
+      getBlockingRouteErrorDetails(createDynamicOrRuntimeBodyError(ROUTE))
+    ).toEqual({ type: 'blocking-route', variant: 'navigation' })
+  })
+
+  it('classifies createRuntimeMetadataError as dynamic-metadata + runtime', () => {
+    expect(
+      getBlockingRouteErrorDetails(createRuntimeMetadataError(ROUTE))
+    ).toEqual({ type: 'dynamic-metadata', variant: 'runtime' })
+  })
+
+  it('classifies createDynamicMetadataError as dynamic-metadata + navigation', () => {
+    expect(
+      getBlockingRouteErrorDetails(createDynamicMetadataError(ROUTE))
+    ).toEqual({ type: 'dynamic-metadata', variant: 'navigation' })
+  })
+
+  it('classifies createDynamicOrRuntimeMetadataError as dynamic-metadata + navigation', () => {
+    expect(
+      getBlockingRouteErrorDetails(createDynamicOrRuntimeMetadataError(ROUTE))
+    ).toEqual({ type: 'dynamic-metadata', variant: 'navigation' })
+  })
+
+  it('classifies createRuntimeViewportError as dynamic-viewport + runtime', () => {
+    expect(
+      getBlockingRouteErrorDetails(createRuntimeViewportError(ROUTE))
+    ).toEqual({ type: 'dynamic-viewport', variant: 'runtime' })
+  })
+
+  it('classifies createDynamicViewportError as dynamic-viewport + navigation', () => {
+    expect(
+      getBlockingRouteErrorDetails(createDynamicViewportError(ROUTE))
+    ).toEqual({ type: 'dynamic-viewport', variant: 'navigation' })
+  })
+
+  it('classifies createDynamicOrRuntimeViewportError as dynamic-viewport + navigation', () => {
+    expect(
+      getBlockingRouteErrorDetails(createDynamicOrRuntimeViewportError(ROUTE))
+    ).toEqual({ type: 'dynamic-viewport', variant: 'navigation' })
+  })
+
+  it.each<[SyncIOApiType, string, string]>([
+    ['time', 'Date.now()', 'Date.now()'],
+    ['random', 'Math.random()', 'Math.random()'],
+    ['crypto', 'crypto.randomUUID()', 'crypto.randomUUID()'],
+  ])(
+    'classifies createSyncIOError(%s) as sync-io + cause %s',
+    (type, expression, expectedCause) => {
+      expect(
+        getBlockingRouteErrorDetails(createSyncIOError(ROUTE, expression, type))
+      ).toEqual({ type: 'sync-io', cause: expectedCause })
+    }
+  )
+
+  it.each<[SyncIOApiType, string, string]>([
+    ['time', 'Date.now()', 'Date.now()'],
+    ['random', 'Math.random()', 'Math.random()'],
+    ['crypto', 'crypto.randomUUID()', 'crypto.randomUUID()'],
+  ])(
+    'classifies createSyncIOClientError(%s) as sync-io-client + cause %s',
+    (type, expression, expectedCause) => {
+      expect(
+        getBlockingRouteErrorDetails(
+          createSyncIOClientError(ROUTE, expression, type)
+        )
+      ).toEqual({ type: 'sync-io-client', cause: expectedCause })
+    }
+  )
+
+  // The time-type factory always appends `elapsedTimeBullet` text containing
+  // `Date.now()` regardless of which API the user actually called. If
+  // SYNC_IO_APIS is ordered wrong, `Date.now()` will match the bullet text
+  // and shadow the real cause.
+  it.each<[string, string]>([
+    ['Date.now()', 'Date.now()'],
+    ['new Date()', 'new Date()'],
+    ['Date()', 'Date()'],
+  ])(
+    'preserves cause %s against the `Date.now()` mention in the time bullet',
+    (expression, expectedCause) => {
+      const error = createSyncIOError(ROUTE, expression, 'time')
+      expect(getBlockingRouteErrorDetails(error)).toEqual({
+        type: 'sync-io',
+        cause: expectedCause,
+      })
+    }
+  )
+
+  it('returns null for an unrelated error', () => {
+    expect(getBlockingRouteErrorDetails(new Error('regular bug'))).toBe(null)
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -269,7 +269,7 @@ function InstantRuntimeError({
   )
 }
 
-function isRuntimeVariant(message: string): boolean {
+export function isRuntimeVariant(message: string): boolean {
   // Discriminates between `createRuntimeBodyError` and `createDynamicBodyError`
   return (
     message.includes('encountered runtime data') &&
@@ -280,10 +280,12 @@ function isRuntimeVariant(message: string): boolean {
 const SYNC_IO_APIS = [
   // Math
   'Math.random()',
-  // Date/Time — `new Date()` before `Date()` to avoid substring false positive
-  'Date.now()',
+  // Date/Time — `new Date()` before `Date()` (substring false positive) and
+  // both before `Date.now()` (the `elapsedTimeBullet` text always contains
+  // `Date.now()` regardless of which API the user actually called).
   'new Date()',
   'Date()',
+  'Date.now()',
   // Node Crypto — longer strings first to avoid substring false positives
   "require('node:crypto').generateKeyPairSync(...)",
   "require('node:crypto').generateKeySync(...)",
@@ -303,16 +305,18 @@ const SYNC_IO_DOCS_PATTERN =
 // Discriminate sync IO errors via the docs URL embedded in the user-facing
 // message by `createSyncIOError`, `createSyncIORuntimeError`, and
 // `createSyncIOClientError`.
-function isSyncIOError(message: string): boolean {
+export function isSyncIOError(message: string): boolean {
   return SYNC_IO_DOCS_PATTERN.test(message)
 }
 
-function isSyncIOClientError(message: string): boolean {
+export function isSyncIOClientError(message: string): boolean {
   const match = SYNC_IO_DOCS_PATTERN.exec(message)
   return match !== null && match[2] === '-client'
 }
 
-function getBlockingRouteErrorDetails(error: Error): null | ErrorDetails {
+export function getBlockingRouteErrorDetails(
+  error: Error
+): null | ErrorDetails {
   const message = error.message
 
   const isBlockingPageLoadError = message.includes('/blocking-route')

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -4949,7 +4949,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
           await expect(browser).toDisplayCollapsedRedbox(`
            {
              "code": "E1242",
-             "description": "Next.js encountered Date.now() without an explicit rendering intent.",
+             "description": "Next.js encountered Date() without an explicit rendering intent.",
              "environmentLabel": "Server",
              "label": "Instant",
              "source": "app/sync-io-current-time/date/page.tsx (19:16) @ DateReadingComponent
@@ -5239,7 +5239,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
           await expect(browser).toDisplayCollapsedRedbox(`
            {
              "code": "E1242",
-             "description": "Next.js encountered Date.now() without an explicit rendering intent.",
+             "description": "Next.js encountered new Date() without an explicit rendering intent.",
              "environmentLabel": "Server",
              "label": "Instant",
              "source": "app/sync-io-current-time/new-date/page.tsx (19:16) @ DateReadingComponent


### PR DESCRIPTION
## What

When a user writes `Date()` or `new Date()` in a Server Component and instant validation surfaces a sync IO error, the dev overlay incorrectly labels the cause as `Date.now()`.

```tsx
return <p>{new Date().toString()}</p>
```
Overlay headline says: `Next.js encountered Date.now() without an explicit rendering intent.`

## Why

`getBlockingRouteErrorDetails` in `errors.tsx` classifies the API by scanning the error message with `String.prototype.includes` against `SYNC_IO_APIS` in order, first match wins. The time-type factory always embeds `Date.now()` in the `elapsedTimeBullet` text (`Measure elapsed time with \`performance.now()\` instead of \`Date.now()\``) regardless of which API the user called. Because `Date.now()` was first in the array, it matched the bullet text and shadowed the real expression.

Fix: put `new Date()` and `Date()` before `Date.now()` so the more-specific entries win when both appear in the message.

User-visible cards and docs URL are unaffected — all three time variants map to the same card set — only the cause label was wrong.