### PR TITLE
@vercel/devlow-bench: 0.3.5 → 0.4.0

### DIFF
--- a/turbopack/packages/devlow-bench/package.json
+++ b/turbopack/packages/devlow-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/devlow-bench",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "Benchmarking tool for the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump so we can publish the changes from #93950 (and the previously-unpublished 0.3.5 work) to npm.

Stacked on top of #93950.

<!-- NEXT_JS_LLM_PR -->