### PR TITLE
turbopack: emit assets before duplicate check in emit_assets

### DIFF
--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -104,22 +104,22 @@ pub async fn emit_assets(
         let mut iter = assets.into_iter();
         let first = iter.next().unwrap();
         let ext: RcStr = path.extension().unwrap_or_default().into();
-        iter.map(async |next| {
-            if let Some(detail) = assets_diff(*next, *first, ext.clone(), node_root.clone())
-                .owned()
-                .await?
-            {
-                EmitConflictIssue {
-                    asset_path: path.clone(),
-                    detail,
-                }
-                .resolved_cell()
-                .emit();
+        let conflicts = iter
+            .map(async |next| {
+                assets_diff(*next, *first, ext.clone(), node_root.clone())
+                    .owned()
+                    .await
+            })
+            .try_flat_join()
+            .await?;
+        if let Some(detail) = conflicts.into_iter().next() {
+            EmitConflictIssue {
+                asset_path: path.clone(),
+                detail,
             }
-            Ok(())
-        })
-        .try_join()
-        .await?;
+            .resolved_cell()
+            .emit();
+        }
         Ok(())
     }
 

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -103,9 +103,9 @@ pub async fn emit_assets(
     ) -> Result<()> {
         let mut iter = assets.into_iter();
         let first = iter.next().unwrap();
-        for next in iter {
-            let ext: RcStr = path.extension().unwrap_or_default().into();
-            if let Some(detail) = assets_diff(*next, *first, ext, node_root.clone())
+        let ext: RcStr = path.extension().unwrap_or_default().into();
+        iter.map(async |next| {
+            if let Some(detail) = assets_diff(*next, *first, ext.clone(), node_root.clone())
                 .owned()
                 .await?
             {
@@ -116,7 +116,10 @@ pub async fn emit_assets(
                 .resolved_cell()
                 .emit();
             }
-        }
+            Ok(())
+        })
+        .try_join()
+        .await?;
         Ok(())
     }
 

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -113,12 +113,18 @@ pub async fn emit_assets(
             .try_flat_join()
             .await?;
         if let Some(detail) = conflicts.into_iter().next() {
-            EmitConflictIssue {
-                asset_path: path.clone(),
-                detail,
+            #[turbo_tasks::function]
+            fn emit_conflict_issue(path: FileSystemPath, detail: RcStr) {
+                EmitConflictIssue {
+                    asset_path: path.clone(),
+                    detail,
+                }
+                .resolved_cell()
+                .emit();
             }
-            .resolved_cell()
-            .emit();
+            emit_conflict_issue(path.clone(), detail)
+                .as_side_effect()
+                .await?;
         }
         Ok(())
     }

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -100,7 +100,7 @@ pub async fn emit_assets(
         path: &FileSystemPath,
         assets: AssetVec,
         node_root: &FileSystemPath,
-    ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
+    ) -> Result<()> {
         let mut iter = assets.into_iter();
         let first = iter.next().unwrap();
         for next in iter {
@@ -117,7 +117,7 @@ pub async fn emit_assets(
                 .emit();
             }
         }
-        Ok(first)
+        Ok(())
     }
 
     // Use join! instead of try_join! to collect all errors deterministically
@@ -129,14 +129,20 @@ pub async fn emit_assets(
                 let node_root = node_root.clone();
 
                 async move {
-                    let asset = check_duplicates(&path, assets, &node_root).await?;
+                    let asset = *assets.first().unwrap();
                     let span = tracing::info_span!(
                         "emit asset",
                         name = %path.to_string_ref().await?
                     );
-                    async move { emit(*asset).as_side_effect().await }
-                        .instrument(span)
-                        .await
+                    async move {
+                        emit(*asset).as_side_effect().await?;
+                        // This need to be after `emit()`, so the asset is emitted even if this
+                        // method crashes due to eventual consistency.
+                        check_duplicates(&path, assets, &node_root).await?;
+                        Ok(())
+                    }
+                    .instrument(span)
+                    .await
                 }
             })
             .try_join(),
@@ -148,18 +154,22 @@ pub async fn emit_assets(
                 let client_output_path = client_output_path.clone();
 
                 async move {
-                    let asset = check_duplicates(&path, assets, &node_root).await?;
                     let span = tracing::info_span!(
                         "emit asset",
                         name = %path.to_string_ref().await?
                     );
                     async move {
+                        let asset = *assets.first().unwrap();
                         // Client assets are emitted to the client output path, which is
                         // prefixed with _next. We need to rebase them to
                         // remove that prefix.
                         emit_rebase(*asset, client_relative_path, client_output_path)
                             .as_side_effect()
-                            .await
+                            .await?;
+                        // This need to be after `emit_rebase()`, so the asset is emitted even if
+                        // this method crashes due to eventual consistency.
+                        check_duplicates(&path, assets, &node_root).await?;
+                        Ok(())
                     }
                     .instrument(span)
                     .await


### PR DESCRIPTION
### What?

Reworks `emit_assets` in `crates/next-core/src/emit.rs` so that:

- The actual `emit()` / `emit_rebase()` write runs **before** `check_duplicates()`.
- Per-duplicate diff checks inside `check_duplicates` run in parallel.
- At most one `EmitConflictIssue` is emitted per asset path, even when multiple duplicates conflict.
- The conflict-issue emission is wrapped in a `turbo_tasks::function` and reported via `as_side_effect()`.

### Why?

Under eventual consistency, all children might be removed from `emit_assets`. This causes all `content()` and `emit()` tasks being inactive and keeping the stale value (which is potentially an error).

On recomputation of `emit_assets()` this only makes very few `content()` tasks active, as tasks are still in a stale error state and make `emit_assets()` exit early. So it takes N recomputations of `emit_assets()` to be up-to-date, where N is the number of duplicate assets. This can slow down builds drastically and did cause build time up to 30min.

Emitting the asset first ensures the file is written to disk even if the subsequent duplicate diagnostic crashes under eventual consistency. Doing the diff checks in parallel and folding conflicts into a single issue keeps the diagnostic path cheap and avoids noisy duplicate output for the same path. Tracking the issue emission as a turbo-tasks side effect means it is properly attributed to a task instead of being emitted ad-hoc from `emit_assets`.

### How?

- Swap the order in both branches of `emit_assets` (server-side `emit` and client-side `emit_rebase`) so the write happens first, then `check_duplicates` runs as a diagnostic afterwards. A comment is left explaining the ordering requirement.
- `check_duplicates` now returns `Result<()>` instead of returning the picked asset. The caller picks `assets.first()` directly, since `check_duplicates` only validated equivalence — it didn't choose a different asset.
- The inner loop in `check_duplicates` uses `iter.map(async |next| { ... }).try_flat_join().await?` to run the diff comparisons in parallel and collect conflict details. `ext` is computed once before the loop and cloned into each task.
- Only the first conflict from the collected list is reported, instead of one issue per conflicting asset.
- The `EmitConflictIssue` emission is moved into a local `#[turbo_tasks::function] fn emit_conflict_issue(...)` invoked via `.as_side_effect().await?`, so the issue is tracked as a task side effect.

<!-- NEXT_JS_LLM_PR -->