### PR TITLE
fix(load-manifest): avoid per-page V8 context allocation in evalManifest

### DIFF
--- a/packages/next/src/server/load-manifest.external.ts
+++ b/packages/next/src/server/load-manifest.external.ts
@@ -2,7 +2,6 @@ import type { DeepReadonly } from '../shared/lib/deep-readonly'
 
 import { join } from 'path'
 import { readFileSync } from 'fs'
-import { runInNewContext } from 'vm'
 import { deepFreeze } from '../shared/lib/deep-freeze'
 
 const sharedCache = new Map<string, unknown>()
@@ -123,7 +122,23 @@ export function evalManifest<T extends object>(
   let contextObject = {
     process: { env: { NEXT_DEPLOYMENT_ID: process.env.NEXT_DEPLOYMENT_ID } },
   }
-  runInNewContext(content, contextObject)
+  // Evaluate the manifest in the existing V8 context instead of a fresh one.
+  // The previous `runInNewContext(content, contextObject)` allocated a new
+  // V8 native context per call; on app-router builds with many pages the
+  // per-page client-reference-manifest evaluations accumulate retained
+  // contexts (~3-4 MB RSS each) for the process lifetime via the sharedCache
+  // map, leading to OOM on memory-constrained standalone deployments. See
+  // the linked issue for diagnostic data.
+  //
+  // The Function wrapper exposes contextObject as `globalThis`, `self`, and
+  // `process` inside the body, preserving the manifest's existing
+  // `globalThis.__RSC_MANIFEST[entry] = ...` write pattern without spawning
+  // a new V8 context.
+  new Function('globalThis', 'self', 'process', content as string)(
+    contextObject,
+    contextObject,
+    contextObject.process
+  )
 
   // Freeze the context object so it cannot be modified if we're caching it.
   if (shouldCache) {


### PR DESCRIPTION
Closes #93964.

### What

Replace `vm.runInNewContext` with a `new Function` wrapper inside `evalManifest`.

### Why

Each `runInNewContext(content, contextObject)` allocates a fresh V8 native context that the `sharedCache` `Map` retains for the process lifetime via the returned `contextObject` (which IS the new context's `globalThis`). On `output: 'standalone'` deploys, every distinct page's `*_client-reference-manifest.js` triggers one such allocation through `tryLoadClientReferenceManifest`. Empirically each context costs ~3 to 4 MB residual RSS.

On app-router apps with ~360 pages this accumulates to ~1.4 GB before the fetch cache leak tracked in #85914 / #90433 adds anything. 1 GB containers OOM after 30 to 60 min uptime, restart, repeat. Diagnostic data and CDP samples are in #93964.

### How

The Function wrapper exposes `contextObject` as `globalThis`, `self`, and `process` inside the body, so the manifest's `globalThis.__RSC_MANIFEST[entry] = ...` writes still land on `contextObject` and the existing cache + `deepFreeze` path continues to work unchanged.

```ts
new Function('globalThis', 'self', 'process', content as string)(
  contextObject,
  contextObject,
  contextObject.process
)
```

### Known semantic divergence

Generated manifest content today only writes `globalThis.X = ...` and `self.Y = ...`. The Function wrapper differs from `runInNewContext` in:

* `this` in a non-strict Function body is the host global, not the sandbox. Current manifests don't use `this`.
* Top-level `var x` becomes a local to the wrapper rather than a property on `contextObject`. Current manifests don't declare top-level `var`.
* `Object.prototype` is shared with the host instead of isolated. Current manifests don't touch prototypes.

If any of those constraints are important to preserve for future manifest generators, alternatives are:

1. Reuse a single shared `vm.Context` across all manifests by namespacing reads/writes on a host-owned object.
2. Tear down the context after eval by extracting just the needed properties from `contextObject` and discarding the rest.
3. Compile-once-invoke-many: cache the compiled `Function` per manifest path.

Happy to follow guidance on which approach the team prefers; this PR takes the smallest-diff route that fixes the observed leak.

### Verified

Locally on a Next.js 16.2.6 standalone deploy (~360 pages), patched node_modules: `nativeContextCount` no longer grows per page first-access, RSS plateau at ~430 MB instead of climbing to OOM at ~1 GB. Will re-verify on canary once this lands.

### Notes for reviewers

* Removes the now-unused `runInNewContext` import.
* Comment block in source explains the trade-off so future readers don't restore `runInNewContext` without understanding the memory cost.
* Commit is unsigned; happy to re-push signed once a reviewer chimes in on the approach.