### PR TITLE
Allow inspecting prerender worker again

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -16,7 +16,7 @@ import { bold, yellow } from '../lib/picocolors'
 import { makeRe } from 'next/dist/compiled/picomatch'
 import { existsSync, promises as fs } from 'fs'
 import os from 'os'
-import { Worker } from '../lib/worker'
+import { getNextBuildDebuggerPortOffset, Worker } from '../lib/worker'
 import { defaultConfig, getNextConfigRuntime } from '../server/config-shared'
 import devalue from 'next/dist/compiled/devalue'
 import findUp from 'next/dist/compiled/find-up'
@@ -2047,7 +2047,9 @@ export default async function build(
 
       staticWorker = createStaticWorker(config, {
         numberOfWorkers,
-        debuggerPortOffset: -1,
+        debuggerPortOffset: getNextBuildDebuggerPortOffset({
+          kind: 'export-page',
+        }),
       })
 
       const analysisBegin = process.hrtime()


### PR DESCRIPTION
PR #79098 made it possible to attach a debugger to the prerender worker during `next build` by passing a non-`-1` `debuggerPortOffset` to the worker that runs `exportPages`. PR #85860 then unified the static-check worker and the prerender worker into a single shared instance, but kept the static-check worker's `debuggerPortOffset: -1`. Since the shared instance is now also used for prerendering, the inspector flags get stripped from the worker's `NODE_OPTIONS` and only the outer build process can be inspected.

This switches the shared worker over to
`getNextBuildDebuggerPortOffset({ kind: 'export-page' })` so the prerender worker is inspectable again. The `else` branch in `export/index.ts` that still creates an inspectable worker on its own remains reachable through `writeFullyStaticExport` (the `output: 'export'` path), so it is left untouched.

### Test Plan

In `test/e2e/app-dir/hello-world`:

- Add a `debugger` statement to `app/page.tsx`.
- Set `experimental.cpus: 1` in `next.config.js` so only one prerender worker is created.
- Set `experimental.turbopackMinify: false` in `next.config.js`, otherwise the `debugger` statement gets stripped from the prerendered bundle.

Then run `pnpm debug-brk build test/e2e/app-dir/hello-world`. The build output should print two `Debugger listening` lines — one for the parent process and one for the prerender worker on the next port — and attaching DevTools to the worker port should pause on the `debugger` statement inside `Page`.