### PR TITLE
fix(devtools): detect VS Code renamed macOS binary in launch-editor

### DIFF
--- a/packages/next/src/next-devtools/server/launch-editor.ts
+++ b/packages/next/src/next-devtools/server/launch-editor.ts
@@ -61,7 +61,11 @@ const COMMON_EDITORS_MACOS = {
     '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron':
     '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
+  '/Applications/Visual Studio Code.app/Contents/MacOS/Code':
+    '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
   '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Electron':
+    '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code',
+  '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders':
     '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code',
   '/Applications/VSCodium.app/Contents/MacOS/Electron':
     '/Applications/VSCodium.app/Contents/Resources/app/bin/code',


### PR DESCRIPTION
### What?

Add the new VS Code macOS binary name (`Code`) to the `COMMON_EDITORS_MACOS` detection map in `launch-editor.ts`, alongside the legacy `Electron` entry. Same for VS Code Insiders (`Code - Insiders`).

### Why?

VS Code renamed its macOS binary from `Electron` to `Code`. The `guessEditor()` function detects running editors by matching `ps x` output against known process paths. Since the old key (`…/MacOS/Electron`) no longer appears in the process list, VS Code is not detected — the "open in editor" button silently does nothing.

### How?

Added two new entries to `COMMON_EDITORS_MACOS` that map the renamed binaries to the same `code` CLI path. The old entries are kept for backward compatibility.

<!-- NEXT_JS_LLM_PR -->