### PR TITLE
[ci] Use Turbopack in non-webpack-specific e2e test jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -806,11 +806,11 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      # Should this be using turbopack? a variation?
       afterBuild: |
         export NEXT_TEST_MODE=dev
-        export IS_WEBPACK_TEST=1
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_DEV=1
 
         node run-tests.js \
           test/e2e/app-dir/app/index.test.ts \
@@ -832,8 +832,9 @@ jobs:
       nodeVersion: 20.9.0
       afterBuild: |
         export NEXT_TEST_MODE=start
-        export IS_WEBPACK_TEST=1
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export IS_TURBOPACK_TEST=1
+
         node run-tests.js --type production \
           --concurrency 4 \
           test/production/pages-dir/production/test/index.test.ts \
@@ -855,8 +856,9 @@ jobs:
     with:
       afterBuild: |
         export NEXT_TEST_MODE=start
-        export IS_WEBPACK_TEST=1
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_BUILD=1
 
         node run-tests.js --type production \
           test/e2e/app-dir/app/index.test.ts \
@@ -962,7 +964,8 @@ jobs:
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=dev
-        export IS_WEBPACK_TEST=1
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_DEV=1
 
         node run-tests.js \
           --timings \
@@ -997,7 +1000,8 @@ jobs:
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=start
-        export IS_WEBPACK_TEST=1
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_BUILD=1
 
         node run-tests.js \
           --timings \
@@ -1033,7 +1037,8 @@ jobs:
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=dev
-        export IS_WEBPACK_TEST=1
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_DEV=1
 
         node run-tests.js \
           --timings \
@@ -1069,7 +1074,8 @@ jobs:
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=start
-        export IS_WEBPACK_TEST=1
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_BUILD=1
 
         node run-tests.js \
           --timings \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -834,6 +834,7 @@ jobs:
         export NEXT_TEST_MODE=start
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
         export IS_TURBOPACK_TEST=1
+        export TURBOPACK_BUILD=1
 
         node run-tests.js --type production \
           --concurrency 4 \

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -48,17 +48,20 @@ describe('non-root-project-monorepo', () => {
     })
   })
 
+  // TODO: These file URIs are wrong on turbopack+windows:
+  // https://en.wikipedia.org/wiki/File_URI_scheme
+  // The URIs should always use forward slashes, but use backslashes on windows.
   describe('import.meta.url', () => {
     it('should work during RSC', async () => {
       const $ = await next.render$('/import-meta-url-rsc')
-      expect($('p').text()).toMatch(
+      expect($('p').text().replaceAll('\\', '/')).toMatch(
         /^file:\/\/.*\/next-install-[^/]+\/apps\/web\/app\/import-meta-url-rsc\/page.tsx$/
       )
     })
 
     it('should work during SSR', async () => {
       const $ = await next.render$('/import-meta-url-ssr')
-      expect($('p').text()).toMatch(
+      expect($('p').text().replaceAll('\\', '/')).toMatch(
         /^file:\/\/.*\/next-install-[^/]+\/apps\/web\/app\/import-meta-url-ssr\/page.tsx$/
       )
     })
@@ -68,11 +71,13 @@ describe('non-root-project-monorepo', () => {
       await waitForNoRedbox(browser)
       if (isTurbopack) {
         // Turbopack intentionally doesn't expose the full path to the browser bundles
-        expect(await browser.elementByCss('p').text()).toBe(
-          'file:///ROOT/apps/web/app/import-meta-url-ssr/page.tsx'
-        )
+        expect(
+          (await browser.elementByCss('p').text()).replaceAll('\\', '/')
+        ).toBe('file:///ROOT/apps/web/app/import-meta-url-ssr/page.tsx')
       } else {
-        expect(await browser.elementByCss('p').text()).toMatch(
+        expect(
+          (await browser.elementByCss('p').text()).replaceAll('\\', '/')
+        ).toMatch(
           /^file:\/\/.*\/next-install-[^/]+\/apps\/web\/app\/import-meta-url-ssr\/page.tsx$/
         )
       }


### PR DESCRIPTION
Turbopack is the default bundler, so we should prioritize testing that in these variants of the CI runs (cache components, node streams, windows).

There's also some limited evidence that indicates that it might be faster for e2e test runs, though that's not conclusive (because of different shard sizes): https://vercel.slack.com/archives/C0B0LKK5QD7/p1779320615501259