### PR TITLE
Use node streams for server inserted HTML

### DIFF
--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -87,11 +87,6 @@ export function makeGetServerInsertedHTML({
       return ''
     }
 
-    const streamOptions = {
-      // Larger chunk because this isn't sent over the network.
-      // Let's set it to 1MB.
-      progressiveChunkSize: 1024 * 1024,
-    }
     const { stream } = await (
       process.env.__NEXT_USE_NODE_STREAMS
         ? renderToNodeFizzStream
@@ -103,7 +98,11 @@ export function makeGetServerInsertedHTML({
         {traceMetaTags}
         {errorMetaTags}
       </>,
-      streamOptions
+      {
+        // Larger chunk because this isn't sent over the network.
+        // Let's set it to 1MB.
+        progressiveChunkSize: 1024 * 1024,
+      }
     )
 
     // The polyfills and trace metadata have been flushed, so they don't need to be rendered again

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -6,11 +6,14 @@ import {
   getRedirectStatusCodeFromError,
 } from '../../client/components/redirect'
 import { isRedirectError } from '../../client/components/redirect-error'
-import { renderToReadableStream } from 'react-dom/server'
-import { streamToString } from '../stream-utils/node-web-streams-helper'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
 import type { ClientTraceDataEntry } from '../lib/trace/tracer'
+import {
+  renderToNodeFizzStream,
+  renderToWebFizzStream,
+  streamToString,
+} from './stream-ops'
 
 export function makeGetServerInsertedHTML({
   polyfills,
@@ -84,19 +87,23 @@ export function makeGetServerInsertedHTML({
       return ''
     }
 
-    // TODO: This should use Node streams when __NEXT_USE_NODE_STREAMS is true
-    const stream = await renderToReadableStream(
+    const streamOptions = {
+      // Larger chunk because this isn't sent over the network.
+      // Let's set it to 1MB.
+      progressiveChunkSize: 1024 * 1024,
+    }
+    const { stream } = await (
+      process.env.__NEXT_USE_NODE_STREAMS
+        ? renderToNodeFizzStream
+        : renderToWebFizzStream
+    )(
       <>
         {polyfillTags}
         {serverInsertedHTML}
         {traceMetaTags}
         {errorMetaTags}
       </>,
-      {
-        // Larger chunk because this isn't sent over the network.
-        // Let's set it to 1MB.
-        progressiveChunkSize: 1024 * 1024,
-      }
+      streamOptions
     )
 
     // The polyfills and trace metadata have been flushed, so they don't need to be rendered again


### PR DESCRIPTION
### What?

Routes server-inserted HTML rendering through the app-render stream-ops Fizz helpers instead of calling `renderToReadableStream` directly.

### Why?

This lets server-inserted HTML use Node streams when `__NEXT_USE_NODE_STREAMS` is enabled, matching the runtime stream selection used elsewhere in app render.

### How?

Imports `renderToNodeFizzStream`, `renderToWebFizzStream`, and `streamToString` from `./stream-ops`, then selects the appropriate Fizz renderer based on `process.env.__NEXT_USE_NODE_STREAMS` while preserving the existing progressive chunk size.


<!-- NEXT_JS_LLM_PR -->