### PR TITLE
[turbopack] Disable ctor under RA

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -315,6 +315,8 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             // `LazyLock` initializer (via `CollectableTraitMethods::finalize_vtable_registry`).
             // The vtable pointer is materialized at compile time via the null-fat-ptr trick, so
             // there's no runtime `transmute` or indirect fn call.
+
+            #[cfg(not(rust_analyzer))]
             #[turbo_tasks::macro_helpers::ctor::ctor(
                 crate_path = turbo_tasks::macro_helpers::ctor,
             )]


### PR DESCRIPTION
Fix the `leftover tokens` issue we have been getting from rust-analyzer

maybe?