### PR TITLE
Remove redundant Sparkle varyParams fixture overrides

### DIFF
--- a/test/e2e/app-dir/optimistic-routing/next.config.js
+++ b/test/e2e/app-dir/optimistic-routing/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     optimisticRouting: true,
-    varyParams: true,
   },
   productionBrowserSourceMaps: true,
 }

--- a/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
@@ -10,7 +10,6 @@ const nextConfig: NextConfig = {
     instantNavigationDevToolsToggle: true,
     optimisticRouting: true,
     useOffline: true,
-    varyParams: true,
   },
 }
 

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-rewrite-detection-regression/next.config.js
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-rewrite-detection-regression/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     optimisticRouting: true,
-    varyParams: true,
   },
   // Each rewrite below crafts one of the rewrite-affected response shapes
   // we want to verify. They live in `beforeFiles` so they take precedence

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
@@ -4,9 +4,12 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   productionBrowserSourceMaps: true,
   experimental: {
-    // TODO: This test asserts on the pre-`varyParams` cache-keying behavior
-    // for root params. Pin the fixture to the old default until the test is
-    // updated to reflect the new shape (or until the flag is removed).
+    // TODO: With `varyParams: true`, the "includes root params, but not
+    // dynamic content" test fails for the `de` case (a root param that's
+    // not in `generateStaticParams`). This is similar to the existing
+    // `runtime-ppr` TODO that already skips the `de` case when deployed.
+    // Pin to the old default until the runtime-prefetch path is fixed for
+    // unknown root params under `varyParams`.
     varyParams: false,
   },
 }

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
@@ -13,7 +13,6 @@ const nextConfig = {
   experimental: {
     optimisticRouting: true,
     prefetchInlining: false,
-    varyParams: true,
   },
 }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params/next.config.js
@@ -6,7 +6,6 @@ const nextConfig = {
   experimental: {
     optimisticRouting: true,
     prefetchInlining: false,
-    varyParams: true,
   },
 }
 

--- a/test/e2e/app-dir/use-offline/next.config.js
+++ b/test/e2e/app-dir/use-offline/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     useOffline: true,
-    varyParams: true,
     optimisticRouting: true,
     cachedNavigations: true,
   },


### PR DESCRIPTION
Now that `experimental.varyParams` defaults to `true` in canary, fixtures that explicitly set `varyParams: true` are redundant. Drop them.

`prefetch-runtime` keeps its `varyParams: false` override: under the new default, the "includes root params, but not dynamic content" sub-case fails for root-param values not in `generateStaticParams` (the same shape as the existing `runtime-ppr` TODO that already skips the case when deployed). Left for follow-up.

<!-- NEXT_JS_LLM_PR -->