### PR TITLE
[test] split `og-api` test suite into default and standalone variants

### DIFF
--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -325,6 +325,7 @@
       "test/e2e/next-link-errors/next-link-errors.test.ts",
       "test/e2e/nonce-head-manager/index.test.ts",
       "test/e2e/og-api/index.test.ts",
+      "test/e2e/og-api/standalone.test.ts",
       "test/e2e/og-routes-custom-font/og-routes-custom-font.test.ts",
       "test/e2e/on-request-error/basic/basic.test.ts",
       "test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts",

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -118,6 +118,7 @@
       "test/e2e/socket-io/index.test.ts",
       "test/e2e/middleware-matcher/index.test.ts",
       "test/e2e/next-script/index.test.ts",
+      "test/e2e/og-api/standalone.test.ts",
       "test/production/standalone-mode/**/*"
     ]
   }

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -118,7 +118,6 @@
       "test/e2e/socket-io/index.test.ts",
       "test/e2e/middleware-matcher/index.test.ts",
       "test/e2e/next-script/index.test.ts",
-      "test/e2e/og-api/standalone.test.ts",
       "test/production/standalone-mode/**/*"
     ]
   }

--- a/test/e2e/og-api/app/next.config.js
+++ b/test/e2e/og-api/app/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  output: 'standalone',
+  ...(process.env.TEST_OUTPUT_STANDALONE === 'true'
+    ? { output: 'standalone' }
+    : {}),
 }

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -4,9 +4,11 @@ import fs from 'fs-extra'
 import { join } from 'path'
 
 describe('og-api', () => {
-  const { next } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),
+    skipDeployment:  process.env.TEST_OUTPUT_STANDALONE === 'true',
   })
+if (skipped) return
 
   it('should respond from index', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -6,9 +6,10 @@ import { join } from 'path'
 describe('og-api', () => {
   const { next, skipped } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),
-    skipDeployment:  process.env.TEST_OUTPUT_STANDALONE === 'true',
+    skipDeployment: process.env.TEST_OUTPUT_STANDALONE === 'true',
   })
-if (skipped) return
+
+  if (skipped) return
 
   it('should respond from index', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -45,7 +45,10 @@ describe('og-api', () => {
     expect(body.size).toBeGreaterThan(0)
   })
 
-  if ((global as any).isNextStart) {
+  if (
+    (global as any).isNextStart &&
+    process.env.TEST_OUTPUT_STANDALONE === 'true'
+  ) {
     it('should copy files correctly', async () => {
       expect(next.cliOutput).not.toContain('Failed to copy traced files')
 

--- a/test/e2e/og-api/standalone.test.ts
+++ b/test/e2e/og-api/standalone.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_OUTPUT_STANDALONE = 'true'
+
+require('./index.test')


### PR DESCRIPTION
The fixture's `next.config.js` had `output: 'standalone'` hardcoded, which is meaningless on Vercel deployments (the standalone directory is ignored) but became a build-time crash after #93684 made the Turbopack NFT generator skip `next-server.js.nft.json` whenever an adapter is configured. With `output: 'standalone'` still active, `writeStandaloneDirectory` then fails with `ENOENT` when it tries to read that file ([x-ref](https://github.com/vercel/next.js/actions/runs/26006483168/job/76441905221)).

This PR splits the `og-api` E2E suite into a default variant and a `standalone.test.ts` wrapper that enables `output: 'standalone'` via the `TEST_OUTPUT_STANDALONE` env var, and excludes the standalone wrapper from the deploy test manifest.

The default variant still runs in `deploy` mode and preserves coverage of `next/og` from Pages Router API routes, App Router route handlers (edge and node), and middleware — paths not covered by the metadata-* fixtures. The standalone variant continues to exercise the trace-copy assertion in `next start` mode.