### PR TITLE
[ci] Give the build cache in cache in build_and_deploy a more obvious name, not just a hash and run number

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -159,7 +159,7 @@ jobs:
         id: cache-build
         with:
           path: ./*
-          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
+          key: build-and-deploy-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
 
   # Generate the build matrix for native binaries.
   # For automated-preview, only build linux/x86_64/gnu (the target we run automated tests against).

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -456,17 +456,17 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         timeout-minutes: 5
         id: restore-build
         with:
           path: ./*
           # Cache includes repo checkout which is required for later scripts
           fail-on-cache-miss: true
-          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+          key: build-and-deploy-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
           restore-keys: |
-            ${{ github.sha }}-${{ github.run_number }}
-            ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
+            build-and-deploy-${{ github.sha }}-${{ github.run_number }}
+            build-and-deploy-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -521,17 +521,17 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         timeout-minutes: 5
         id: restore-build
         with:
           path: ./*
           # Cache includes repo checkout which is required for later scripts
           fail-on-cache-miss: true
-          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+          key: build-and-deploy-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
           restore-keys: |
-            ${{ github.sha }}-${{ github.run_number }}
-            ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
+            build-and-deploy-${{ github.sha }}-${{ github.run_number }}
+            build-and-deploy-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
This should make the output of `gh cache list` a lot clearer. Without this, it's not obvious where these cache keys are coming from.