### PR TITLE
turbo-tasks: prioritize recomputed tasks with Recomputation priority

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -758,7 +758,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // done: true } it must have Output and would early return.
         let old = task.set_in_progress(in_progress_state);
         debug_assert!(old.is_none(), "InProgress already exists");
-        ctx.schedule_task(task, TaskPriority::Initial);
+        ctx.schedule_task(task, TaskPriority::Recomputation);
 
         Ok(Err(listener))
     }
@@ -896,7 +896,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             TaskExecutionReason::CellNotAvailable,
             EventDescription::new(|| task.get_task_desc_fn()),
         );
-        ctx.schedule_task(task, TaskPriority::Initial);
+        ctx.schedule_task(task, TaskPriority::Recomputation);
 
         Ok(Err(listener))
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -1,6 +1,6 @@
 use bincode::{Decode, Encode};
 use smallvec::SmallVec;
-use turbo_tasks::{TaskExecutionReason, TaskId, event::EventDescription};
+use turbo_tasks::{TaskExecutionReason, TaskId, TaskPriority, event::EventDescription};
 
 use crate::{
     backend::{
@@ -224,6 +224,16 @@ pub fn make_task_dirty_internal(
         *stale = true;
     }
     let current = task.get_dirty();
+    let parent_priority = ctx.get_current_task_priority();
+    let parent_priority = if matches!(parent_priority, TaskPriority::Recomputation) {
+        // When an invalidation was triggered during recomputation (or an initial execution that was
+        // triggered from recomputation), we do not want to treat that as recomputation.
+        // That would make recomputation to be very viral, and breaks ordering. So we reset
+        // execution order to initial.
+        TaskPriority::Initial
+    } else {
+        parent_priority
+    };
     let (old_self_dirty, old_current_session_self_clean, parent_priority) = match current {
         Some(Dirtyness::Dirty(current_priority)) => {
             #[cfg(feature = "trace_task_dirty")]
@@ -235,15 +245,15 @@ pub fn make_task_dirty_internal(
             )
             .entered();
             // already dirty
-            let parent_priority = ctx.get_current_task_priority();
-            if *current_priority >= parent_priority {
+            if matches!(*current_priority, TaskPriority::Initial)
+                || *current_priority > parent_priority
+            {
                 // Update the priority to be the lower one
                 task.set_dirty(Dirtyness::Dirty(parent_priority));
             }
             return;
         }
         Some(Dirtyness::SessionDependent) => {
-            let parent_priority = ctx.get_current_task_priority();
             task.set_dirty(Dirtyness::Dirty(parent_priority));
             // It was a session-dependent dirty before, so we need to remove that clean count
             let was_current_session_clean = task.current_session_clean();
@@ -265,7 +275,6 @@ pub fn make_task_dirty_internal(
             }
         }
         None => {
-            let parent_priority = ctx.get_current_task_priority();
             task.set_dirty(Dirtyness::Dirty(parent_priority));
             // It was clean before, so we need to increase the dirty count
             (false, false, parent_priority)

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -410,6 +410,7 @@ pub enum TaskPriority {
     Invalidation {
         priority: Reverse<u32>,
     },
+    Recomputation,
 }
 
 impl TaskPriority {
@@ -445,6 +446,7 @@ impl TaskPriority {
                     *self
                 }
             }
+            TaskPriority::Recomputation => TaskPriority::Recomputation,
         }
     }
 }
@@ -454,6 +456,7 @@ impl Display for TaskPriority {
         match self {
             TaskPriority::Initial => write!(f, "initial"),
             TaskPriority::Invalidation { priority } => write!(f, "invalidation({})", priority.0),
+            TaskPriority::Recomputation => write!(f, "recomputation"),
         }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/task_execution_reason.rs
+++ b/turbopack/crates/turbo-tasks/src/task_execution_reason.rs
@@ -1,13 +1,28 @@
 #[derive(Debug)]
 pub enum TaskExecutionReason {
+    /// A root task was initially scheduled and is executed
     Initial,
-    Local,
+    /// A task output was read, but the output is not available, so the task was scheduled and
+    /// executed to produce the output
     OutputNotAvailable,
+    /// A task cell was read, but the cell content is not available, so the task was scheduled and
+    /// executed to produce the cell content
     CellNotAvailable,
+    /// A task was marked as dirty and is active on it's own (maybe root or currently awaited), so
+    /// it was scheduled and executed to update the task output
     Invalidated,
+    /// A dirty task has been activated, so it was scheduled and executed to update the task output
     ActivateDirty,
+    /// A task has been activated for the first time (no output yet), so it was scheduled and
+    /// executed to produce the task output
     ActivateInitial,
+    /// A task was connected as child in `active_tracking == false` mode for the first time (no
+    /// output yet), so it was scheduled and executed to produce the task output.
+    /// Or a task was called inside of a turbo_tasks::run closure for the first time (no output
+    /// yet), so it was scheduled and executed to produce the task output.
     Connect,
+    /// An in-progress task was marked as stale, so it was scheduled again after execution and is
+    /// executing again to update the task output.
     Stale,
 }
 
@@ -15,7 +30,6 @@ impl TaskExecutionReason {
     pub fn as_str(&self) -> &'static str {
         match self {
             TaskExecutionReason::Initial => "initial",
-            TaskExecutionReason::Local => "local",
             TaskExecutionReason::OutputNotAvailable => "output_not_available",
             TaskExecutionReason::CellNotAvailable => "cell_not_available",
             TaskExecutionReason::Invalidated => "invalidated",


### PR DESCRIPTION
### What?

Introduces a new `Recomputation` priority in `TaskPriority` that schedules recomputed tasks (tasks re-run because their output or cell wasn't available when read) ahead of all invalidation phases. Also documents every `TaskExecutionReason` variant and removes the unused `Local` variant.

### Why?

When a task is recomputed because a downstream consumer needed its output/cell, that recomputation should run before lower-priority invalidations so the consumer can make progress. Previously these recomputations were scheduled with `Initial` priority, which placed them alongside fresh work and behind ongoing invalidation phases, hurting latency for the task actually being awaited.

Care is needed so the new priority doesn't spread virally: any invalidation triggered during a `Recomputation` task must not itself be tagged `Recomputation`, otherwise the priority would leak across the graph and break ordering. The change therefore resets the priority to `Initial` for invalidations triggered from a recomputation context.

### How?

- `turbo-tasks/src/manager.rs`: Add `TaskPriority::Recomputation` variant, ordered before `Invalidation`. Update `Display` and `update` impls.
- `turbo-tasks-backend/src/backend/mod.rs`: Schedule output-not-available and cell-not-available recomputations with `TaskPriority::Recomputation` instead of `Initial`.
- `turbo-tasks-backend/src/backend/operation/invalidate.rs`: When `make_task_dirty_internal` runs under a parent task with `Recomputation` priority, downgrade the propagated priority to `Initial` so the recomputation marker does not spread. Also tighten the "already dirty" branch so a stored `Initial` priority is always replaced by a more specific parent priority.
- `turbo-tasks/src/task_execution_reason.rs`: Document each variant and drop the unused `Local` variant (and its `as_str` arm).

Closes NEXT-

<!-- NEXT_JS_LLM_PR -->