### PR TITLE
Pass projectDir to adapter modifyConfig

### DIFF
--- a/docs/01-app/03-api-reference/07-adapters/02-creating-an-adapter.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/02-creating-an-adapter.mdx
@@ -42,6 +42,7 @@ export interface NextAdapter {
     ctx: {
       phase: PHASE_TYPE
       nextVersion: string
+      projectDir: string
     }
   ) => Promise<NextConfigComplete> | NextConfigComplete
   onBuildComplete?: (ctx: {

--- a/docs/01-app/03-api-reference/07-adapters/03-api-reference.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/03-api-reference.mdx
@@ -12,6 +12,7 @@ Called for any CLI command that loads the `next.config.js` file to allow modific
 - `config`: The complete Next.js configuration object
 - `context.phase`: The current build phase (see [phases](/docs/app/api-reference/config/next-config-js#phase))
 - `context.nextVersion`: Version of Next.js being used
+- `context.projectDir`: Absolute path to the Next.js project directory
 
 **Returns:** The modified configuration object (can be async)
 

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -379,6 +379,10 @@ export interface NextAdapter {
        * nextVersion is the current version of Next.js being used
        */
       nextVersion: string
+      /**
+       * projectDir is the absolute directory the Next.js application is in
+       */
+      projectDir: string
     }
   ) => Promise<NextConfigComplete> | NextConfigComplete
   onBuildComplete?: (ctx: {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1590,7 +1590,8 @@ function finalizeConfig(config: NextConfigComplete): NextConfigComplete {
 async function applyModifyConfig(
   config: NextConfigComplete,
   phase: PHASE_TYPE,
-  silent: boolean
+  silent: boolean,
+  dir: string
 ): Promise<NextConfigComplete> {
   // we always call modify config  and phase can be used to only
   // modify for specific times
@@ -1607,6 +1608,7 @@ async function applyModifyConfig(
       config = await adapterMod.modifyConfig(config, {
         phase,
         nextVersion: process.env.__NEXT_VERSION as string,
+        projectDir: dir,
       })
     }
   }
@@ -1779,7 +1781,8 @@ export default async function loadConfig(
           phase
         ),
         phase,
-        silent
+        silent,
+        dir
       )
     )
 
@@ -1977,7 +1980,7 @@ export default async function loadConfig(
     )
 
     const finalConfig = finalizeConfig(
-      await applyModifyConfig(completeConfig, phase, silent)
+      await applyModifyConfig(completeConfig, phase, silent, dir)
     )
 
     // Cache the final result
@@ -2036,7 +2039,7 @@ export default async function loadConfig(
   setHttpClientAndAgentOptions(completeConfig)
 
   const finalConfig = finalizeConfig(
-    await applyModifyConfig(completeConfig, phase, silent)
+    await applyModifyConfig(completeConfig, phase, silent, dir)
   )
 
   // Cache the default config result

--- a/test/production/adapter-config/adapter-config-export.test.ts
+++ b/test/production/adapter-config/adapter-config-export.test.ts
@@ -55,6 +55,7 @@ describe('adapter-config export', () => {
     }
 
     expect(ctx.nextVersion).toBe(nextVersion)
+    expect(ctx.projectDir).toBe(next.testDir)
     expect(config?.basePath).toBe('/docs')
 
     const combinedRouteOutputs = [

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -43,6 +43,7 @@ describe('adapter-config', () => {
     }
 
     expect(ctx.nextVersion).toBe(nextVersion)
+    expect(ctx.projectDir).toBe(next.testDir)
     expect(config?.basePath).toBe('/docs')
 
     const combinedRouteOutputs = [


### PR DESCRIPTION
Adapters implementing `modifyConfig` may need to know the absolute project directory to perform path resolution or apply directory-specific configuration logic. Without this value, adapters had no reliable way to determine where the application lives on disk.

onBuildComplete already received the directory as a parameter.