### PR TITLE
Fix Yarn berry tests

### DIFF
--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -71,9 +71,13 @@ export function runTests(
             'turbo',
           ])
         )
-        return `yarn set version 4.15.0 && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn config set npmPreapprovedPackages --json ${minimumReleaseAgeExclude} && yarn add ${pkgs.join(
-          ' '
-        )}`
+        return [
+          `yarn set version 4.15.0`,
+          `yarn config set enableGlobalCache true`,
+          `yarn config set compressionLevel 0`,
+          `yarn config set npmPreapprovedPackages --json ${minimumReleaseAgeExclude}`,
+          `yarn add ${pkgs.join(' ')}`,
+        ].join(' && ')
       },
       buildCommand: `yarn next build`,
       startCommand: (global as any).isNextDev ? `yarn next` : `yarn next start`,

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -55,7 +55,23 @@ export function runTests(
           prev.push(`${cur}@${dependencies[cur]}`)
           return prev
         }, [] as string[])
-        return `yarn set version berry && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
+        const minimumReleaseAgeExclude = JSON.stringify(
+          JSON.stringify([
+            '@next/*',
+            '@turbo/*',
+            '@vercel/*',
+            '@workflow/*',
+            'babel-plugin-react-compiler',
+            'next',
+            'react',
+            'react-dom',
+            'react-is',
+            'react-server-dom-*',
+            'scheduler',
+            'turbo',
+          ])
+        )
+        return `yarn set version 4.15.0 && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn config set npmPreapprovedPackages --json ${minimumReleaseAgeExclude} && yarn add ${pkgs.join(
           ' '
         )}`
       },


### PR DESCRIPTION
4.15 made [npmMinimalAgeGate: 1d the default](https://github.com/yarnpkg/berry/pull/7135)

1. Pin yarn version to prevent random breakages in the future
2. Add trusted packages to ignore npmMinimalAgeGate for them

https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.15.0

