### PR TITLE
Optimize RSC dev tracing stack probes

### DIFF
--- a/bench/rsc-dev-tracing/.gitignore
+++ b/bench/rsc-dev-tracing/.gitignore
@@ -1,0 +1,3 @@
+artifacts/
+app/.next/
+app/.next-profiles/

--- a/bench/rsc-dev-tracing/README.md
+++ b/bench/rsc-dev-tracing/README.md
@@ -1,0 +1,84 @@
+# RSC Dev Tracing Benchmark
+
+This fixture profiles `next dev --experimental-cpu-prof` overhead in App Router
+RSC rendering when React debug tracing is enabled. It was added to investigate
+the cost of React Server Components async hooks and await-stack attribution in
+development.
+
+The app has two routes:
+
+- `/`: 500 synchronous server component leaves behind `await connection()` and a
+  Suspense boundary.
+- `/async`: 500 async server component leaves, each awaiting two resolved
+  promises, also behind `await connection()` and a Suspense boundary.
+
+The route shape intentionally keeps the application code simple so the profile is
+dominated by framework/dev tracing work. Treat absolute numbers as local-machine
+data and compare relative before/after runs.
+
+## Commands
+
+Build `next` after source changes:
+
+```bash
+pnpm --filter=next build
+```
+
+Run the benchmark in regular App Router mode:
+
+```bash
+RUN_LABEL=app-router PORT=3157 ITERATIONS=40 \
+  pnpm --silent bench:rsc-dev-tracing
+```
+
+Run the same app with Cache Components enabled:
+
+```bash
+CACHE_COMPONENTS=1 RUN_LABEL=cache-components PORT=3158 ITERATIONS=40 \
+  pnpm --silent bench:rsc-dev-tracing
+```
+
+Artifacts are written to:
+
+```text
+bench/rsc-dev-tracing/artifacts/<run-label>/
+```
+
+Each run writes:
+
+- `results.json`: cold request timings and warm p50/p95/avg/min/max.
+- `next-dev.log`: dev server output.
+- copied `.cpuprofile` files from `app/.next-profiles/`.
+
+Analyze a profile:
+
+```bash
+pnpm --silent bench:rsc-dev-tracing:analyze \
+  bench/rsc-dev-tracing/artifacts/<run-label>/<profile>.cpuprofile
+```
+
+## Investigation Notes
+
+Environment used for the benchmark data below:
+
+- Node `v24.14.0`
+- 40 warm iterations per route
+- local `pnpm --filter=next build` before each source variant
+
+Warm p50/p95 in milliseconds:
+
+| Variant | App sync | App async | Cache sync | Cache async |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline | 67.8 / 92.3 | 145.6 / 173.3 | 117.9 / 136.1 | 187.5 / 212.3 |
+| Specialized userspace stack probe | 62.1 / 100.7 | 121.5 / 132.7 | 110.1 / 115.6 | 160.1 / 170.6 |
+| `filterStackFrame` cache | 59.2 / 125.3 | 120.7 / 135.6 | 107.7 / 140.1 | 166.6 / 174.0 |
+| Combined stack probe + filter cache | 59.5 / 75.8 | 109.7 / 125.8 | 111.8 / 184.2 | 156.4 / 202.1 |
+| No-bind allocation experiment | 78.3 / 124.0 | 144.2 / 210.0 | 182.5 / 369.4 | 247.6 / 713.5 |
+| `performance.now()` coalescing | 128.2 / 604.8 | 215.7 / 758.6 | 141.5 / 222.8 | 198.2 / 303.6 |
+| Skip await stack capture | 60.2 / 76.9 | 77.5 / 91.9 | 128.6 / 215.0 | 140.8 / 264.2 |
+
+The only change kept in this PR is the specialized userspace stack probe. The
+`filterStackFrame` cache was not kept because the benchmark repeats the same
+component sites many times, so it may overstate real-world benefit. The no-bind
+and timestamp coalescing experiments regressed. Skipping await stack capture is
+the largest win, but loses precise await callsite attribution.

--- a/bench/rsc-dev-tracing/analyze-cpuprofile.mjs
+++ b/bench/rsc-dev-tracing/analyze-cpuprofile.mjs
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises'
+
+const profilePath = process.argv[2]
+if (!profilePath) {
+  console.error(
+    'Usage: node bench/rsc-dev-tracing/analyze-cpuprofile.mjs <profile.cpuprofile>'
+  )
+  process.exit(1)
+}
+
+const profile = JSON.parse(await readFile(profilePath, 'utf8'))
+const nodesById = new Map(profile.nodes.map((node) => [node.id, node]))
+const selfSamples = new Map()
+const totalSamples = new Map()
+
+for (const id of profile.samples || []) {
+  selfSamples.set(id, (selfSamples.get(id) || 0) + 1)
+  let node = nodesById.get(id)
+  while (node) {
+    totalSamples.set(node.id, (totalSamples.get(node.id) || 0) + 1)
+    node = nodesById.get(node.parent)
+  }
+}
+
+function label(node) {
+  const frame = node.callFrame
+  const url = frame.url ? frame.url.replace(process.cwd(), '') : ''
+  const line =
+    frame.lineNumber >= 0
+      ? `:${frame.lineNumber + 1}:${frame.columnNumber + 1}`
+      : ''
+  return `${frame.functionName || '(anonymous)'} ${url}${line}`.trim()
+}
+
+function topEntries(map, filter = () => true, limit = 30) {
+  const total = (profile.samples || []).length || 1
+  return [...map.entries()]
+    .map(([id, count]) => ({ node: nodesById.get(id), count }))
+    .filter((entry) => entry.node && filter(entry.node))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit)
+    .map(({ node, count }) => ({
+      samples: count,
+      pct: Number(((count / total) * 100).toFixed(2)),
+      frame: label(node),
+    }))
+}
+
+function aggregateByLabel(map, filter = () => true, limit = 30) {
+  const total = (profile.samples || []).length || 1
+  const labels = new Map()
+  for (const [id, count] of map.entries()) {
+    const node = nodesById.get(id)
+    if (!node || !filter(node)) continue
+    const key = label(node)
+    labels.set(key, (labels.get(key) || 0) + count)
+  }
+  return [...labels.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([frame, count]) => ({
+      samples: count,
+      pct: Number(((count / total) * 100).toFixed(2)),
+      frame,
+    }))
+}
+
+const interestingPattern =
+  /async_hooks|AsyncLocalStorage|executionAsyncId|createHook|react-server-dom-webpack|react-server-dom-turbopack|react-dom-server|requestStorage|componentStorage|parseStackTrace|Error\b/
+
+const summary = {
+  sampleCount: (profile.samples || []).length,
+  topSelf: topEntries(selfSamples),
+  topSelfAggregated: aggregateByLabel(selfSamples),
+  topTotalReactAsync: topEntries(totalSamples, (node) =>
+    interestingPattern.test(label(node))
+  ),
+  topSelfReactAsync: topEntries(selfSamples, (node) =>
+    interestingPattern.test(label(node))
+  ),
+  topSelfReactAsyncAggregated: aggregateByLabel(selfSamples, (node) =>
+    interestingPattern.test(label(node))
+  ),
+}
+
+console.log(JSON.stringify(summary, null, 2))

--- a/bench/rsc-dev-tracing/app/app/async/page.jsx
+++ b/bench/rsc-dev-tracing/app/app/async/page.jsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function AsyncLeaf({ index }) {
+  await Promise.resolve(index)
+  await Promise.resolve(index + 1)
+  return <span data-index={index}>async-{index}</span>
+}
+
+function AsyncList() {
+  const leaves = []
+  for (let index = 0; index < 500; index++) {
+    leaves.push(<AsyncLeaf key={index} index={index} />)
+  }
+
+  return <div>{leaves}</div>
+}
+
+async function DynamicAsyncList() {
+  await connection()
+
+  return <AsyncList />
+}
+
+export default function AsyncPage() {
+  return (
+    <main>
+      <h1>Async RSC route</h1>
+      <Suspense fallback={<p>Loading async route...</p>}>
+        <DynamicAsyncList />
+      </Suspense>
+    </main>
+  )
+}

--- a/bench/rsc-dev-tracing/app/app/layout.jsx
+++ b/bench/rsc-dev-tracing/app/app/layout.jsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'RSC dev tracing benchmark',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/bench/rsc-dev-tracing/app/app/page.jsx
+++ b/bench/rsc-dev-tracing/app/app/page.jsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+function SyncLeaf({ index }) {
+  return <span data-index={index}>sync-{index}</span>
+}
+
+function SyncList() {
+  const leaves = []
+  for (let index = 0; index < 500; index++) {
+    leaves.push(<SyncLeaf key={index} index={index} />)
+  }
+
+  return <div>{leaves}</div>
+}
+
+async function DynamicSyncRoute() {
+  await connection()
+
+  return (
+    <main>
+      <h1>Sync RSC route</h1>
+      <SyncList />
+    </main>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading sync route...</p>}>
+      <DynamicSyncRoute />
+    </Suspense>
+  )
+}

--- a/bench/rsc-dev-tracing/app/next.config.mjs
+++ b/bench/rsc-dev-tracing/app/next.config.mjs
@@ -1,0 +1,8 @@
+const nextConfig = {
+  experimental: {
+    reactDebugChannel: process.env.REACT_DEBUG_CHANNEL !== '0',
+  },
+  cacheComponents: process.env.CACHE_COMPONENTS === '1',
+}
+
+export default nextConfig

--- a/bench/rsc-dev-tracing/app/package.json
+++ b/bench/rsc-dev-tracing/app/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "workspace:*",
+    "react": "workspace:*",
+    "react-dom": "workspace:*"
+  }
+}

--- a/bench/rsc-dev-tracing/profile-next-dev.mjs
+++ b/bench/rsc-dev-tracing/profile-next-dev.mjs
@@ -1,0 +1,155 @@
+import { createWriteStream } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { copyFile, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const repoRoot = resolve(import.meta.dirname, '../..')
+const appDir = resolve(import.meta.dirname, 'app')
+const runLabel = process.env.RUN_LABEL || 'default'
+const outDir = resolve(import.meta.dirname, 'artifacts', runLabel)
+const profileDir = resolve(appDir, '.next-profiles')
+const port = Number(process.env.PORT || 3157)
+const iterations = Number(process.env.ITERATIONS || 40)
+const nextBin = resolve(repoRoot, 'packages/next/dist/bin/next')
+const extraNextArgs = (process.env.EXTRA_NEXT_ARGS || '')
+  .split(/\s+/)
+  .filter(Boolean)
+
+await rm(outDir, { recursive: true, force: true })
+await rm(profileDir, { recursive: true, force: true })
+await mkdir(outDir, { recursive: true })
+await mkdir(profileDir, { recursive: true })
+
+const serverLog = createWriteStream(resolve(outDir, 'next-dev.log'))
+const server = spawn(
+  process.execPath,
+  [
+    nextBin,
+    'dev',
+    '--experimental-cpu-prof',
+    ...extraNextArgs,
+    '--port',
+    String(port),
+  ],
+  {
+    cwd: appDir,
+    env: {
+      ...process.env,
+      NEXT_TELEMETRY_DISABLED: '1',
+      NEXT_PRIVATE_LOCAL_DEV: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }
+)
+
+let logBuffer = ''
+server.stdout.on('data', (chunk) => {
+  logBuffer += chunk.toString()
+  serverLog.write(chunk)
+})
+server.stderr.on('data', (chunk) => {
+  logBuffer += chunk.toString()
+  serverLog.write(chunk)
+})
+
+async function waitForReady() {
+  const started = Date.now()
+  while (Date.now() - started < 60_000) {
+    if (logBuffer.includes('Ready in')) return
+    if (server.exitCode !== null) {
+      throw new Error(`next dev exited early with code ${server.exitCode}`)
+    }
+    await sleep(100)
+  }
+  throw new Error('Timed out waiting for next dev to become ready')
+}
+
+async function timedFetch(pathname) {
+  const started = performance.now()
+  const response = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    headers: {
+      'x-profile-run': '1',
+    },
+  })
+  const text = await response.text()
+  const duration = performance.now() - started
+  if (!response.ok || !text.includes('RSC route')) {
+    throw new Error(
+      `Unexpected response for ${pathname}: ${response.status} ${text.slice(
+        0,
+        120
+      )}`
+    )
+  }
+  return duration
+}
+
+function summarize(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const sum = values.reduce((total, value) => total + value, 0)
+  const percentile = (p) => sorted[Math.floor((sorted.length - 1) * p)]
+  return {
+    count: values.length,
+    avg: sum / values.length,
+    min: sorted[0],
+    p50: percentile(0.5),
+    p95: percentile(0.95),
+    max: sorted[sorted.length - 1],
+  }
+}
+
+try {
+  await waitForReady()
+
+  const cold = {
+    sync: await timedFetch('/'),
+    async: await timedFetch('/async'),
+  }
+
+  const warm = {
+    sync: [],
+    async: [],
+  }
+
+  for (let index = 0; index < iterations; index++) {
+    warm.sync.push(await timedFetch('/'))
+    warm.async.push(await timedFetch('/async'))
+  }
+
+  server.kill('SIGINT')
+  await new Promise((resolveExit) => server.once('exit', resolveExit))
+  serverLog.end()
+
+  const profileFiles = (await readdir(profileDir)).filter((file) =>
+    file.endsWith('.cpuprofile')
+  )
+  for (const file of profileFiles) {
+    await copyFile(resolve(profileDir, file), resolve(outDir, file))
+  }
+
+  const result = {
+    appDir,
+    runLabel,
+    cacheComponents: process.env.CACHE_COMPONENTS === '1',
+    extraNextArgs,
+    port,
+    iterations,
+    coldMs: cold,
+    warmMs: {
+      sync: summarize(warm.sync),
+      async: summarize(warm.async),
+    },
+    profileFiles,
+  }
+
+  await writeFile(
+    resolve(outDir, 'results.json'),
+    `${JSON.stringify(result, null, 2)}\n`
+  )
+  console.log(JSON.stringify(result, null, 2))
+} finally {
+  if (server.exitCode === null && !server.killed) {
+    server.kill('SIGINT')
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "dev": "turbo run dev --parallel --filter=\"!@next/bundle-analyzer-ui\"",
     "bench:render-pipeline": "tsx bench/render-pipeline/benchmark.ts",
     "bench:render-pipeline:analyze": "tsx bench/render-pipeline/analyze-profiles.ts",
+    "bench:rsc-dev-tracing": "node bench/rsc-dev-tracing/profile-next-dev.mjs",
+    "bench:rsc-dev-tracing:analyze": "node bench/rsc-dev-tracing/analyze-cpuprofile.mjs",
     "pack-next": "tsx scripts/pack-next.ts",
     "eval": "node run-evals.js",
     "test-types": "tsc",

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -950,6 +950,104 @@
       }
       return !1;
     }
+    function collectSingleStackFrame(callSite) {
+      var name = callSite.getFunctionName() || "<anonymous>";
+      if (name.includes("react_stack_bottom_frame")) return null;
+      if (callSite.isNative())
+        return [name, "", 0, 0, 0, 0, callSite.isAsync()];
+      if (callSite.isConstructor()) name = "new " + name;
+      else if (!callSite.isToplevel()) {
+        var callSite$jscomp$0 = callSite;
+        name = callSite$jscomp$0.getTypeName();
+        var methodName = callSite$jscomp$0.getMethodName();
+        callSite$jscomp$0 = callSite$jscomp$0.getFunctionName();
+        var result = "";
+        callSite$jscomp$0
+          ? (name &&
+              identifierRegExp.test(callSite$jscomp$0) &&
+              callSite$jscomp$0 !== name &&
+              (result += name + "."),
+            (result += callSite$jscomp$0),
+            !methodName ||
+              callSite$jscomp$0 === methodName ||
+              callSite$jscomp$0.endsWith("." + methodName) ||
+              callSite$jscomp$0.endsWith(" " + methodName) ||
+              (result += " [as " + methodName + "]"))
+          : (name && (result += name + "."),
+            (result = methodName
+              ? result + methodName
+              : result + "<anonymous>"));
+        name = result;
+      }
+      "<anonymous>" === name && (name = "");
+      methodName = callSite.getScriptNameOrSourceURL() || "<anonymous>";
+      "<anonymous>" === methodName &&
+        ((methodName = ""),
+        callSite.isEval() &&
+          (callSite$jscomp$0 = callSite.getEvalOrigin()) &&
+          (methodName = callSite$jscomp$0.toString() + ", <anonymous>"));
+      callSite$jscomp$0 = callSite.getLineNumber() || 0;
+      result = callSite.getColumnNumber() || 0;
+      var enclosingLine =
+          "function" === typeof callSite.getEnclosingLineNumber
+            ? callSite.getEnclosingLineNumber() || 0
+            : 0,
+        enclosingCol =
+          "function" === typeof callSite.getEnclosingColumnNumber
+            ? callSite.getEnclosingColumnNumber() || 0
+            : 0;
+      return [
+        name,
+        methodName,
+        callSite$jscomp$0,
+        result,
+        enclosingLine,
+        enclosingCol,
+        callSite.isAsync()
+      ];
+    }
+    function collectStackTracePrivateIfAwaitInUserspace(
+      request,
+      error,
+      structuredStackTrace
+    ) {
+      for (var i = framesToSkip; i < structuredStackTrace.length; i++) {
+        var callsite = collectSingleStackFrame(structuredStackTrace[i]);
+        if (null === callsite) break;
+        if (isPromiseAwaitInternal(callsite[1], callsite[0])) continue;
+        if (
+          !callsite[6] &&
+          request.filterStackFrame(
+            devirtualizeURL(callsite[1]),
+            callsite[0],
+            callsite[2],
+            callsite[3]
+          ) &&
+          "" !== callsite[1]
+        )
+          return collectStackTracePrivate(error, structuredStackTrace);
+        break;
+      }
+      collectedStackTrace = null;
+      return "";
+    }
+    function parseStackTracePrivateIfAwaitInUserspace(
+      request,
+      error,
+      skipFrames
+    ) {
+      collectedStackTrace = null;
+      framesToSkip = skipFrames;
+      skipFrames = Error.prepareStackTrace;
+      Error.prepareStackTrace =
+        collectStackTracePrivateIfAwaitInUserspace.bind(null, request);
+      try {
+        if ("" !== error.stack) return null;
+      } finally {
+        Error.prepareStackTrace = skipFrames;
+      }
+      return collectedStackTrace;
+    }
     function patchConsole(consoleInst, methodName) {
       var descriptor = Object.getOwnPropertyDescriptor(consoleInst, methodName);
       if (
@@ -6183,10 +6281,12 @@
                   resource = new WeakRef(resource);
                   var request = resolveRequest();
                   null !== request &&
-                    ((triggerAsyncId = parseStackTracePrivate(Error(), 5)),
-                    null === triggerAsyncId ||
-                      isAwaitInUserspace(request, triggerAsyncId) ||
-                      (triggerAsyncId = null));
+                    (triggerAsyncId =
+                      parseStackTracePrivateIfAwaitInUserspace(
+                        request,
+                        Error(),
+                        5
+                      ));
                 } else
                   (triggerAsyncId = emptyStack),
                     (resource =

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -950,6 +950,104 @@
       }
       return !1;
     }
+    function collectSingleStackFrame(callSite) {
+      var name = callSite.getFunctionName() || "<anonymous>";
+      if (name.includes("react_stack_bottom_frame")) return null;
+      if (callSite.isNative())
+        return [name, "", 0, 0, 0, 0, callSite.isAsync()];
+      if (callSite.isConstructor()) name = "new " + name;
+      else if (!callSite.isToplevel()) {
+        var callSite$jscomp$0 = callSite;
+        name = callSite$jscomp$0.getTypeName();
+        var methodName = callSite$jscomp$0.getMethodName();
+        callSite$jscomp$0 = callSite$jscomp$0.getFunctionName();
+        var result = "";
+        callSite$jscomp$0
+          ? (name &&
+              identifierRegExp.test(callSite$jscomp$0) &&
+              callSite$jscomp$0 !== name &&
+              (result += name + "."),
+            (result += callSite$jscomp$0),
+            !methodName ||
+              callSite$jscomp$0 === methodName ||
+              callSite$jscomp$0.endsWith("." + methodName) ||
+              callSite$jscomp$0.endsWith(" " + methodName) ||
+              (result += " [as " + methodName + "]"))
+          : (name && (result += name + "."),
+            (result = methodName
+              ? result + methodName
+              : result + "<anonymous>"));
+        name = result;
+      }
+      "<anonymous>" === name && (name = "");
+      methodName = callSite.getScriptNameOrSourceURL() || "<anonymous>";
+      "<anonymous>" === methodName &&
+        ((methodName = ""),
+        callSite.isEval() &&
+          (callSite$jscomp$0 = callSite.getEvalOrigin()) &&
+          (methodName = callSite$jscomp$0.toString() + ", <anonymous>"));
+      callSite$jscomp$0 = callSite.getLineNumber() || 0;
+      result = callSite.getColumnNumber() || 0;
+      var enclosingLine =
+          "function" === typeof callSite.getEnclosingLineNumber
+            ? callSite.getEnclosingLineNumber() || 0
+            : 0,
+        enclosingCol =
+          "function" === typeof callSite.getEnclosingColumnNumber
+            ? callSite.getEnclosingColumnNumber() || 0
+            : 0;
+      return [
+        name,
+        methodName,
+        callSite$jscomp$0,
+        result,
+        enclosingLine,
+        enclosingCol,
+        callSite.isAsync()
+      ];
+    }
+    function collectStackTracePrivateIfAwaitInUserspace(
+      request,
+      error,
+      structuredStackTrace
+    ) {
+      for (var i = framesToSkip; i < structuredStackTrace.length; i++) {
+        var callsite = collectSingleStackFrame(structuredStackTrace[i]);
+        if (null === callsite) break;
+        if (isPromiseAwaitInternal(callsite[1], callsite[0])) continue;
+        if (
+          !callsite[6] &&
+          request.filterStackFrame(
+            devirtualizeURL(callsite[1]),
+            callsite[0],
+            callsite[2],
+            callsite[3]
+          ) &&
+          "" !== callsite[1]
+        )
+          return collectStackTracePrivate(error, structuredStackTrace);
+        break;
+      }
+      collectedStackTrace = null;
+      return "";
+    }
+    function parseStackTracePrivateIfAwaitInUserspace(
+      request,
+      error,
+      skipFrames
+    ) {
+      collectedStackTrace = null;
+      framesToSkip = skipFrames;
+      skipFrames = Error.prepareStackTrace;
+      Error.prepareStackTrace =
+        collectStackTracePrivateIfAwaitInUserspace.bind(null, request);
+      try {
+        if ("" !== error.stack) return null;
+      } finally {
+        Error.prepareStackTrace = skipFrames;
+      }
+      return collectedStackTrace;
+    }
     function patchConsole(consoleInst, methodName) {
       var descriptor = Object.getOwnPropertyDescriptor(consoleInst, methodName);
       if (
@@ -6186,10 +6284,12 @@
                   resource = new WeakRef(resource);
                   var request = resolveRequest();
                   null !== request &&
-                    ((triggerAsyncId = parseStackTracePrivate(Error(), 5)),
-                    null === triggerAsyncId ||
-                      isAwaitInUserspace(request, triggerAsyncId) ||
-                      (triggerAsyncId = null));
+                    (triggerAsyncId =
+                      parseStackTracePrivateIfAwaitInUserspace(
+                        request,
+                        Error(),
+                        5
+                      ));
                 } else
                   (triggerAsyncId = emptyStack),
                     (resource =


### PR DESCRIPTION
### What?

Optimizes React Server Components dev tracing by adding a specialized await-stack probe for userspace detection before falling back to full stack collection.

Also adds `bench/rsc-dev-tracing`, a small dev CPU profiling fixture and analyzer used for this investigation, with App Router and Cache Components commands plus the measured candidate results.

### Why?

`next dev` can spend significant CPU time in React debug tracing when async Server Components create many promise/await operations. The full stack conversion is only needed when an await is attributable to userspace, so the hot path can avoid unnecessary full-stack work while preserving precise await attribution when it matters.

### How?

- Adds `parseStackTracePrivateIfAwaitInUserspace()` in the vendored RSC dev server bundles.
- Scans only enough structured stack information to decide whether an await is in userspace.
- Falls back to the existing full `collectStackTracePrivate()` path when a userspace await is found.
- Keeps the broader async hook/debug tracing behavior intact.
- Adds `pnpm bench:rsc-dev-tracing` and `pnpm bench:rsc-dev-tracing:analyze` for reproducing the investigation.

### Verification

- `fnm exec --using v24.14.0 pnpm --filter=next build`
- `ITERATIONS=2 RUN_LABEL=smoke-script PORT=3193 fnm exec --using v24.14.0 pnpm bench:rsc-dev-tracing`
- `fnm exec --using v24.14.0 pnpm --silent bench:rsc-dev-tracing:analyze <dev-server cpuprofile>`
- `pnpm prettier --check bench/rsc-dev-tracing/README.md bench/rsc-dev-tracing/profile-next-dev.mjs bench/rsc-dev-tracing/analyze-cpuprofile.mjs bench/rsc-dev-tracing/app/app/page.jsx bench/rsc-dev-tracing/app/app/async/page.jsx bench/rsc-dev-tracing/app/app/layout.jsx bench/rsc-dev-tracing/app/next.config.mjs bench/rsc-dev-tracing/app/package.json package.json`
- `fnm exec --using v24.14.0 node --check packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js`
- `fnm exec --using v24.14.0 node --check packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js`

<!-- NEXT_JS_LLM_PR -->
