### PR TITLE
use the action cache for passing tests

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -128,10 +128,7 @@ env:
   KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
   KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
   NEXT_TEST_JOB: 1
-  # Per-job memoization of passed test files. run-tests.js appends to
-  # this file as each test passes; the cache steps below restore it at
-  # job start and save it at job end (including on cancel) so that
-  # re-attempts skip what already passed.
+  # Per-job memoization of passed test files.
   NEXT_TEST_PASSED_FILE: .next-test-passed.txt
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
@@ -377,9 +374,7 @@ jobs:
         run: pnpm dlx turbo@${TURBO_VERSION} run get-test-timings -- --build ${{ github.sha }}
 
       # Restore the list of tests that already passed in an earlier
-      # attempt of this same workflow run. `run-tests.js` reads
-      # `$NEXT_TEST_PASSED_FILE` on startup and skips entries that match.
-      # Save happens in the post-`afterBuild` step below.
+      # attempt of this same workflow run.
       - name: Restore passed-tests cache
         if: ${{ inputs.afterBuild && runner.environment == 'github-hosted' }}
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -399,10 +394,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout_minutes }}
 
       # Save the passed-tests file so the next attempt (if any) can skip
-      # them. `if: always()` makes this run on success, failure, AND
-      # cancel — which is the whole point: a cancelled test step still
-      # gets to preserve its progress for retry. Cache keys are immutable,
-      # so each attempt writes under a key tagged with its run_attempt.
+      # them. `always()` makes this run on success, failure, or cancellation.
       - name: Save passed-tests cache
         if: ${{ always() && inputs.afterBuild && runner.environment == 'github-hosted' }}
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -128,6 +128,11 @@ env:
   KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
   KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
   NEXT_TEST_JOB: 1
+  # Per-job memoization of passed test files. run-tests.js appends to
+  # this file as each test passes; the cache steps below restore it at
+  # job start and save it at job end (including on cancel) so that
+  # re-attempts skip what already passed.
+  NEXT_TEST_PASSED_FILE: .next-test-passed.txt
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
   VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
@@ -371,6 +376,19 @@ jobs:
         if: ${{ inputs.testTimingsArtifact == '' }}
         run: pnpm dlx turbo@${TURBO_VERSION} run get-test-timings -- --build ${{ github.sha }}
 
+      # Restore the list of tests that already passed in an earlier
+      # attempt of this same workflow run. `run-tests.js` reads
+      # `$NEXT_TEST_PASSED_FILE` on startup and skips entries that match.
+      # Save happens in the post-`afterBuild` step below.
+      - name: Restore passed-tests cache
+        if: ${{ inputs.afterBuild && runner.environment == 'github-hosted' }}
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ env.NEXT_TEST_PASSED_FILE }}
+          key: next-test-passed-${{ steps.var.outputs.input_step_key }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
+          restore-keys: |
+            next-test-passed-${{ steps.var.outputs.input_step_key }}-${{ github.run_id }}-
+
       - run: ${{ inputs.afterBuild }}
         # defaults.run.shell sets a stronger options (`-leo pipefail`)
         # Set this back to github action's weaker defaults:
@@ -379,6 +397,18 @@ jobs:
         # We must use a login shell: fnm installation may modify the `.profile`
         shell: bash -le {0}
         timeout-minutes: ${{ inputs.timeout_minutes }}
+
+      # Save the passed-tests file so the next attempt (if any) can skip
+      # them. `if: always()` makes this run on success, failure, AND
+      # cancel — which is the whole point: a cancelled test step still
+      # gets to preserve its progress for retry. Cache keys are immutable,
+      # so each attempt writes under a key tagged with its run_attempt.
+      - name: Save passed-tests cache
+        if: ${{ always() && inputs.afterBuild && runner.environment == 'github-hosted' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ env.NEXT_TEST_PASSED_FILE }}
+          key: next-test-passed-${{ steps.var.outputs.input_step_key }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
 
       - name: Upload test result artifacts
         if: ${{ inputs.testReportsArtifactPrefix != '' && inputs.afterBuild && always() }}

--- a/run-tests.js
+++ b/run-tests.js
@@ -855,27 +855,12 @@ ${ENDGROUP}`)
     }
   }
 
-  // Per-test file append. Sync I/O — the write is sequenced before we
-  // return from `runTest`, no Promise queue or libuv ordering questions.
-  // We keep the fd open across calls and fsync after each write so a
-  // runner-level kill between the test step and the post-job cache save
-  // step can't drop entries that are still in the kernel page cache.
-  // Best-effort: a single write failure shouldn't break the test run,
-  // so we just log it once.
-  const passedTestsPath = process.env.NEXT_TEST_PASSED_FILE
+  // Stream passing test names to this file.
   /** @type {number | null} */
   let passedTestsFd = null
-  let appendFailureLogged = false
-  if (passedTestsPath) {
+  if (profile.cachingEnabled) {
     try {
-      passedTestsFd = fs.openSync(passedTestsPath, 'a')
-      process.on('exit', () => {
-        if (passedTestsFd !== null) {
-          try {
-            fs.closeSync(passedTestsFd)
-          } catch {}
-        }
-      })
+      passedTestsFd = fs.openSync(process.env.NEXT_TEST_PASSED_FILE, 'a')
     } catch (err) {
       console.log(`Test result cache: open failed (${err.message})`)
     }
@@ -884,13 +869,12 @@ ${ENDGROUP}`)
   const recordPassed = (file) => {
     if (passedTestsFd === null) return
     try {
+      // Ensure durability of our writes by syncing each one.
+      // This is a tiny bit of overhead but shouldn't really matter.
       fs.writeSync(passedTestsFd, `${file}\n`)
-      fs.fsyncSync(passedTestsFd)
+      fs.fdatasyncSync(passedTestsFd)
     } catch (err) {
-      if (!appendFailureLogged) {
-        appendFailureLogged = true
-        console.log(`Test result cache: append failed (${err.message})`)
-      }
+      console.log(`Test result cache: append failed (${err.message})`)
     }
   }
 
@@ -1017,6 +1001,12 @@ ${ENDGROUP}`)
       hadFailures = true
       console.error(result.reason)
     }
+  }
+
+  if (passedTestsFd !== null) {
+    try {
+      fs.closeSync(passedTestsFd)
+    } catch {}
   }
 
   if (cachedPassedTests.size > 0) {

--- a/run-tests.js
+++ b/run-tests.js
@@ -3,7 +3,6 @@
 const path = require('path')
 const _glob = require('glob')
 const fs = require('fs')
-const { existsSync } = fs
 const fsp = require('fs/promises')
 const { createClient } = require('@vercel/kv')
 const { promisify } = require('util')
@@ -16,18 +15,9 @@ const core = require('@actions/core')
 const { getTestFilter } = require('./test/get-test-filter')
 const { checkBuildFreshness } = require('./test/lib/check-build-freshness')
 
-// --- Test profile and passed-tests memoization ---
-// On CI retry attempts — including after timeout/cancellation of an
-// earlier attempt of the same workflow run — skip tests that already
-// passed on this commit.
-//
-// Mechanism: when `NEXT_TEST_PASSED_FILE` is set (by the workflow), each
-// passing test's filename is appended (one per line) to that file as it
-// finishes. The workflow wraps the test step with `actions/cache@v4`
-// (restore + save-with-`if: always()`) so the file is restored at job
-// start and saved at job end, including on cancel. See
-// `.github/workflows/build_reusable.yml` around the `afterBuild` step
-// for the cache wiring.
+// --- Test profile and result caching via actions cache ---
+// On CI retry attempts, skip tests that already passed on this commit.
+// The file contains null-byte delimited filenames
 
 class TestProfile {
   // Env vars that always affect test behavior (non-NEXT prefixed).
@@ -140,17 +130,11 @@ class TestProfile {
     if (!file) return new Set()
     try {
       const data = fs.readFileSync(file, 'utf8')
-      const passed = new Set()
       // Tolerate a partial trailing line from a hard kill mid-append by
-      // requiring an explicit '\n' terminator. Lines without it are
+      // requiring an explicit '\0' terminator. Lines without it are
       // dropped.
-      const lines = data.split('\n')
-      const last = data.endsWith('\n') ? lines.length : lines.length - 1
-      for (let i = 0; i < last; i++) {
-        const line = lines[i]
-        if (line) passed.add(line)
-      }
-      return passed
+      const lines = data.split('\0')
+      return new Set(data.endsWith('\0') ? lines : lines.slice(0, -1))
     } catch (err) {
       // ENOENT is the normal "no prior attempt" path — silent.
       if (err && err.code !== 'ENOENT') {
@@ -871,7 +855,7 @@ ${ENDGROUP}`)
     try {
       // Ensure durability of our writes by syncing each one.
       // This is a tiny bit of overhead but shouldn't really matter.
-      fs.writeSync(passedTestsFd, `${file}\n`)
+      fs.writeSync(passedTestsFd, `${file}\0`)
       fs.fdatasyncSync(passedTestsFd)
     } catch (err) {
       console.log(`Test result cache: append failed (${err.message})`)
@@ -1057,7 +1041,7 @@ ${ENDGROUP}`)
 
           // Clean up stale timings for deleted tests
           for (const test of Object.keys(newTimings)) {
-            if (!existsSync(path.join(__dirname, test))) {
+            if (!fs.existsSync(path.join(__dirname, test))) {
               console.log('removing stale timing', test)
               delete newTimings[test]
             }

--- a/run-tests.js
+++ b/run-tests.js
@@ -2,11 +2,11 @@
 
 const path = require('path')
 const _glob = require('glob')
-const { existsSync } = require('fs')
+const fs = require('fs')
+const { existsSync } = fs
 const fsp = require('fs/promises')
 const { createClient } = require('@vercel/kv')
 const { promisify } = require('util')
-const { createHash } = require('crypto')
 const { Sema } = require('async-sema')
 const { spawn, exec: execOrig } = require('child_process')
 const { createNextInstall } = require('./test/lib/create-next-install')
@@ -16,8 +16,18 @@ const core = require('@actions/core')
 const { getTestFilter } = require('./test/get-test-filter')
 const { checkBuildFreshness } = require('./test/lib/check-build-freshness')
 
-// --- Test profile and result caching via turbo remote cache ---
-// On CI retry attempts, skip tests that already passed on this commit.
+// --- Test profile and passed-tests memoization ---
+// On CI retry attempts — including after timeout/cancellation of an
+// earlier attempt of the same workflow run — skip tests that already
+// passed on this commit.
+//
+// Mechanism: when `NEXT_TEST_PASSED_FILE` is set (by the workflow), each
+// passing test's filename is appended (one per line) to that file as it
+// finishes. The workflow wraps the test step with `actions/cache@v4`
+// (restore + save-with-`if: always()`) so the file is restored at job
+// start and saved at job end, including on cancel. See
+// `.github/workflows/build_reusable.yml` around the `afterBuild` step
+// for the cache wiring.
 
 class TestProfile {
   // Env vars that always affect test behavior (non-NEXT prefixed).
@@ -39,20 +49,21 @@ class TestProfile {
     'NEXT_CI_RUNNER',
     'NEXT_E2E_TEST_TIMEOUT',
     'NEXT_TURBOPACK_IO_CONCURRENCY',
+    'NEXT_TEST_PASSED_FILE',
   ])
 
-  // All key=value pairs that form the cache identity, sorted by key.
-  // Computed once at construction from a snapshot of process.env.
+  // All key=value pairs identifying this test profile, sorted by key.
+  // Used for the diagnostic `log()` output. Computed once at construction
+  // from a snapshot of process.env. The actual cache key for the workflow
+  // is `input_step_key` (see `.github/workflows/build_reusable.yml`).
   entries
   // NEXT_*/__NEXT* vars that matched the pattern but were ignored.
   ignoredVars
   cachingEnabled
-  #cacheKey
 
   constructor({ group = '', type = '', testPattern = '' } = {}) {
     this.cachingEnabled = !!(
       process.env.CI &&
-      process.env.TURBO_TOKEN &&
       process.env.GITHUB_SHA &&
       !process.env.NEXT_FLAKE_DETECTION &&
       !process.env.NEXT_TEST_SKIP_RESULT_CACHE
@@ -102,18 +113,6 @@ class TestProfile {
     this.entries = [...map.entries()]
   }
 
-  get cacheKey() {
-    if (!this.#cacheKey) {
-      const hash = createHash('sha256')
-      hash.update('test-result-v2\0')
-      for (const [k, v] of this.entries) {
-        hash.update(`${k}=${v}\0`)
-      }
-      this.#cacheKey = hash.digest('hex')
-    }
-    return this.#cacheKey
-  }
-
   get description() {
     return this.entries
       .map(([k, v]) => (k === 'sha' ? `sha=${v?.slice(0, 10)}` : `${k}=${v}`))
@@ -132,42 +131,32 @@ class TestProfile {
     console.log('')
   }
 
-  // --- Cache operations ---
-
-  #turboCache = null
-  async #getTurboCache() {
-    if (this.#turboCache) return this.#turboCache
-    if (!this.cachingEnabled) return null
+  // Read the passed-tests file (restored from cache by the workflow
+  // before this script runs). Returns a Set of test filenames. Empty
+  // Set on miss / parse error — best-effort by design.
+  loadPassedTests() {
+    if (!this.cachingEnabled) return new Set()
+    const file = process.env.NEXT_TEST_PASSED_FILE
+    if (!file) return new Set()
     try {
-      this.#turboCache = await import('./scripts/turbo-cache.mjs')
-      return this.#turboCache
-    } catch {
-      return null
-    }
-  }
-
-  async loadPassedTests() {
-    try {
-      const cache = await this.#getTurboCache()
-      if (!cache) return new Set()
-      const data = await cache.get(this.cacheKey)
-      if (!data) return new Set()
-      const parsed = JSON.parse(data.toString())
-      return new Set(parsed.passed || [])
-    } catch {
+      const data = fs.readFileSync(file, 'utf8')
+      const passed = new Set()
+      // Tolerate a partial trailing line from a hard kill mid-append by
+      // requiring an explicit '\n' terminator. Lines without it are
+      // dropped.
+      const lines = data.split('\n')
+      const last = data.endsWith('\n') ? lines.length : lines.length - 1
+      for (let i = 0; i < last; i++) {
+        const line = lines[i]
+        if (line) passed.add(line)
+      }
+      return passed
+    } catch (err) {
+      // ENOENT is the normal "no prior attempt" path — silent.
+      if (err && err.code !== 'ENOENT') {
+        console.log(`Test result cache: failed to load (${err.message})`)
+      }
       return new Set()
-    }
-  }
-
-  async savePassedTests(passedFiles) {
-    try {
-      const cache = await this.#getTurboCache()
-      if (!cache) return false
-      const payload = JSON.stringify({ passed: [...passedFiles].sort() })
-      await cache.put(this.cacheKey, Buffer.from(payload))
-      return true
-    } catch {
-      return false
     }
   }
 }
@@ -849,18 +838,59 @@ ${ENDGROUP}`)
 
   const isRetryAttempt =
     process.env.CI && parseInt(process.env.GITHUB_RUN_ATTEMPT || '1', 10) > 1
-  const passedTestFiles = new Set()
 
-  // On retry, load previously-passed tests and filter them out
+  // Load tests that already passed (either on this attempt — restored
+  // from cache by the workflow — or after a timeout/cancel of an earlier
+  // attempt). The workflow's `actions/cache/restore` step lands the file
+  // at the path `loadPassedTests` reads.
   let cachedPassedTests = new Set()
-  if (isRetryAttempt) {
+  if (process.env.CI) {
     cachedPassedTests = await profile.loadPassedTests()
     if (cachedPassedTests.size > 0) {
       console.log(
         `Test result cache: loaded ${cachedPassedTests.size} passed test(s) (${profile.description})`
       )
-    } else {
+    } else if (isRetryAttempt) {
       console.log(`Test result cache: miss (${profile.description})`)
+    }
+  }
+
+  // Per-test file append. Sync I/O — the write is sequenced before we
+  // return from `runTest`, no Promise queue or libuv ordering questions.
+  // We keep the fd open across calls and fsync after each write so a
+  // runner-level kill between the test step and the post-job cache save
+  // step can't drop entries that are still in the kernel page cache.
+  // Best-effort: a single write failure shouldn't break the test run,
+  // so we just log it once.
+  const passedTestsPath = process.env.NEXT_TEST_PASSED_FILE
+  /** @type {number | null} */
+  let passedTestsFd = null
+  let appendFailureLogged = false
+  if (passedTestsPath) {
+    try {
+      passedTestsFd = fs.openSync(passedTestsPath, 'a')
+      process.on('exit', () => {
+        if (passedTestsFd !== null) {
+          try {
+            fs.closeSync(passedTestsFd)
+          } catch {}
+        }
+      })
+    } catch (err) {
+      console.log(`Test result cache: open failed (${err.message})`)
+    }
+  }
+  /** @param {string} file */
+  const recordPassed = (file) => {
+    if (passedTestsFd === null) return
+    try {
+      fs.writeSync(passedTestsFd, `${file}\n`)
+      fs.fsyncSync(passedTestsFd)
+    } catch (err) {
+      if (!appendFailureLogged) {
+        appendFailureLogged = true
+        console.log(`Test result cache: append failed (${err.message})`)
+      }
     }
   }
 
@@ -909,7 +939,7 @@ ${ENDGROUP}`)
     }
 
     if (passed) {
-      passedTestFiles.add(test.file)
+      recordPassed(test.file)
     }
 
     if (!passed) {
@@ -989,16 +1019,6 @@ ${ENDGROUP}`)
     }
   }
 
-  // Save all passed tests (from this run + previously cached) as a single cache entry
-  if (process.env.CI && passedTestFiles.size > 0) {
-    const allPassed = new Set([...cachedPassedTests, ...passedTestFiles])
-    const saved = await profile.savePassedTests(allPassed)
-    if (saved) {
-      console.log(
-        `Test result cache: saved ${allPassed.size} passed test(s) (${profile.description})`
-      )
-    }
-  }
   if (cachedPassedTests.size > 0) {
     const skipped = tests.filter((t) => cachedPassedTests.has(t.file)).length
     if (skipped > 0) {


### PR DESCRIPTION
## Summary

Memoize passing tests across attempts of the same workflow run, so a re-attempt after a timeout or cancellation can skip what already passed.


## What changed

- `run-tests.js` appends each passing test's filename to `$NEXT_TEST_PASSED_FILE` as it finishes (sync `write` + `fsync`, fd kept open across calls). On startup it reads the same file and skips any entries that match.
- `build_reusable.yml` wraps the test step with `actions/cache/restore` (before) and `actions/cache/save` (after, with `if: always()`). The save step runs on success, failure, and cancel — which is the whole point: a cancelled attempt still gets to preserve its progress for retry.
- Cache key is scoped to `${input_step_key}-${run_id}-attempt${run_attempt}`, with `restore-keys` falling back to any earlier attempt of the same run.

The previous implementation wrote a single Turbo-remote-cache blob *after* `Promise.allSettled` resolved — so a cancellation (like [run 26127371192](https://github.com/vercel/next.js/actions/runs/26127371192/job/76845288867)) lost every passed test from that attempt. 

This also removes one dependency on the turbo-remote cache (there are still two more uses of `scripts/turbo-cache.mjs`)

<!-- NEXT_JS_LLM_PR -->