### PR TITLE
Make `--debug-build-paths` work with `src/` directory projects

### DIFF
--- a/packages/next/src/lib/resolve-build-paths.ts
+++ b/packages/next/src/lib/resolve-build-paths.ts
@@ -40,6 +40,12 @@ export async function resolveBuildPaths(
   const appPaths: Set<string> = new Set()
   const pagePaths: Set<string> = new Set()
 
+  // Detect whether the project keeps its routes under `src/` so we can accept
+  // patterns written with or without that prefix (e.g. both `app/foo/page.tsx`
+  // and `src/app/foo/page.tsx`).
+  const useSrcApp = fs.existsSync(path.join(projectDir, 'src', 'app'))
+  const useSrcPages = fs.existsSync(path.join(projectDir, 'src', 'pages'))
+
   const includePatterns: string[] = []
   const excludePatterns: string[] = []
 
@@ -48,9 +54,15 @@ export async function resolveBuildPaths(
     if (!trimmed) continue
 
     if (trimmed.startsWith('!')) {
-      excludePatterns.push(escapeBrackets(trimmed.slice(1)))
+      excludePatterns.push(
+        escapeBrackets(
+          addSrcPrefixIfNeeded(trimmed.slice(1), useSrcApp, useSrcPages)
+        )
+      )
     } else {
-      includePatterns.push(escapeBrackets(trimmed))
+      includePatterns.push(
+        escapeBrackets(addSrcPrefixIfNeeded(trimmed, useSrcApp, useSrcPages))
+      )
     }
   }
 
@@ -95,11 +107,35 @@ export async function resolveBuildPaths(
 }
 
 /**
+ * When the project keeps its `app/` or `pages/` directory under `src/`, prepend
+ * `src/` to bare patterns so the glob actually matches files on disk. Patterns
+ * that already include the `src/` prefix are returned unchanged.
+ */
+function addSrcPrefixIfNeeded(
+  pattern: string,
+  useSrcApp: boolean,
+  useSrcPages: boolean
+): string {
+  const normalized = pattern.replace(/\\/g, '/')
+  if (useSrcApp && /^app\//.test(normalized)) {
+    return 'src/' + normalized
+  }
+  if (useSrcPages && /^pages\//.test(normalized)) {
+    return 'src/' + normalized
+  }
+  return pattern
+}
+
+/**
  * Categorizes a file path to either app or pages router based on its prefix.
  * For app router, only route-defining files (page.*, route.*) are included.
  *
+ * Accepts both top-level (`app/...`, `pages/...`) and src-prefixed
+ * (`src/app/...`, `src/pages/...`) project structures.
+ *
  * Examples:
  * - "app/page.tsx" → appPaths.add("/page.tsx")
+ * - "src/app/page.tsx" → appPaths.add("/page.tsx")
  * - "app/layout.tsx" → skipped (not a route file)
  * - "pages/index.tsx" → pagePaths.add("/index.tsx")
  */
@@ -108,7 +144,11 @@ function categorizeAndAddPath(
   appPaths: Set<string>,
   pagePaths: Set<string>
 ): void {
-  const normalized = filePath.replace(/\\/g, '/')
+  let normalized = filePath.replace(/\\/g, '/')
+
+  if (normalized.startsWith('src/')) {
+    normalized = normalized.slice(4)
+  }
 
   if (normalized.startsWith('app/')) {
     // Only include route-defining files (page.* or route.*)

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -3,12 +3,10 @@ import { nextTestSetup } from 'e2e-utils'
 
 describe('debug-build-paths', () => {
   describe('default fixture', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: path.join(__dirname, 'fixtures/default'),
       skipStart: true,
     })
-
-    if (skipped) return
 
     describe('explicit path formats', () => {
       it('should build single page with pages/ prefix', async () => {
@@ -279,13 +277,62 @@ describe('debug-build-paths', () => {
     })
   })
 
-  describe('with-compile-error fixture', () => {
-    const { next, skipped } = nextTestSetup({
-      files: path.join(__dirname, 'fixtures/with-compile-error'),
+  describe('src-dir fixture', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures/src-dir'),
       skipStart: true,
     })
 
-    if (skipped) return
+    it('should resolve app patterns with explicit src/ prefix', async () => {
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'src/app/blog/[slug]/page.tsx'],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toContain('Route (app)')
+      expect(buildResult.cliOutput).toContain('/blog/[slug]')
+      // Should not build other app routes
+      expect(buildResult.cliOutput).not.toMatch(/○ \/\n/)
+      expect(buildResult.cliOutput).not.toContain('Route (pages)')
+    })
+
+    it('should resolve app patterns without src/ prefix when project uses src/app', async () => {
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'app/blog/[slug]/page.tsx'],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toContain('Route (app)')
+      expect(buildResult.cliOutput).toContain('/blog/[slug]')
+      expect(buildResult.cliOutput).not.toMatch(/○ \/\n/)
+      expect(buildResult.cliOutput).not.toContain('Route (pages)')
+    })
+
+    it('should resolve pages patterns without src/ prefix when project uses src/pages', async () => {
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'pages/foo.tsx'],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toContain('Route (pages)')
+      expect(buildResult.cliOutput).toContain('○ /foo')
+      expect(buildResult.cliOutput).not.toContain('Route (app)')
+    })
+
+    it('should resolve glob patterns without src/ prefix when project uses src/app', async () => {
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'app/(group)/**/page.tsx'],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toContain('Route (app)')
+      // Route groups are stripped from the path
+      expect(buildResult.cliOutput).toContain('/nested')
+      expect(buildResult.cliOutput).not.toContain('/blog/[slug]')
+    })
+  })
+
+  describe('with-compile-error fixture', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures/with-compile-error'),
+      skipStart: true,
+    })
 
     it('should skip compilation of excluded routes with compile errors', async () => {
       // Build only the valid page, excluding the broken page

--- a/test/production/debug-build-path/fixtures/src-dir/next.config.js
+++ b/test/production/debug-build-path/fixtures/src-dir/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/debug-build-path/fixtures/src-dir/src/app/(group)/nested/page.tsx
+++ b/test/production/debug-build-path/fixtures/src-dir/src/app/(group)/nested/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Grouped nested page (src dir)</div>
+}

--- a/test/production/debug-build-path/fixtures/src-dir/src/app/blog/[slug]/page.tsx
+++ b/test/production/debug-build-path/fixtures/src-dir/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Blog slug</div>
+}

--- a/test/production/debug-build-path/fixtures/src-dir/src/app/layout.tsx
+++ b/test/production/debug-build-path/fixtures/src-dir/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export const metadata = {
+  title: 'Debug Build Paths Test (src dir)',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/debug-build-path/fixtures/src-dir/src/app/page.tsx
+++ b/test/production/debug-build-path/fixtures/src-dir/src/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>App Home (src dir)</h1>
+}

--- a/test/production/debug-build-path/fixtures/src-dir/src/pages/foo.tsx
+++ b/test/production/debug-build-path/fixtures/src-dir/src/pages/foo.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Foo</h1>
+}


### PR DESCRIPTION
The `--debug-build-paths` option silently dropped routes in projects that keep their `app` or `pages` directory under `src/`. When a user passed `src/app/foo/page.tsx`, the glob matched the file but `categorizeAndAddPath` only recognized paths starting with `app/` or `pages/`, so nothing was added to the resolved app paths and the build produced no user routes. Conversely, when a user passed the bare `app/foo/page.tsx` form against a `src/app` project, glob found nothing and emitted `did not match any files`.

`resolveBuildPaths` now detects whether `src/app` or `src/pages` exists and prepends `src/` to bare patterns before globbing, and `categorizeAndAddPath` strips a leading `src/` from matched files so route keys are normalized either way. Added a `src-dir` fixture and four tests covering explicit `src/` prefixes, bare patterns with auto-prefixing, and glob patterns through route groups.