### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -20,6 +20,9 @@ env:
   TURBO_VERSION: 2.9.4
   NODE_LTS_VERSION: 20
 
+permissions:
+  contents: read
+
 jobs:
   start:
     runs-on: ubuntu-latest

--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   test-dev:
     name: Rspack integration tests

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   test-dev:
     name: Rspack integration tests


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `popular.yml`, `rspack-update-tests-manifest.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.