### PR TITLE
[ci] Explicitly disable package-manager-cache for uses of actions/setup-node

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31
@@ -124,6 +125,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31
@@ -248,6 +250,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Prepare corepack
         if: ${{ matrix.os != 'windows' }}
@@ -401,6 +404,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
       - run: corepack enable
 
       - name: Install Rust
@@ -447,6 +451,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31
@@ -512,6 +517,7 @@ jobs:
           node-version: 24
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -150,10 +150,11 @@ jobs:
       NEXT_SKIP_NATIVE_POSTINSTALL: 1
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup pnpm
         run: |
@@ -227,9 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -27,10 +27,11 @@ jobs:
     environment: release-${{ github.event.inputs.releaseType }}
     steps:
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           check-latest: true
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -30,10 +30,11 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           check-latest: true
+          package-manager-cache: false
 
       - name: Create GitHub App token
         id: release-app-token

--- a/.github/workflows/issue_wrong_template.yml
+++ b/.github/workflows/issue_wrong_template.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31

--- a/.github/workflows/popular.yml
+++ b/.github/workflows/popular.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -155,9 +155,10 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
+          package-manager-cache: false
 
       - name: Install dependencies
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}

--- a/.github/workflows/release-next-rspack.yml
+++ b/.github/workflows/release-next-rspack.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Enable corepack
         run: corepack enable

--- a/.github/workflows/rspack-update-tests-manifest.yml
+++ b/.github/workflows/rspack-update-tests-manifest.yml
@@ -39,10 +39,11 @@ jobs:
           token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup corepack
         run: |
@@ -100,10 +101,11 @@ jobs:
           token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup corepack
         run: |

--- a/.github/workflows/sync_backport_canary_release.yml
+++ b/.github/workflows/sync_backport_canary_release.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           node-version: 20
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup corepack
         if: steps.precheck.outputs.should_evaluate == 'true'

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -37,10 +37,11 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
       - run: corepack enable
 
       # We need to install the dependencies for the benchmark apps

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -52,10 +52,11 @@ jobs:
       next-version: ${{ steps.version.outputs.value }}
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup pnpm
         run: |
@@ -274,10 +275,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.9.0
           check-latest: true
+          package-manager-cache: false
 
       - name: Download adapter test result artifacts
         continue-on-error: true

--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -27,10 +27,11 @@ jobs:
     if: github.repository_owner == 'vercel'
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup pnpm
         run: |

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -35,10 +35,11 @@ jobs:
         run: sudo ethtool -K eth0 tx off rx off
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           check-latest: true
+          package-manager-cache: false
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -47,10 +47,11 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           check-latest: true
+          package-manager-cache: false
 
       - name: Create GitHub App token
         id: release-app-token

--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -39,10 +39,11 @@ jobs:
           token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup corepack
         run: |
@@ -96,10 +97,11 @@ jobs:
           token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup corepack
         run: |

--- a/.github/workflows/update_fonts_data.yml
+++ b/.github/workflows/update_fonts_data.yml
@@ -41,10 +41,11 @@ jobs:
           token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup corepack
         run: |

--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -47,10 +47,11 @@ jobs:
           token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Setup corepack
         run: |

--- a/.github/workflows/upload-tests-manifest.yml
+++ b/.github/workflows/upload-tests-manifest.yml
@@ -19,10 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
+          package-manager-cache: false
 
       # Checkout from the default branch (canary) -- workflow_run always uses
       # the default branch's version of the workflow file and this checkout


### PR DESCRIPTION
If this action detects that you're likely using `npm` it (by default) enables a cache for `npm`. We use `pnpm`, so it doesn't do anything (and we manually set up a pnpm cache in some places), but the implicit behavior here is a little dangerous: e.g. https://adnanthekhan.com/posts/angular-compromise-through-dev-infra/#finding-the-pivot

So let's explicitly disable this everywhere. It wasn't doing anything for us anyways.