### PR TITLE
Turbopack: Perform issue filtering without turbo-task functions

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1186,7 +1186,7 @@ impl Project {
     pub async fn issue_filter(self: Vc<Self>) -> Result<Vc<IssueFilter>> {
         let ignore_rules = self.next_config().turbopack_ignore_issue_rules().await?;
         Ok(IssueFilter::warnings_and_foreign_errors()
-            .with_ignore_rules(ignore_rules.to_vec())
+            .with_ignore_rules(ReadRef::into_owned(ignore_rules))
             .cell())
     }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1605,7 +1605,7 @@ pub struct OptionSubResourceIntegrity(Option<SubResourceIntegrity>);
 pub struct OptionFileSystemPath(Option<FileSystemPath>);
 
 #[turbo_tasks::value(transparent)]
-pub struct IgnoreIssues(Vec<IgnoreIssue>);
+pub struct IgnoreIssues(Box<[IgnoreIssue]>);
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionJsonValue(
@@ -2531,7 +2531,7 @@ impl NextConfig {
                         .transpose()?,
                 })
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<_>>()?;
         Ok(Vc::cell(rules))
     }
 

--- a/crates/next-napi-bindings/src/next_api/analyze.rs
+++ b/crates/next-napi-bindings/src/next_api/analyze.rs
@@ -29,7 +29,7 @@ pub async fn write_analyze_data_with_issues_operation(
     let filter = project.project().issue_filter().await?;
 
     let (_analyze_data, issues, effects) =
-        strongly_consistent_catch_collectables(analyze_data_op, &*filter).await?;
+        strongly_consistent_catch_collectables(analyze_data_op, &filter).await?;
 
     Ok(WriteAnalyzeResult { issues, effects }.cell())
 }

--- a/crates/next-napi-bindings/src/next_api/analyze.rs
+++ b/crates/next-napi-bindings/src/next_api/analyze.rs
@@ -26,10 +26,10 @@ pub async fn write_analyze_data_with_issues_operation(
     app_dir_only: bool,
 ) -> Result<Vc<WriteAnalyzeResult>> {
     let analyze_data_op = write_analyze_data_with_issues_operation_inner(project, app_dir_only);
-    let filter = project.project().issue_filter();
+    let filter = project.project().issue_filter().await?;
 
     let (_analyze_data, issues, effects) =
-        strongly_consistent_catch_collectables(analyze_data_op, filter).await?;
+        strongly_consistent_catch_collectables(analyze_data_op, &*filter).await?;
 
     Ok(WriteAnalyzeResult { issues, effects }.cell())
 }

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -107,16 +107,16 @@ impl Deref for ExternalEndpoint {
 /// `node_modules` reshuffle), this falls back to a default filter rather than
 /// propagating the error.  In this scenario we believe the caller will already be observing the
 /// same error
-async fn issue_filter_from_endpoint(endpoint_op: OperationVc<OptionEndpoint>) -> Vc<IssueFilter> {
-    match endpoint_op.connect().await {
-        Ok(endpoint_option) => {
-            if let Some(ep) = &*endpoint_option {
-                ep.project().issue_filter()
-            } else {
-                IssueFilter::warnings_and_foreign_errors().cell()
-            }
-        }
-        Err(_) => IssueFilter::warnings_and_foreign_errors().cell(),
+async fn issue_filter_from_endpoint(
+    endpoint_op: OperationVc<OptionEndpoint>,
+) -> ReadRef<IssueFilter> {
+    if let Ok(ep_option) = endpoint_op.connect().await
+        && let Some(ep) = &*ep_option
+        && let Ok(filter) = ep.project().issue_filter().await
+    {
+        filter
+    } else {
+        ReadRef::new_owned(IssueFilter::warnings_and_foreign_errors())
     }
 }
 
@@ -134,7 +134,7 @@ async fn get_written_endpoint_with_issues_operation(
     let write_to_disk_op = endpoint_write_to_disk_operation(endpoint_op);
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (written, issues, effects) =
-        strongly_consistent_catch_collectables(write_to_disk_op, filter).await?;
+        strongly_consistent_catch_collectables(write_to_disk_op, &*filter).await?;
     Ok(WrittenEndpointWithIssues {
         written,
         issues,
@@ -244,7 +244,7 @@ async fn subscribe_issues_and_diags_operation(
     // payload, but we still need the catch path to avoid the FATAL.
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (changed_value, issues, effects) =
-        strongly_consistent_catch_collectables(changed_op, filter).await?;
+        strongly_consistent_catch_collectables(changed_op, &*filter).await?;
     Ok(EndpointIssuesAndDiags {
         changed: changed_value,
         issues: if should_include_issues {

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -134,7 +134,7 @@ async fn get_written_endpoint_with_issues_operation(
     let write_to_disk_op = endpoint_write_to_disk_operation(endpoint_op);
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (written, issues, effects) =
-        strongly_consistent_catch_collectables(write_to_disk_op, &*filter).await?;
+        strongly_consistent_catch_collectables(write_to_disk_op, &filter).await?;
     Ok(WrittenEndpointWithIssues {
         written,
         issues,
@@ -244,7 +244,7 @@ async fn subscribe_issues_and_diags_operation(
     // payload, but we still need the catch path to avoid the FATAL.
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (changed_value, issues, effects) =
-        strongly_consistent_catch_collectables(changed_op, &*filter).await?;
+        strongly_consistent_catch_collectables(changed_op, &filter).await?;
     Ok(EndpointIssuesAndDiags {
         changed: changed_value,
         issues: if should_include_issues {

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -998,7 +998,7 @@ async fn get_entrypoints_with_issues_operation(
         EntrypointsOperation::new(project_container_entrypoints_operation(container));
     let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &filter).await?;
     Ok(EntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1554,7 +1554,7 @@ async fn get_all_written_entrypoints_with_issues_operation(
     ));
     let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &filter).await?;
     Ok(AllWrittenEntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1637,7 +1637,7 @@ async fn emit_all_output_assets_once_with_issues_operation(
     ));
     let filter = container.project().issue_filter().await?;
     let (_, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &filter).await?;
 
     Ok(OperationResult { issues, effects }.cell())
 }
@@ -1822,7 +1822,7 @@ async fn hmr_update_with_issues_operation(
     // failures to trigger their recovery paths
     let update = update_op.read_strongly_consistent().await?;
     let filter = project.issue_filter().await?;
-    let issues = get_issues(update_op, &*filter).await?;
+    let issues = get_issues(update_op, &filter).await?;
     let effects = Arc::new(take_effects(update_op).await?);
     Ok(HmrUpdateWithIssues {
         update,
@@ -1964,7 +1964,7 @@ async fn get_hmr_chunk_names_with_issues_operation(
     // failure from the dev server log.
     let hmr_chunk_names = hmr_chunk_names_op.read_strongly_consistent().await?;
     let filter = container.project().issue_filter().await?;
-    let issues = get_issues(hmr_chunk_names_op, &*filter).await?;
+    let issues = get_issues(hmr_chunk_names_op, &filter).await?;
     let effects = Arc::new(take_effects(hmr_chunk_names_op).await?);
     Ok(HmrChunkNamesWithIssues {
         chunk_names: hmr_chunk_names,
@@ -2508,7 +2508,7 @@ async fn get_all_compilation_issues_operation(
 ) -> Result<Vc<OperationResult>> {
     let inner_op = get_all_compilation_issues_inner_operation(container);
     let filter = container.project().issue_filter().await?;
-    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &*filter).await?;
+    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &filter).await?;
     Ok(OperationResult { issues, effects }.cell())
 }
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -62,7 +62,7 @@ use turbo_tasks_fs::{
 use turbo_unix_path::{get_relative_path_to, sys_to_unix, unix_to_sys};
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
-    issue::{IssueFilter, PlainIssue},
+    issue::PlainIssue,
     output::{OutputAsset, OutputAssets},
     source_map::{SourceMap, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
@@ -98,11 +98,6 @@ const SLOW_FILESYSTEM_THRESHOLD: Duration = Duration::from_millis(200);
 static SOURCE_MAP_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{SOURCE_URL_PROTOCOL}///"));
 static SOURCE_MAP_PREFIX_PROJECT: LazyLock<String> =
     LazyLock::new(|| format!("{SOURCE_URL_PROTOCOL}///[{PROJECT_FILESYSTEM_NAME}]/"));
-
-/// Get the `Vc<IssueFilter>` for a `ProjectContainer`.
-fn issue_filter_from_container(container: ResolvedVc<ProjectContainer>) -> Vc<IssueFilter> {
-    container.project().issue_filter()
-}
 
 #[napi(object)]
 #[derive(Clone, Debug)]
@@ -1001,9 +996,9 @@ async fn get_entrypoints_with_issues_operation(
 ) -> Result<Vc<EntrypointsWithIssues>> {
     let entrypoints_operation =
         EntrypointsOperation::new(project_container_entrypoints_operation(container));
-    let filter = issue_filter_from_container(container);
+    let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
     Ok(EntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1557,9 +1552,9 @@ async fn get_all_written_entrypoints_with_issues_operation(
         app_dir_only,
         write_phase,
     ));
-    let filter = issue_filter_from_container(container);
+    let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
     Ok(AllWrittenEntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1640,9 +1635,9 @@ async fn emit_all_output_assets_once_with_issues_operation(
         app_dir_only,
         has_deferred_entrypoints,
     ));
-    let filter = issue_filter_from_container(container);
+    let filter = container.project().issue_filter().await?;
     let (_, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
 
     Ok(OperationResult { issues, effects }.cell())
 }
@@ -1826,8 +1821,8 @@ async fn hmr_update_with_issues_operation(
     // `subscribeToClientHmrEvents`) rely on this read *throwing* on build-graph
     // failures to trigger their recovery paths
     let update = update_op.read_strongly_consistent().await?;
-    let filter = project.issue_filter();
-    let issues = get_issues(update_op, filter).await?;
+    let filter = project.issue_filter().await?;
+    let issues = get_issues(update_op, &*filter).await?;
     let effects = Arc::new(take_effects(update_op).await?);
     Ok(HmrUpdateWithIssues {
         update,
@@ -1968,8 +1963,8 @@ async fn get_hmr_chunk_names_with_issues_operation(
     // list keeps the loop running but with stale state, and obscures the real
     // failure from the dev server log.
     let hmr_chunk_names = hmr_chunk_names_op.read_strongly_consistent().await?;
-    let filter = issue_filter_from_container(container);
-    let issues = get_issues(hmr_chunk_names_op, filter).await?;
+    let filter = container.project().issue_filter().await?;
+    let issues = get_issues(hmr_chunk_names_op, &*filter).await?;
     let effects = Arc::new(take_effects(hmr_chunk_names_op).await?);
     Ok(HmrChunkNamesWithIssues {
         chunk_names: hmr_chunk_names,
@@ -2512,8 +2507,8 @@ async fn get_all_compilation_issues_operation(
     container: ResolvedVc<ProjectContainer>,
 ) -> Result<Vc<OperationResult>> {
     let inner_op = get_all_compilation_issues_inner_operation(container);
-    let filter = issue_filter_from_container(container);
-    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, filter).await?;
+    let filter = container.project().issue_filter().await?;
+    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &*filter).await?;
     Ok(OperationResult { issues, effects }.cell())
 }
 

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -107,7 +107,7 @@ pub fn root_task_dispose(
 /// [consume]: turbo_tasks::CollectiblesSource::take_collectibles
 pub async fn get_issues<T: Send>(
     source: OperationVc<T>,
-    filter: Vc<IssueFilter>,
+    filter: &IssueFilter,
 ) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
     Ok(Arc::new(
         source.peek_issues().get_plain_issues(filter).await?,
@@ -447,7 +447,7 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
 // propagate any actual error results.
 pub async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
     source_op: OperationVc<R>,
-    filter: Vc<IssueFilter>,
+    filter: &IssueFilter,
 ) -> Result<(
     Option<ReadRef<R>>,
     Arc<Vec<ReadRef<PlainIssue>>>,

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -395,7 +395,7 @@ impl IssueReporter for ConsoleUi {
         } = self.options;
         let mut grouped_issues: GroupedIssues = FxHashMap::default();
 
-        let plain_issues = issues.get_plain_issues(IssueFilter::everything()).await?;
+        let plain_issues = issues.get_plain_issues(&IssueFilter::everything()).await?;
         let issues = plain_issues
             .iter()
             .map(|plain_issue| {

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -301,85 +301,12 @@ impl IssueFilter {
     /// Returns true if the issue is allowed by this filter.
     #[turbo_tasks::function]
     pub async fn matches(&self, issue: ResolvedVc<Box<dyn Issue>>) -> Result<Vc<bool>> {
-        let has_no_ignore_rules = self.ignore_rules.is_empty();
-        let is_everything = self.severity == IssueSeverity::Info
-            && self.foreign_severity == IssueSeverity::Info
-            && has_no_ignore_rules;
-
-        if is_everything {
-            return Ok(Vc::cell(true));
-        }
-
-        let trait_ref = issue.into_trait_ref().await?;
-
-        // Fetch the file path once — it's used by both severity and ignore-rule
-        // checks.
-        let file_path = trait_ref.file_path().await?;
-
-        // Check severity first — this is cheap and avoids fetching
-        // title/description for issues that would be filtered out anyway.
-        let severity = trait_ref.severity();
-        // NOTE: Lower severities are _more_ severe
-        let severity_allowed = if severity <= self.severity || severity <= self.foreign_severity {
-            // we need to check the path to see if it is foreign or not.  Only await the
-            // path if it might possibly matter
-            if severity <= self.severity && severity <= self.foreign_severity {
-                // it matches no matter where the path is
-                true
-            } else if ContextCondition::InNodeModules.matches(&file_path) {
-                severity <= self.foreign_severity
-            } else {
-                severity <= self.severity
-            }
-        } else {
-            // it is too low severity to match either way
-            false
-        };
-
-        if !severity_allowed {
-            return Ok(Vc::cell(false));
-        }
-
-        // Check ignore rules — if any rule matches, the issue is dropped.
-        // Title and description are fetched lazily: only when a rule's path
-        // matches and the rule also specifies a title/description pattern.
-        if !has_no_ignore_rules {
-            let file_path_str = file_path.to_string();
-            let mut title_str: Option<String> = None;
-            let mut description_text: Option<Option<String>> = None;
-
-            for rule in &self.ignore_rules {
-                if !rule.path.matches(&file_path_str) {
-                    continue;
-                }
-                if let Some(ref title_pat) = rule.title {
-                    if title_str.is_none() {
-                        title_str = Some(trait_ref.title().await?.to_unstyled_string());
-                    }
-                    if !title_pat.matches(title_str.as_deref().unwrap()) {
-                        continue;
-                    }
-                }
-                if let Some(ref desc_pat) = rule.description {
-                    if description_text.is_none() {
-                        description_text = Some(
-                            trait_ref
-                                .description()
-                                .await?
-                                .map(|s| s.to_unstyled_string()),
-                        );
-                    }
-                    match description_text.as_ref().unwrap().as_deref() {
-                        Some(desc) if desc_pat.matches(desc) => {}
-                        _ => continue,
-                    }
-                }
-                // All specified fields matched — ignore this issue.
-                return Ok(Vc::cell(false));
-            }
-        }
-
-        Ok(Vc::cell(true))
+        Ok(Vc::cell(
+            self.matches_all_fast_path()
+                || self
+                    .matches_ref_slow_path(&*issue.into_trait_ref().await?)
+                    .await?,
+        ))
     }
 }
 
@@ -398,6 +325,83 @@ impl IssueFilter {
         self.ignore_rules = rules;
         self
     }
+
+    pub async fn matches_ref(&self, issue: &dyn Issue) -> Result<bool> {
+        Ok(self.matches_all_fast_path() || self.matches_ref_slow_path(issue).await?)
+    }
+
+    fn matches_all_fast_path(&self) -> bool {
+        self.severity == IssueSeverity::Info
+            && self.foreign_severity == IssueSeverity::Info
+            && self.ignore_rules.is_empty()
+    }
+
+    async fn matches_ref_slow_path(&self, issue: &dyn Issue) -> Result<bool> {
+        // Fetch the file path once — it's used by both severity and ignore-rule
+        // checks.
+        let file_path = issue.file_path().await?;
+
+        // Check severity first — this is cheap and avoids fetching
+        // title/description for issues that would be filtered out anyway.
+        let severity = issue.severity();
+        // NOTE: Lower severities are _more_ severe
+        let severity_allowed = if severity <= self.severity || severity <= self.foreign_severity {
+            // we need to check the path to see if it is foreign or not.  Only await the
+            // path if it might possibly matter
+            if severity <= self.severity && severity <= self.foreign_severity {
+                // it matches no matter where the path is
+                true
+            } else if ContextCondition::InNodeModules.matches(&file_path) {
+                severity <= self.foreign_severity
+            } else {
+                severity <= self.severity
+            }
+        } else {
+            // it is too low severity to match either way
+            false
+        };
+
+        if !severity_allowed {
+            return Ok(false);
+        }
+
+        // Check ignore rules — if any rule matches, the issue is dropped.
+        // Title and description are fetched lazily: only when a rule's path
+        // matches and the rule also specifies a title/description pattern.
+        if !self.ignore_rules.is_empty() {
+            let file_path_str = file_path.to_string();
+            let mut title_str: Option<String> = None;
+            let mut description_text: Option<Option<String>> = None;
+
+            for rule in &self.ignore_rules {
+                if !rule.path.matches(&file_path_str) {
+                    continue;
+                }
+                if let Some(ref title_pat) = rule.title {
+                    if title_str.is_none() {
+                        title_str = Some(issue.title().await?.to_unstyled_string());
+                    }
+                    if !title_pat.matches(title_str.as_deref().unwrap()) {
+                        continue;
+                    }
+                }
+                if let Some(ref desc_pat) = rule.description {
+                    if description_text.is_none() {
+                        description_text =
+                            Some(issue.description().await?.map(|s| s.to_unstyled_string()));
+                    }
+                    match description_text.as_ref().unwrap().as_deref() {
+                        Some(desc) if desc_pat.matches(desc) => {}
+                        _ => continue,
+                    }
+                }
+                // All specified fields matched — ignore this issue.
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
 }
 
 /// A list of issues captured with [`CollectibleIssuesExt::peek_issues`].
@@ -415,15 +419,12 @@ impl CapturedIssues {
     }
 
     // Returns all the issues as formatted `PlainIssues`.
-    pub async fn get_plain_issues(
-        &self,
-        filter: Vc<IssueFilter>,
-    ) -> Result<Vec<ReadRef<PlainIssue>>> {
+    pub async fn get_plain_issues(&self, filter: &IssueFilter) -> Result<Vec<ReadRef<PlainIssue>>> {
         let mut list = self
             .issues
             .iter()
             .map(async |issue| {
-                if *filter.matches(**issue).await? {
+                if *filter.matches_ref(**issue).await? {
                     Ok(Some(
                         PlainIssue::from_issue(**issue, Some(*self.tracer)).await?,
                     ))
@@ -975,12 +976,24 @@ impl PlainIssue {
         issue: ResolvedVc<Box<dyn Issue>>,
         import_tracer: Option<ResolvedVc<DelegatingImportTracer>>,
     ) -> Result<Vc<Self>> {
-        let trait_ref = issue.into_trait_ref().await?;
+        Ok(
+            Self::from_issue_ref(&*issue.into_trait_ref().await?, import_tracer)
+                .await?
+                .cell(),
+        )
+    }
+}
+
+impl PlainIssue {
+    pub async fn from_issue_ref(
+        trait_ref: &dyn Issue,
+        import_tracer: Option<ResolvedVc<DelegatingImportTracer>>,
+    ) -> Result<Self> {
         let severity = trait_ref.severity();
         let file_path = trait_ref.file_path().await?;
         let file_path_str = file_path.to_string_ref().await?;
 
-        Ok(Self::cell(Self {
+        Ok(Self {
             severity,
             file_path: file_path_str,
             stage: trait_ref.stage(),
@@ -1015,7 +1028,7 @@ impl PlainIssue {
                 }
                 None => vec![],
             },
-        }))
+        })
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -282,7 +282,7 @@ pub struct IssueFilter {
     /// The minimum severity for issues in node_modules
     foreign_severity: IssueSeverity,
     /// Issues matching any of these rules are ignored (dropped from results).
-    ignore_rules: Vec<IgnoreIssue>,
+    ignore_rules: Box<[IgnoreIssue]>,
 }
 
 impl IssueFilter {
@@ -291,7 +291,7 @@ impl IssueFilter {
         IssueFilter {
             severity: IssueSeverity::Info,
             foreign_severity: IssueSeverity::Info,
-            ignore_rules: Vec::new(),
+            ignore_rules: Box::from([]),
         }
     }
 
@@ -300,12 +300,12 @@ impl IssueFilter {
         IssueFilter {
             severity: IssueSeverity::Warning,
             foreign_severity: IssueSeverity::Error,
-            ignore_rules: Vec::new(),
+            ignore_rules: Box::from([]),
         }
     }
 
     /// Set the ignore rules for this filter.
-    pub fn with_ignore_rules(mut self, rules: Vec<IgnoreIssue>) -> Self {
+    pub fn with_ignore_rules(mut self, rules: Box<[IgnoreIssue]>) -> Self {
         self.ignore_rules = rules;
         self
     }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -285,32 +285,16 @@ pub struct IssueFilter {
     ignore_rules: Vec<IgnoreIssue>,
 }
 
-#[turbo_tasks::value_impl]
 impl IssueFilter {
     /// A filter that lets everything through.
-    #[turbo_tasks::function]
-    pub fn everything() -> Vc<Self> {
+    pub fn everything() -> Self {
         IssueFilter {
             severity: IssueSeverity::Info,
             foreign_severity: IssueSeverity::Info,
             ignore_rules: Vec::new(),
         }
-        .cell()
     }
 
-    /// Returns true if the issue is allowed by this filter.
-    #[turbo_tasks::function]
-    pub async fn matches(&self, issue: ResolvedVc<Box<dyn Issue>>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.matches_all_fast_path()
-                || self
-                    .matches_ref_slow_path(&*issue.into_trait_ref().await?)
-                    .await?,
-        ))
-    }
-}
-
-impl IssueFilter {
     /// Construct a filter with the standard warning/foreign-error severities.
     pub fn warnings_and_foreign_errors() -> Self {
         IssueFilter {
@@ -324,6 +308,14 @@ impl IssueFilter {
     pub fn with_ignore_rules(mut self, rules: Vec<IgnoreIssue>) -> Self {
         self.ignore_rules = rules;
         self
+    }
+
+    /// Returns true if the issue is allowed by this filter.
+    pub async fn matches(&self, issue: ResolvedVc<Box<dyn Issue>>) -> Result<bool> {
+        Ok(self.matches_all_fast_path()
+            || self
+                .matches_ref_slow_path(&*issue.into_trait_ref().await?)
+                .await?)
     }
 
     pub async fn matches_ref(&self, issue: &dyn Issue) -> Result<bool> {
@@ -424,7 +416,7 @@ impl CapturedIssues {
             .issues
             .iter()
             .map(async |issue| {
-                if *filter.matches_ref(**issue).await? {
+                if filter.matches(*issue).await? {
                     Ok(Some(
                         PlainIssue::from_issue(**issue, Some(*self.tracer)).await?,
                     ))

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -90,7 +90,7 @@ impl GetContentFn {
 async fn peek_issues<T: Send>(source: OperationVc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
     let captured = source.peek_issues();
 
-    captured.get_plain_issues(IssueFilter::everything()).await
+    captured.get_plain_issues(&IssueFilter::everything()).await
 }
 
 fn extend_issues(issues: &mut Vec<ReadRef<PlainIssue>>, new_issues: Vec<ReadRef<PlainIssue>>) {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -638,7 +638,7 @@ async fn snapshot_issues(
 
     let plain_issues = run_result_op
         .peek_issues()
-        .get_plain_issues(IssueFilter::everything())
+        .get_plain_issues(&IssueFilter::everything())
         .await?;
 
     turbopack_test_utils::snapshot::snapshot_issues(plain_issues, path.join("issues")?, &REPO_ROOT)

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -234,7 +234,7 @@ async fn run(resource: PathBuf) -> Result<()> {
 
             let plain_issues = out_op
                 .peek_issues()
-                .get_plain_issues(IssueFilter::everything())
+                .get_plain_issues(&IssueFilter::everything())
                 .await?;
 
             snapshot_issues(plain_issues, out_vc.join("issues")?, &REPO_ROOT)


### PR DESCRIPTION
The filtering logic is generally very cheap, many issues are short-lived, and filtering is unlikely to trigger more than 1-2 turbo tasks per issue.

Wrapping it in another task per issue doesn't make a ton of sense.