### PR TITLE
Remove redundant Sparkle cachedNavigations fixture overrides

### DIFF
--- a/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
@@ -4,7 +4,6 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   productionBrowserSourceMaps: true,
   experimental: {
-    cachedNavigations: true,
     prefetchInlining: false,
     exposeTestingApiInProductionBuild: true,
     instantNavigationDevToolsToggle: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/next.config.js
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/next.config.js
@@ -5,6 +5,12 @@ const nextConfig = {
   cacheComponents: false,
   experimental: {
     prefetchInlining: true,
+    // Defensively pin `cachedNavigations: false`: this fixture sets
+    // `cacheComponents: false`, but CI jobs that set
+    // `__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true` would otherwise
+    // auto-enable `cachedNavigations`, tripping the validation that
+    // requires `cacheComponents`. Can be removed once the env-var
+    // auto-enable is dropped (TODO in config.ts).
     cachedNavigations: false,
   },
 }

--- a/test/e2e/app-dir/use-offline/next.config.js
+++ b/test/e2e/app-dir/use-offline/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     useOffline: true,
-    cachedNavigations: true,
   },
 }
 


### PR DESCRIPTION
Now that `experimental.cachedNavigations` auto-enables whenever `cacheComponents` is enabled, fixtures that explicitly set both no longer need the override. Drop them.

`prefetch-inlining-no-cache-components` keeps its `cachedNavigations: false`: the fixture sets `cacheComponents: false`, but CI jobs that set `__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true` would otherwise auto-enable `cachedNavigations` and trip the validation that requires `cacheComponents`. The override can be dropped when the env-var auto-enable itself is removed.

<!-- NEXT_JS_LLM_PR -->