### PR TITLE
Rename TaskExecutionReason::Initial to Root

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -781,7 +781,7 @@ impl TaskStorage {
         }));
         self.set_in_progress(InProgressState::Scheduled {
             done_event,
-            reason: TaskExecutionReason::Initial,
+            reason: TaskExecutionReason::Root,
         });
     }
 

--- a/turbopack/crates/turbo-tasks/src/task_execution_reason.rs
+++ b/turbopack/crates/turbo-tasks/src/task_execution_reason.rs
@@ -1,7 +1,7 @@
 #[derive(Debug)]
 pub enum TaskExecutionReason {
     /// A root task was initially scheduled and is executed
-    Initial,
+    Root,
     /// A task output was read, but the output is not available, so the task was scheduled and
     /// executed to produce the output
     OutputNotAvailable,
@@ -29,7 +29,7 @@ pub enum TaskExecutionReason {
 impl TaskExecutionReason {
     pub fn as_str(&self) -> &'static str {
         match self {
-            TaskExecutionReason::Initial => "initial",
+            TaskExecutionReason::Root => "root",
             TaskExecutionReason::OutputNotAvailable => "output_not_available",
             TaskExecutionReason::CellNotAvailable => "cell_not_available",
             TaskExecutionReason::Invalidated => "invalidated",


### PR DESCRIPTION
### What?

Renames the `TaskExecutionReason::Initial` variant to `TaskExecutionReason::Root` in turbo-tasks, and updates its `as_str()` representation from `"initial"` to `"root"`.

### Why?

The variant's doc comment already describes it as "A root task was initially scheduled and is executed". The name `Initial` is misleading because it suggests "first execution of any task", which overlaps semantically with other variants like `ActivateInitial` (a task activated for the first time with no output yet). `Root` accurately reflects that this reason is specifically used when a root task is scheduled, making the enum easier to read and reason about at call sites and in traces.

### How?

- `turbopack/crates/turbo-tasks/src/task_execution_reason.rs`: rename the enum variant `Initial` → `Root` and update the `as_str()` mapping to return `"root"`.
- `turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs`: update the single construction site that used `TaskExecutionReason::Initial` when scheduling a root task.

No behavioral changes — this is a pure rename. The other `*Initial` variant (`ActivateInitial`) is intentionally left untouched because it describes a different concept (first-time activation of a non-root task).

Verified with `cargo check` and `cargo clippy` on `turbo-tasks` and `turbo-tasks-backend`.

Closes NEXT-
Fixes #
