### PR TITLE
Yav/redesign unrendered segment overlay followup

### DIFF
--- a/packages/next/.storybook/fixtures/errors.ts
+++ b/packages/next/.storybook/fixtures/errors.ts
@@ -648,3 +648,18 @@ export const instantClientMathRandomErrors: ReadyRuntimeError[] = [
     type: 'runtime',
   },
 ]
+
+export const instantUnrenderedSegmentErrors: ReadyRuntimeError[] = [
+  {
+    id: 130,
+    runtime: true,
+    error: Object.assign(
+      new Error(
+        'Route "/81-instant-wrapper-unrendered-segment/trigger": Could not validate that a segment in your UI has instant navigation.\n\nThis segment was dropped from rendering. Issues that would prevent instant navigation will go undetected.\n\nDropped segment:\n  test-app/app/81-instant-wrapper-unrendered-segment/trigger/page.tsx\n\nWays to fix this:\n  - Render the dropped segment\n  - Set `export const instant = false` on the dropped segment to skip validation\n\nLearn more: https://nextjs.org/docs/messages/unrendered-instant-segment'
+      ),
+      { __NEXT_ERROR_CODE: 'E1248' }
+    ),
+    frames: () => Promise.resolve([]),
+    type: 'runtime',
+  },
+]

--- a/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
@@ -204,7 +204,7 @@ export const CODE_FRAME_STYLES = `
   }
 
   [data-nextjs-codeframe-line] > span:first-child {
-    color: var(--color-gray-alpha-700) !important;
+    color: var(--color-gray-alpha-500) !important;
   }
 
   [data-nextjs-codeframe-line][data-nextjs-codeframe-line--errored="true"]

--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance-data.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance-data.ts
@@ -185,6 +185,7 @@ const unrenderedSegmentCards: FixCard[] = [
     link: 'https://nextjs.org/docs/messages/unrendered-instant-segment#skip-validation-on-the-segment',
     snippets: [
       { text: '// page.tsx or layout.tsx' },
+      { text: '' },
       { text: 'export const instant = false', highlight: true },
     ],
   },

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
@@ -10,6 +10,7 @@ import {
   instantMetadataErrors,
   instantMetadataUncachedErrors,
   instantMathRandomErrors,
+  instantUnrenderedSegmentErrors,
   instantRuntimeDataErrors,
   instantUncachedDataErrors,
   instantViewportErrors,
@@ -176,5 +177,12 @@ export const InstantClientMathRandom: Story = {
   args: {
     ...Default.args,
     runtimeErrors: instantClientMathRandomErrors,
+  },
+}
+
+export const InstantUnrenderedSegment: Story = {
+  args: {
+    ...Default.args,
+    runtimeErrors: instantUnrenderedSegmentErrors,
   },
 }


### PR DESCRIPTION
## Summary

Adds a Storybook example for the unrendered-segment instant validation error, and keeps the small UI polish tweaks for the code snippet presentation.

## What changed

- Added `InstantUnrenderedSegment` to the dev overlay error stories
- Added a matching Storybook fixture for the unrendered-segment error
- Added a blank line in the “Skip validation on the segment” fix-card snippet
- Adjusted the code-frame gutter color to `var(--color-gray-alpha-500)`

## Why

This makes the unrendered-segment instant validation state easier to review in isolation in Storybook, while also preserving the two small visual refinements requested for the snippet/code-frame presentation.