### PR TITLE
Enable experimental.varyParams by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1978,7 +1978,7 @@ export const defaultConfig = Object.freeze({
     cachedNavigations: false,
     dynamicOnHover: false,
     useOffline: false,
-    varyParams: false,
+    varyParams: true,
     prefetchInlining: true,
     preloadEntriesOnStart: true,
     clientRouterFilter: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
@@ -3,6 +3,12 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   cacheComponents: true,
   productionBrowserSourceMaps: true,
+  experimental: {
+    // TODO: This test asserts on the pre-`varyParams` cache-keying behavior
+    // for root params. Pin the fixture to the old default until the test is
+    // updated to reflect the new shape (or until the flag is removed).
+    varyParams: false,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Turns on `experimental.varyParams` by default. First of a short stack flipping the remaining Sparkle flags to their new defaults — landing one flag at a time so any regressions are bisectable.

A test in `segment-cache/prefetch-runtime` asserts on the pre-flip root-param cache-keying; pinned to `varyParams: false` until the test catches up.

<!-- NEXT_JS_LLM_PR -->