### PR TITLE
fix: add CSP nonce to component chunk scripts

### DIFF
--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -37,6 +37,7 @@ export async function createComponentStylesAndScripts({
         src: `${ctx.assetPrefix}/_next/${encodeURIPath(href)}${getAssetQueryString(ctx, true)}`,
         async: true,
         key: `script-${scriptIndex}`,
+        nonce: ctx.nonce,
       })
     )
     scriptIndex++

--- a/test/e2e/app-dir/next-dynamic-csp-nonce/app/with-template/page.js
+++ b/test/e2e/app-dir/next-dynamic-csp-nonce/app/with-template/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="page-title">Template chunk nonce test</h1>
+}

--- a/test/e2e/app-dir/next-dynamic-csp-nonce/app/with-template/template.js
+++ b/test/e2e/app-dir/next-dynamic-csp-nonce/app/with-template/template.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Template({ children }) {
+  return <div id="template-wrapper">{children}</div>
+}

--- a/test/e2e/app-dir/next-dynamic-csp-nonce/middleware.js
+++ b/test/e2e/app-dir/next-dynamic-csp-nonce/middleware.js
@@ -1,13 +1,20 @@
 import { NextResponse } from 'next/server'
 
 export function middleware(request) {
-  const response = NextResponse.next()
   const nonce = 'test-nonce'
+  const csp = `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'`
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-nonce', nonce)
+  requestHeaders.set('content-security-policy', csp)
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+
   response.headers.set('x-nonce', nonce)
-  response.headers.set(
-    'Content-Security-Policy',
-    `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'`
-  )
+  response.headers.set('Content-Security-Policy', csp)
   return response
 }
 

--- a/test/e2e/app-dir/next-dynamic-csp-nonce/next-dynamic-csp-nonce.test.ts
+++ b/test/e2e/app-dir/next-dynamic-csp-nonce/next-dynamic-csp-nonce.test.ts
@@ -31,6 +31,21 @@ describe('next/dynamic with CSP nonce', () => {
     })
   })
 
+  it('should include nonce attribute on component convention chunk scripts', async () => {
+    const $ = await next.render$('/with-template')
+
+    const chunkScripts = $('script[src]').filter((_, element) => {
+      const src = $(element).attr('src')
+      return src ? /_next\/static\/(immutable\/)?chunks\//.test(src) : false
+    })
+
+    expect(chunkScripts.length).toBeGreaterThan(0)
+
+    chunkScripts.each((_, element) => {
+      expect($(element).attr('nonce')).toBe('test-nonce')
+    })
+  })
+
   it('should not generate CSP violations when using next/dynamic with nonce', async () => {
     const browser = await next.browser('/')
 


### PR DESCRIPTION
### What?

Adds the parsed CSP nonce to App Router component convention chunk scripts emitted by `createComponentStylesAndScripts`.

### Why?

Next already applies `ctx.nonce` to similar `_next` script tags in `get-layer-assets`, and `next/dynamic` preload nonce propagation was fixed in #81999. This path still emitted `/_next/static/chunks/...` scripts without a nonce, which can trigger `script-src-elem` violations under nonce-based CSP policies.

### How?

Passes `nonce: ctx.nonce` when creating component convention script tags, and extends the CSP nonce e2e fixture with a client `template` route that exercises this renderer and asserts chunk scripts include the nonce.

Fixes #93903

LLM disclosure: Codex helped prepare this PR; I reviewed the change.

Local checks: `git diff --check`. I could not run the e2e suite in this fresh checkout because dependencies are not installed locally.