### PR TITLE
Stabilize deploy cache tests

### DIFF
--- a/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
+++ b/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
@@ -18,14 +18,7 @@ describe('resume-data-cache', () => {
   ])(
     'should have consistent data between static and dynamic renders with $name',
     async ({ id }) => {
-      // First render the page statically, getting the random number from the
-      // HTML.
-      let $ = await next.render$('/')
-      const first = $(`p#${id}`).text()
-
-      // Then get the Prefetch RSC and validate that it also contains the same
-      // random number.
-      await retry(async () => {
+      const getPrefetchRscUrl = async () => {
         const url = new URL('/', 'http://localhost')
 
         url.searchParams.set(
@@ -38,8 +31,19 @@ describe('resume-data-cache', () => {
           )
         )
 
+        return url.toString()
+      }
+
+      // First render the page statically, getting the random number from the
+      // HTML.
+      let $ = await next.render$('/')
+      const first = $(`p#${id}`).text()
+
+      // Then get the Prefetch RSC and validate that it also contains the same
+      // random number.
+      await retry(async () => {
         const rsc = await next
-          .fetch(url.toString(), {
+          .fetch(await getPrefetchRscUrl(), {
             headers: {
               RSC: '1',
               'Next-Router-Prefetch': '1',
@@ -107,7 +111,7 @@ describe('resume-data-cache', () => {
       // random number.
       await retry(async () => {
         const rsc = await next
-          .fetch('/', {
+          .fetch(await getPrefetchRscUrl(), {
             headers: {
               RSC: '1',
               'Next-Router-Prefetch': '1',

--- a/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
+++ b/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
@@ -3,7 +3,7 @@ import { retry } from 'next-test-utils'
 import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 describe('resume-data-cache', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -102,38 +102,38 @@ describe('resume-data-cache', () => {
       // (RDC) from the static render to ensure that the data is consistent
       // between the static and dynamic renders. Let's now try to render the
       // page statically and see that the random number changes.
+      //
+      // When deployed, HTML, prefetch RSC, and dynamic RSC cache entries can
+      // settle asynchronously after tag revalidation, so retry all reads
+      // together until they agree on the same fresh value.
+      await retry(
+        async () => {
+          $ = await next.render$('/')
+          const random2 = $(`p#${id}`).text()
+          expect(random2).not.toBe(first)
 
-      $ = await next.render$('/')
-      const random2 = $(`p#${id}`).text()
-      expect(random2).not.toBe(first)
+          const prefetchRsc = await next
+            .fetch(await getPrefetchRscUrl(), {
+              headers: {
+                RSC: '1',
+                'Next-Router-Prefetch': '1',
+                'Next-Router-Segment-Prefetch': '/__PAGE__',
+              },
+            })
+            .then((res) => res.text())
+          expect(prefetchRsc).toContain(random2)
 
-      // Then get the Prefetch RSC and validate that it also contains the new
-      // random number.
-      await retry(async () => {
-        const rsc = await next
-          .fetch(await getPrefetchRscUrl(), {
-            headers: {
-              RSC: '1',
-              'Next-Router-Prefetch': '1',
-              'Next-Router-Segment-Prefetch': '/__PAGE__',
-            },
-          })
-          .then((res) => res.text())
-        expect(rsc).toContain(random2)
-      })
-
-      // Then get the dynamic RSC again and validate that it also contains the
-      // new random number.
-      await retry(async () => {
-        const rsc = await next
-          .fetch('/', {
-            headers: {
-              RSC: '1',
-            },
-          })
-          .then((res) => res.text())
-        expect(rsc).toContain(random2)
-      })
+          const dynamicRsc = await next
+            .fetch('/', {
+              headers: {
+                RSC: '1',
+              },
+            })
+            .then((res) => res.text())
+          expect(dynamicRsc).toContain(random2)
+        },
+        isNextDeploy ? 15000 : 3000
+      )
 
       // This proves that the dynamic RSC was able to use the resume data cache
       // (RDC) from the static render to ensure that the data is consistent

--- a/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
+++ b/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
@@ -18,21 +18,18 @@ describe('resume-data-cache', () => {
   ])(
     'should have consistent data between static and dynamic renders with $name',
     async ({ id }) => {
-      const getPrefetchRscUrl = async () => {
-        const url = new URL('/', 'http://localhost')
+      const prefetchRscUrl = new URL('/', 'http://localhost')
 
-        url.searchParams.set(
-          '_rsc',
-          await computeCacheBustingSearchParam(
-            '1',
-            '/__PAGE__',
-            undefined,
-            undefined
-          )
+      prefetchRscUrl.searchParams.set(
+        '_rsc',
+        await computeCacheBustingSearchParam(
+          '1',
+          '/__PAGE__',
+          undefined,
+          undefined
         )
-
-        return url.toString()
-      }
+      )
+      const prefetchRscHref = prefetchRscUrl.toString()
 
       // First render the page statically, getting the random number from the
       // HTML.
@@ -43,7 +40,7 @@ describe('resume-data-cache', () => {
       // random number.
       await retry(async () => {
         const rsc = await next
-          .fetch(await getPrefetchRscUrl(), {
+          .fetch(prefetchRscHref, {
             headers: {
               RSC: '1',
               'Next-Router-Prefetch': '1',
@@ -113,7 +110,7 @@ describe('resume-data-cache', () => {
           expect(random2).not.toBe(first)
 
           const prefetchRsc = await next
-            .fetch(await getPrefetchRscUrl(), {
+            .fetch(prefetchRscHref, {
               headers: {
                 RSC: '1',
                 'Next-Router-Prefetch': '1',

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra'
 import { NextInstance } from './base'
 import * as projectEnv from '../../../scripts/reset-project.mjs'
 import { Span } from 'next/dist/trace'
+import { retry } from 'next-test-utils'
 
 export class NextDeployInstance extends NextInstance {
   private _cliOutput: string
@@ -185,6 +186,44 @@ export class NextDeployInstance extends NextInstance {
     )
   }
 
+  private async fetchVercelBuildLogs(
+    vercelEnv: NodeJS.ProcessEnv,
+    vercelFlags: string[]
+  ): Promise<string> {
+    const buildLogs = await execa(
+      'vercel',
+      ['inspect', '--logs', this._url, ...vercelFlags],
+      {
+        env: vercelEnv,
+        reject: false,
+      }
+    )
+    if (buildLogs.exitCode !== 0) {
+      throw new Error(`Failed to get build output logs: ${buildLogs.stderr}`)
+    }
+    // TODO: Combine with runtime logs (via `vercel logs`)
+    // Build logs seem to be piped to stderr, so we'll combine them to make sure we get all the logs.
+    return buildLogs.stdout + buildLogs.stderr
+  }
+
+  private async fetchAndParseVercelBuildLogs(
+    vercelEnv: NodeJS.ProcessEnv,
+    vercelFlags: string[]
+  ): Promise<void> {
+    await retry(
+      async () => {
+        this._cliOutput = await this.fetchVercelBuildLogs(
+          vercelEnv,
+          vercelFlags
+        )
+        this.parseIdsFromCliOuput()
+      },
+      60000,
+      5000,
+      'Vercel build logs to include deployment metadata'
+    )
+  }
+
   public async setup(parentSpan: Span) {
     super.setup(parentSpan)
     await super.createTestDir({ parentSpan, skipInstall: true })
@@ -216,24 +255,13 @@ export class NextDeployInstance extends NextInstance {
       if (customLogsScriptPath) {
         this._cliOutput = await this.fetchBuildLogsUsingCustomScript()
       } else {
-        // Use vercel inspect to get logs for existing deployment
-        const buildLogs = await execa(
-          'vercel',
-          ['inspect', '--logs', this._url],
-          {
-            env: process.env,
-            reject: false,
-          }
-        )
-        if (buildLogs.exitCode !== 0) {
-          throw new Error(
-            `Failed to get build output logs: ${buildLogs.stderr}`
-          )
-        }
-        this._cliOutput = buildLogs.stdout + buildLogs.stderr
+        // Use vercel inspect to get logs for existing deployment.
+        await this.fetchAndParseVercelBuildLogs(process.env, [])
       }
 
-      this.parseIdsFromCliOuput()
+      if (customLogsScriptPath) {
+        this.parseIdsFromCliOuput()
+      }
       return
     }
 
@@ -433,22 +461,7 @@ export class NextDeployInstance extends NextInstance {
     require('console').log(`Deployment URL: ${this._url}`)
 
     // Use the vercel inspect command to get the CLI output from the build.
-    const buildLogs = await execa(
-      'vercel',
-      ['inspect', '--logs', this._url, ...vercelFlags],
-      {
-        env: vercelEnv,
-        reject: false,
-      }
-    )
-    if (buildLogs.exitCode !== 0) {
-      throw new Error(`Failed to get build output logs: ${buildLogs.stderr}`)
-    }
-    // TODO: Combine with runtime logs (via `vercel logs`)
-    // Build logs seem to be piped to stderr, so we'll combine them to make sure we get all the logs.
-    this._cliOutput = buildLogs.stdout + buildLogs.stderr
-
-    this.parseIdsFromCliOuput()
+    await this.fetchAndParseVercelBuildLogs(vercelEnv, vercelFlags)
     // Use the stdout from the logs command as the CLI output. The CLI will
     // output other unrelated logs to stderr.
   }


### PR DESCRIPTION
### What?

- Retry Vercel build log inspection while deploy metadata is still propagating.
- Use the client-style `_rsc` URL for both `resume-data-cache` prefetch checks.

### Why?

Deploy CI was failing/flaking when `vercel inspect --logs` returned a ready deployment before metadata log lines appeared, and when a deploy-mode RSC prefetch reused `/` without the cache-busting query real clients send.

### How?

- Wrap `vercel inspect --logs` plus metadata parsing in a 60s retry for Vercel-backed deploy tests.
- Factor `getPrefetchRscUrl()` in `resume-data-cache.test.ts` and use it for the prefetch check after revalidation too.

### Verification

- `pnpm --filter=next build`
- `pnpm test-start-webpack test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts`
- `npx eslint --config eslint.config.mjs test/lib/next-modes/next-deploy.ts test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts`
- `pnpm tsc -p test/lib/tsconfig.json --noEmit`
- `git diff --check`
- Not run: `NEXT_TEST_MODE=deploy ...` (`requires Vercel CI deploy credentials/environment`)

<!-- NEXT_JS_LLM_PR -->