### PR TITLE
docs: Fix broken link to Node.js Debugging Guide

### DIFF
--- a/docs/01-app/02-guides/debugging.mdx
+++ b/docs/01-app/02-guides/debugging.mdx
@@ -8,7 +8,7 @@ description: Learn how to debug your Next.js application with VS Code, Chrome De
 
 This documentation explains how you can debug your Next.js frontend and backend code with full source maps support using the [VS Code debugger](https://code.visualstudio.com/docs/editor/debugging), [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools), or [Firefox DevTools](https://firefox-source-docs.mozilla.org/devtools-user/).
 
-Any debugger that can attach to Node.js can also be used to debug a Next.js application. You can find more details in the Node.js [Debugging Guide](https://nodejs.org/en/docs/guides/debugging-getting-started/).
+Any debugger that can attach to Node.js can also be used to debug a Next.js application. You can find more details in the Node.js [Debugging Guide](https://nodejs.org/learn/getting-started/debugging/).
 
 ## Debugging with VS Code
 


### PR DESCRIPTION
[Live page](https://nextjs.org/docs/app/guides/debugging) links to:
https://nodejs.org/en/docs/guides/debugging-getting-started

Which is 404 now

Seems like this is where it should point now:
https://nodejs.org/learn/getting-started/debugging