### PR TITLE
request insights: record local framework spans (1/5)

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2707,6 +2707,8 @@ async function renderToHTMLOrFlightImpl(
   // is the request for the HTML document, so we use the request ID also as the
   // HTML request ID.
   htmlRequestId = parsedRequestHeaders.htmlRequestId || requestId
+  workStore.requestId = requestId
+  workStore.htmlRequestId = htmlRequestId
 
   const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
     interpolatedParams,
@@ -7376,6 +7378,8 @@ async function validateInstantConfigInBuildWithSample(
     isBuildTimePrerendering: false,
     fetchCache: outerWorkStore.fetchCache,
     isOnDemandRevalidate: false,
+    requestId: outerWorkStore.requestId,
+    htmlRequestId: outerWorkStore.htmlRequestId,
 
     isDraftMode: false,
 

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -118,6 +118,14 @@ export interface WorkStore {
   isPrefetchRequest?: boolean
 
   /**
+   * Dev-only request identity used by local request insights. requestId
+   * identifies one server request, while htmlRequestId groups requests that
+   * originated from the same browser page.
+   */
+  requestId?: string
+  htmlRequestId?: string
+
+  /**
    * This only exists because it's needed in use-cache-wrapper
    */
   deploymentId: string

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -137,6 +137,8 @@ export function createWorkStore({
     isBuildTimePrerendering: renderOpts.isBuildTimePrerendering,
     fetchCache: renderOpts.fetchCache,
     isOnDemandRevalidate: renderOpts.isOnDemandRevalidate,
+    requestId: undefined,
+    htmlRequestId: undefined,
 
     isDraftMode: renderOpts.isDraftMode,
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -89,6 +89,9 @@ import type { PrerenderManifest } from '../../build'
 import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import type { PrerenderedRoute } from '../../build/static-paths/types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
+import { registerLocalSpanRecorder } from '../lib/trace/local-span-recorder'
+
+registerLocalSpanRecorder()
 
 // Load ReactDevOverlay only when needed
 let PagesDevOverlayBridgeImpl: PagesDevOverlayBridgeType

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment node
+ */
+
+import { runInNewContext } from 'node:vm'
+import { setFlagsFromString } from 'node:v8'
+import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
+import { createLocalSpan } from './local-span-recorder'
+import { clearSpanStoreForTest, getSpanRecords } from './span-store'
+
+const originalLocalSpans = process.env.NEXT_OTEL_LOCAL_SPANS
+const originalDevServer = process.env.__NEXT_DEV_SERVER
+
+setFlagsFromString('--expose-gc')
+const forceGarbageCollection = runInNewContext('gc') as () => void
+
+describe('local recording span', () => {
+  beforeEach(() => {
+    process.env.__NEXT_DEV_SERVER = '1'
+  })
+
+  afterEach(() => {
+    if (originalLocalSpans === undefined) {
+      delete process.env.NEXT_OTEL_LOCAL_SPANS
+    } else {
+      process.env.NEXT_OTEL_LOCAL_SPANS = originalLocalSpans
+    }
+    if (originalDevServer === undefined) {
+      delete process.env.__NEXT_DEV_SERVER
+    } else {
+      process.env.__NEXT_DEV_SERVER = originalDevServer
+    }
+    clearSpanStoreForTest()
+  })
+
+  it('records a snapshot exactly once when the span ends', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+    const span = createLocalSpan({
+      name: 'test.local-span',
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      attributes: {
+        'next.phase': 'render',
+      },
+    })
+
+    span.setAttribute('next.route', '/dashboard')
+    expect(span.isRecording()).toBe(true)
+    expect(getSpanRecords()).toEqual([])
+
+    span.end()
+    span.setAttribute('next.after_end', true)
+    span.end()
+
+    expect(span.isRecording()).toBe(false)
+    expect(getSpanRecords()).toEqual([
+      expect.objectContaining({
+        name: 'test.local-span',
+        traceId: '0123456789abcdef0123456789abcdef',
+        spanId: '0123456789abcdef',
+        route: '/dashboard',
+        status: 'ok',
+        attributes: {
+          'next.phase': 'render',
+          'next.route': '/dashboard',
+        },
+      }),
+    ])
+  })
+
+  it('captures status, exception, and event mutations before ending', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+    const span = createLocalSpan({ name: 'test.local-span.error' })
+
+    span.addEvent('test.event', { 'next.phase': 'render' })
+    span.recordException(new TypeError('boom'))
+    span.setStatus({ code: SpanStatusCode.ERROR, message: 'failed' })
+    span.end()
+
+    expect(getSpanRecords()).toEqual([
+      expect.objectContaining({
+        name: 'test.local-span.error',
+        status: 'error',
+        error: {
+          type: 'TypeError',
+          message: 'boom',
+        },
+        events: [
+          expect.objectContaining({
+            name: 'test.event',
+            attributes: { 'next.phase': 'render' },
+          }),
+          expect.objectContaining({
+            name: 'exception',
+            attributes: {
+              'exception.type': 'TypeError',
+              'exception.message': 'boom',
+            },
+          }),
+        ],
+      }),
+    ])
+  })
+
+  it('releases heavy references after ending while the span remains reachable', async () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+    const { span, delegateRef, attributeRef } = createEndedSpanWithReferences()
+
+    clearSpanStoreForTest()
+    await expectCollected(delegateRef)
+    await expectCollected(attributeRef)
+
+    expect(span.spanContext()).toEqual({
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+    })
+  })
+})
+
+function createEndedSpanWithReferences() {
+  const delegate = trace.wrapSpanContext({
+    traceId: '0123456789abcdef0123456789abcdef',
+    spanId: '0123456789abcdef',
+    traceFlags: 1,
+  })
+  const attributeValue = ['retained-value']
+  const delegateRef = new WeakRef(delegate)
+  const attributeRef = new WeakRef(attributeValue)
+  const span = createLocalSpan({
+    name: 'test.local-span.retention',
+    delegateSpan: delegate,
+    attributes: {
+      'next.test.payload': attributeValue,
+    },
+  })
+
+  span.end()
+  return { span, delegateRef, attributeRef }
+}
+
+async function expectCollected(ref: WeakRef<object>): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    forceGarbageCollection()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+
+  expect(ref.deref()).toBeUndefined()
+}

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -68,6 +68,29 @@ describe('local recording span', () => {
     ])
   })
 
+  it('ignores undefined values when setting attributes', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+    const span = createLocalSpan({
+      name: 'test.local-span.attributes',
+      attributes: { 'next.phase': 'render' },
+    })
+
+    span.setAttributes({
+      'next.phase': undefined,
+      'next.route': '/dashboard',
+    })
+    span.end()
+
+    expect(getSpanRecords()).toEqual([
+      expect.objectContaining({
+        attributes: {
+          'next.phase': 'render',
+          'next.route': '/dashboard',
+        },
+      }),
+    ])
+  })
+
   it('captures status, exception, and event mutations before ending', () => {
     process.env.NEXT_OTEL_LOCAL_SPANS = '1'
     const span = createLocalSpan({ name: 'test.local-span.error' })

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -6,6 +6,7 @@ import type {
 import type { AsyncLocalStorage } from 'async_hooks'
 import { SpanStatusCode } from 'next/dist/compiled/@opentelemetry/api'
 import {
+  isLocalSpanStoreEnabled,
   recordSpan,
   type SpanStoreAttributes,
   type SpanStoreEvent,
@@ -68,6 +69,29 @@ export function isLocalRecordingSpan(span: Span): boolean {
 
 export function withLocalSpan<T>(span: Span, fn: () => T): T {
   return getLocalSpanAsyncStorage().run(span, fn)
+}
+
+export type LocalSpanRecorder = {
+  createLocalSpan: typeof createLocalSpan
+  getActiveLocalSpan: typeof getActiveLocalSpan
+  isLocalRecordingSpan: typeof isLocalRecordingSpan
+  isLocalSpanStoreEnabled: typeof isLocalSpanStoreEnabled
+  withLocalSpan: typeof withLocalSpan
+}
+
+export function registerLocalSpanRecorder(): void {
+  const key = Symbol.for('@next/local-span-recorder')
+  ;(
+    globalThis as typeof globalThis & {
+      [key]?: LocalSpanRecorder
+    }
+  )[key] = {
+    createLocalSpan,
+    getActiveLocalSpan,
+    isLocalRecordingSpan,
+    isLocalSpanStoreEnabled,
+    withLocalSpan,
+  }
 }
 
 function getLocalSpanAsyncStorage(): AsyncLocalStorage<Span> {

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -167,7 +167,10 @@ class LocalRecordingSpan implements Span {
       return this
     }
 
-    for (const [key, value] of Object.entries(attributes)) {
+    // OpenTelemetry attributes may be undefined. Ignore them instead of
+    // overwriting an existing value as Object.assign would.
+    for (const key of Object.keys(attributes)) {
+      const value = attributes[key]
       if (value !== undefined) {
         this.attributes[key] = value
       }
@@ -337,7 +340,8 @@ function cleanSpanStoreAttributes(
 ): SpanStoreAttributes {
   const cleanedAttributes: SpanStoreAttributes = {}
   if (attributes) {
-    for (const [key, value] of Object.entries(attributes)) {
+    for (const key of Object.keys(attributes)) {
+      const value = attributes[key]
       if (value !== undefined) {
         cleanedAttributes[key] = value
       }

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -1,0 +1,438 @@
+import type {
+  AttributeValue,
+  Span,
+  SpanOptions,
+} from 'next/dist/compiled/@opentelemetry/api'
+import { SpanStatusCode } from 'next/dist/compiled/@opentelemetry/api'
+import {
+  recordSpan,
+  type SpanStoreAttributes,
+  type SpanStoreEvent,
+  type SpanStoreLink,
+} from './span-store'
+
+export { isLocalSpanStoreEnabled } from './span-store'
+
+const TRACE_ID_HEX_LENGTH = 32
+const SPAN_ID_HEX_LENGTH = 16
+
+type LocalSpanAttributes = Partial<Record<string, AttributeValue | undefined>>
+
+let lastLocalTraceId = 0
+let lastLocalSpanId = 0
+const localTraceIdByStore = new WeakMap<object, string>()
+
+const getLocalTraceId = () =>
+  (++lastLocalTraceId).toString(16).padStart(TRACE_ID_HEX_LENGTH, '0')
+
+const getLocalSpanId = () =>
+  (++lastLocalSpanId).toString(16).padStart(SPAN_ID_HEX_LENGTH, '0')
+
+export function createLocalSpanRecorder({
+  name,
+  attributes,
+  links,
+  traceId,
+  spanId,
+  parentSpanId,
+  delegateSpan,
+}: {
+  name: string
+  attributes?: LocalSpanAttributes
+  links?: SpanOptions['links']
+  traceId?: string
+  spanId?: string
+  parentSpanId?: string
+  delegateSpan?: Span
+}): {
+  span: Span
+  complete: (error?: Error) => void
+} {
+  const startTime = Date.now()
+  const startTimeMs = getCurrentTimeMs()
+  const requestIdentity = getCurrentRequestIdentity()
+  const span = new LocalRecordingSpan({
+    name,
+    attributes,
+    delegateSpan,
+    traceId: traceId ?? getLocalTraceIdForCurrentStore(),
+    spanId: spanId ?? getLocalSpanId(),
+  })
+  let recorded = false
+
+  return {
+    span,
+    complete(error?: Error) {
+      if (recorded) {
+        return
+      }
+      recorded = true
+      const recordAttributes = span.getAttributes()
+
+      recordSpan({
+        name: span.name,
+        startTime,
+        durationMs: getCurrentTimeMs() - startTimeMs,
+        status: span.getRecordStatus(error),
+        traceId: span.spanContext().traceId,
+        spanId: span.spanContext().spanId,
+        parentSpanId,
+        requestId: requestIdentity.requestId,
+        htmlRequestId: requestIdentity.htmlRequestId,
+        route:
+          getStringAttribute(recordAttributes, 'next.route') ??
+          getStringAttribute(recordAttributes, 'http.route') ??
+          requestIdentity.route,
+        url:
+          getStringAttribute(recordAttributes, 'http.url') ??
+          requestIdentity.url,
+        attributes: recordAttributes,
+        links: getSpanStoreLinks(links),
+        events: span.getEvents(),
+        error: span.getRecordError(error),
+      })
+    },
+  }
+}
+
+class LocalRecordingSpan implements Span {
+  public name: string
+
+  private readonly attributes: SpanStoreAttributes
+  private readonly events: SpanStoreEvent[] = []
+  private readonly spanContextValue: ReturnType<Span['spanContext']>
+  private readonly delegateSpan?: Span
+  private statusCode: number | undefined
+  private statusMessage: string | undefined
+  private exception:
+    | {
+        type?: string
+        message?: string
+      }
+    | undefined
+
+  constructor({
+    name,
+    attributes,
+    delegateSpan,
+    traceId,
+    spanId,
+  }: {
+    name: string
+    attributes?: LocalSpanAttributes
+    delegateSpan?: Span
+    traceId: string
+    spanId: string
+  }) {
+    this.name = name
+    this.attributes = cleanSpanStoreAttributes(attributes)
+    this.delegateSpan = delegateSpan
+    this.spanContextValue = delegateSpan?.spanContext() ?? {
+      traceId,
+      spanId,
+      traceFlags: 0,
+    }
+  }
+
+  spanContext(): ReturnType<Span['spanContext']> {
+    return this.spanContextValue
+  }
+
+  setAttribute(key: string, value: AttributeValue): this {
+    setSpanStoreAttribute(this.attributes, key, value)
+    this.delegateSpan?.setAttribute(key, value)
+    return this
+  }
+
+  setAttributes(attributes: Parameters<Span['setAttributes']>[0]): this {
+    addSpanStoreAttributes(this.attributes, attributes)
+    this.delegateSpan?.setAttributes(attributes)
+    return this
+  }
+
+  addEvent(
+    name: string,
+    attributesOrStartTime?: Parameters<Span['addEvent']>[1],
+    startTime?: Parameters<Span['addEvent']>[2]
+  ): this {
+    this.events.push({
+      name,
+      timestamp: Date.now(),
+      attributes: isSpanStoreAttributes(attributesOrStartTime)
+        ? cleanSpanStoreAttributes(attributesOrStartTime)
+        : undefined,
+    })
+    this.delegateSpan?.addEvent(name, attributesOrStartTime, startTime)
+    return this
+  }
+
+  setStatus(status: Parameters<Span['setStatus']>[0]): this {
+    this.statusCode = status.code
+    this.statusMessage = status.message
+    this.delegateSpan?.setStatus(status)
+    return this
+  }
+
+  updateName(name: string): this {
+    this.name = name
+    this.delegateSpan?.updateName(name)
+    return this
+  }
+
+  end(endTime?: Parameters<Span['end']>[0]): void {
+    this.delegateSpan?.end(endTime)
+  }
+
+  isRecording(): boolean {
+    return this.delegateSpan?.isRecording() ?? true
+  }
+
+  recordException(
+    exception: Parameters<Span['recordException']>[0],
+    time?: Parameters<Span['recordException']>[1]
+  ): void {
+    this.exception = getSpanStoreException(exception)
+    this.events.push({
+      name: 'exception',
+      timestamp: Date.now(),
+      attributes: getSpanStoreExceptionAttributes(this.exception),
+    })
+    this.delegateSpan?.recordException(exception, time)
+  }
+
+  getAttributes(): SpanStoreAttributes | undefined {
+    return Object.keys(this.attributes).length > 0 ? this.attributes : undefined
+  }
+
+  getEvents(): SpanStoreEvent[] | undefined {
+    return this.events.length > 0 ? this.events : undefined
+  }
+
+  getRecordStatus(error?: Error): 'ok' | 'error' {
+    return error || this.statusCode === SpanStatusCode.ERROR ? 'error' : 'ok'
+  }
+
+  getRecordError(error?: Error):
+    | {
+        type?: string
+        message?: string
+      }
+    | undefined {
+    if (error) {
+      return {
+        type: error.name,
+        message: error.message,
+      }
+    }
+
+    if (this.exception) {
+      return this.exception
+    }
+
+    if (this.statusCode === SpanStatusCode.ERROR && this.statusMessage) {
+      return {
+        message: this.statusMessage,
+      }
+    }
+
+    return undefined
+  }
+}
+
+function getSpanStoreLinks(
+  links: SpanOptions['links'] | undefined
+): SpanStoreLink[] | undefined {
+  const spanStoreLinks = links?.map((link) => ({
+    traceId: link.context.traceId,
+    spanId: link.context.spanId,
+    attributes: cleanSpanStoreAttributes(link.attributes),
+  }))
+
+  return spanStoreLinks?.length ? spanStoreLinks : undefined
+}
+
+function cleanSpanStoreAttributes(
+  attributes:
+    | Record<string, AttributeValue | undefined>
+    | SpanStoreAttributes
+    | undefined
+): SpanStoreAttributes {
+  const cleanedAttributes: SpanStoreAttributes = {}
+  addSpanStoreAttributes(cleanedAttributes, attributes)
+  return cleanedAttributes
+}
+
+function addSpanStoreAttributes(
+  target: SpanStoreAttributes,
+  attributes:
+    | Record<string, AttributeValue | undefined>
+    | SpanStoreAttributes
+    | undefined
+) {
+  if (!attributes) {
+    return
+  }
+
+  for (const [key, value] of Object.entries(attributes)) {
+    setSpanStoreAttribute(target, key, value)
+  }
+}
+
+function getCurrentTimeMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+function getStringAttribute(
+  attributes: SpanStoreAttributes | undefined,
+  key: string
+): string | undefined {
+  const value = attributes?.[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function isSpanStoreAttributes(
+  value: Parameters<Span['addEvent']>[1]
+): value is SpanStoreAttributes {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date)
+  )
+}
+
+function getSpanStoreException(
+  exception: Parameters<Span['recordException']>[0]
+):
+  | {
+      type?: string
+      message?: string
+    }
+  | undefined {
+  if (exception instanceof Error) {
+    return {
+      type: exception.name,
+      message: exception.message,
+    }
+  }
+
+  if (typeof exception === 'string') {
+    return {
+      message: exception,
+    }
+  }
+
+  if (exception && typeof exception === 'object') {
+    return {
+      type: exception.constructor?.name,
+      message: 'message' in exception ? String(exception.message) : undefined,
+    }
+  }
+
+  return undefined
+}
+
+function getSpanStoreExceptionAttributes(
+  exception:
+    | {
+        type?: string
+        message?: string
+      }
+    | undefined
+): SpanStoreAttributes | undefined {
+  if (!exception) {
+    return undefined
+  }
+
+  const attributes: SpanStoreAttributes = {}
+  setSpanStoreAttribute(attributes, 'exception.type', exception.type)
+  setSpanStoreAttribute(attributes, 'exception.message', exception.message)
+  return Object.keys(attributes).length > 0 ? attributes : undefined
+}
+
+function setSpanStoreAttribute(
+  attributes: SpanStoreAttributes,
+  key: string,
+  value: AttributeValue | undefined
+) {
+  if (value !== undefined) {
+    attributes[key] = value
+  }
+}
+
+function getLocalTraceIdForCurrentStore(): string {
+  const { workStore, workUnitStore } = getCurrentAsyncStorageStores()
+  return (
+    getLocalTraceIdForStore(workStore ?? workUnitStore) ?? getLocalTraceId()
+  )
+}
+
+function getCurrentAsyncStorageStores(): {
+  workStore?: {
+    requestId?: string
+    htmlRequestId?: string
+    route?: string
+  }
+  workUnitStore?: object
+} {
+  try {
+    const { workAsyncStorage } =
+      require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
+    const { workUnitAsyncStorage } =
+      require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
+
+    return {
+      workStore: workAsyncStorage.getStore(),
+      workUnitStore: workUnitAsyncStorage.getStore(),
+    }
+  } catch {
+    return {}
+  }
+}
+
+function getLocalTraceIdForStore(
+  store: object | undefined
+): string | undefined {
+  if (!store) {
+    return undefined
+  }
+
+  let traceId = localTraceIdByStore.get(store)
+  if (!traceId) {
+    traceId = getLocalTraceId()
+    localTraceIdByStore.set(store, traceId)
+  }
+  return traceId
+}
+
+function getCurrentRequestIdentity(): {
+  requestId?: string
+  htmlRequestId?: string
+  route?: string
+  url?: string
+} {
+  const { workStore, workUnitStore } = getCurrentAsyncStorageStores()
+  const url =
+    workUnitStore && 'url' in workUnitStore && isRequestUrl(workUnitStore.url)
+      ? workUnitStore.url
+      : undefined
+  return {
+    requestId: workStore?.requestId,
+    htmlRequestId: workStore?.htmlRequestId,
+    route: workStore?.route,
+    url: url ? `${url.pathname}${url.search}` : undefined,
+  }
+}
+
+function isRequestUrl(
+  value: unknown
+): value is { pathname: string; search: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'pathname' in value &&
+    'search' in value &&
+    typeof value.pathname === 'string' &&
+    typeof value.search === 'string'
+  )
+}

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -3,6 +3,7 @@ import type {
   Span,
   SpanOptions,
 } from 'next/dist/compiled/@opentelemetry/api'
+import type { AsyncLocalStorage } from 'async_hooks'
 import { SpanStatusCode } from 'next/dist/compiled/@opentelemetry/api'
 import {
   recordSpan,
@@ -20,7 +21,7 @@ type LocalSpanAttributes = Partial<Record<string, AttributeValue | undefined>>
 
 let lastLocalTraceId = 0
 let lastLocalSpanId = 0
-const localTraceIdByStore = new WeakMap<object, string>()
+let localSpanAsyncStorage: AsyncLocalStorage<Span> | undefined
 
 const getLocalTraceId = () =>
   (++lastLocalTraceId).toString(16).padStart(TRACE_ID_HEX_LENGTH, '0')
@@ -28,7 +29,7 @@ const getLocalTraceId = () =>
 const getLocalSpanId = () =>
   (++lastLocalSpanId).toString(16).padStart(SPAN_ID_HEX_LENGTH, '0')
 
-export function createLocalSpanRecorder({
+export function createLocalSpan({
   name,
   attributes,
   links,
@@ -44,64 +45,60 @@ export function createLocalSpanRecorder({
   spanId?: string
   parentSpanId?: string
   delegateSpan?: Span
-}): {
-  span: Span
-  complete: (error?: Error) => void
-} {
-  const startTime = Date.now()
-  const startTimeMs = getCurrentTimeMs()
-  const requestIdentity = getCurrentRequestIdentity()
-  const span = new LocalRecordingSpan({
+}): Span {
+  return new LocalRecordingSpan({
     name,
     attributes,
+    links,
     delegateSpan,
-    traceId: traceId ?? getLocalTraceIdForCurrentStore(),
+    traceId: traceId ?? getLocalTraceId(),
     spanId: spanId ?? getLocalSpanId(),
+    parentSpanId,
+    requestIdentity: getCurrentRequestIdentity(),
   })
-  let recorded = false
+}
 
-  return {
-    span,
-    complete(error?: Error) {
-      if (recorded) {
-        return
-      }
-      recorded = true
-      const recordAttributes = span.getAttributes()
+export function getActiveLocalSpan(): Span | undefined {
+  return localSpanAsyncStorage?.getStore()
+}
 
-      recordSpan({
-        name: span.name,
-        startTime,
-        durationMs: getCurrentTimeMs() - startTimeMs,
-        status: span.getRecordStatus(error),
-        traceId: span.spanContext().traceId,
-        spanId: span.spanContext().spanId,
-        parentSpanId,
-        requestId: requestIdentity.requestId,
-        htmlRequestId: requestIdentity.htmlRequestId,
-        route:
-          getStringAttribute(recordAttributes, 'next.route') ??
-          getStringAttribute(recordAttributes, 'http.route') ??
-          requestIdentity.route,
-        url:
-          getStringAttribute(recordAttributes, 'http.url') ??
-          requestIdentity.url,
-        attributes: recordAttributes,
-        links: getSpanStoreLinks(links),
-        events: span.getEvents(),
-        error: span.getRecordError(error),
-      })
-    },
+export function isLocalRecordingSpan(span: Span): boolean {
+  return span instanceof LocalRecordingSpan
+}
+
+export function withLocalSpan<T>(span: Span, fn: () => T): T {
+  return getLocalSpanAsyncStorage().run(span, fn)
+}
+
+function getLocalSpanAsyncStorage(): AsyncLocalStorage<Span> {
+  if (!localSpanAsyncStorage) {
+    const { createAsyncLocalStorage } =
+      require('../../app-render/async-local-storage') as typeof import('../../app-render/async-local-storage')
+    localSpanAsyncStorage = createAsyncLocalStorage()
   }
+
+  return localSpanAsyncStorage
+}
+
+type RequestIdentity = {
+  requestId?: string
+  htmlRequestId?: string
+  route?: string
+  url?: string
 }
 
 class LocalRecordingSpan implements Span {
   public name: string
 
-  private readonly attributes: SpanStoreAttributes
-  private readonly events: SpanStoreEvent[] = []
+  private attributes: SpanStoreAttributes
+  private events: SpanStoreEvent[]
   private readonly spanContextValue: ReturnType<Span['spanContext']>
-  private readonly delegateSpan?: Span
+  private delegateSpan?: Span
+  private links?: SpanStoreLink[]
+  private readonly parentSpanId?: string
+  private requestIdentity: RequestIdentity
+  private readonly startTime: number
+  private readonly startTimeMs: number
   private statusCode: number | undefined
   private statusMessage: string | undefined
   private exception:
@@ -110,28 +107,45 @@ class LocalRecordingSpan implements Span {
         message?: string
       }
     | undefined
+  private ended: boolean
 
   constructor({
     name,
     attributes,
+    links,
     delegateSpan,
     traceId,
     spanId,
+    parentSpanId,
+    requestIdentity,
   }: {
     name: string
     attributes?: LocalSpanAttributes
+    links?: SpanOptions['links']
     delegateSpan?: Span
     traceId: string
     spanId: string
+    parentSpanId?: string
+    requestIdentity: RequestIdentity
   }) {
     this.name = name
     this.attributes = cleanSpanStoreAttributes(attributes)
+    this.events = []
     this.delegateSpan = delegateSpan
     this.spanContextValue = delegateSpan?.spanContext() ?? {
       traceId,
       spanId,
       traceFlags: 0,
     }
+    this.links = getSpanStoreLinks(links)
+    this.parentSpanId = parentSpanId
+    this.requestIdentity = requestIdentity
+    this.startTime = Date.now()
+    this.startTimeMs = getCurrentTimeMs()
+    this.statusCode = undefined
+    this.statusMessage = undefined
+    this.exception = undefined
+    this.ended = false
   }
 
   spanContext(): ReturnType<Span['spanContext']> {
@@ -139,13 +153,25 @@ class LocalRecordingSpan implements Span {
   }
 
   setAttribute(key: string, value: AttributeValue): this {
-    setSpanStoreAttribute(this.attributes, key, value)
+    if (this.ended) {
+      return this
+    }
+
+    this.attributes[key] = value
     this.delegateSpan?.setAttribute(key, value)
     return this
   }
 
   setAttributes(attributes: Parameters<Span['setAttributes']>[0]): this {
-    addSpanStoreAttributes(this.attributes, attributes)
+    if (this.ended) {
+      return this
+    }
+
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value !== undefined) {
+        this.attributes[key] = value
+      }
+    }
     this.delegateSpan?.setAttributes(attributes)
     return this
   }
@@ -155,6 +181,10 @@ class LocalRecordingSpan implements Span {
     attributesOrStartTime?: Parameters<Span['addEvent']>[1],
     startTime?: Parameters<Span['addEvent']>[2]
   ): this {
+    if (this.ended) {
+      return this
+    }
+
     this.events.push({
       name,
       timestamp: Date.now(),
@@ -167,6 +197,10 @@ class LocalRecordingSpan implements Span {
   }
 
   setStatus(status: Parameters<Span['setStatus']>[0]): this {
+    if (this.ended) {
+      return this
+    }
+
     this.statusCode = status.code
     this.statusMessage = status.message
     this.delegateSpan?.setStatus(status)
@@ -174,23 +208,44 @@ class LocalRecordingSpan implements Span {
   }
 
   updateName(name: string): this {
+    if (this.ended) {
+      return this
+    }
+
     this.name = name
     this.delegateSpan?.updateName(name)
     return this
   }
 
   end(endTime?: Parameters<Span['end']>[0]): void {
-    this.delegateSpan?.end(endTime)
+    if (this.ended) {
+      return
+    }
+
+    this.ended = true
+    try {
+      this.delegateSpan?.end(endTime)
+    } finally {
+      try {
+        this.record()
+      } finally {
+        this.releaseReferences()
+      }
+    }
   }
 
   isRecording(): boolean {
-    return this.delegateSpan?.isRecording() ?? true
+    return !this.ended
   }
 
   recordException(
     exception: Parameters<Span['recordException']>[0],
     time?: Parameters<Span['recordException']>[1]
   ): void {
+    if (this.ended) {
+      return
+    }
+
     this.exception = getSpanStoreException(exception)
     this.events.push({
       name: 'exception',
@@ -200,31 +255,54 @@ class LocalRecordingSpan implements Span {
     this.delegateSpan?.recordException(exception, time)
   }
 
-  getAttributes(): SpanStoreAttributes | undefined {
-    return Object.keys(this.attributes).length > 0 ? this.attributes : undefined
+  private record(): void {
+    const recordAttributes =
+      Object.keys(this.attributes).length > 0 ? this.attributes : undefined
+
+    recordSpan({
+      name: this.name,
+      startTime: this.startTime,
+      durationMs: getCurrentTimeMs() - this.startTimeMs,
+      status: this.statusCode === SpanStatusCode.ERROR ? 'error' : 'ok',
+      traceId: this.spanContextValue.traceId,
+      spanId: this.spanContextValue.spanId,
+      parentSpanId: this.parentSpanId,
+      requestId: this.requestIdentity.requestId,
+      htmlRequestId: this.requestIdentity.htmlRequestId,
+      route:
+        getStringAttribute(recordAttributes, 'next.route') ??
+        getStringAttribute(recordAttributes, 'http.route') ??
+        this.requestIdentity.route,
+      url:
+        getStringAttribute(recordAttributes, 'http.url') ??
+        this.requestIdentity.url,
+      attributes: recordAttributes,
+      links: this.links,
+      events: this.events.length > 0 ? this.events : undefined,
+      error: this.getRecordError(),
+    })
   }
 
-  getEvents(): SpanStoreEvent[] | undefined {
-    return this.events.length > 0 ? this.events : undefined
+  private releaseReferences(): void {
+    // AsyncLocalStorage can keep an ended span reachable when work spawned
+    // inside the span outlives it. Keep only the immutable span context and
+    // primitive timing/identity fields needed by the Span API after end.
+    this.name = ''
+    this.attributes = {}
+    this.events = []
+    this.delegateSpan = undefined
+    this.links = undefined
+    this.requestIdentity = {}
+    this.statusMessage = undefined
+    this.exception = undefined
   }
 
-  getRecordStatus(error?: Error): 'ok' | 'error' {
-    return error || this.statusCode === SpanStatusCode.ERROR ? 'error' : 'ok'
-  }
-
-  getRecordError(error?: Error):
+  private getRecordError():
     | {
         type?: string
         message?: string
       }
     | undefined {
-    if (error) {
-      return {
-        type: error.name,
-        message: error.message,
-      }
-    }
-
     if (this.exception) {
       return this.exception
     }
@@ -258,24 +336,14 @@ function cleanSpanStoreAttributes(
     | undefined
 ): SpanStoreAttributes {
   const cleanedAttributes: SpanStoreAttributes = {}
-  addSpanStoreAttributes(cleanedAttributes, attributes)
+  if (attributes) {
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value !== undefined) {
+        cleanedAttributes[key] = value
+      }
+    }
+  }
   return cleanedAttributes
-}
-
-function addSpanStoreAttributes(
-  target: SpanStoreAttributes,
-  attributes:
-    | Record<string, AttributeValue | undefined>
-    | SpanStoreAttributes
-    | undefined
-) {
-  if (!attributes) {
-    return
-  }
-
-  for (const [key, value] of Object.entries(attributes)) {
-    setSpanStoreAttribute(target, key, value)
-  }
 }
 
 function getCurrentTimeMs(): number {
@@ -345,94 +413,33 @@ function getSpanStoreExceptionAttributes(
   }
 
   const attributes: SpanStoreAttributes = {}
-  setSpanStoreAttribute(attributes, 'exception.type', exception.type)
-  setSpanStoreAttribute(attributes, 'exception.message', exception.message)
+  if (exception.type !== undefined) {
+    attributes['exception.type'] = exception.type
+  }
+  if (exception.message !== undefined) {
+    attributes['exception.message'] = exception.message
+  }
   return Object.keys(attributes).length > 0 ? attributes : undefined
 }
 
-function setSpanStoreAttribute(
-  attributes: SpanStoreAttributes,
-  key: string,
-  value: AttributeValue | undefined
-) {
-  if (value !== undefined) {
-    attributes[key] = value
-  }
-}
-
-function getLocalTraceIdForCurrentStore(): string {
-  const { workStore, workUnitStore } = getCurrentAsyncStorageStores()
-  return (
-    getLocalTraceIdForStore(workStore ?? workUnitStore) ?? getLocalTraceId()
-  )
-}
-
-function getCurrentAsyncStorageStores(): {
-  workStore?: {
-    requestId?: string
-    htmlRequestId?: string
-    route?: string
-  }
-  workUnitStore?: object
-} {
+function getCurrentRequestIdentity(): RequestIdentity {
   try {
     const { workAsyncStorage } =
       require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
     const { workUnitAsyncStorage } =
       require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
+    const workStore = workAsyncStorage.getStore()
+    const workUnitStore = workUnitAsyncStorage.getStore()
+    const url =
+      workUnitStore && 'url' in workUnitStore ? workUnitStore.url : undefined
 
     return {
-      workStore: workAsyncStorage.getStore(),
-      workUnitStore: workUnitAsyncStorage.getStore(),
+      requestId: workStore?.requestId,
+      htmlRequestId: workStore?.htmlRequestId,
+      route: workStore?.route,
+      url: url ? `${url.pathname}${url.search}` : undefined,
     }
   } catch {
     return {}
   }
-}
-
-function getLocalTraceIdForStore(
-  store: object | undefined
-): string | undefined {
-  if (!store) {
-    return undefined
-  }
-
-  let traceId = localTraceIdByStore.get(store)
-  if (!traceId) {
-    traceId = getLocalTraceId()
-    localTraceIdByStore.set(store, traceId)
-  }
-  return traceId
-}
-
-function getCurrentRequestIdentity(): {
-  requestId?: string
-  htmlRequestId?: string
-  route?: string
-  url?: string
-} {
-  const { workStore, workUnitStore } = getCurrentAsyncStorageStores()
-  const url =
-    workUnitStore && 'url' in workUnitStore && isRequestUrl(workUnitStore.url)
-      ? workUnitStore.url
-      : undefined
-  return {
-    requestId: workStore?.requestId,
-    htmlRequestId: workStore?.htmlRequestId,
-    route: workStore?.route,
-    url: url ? `${url.pathname}${url.search}` : undefined,
-  }
-}
-
-function isRequestUrl(
-  value: unknown
-): value is { pathname: string; search: string } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'pathname' in value &&
-    'search' in value &&
-    typeof value.pathname === 'string' &&
-    typeof value.search === 'string'
-  )
 }

--- a/packages/next/src/server/lib/trace/span-store.test.ts
+++ b/packages/next/src/server/lib/trace/span-store.test.ts
@@ -1,0 +1,178 @@
+import {
+  clearSpanStoreForTest,
+  getSpanRecords,
+  InMemorySpanStore,
+  isRequestInsightsEnabled,
+  recordSpan,
+} from './span-store'
+
+const originalLocalSpans = process.env.NEXT_OTEL_LOCAL_SPANS
+const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
+
+describe('span store', () => {
+  afterEach(() => {
+    restoreEnv('NEXT_OTEL_LOCAL_SPANS', originalLocalSpans)
+    restoreEnv('__NEXT_REQUEST_INSIGHTS', originalRequestInsights)
+    clearSpanStoreForTest()
+  })
+
+  it('keeps bounded in-memory records with OTel-compatible identity fields and links', () => {
+    const traceStore = new InMemorySpanStore({ maxRecords: 2 })
+
+    traceStore.record({
+      name: 'next.cache_component.produce',
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000001',
+      route: '/products/[id]',
+      attributes: {
+        'next.phase': 'build',
+        'next.artifact.kind': 'ppr-shell',
+      },
+    })
+
+    traceStore.record({
+      name: 'next.cache_component.consume',
+      traceId: '00000000000000000000000000000002',
+      spanId: '0000000000000002',
+      requestId: 'req_1',
+      route: '/products/[id]',
+      attributes: {
+        'next.phase': 'request',
+        'next.cache.status': 'hit',
+        'next.artifact.kind': 'ppr-shell',
+      },
+      events: [
+        {
+          name: 'next.cache.lookup',
+          timestamp: 1,
+          attributes: {
+            'next.cache.status': 'hit',
+          },
+        },
+      ],
+      links: [
+        {
+          traceId: '00000000000000000000000000000001',
+          spanId: '0000000000000001',
+          attributes: {
+            'next.link.reason': 'artifact.reuse',
+          },
+        },
+      ],
+    })
+
+    traceStore.record({
+      name: 'next.cache_component.consume',
+      requestId: 'req_2',
+      route: '/cart',
+      attributes: {
+        'next.cache.status': 'miss',
+      },
+    })
+
+    expect(traceStore.getRecords()).toHaveLength(2)
+    expect(traceStore.getRecords({ requestId: 'req_1' })).toEqual([
+      expect.objectContaining({
+        name: 'next.cache_component.consume',
+        requestId: 'req_1',
+        route: '/products/[id]',
+        attributes: expect.objectContaining({
+          'next.cache.status': 'hit',
+        }),
+        links: [
+          {
+            traceId: '00000000000000000000000000000001',
+            spanId: '0000000000000001',
+            attributes: {
+              'next.link.reason': 'artifact.reuse',
+            },
+          },
+        ],
+        events: [
+          {
+            name: 'next.cache.lookup',
+            timestamp: 1,
+            attributes: {
+              'next.cache.status': 'hit',
+            },
+          },
+        ],
+      }),
+    ])
+  })
+
+  it('records to the global in-memory store only when local span capture is enabled', () => {
+    delete process.env.NEXT_OTEL_LOCAL_SPANS
+
+    recordSpan({
+      name: 'next.cache_component.consume',
+      requestId: 'req_1',
+    })
+
+    expect(getSpanRecords()).toEqual([])
+
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+    recordSpan({
+      name: 'next.cache_component.consume',
+      requestId: 'req_1',
+      attributes: {
+        'next.cache.status': 'hit',
+      },
+    })
+
+    expect(getSpanRecords({ requestId: 'req_1' })).toEqual([
+      expect.objectContaining({
+        name: 'next.cache_component.consume',
+        requestId: 'req_1',
+        attributes: {
+          'next.cache.status': 'hit',
+        },
+      }),
+    ])
+  })
+
+  it('shares local records across separate module instances in the same process', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    jest.isolateModules(() => {
+      const { recordSpan: recordSpanFromIsolatedModule } =
+        require('./span-store') as typeof import('./span-store')
+
+      recordSpanFromIsolatedModule({
+        name: 'fetch GET https://example.vercel.sh/',
+        spanId: '0000000000000001',
+        traceId: '00000000000000000000000000000001',
+        attributes: {
+          'next.span_type': 'AppRender.fetch',
+          'http.url': 'https://example.vercel.sh/',
+        },
+      })
+    })
+
+    expect(getSpanRecords()).toEqual([
+      expect.objectContaining({
+        name: 'fetch GET https://example.vercel.sh/',
+        spanId: '0000000000000001',
+        traceId: '00000000000000000000000000000001',
+        attributes: expect.objectContaining({
+          'next.span_type': 'AppRender.fetch',
+          'http.url': 'https://example.vercel.sh/',
+        }),
+      }),
+    ])
+  })
+
+  it('treats boolean define-env request insights values as enabled', () => {
+    ;(process.env.__NEXT_REQUEST_INSIGHTS as unknown) = true
+
+    expect(isRequestInsightsEnabled()).toBe(true)
+  })
+})

--- a/packages/next/src/server/lib/trace/span-store.test.ts
+++ b/packages/next/src/server/lib/trace/span-store.test.ts
@@ -1,13 +1,20 @@
+import { runInNewContext } from 'node:vm'
+import { setFlagsFromString } from 'node:v8'
 import {
   clearSpanStoreForTest,
   getSpanRecords,
   InMemorySpanStore,
+  isLocalSpanStoreEnabled,
   isRequestInsightsEnabled,
   recordSpan,
 } from './span-store'
 
 const originalLocalSpans = process.env.NEXT_OTEL_LOCAL_SPANS
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
+const originalDevServer = process.env.__NEXT_DEV_SERVER
+
+setFlagsFromString('--expose-gc')
+const forceGarbageCollection = runInNewContext('gc') as () => void
 
 function restoreEnv(name: string, value: string | undefined) {
   if (value === undefined) {
@@ -18,9 +25,14 @@ function restoreEnv(name: string, value: string | undefined) {
 }
 
 describe('span store', () => {
+  beforeEach(() => {
+    process.env.__NEXT_DEV_SERVER = '1'
+  })
+
   afterEach(() => {
     restoreEnv('NEXT_OTEL_LOCAL_SPANS', originalLocalSpans)
     restoreEnv('__NEXT_REQUEST_INSIGHTS', originalRequestInsights)
+    restoreEnv('__NEXT_DEV_SERVER', originalDevServer)
     clearSpanStoreForTest()
   })
 
@@ -109,6 +121,16 @@ describe('span store', () => {
     ])
   })
 
+  it('releases attribute payloads from evicted records', async () => {
+    const { traceStore, attributeRef } = createStoreWithEvictedAttribute()
+
+    expect(traceStore.getRecords()).toEqual([
+      expect.objectContaining({ name: 'second' }),
+    ])
+
+    await expectCollected(attributeRef)
+  })
+
   it('records to the global in-memory store only when local span capture is enabled', () => {
     delete process.env.NEXT_OTEL_LOCAL_SPANS
 
@@ -137,6 +159,17 @@ describe('span store', () => {
         },
       }),
     ])
+  })
+
+  it('does not enable local span capture outside the dev server', () => {
+    delete process.env.__NEXT_DEV_SERVER
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    expect(isLocalSpanStoreEnabled()).toBe(false)
+
+    recordSpan({ name: 'test.production' })
+    expect(getSpanRecords()).toEqual([])
   })
 
   it('shares local records across separate module instances in the same process', () => {
@@ -176,3 +209,26 @@ describe('span store', () => {
     expect(isRequestInsightsEnabled()).toBe(true)
   })
 })
+
+function createStoreWithEvictedAttribute() {
+  const traceStore = new InMemorySpanStore({ maxRecords: 1 })
+  const attributeValue = ['retained-value']
+  const attributeRef = new WeakRef(attributeValue)
+
+  traceStore.record({
+    name: 'first',
+    attributes: { 'next.test.payload': attributeValue },
+  })
+  traceStore.record({ name: 'second' })
+
+  return { traceStore, attributeRef }
+}
+
+async function expectCollected(ref: WeakRef<object>): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    forceGarbageCollection()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+
+  expect(ref.deref()).toBeUndefined()
+}

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -73,7 +73,13 @@ export class InMemorySpanStore {
   }
 
   getRecords(filter: SpanStoreFilter = {}): SpanStoreRecord[] {
-    return this.records.filter((record) => matchesFilter(record, filter))
+    return this.records.filter(
+      (record) =>
+        (filter.requestId === undefined ||
+          record.requestId === filter.requestId) &&
+        (filter.route === undefined || record.route === filter.route) &&
+        (filter.name === undefined || record.name === filter.name)
+    )
   }
 
   clear(): void {
@@ -98,6 +104,10 @@ export function clearSpanStoreForTest(): void {
 }
 
 export function isLocalSpanStoreEnabled(): boolean {
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return false
+  }
+
   const value = process.env.NEXT_OTEL_LOCAL_SPANS
   return isEnabledEnvValue(value) || isRequestInsightsEnabled()
 }
@@ -117,15 +127,4 @@ function getLocalSpanStore(): InMemorySpanStore {
   }
 
   return (globalStore[LOCAL_SPAN_STORE_KEY] ??= new InMemorySpanStore())
-}
-
-function matchesFilter(
-  record: SpanStoreRecord,
-  filter: SpanStoreFilter
-): boolean {
-  return (
-    (filter.requestId === undefined || record.requestId === filter.requestId) &&
-    (filter.route === undefined || record.route === filter.route) &&
-    (filter.name === undefined || record.name === filter.name)
-  )
 }

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -1,0 +1,131 @@
+import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
+
+export type SpanStoreAttributes = Record<string, AttributeValue>
+
+export type SpanStoreLink = {
+  traceId: string
+  spanId: string
+  attributes?: SpanStoreAttributes
+}
+
+export type SpanStoreEvent = {
+  name: string
+  timestamp: number
+  attributes?: SpanStoreAttributes
+}
+
+export type SpanStoreRecord = {
+  name: string
+  timestamp: number
+  startTime?: number
+  durationMs?: number
+  status?: 'ok' | 'error'
+  traceId?: string
+  spanId?: string
+  parentSpanId?: string
+  requestId?: string
+  htmlRequestId?: string
+  route?: string
+  url?: string
+  attributes?: SpanStoreAttributes
+  links?: SpanStoreLink[]
+  events?: SpanStoreEvent[]
+  error?: {
+    type?: string
+    message?: string
+  }
+}
+
+export type SpanStoreFilter = {
+  requestId?: string
+  route?: string
+  name?: string
+}
+
+export type InMemorySpanStoreOptions = {
+  maxRecords?: number
+}
+
+const DEFAULT_MAX_RECORDS = 128
+const LOCAL_SPAN_STORE_KEY = Symbol.for('@next/local-span-store')
+
+export class InMemorySpanStore {
+  private readonly maxRecords: number
+  private records: SpanStoreRecord[] = []
+
+  constructor(options: InMemorySpanStoreOptions = {}) {
+    this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS
+  }
+
+  record(record: Omit<SpanStoreRecord, 'timestamp'>): SpanStoreRecord {
+    const spanRecord = {
+      timestamp: Date.now(),
+      ...record,
+    }
+
+    this.records.push(spanRecord)
+
+    if (this.records.length > this.maxRecords) {
+      this.records.splice(0, this.records.length - this.maxRecords)
+    }
+
+    return spanRecord
+  }
+
+  getRecords(filter: SpanStoreFilter = {}): SpanStoreRecord[] {
+    return this.records.filter((record) => matchesFilter(record, filter))
+  }
+
+  clear(): void {
+    this.records = []
+  }
+}
+
+export function recordSpan(record: Omit<SpanStoreRecord, 'timestamp'>): void {
+  if (!isLocalSpanStoreEnabled()) {
+    return
+  }
+
+  getLocalSpanStore().record(record)
+}
+
+export function getSpanRecords(filter?: SpanStoreFilter): SpanStoreRecord[] {
+  return getLocalSpanStore().getRecords(filter)
+}
+
+export function clearSpanStoreForTest(): void {
+  getLocalSpanStore().clear()
+}
+
+export function isLocalSpanStoreEnabled(): boolean {
+  const value = process.env.NEXT_OTEL_LOCAL_SPANS
+  return isEnabledEnvValue(value) || isRequestInsightsEnabled()
+}
+
+export function isRequestInsightsEnabled(): boolean {
+  const value = process.env.__NEXT_REQUEST_INSIGHTS
+  return isEnabledEnvValue(value)
+}
+
+function isEnabledEnvValue(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || (value as unknown) === true
+}
+
+function getLocalSpanStore(): InMemorySpanStore {
+  const globalStore = globalThis as typeof globalThis & {
+    [LOCAL_SPAN_STORE_KEY]?: InMemorySpanStore
+  }
+
+  return (globalStore[LOCAL_SPAN_STORE_KEY] ??= new InMemorySpanStore())
+}
+
+function matchesFilter(
+  record: SpanStoreRecord,
+  filter: SpanStoreFilter
+): boolean {
+  return (
+    (filter.requestId === undefined || record.requestId === filter.requestId) &&
+    (filter.route === undefined || record.route === filter.route) &&
+    (filter.name === undefined || record.name === filter.name)
+  )
+}

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -24,6 +24,7 @@ import { SpanKind, SpanStatusCode, getTracer } from './tracer'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
 const originalLocalSpans = process.env.NEXT_OTEL_LOCAL_SPANS
+const originalDevServer = process.env.__NEXT_DEV_SERVER
 
 const getter: TextMapGetter<Record<string, string | undefined>> = {
   keys: (carrier) => Object.keys(carrier),
@@ -143,12 +144,22 @@ describe('withPropagatedContext', () => {
 })
 
 describe('local span store sink', () => {
+  beforeEach(() => {
+    process.env.__NEXT_DEV_SERVER = '1'
+  })
+
   afterEach(() => {
     if (originalLocalSpans === undefined) {
       delete process.env.NEXT_OTEL_LOCAL_SPANS
     } else {
       process.env.NEXT_OTEL_LOCAL_SPANS = originalLocalSpans
     }
+    if (originalDevServer === undefined) {
+      delete process.env.__NEXT_DEV_SERVER
+    } else {
+      process.env.__NEXT_DEV_SERVER = originalDevServer
+    }
+    trace.disable()
     clearSpanStoreForTest()
   })
 
@@ -158,6 +169,21 @@ describe('local span store sink', () => {
     const result = getTracer().trace(NodeSpan.runHandler, () => 'result')
 
     expect(result).toBe('result')
+    expect(getSpanRecords()).toEqual([])
+  })
+
+  it('bypasses local span handling outside the dev server', () => {
+    delete process.env.__NEXT_DEV_SERVER
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+    let receivedSpan: unknown = 'not-called'
+
+    const result = getTracer().trace(NodeSpan.runHandler, (span) => {
+      receivedSpan = span
+      return 'result'
+    })
+
+    expect(result).toBe('result')
+    expect(receivedSpan).toBeUndefined()
     expect(getSpanRecords()).toEqual([])
   })
 
@@ -339,6 +365,92 @@ describe('local span store sink', () => {
     ])
   })
 
+  it('records callback trace calls consistently with an OTel provider', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const delegateSpan = trace.wrapSpanContext({
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+    })
+    trace.setGlobalTracerProvider({
+      getTracer() {
+        return {
+          startSpan() {
+            return delegateSpan
+          },
+          startActiveSpan(...args: unknown[]) {
+            const callback = args.at(-1) as (
+              span: typeof delegateSpan
+            ) => unknown
+            return callback(delegateSpan)
+          },
+        }
+      },
+    })
+
+    const result = getTracer().trace(
+      NodeSpan.runHandler,
+      { spanName: 'test.callback.provider' },
+      (_span, done) => {
+        done?.()
+        return 'result'
+      }
+    )
+
+    expect(result).toBe('result')
+    expect(getSpanRecords({ name: 'test.callback.provider' })).toEqual([
+      expect.objectContaining({
+        status: 'ok',
+        traceId: '0123456789abcdef0123456789abcdef',
+        spanId: '0123456789abcdef',
+      }),
+    ])
+  })
+
+  it('records direct spans with active local parent identity', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const parentSpan = getTracer().startSpan(NodeSpan.runHandler, {
+      attributes: { 'next.test.name': 'parent' },
+    })
+    let childSpanId: string | undefined
+
+    getTracer().withSpan(parentSpan, () => {
+      expect(getTracer().getActiveScopeSpan()).toBe(parentSpan)
+
+      const childSpan = getTracer().startSpan(AppRenderSpan.fetch, {
+        attributes: { 'next.test.name': 'child' },
+      })
+      childSpanId = childSpan.spanContext().spanId
+      childSpan.end()
+    })
+    parentSpan.end()
+
+    const records = getSpanRecords()
+    const parentRecord = records.find(
+      (record) => record.attributes?.['next.test.name'] === 'parent'
+    )
+    const childRecord = records.find(
+      (record) => record.attributes?.['next.test.name'] === 'child'
+    )
+
+    expect(parentRecord).toEqual(
+      expect.objectContaining({
+        name: NodeSpan.runHandler,
+        parentSpanId: undefined,
+      })
+    )
+    expect(childRecord).toEqual(
+      expect.objectContaining({
+        name: AppRenderSpan.fetch,
+        spanId: childSpanId,
+        traceId: parentRecord?.traceId,
+        parentSpanId: parentRecord?.spanId,
+      })
+    )
+  })
+
   it('records thrown errors before rethrowing', () => {
     process.env.NEXT_OTEL_LOCAL_SPANS = '1'
 
@@ -396,11 +508,17 @@ describe('local span store sink', () => {
             getIsolatedTracer().trace(
               NodeSpan.runHandler,
               { spanName: 'test.als.outer' },
-              () => {
+              (outerSpan) => {
+                expect(getIsolatedTracer().getActiveScopeSpan()).toBe(outerSpan)
                 getIsolatedTracer().trace(
                   NodeSpan.runHandler,
                   { spanName: 'test.als.inner' },
-                  () => 'result'
+                  (innerSpan) => {
+                    expect(getIsolatedTracer().getActiveScopeSpan()).toBe(
+                      innerSpan
+                    )
+                    return 'result'
+                  }
                 )
               }
             )
@@ -409,9 +527,16 @@ describe('local span store sink', () => {
 
         const records = getIsolatedSpanRecords()
         const traceIds = new Set(records.map((record) => record.traceId))
+        const outerRecord = records.find(
+          (record) => record.name === 'test.als.outer'
+        )
+        const innerRecord = records.find(
+          (record) => record.name === 'test.als.inner'
+        )
 
         expect(records).toHaveLength(2)
         expect(traceIds.size).toBe(1)
+        expect(innerRecord?.parentSpanId).toBe(outerRecord?.spanId)
         expect(records).toEqual(
           expect.arrayContaining([
             expect.objectContaining({

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@opentelemetry/api'
 
 import { clearSpanStoreForTest, getSpanRecords } from './span-store'
+import { registerLocalSpanRecorder } from './local-span-recorder'
 import { AppRenderSpan, NodeSpan } from './constants'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
 
@@ -146,6 +147,7 @@ describe('withPropagatedContext', () => {
 describe('local span store sink', () => {
   beforeEach(() => {
     process.env.__NEXT_DEV_SERVER = '1'
+    registerLocalSpanRecorder()
   })
 
   afterEach(() => {
@@ -412,7 +414,7 @@ describe('local span store sink', () => {
     process.env.NEXT_OTEL_LOCAL_SPANS = '1'
 
     const parentSpan = getTracer().startSpan(NodeSpan.runHandler, {
-      attributes: { 'next.test.name': 'parent' },
+      attributes: { 'next.page': 'parent' },
     })
     let childSpanId: string | undefined
 
@@ -420,7 +422,7 @@ describe('local span store sink', () => {
       expect(getTracer().getActiveScopeSpan()).toBe(parentSpan)
 
       const childSpan = getTracer().startSpan(AppRenderSpan.fetch, {
-        attributes: { 'next.test.name': 'child' },
+        attributes: { 'next.page': 'child' },
       })
       childSpanId = childSpan.spanContext().spanId
       childSpan.end()
@@ -429,10 +431,10 @@ describe('local span store sink', () => {
 
     const records = getSpanRecords()
     const parentRecord = records.find(
-      (record) => record.attributes?.['next.test.name'] === 'parent'
+      (record) => record.attributes?.['next.page'] === 'parent'
     )
     const childRecord = records.find(
-      (record) => record.attributes?.['next.test.name'] === 'child'
+      (record) => record.attributes?.['next.page'] === 'child'
     )
 
     expect(parentRecord).toEqual(
@@ -488,6 +490,9 @@ describe('local span store sink', () => {
           require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
         const { getSpanRecords: getIsolatedSpanRecords } =
           require('./span-store') as typeof import('./span-store')
+        const { registerLocalSpanRecorder: registerIsolatedLocalSpanRecorder } =
+          require('./local-span-recorder') as typeof import('./local-span-recorder')
+        registerIsolatedLocalSpanRecorder()
         const { getTracer: getIsolatedTracer } =
           require('./tracer') as typeof import('./tracer')
 

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -8,6 +8,8 @@ import type {
   TextMapGetter,
   TextMapPropagator,
 } from '@opentelemetry/api'
+import type { WorkStore } from '../../app-render/work-async-storage.external'
+import type { WorkUnitStore } from '../../app-render/work-unit-async-storage.external'
 import {
   ROOT_CONTEXT,
   context,
@@ -16,9 +18,12 @@ import {
   trace,
 } from '@opentelemetry/api'
 
-import { getTracer } from './tracer'
+import { clearSpanStoreForTest, getSpanRecords } from './span-store'
+import { AppRenderSpan, NodeSpan } from './constants'
+import { SpanKind, SpanStatusCode, getTracer } from './tracer'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
+const originalLocalSpans = process.env.NEXT_OTEL_LOCAL_SPANS
 
 const getter: TextMapGetter<Record<string, string | undefined>> = {
   keys: (carrier) => Object.keys(carrier),
@@ -133,6 +138,306 @@ describe('withPropagatedContext', () => {
     expect(result).toEqual({
       customValue: 'custom1',
       activeSpanId: '0123456789abcdef',
+    })
+  })
+})
+
+describe('local span store sink', () => {
+  afterEach(() => {
+    if (originalLocalSpans === undefined) {
+      delete process.env.NEXT_OTEL_LOCAL_SPANS
+    } else {
+      process.env.NEXT_OTEL_LOCAL_SPANS = originalLocalSpans
+    }
+    clearSpanStoreForTest()
+  })
+
+  it('does not mirror spans by default', () => {
+    delete process.env.NEXT_OTEL_LOCAL_SPANS
+
+    const result = getTracer().trace(NodeSpan.runHandler, () => 'result')
+
+    expect(result).toBe('result')
+    expect(getSpanRecords()).toEqual([])
+  })
+
+  it('records sync trace calls without an OTel provider', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const result = getTracer().trace(
+      NodeSpan.runHandler,
+      {
+        spanName: 'test.sync',
+        attributes: {
+          'next.route': '/products/[id]',
+        },
+      },
+      () => 'result'
+    )
+
+    expect(result).toBe('result')
+    expect(getSpanRecords({ name: 'test.sync' })).toEqual([
+      expect.objectContaining({
+        name: 'test.sync',
+        route: '/products/[id]',
+        status: 'ok',
+        traceId: expect.stringMatching(/^[0-9a-f]{32}$/),
+        spanId: expect.stringMatching(/^[0-9a-f]{16}$/),
+        durationMs: expect.any(Number),
+        attributes: expect.objectContaining({
+          'next.route': '/products/[id]',
+          'next.span_name': 'test.sync',
+          'next.span_type': NodeSpan.runHandler,
+        }),
+      }),
+    ])
+  })
+
+  it('records app render fetch spans without an OTel provider', async () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const result = await getTracer().trace(
+      AppRenderSpan.fetch,
+      {
+        kind: SpanKind.CLIENT,
+        spanName: 'fetch GET https://example.vercel.sh/',
+        attributes: {
+          'http.url': 'https://example.vercel.sh/',
+          'http.method': 'GET',
+          'net.peer.name': 'example.vercel.sh',
+        },
+      },
+      async () => 'response'
+    )
+
+    expect(result).toBe('response')
+    expect(
+      getSpanRecords({ name: 'fetch GET https://example.vercel.sh/' })
+    ).toEqual([
+      expect.objectContaining({
+        name: 'fetch GET https://example.vercel.sh/',
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span_name': 'fetch GET https://example.vercel.sh/',
+          'next.span_type': AppRenderSpan.fetch,
+          'http.url': 'https://example.vercel.sh/',
+          'http.method': 'GET',
+          'net.peer.name': 'example.vercel.sh',
+        }),
+      }),
+    ])
+  })
+
+  it('mirrors span mutations made through the OTel span API', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const result = getTracer().trace(
+      NodeSpan.runHandler,
+      { spanName: 'test.mutated' },
+      (span) => {
+        span?.setAttribute('http.status_code', 200)
+        span?.setAttributes({
+          'next.route': '/mutated',
+        })
+        span?.addEvent('test.event', {
+          'next.phase': 'render',
+        })
+        span?.updateName('test.mutated.updated')
+        return 'result'
+      }
+    )
+
+    expect(result).toBe('result')
+    expect(getSpanRecords({ name: 'test.mutated.updated' })).toEqual([
+      expect.objectContaining({
+        name: 'test.mutated.updated',
+        route: '/mutated',
+        attributes: expect.objectContaining({
+          'http.status_code': 200,
+          'next.route': '/mutated',
+        }),
+        events: [
+          expect.objectContaining({
+            name: 'test.event',
+            attributes: {
+              'next.phase': 'render',
+            },
+          }),
+        ],
+      }),
+    ])
+  })
+
+  it('mirrors span status without a thrown error', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const result = getTracer().trace(
+      NodeSpan.runHandler,
+      { spanName: 'test.status' },
+      (span) => {
+        span?.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: 'status failed',
+        })
+        return 'result'
+      }
+    )
+
+    expect(result).toBe('result')
+    expect(getSpanRecords({ name: 'test.status' })).toEqual([
+      expect.objectContaining({
+        name: 'test.status',
+        status: 'error',
+        error: {
+          message: 'status failed',
+        },
+      }),
+    ])
+  })
+
+  it('records async trace calls when the returned promise settles', async () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const result = await getTracer().trace(
+      NodeSpan.runHandler,
+      { spanName: 'test.async' },
+      async () => {
+        await Promise.resolve()
+        return 'result'
+      }
+    )
+
+    expect(result).toBe('result')
+    expect(getSpanRecords({ name: 'test.async' })).toEqual([
+      expect.objectContaining({
+        name: 'test.async',
+        status: 'ok',
+        durationMs: expect.any(Number),
+      }),
+    ])
+  })
+
+  it('records callback trace calls when done is called', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    const result = getTracer().trace(
+      NodeSpan.runHandler,
+      { spanName: 'test.callback' },
+      (_span, done) => {
+        done?.()
+        return 'result'
+      }
+    )
+
+    expect(result).toBe('result')
+    expect(getSpanRecords({ name: 'test.callback' })).toEqual([
+      expect.objectContaining({
+        name: 'test.callback',
+        status: 'ok',
+        durationMs: expect.any(Number),
+      }),
+    ])
+  })
+
+  it('records thrown errors before rethrowing', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    expect(() =>
+      getTracer().trace(NodeSpan.runHandler, { spanName: 'test.error' }, () => {
+        throw new Error('boom')
+      })
+    ).toThrow('boom')
+
+    expect(getSpanRecords({ name: 'test.error' })).toEqual([
+      expect.objectContaining({
+        name: 'test.error',
+        status: 'error',
+        error: {
+          type: 'Error',
+          message: 'boom',
+        },
+      }),
+    ])
+  })
+
+  it('groups local spans by existing async storage without adding extra attributes', () => {
+    process.env.NEXT_OTEL_LOCAL_SPANS = '1'
+
+    jest.isolateModules(() => {
+      const previousAsyncLocalStorage = (globalThis as any).AsyncLocalStorage
+      try {
+        const { AsyncLocalStorage } =
+          require('node:async_hooks') as typeof import('node:async_hooks')
+        ;(globalThis as any).AsyncLocalStorage = AsyncLocalStorage
+
+        const { workAsyncStorage } =
+          require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
+        const { workUnitAsyncStorage } =
+          require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
+        const { getSpanRecords: getIsolatedSpanRecords } =
+          require('./span-store') as typeof import('./span-store')
+        const { getTracer: getIsolatedTracer } =
+          require('./tracer') as typeof import('./tracer')
+
+        const workStore = {
+          isStaticGeneration: false,
+          page: '/products/[id]/page',
+          route: '/products/[id]',
+          cacheComponentsEnabled: true,
+        } as WorkStore
+        const requestStore = {
+          type: 'request',
+          phase: 'render',
+          isHmrRefresh: true,
+        } as WorkUnitStore
+
+        workAsyncStorage.run(workStore, () =>
+          workUnitAsyncStorage.run(requestStore, () => {
+            getIsolatedTracer().trace(
+              NodeSpan.runHandler,
+              { spanName: 'test.als.outer' },
+              () => {
+                getIsolatedTracer().trace(
+                  NodeSpan.runHandler,
+                  { spanName: 'test.als.inner' },
+                  () => 'result'
+                )
+              }
+            )
+          })
+        )
+
+        const records = getIsolatedSpanRecords()
+        const traceIds = new Set(records.map((record) => record.traceId))
+
+        expect(records).toHaveLength(2)
+        expect(traceIds.size).toBe(1)
+        expect(records).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: 'test.als.inner',
+              attributes: expect.objectContaining({
+                'next.span_name': 'test.als.inner',
+                'next.span_type': NodeSpan.runHandler,
+              }),
+            }),
+            expect.objectContaining({
+              name: 'test.als.outer',
+            }),
+          ])
+        )
+        expect(
+          records.some(
+            (record) => record.attributes?.['next.work_unit.type'] !== undefined
+          )
+        ).toBe(false)
+      } finally {
+        if (previousAsyncLocalStorage === undefined) {
+          delete (globalThis as any).AsyncLocalStorage
+        } else {
+          ;(globalThis as any).AsyncLocalStorage = previousAsyncLocalStorage
+        }
+      }
     })
   })
 })

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -224,7 +224,7 @@ class NextTracerImpl implements NextTracer {
     return trace.getTracer('next.js', '0.0.1')
   }
 
-  private isTracingEnabled(): boolean {
+  private isOpenTelemetryEnabled(): boolean {
     const activeSpan = trace.getSpan(context.active())
     if (activeSpan?.isRecording()) {
       return true
@@ -269,7 +269,7 @@ class NextTracerImpl implements NextTracer {
    * edge middleware which runs in a detached sandbox.
    */
   public runWithDetachedContext<T>(fn: () => T): T {
-    if (!NEXT_OTEL_PERFORMANCE_PREFIX && !this.isTracingEnabled()) {
+    if (!NEXT_OTEL_PERFORMANCE_PREFIX && !this.isOpenTelemetryEnabled()) {
       return fn()
     }
     return context.with(ROOT_CONTEXT, fn)
@@ -285,7 +285,7 @@ class NextTracerImpl implements NextTracer {
 
     if (
       !NEXT_OTEL_PERFORMANCE_PREFIX &&
-      !this.isTracingEnabled() &&
+      !this.isOpenTelemetryEnabled() &&
       !trace.getSpanContext(activeContext)
     ) {
       return fn()
@@ -336,7 +336,7 @@ class NextTracerImpl implements NextTracer {
   public trace<T>(...args: Array<any>) {
     const [type, fnOrOptions, fnOrEmpty] = args
     const tracingEnabled =
-      Boolean(NEXT_OTEL_PERFORMANCE_PREFIX) || this.isTracingEnabled()
+      Boolean(NEXT_OTEL_PERFORMANCE_PREFIX) || this.isOpenTelemetryEnabled()
     const localSpanStoreEnabled =
       getLocalSpanRecorder()?.isLocalSpanStoreEnabled() ?? false
 
@@ -615,7 +615,7 @@ class NextTracerImpl implements NextTracer {
       return this.getTracerInstance().startSpan(type, options, parentContext)
     }
 
-    const delegateSpan = this.isTracingEnabled()
+    const delegateSpan = this.isOpenTelemetryEnabled()
       ? this.getTracerInstance().startSpan(type, options, parentContext)
       : undefined
 

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -3,11 +3,15 @@ import type { TextMapSetter } from '@opentelemetry/api'
 import type { SpanTypes } from './constants'
 import { LogSpanAllowList, NextVanillaSpanAllowlist } from './constants'
 import {
-  createLocalSpanRecorder,
+  createLocalSpan,
+  getActiveLocalSpan,
+  isLocalRecordingSpan,
   isLocalSpanStoreEnabled,
+  withLocalSpan,
 } from './local-span-recorder'
 
 import type {
+  Context,
   ContextAPI,
   Span,
   SpanOptions,
@@ -214,7 +218,8 @@ class NextTracerImpl implements NextTracer {
   }
 
   private isTracingEnabled(): boolean {
-    if (this.getActiveScopeSpan()?.isRecording()) {
+    const activeSpan = trace.getSpan(context.active())
+    if (activeSpan?.isRecording()) {
       return true
     }
 
@@ -243,7 +248,11 @@ class NextTracerImpl implements NextTracer {
   }
 
   public getActiveScopeSpan(): Span | undefined {
-    return trace.getSpan(context?.active())
+    const activeSpan = trace.getSpan(context.active())
+    if (activeSpan || !process.env.__NEXT_DEV_SERVER) {
+      return activeSpan
+    }
+    return getActiveLocalSpan()
   }
 
   /**
@@ -320,8 +329,9 @@ class NextTracerImpl implements NextTracer {
   public trace<T>(...args: Array<any>) {
     const [type, fnOrOptions, fnOrEmpty] = args
     const tracingEnabled =
-      NEXT_OTEL_PERFORMANCE_PREFIX || this.isTracingEnabled()
-    const localSpanStoreEnabled = isLocalSpanStoreEnabled()
+      Boolean(NEXT_OTEL_PERFORMANCE_PREFIX) || this.isTracingEnabled()
+    const localSpanStoreEnabled =
+      Boolean(process.env.__NEXT_DEV_SERVER) && isLocalSpanStoreEnabled()
 
     if (!tracingEnabled && !localSpanStoreEnabled) {
       return typeof fnOrOptions === 'function' ? fnOrOptions() : fnOrEmpty()
@@ -380,30 +390,14 @@ class NextTracerImpl implements NextTracer {
       ...options.attributes,
     }
 
-    if (!tracingEnabled) {
-      return traceLocalSpanOnly(spanName, options, fn)
-    }
-
     return context.with(spanContext.setValue(rootSpanIdKey, spanId), () =>
-      this.getTracerInstance().startActiveSpan(
+      this.runWithActiveSpan(
         spanName,
         options,
+        spanContext,
+        tracingEnabled,
+        localSpanStoreEnabled,
         (span: Span) => {
-          const spanStoreRecorder = localSpanStoreEnabled
-            ? createLocalSpanRecorder({
-                name: spanName,
-                attributes: options.attributes,
-                links: options.links,
-                delegateSpan: span,
-                spanId: span.spanContext().spanId,
-                traceId: span.spanContext().traceId,
-                parentSpanId: trace.getSpanContext(spanContext)?.spanId,
-              })
-            : undefined
-          const recordedSpan = spanStoreRecorder?.span ?? span
-          const completeSpanStoreRecord =
-            spanStoreRecorder?.complete ?? noopSpanStoreRecorder
-
           let startTime: number | undefined
           if (
             NEXT_OTEL_PERFORMANCE_PREFIX &&
@@ -450,13 +444,15 @@ class NextTracerImpl implements NextTracer {
           }
           if (fn.length > 1) {
             try {
-              return fn(recordedSpan, (err) => {
-                closeSpanWithError(recordedSpan, err)
-                completeSpanStoreRecord(err)
+              return fn(span, (err) => {
+                if (err) {
+                  closeSpanWithError(span, err)
+                } else {
+                  span.end()
+                }
               })
             } catch (err: any) {
-              closeSpanWithError(recordedSpan, err)
-              completeSpanStoreRecord(err)
+              closeSpanWithError(span, err)
               throw err
             } finally {
               onCleanup()
@@ -464,39 +460,89 @@ class NextTracerImpl implements NextTracer {
           }
 
           try {
-            const result = fn(recordedSpan)
+            const result = fn(span)
             if (isThenable(result)) {
               // If there's error make sure it throws
               return result
                 .then((res) => {
-                  recordedSpan.end()
-                  completeSpanStoreRecord()
+                  span.end()
                   // Need to pass down the promise result,
                   // it could be react stream response with error { error, stream }
                   return res
                 })
                 .catch((err) => {
-                  closeSpanWithError(recordedSpan, err)
-                  completeSpanStoreRecord(err)
+                  closeSpanWithError(span, err)
                   throw err
                 })
                 .finally(onCleanup)
             } else {
-              recordedSpan.end()
-              completeSpanStoreRecord()
+              span.end()
               onCleanup()
             }
 
             return result
           } catch (err: any) {
-            closeSpanWithError(recordedSpan, err)
-            completeSpanStoreRecord(err)
+            closeSpanWithError(span, err)
             onCleanup()
             throw err
           }
         }
       )
     )
+  }
+
+  private runWithActiveSpan<T>(
+    spanName: string,
+    options: TracerSpanOptions,
+    parentContext: Context,
+    tracingEnabled: boolean,
+    localSpanStoreEnabled: boolean,
+    fn: (span: Span) => T
+  ): T {
+    if (tracingEnabled) {
+      return this.getTracerInstance().startActiveSpan(
+        spanName,
+        options,
+        (span: Span) =>
+          fn(
+            localSpanStoreEnabled
+              ? this.createLocalRecordingSpan(
+                  spanName,
+                  options,
+                  parentContext,
+                  span
+                )
+              : span
+          )
+      )
+    }
+
+    const span = this.createLocalRecordingSpan(spanName, options, parentContext)
+    const activeContext = trace.setSpan(context.active(), span)
+
+    return withLocalSpan(span, () =>
+      context.with(activeContext, fn, undefined, span)
+    )
+  }
+
+  private createLocalRecordingSpan(
+    name: string,
+    options: TracerSpanOptions,
+    parentContext: Context,
+    delegateSpan?: Span
+  ): Span {
+    const parentSpanContext = trace.getSpanContext(parentContext)
+    const delegateSpanContext = delegateSpan?.spanContext()
+
+    return createLocalSpan({
+      name,
+      attributes: options.attributes,
+      links: options.links,
+      delegateSpan,
+      traceId: delegateSpanContext?.traceId ?? parentSpanContext?.traceId,
+      spanId: delegateSpanContext?.spanId,
+      parentSpanId: parentSpanContext?.spanId,
+    })
   }
 
   public wrap<T = (...args: Array<any>) => any>(type: SpanTypes, fn: T): T
@@ -552,10 +598,26 @@ class NextTracerImpl implements NextTracer {
   public startSpan(...args: Array<any>): Span {
     const [type, options]: [string, TracerSpanOptions | undefined] = args as any
 
-    const spanContext = this.getSpanContext(
-      options?.parentSpan ?? this.getActiveScopeSpan()
+    const parentContext =
+      this.getSpanContext(options?.parentSpan ?? this.getActiveScopeSpan()) ??
+      context.active()
+    const localSpanStoreEnabled =
+      Boolean(process.env.__NEXT_DEV_SERVER) && isLocalSpanStoreEnabled()
+
+    if (!localSpanStoreEnabled) {
+      return this.getTracerInstance().startSpan(type, options, parentContext)
+    }
+
+    const delegateSpan = this.isTracingEnabled()
+      ? this.getTracerInstance().startSpan(type, options, parentContext)
+      : undefined
+
+    return this.createLocalRecordingSpan(
+      type,
+      options ?? {},
+      parentContext,
+      delegateSpan
     )
-    return this.getTracerInstance().startSpan(type, options, spanContext)
   }
 
   private getSpanContext(parentSpan?: Span) {
@@ -577,10 +639,20 @@ class NextTracerImpl implements NextTracer {
     if (attributes && !attributes.has(key)) {
       attributes.set(key, value)
     }
+
+    if (process.env.__NEXT_DEV_SERVER) {
+      const localSpan = getActiveLocalSpan()
+      if (localSpan) {
+        localSpan.setAttribute(key, value)
+      }
+    }
   }
 
   public withSpan<T>(span: Span, fn: () => T): T {
     const spanContext = trace.setSpan(context.active(), span)
+    if (process.env.__NEXT_DEV_SERVER && isLocalRecordingSpan(span)) {
+      return withLocalSpan(span, () => context.with(spanContext, fn))
+    }
     return context.with(spanContext, fn)
   }
 }
@@ -593,61 +665,3 @@ const getTracer = (() => {
 
 export { getTracer, SpanStatusCode, SpanKind }
 export type { NextTracer, Span, SpanOptions, ContextAPI, TracerSpanOptions }
-
-function traceLocalSpanOnly<T>(
-  spanName: string,
-  options: TracerSpanOptions,
-  fn: (span?: Span, done?: (error?: Error) => any) => T | Promise<T>
-): T | Promise<T> {
-  const spanStoreRecorder = createLocalSpanRecorder({
-    name: spanName,
-    attributes: options.attributes,
-    links: options.links,
-  })
-  const recordedSpan = spanStoreRecorder.span
-  const completeSpanStoreRecord = spanStoreRecorder.complete
-
-  if (fn.length > 1) {
-    try {
-      return fn(recordedSpan, (err) => {
-        if (err) {
-          closeSpanWithError(recordedSpan, err)
-        } else {
-          recordedSpan.end()
-        }
-        completeSpanStoreRecord(err)
-      })
-    } catch (err: any) {
-      closeSpanWithError(recordedSpan, err)
-      completeSpanStoreRecord(err)
-      throw err
-    }
-  }
-
-  try {
-    const result = fn(recordedSpan)
-    if (isThenable(result)) {
-      return result
-        .then((res) => {
-          recordedSpan.end()
-          completeSpanStoreRecord()
-          return res
-        })
-        .catch((err) => {
-          closeSpanWithError(recordedSpan, err)
-          completeSpanStoreRecord(err)
-          throw err
-        }) as Promise<T>
-    }
-
-    recordedSpan.end()
-    completeSpanStoreRecord()
-    return result
-  } catch (err: any) {
-    closeSpanWithError(recordedSpan, err)
-    completeSpanStoreRecord(err)
-    throw err
-  }
-}
-
-function noopSpanStoreRecorder(): void {}

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -1,14 +1,8 @@
 import type { FetchEventResult } from '../../web/types'
 import type { TextMapSetter } from '@opentelemetry/api'
 import type { SpanTypes } from './constants'
+import type { LocalSpanRecorder } from './local-span-recorder'
 import { LogSpanAllowList, NextVanillaSpanAllowlist } from './constants'
-import {
-  createLocalSpan,
-  getActiveLocalSpan,
-  isLocalRecordingSpan,
-  isLocalSpanStoreEnabled,
-  withLocalSpan,
-} from './local-span-recorder'
 
 import type {
   Context,
@@ -22,8 +16,21 @@ import type {
 import { isThenable } from '../../../shared/lib/is-thenable'
 
 const NEXT_OTEL_PERFORMANCE_PREFIX = process.env.NEXT_OTEL_PERFORMANCE_PREFIX
+const LOCAL_SPAN_RECORDER_KEY = Symbol.for('@next/local-span-recorder')
+
+type GlobalWithLocalSpanRecorder = typeof globalThis & {
+  [LOCAL_SPAN_RECORDER_KEY]?: LocalSpanRecorder
+}
 
 let api: typeof import('next/dist/compiled/@opentelemetry/api')
+
+function getLocalSpanRecorder() {
+  if (process.env.__NEXT_DEV_SERVER) {
+    return (globalThis as GlobalWithLocalSpanRecorder)[LOCAL_SPAN_RECORDER_KEY]
+  } else {
+    return undefined
+  }
+}
 
 // we want to allow users to use their own version of @opentelemetry/api if they
 // want to, so we try to require it first, and if it fails we fall back to the
@@ -252,7 +259,7 @@ class NextTracerImpl implements NextTracer {
     if (activeSpan || !process.env.__NEXT_DEV_SERVER) {
       return activeSpan
     }
-    return getActiveLocalSpan()
+    return getLocalSpanRecorder()?.getActiveLocalSpan()
   }
 
   /**
@@ -331,7 +338,7 @@ class NextTracerImpl implements NextTracer {
     const tracingEnabled =
       Boolean(NEXT_OTEL_PERFORMANCE_PREFIX) || this.isTracingEnabled()
     const localSpanStoreEnabled =
-      Boolean(process.env.__NEXT_DEV_SERVER) && isLocalSpanStoreEnabled()
+      getLocalSpanRecorder()?.isLocalSpanStoreEnabled() ?? false
 
     if (!tracingEnabled && !localSpanStoreEnabled) {
       return typeof fnOrOptions === 'function' ? fnOrOptions() : fnOrEmpty()
@@ -520,7 +527,7 @@ class NextTracerImpl implements NextTracer {
     const span = this.createLocalRecordingSpan(spanName, options, parentContext)
     const activeContext = trace.setSpan(context.active(), span)
 
-    return withLocalSpan(span, () =>
+    return getLocalSpanRecorder()!.withLocalSpan(span, () =>
       context.with(activeContext, fn, undefined, span)
     )
   }
@@ -534,7 +541,7 @@ class NextTracerImpl implements NextTracer {
     const parentSpanContext = trace.getSpanContext(parentContext)
     const delegateSpanContext = delegateSpan?.spanContext()
 
-    return createLocalSpan({
+    return getLocalSpanRecorder()!.createLocalSpan({
       name,
       attributes: options.attributes,
       links: options.links,
@@ -602,7 +609,7 @@ class NextTracerImpl implements NextTracer {
       this.getSpanContext(options?.parentSpan ?? this.getActiveScopeSpan()) ??
       context.active()
     const localSpanStoreEnabled =
-      Boolean(process.env.__NEXT_DEV_SERVER) && isLocalSpanStoreEnabled()
+      getLocalSpanRecorder()?.isLocalSpanStoreEnabled() ?? false
 
     if (!localSpanStoreEnabled) {
       return this.getTracerInstance().startSpan(type, options, parentContext)
@@ -641,7 +648,7 @@ class NextTracerImpl implements NextTracer {
     }
 
     if (process.env.__NEXT_DEV_SERVER) {
-      const localSpan = getActiveLocalSpan()
+      const localSpan = getLocalSpanRecorder()?.getActiveLocalSpan()
       if (localSpan) {
         localSpan.setAttribute(key, value)
       }
@@ -650,8 +657,9 @@ class NextTracerImpl implements NextTracer {
 
   public withSpan<T>(span: Span, fn: () => T): T {
     const spanContext = trace.setSpan(context.active(), span)
-    if (process.env.__NEXT_DEV_SERVER && isLocalRecordingSpan(span)) {
-      return withLocalSpan(span, () => context.with(spanContext, fn))
+    const recorder = getLocalSpanRecorder()
+    if (recorder?.isLocalRecordingSpan(span)) {
+      return recorder.withLocalSpan(span, () => context.with(spanContext, fn))
     }
     return context.with(spanContext, fn)
   }

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -2,6 +2,10 @@ import type { FetchEventResult } from '../../web/types'
 import type { TextMapSetter } from '@opentelemetry/api'
 import type { SpanTypes } from './constants'
 import { LogSpanAllowList, NextVanillaSpanAllowlist } from './constants'
+import {
+  createLocalSpanRecorder,
+  isLocalSpanStoreEnabled,
+} from './local-span-recorder'
 
 import type {
   ContextAPI,
@@ -315,8 +319,11 @@ class NextTracerImpl implements NextTracer {
   ): T
   public trace<T>(...args: Array<any>) {
     const [type, fnOrOptions, fnOrEmpty] = args
+    const tracingEnabled =
+      NEXT_OTEL_PERFORMANCE_PREFIX || this.isTracingEnabled()
+    const localSpanStoreEnabled = isLocalSpanStoreEnabled()
 
-    if (!NEXT_OTEL_PERFORMANCE_PREFIX && !this.isTracingEnabled()) {
+    if (!tracingEnabled && !localSpanStoreEnabled) {
       return typeof fnOrOptions === 'function' ? fnOrOptions() : fnOrEmpty()
     }
 
@@ -373,11 +380,30 @@ class NextTracerImpl implements NextTracer {
       ...options.attributes,
     }
 
+    if (!tracingEnabled) {
+      return traceLocalSpanOnly(spanName, options, fn)
+    }
+
     return context.with(spanContext.setValue(rootSpanIdKey, spanId), () =>
       this.getTracerInstance().startActiveSpan(
         spanName,
         options,
         (span: Span) => {
+          const spanStoreRecorder = localSpanStoreEnabled
+            ? createLocalSpanRecorder({
+                name: spanName,
+                attributes: options.attributes,
+                links: options.links,
+                delegateSpan: span,
+                spanId: span.spanContext().spanId,
+                traceId: span.spanContext().traceId,
+                parentSpanId: trace.getSpanContext(spanContext)?.spanId,
+              })
+            : undefined
+          const recordedSpan = spanStoreRecorder?.span ?? span
+          const completeSpanStoreRecord =
+            spanStoreRecorder?.complete ?? noopSpanStoreRecorder
+
           let startTime: number | undefined
           if (
             NEXT_OTEL_PERFORMANCE_PREFIX &&
@@ -424,9 +450,13 @@ class NextTracerImpl implements NextTracer {
           }
           if (fn.length > 1) {
             try {
-              return fn(span, (err) => closeSpanWithError(span, err))
+              return fn(recordedSpan, (err) => {
+                closeSpanWithError(recordedSpan, err)
+                completeSpanStoreRecord(err)
+              })
             } catch (err: any) {
-              closeSpanWithError(span, err)
+              closeSpanWithError(recordedSpan, err)
+              completeSpanStoreRecord(err)
               throw err
             } finally {
               onCleanup()
@@ -434,29 +464,33 @@ class NextTracerImpl implements NextTracer {
           }
 
           try {
-            const result = fn(span)
+            const result = fn(recordedSpan)
             if (isThenable(result)) {
               // If there's error make sure it throws
               return result
                 .then((res) => {
-                  span.end()
+                  recordedSpan.end()
+                  completeSpanStoreRecord()
                   // Need to pass down the promise result,
                   // it could be react stream response with error { error, stream }
                   return res
                 })
                 .catch((err) => {
-                  closeSpanWithError(span, err)
+                  closeSpanWithError(recordedSpan, err)
+                  completeSpanStoreRecord(err)
                   throw err
                 })
                 .finally(onCleanup)
             } else {
-              span.end()
+              recordedSpan.end()
+              completeSpanStoreRecord()
               onCleanup()
             }
 
             return result
           } catch (err: any) {
-            closeSpanWithError(span, err)
+            closeSpanWithError(recordedSpan, err)
+            completeSpanStoreRecord(err)
             onCleanup()
             throw err
           }
@@ -559,3 +593,61 @@ const getTracer = (() => {
 
 export { getTracer, SpanStatusCode, SpanKind }
 export type { NextTracer, Span, SpanOptions, ContextAPI, TracerSpanOptions }
+
+function traceLocalSpanOnly<T>(
+  spanName: string,
+  options: TracerSpanOptions,
+  fn: (span?: Span, done?: (error?: Error) => any) => T | Promise<T>
+): T | Promise<T> {
+  const spanStoreRecorder = createLocalSpanRecorder({
+    name: spanName,
+    attributes: options.attributes,
+    links: options.links,
+  })
+  const recordedSpan = spanStoreRecorder.span
+  const completeSpanStoreRecord = spanStoreRecorder.complete
+
+  if (fn.length > 1) {
+    try {
+      return fn(recordedSpan, (err) => {
+        if (err) {
+          closeSpanWithError(recordedSpan, err)
+        } else {
+          recordedSpan.end()
+        }
+        completeSpanStoreRecord(err)
+      })
+    } catch (err: any) {
+      closeSpanWithError(recordedSpan, err)
+      completeSpanStoreRecord(err)
+      throw err
+    }
+  }
+
+  try {
+    const result = fn(recordedSpan)
+    if (isThenable(result)) {
+      return result
+        .then((res) => {
+          recordedSpan.end()
+          completeSpanStoreRecord()
+          return res
+        })
+        .catch((err) => {
+          closeSpanWithError(recordedSpan, err)
+          completeSpanStoreRecord(err)
+          throw err
+        }) as Promise<T>
+    }
+
+    recordedSpan.end()
+    completeSpanStoreRecord()
+    return result
+  } catch (err: any) {
+    closeSpanWithError(recordedSpan, err)
+    completeSpanStoreRecord(err)
+    throw err
+  }
+}
+
+function noopSpanStoreRecorder(): void {}


### PR DESCRIPTION
## What

Adds a dev-only local recorder for framework OTEL spans. This lets Next mirror span data into an in-memory store when local span capture is enabled, without requiring a user to run an OTEL provider.

Stack:

1. request insights: record local framework spans (1/5) ← current
2. request insights: derive request history and fetch data (2/5)
3. request insights: expose dev snapshots to tools and HMR (3/5)
4. request insights: add agent diagnosis access (4/5)
5. request insights: add DevTools request panel (5/5)

## Review Focus

- Local recorder behavior when no OTEL provider is installed.
- Preserving existing OTEL span API behavior when a provider is installed.
- Request identity propagation through existing app render async storage.

## Proof In This PR

- `pnpm jest packages/next/src/server/lib/trace/tracer.test.ts packages/next/src/server/lib/trace/span-store.test.ts --runInBand`
- `pnpm --filter=next types`

## Deferred Coverage

- Request-level aggregation, fetch enrichment, dev transport, CLI/MCP access, and the DevTools panel are later PRs in this stack.

<!-- NEXT_JS_LLM_PR -->
