### PR TITLE
[ci] Resize tiny jobs in integration_tests_reusable.yml to use smaller machines

### DIFF
--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -56,7 +56,7 @@ jobs:
     secrets: inherit
 
   generate-matrices:
-    runs-on: ubuntu-latest-16-core-oss
+    runs-on: ubuntu-latest-4-core-oss
     steps:
       - id: out
         run: |
@@ -147,7 +147,7 @@ jobs:
   collect_nextjs_development_integration_stat:
     needs: [test-e2e, test-integration]
     name: Next.js integration test development status report
-    runs-on: ubuntu-latest-16-core-oss
+    runs-on: ubuntu-latest-4-core-oss
     if: always()
     permissions:
       pull-requests: write


### PR DESCRIPTION
Claude identified these as clear candidates for shrinking machine size.

Here are the runner types we have that are attributed to the OSS cost center:

![Screenshot 2026-05-15 at 6.18.18 PM.png](https://app.graphite.com/user-attachments/assets/7f6d927b-1820-4be5-bf8b-3ee8fc5c2988.png)

Ideally we'd have 1 and 2 core machines as well, but I don't really want to bother IT right now.