### PR TITLE
Enable rootParams by default

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1220,7 +1220,6 @@ pub struct ExperimentalConfig {
     /// This field is kept for backwards compatibility during migration.
     cache_components: Option<bool>,
     use_cache: Option<bool>,
-    root_params: Option<bool>,
     runtime_server_deployment_id: Option<bool>,
     supports_immutable_assets: Option<bool>,
 
@@ -2175,16 +2174,6 @@ impl NextConfig {
                 // "use cache" was originally implicitly enabled with the
                 // cacheComponents flag, so we transfer the value for cacheComponents to the
                 // explicit useCache flag to ensure backwards compatibility.
-                .unwrap_or(self.cache_components.unwrap_or(false)),
-        )
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_root_params(&self) -> Vc<bool> {
-        Vc::cell(
-            self.experimental
-                .root_params
-                // rootParams should be enabled implicitly in cacheComponents.
                 .unwrap_or(self.cache_components.unwrap_or(false)),
         )
     }

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -211,13 +211,7 @@ pub async fn get_next_client_import_map(
         rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/index"),
         rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/index"),},
     );
-    insert_next_root_params_mapping(
-        &mut import_map,
-        next_config.enable_root_params(),
-        Either::Right(ty.clone()),
-        None,
-    )
-    .await?;
+    insert_next_root_params_mapping(&mut import_map, Either::Right(ty.clone()), None).await?;
 
     match ty {
         ClientContextType::Pages { .. }
@@ -747,13 +741,7 @@ async fn insert_next_server_special_aliases(
         }
     }
 
-    insert_next_root_params_mapping(
-        import_map,
-        next_config.enable_root_params(),
-        Either::Left(ty),
-        collected_root_params,
-    )
-    .await?;
+    insert_next_root_params_mapping(import_map, Either::Left(ty), collected_root_params).await?;
 
     import_map.insert_exact_alias(
         rcstr!("@vercel/og"),

--- a/crates/next-core/src/next_root_params/mod.rs
+++ b/crates/next-core/src/next_root_params/mod.rs
@@ -30,26 +30,20 @@ use crate::{
 
 pub async fn insert_next_root_params_mapping(
     import_map: &mut ImportMap,
-    is_root_params_enabled: Vc<bool>,
     ty: Either<ServerContextType, ClientContextType>,
     collected_root_params: Option<Vc<CollectedRootParams>>,
 ) -> Result<()> {
     import_map.insert_exact_alias(
         "next/root-params",
-        get_next_root_params_mapping(
-            is_root_params_enabled,
-            EitherTaskInput(ty),
-            collected_root_params,
-        )
-        .to_resolved()
-        .await?,
+        get_next_root_params_mapping(EitherTaskInput(ty), collected_root_params)
+            .to_resolved()
+            .await?,
     );
     Ok(())
 }
 
 #[turbo_tasks::function]
 async fn get_next_root_params_mapping(
-    is_root_params_enabled: Vc<bool>,
     ty: EitherTaskInput<ServerContextType, ClientContextType>,
     collected_root_params: Option<Vc<CollectedRootParams>>,
 ) -> Result<Vc<ImportMapping>> {
@@ -61,7 +55,7 @@ async fn get_next_root_params_mapping(
     // `collected_root_params` changes, the resolve options will remain the same, and
     // only the mapping result will be invalidated.
     let mapping = ImportMapping::Dynamic(ResolvedVc::upcast(
-        NextRootParamsMapper::new(is_root_params_enabled, ty, collected_root_params)
+        NextRootParamsMapper::new(ty, collected_root_params)
             .to_resolved()
             .await?,
     ));
@@ -70,7 +64,6 @@ async fn get_next_root_params_mapping(
 
 #[turbo_tasks::value]
 struct NextRootParamsMapper {
-    is_root_params_enabled: ResolvedVc<bool>,
     #[bincode(with = "turbo_bincode::either")]
     context_type: Either<ServerContextType, ClientContextType>,
     collected_root_params: Option<ResolvedVc<CollectedRootParams>>,
@@ -80,12 +73,10 @@ struct NextRootParamsMapper {
 impl NextRootParamsMapper {
     #[turbo_tasks::function]
     pub fn new(
-        is_root_params_enabled: ResolvedVc<bool>,
         context_type: EitherTaskInput<ServerContextType, ClientContextType>,
         collected_root_params: Option<ResolvedVc<CollectedRootParams>>,
     ) -> Vc<Self> {
         NextRootParamsMapper {
-            is_root_params_enabled,
             context_type: context_type.0,
             collected_root_params,
         }
@@ -95,61 +86,47 @@ impl NextRootParamsMapper {
     #[turbo_tasks::function]
     async fn import_map_result(self: Vc<Self>) -> Result<Vc<ImportMapResult>> {
         let this = self.await?;
-        Ok({
-            if !(*this.is_root_params_enabled.await?) {
+        Ok(match &this.context_type {
+            Either::Left(server_ty) => match &server_ty {
+                ServerContextType::AppRSC { .. } | ServerContextType::AppRoute { .. } => {
+                    let collected_root_params = *this.collected_root_params.ok_or_else(|| {
+                        anyhow!(
+                            "Invariant: Root params should have been collected for context {:?}. \
+                             This is a bug in Next.js.",
+                            server_ty.clone()
+                        )
+                    })?;
+                    Self::valid_import_map_result(collected_root_params)
+                }
+                ServerContextType::PagesApi { .. }
+                | ServerContextType::Instrumentation { .. }
+                | ServerContextType::Middleware { .. } => {
+                    // There's no sensible way to use root params outside of the app
+                    // directory. TODO: make sure this error is consistent with webpack
+                    Self::invalid_import_map_result(
+                        "'next/root-params' can only be used inside the App Directory.".into(),
+                    )
+                }
+                _ => {
+                    // In general, the compiler should prevent importing 'next/root-params'
+                    // from client modules, but it doesn't catch everything. If an import
+                    // slips through our validation, make it error.
+                    Self::invalid_import_map_result(
+                        "'next/root-params' cannot be imported from a Client Component module. It \
+                         should only be used from a Server Component."
+                            .into(),
+                    )
+                }
+            },
+            Either::Right(_) => {
+                // In general, the compiler should prevent importing 'next/root-params' from
+                // client modules, but it doesn't catch everything. If an import slips
+                // through our validation, make it error.
                 Self::invalid_import_map_result(
-                    "'next/root-params' can only be imported when `experimental.rootParams` is \
-                     enabled."
+                    "'next/root-params' cannot be imported from a Client Component module. It \
+                     should only be used from a Server Component."
                         .into(),
                 )
-            } else {
-                match &this.context_type {
-                    Either::Left(server_ty) => match &server_ty {
-                        ServerContextType::AppRSC { .. } | ServerContextType::AppRoute { .. } => {
-                            let collected_root_params =
-                                *this.collected_root_params.ok_or_else(|| {
-                                    anyhow!(
-                                        "Invariant: Root params should have been collected for \
-                                         context {:?}. This is a bug in Next.js.",
-                                        server_ty.clone()
-                                    )
-                                })?;
-                            Self::valid_import_map_result(collected_root_params)
-                        }
-                        ServerContextType::PagesApi { .. }
-                        | ServerContextType::Instrumentation { .. }
-                        | ServerContextType::Middleware { .. } => {
-                            // There's no sensible way to use root params outside of the app
-                            // directory. TODO: make sure this error is
-                            // consistent with webpack
-                            Self::invalid_import_map_result(
-                                "'next/root-params' can only be used inside the App Directory."
-                                    .into(),
-                            )
-                        }
-                        _ => {
-                            // In general, the compiler should prevent importing 'next/root-params'
-                            // from client modules, but it doesn't catch
-                            // everything. If an import slips through
-                            // our validation, make it error.
-                            Self::invalid_import_map_result(
-                                "'next/root-params' cannot be imported from a Client Component \
-                                 module. It should only be used from a Server Component."
-                                    .into(),
-                            )
-                        }
-                    },
-                    Either::Right(_) => {
-                        // In general, the compiler should prevent importing 'next/root-params' from
-                        // client modules, but it doesn't catch everything. If an
-                        // import slips through our validation, make it error.
-                        Self::invalid_import_map_result(
-                            "'next/root-params' cannot be imported from a Client Component \
-                             module. It should only be used from a Server Component."
-                                .into(),
-                        )
-                    }
-                }
             }
         })
     }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1430,8 +1430,7 @@ export default async function build(
 
           await writeRootParamsTypes(
             routeTypesManifest,
-            path.join(distDir, 'types', 'root-params.d.ts'),
-            config
+            path.join(distDir, 'types', 'root-params.d.ts')
           )
         })
 

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -31,8 +31,7 @@ function verifyAndRunTypeScript(
   hasPagesDir: boolean,
   appDir: string | undefined,
   pagesDir: string | undefined,
-  debugBuildPaths: { app: string[]; pages: string[] } | undefined,
-  rootParams: boolean
+  debugBuildPaths: { app: string[]; pages: string[] } | undefined
 ) {
   let impl: typeof import('../lib/verify-typescript-setup').verifyAndRunTypeScript
   let typeCheckWorker:
@@ -75,7 +74,6 @@ function verifyAndRunTypeScript(
     appDir,
     pagesDir,
     debugBuildPaths,
-    rootParams,
   })
     .then((result) => {
       typeCheckWorker?.end()
@@ -144,8 +142,7 @@ export async function startTypeChecking({
           !!pagesDir,
           appDir,
           pagesDir,
-          debugBuildPaths,
-          !!config.experimental.rootParams || !!config.cacheComponents
+          debugBuildPaths
         ).then((resolved) => {
           const checkEnd = process.hrtime(typeCheckAndLintStart)
           return [resolved, checkEnd] as const

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1577,11 +1577,6 @@ export default async function getBaseWebpackConfig(
           : []),
 
         ...getNextRootParamsRules({
-          isRootParamsEnabled:
-            config.experimental.rootParams ??
-            // `cacheComponents` implies `experimental.rootParams`.
-            config.cacheComponents ??
-            false,
           isClient,
           appDir,
           pageExtensions,
@@ -2881,12 +2876,10 @@ export default async function getBaseWebpackConfig(
 }
 
 function getNextRootParamsRules({
-  isRootParamsEnabled,
   isClient,
   appDir,
   pageExtensions,
 }: {
-  isRootParamsEnabled: boolean
   isClient: boolean
   appDir: string | undefined
   pageExtensions: string[]
@@ -2902,15 +2895,6 @@ function getNextRootParamsRules({
         message,
       } satisfies InvalidImportLoaderOpts,
     } satisfies webpack.RuleSetRule
-  }
-
-  // Hard-error if the flag is not enabled, regardless of if we're on the server or on the client.
-  if (!isRootParamsEnabled) {
-    return [
-      createInvalidImportRule(
-        "'next/root-params' can only be imported when `experimental.rootParams` is enabled."
-      ),
-    ]
   }
 
   // If there's no app-dir (and thus no layouts), there's no sensible way to use 'next/root-params',

--- a/packages/next/src/cli/next-test.ts
+++ b/packages/next/src/cli/next-test.ts
@@ -149,8 +149,6 @@ async function runPlaywright(
       hasPagesDir: !!pagesDir,
       appDir: appDir || undefined,
       pagesDir: pagesDir || undefined,
-      rootParams:
-        !!nextConfig.experimental.rootParams || !!nextConfig.cacheComponents,
     })
 
     const isUsingTypeScript = !!typeScriptVersion

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -55,8 +55,6 @@ const nextTypegen = async (
     hasPagesDir: !!pagesDir,
     appDir: appDir || undefined,
     pagesDir: pagesDir || undefined,
-    rootParams:
-      !!nextConfig.experimental.rootParams || !!nextConfig.cacheComponents,
   })
 
   console.log('Generating route types...')
@@ -117,8 +115,7 @@ const nextTypegen = async (
 
   await writeRootParamsTypes(
     routeTypesManifest,
-    join(distDir, 'types', 'root-params.d.ts'),
-    nextConfig
+    join(distDir, 'types', 'root-params.d.ts')
   )
 
   console.log('✓ Types generated successfully')

--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -10,7 +10,6 @@ export async function writeAppTypeDeclarations({
   hasAppDir,
   strictRouteTypes,
   typedRoutes,
-  rootParams,
 }: {
   baseDir: string
   distDir: string
@@ -19,7 +18,6 @@ export async function writeAppTypeDeclarations({
   hasAppDir: boolean
   strictRouteTypes: boolean
   typedRoutes: boolean
-  rootParams: boolean
 }): Promise<void> {
   // Reference `next` types
   const appTypeDeclarations = path.join(baseDir, 'next-env.d.ts')
@@ -71,13 +69,11 @@ export async function writeAppTypeDeclarations({
   // Use ESM import instead of triple-slash reference for better ESLint compatibility
   lines.push(`import "./${routeTypesPath}";`)
 
-  if (rootParams) {
-    const rootParamsTypesPath = path.posix.join(
-      distDir.replaceAll(path.win32.sep, path.posix.sep),
-      'types/root-params.d.ts'
-    )
-    lines.push(`import "./${rootParamsTypesPath}";`)
-  }
+  const rootParamsTypesPath = path.posix.join(
+    distDir.replaceAll(path.win32.sep, path.posix.sep),
+    'types/root-params.d.ts'
+  )
+  lines.push(`import "./${rootParamsTypesPath}";`)
 
   if (strictRouteTypes) {
     const cacheLifePath = path.posix.join(

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -67,7 +67,6 @@ export async function verifyAndRunTypeScript({
   appDir,
   pagesDir,
   debugBuildPaths,
-  rootParams,
 }: {
   dir: string
   distDir: string
@@ -82,7 +81,6 @@ export async function verifyAndRunTypeScript({
   appDir?: string
   pagesDir?: string
   debugBuildPaths?: { app?: string[]; pages?: string[] }
-  rootParams?: boolean
 }): Promise<{ result?: TypeCheckResult; version: string | null }> {
   const tsConfigFileName = tsconfigPath || 'tsconfig.json'
   const resolvedTsConfigPath = path.join(dir, tsConfigFileName)
@@ -133,7 +131,6 @@ export async function verifyAndRunTypeScript({
           hasAppDir,
           strictRouteTypes,
           typedRoutes,
-          rootParams: !!rootParams,
         })
 
         return { version: null }
@@ -217,7 +214,6 @@ export async function verifyAndRunTypeScript({
       hasAppDir,
       strictRouteTypes,
       typedRoutes,
-      rootParams: !!rootParams,
     })
 
     let result

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1197,11 +1197,6 @@ export interface ExperimentalConfig {
       }
 
   /**
-   * Enable accessing root params via the `next/root-params` module.
-   */
-  rootParams?: boolean
-
-  /**
    * Body size limit for request bodies with middleware configured.
    * Defaults to 10MB. Can be specified as a number (bytes) or string (e.g. '5mb').
    *

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -182,6 +182,13 @@ function checkDeprecations(
 
   warnOptionHasBeenDeprecated(
     userConfig,
+    'experimental.rootParams',
+    `\`experimental.rootParams\` is no longer needed, because \`next/root-params\` is available by default. You can remove it from ${configFileName}.`,
+    silent
+  )
+
+  warnOptionHasBeenDeprecated(
+    userConfig,
     'eslint',
     `\`eslint\` configuration in ${configFileName} is no longer supported. See more info here: https://nextjs.org/docs/app/api-reference/cli/next#next-lint-options`,
     silent

--- a/packages/next/src/server/lib/router-utils/root-params-type-utils.ts
+++ b/packages/next/src/server/lib/router-utils/root-params-type-utils.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import type { RouteTypesManifest } from './route-types-utils'
-import type { NextConfigComplete } from '../../config-shared'
 
 export type RootParamValueType = 'string' | 'string[]' | 'undefined'
 
@@ -45,23 +44,14 @@ function getRootParamReturnType(valueTypes: RootParamInfo): string {
 }
 
 /**
- * Writes root-params type definitions to a file if the feature is enabled
- * and root params were collected from layouts.
+ * Writes root-params type definitions to a file if root params were collected
+ * from layouts.
  */
 export async function writeRootParamsTypes(
   manifest: RouteTypesManifest,
-  filePath: string,
-  config: NextConfigComplete
+  filePath: string
 ) {
   const rootParams = manifest.rootParams
-
-  const featureEnabled =
-    !!config.experimental.rootParams || !!config.cacheComponents
-
-  if (!featureEnabled) {
-    await fs.promises.rm(filePath, { force: true })
-    return
-  }
 
   await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -165,9 +165,6 @@ async function verifyTypeScript(opts: SetupOpts) {
     hasPagesDir: !!opts.pagesDir,
     appDir: opts.appDir,
     pagesDir: opts.pagesDir,
-    rootParams:
-      !!opts.nextConfig.experimental.rootParams ||
-      !!opts.nextConfig.cacheComponents,
   })
 
   if (verifyResult.version) {
@@ -1200,8 +1197,7 @@ async function startWatcher(
 
           await writeRootParamsTypes(
             routeTypesManifest,
-            path.join(distTypesDir, 'root-params.d.ts'),
-            opts.nextConfig
+            path.join(distTypesDir, 'root-params.d.ts')
           )
         }
 

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -371,9 +371,7 @@ describe('Error overlay - RSC build errors', () => {
   })
 
   describe('next/root-params', () => {
-    const isCacheComponentsEnabled =
-      process.env.__NEXT_CACHE_COMPONENTS === 'true'
-    it("importing 'next/root-params' when experimental.rootParams is not enabled", async () => {
+    it("importing a non-existent getter from 'next/root-params'", async () => {
       await using sandbox = await createSandbox(
         next,
         undefined,
@@ -381,16 +379,13 @@ describe('Error overlay - RSC build errors', () => {
       )
       const { session } = sandbox
       await session.waitForRedbox()
-      if (!isCacheComponentsEnabled) {
+      if (isTurbopack) {
         expect(await session.getRedboxSource()).toInclude(
-          `'next/root-params' can only be imported when \`experimental.rootParams\` is enabled.`
+          `Export whatever doesn't exist in target module`
         )
       } else {
-        // in cacheComponents we auto-enable 'next/root-params', so we should get an error about using a non-existent getter instead.
-        expect(await session.getRedboxSource()).toInclude(
-          isTurbopack
-            ? `Export whatever doesn't exist in target module`
-            : `Attempted import error: 'whatever' is not exported from 'next/root-params' (imported as 'whatever').`
+        expect(await session.getRedboxDescription()).toInclude(
+          `whatever) is not a function`
         )
       }
     })
@@ -398,17 +393,7 @@ describe('Error overlay - RSC build errors', () => {
     it("importing 'next/root-params' in a client component", async () => {
       await using sandbox = await createSandbox(
         next,
-        // if cacheComponents is not enabled, the import is guarded behind an experimental flag
-        isCacheComponentsEnabled
-          ? new Map()
-          : new Map([
-              [
-                'next.config.js',
-                outdent`
-                  module.exports = { experimental: { rootParams: true } }
-                `,
-              ],
-            ]),
+        undefined,
         `/server-with-errors/next-root-params/in-client`
       )
       const { session } = sandbox
@@ -421,17 +406,7 @@ describe('Error overlay - RSC build errors', () => {
     it("importing 'next/root-params' in a client component in a way that bypasses import analysis", async () => {
       await using sandbox = await createSandbox(
         next,
-        // if cacheComponents is not enabled, the import is guarded behind an experimental flag
-        isCacheComponentsEnabled
-          ? new Map()
-          : new Map([
-              [
-                'next.config.js',
-                outdent`
-                  module.exports = { experimental: { rootParams: true } }
-                `,
-              ],
-            ]),
+        undefined,
         `/server-with-errors/next-root-params/in-client-await-import`
       )
       const { session } = sandbox

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -306,13 +306,6 @@ describe('Error Overlay for server components compiler errors in pages', () => {
           }
         `,
       ],
-      [
-        // the import is guarded behind an experimental flag
-        'next.config.js',
-        outdent`
-          module.exports = { experimental: { rootParams: true } }
-        `,
-      ],
     ])
     await using sandbox = await createSandbox(next, files)
     const { session } = sandbox

--- a/test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
+++ b/test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
@@ -15,6 +15,7 @@ const nextEnvDts = strictRouteTypes
   ? `/// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 import "./.next/dev/types/cache-life.d.ts";
 import "./.next/dev/types/validator.ts";
 
@@ -24,6 +25,7 @@ import "./.next/dev/types/validator.ts";
   : `/// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/next.config.ts
@@ -1,9 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  experimental: {
-    rootParams: true,
-  },
-}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  cacheComponents: true, // implies `rootParams: true`.
+  cacheComponents: true,
 }
 
 export default nextConfig

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/multiple-roots/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/multiple-roots/next.config.ts
@@ -1,9 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  experimental: {
-    rootParams: true,
-  },
-}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/simple/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/simple/next.config.ts
@@ -1,9 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  experimental: {
-    rootParams: true,
-  },
-}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-build/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-build/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   experimental: {
     useCache: true,
-    rootParams: true,
   },
 }
 

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-dedup/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-dedup/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   experimental: {
     useCache: true,
-    rootParams: true,
   },
 }
 

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   experimental: {
     useCache: true,
-    rootParams: true,
   },
 }
 

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-runtime/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-runtime/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   experimental: {
     useCache: true,
-    rootParams: true,
   },
 }
 

--- a/test/e2e/app-dir/ppr-root-param-rsc-fallback/next.config.js
+++ b/test/e2e/app-dir/ppr-root-param-rsc-fallback/next.config.js
@@ -3,9 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: {
-    rootParams: true,
-  },
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/generate-static-params-errors/next.config.ts
+++ b/test/production/app-dir/generate-static-params-errors/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  experimental: { rootParams: true },
-}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -225,7 +225,7 @@
       "Error overlay - RSC build errors importing 'next/cache' APIs in a client component unstable_noStore is allowed",
       "Error overlay - RSC build errors next/root-params importing 'next/root-params' in a client component",
       "Error overlay - RSC build errors next/root-params importing 'next/root-params' in a client component in a way that bypasses import analysis",
-      "Error overlay - RSC build errors next/root-params importing 'next/root-params' when experimental.rootParams is not enabled",
+      "Error overlay - RSC build errors next/root-params importing a non-existent getter from 'next/root-params'",
       "Error overlay - RSC build errors should allow to use and handle rsc poisoning client-only",
       "Error overlay - RSC build errors should allow to use and handle rsc poisoning server-only",
       "Error overlay - RSC build errors should error for invalid undefined module retuning from next dynamic",

--- a/test/unit/write-app-declarations.test.ts
+++ b/test/unit/write-app-declarations.test.ts
@@ -24,6 +24,8 @@ describe('find config', () => {
         : '') +
       `import "./.next/types/routes.d.ts";` +
       eol +
+      `import "./.next/types/root-params.d.ts";` +
+      eol +
       eol +
       '// NOTE: This file should not be edited' +
       eol +
@@ -40,7 +42,6 @@ describe('find config', () => {
       hasAppDir: false,
       strictRouteTypes: false,
       typedRoutes: true,
-      rootParams: false,
     })
     expect(await fs.readFile(declarationFile, 'utf8')).toBe(content)
   })
@@ -55,6 +56,8 @@ describe('find config', () => {
         : '') +
       `import "./.next/types/routes.d.ts";` +
       eol +
+      `import "./.next/types/root-params.d.ts";` +
+      eol +
       eol +
       '// NOTE: This file should not be edited' +
       eol +
@@ -71,7 +74,6 @@ describe('find config', () => {
       hasAppDir: false,
       strictRouteTypes: false,
       typedRoutes: true,
-      rootParams: false,
     })
     expect(await fs.readFile(declarationFile, 'utf8')).toBe(content)
   })
@@ -85,6 +87,8 @@ describe('find config', () => {
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
       `import "./.next/types/routes.d.ts";` +
+      eol +
+      `import "./.next/types/root-params.d.ts";` +
       eol +
       eol +
       '// NOTE: This file should not be edited' +
@@ -100,7 +104,6 @@ describe('find config', () => {
       hasAppDir: false,
       strictRouteTypes: false,
       typedRoutes: true,
-      rootParams: false,
     })
     expect(await fs.readFile(declarationFile, 'utf8')).toBe(content)
   })
@@ -114,7 +117,6 @@ describe('find config', () => {
       hasAppDir: true,
       strictRouteTypes: false,
       typedRoutes: true,
-      rootParams: false,
     })
 
     await expect(fs.readFile(declarationFile, 'utf8')).resolves.not.toContain(
@@ -129,7 +131,6 @@ describe('find config', () => {
       hasAppDir: true,
       strictRouteTypes: false,
       typedRoutes: true,
-      rootParams: false,
     })
 
     await expect(fs.readFile(declarationFile, 'utf8')).resolves.toContain(


### PR DESCRIPTION
rootParams is now available by default. the flag is removed.

There are still intentional limitations. For instance rootParams cannot be used in route handlers and Server Actions. The feature will be expanded with some support for this in the future.