### PR TITLE
Improve notFound recovery in error pathway

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1280,5 +1280,9 @@
   "1279": "\\`experimental.appShells\\` requires the following to also be enabled: %s. Please update your %s accordingly.",
   "1280": "Invariant: expected static metadata route to have a prerender pathname (%s)",
   "1281": "Cache Components HTTP fallback recovery unexpectedly produced a DynamicServerError",
-  "1282": "Cache Components error recovery expected an original Flight prerender result"
+  "1282": "Cache Components error recovery expected an original Flight prerender result",
+  "1283": "Cache Components error recovery expected to know whether the original Flight prerender result was dynamic",
+  "1284": "Cache Components error recovery expected an original prerender resume data cache",
+  "1285": "Cache Components error recovery expected an original prerender store",
+  "1286": "Cache Components error recovery unexpectedly produced a dynamic HTML hole"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1278,5 +1278,6 @@
   "1277": "no route matched for path \"%s\"",
   "1278": "compileRoute: either routeSpecifier or path is required",
   "1279": "\\`experimental.appShells\\` requires the following to also be enabled: %s. Please update your %s accordingly.",
-  "1280": "Invariant: expected static metadata route to have a prerender pathname (%s)"
+  "1280": "Invariant: expected static metadata route to have a prerender pathname (%s)",
+  "1281": "Cache Components HTTP fallback recovery unexpectedly produced a DynamicServerError"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1279,5 +1279,6 @@
   "1278": "compileRoute: either routeSpecifier or path is required",
   "1279": "\\`experimental.appShells\\` requires the following to also be enabled: %s. Please update your %s accordingly.",
   "1280": "Invariant: expected static metadata route to have a prerender pathname (%s)",
-  "1281": "Cache Components HTTP fallback recovery unexpectedly produced a DynamicServerError"
+  "1281": "Cache Components HTTP fallback recovery unexpectedly produced a DynamicServerError",
+  "1282": "Cache Components error recovery expected an original Flight prerender result"
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -7339,107 +7339,228 @@ async function prerenderToStream(
 
   let prerenderStore: PrerenderStore | null = null
 
-  try {
-    if (cacheComponents) {
-      /**
-       * cacheComponents with PPR
-       *
-       * The general approach is to render the RSC stream first allowing any cache reads to resolve.
-       * Once we have settled all cache reads we restart the render and abort after a single Task.
-       *
-       * Unlike with the non PPR case we can't synchronously abort the render when a dynamic API is used
-       * during the initial render because we need to ensure all caches can be filled as part of the initial Task
-       * and a synchronous abort might prevent us from filling all caches.
-       *
-       * Once the render is complete we allow the SSR render to finish and use a combination of the postponed state
-       * and the reactServerIsDynamic value to determine how to treat the resulting render
-       */
+  const prerenderWithCacheComponents = async (
+    getPayload: () => Promise<InitialRSCPayload>
+  ): Promise<PrerenderToStreamResult> => {
+    /**
+     * cacheComponents with PPR
+     *
+     * The general approach is to render the RSC stream first allowing any cache reads to resolve.
+     * Once we have settled all cache reads we restart the render and abort after a single Task.
+     *
+     * Unlike with the non PPR case we can't synchronously abort the render when a dynamic API is used
+     * during the initial render because we need to ensure all caches can be filled as part of the initial Task
+     * and a synchronous abort might prevent us from filling all caches.
+     *
+     * Once the render is complete we allow the SSR render to finish and use a combination of the postponed state
+     * and the reactServerIsDynamic value to determine how to treat the resulting render
+     */
 
-      // The prerender controller represents the lifetime of the prerender. It
-      // will be aborted when a task is complete or a synchronously aborting API
-      // is called. Notably, during prospective prerenders, this does not
-      // actually terminate the prerender itself, which will continue until all
-      // caches are filled.
-      const initialServerPrerenderController = new AbortController()
+    // The prerender controller represents the lifetime of the prerender. It
+    // will be aborted when a task is complete or a synchronously aborting API
+    // is called. Notably, during prospective prerenders, this does not
+    // actually terminate the prerender itself, which will continue until all
+    // caches are filled.
+    const initialServerPrerenderController = new AbortController()
 
-      // This controller is used to abort the React prerender.
-      const initialServerReactController = new AbortController()
+    // This controller is used to abort the React prerender.
+    const initialServerReactController = new AbortController()
 
-      // This controller represents the lifetime of the React prerender. Its
-      // signal can be used for any I/O operation to abort the I/O and/or to
-      // reject, when prerendering aborts. This includes our own hanging
-      // promises for accessing request data, and for fetch calls. It might be
-      // replaced in the future by React.cacheSignal(). It's aborted after the
-      // React controller, so that no pending I/O can register abort listeners
-      // that are called before React's abort listener is called. This ensures
-      // that pending I/O is not rejected too early when aborting the prerender.
-      // Notably, during the prospective prerender, it is different from the
-      // prerender controller because we don't want to end the React prerender
-      // until all caches are filled.
-      const initialServerRenderController = new AbortController()
+    // This controller represents the lifetime of the React prerender. Its
+    // signal can be used for any I/O operation to abort the I/O and/or to
+    // reject, when prerendering aborts. This includes our own hanging
+    // promises for accessing request data, and for fetch calls. It might be
+    // replaced in the future by React.cacheSignal(). It's aborted after the
+    // React controller, so that no pending I/O can register abort listeners
+    // that are called before React's abort listener is called. This ensures
+    // that pending I/O is not rejected too early when aborting the prerender.
+    // Notably, during the prospective prerender, it is different from the
+    // prerender controller because we don't want to end the React prerender
+    // until all caches are filled.
+    const initialServerRenderController = new AbortController()
 
-      // The cacheSignal helps us track whether caches are still filling or we are ready
-      // to cut the render off.
-      const cacheSignal = new CacheSignal()
+    // The cacheSignal helps us track whether caches are still filling or we are ready
+    // to cut the render off.
+    const cacheSignal = new CacheSignal()
 
-      // Always start with a fresh prerender RDC so warmup can fill misses,
-      // even when we have a prefilled render RDC to seed from.
-      const prerenderResumeDataCache = createPrerenderResumeDataCache()
-      let renderResumeDataCache: RenderResumeDataCache | null =
-        renderOpts.renderResumeDataCache ?? null
+    // Always start with a fresh prerender RDC so warmup can fill misses,
+    // even when we have a prefilled render RDC to seed from.
+    const prerenderResumeDataCache = createPrerenderResumeDataCache()
+    let renderResumeDataCache: RenderResumeDataCache | null =
+      renderOpts.renderResumeDataCache ?? null
 
-      const initialServerPayloadPrerenderStore: PrerenderStore = {
-        type: 'prerender',
-        phase: 'render',
-        rootParams,
-        fallbackRouteParams,
-        implicitTags,
-        // While this render signal isn't going to be used to abort a React render while getting the RSC payload
-        // various request data APIs bind to this controller to reject after completion.
-        renderSignal: initialServerRenderController.signal,
-        // When we generate the RSC payload we might abort this controller due to sync IO
-        // but we don't actually care about sync IO in this phase so we use a throw away controller
-        // that isn't connected to anything
-        controller: new AbortController(),
-        // During the initial prerender we need to track all cache reads to ensure
-        // we render long enough to fill every cache it is possible to visit during
-        // the final prerender.
-        cacheSignal,
-        dynamicTracking: null,
-        allowEmptyStaticShell,
-        revalidate: INFINITE_CACHE,
-        expire: INFINITE_CACHE,
-        stale: INFINITE_CACHE,
-        tags: [...implicitTags.tags],
-        prerenderResumeDataCache,
-        renderResumeDataCache,
-        hmrRefreshHash: undefined,
-        // We don't track vary params during initial prerender, only the final one
-        varyParamsAccumulator: null,
-      }
+    const initialServerPayloadPrerenderStore: PrerenderStore = {
+      type: 'prerender',
+      phase: 'render',
+      rootParams,
+      fallbackRouteParams,
+      implicitTags,
+      // While this render signal isn't going to be used to abort a React render while getting the RSC payload
+      // various request data APIs bind to this controller to reject after completion.
+      renderSignal: initialServerRenderController.signal,
+      // When we generate the RSC payload we might abort this controller due to sync IO
+      // but we don't actually care about sync IO in this phase so we use a throw away controller
+      // that isn't connected to anything
+      controller: new AbortController(),
+      // During the initial prerender we need to track all cache reads to ensure
+      // we render long enough to fill every cache it is possible to visit during
+      // the final prerender.
+      cacheSignal,
+      dynamicTracking: null,
+      allowEmptyStaticShell,
+      revalidate: INFINITE_CACHE,
+      expire: INFINITE_CACHE,
+      stale: INFINITE_CACHE,
+      tags: [...implicitTags.tags],
+      prerenderResumeDataCache,
+      renderResumeDataCache,
+      hmrRefreshHash: undefined,
+      // We don't track vary params during initial prerender, only the final one
+      varyParamsAccumulator: null,
+    }
 
-      // We're not going to use the result of this render because the only time it could be used
-      // is if it completes in a microtask and that's likely very rare for any non-trivial app
-      const initialServerPayload = await workUnitAsyncStorage.run(
-        initialServerPayloadPrerenderStore,
-        getRSCPayload,
-        tree,
-        ctx,
-        { is404: res.statusCode === 404 }
+    // We're not going to use the result of this render because the only time it could be used
+    // is if it completes in a microtask and that's likely very rare for any non-trivial app
+    const initialServerPayload = await workUnitAsyncStorage.run(
+      initialServerPayloadPrerenderStore,
+      getPayload
+    )
+
+    const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
+      type: 'prerender',
+      phase: 'render',
+      rootParams,
+      fallbackRouteParams,
+      implicitTags,
+      renderSignal: initialServerRenderController.signal,
+      controller: initialServerPrerenderController,
+      // During the initial prerender we need to track all cache reads to ensure
+      // we render long enough to fill every cache it is possible to visit during
+      // the final prerender.
+      cacheSignal,
+      dynamicTracking: null,
+      allowEmptyStaticShell,
+      revalidate: INFINITE_CACHE,
+      expire: INFINITE_CACHE,
+      stale: INFINITE_CACHE,
+      tags: [...implicitTags.tags],
+      prerenderResumeDataCache,
+      renderResumeDataCache,
+      hmrRefreshHash: undefined,
+      // We don't track vary params during initial prerender, only the final one
+      varyParamsAccumulator: null,
+    })
+
+    const initialPrerenderOptions = {
+      filterStackFrame,
+      onError: (err: unknown) => {
+        const digest = getDigestForWellKnownError(err)
+
+        if (digest) {
+          return digest
+        }
+
+        if (isReactLargeShellError(err)) {
+          // TODO: Aggregate
+          console.error(err)
+          return undefined
+        }
+
+        if (initialServerPrerenderController.signal.aborted) {
+          // The render aborted before this error was handled which indicates
+          // the error is caused by unfinished components within the render
+          return
+        } else if (
+          process.env.NEXT_DEBUG_BUILD ||
+          process.env.__NEXT_VERBOSE_LOGGING
+        ) {
+          printDebugThrownValueForProspectiveRender(
+            err,
+            workStore.route,
+            Phase.ProspectiveRender
+          )
+        }
+      },
+      // We don't want to stop rendering until the cacheSignal is complete so we pass
+      // a different signal to this render call than is used by dynamic APIs to signify
+      // transitioning out of the prerender environment
+      signal: initialServerReactController.signal,
+    }
+
+    const pendingInitialServerResult = workUnitAsyncStorage.run(
+      initialServerPrerenderStore,
+      getServerPrerender(ComponentMod),
+      initialServerPayload,
+      clientModules,
+      initialPrerenderOptions
+    )
+
+    // The listener to abort our own render controller must be added after
+    // React has added its listener, to ensure that pending I/O is not
+    // aborted/rejected too early.
+    initialServerReactController.signal.addEventListener(
+      'abort',
+      () => {
+        initialServerRenderController.abort()
+        initialServerPrerenderController.abort()
+      },
+      { once: true }
+    )
+
+    // Wait for all caches to be finished filling and for async imports to resolve
+    trackPendingModules(cacheSignal)
+    await cacheSignal.cacheReady()
+
+    initialServerReactController.abort()
+
+    // We don't need to continue the prerender process if we already
+    // detected invalid dynamic usage in the initial prerender phase.
+    if (workStore.invalidDynamicUsageError) {
+      logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
+      throw new StaticGenBailoutError()
+    }
+
+    let initialServerResult
+    try {
+      initialServerResult = await createReactServerPrerenderResult(
+        pendingInitialServerResult
       )
+    } catch (err) {
+      if (
+        initialServerReactController.signal.aborted ||
+        initialServerPrerenderController.signal.aborted
+      ) {
+        // These are expected errors that might error the prerender. we ignore them.
+      } else if (
+        process.env.NEXT_DEBUG_BUILD ||
+        process.env.__NEXT_VERBOSE_LOGGING
+      ) {
+        // We don't normally log these errors because we are going to retry anyway but
+        // it can be useful for debugging Next.js itself to get visibility here when needed
+        printDebugThrownValueForProspectiveRender(
+          err,
+          workStore.route,
+          Phase.ProspectiveRender
+        )
+      }
+    }
 
-      const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
-        type: 'prerender',
+    if (initialServerResult) {
+      const initialClientPrerenderController = new AbortController()
+      const initialClientReactController = new AbortController()
+      const initialClientRenderController = new AbortController()
+
+      const initialClientPrerenderStore: PrerenderStore = {
+        type: 'prerender-client',
         phase: 'render',
         rootParams,
         fallbackRouteParams,
         implicitTags,
-        renderSignal: initialServerRenderController.signal,
-        controller: initialServerPrerenderController,
-        // During the initial prerender we need to track all cache reads to ensure
-        // we render long enough to fill every cache it is possible to visit during
-        // the final prerender.
-        cacheSignal,
+        renderSignal: initialClientRenderController.signal,
+        controller: initialClientPrerenderController,
+        // For HTML Generation the only cache tracked activity
+        // is module loading, which has it's own cache signal
+        cacheSignal: null,
         dynamicTracking: null,
         allowEmptyStaticShell,
         revalidate: INFINITE_CACHE,
@@ -7449,88 +7570,72 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        // We don't track vary params during initial prerender, only the final one
+        // Client prerenders don't track server param access
         varyParamsAccumulator: null,
-      })
-
-      const initialPrerenderOptions = {
-        filterStackFrame,
-        onError: (err: unknown) => {
-          const digest = getDigestForWellKnownError(err)
-
-          if (digest) {
-            return digest
-          }
-
-          if (isReactLargeShellError(err)) {
-            // TODO: Aggregate
-            console.error(err)
-            return undefined
-          }
-
-          if (initialServerPrerenderController.signal.aborted) {
-            // The render aborted before this error was handled which indicates
-            // the error is caused by unfinished components within the render
-            return
-          } else if (
-            process.env.NEXT_DEBUG_BUILD ||
-            process.env.__NEXT_VERBOSE_LOGGING
-          ) {
-            printDebugThrownValueForProspectiveRender(
-              err,
-              workStore.route,
-              Phase.ProspectiveRender
-            )
-          }
-        },
-        // We don't want to stop rendering until the cacheSignal is complete so we pass
-        // a different signal to this render call than is used by dynamic APIs to signify
-        // transitioning out of the prerender environment
-        signal: initialServerReactController.signal,
       }
 
-      const pendingInitialServerResult = workUnitAsyncStorage.run(
-        initialServerPrerenderStore,
-        getServerPrerender(ComponentMod),
-        initialServerPayload,
-        clientModules,
-        initialPrerenderOptions
+      const pendingInitialClientResult = workUnitAsyncStorage.run(
+        initialClientPrerenderStore,
+        getClientPrerender,
+        // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+        <App
+          reactServerStream={initialServerResult.asUnclosingStream()}
+          reactDebugStream={undefined}
+          debugEndTime={undefined}
+          preinitScripts={preinitScripts}
+          ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+          nonce={nonce}
+          images={ctx.renderOpts.images}
+        />,
+        {
+          signal: initialClientReactController.signal,
+          onError: (err: unknown) => {
+            const digest = getDigestForWellKnownError(err)
+
+            if (digest) {
+              return digest
+            }
+
+            if (isReactLargeShellError(err)) {
+              // TODO: Aggregate
+              console.error(err)
+              return undefined
+            }
+
+            if (initialClientReactController.signal.aborted) {
+              // These are expected errors that might error the prerender. we ignore them.
+            } else if (
+              process.env.NEXT_DEBUG_BUILD ||
+              process.env.__NEXT_VERBOSE_LOGGING
+            ) {
+              // We don't normally log these errors because we are going to retry anyway but
+              // it can be useful for debugging Next.js itself to get visibility here when needed
+              printDebugThrownValueForProspectiveRender(
+                err,
+                workStore.route,
+                Phase.ProspectiveRender
+              )
+            }
+          },
+          bootstrapScripts: [bootstrapScript],
+        }
       )
 
       // The listener to abort our own render controller must be added after
       // React has added its listener, to ensure that pending I/O is not
       // aborted/rejected too early.
-      initialServerReactController.signal.addEventListener(
+      initialClientReactController.signal.addEventListener(
         'abort',
         () => {
-          initialServerRenderController.abort()
-          initialServerPrerenderController.abort()
+          initialClientRenderController.abort()
         },
         { once: true }
       )
 
-      // Wait for all caches to be finished filling and for async imports to resolve
-      trackPendingModules(cacheSignal)
-      await cacheSignal.cacheReady()
-
-      initialServerReactController.abort()
-
-      // We don't need to continue the prerender process if we already
-      // detected invalid dynamic usage in the initial prerender phase.
-      if (workStore.invalidDynamicUsageError) {
-        logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
-        throw new StaticGenBailoutError()
-      }
-
-      let initialServerResult
-      try {
-        initialServerResult = await createReactServerPrerenderResult(
-          pendingInitialServerResult
-        )
-      } catch (err) {
+      pendingInitialClientResult.catch((err: unknown) => {
         if (
-          initialServerReactController.signal.aborted ||
-          initialServerPrerenderController.signal.aborted
+          initialClientReactController.signal.aborted ||
+          isPrerenderInterruptedError(err)
         ) {
           // These are expected errors that might error the prerender. we ignore them.
         } else if (
@@ -7545,43 +7650,217 @@ async function prerenderToStream(
             Phase.ProspectiveRender
           )
         }
+      })
+
+      // This is mostly needed for dynamic `import()`s in client components.
+      // Promises passed to client were already awaited above (assuming that they came from cached functions)
+      trackPendingModules(cacheSignal)
+      await cacheSignal.cacheReady()
+      initialClientReactController.abort()
+    }
+
+    if (renderOpts.renderResumeDataCache) {
+      // Swap to the warmed cache so the final render uses entries produced during warmup.
+      renderResumeDataCache = createRenderResumeDataCache(
+        prerenderResumeDataCache
+      )
+    }
+
+    const finalServerReactController = new AbortController()
+    const finalServerRenderController = new AbortController()
+
+    const varyParamsAccumulator = createResponseVaryParamsAccumulator()
+
+    const finalServerPayloadPrerenderStore: PrerenderStore = {
+      type: 'prerender',
+      phase: 'render',
+      rootParams,
+      fallbackRouteParams,
+      implicitTags,
+      // While this render signal isn't going to be used to abort a React render while getting the RSC payload
+      // various request data APIs bind to this controller to reject after completion.
+      renderSignal: finalServerRenderController.signal,
+      // When we generate the RSC payload we might abort this controller due to sync IO
+      // but we don't actually care about sync IO in this phase so we use a throw away controller
+      // that isn't connected to anything
+      controller: new AbortController(),
+      // All caches we could read must already be filled so no tracking is necessary
+      cacheSignal: null,
+      dynamicTracking: null,
+      allowEmptyStaticShell,
+      revalidate: INFINITE_CACHE,
+      expire: INFINITE_CACHE,
+      stale: INFINITE_CACHE,
+      tags: [...implicitTags.tags],
+      prerenderResumeDataCache,
+      renderResumeDataCache,
+      hmrRefreshHash: undefined,
+      varyParamsAccumulator,
+    }
+
+    const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
+      finalServerPayloadPrerenderStore,
+      getPayload
+    )
+
+    let staleTimeIterable: StaleTimeIterable | undefined
+    if (cachedNavigations) {
+      staleTimeIterable = new StaleTimeIterable()
+      finalAttemptRSCPayload.s = staleTimeIterable
+    }
+
+    const serverDynamicTracking = createDynamicTrackingState(
+      isDebugDynamicAccesses
+    )
+    let serverIsDynamic = false
+
+    const finalServerPrerenderStore: PrerenderStore = (prerenderStore = {
+      type: 'prerender',
+      phase: 'render',
+      rootParams,
+      fallbackRouteParams,
+      implicitTags,
+      renderSignal: finalServerRenderController.signal,
+      controller: finalServerReactController,
+      // All caches we could read must already be filled so no tracking is necessary
+      cacheSignal: null,
+      dynamicTracking: serverDynamicTracking,
+      allowEmptyStaticShell,
+      revalidate: INFINITE_CACHE,
+      expire: INFINITE_CACHE,
+      stale: INFINITE_CACHE,
+      tags: [...implicitTags.tags],
+      prerenderResumeDataCache,
+      renderResumeDataCache,
+      hmrRefreshHash: undefined,
+      varyParamsAccumulator,
+    })
+
+    if (staleTimeIterable !== undefined) {
+      trackStaleTime(
+        finalServerPrerenderStore,
+        staleTimeIterable,
+        selectStaleTime
+      )
+    }
+
+    let prerenderIsPending = true
+    const finalRSCPrerenderOptions = {
+      filterStackFrame,
+      onError: (err: unknown) => {
+        return serverComponentsErrorHandler(err)
+      },
+      signal: finalServerReactController.signal,
+    }
+    const finalRSCAbortCallback = async () => {
+      // Now that the prerendering is complete, we know the final stale
+      // time and vary params. Close the stale time iterable and resolve
+      // the vary params thenable so Flight can serialize their values
+      // into the stream. The timing here is important: both were
+      // included in the Flight payload, but they can only be serialized
+      // at the very end, after all the components have finished.
+      //
+      // We resolve these directly here instead of reading from the work
+      // unit store because this callback runs in a separate task (via
+      // setTimeout) and may not have access to the async storage context.
+      const pendingFinishes: Promise<void>[] = [
+        finishAccumulatingVaryParams(varyParamsAccumulator),
+      ]
+      if (staleTimeIterable !== undefined) {
+        pendingFinishes.push(finishStaleTimeTracking(staleTimeIterable))
+      }
+      await Promise.all(pendingFinishes)
+
+      if (finalServerReactController.signal.aborted) {
+        // If the server controller is already aborted we must have called something
+        // that required aborting the prerender synchronously such as with new Date()
+        serverIsDynamic = true
+        return
       }
 
-      if (initialServerResult) {
-        const initialClientPrerenderController = new AbortController()
-        const initialClientReactController = new AbortController()
-        const initialClientRenderController = new AbortController()
+      if (prerenderIsPending) {
+        // If prerenderIsPending then we have blocked for longer than a Task and we assume
+        // there is something unfinished.
+        serverIsDynamic = true
+      }
 
-        const initialClientPrerenderStore: PrerenderStore = {
-          type: 'prerender-client',
-          phase: 'render',
-          rootParams,
-          fallbackRouteParams,
-          implicitTags,
-          renderSignal: initialClientRenderController.signal,
-          controller: initialClientPrerenderController,
-          // For HTML Generation the only cache tracked activity
-          // is module loading, which has it's own cache signal
-          cacheSignal: null,
-          dynamicTracking: null,
-          allowEmptyStaticShell,
-          revalidate: INFINITE_CACHE,
-          expire: INFINITE_CACHE,
-          stale: INFINITE_CACHE,
-          tags: [...implicitTags.tags],
-          prerenderResumeDataCache,
-          renderResumeDataCache,
-          hmrRefreshHash: undefined,
-          // Client prerenders don't track server param access
-          varyParamsAccumulator: null,
-        }
+      finalServerReactController.abort()
+    }
+    const finalRSCPrerenderFn = async () => {
+      const pendingPrerenderResult = workUnitAsyncStorage.run(
+        // The store to scope
+        finalServerPrerenderStore,
+        // The function to run
+        getServerPrerender(ComponentMod),
+        // ... the arguments for the function to run
+        finalAttemptRSCPayload,
+        clientModules,
+        finalRSCPrerenderOptions
+      )
 
-        const pendingInitialClientResult = workUnitAsyncStorage.run(
-          initialClientPrerenderStore,
+      // The listener to abort our own render controller must be added
+      // after React has added its listener, to ensure that pending I/O
+      // is not aborted/rejected too early.
+      finalServerReactController.signal.addEventListener(
+        'abort',
+        () => {
+          finalServerRenderController.abort()
+        },
+        { once: true }
+      )
+
+      const prerenderResult = await pendingPrerenderResult
+      prerenderIsPending = false
+
+      return prerenderResult
+    }
+    const reactServerResult = (reactServerPrerenderResult =
+      await createReactServerPrerenderResult(
+        runInSequentialTasks(finalRSCPrerenderFn, finalRSCAbortCallback)
+      ))
+
+    const clientDynamicTracking = createDynamicTrackingState(
+      isDebugDynamicAccesses
+    )
+
+    const finalClientReactController = new AbortController()
+    const finalClientRenderController = new AbortController()
+
+    const finalClientPrerenderStore: PrerenderStore = {
+      type: 'prerender-client',
+      phase: 'render',
+      rootParams,
+      fallbackRouteParams,
+      implicitTags,
+      renderSignal: finalClientRenderController.signal,
+      controller: finalClientReactController,
+      // No APIs require a cacheSignal through the workUnitStore during the HTML prerender
+      cacheSignal: null,
+      dynamicTracking: clientDynamicTracking,
+      allowEmptyStaticShell,
+      revalidate: INFINITE_CACHE,
+      expire: INFINITE_CACHE,
+      stale: INFINITE_CACHE,
+      tags: [...implicitTags.tags],
+      prerenderResumeDataCache,
+      renderResumeDataCache,
+      hmrRefreshHash: undefined,
+      // Client prerenders don't track server param access
+      varyParamsAccumulator: null,
+    }
+
+    let dynamicValidation = createDynamicValidationState()
+
+    const finalClientOnHeaders = createOnHeadersCallback(appendHeader)
+
+    let { prelude: unprocessedPrelude, postponed } = await runInSequentialTasks(
+      () => {
+        const pendingFinalClientResult = workUnitAsyncStorage.run(
+          finalClientPrerenderStore,
           getClientPrerender,
           // eslint-disable-next-line @next/internal/no-ambiguous-jsx
           <App
-            reactServerStream={initialServerResult.asUnclosingStream()}
+            reactServerStream={reactServerResult.asUnclosingStream()}
             reactDebugStream={undefined}
             debugEndTime={undefined}
             preinitScripts={preinitScripts}
@@ -7590,534 +7869,255 @@ async function prerenderToStream(
             images={ctx.renderOpts.images}
           />,
           {
-            signal: initialClientReactController.signal,
-            onError: (err: unknown) => {
-              const digest = getDigestForWellKnownError(err)
-
-              if (digest) {
-                return digest
-              }
-
-              if (isReactLargeShellError(err)) {
-                // TODO: Aggregate
-                console.error(err)
-                return undefined
-              }
-
-              if (initialClientReactController.signal.aborted) {
-                // These are expected errors that might error the prerender. we ignore them.
-              } else if (
-                process.env.NEXT_DEBUG_BUILD ||
-                process.env.__NEXT_VERBOSE_LOGGING
+            signal: finalClientReactController.signal,
+            onError: (err: unknown, errorInfo: ErrorInfo) => {
+              if (
+                isPrerenderInterruptedError(err) ||
+                finalClientReactController.signal.aborted
               ) {
-                // We don't normally log these errors because we are going to retry anyway but
-                // it can be useful for debugging Next.js itself to get visibility here when needed
-                printDebugThrownValueForProspectiveRender(
-                  err,
-                  workStore.route,
-                  Phase.ProspectiveRender
-                )
+                const componentStack: string | undefined = (errorInfo as any)
+                  .componentStack
+                if (typeof componentStack === 'string') {
+                  trackAllowedDynamicAccess(
+                    workStore,
+                    componentStack,
+                    dynamicValidation,
+                    clientDynamicTracking
+                  )
+                }
+                return
               }
+
+              return htmlRendererErrorHandler(err, errorInfo)
             },
+            onHeaders: finalClientOnHeaders,
+            maxHeadersLength: reactMaxHeadersLength,
             bootstrapScripts: [bootstrapScript],
           }
         )
 
-        // The listener to abort our own render controller must be added after
-        // React has added its listener, to ensure that pending I/O is not
-        // aborted/rejected too early.
-        initialClientReactController.signal.addEventListener(
-          'abort',
-          () => {
-            initialClientRenderController.abort()
-          },
-          { once: true }
-        )
-
-        pendingInitialClientResult.catch((err: unknown) => {
-          if (
-            initialClientReactController.signal.aborted ||
-            isPrerenderInterruptedError(err)
-          ) {
-            // These are expected errors that might error the prerender. we ignore them.
-          } else if (
-            process.env.NEXT_DEBUG_BUILD ||
-            process.env.__NEXT_VERBOSE_LOGGING
-          ) {
-            // We don't normally log these errors because we are going to retry anyway but
-            // it can be useful for debugging Next.js itself to get visibility here when needed
-            printDebugThrownValueForProspectiveRender(
-              err,
-              workStore.route,
-              Phase.ProspectiveRender
-            )
-          }
-        })
-
-        // This is mostly needed for dynamic `import()`s in client components.
-        // Promises passed to client were already awaited above (assuming that they came from cached functions)
-        trackPendingModules(cacheSignal)
-        await cacheSignal.cacheReady()
-        initialClientReactController.abort()
-      }
-
-      if (renderOpts.renderResumeDataCache) {
-        // Swap to the warmed cache so the final render uses entries produced during warmup.
-        renderResumeDataCache = createRenderResumeDataCache(
-          prerenderResumeDataCache
-        )
-      }
-
-      const finalServerReactController = new AbortController()
-      const finalServerRenderController = new AbortController()
-
-      const varyParamsAccumulator = createResponseVaryParamsAccumulator()
-
-      const finalServerPayloadPrerenderStore: PrerenderStore = {
-        type: 'prerender',
-        phase: 'render',
-        rootParams,
-        fallbackRouteParams,
-        implicitTags,
-        // While this render signal isn't going to be used to abort a React render while getting the RSC payload
-        // various request data APIs bind to this controller to reject after completion.
-        renderSignal: finalServerRenderController.signal,
-        // When we generate the RSC payload we might abort this controller due to sync IO
-        // but we don't actually care about sync IO in this phase so we use a throw away controller
-        // that isn't connected to anything
-        controller: new AbortController(),
-        // All caches we could read must already be filled so no tracking is necessary
-        cacheSignal: null,
-        dynamicTracking: null,
-        allowEmptyStaticShell,
-        revalidate: INFINITE_CACHE,
-        expire: INFINITE_CACHE,
-        stale: INFINITE_CACHE,
-        tags: [...implicitTags.tags],
-        prerenderResumeDataCache,
-        renderResumeDataCache,
-        hmrRefreshHash: undefined,
-        varyParamsAccumulator,
-      }
-
-      const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
-        finalServerPayloadPrerenderStore,
-        getRSCPayload,
-        tree,
-        ctx,
-        { is404: res.statusCode === 404 }
-      )
-
-      let staleTimeIterable: StaleTimeIterable | undefined
-      if (cachedNavigations) {
-        staleTimeIterable = new StaleTimeIterable()
-        finalAttemptRSCPayload.s = staleTimeIterable
-      }
-
-      const serverDynamicTracking = createDynamicTrackingState(
-        isDebugDynamicAccesses
-      )
-      let serverIsDynamic = false
-
-      const finalServerPrerenderStore: PrerenderStore = (prerenderStore = {
-        type: 'prerender',
-        phase: 'render',
-        rootParams,
-        fallbackRouteParams,
-        implicitTags,
-        renderSignal: finalServerRenderController.signal,
-        controller: finalServerReactController,
-        // All caches we could read must already be filled so no tracking is necessary
-        cacheSignal: null,
-        dynamicTracking: serverDynamicTracking,
-        allowEmptyStaticShell,
-        revalidate: INFINITE_CACHE,
-        expire: INFINITE_CACHE,
-        stale: INFINITE_CACHE,
-        tags: [...implicitTags.tags],
-        prerenderResumeDataCache,
-        renderResumeDataCache,
-        hmrRefreshHash: undefined,
-        varyParamsAccumulator,
-      })
-
-      if (staleTimeIterable !== undefined) {
-        trackStaleTime(
-          finalServerPrerenderStore,
-          staleTimeIterable,
-          selectStaleTime
-        )
-      }
-
-      let prerenderIsPending = true
-      const finalRSCPrerenderOptions = {
-        filterStackFrame,
-        onError: (err: unknown) => {
-          return serverComponentsErrorHandler(err)
-        },
-        signal: finalServerReactController.signal,
-      }
-      const finalRSCAbortCallback = async () => {
-        // Now that the prerendering is complete, we know the final stale
-        // time and vary params. Close the stale time iterable and resolve
-        // the vary params thenable so Flight can serialize their values
-        // into the stream. The timing here is important: both were
-        // included in the Flight payload, but they can only be serialized
-        // at the very end, after all the components have finished.
-        //
-        // We resolve these directly here instead of reading from the work
-        // unit store because this callback runs in a separate task (via
-        // setTimeout) and may not have access to the async storage context.
-        const pendingFinishes: Promise<void>[] = [
-          finishAccumulatingVaryParams(varyParamsAccumulator),
-        ]
-        if (staleTimeIterable !== undefined) {
-          pendingFinishes.push(finishStaleTimeTracking(staleTimeIterable))
-        }
-        await Promise.all(pendingFinishes)
-
-        if (finalServerReactController.signal.aborted) {
-          // If the server controller is already aborted we must have called something
-          // that required aborting the prerender synchronously such as with new Date()
-          serverIsDynamic = true
-          return
-        }
-
-        if (prerenderIsPending) {
-          // If prerenderIsPending then we have blocked for longer than a Task and we assume
-          // there is something unfinished.
-          serverIsDynamic = true
-        }
-
-        finalServerReactController.abort()
-      }
-      const finalRSCPrerenderFn = async () => {
-        const pendingPrerenderResult = workUnitAsyncStorage.run(
-          // The store to scope
-          finalServerPrerenderStore,
-          // The function to run
-          getServerPrerender(ComponentMod),
-          // ... the arguments for the function to run
-          finalAttemptRSCPayload,
-          clientModules,
-          finalRSCPrerenderOptions
-        )
-
         // The listener to abort our own render controller must be added
-        // after React has added its listener, to ensure that pending I/O
-        // is not aborted/rejected too early.
-        finalServerReactController.signal.addEventListener(
+        // after React has added its listener, to ensure that pending I/O is
+        // not aborted/rejected too early.
+        finalClientReactController.signal.addEventListener(
           'abort',
           () => {
-            finalServerRenderController.abort()
+            finalClientRenderController.abort()
           },
           { once: true }
         )
 
-        const prerenderResult = await pendingPrerenderResult
-        prerenderIsPending = false
-
-        return prerenderResult
+        return pendingFinalClientResult
+      },
+      () => {
+        finalClientReactController.abort()
       }
-      const reactServerResult = (reactServerPrerenderResult =
-        await createReactServerPrerenderResult(
-          runInSequentialTasks(finalRSCPrerenderFn, finalRSCAbortCallback)
-        ))
+    )
 
-      const clientDynamicTracking = createDynamicTrackingState(
-        isDebugDynamicAccesses
-      )
+    const { prelude, preludeIsEmpty } =
+      await processPreludeOp(unprocessedPrelude)
 
-      const finalClientReactController = new AbortController()
-      const finalClientRenderController = new AbortController()
+    throwIfDisallowedDynamic(
+      workStore,
+      preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
+      dynamicValidation,
+      serverDynamicTracking,
+      allowEmptyStaticShell
+    )
 
-      const finalClientPrerenderStore: PrerenderStore = {
-        type: 'prerender-client',
-        phase: 'render',
-        rootParams,
-        fallbackRouteParams,
-        implicitTags,
-        renderSignal: finalClientRenderController.signal,
-        controller: finalClientReactController,
-        // No APIs require a cacheSignal through the workUnitStore during the HTML prerender
-        cacheSignal: null,
-        dynamicTracking: clientDynamicTracking,
-        allowEmptyStaticShell,
-        revalidate: INFINITE_CACHE,
-        expire: INFINITE_CACHE,
-        stale: INFINITE_CACHE,
-        tags: [...implicitTags.tags],
-        prerenderResumeDataCache,
-        renderResumeDataCache,
-        hmrRefreshHash: undefined,
-        // Client prerenders don't track server param access
-        varyParamsAccumulator: null,
+    const getServerInsertedHTML = makeGetServerInsertedHTML({
+      polyfills,
+      renderServerInsertedHTML,
+      serverCapturedErrors: allCapturedErrors,
+      basePath,
+      tracingMetadata: tracingMetadata,
+    })
+
+    metadata.flightData = await streamToBuffer(
+      cachedNavigations
+        ? prependIsPartialByte(reactServerResult.asStream(), serverIsDynamic)
+        : reactServerResult.asStream()
+    )
+
+    // collectSegmentData needs the raw flight data without the marker byte.
+    const flightData = cachedNavigations
+      ? metadata.flightData.subarray(1)
+      : metadata.flightData
+
+    await collectSegmentData(
+      flightData,
+      finalServerPrerenderStore,
+      ComponentMod,
+      renderOpts,
+      ctx.pagePath,
+      metadata
+    )
+
+    if (serverIsDynamic) {
+      // Dynamic case
+      // We will always need to perform a "resume" render of some kind when this route is accessed
+      // because the RSC data itself is dynamic. We determine if there are any HTML holes or not
+      // but generally this is a "partial" prerender in that there will be a per-request compute
+      // concatenated to the static shell.
+      if (postponed != null) {
+        // Dynamic HTML case
+        metadata.postponed = await getDynamicHTMLPostponedState(
+          postponed,
+          preludeIsEmpty
+            ? DynamicHTMLPreludeState.Empty
+            : DynamicHTMLPreludeState.Full,
+          fallbackRouteParams,
+          prerenderResumeDataCache,
+          cacheComponents
+        )
+      } else {
+        // Dynamic Data case
+        metadata.postponed = await getDynamicDataPostponedState(
+          prerenderResumeDataCache,
+          cacheComponents
+        )
+      }
+      reactServerResult.consume()
+      const continueDynamicPrerenderOpts = {
+        getServerInsertedHTML,
+        getServerInsertedMetadata,
+        deploymentId: ctx.sharedContext.deploymentId,
+      }
+      return {
+        digestErrorsMap: reactServerErrorsByDigest,
+        ssrErrors: allCapturedErrors,
+        stream: await continueDynamicPrerender(
+          prelude,
+          continueDynamicPrerenderOpts
+        ),
+        dynamicAccess: consumeDynamicAccess(
+          serverDynamicTracking,
+          clientDynamicTracking
+        ),
+        // TODO: Should this include the SSR pass?
+        collectedRevalidate: finalServerPrerenderStore.revalidate,
+        collectedExpire: finalServerPrerenderStore.expire,
+        collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
+        collectedTags: finalServerPrerenderStore.tags,
+        renderResumeDataCache: createRenderResumeDataCache(
+          prerenderResumeDataCache
+        ),
+      }
+    } else {
+      // Static case
+      // We will not perform resumption per request. The result can be served statically to the requestor
+      // and if there was anything dynamic it will only be rendered in the browser.
+      if (workStore.forceDynamic) {
+        throw new StaticGenBailoutError(
+          'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
+        )
       }
 
-      let dynamicValidation = createDynamicValidationState()
-
-      const finalClientOnHeaders = createOnHeadersCallback(appendHeader)
-
-      let { prelude: unprocessedPrelude, postponed } =
-        await runInSequentialTasks(
-          () => {
-            const pendingFinalClientResult = workUnitAsyncStorage.run(
-              finalClientPrerenderStore,
-              getClientPrerender,
-              // eslint-disable-next-line @next/internal/no-ambiguous-jsx
-              <App
-                reactServerStream={reactServerResult.asUnclosingStream()}
-                reactDebugStream={undefined}
-                debugEndTime={undefined}
-                preinitScripts={preinitScripts}
-                ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
-                nonce={nonce}
-                images={ctx.renderOpts.images}
-              />,
-              {
-                signal: finalClientReactController.signal,
-                onError: (err: unknown, errorInfo: ErrorInfo) => {
-                  if (
-                    isPrerenderInterruptedError(err) ||
-                    finalClientReactController.signal.aborted
-                  ) {
-                    const componentStack: string | undefined = (
-                      errorInfo as any
-                    ).componentStack
-                    if (typeof componentStack === 'string') {
-                      trackAllowedDynamicAccess(
-                        workStore,
-                        componentStack,
-                        dynamicValidation,
-                        clientDynamicTracking
-                      )
-                    }
-                    return
-                  }
-
-                  return htmlRendererErrorHandler(err, errorInfo)
-                },
-                onHeaders: finalClientOnHeaders,
-                maxHeadersLength: reactMaxHeadersLength,
-                bootstrapScripts: [bootstrapScript],
-              }
-            )
-
-            // The listener to abort our own render controller must be added
-            // after React has added its listener, to ensure that pending I/O is
-            // not aborted/rejected too early.
-            finalClientReactController.signal.addEventListener(
-              'abort',
-              () => {
-                finalClientRenderController.abort()
-              },
-              { once: true }
-            )
-
-            return pendingFinalClientResult
-          },
-          () => {
-            finalClientReactController.abort()
+      let htmlStream: AnyStream = prelude
+      if (postponed != null) {
+        // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
+        // so we can set all the postponed boundaries to client render mode before we store the HTML response
+        const foreverStream = createPendingStream()
+        const resumePrelude = await workUnitAsyncStorage.run(
+          finalServerPrerenderStore,
+          resumeAndAbort,
+          // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+          <App
+            reactServerStream={foreverStream}
+            reactDebugStream={undefined}
+            debugEndTime={undefined}
+            preinitScripts={() => {}}
+            ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+            nonce={nonce}
+            images={ctx.renderOpts.images}
+          />,
+          JSON.parse(JSON.stringify(postponed)),
+          {
+            signal: createRenderInBrowserAbortSignal(),
+            onError: htmlRendererErrorHandler,
+            nonce,
           }
         )
+        // First we write everything from the prerender, then we write everything from the aborted resume render
+        htmlStream = chainStreams(prelude, resumePrelude)
+      }
 
-      const { prelude, preludeIsEmpty } =
-        await processPreludeOp(unprocessedPrelude)
-
-      throwIfDisallowedDynamic(
-        workStore,
-        preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
-        dynamicValidation,
-        serverDynamicTracking,
-        allowEmptyStaticShell
-      )
-
-      const getServerInsertedHTML = makeGetServerInsertedHTML({
-        polyfills,
-        renderServerInsertedHTML,
-        serverCapturedErrors: allCapturedErrors,
-        basePath,
-        tracingMetadata: tracingMetadata,
-      })
-
-      metadata.flightData = await streamToBuffer(
-        cachedNavigations
-          ? prependIsPartialByte(reactServerResult.asStream(), serverIsDynamic)
-          : reactServerResult.asStream()
-      )
-
-      // collectSegmentData needs the raw flight data without the marker byte.
-      const flightData = cachedNavigations
-        ? metadata.flightData.subarray(1)
-        : metadata.flightData
-
-      await collectSegmentData(
-        flightData,
-        finalServerPrerenderStore,
-        ComponentMod,
-        renderOpts,
-        ctx.pagePath,
-        metadata
-      )
-
-      if (serverIsDynamic) {
-        // Dynamic case
-        // We will always need to perform a "resume" render of some kind when this route is accessed
-        // because the RSC data itself is dynamic. We determine if there are any HTML holes or not
-        // but generally this is a "partial" prerender in that there will be a per-request compute
-        // concatenated to the static shell.
-        if (postponed != null) {
-          // Dynamic HTML case
-          metadata.postponed = await getDynamicHTMLPostponedState(
-            postponed,
-            preludeIsEmpty
-              ? DynamicHTMLPreludeState.Empty
-              : DynamicHTMLPreludeState.Full,
-            fallbackRouteParams,
-            prerenderResumeDataCache,
-            cacheComponents
+      let finalStream
+      const hasFallbackRouteParams =
+        fallbackRouteParams && fallbackRouteParams.size > 0
+      if (hasFallbackRouteParams) {
+        // This is a "static fallback" prerender: although the page didn't
+        // access any runtime params in a Server Component, it may have
+        // accessed a runtime param in a client segment.
+        //
+        // TODO: If there were no client segments, we can use the fully static
+        // path instead.
+        //
+        // Rather than use a dynamic server resume to fill in the params,
+        // we can rely on the client to parse the params from the URL and use
+        // that to hydrate the page.
+        //
+        // Send an empty InitialRSCPayload to the server component renderer
+        // The data will be fetched by the client instead.
+        // TODO: In the future, rather than defer the entire hydration payload
+        // to be fetched by the client, we should only defer the client
+        // segments, since those are the only ones whose data is not complete.
+        const emptyReactServerResult =
+          await createReactServerPrerenderResultFromRender(
+            renderFlightStream(ComponentMod, [], clientModules, {
+              filterStackFrame,
+              onError: serverComponentsErrorHandler,
+            })
           )
-        } else {
-          // Dynamic Data case
-          metadata.postponed = await getDynamicDataPostponedState(
-            prerenderResumeDataCache,
-            cacheComponents
-          )
-        }
-        reactServerResult.consume()
-        const continueDynamicPrerenderOpts = {
+        finalStream = await continueStaticFallbackPrerender(htmlStream, {
+          inlinedDataStream: createInlinedDataStream(
+            emptyReactServerResult.consumeAsStream(),
+            nonce,
+            formState
+          ),
           getServerInsertedHTML,
           getServerInsertedMetadata,
           deploymentId: ctx.sharedContext.deploymentId,
-        }
-        return {
-          digestErrorsMap: reactServerErrorsByDigest,
-          ssrErrors: allCapturedErrors,
-          stream: await continueDynamicPrerender(
-            prelude,
-            continueDynamicPrerenderOpts
-          ),
-          dynamicAccess: consumeDynamicAccess(
-            serverDynamicTracking,
-            clientDynamicTracking
-          ),
-          // TODO: Should this include the SSR pass?
-          collectedRevalidate: finalServerPrerenderStore.revalidate,
-          collectedExpire: finalServerPrerenderStore.expire,
-          collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
-          collectedTags: finalServerPrerenderStore.tags,
-          renderResumeDataCache: createRenderResumeDataCache(
-            prerenderResumeDataCache
-          ),
-        }
+        })
       } else {
-        // Static case
-        // We will not perform resumption per request. The result can be served statically to the requestor
-        // and if there was anything dynamic it will only be rendered in the browser.
-        if (workStore.forceDynamic) {
-          throw new StaticGenBailoutError(
-            'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
-          )
-        }
-
-        let htmlStream: AnyStream = prelude
-        if (postponed != null) {
-          // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
-          // so we can set all the postponed boundaries to client render mode before we store the HTML response
-          const foreverStream = createPendingStream()
-          const resumePrelude = await workUnitAsyncStorage.run(
-            finalServerPrerenderStore,
-            resumeAndAbort,
-            // eslint-disable-next-line @next/internal/no-ambiguous-jsx
-            <App
-              reactServerStream={foreverStream}
-              reactDebugStream={undefined}
-              debugEndTime={undefined}
-              preinitScripts={() => {}}
-              ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
-              nonce={nonce}
-              images={ctx.renderOpts.images}
-            />,
-            JSON.parse(JSON.stringify(postponed)),
-            {
-              signal: createRenderInBrowserAbortSignal(),
-              onError: htmlRendererErrorHandler,
-              nonce,
-            }
-          )
-          // First we write everything from the prerender, then we write everything from the aborted resume render
-          htmlStream = chainStreams(prelude, resumePrelude)
-        }
-
-        let finalStream
-        const hasFallbackRouteParams =
-          fallbackRouteParams && fallbackRouteParams.size > 0
-        if (hasFallbackRouteParams) {
-          // This is a "static fallback" prerender: although the page didn't
-          // access any runtime params in a Server Component, it may have
-          // accessed a runtime param in a client segment.
-          //
-          // TODO: If there were no client segments, we can use the fully static
-          // path instead.
-          //
-          // Rather than use a dynamic server resume to fill in the params,
-          // we can rely on the client to parse the params from the URL and use
-          // that to hydrate the page.
-          //
-          // Send an empty InitialRSCPayload to the server component renderer
-          // The data will be fetched by the client instead.
-          // TODO: In the future, rather than defer the entire hydration payload
-          // to be fetched by the client, we should only defer the client
-          // segments, since those are the only ones whose data is not complete.
-          const emptyReactServerResult =
-            await createReactServerPrerenderResultFromRender(
-              renderFlightStream(ComponentMod, [], clientModules, {
-                filterStackFrame,
-                onError: serverComponentsErrorHandler,
-              })
-            )
-          finalStream = await continueStaticFallbackPrerender(htmlStream, {
-            inlinedDataStream: createInlinedDataStream(
-              emptyReactServerResult.consumeAsStream(),
-              nonce,
-              formState
-            ),
-            getServerInsertedHTML,
-            getServerInsertedMetadata,
-            deploymentId: ctx.sharedContext.deploymentId,
-          })
-        } else {
-          // Normal static prerender case, no fallback param handling needed
-          finalStream = await continueStaticPrerender(htmlStream, {
-            inlinedDataStream: createInlinedDataStream(
-              reactServerResult.consumeAsStream(),
-              nonce,
-              formState
-            ),
-            getServerInsertedHTML,
-            getServerInsertedMetadata,
-            deploymentId: ctx.sharedContext.deploymentId,
-          })
-        }
-
-        return {
-          digestErrorsMap: reactServerErrorsByDigest,
-          ssrErrors: allCapturedErrors,
-          stream: finalStream,
-          dynamicAccess: consumeDynamicAccess(
-            serverDynamicTracking,
-            clientDynamicTracking
+        // Normal static prerender case, no fallback param handling needed
+        finalStream = await continueStaticPrerender(htmlStream, {
+          inlinedDataStream: createInlinedDataStream(
+            reactServerResult.consumeAsStream(),
+            nonce,
+            formState
           ),
-          // TODO: Should this include the SSR pass?
-          collectedRevalidate: finalServerPrerenderStore.revalidate,
-          collectedExpire: finalServerPrerenderStore.expire,
-          collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
-          collectedTags: finalServerPrerenderStore.tags,
-          renderResumeDataCache: createRenderResumeDataCache(
-            prerenderResumeDataCache
-          ),
-        }
+          getServerInsertedHTML,
+          getServerInsertedMetadata,
+          deploymentId: ctx.sharedContext.deploymentId,
+        })
       }
+
+      return {
+        digestErrorsMap: reactServerErrorsByDigest,
+        ssrErrors: allCapturedErrors,
+        stream: finalStream,
+        dynamicAccess: consumeDynamicAccess(
+          serverDynamicTracking,
+          clientDynamicTracking
+        ),
+        // TODO: Should this include the SSR pass?
+        collectedRevalidate: finalServerPrerenderStore.revalidate,
+        collectedExpire: finalServerPrerenderStore.expire,
+        collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
+        collectedTags: finalServerPrerenderStore.tags,
+        renderResumeDataCache: createRenderResumeDataCache(
+          prerenderResumeDataCache
+        ),
+      }
+    }
+  }
+
+  try {
+    if (cacheComponents) {
+      return await prerenderWithCacheComponents(() =>
+        getRSCPayload(tree, ctx, { is404: res.statusCode === 404 })
+      )
     } else if (experimental.isRoutePPREnabled) {
       // We're statically generating with PPR and need to do dynamic tracking
       let dynamicTracking = createDynamicTrackingState(isDebugDynamicAccesses)
@@ -8497,8 +8497,6 @@ async function prerenderToStream(
     if (reactServerPrerenderResult === null) {
       throw err
     }
-    const fallbackReactServerPrerenderResult = reactServerPrerenderResult
-
     let errorType: MetadataErrorType | 'redirect' | undefined
 
     if (isHTTPAccessFallbackError(err)) {
@@ -8528,19 +8526,6 @@ async function prerenderToStream(
       '/_not-found/page'
     )
 
-    const recoveryRevalidate =
-      typeof prerenderStore?.revalidate !== 'undefined'
-        ? prerenderStore.revalidate
-        : INFINITE_CACHE
-    const recoveryExpire =
-      typeof prerenderStore?.expire !== 'undefined'
-        ? prerenderStore.expire
-        : INFINITE_CACHE
-    const recoveryStale =
-      typeof prerenderStore?.stale !== 'undefined'
-        ? prerenderStore.stale
-        : INFINITE_CACHE
-    const recoveryTags = prerenderStore?.tags || implicitTags.tags
     let prerenderHTTPError: PrerenderHTTPErrorState | undefined
     if (cacheComponents && isHTTPAccessFallbackError(err)) {
       const triggeredStatus = getAccessFallbackHTTPStatus(
@@ -8560,11 +8545,98 @@ async function prerenderToStream(
       }
     }
 
-    const renderLegacyErrorResult = async (
-      prerenderLegacyStore: PrerenderStore,
-      errorServerStream: AnyStream,
-      flightResult: ReactServerPrerenderResult
-    ) => {
+    if (cacheComponents) {
+      // Route the recovery render through the Cache Components prerender helper
+      // to prerender with CC semantics. This ensures for example that dynamic
+      // API access in the HTTP fallback boundary (e.g. `useSearchParams()` in
+      // `not-found.tsx`) is observed by the helper's dynamic validation and
+      // surfaces as a blocking-route error rather than the legacy
+      // `BailoutToCSRError`. For recoveries that render the synthetic error
+      // shell from `getErrorRSCPayload` (generic `Error`, `RedirectError`,
+      // `HTTPAccessFallbackError` with no matching boundary, or fall-through
+      // from the segment-scoped recovery below), the helper still runs but no
+      // user code participates in the SSR — `global-error.tsx` is plumbed into
+      // the payload but its `RootErrorBoundary` is never triggered because the
+      // synthetic shell can't throw. We still route synthetic-shell recoveries
+      // through the helper so legacy prerendering is never used when Cache
+      // Components is on.
+      if (prerenderHTTPError) {
+        try {
+          return await prerenderWithCacheComponents(() =>
+            getRSCPayload(tree, ctx, {
+              is404: prerenderHTTPError.triggeredStatus === 404,
+              prerenderHTTPError,
+            })
+          )
+        } catch (recoveryErr) {
+          // If the segment-scoped HTTP fallback recovery throws another
+          // control-flow error (e.g. the matched boundary's subtree re-throws
+          // `notFound()` because the boundary was actually above where the
+          // original notFound() was called), fall through to the generic
+          // synthetic-shell recovery below.
+          if (
+            !isHTTPAccessFallbackError(recoveryErr) &&
+            !isStaticGenBailoutError(recoveryErr) &&
+            !isDynamicServerError(recoveryErr) &&
+            !isBailoutToCSRError(recoveryErr)
+          ) {
+            throw recoveryErr
+          }
+        }
+      }
+
+      return await prerenderWithCacheComponents(() =>
+        getErrorRSCPayload(
+          tree,
+          ctx,
+          reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
+          errorType
+        )
+      )
+    }
+
+    const prerenderLegacyStore: PrerenderStore = {
+      type: 'prerender-legacy',
+      phase: 'render',
+      rootParams,
+      implicitTags: implicitTags,
+      revalidate:
+        typeof prerenderStore?.revalidate !== 'undefined'
+          ? prerenderStore.revalidate
+          : INFINITE_CACHE,
+      expire:
+        typeof prerenderStore?.expire !== 'undefined'
+          ? prerenderStore.expire
+          : INFINITE_CACHE,
+      stale:
+        typeof prerenderStore?.stale !== 'undefined'
+          ? prerenderStore.stale
+          : INFINITE_CACHE,
+      tags: [...(prerenderStore?.tags || implicitTags.tags)],
+    }
+
+    const errorRSCPayload = await workUnitAsyncStorage.run(
+      prerenderLegacyStore,
+      getErrorRSCPayload,
+      tree,
+      ctx,
+      reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
+      errorType
+    )
+
+    const errorServerStream = workUnitAsyncStorage.run(
+      prerenderLegacyStore,
+      renderFlightStream,
+      ComponentMod,
+      errorRSCPayload,
+      clientModules,
+      {
+        filterStackFrame,
+        onError: serverComponentsErrorHandler,
+      }
+    )
+
+    try {
       const { stream: errorHtmlStream } = await workUnitAsyncStorage.run(
         prerenderLegacyStore,
         renderFizzStream,
@@ -8585,7 +8657,9 @@ async function prerenderToStream(
       )
 
       if (shouldGenerateStaticFlightData(workStore)) {
-        const flightData = await streamToBuffer(flightResult.asStream())
+        const flightData = await streamToBuffer(
+          reactServerPrerenderResult.asStream()
+        )
         metadata.flightData = flightData
         await collectSegmentData(
           flightData,
@@ -8597,14 +8671,12 @@ async function prerenderToStream(
         )
       }
 
-      const flightStream = flightResult.consumeAsStream()
-
       return {
         digestErrorsMap: reactServerErrorsByDigest,
         ssrErrors: allCapturedErrors,
         stream: await continueFizzStream(errorHtmlStream, {
           inlinedDataStream: createInlinedDataStream(
-            flightStream,
+            reactServerPrerenderResult.consumeAsStream(),
             nonce,
             formState
           ),
@@ -8626,107 +8698,6 @@ async function prerenderToStream(
         collectedStale: selectStaleTime(prerenderLegacyStore.stale),
         collectedTags: prerenderLegacyStore.tags,
       }
-    }
-
-    if (prerenderHTTPError) {
-      try {
-        const prerenderLegacyStore: PrerenderStore = {
-          type: 'prerender-legacy',
-          phase: 'render',
-          rootParams,
-          implicitTags,
-          revalidate: recoveryRevalidate,
-          expire: recoveryExpire,
-          stale: recoveryStale,
-          tags: [...recoveryTags],
-        }
-        const errorRSCPayload = await workUnitAsyncStorage.run(
-          prerenderLegacyStore,
-          getRSCPayload,
-          tree,
-          ctx,
-          {
-            is404: prerenderHTTPError.triggeredStatus === 404,
-            prerenderHTTPError,
-          }
-        )
-        const errorServerStreamRaw = workUnitAsyncStorage.run(
-          prerenderLegacyStore,
-          renderFlightStream,
-          ComponentMod,
-          errorRSCPayload,
-          clientModules,
-          {
-            filterStackFrame,
-            onError: serverComponentsErrorHandler,
-          }
-        )
-        // Fizz still needs to read the Flight stream to render ErrorApp, but
-        // the prerender path also needs a buffered Flight result for the HTML
-        // prelude and segment data collectors. Tee the stream so each consumer
-        // gets its own copy.
-        const [errorServerStream, flightStream] =
-          teeStream(errorServerStreamRaw)
-        const errorFlightResult =
-          await createReactServerPrerenderResultFromRender(flightStream)
-
-        const result = await renderLegacyErrorResult(
-          prerenderLegacyStore,
-          errorServerStream,
-          errorFlightResult
-        )
-        fallbackReactServerPrerenderResult.consume()
-        return result
-      } catch (recoveryErr: any) {
-        // If the segment-scoped HTTP fallback recovery throws, fall through to
-        // the generic error recovery path.
-        if (
-          !isHTTPAccessFallbackError(recoveryErr) &&
-          !isStaticGenBailoutError(recoveryErr) &&
-          !isDynamicServerError(recoveryErr) &&
-          !isBailoutToCSRError(recoveryErr)
-        ) {
-          throw recoveryErr
-        }
-      }
-    }
-
-    try {
-      const prerenderLegacyStore: PrerenderStore = {
-        type: 'prerender-legacy',
-        phase: 'render',
-        rootParams,
-        implicitTags,
-        revalidate: recoveryRevalidate,
-        expire: recoveryExpire,
-        stale: recoveryStale,
-        tags: [...recoveryTags],
-      }
-      const errorRSCPayload = await workUnitAsyncStorage.run(
-        prerenderLegacyStore,
-        getErrorRSCPayload,
-        tree,
-        ctx,
-        reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
-        errorType
-      )
-      const errorServerStream = workUnitAsyncStorage.run(
-        prerenderLegacyStore,
-        renderFlightStream,
-        ComponentMod,
-        errorRSCPayload,
-        clientModules,
-        {
-          filterStackFrame,
-          onError: serverComponentsErrorHandler,
-        }
-      )
-
-      return await renderLegacyErrorResult(
-        prerenderLegacyStore,
-        errorServerStream,
-        fallbackReactServerPrerenderResult
-      )
     } catch (finalErr: any) {
       if (
         process.env.__NEXT_DEV_SERVER &&

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -7340,7 +7340,8 @@ async function prerenderToStream(
   let prerenderStore: PrerenderStore | null = null
 
   const prerenderWithCacheComponents = async (
-    getPayload: () => Promise<InitialRSCPayload>
+    getPayload: () => Promise<InitialRSCPayload>,
+    validateStaticShell = true
   ): Promise<PrerenderToStreamResult> => {
     /**
      * cacheComponents with PPR
@@ -7917,13 +7918,15 @@ async function prerenderToStream(
     const { prelude, preludeIsEmpty } =
       await processPreludeOp(unprocessedPrelude)
 
-    throwIfDisallowedDynamic(
-      workStore,
-      preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
-      dynamicValidation,
-      serverDynamicTracking,
-      allowEmptyStaticShell
-    )
+    if (validateStaticShell) {
+      throwIfDisallowedDynamic(
+        workStore,
+        preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
+        dynamicValidation,
+        serverDynamicTracking,
+        allowEmptyStaticShell
+      )
+    }
 
     const getServerInsertedHTML = makeGetServerInsertedHTML({
       polyfills,
@@ -8547,26 +8550,28 @@ async function prerenderToStream(
 
     if (cacheComponents) {
       // Route the recovery render through the Cache Components prerender helper
-      // to prerender with CC semantics. This ensures for example that dynamic
-      // API access in the HTTP fallback boundary (e.g. `useSearchParams()` in
-      // `not-found.tsx`) is observed by the helper's dynamic validation and
-      // surfaces as a blocking-route error rather than the legacy
-      // `BailoutToCSRError`. For recoveries that render the synthetic error
-      // shell from `getErrorRSCPayload` (generic `Error`, `RedirectError`,
-      // `HTTPAccessFallbackError` with no matching boundary, or fall-through
-      // from the segment-scoped recovery below), the helper still runs but no
-      // user code participates in the SSR — `global-error.tsx` is plumbed into
-      // the payload but its `RootErrorBoundary` is never triggered because the
-      // synthetic shell can't throw. We still route synthetic-shell recoveries
-      // through the helper so legacy prerendering is never used when Cache
-      // Components is on.
+      // to prerender with CC semantics. Segment-scoped HTTP fallback recovery
+      // intentionally skips static shell validation so fallback UIs that were
+      // previously tolerated do not start failing builds. For recoveries that
+      // render the synthetic error shell from `getErrorRSCPayload` (generic
+      // `Error`, `RedirectError`, `HTTPAccessFallbackError` with no matching
+      // boundary, or fall-through from the segment-scoped recovery below), the
+      // helper still runs but no user code participates in the SSR —
+      // `global-error.tsx` is plumbed into the payload but its
+      // `RootErrorBoundary` is never triggered because the synthetic shell can't
+      // throw. We still route synthetic-shell recoveries through the helper so
+      // legacy prerendering is never used when Cache Components is on.
       if (prerenderHTTPError) {
         try {
-          return await prerenderWithCacheComponents(() =>
-            getRSCPayload(tree, ctx, {
-              is404: prerenderHTTPError.triggeredStatus === 404,
-              prerenderHTTPError,
-            })
+          return await prerenderWithCacheComponents(
+            () =>
+              getRSCPayload(tree, ctx, {
+                is404: prerenderHTTPError.triggeredStatus === 404,
+                prerenderHTTPError,
+              }),
+            // validateStaticShell: false. This recovery render should not turn
+            // fallback UI shell validation into a build failure.
+            false
           )
         } catch (recoveryErr) {
           // If the segment-scoped HTTP fallback recovery throws another
@@ -8574,10 +8579,16 @@ async function prerenderToStream(
           // `notFound()` because the boundary was actually above where the
           // original notFound() was called), fall through to the generic
           // synthetic-shell recovery below.
+          if (isDynamicServerError(recoveryErr)) {
+            throw new InvariantError(
+              'Cache Components HTTP fallback recovery unexpectedly produced a DynamicServerError',
+              { cause: recoveryErr }
+            )
+          }
+
           if (
             !isHTTPAccessFallbackError(recoveryErr) &&
             !isStaticGenBailoutError(recoveryErr) &&
-            !isDynamicServerError(recoveryErr) &&
             !isBailoutToCSRError(recoveryErr)
           ) {
             throw recoveryErr

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -8497,6 +8497,7 @@ async function prerenderToStream(
     if (reactServerPrerenderResult === null) {
       throw err
     }
+    const fallbackReactServerPrerenderResult = reactServerPrerenderResult
 
     let errorType: MetadataErrorType | 'redirect' | undefined
 
@@ -8527,25 +8528,19 @@ async function prerenderToStream(
       '/_not-found/page'
     )
 
-    const prerenderLegacyStore: PrerenderStore = (prerenderStore = {
-      type: 'prerender-legacy',
-      phase: 'render',
-      rootParams,
-      implicitTags: implicitTags,
-      revalidate:
-        typeof prerenderStore?.revalidate !== 'undefined'
-          ? prerenderStore.revalidate
-          : INFINITE_CACHE,
-      expire:
-        typeof prerenderStore?.expire !== 'undefined'
-          ? prerenderStore.expire
-          : INFINITE_CACHE,
-      stale:
-        typeof prerenderStore?.stale !== 'undefined'
-          ? prerenderStore.stale
-          : INFINITE_CACHE,
-      tags: [...(prerenderStore?.tags || implicitTags.tags)],
-    })
+    const recoveryRevalidate =
+      typeof prerenderStore?.revalidate !== 'undefined'
+        ? prerenderStore.revalidate
+        : INFINITE_CACHE
+    const recoveryExpire =
+      typeof prerenderStore?.expire !== 'undefined'
+        ? prerenderStore.expire
+        : INFINITE_CACHE
+    const recoveryStale =
+      typeof prerenderStore?.stale !== 'undefined'
+        ? prerenderStore.stale
+        : INFINITE_CACHE
+    const recoveryTags = prerenderStore?.tags || implicitTags.tags
     let prerenderHTTPError: PrerenderHTTPErrorState | undefined
     if (cacheComponents && isHTTPAccessFallbackError(err)) {
       const triggeredStatus = getAccessFallbackHTTPStatus(
@@ -8565,52 +8560,11 @@ async function prerenderToStream(
       }
     }
 
-    const errorRSCPayload = prerenderHTTPError
-      ? await workUnitAsyncStorage.run(
-          prerenderLegacyStore,
-          getRSCPayload,
-          tree,
-          ctx,
-          {
-            is404: errorType === 'not-found',
-            prerenderHTTPError,
-          }
-        )
-      : await workUnitAsyncStorage.run(
-          prerenderLegacyStore,
-          getErrorRSCPayload,
-          tree,
-          ctx,
-          reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
-          errorType
-        )
-
-    const errorServerStreamRaw = workUnitAsyncStorage.run(
-      prerenderLegacyStore,
-      renderFlightStream,
-      ComponentMod,
-      errorRSCPayload,
-      clientModules,
-      {
-        filterStackFrame,
-        onError: serverComponentsErrorHandler,
-      }
-    )
-
-    let errorServerStream = errorServerStreamRaw
-    const errorFlightResultPromise = prerenderHTTPError
-      ? (() => {
-          // Fizz still needs to read the Flight stream to render ErrorApp, but
-          // the prerender path also needs a buffered Flight result for the HTML
-          // prelude and segment data collectors. Tee the stream so each consumer
-          // gets its own copy.
-          const [appStream, flightStream] = teeStream(errorServerStreamRaw)
-          errorServerStream = appStream
-          return createReactServerPrerenderResultFromRender(flightStream)
-        })()
-      : null
-
-    try {
+    const renderLegacyErrorResult = async (
+      prerenderLegacyStore: PrerenderStore,
+      errorServerStream: AnyStream,
+      flightResult: ReactServerPrerenderResult
+    ) => {
       const { stream: errorHtmlStream } = await workUnitAsyncStorage.run(
         prerenderLegacyStore,
         renderFizzStream,
@@ -8630,15 +8584,8 @@ async function prerenderToStream(
         { waitForAllReady: true }
       )
 
-      const resolvedFlightResult = errorFlightResultPromise
-        ? await errorFlightResultPromise
-        : reactServerPrerenderResult
-      if (errorFlightResultPromise) {
-        reactServerPrerenderResult.consume()
-      }
-
       if (shouldGenerateStaticFlightData(workStore)) {
-        const flightData = await streamToBuffer(resolvedFlightResult.asStream())
+        const flightData = await streamToBuffer(flightResult.asStream())
         metadata.flightData = flightData
         await collectSegmentData(
           flightData,
@@ -8650,7 +8597,7 @@ async function prerenderToStream(
         )
       }
 
-      const flightStream = resolvedFlightResult.consumeAsStream()
+      const flightStream = flightResult.consumeAsStream()
 
       return {
         digestErrorsMap: reactServerErrorsByDigest,
@@ -8674,15 +8621,112 @@ async function prerenderToStream(
           deploymentId: ctx.sharedContext.deploymentId,
         }),
         dynamicAccess: null,
-        collectedRevalidate:
-          prerenderStore !== null ? prerenderStore.revalidate : INFINITE_CACHE,
-        collectedExpire:
-          prerenderStore !== null ? prerenderStore.expire : INFINITE_CACHE,
-        collectedStale: selectStaleTime(
-          prerenderStore !== null ? prerenderStore.stale : INFINITE_CACHE
-        ),
-        collectedTags: prerenderStore !== null ? prerenderStore.tags : null,
+        collectedRevalidate: prerenderLegacyStore.revalidate,
+        collectedExpire: prerenderLegacyStore.expire,
+        collectedStale: selectStaleTime(prerenderLegacyStore.stale),
+        collectedTags: prerenderLegacyStore.tags,
       }
+    }
+
+    if (prerenderHTTPError) {
+      try {
+        const prerenderLegacyStore: PrerenderStore = {
+          type: 'prerender-legacy',
+          phase: 'render',
+          rootParams,
+          implicitTags,
+          revalidate: recoveryRevalidate,
+          expire: recoveryExpire,
+          stale: recoveryStale,
+          tags: [...recoveryTags],
+        }
+        const errorRSCPayload = await workUnitAsyncStorage.run(
+          prerenderLegacyStore,
+          getRSCPayload,
+          tree,
+          ctx,
+          {
+            is404: prerenderHTTPError.triggeredStatus === 404,
+            prerenderHTTPError,
+          }
+        )
+        const errorServerStreamRaw = workUnitAsyncStorage.run(
+          prerenderLegacyStore,
+          renderFlightStream,
+          ComponentMod,
+          errorRSCPayload,
+          clientModules,
+          {
+            filterStackFrame,
+            onError: serverComponentsErrorHandler,
+          }
+        )
+        // Fizz still needs to read the Flight stream to render ErrorApp, but
+        // the prerender path also needs a buffered Flight result for the HTML
+        // prelude and segment data collectors. Tee the stream so each consumer
+        // gets its own copy.
+        const [errorServerStream, flightStream] =
+          teeStream(errorServerStreamRaw)
+        const errorFlightResult =
+          await createReactServerPrerenderResultFromRender(flightStream)
+
+        const result = await renderLegacyErrorResult(
+          prerenderLegacyStore,
+          errorServerStream,
+          errorFlightResult
+        )
+        fallbackReactServerPrerenderResult.consume()
+        return result
+      } catch (recoveryErr: any) {
+        // If the segment-scoped HTTP fallback recovery throws, fall through to
+        // the generic error recovery path.
+        if (
+          !isHTTPAccessFallbackError(recoveryErr) &&
+          !isStaticGenBailoutError(recoveryErr) &&
+          !isDynamicServerError(recoveryErr) &&
+          !isBailoutToCSRError(recoveryErr)
+        ) {
+          throw recoveryErr
+        }
+      }
+    }
+
+    try {
+      const prerenderLegacyStore: PrerenderStore = {
+        type: 'prerender-legacy',
+        phase: 'render',
+        rootParams,
+        implicitTags,
+        revalidate: recoveryRevalidate,
+        expire: recoveryExpire,
+        stale: recoveryStale,
+        tags: [...recoveryTags],
+      }
+      const errorRSCPayload = await workUnitAsyncStorage.run(
+        prerenderLegacyStore,
+        getErrorRSCPayload,
+        tree,
+        ctx,
+        reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
+        errorType
+      )
+      const errorServerStream = workUnitAsyncStorage.run(
+        prerenderLegacyStore,
+        renderFlightStream,
+        ComponentMod,
+        errorRSCPayload,
+        clientModules,
+        {
+          filterStackFrame,
+          onError: serverComponentsErrorHandler,
+        }
+      )
+
+      return await renderLegacyErrorResult(
+        prerenderLegacyStore,
+        errorServerStream,
+        fallbackReactServerPrerenderResult
+      )
     } catch (finalErr: any) {
       if (
         process.env.__NEXT_DEV_SERVER &&

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -118,11 +118,7 @@ import {
   walkTreeWithFlightRouterState,
   createFullTreeFlightDataForNavigation,
 } from './walk-tree-with-flight-router-state'
-import {
-  createComponentTree,
-  getRootParams,
-  type PrerenderHTTPErrorState,
-} from './create-component-tree'
+import { createComponentTree, getRootParams } from './create-component-tree'
 import { getAssetQueryString } from './get-asset-query-string'
 import {
   getClientReferenceManifest,
@@ -529,54 +525,6 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
       : { 'global-error': components['global-error'] },
     null, // staticSiblings
   ]
-}
-
-type HTTPAccessErrorStatusCode = 404 | 403 | 401
-
-function hasPrerenderHTTPErrorBoundary(
-  loaderTree: LoaderTree,
-  triggeredStatus: HTTPAccessErrorStatusCode,
-  authInterrupts: boolean
-): boolean {
-  switch (triggeredStatus) {
-    case 404:
-      return !!loaderTree[2]['not-found']
-    case 403:
-      return authInterrupts && !!loaderTree[2].forbidden
-    case 401:
-      return authInterrupts && !!loaderTree[2].unauthorized
-    default:
-      return false
-  }
-}
-
-function findPrerenderHTTPErrorBoundaryTree(
-  loaderTree: LoaderTree,
-  triggeredStatus: HTTPAccessErrorStatusCode,
-  authInterrupts: boolean
-): LoaderTree | null {
-  let boundaryTree: LoaderTree | null = hasPrerenderHTTPErrorBoundary(
-    loaderTree,
-    triggeredStatus,
-    authInterrupts
-  )
-    ? loaderTree
-    : null
-
-  const childrenTree = loaderTree[1].children
-  if (childrenTree) {
-    const deeperBoundaryTree = findPrerenderHTTPErrorBoundaryTree(
-      childrenTree,
-      triggeredStatus,
-      authInterrupts
-    )
-
-    if (deeperBoundaryTree) {
-      boundaryTree = deeperBoundaryTree
-    }
-  }
-
-  return boundaryTree
 }
 
 /**
@@ -2112,9 +2060,6 @@ async function getRSCPayload(
   ctx: AppRenderContext,
   options: {
     is404: boolean
-    // When set, rerender a segment-scoped HTTP fallback inside the normal app
-    // router tree instead of falling back to the generic error shell payload.
-    prerenderHTTPError?: PrerenderHTTPErrorState
     staleTimeIterable?: AsyncIterable<number>
     staticStageByteLengthPromise?: Promise<number>
     runtimePrefetchStream?: ReadableStream<Uint8Array>
@@ -2122,7 +2067,6 @@ async function getRSCPayload(
 ): Promise<InitialRSCPayload & { P: ReactNode }> {
   const {
     is404,
-    prerenderHTTPError,
     staleTimeIterable,
     staticStageByteLengthPromise,
     runtimePrefetchStream,
@@ -2197,7 +2141,6 @@ async function getRSCPayload(
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
     MetadataOutlet,
-    prerenderHTTPError,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -7170,11 +7113,81 @@ type PrerenderToStreamResult = {
 /**
  * Determines whether we should generate static flight data.
  */
+// TODO: This helper used to exclude fallback route params. It now only checks
+// static generation inside prerenderToStream and can be removed. LOE: low.
 function shouldGenerateStaticFlightData(workStore: WorkStore): boolean {
   const { isStaticGeneration } = workStore
   if (!isStaticGeneration) return false
 
   return true
+}
+
+async function continueStaticPrerenderWithInlinedData(
+  htmlStream: AnyStream,
+  reactServerResult: ReactServerPrerenderResult,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null,
+  createInlinedDataStream: typeof createWebInlinedDataStream,
+  formState: unknown | null,
+  nonce: string | undefined,
+  getServerInsertedHTML: () => Promise<string>,
+  getServerInsertedMetadata: () => Promise<string>,
+  deploymentId: string | undefined,
+  ComponentMod: AppPageModule,
+  renderFlightStream: typeof renderToWebFlightStream,
+  clientModules: Parameters<typeof renderToWebFlightStream>[2],
+  filterStackFrameForError: typeof filterStackFrame,
+  serverComponentsErrorHandler: (err: unknown) => string | undefined
+): Promise<AnyStream> {
+  const hasFallbackRouteParams =
+    fallbackRouteParams && fallbackRouteParams.size > 0
+  if (hasFallbackRouteParams) {
+    // This is a "static fallback" prerender: although the page didn't
+    // access any runtime params in a Server Component, it may have
+    // accessed a runtime param in a client segment.
+    //
+    // TODO: If there were no client segments, we can use the fully static
+    // path instead.
+    //
+    // Rather than use a dynamic server resume to fill in the params,
+    // we can rely on the client to parse the params from the URL and use
+    // that to hydrate the page.
+    //
+    // Send an empty InitialRSCPayload to the server component renderer
+    // The data will be fetched by the client instead.
+    // TODO: In the future, rather than defer the entire hydration payload
+    // to be fetched by the client, we should only defer the client
+    // segments, since those are the only ones whose data is not complete.
+    const emptyReactServerResult =
+      await createReactServerPrerenderResultFromRender(
+        renderFlightStream(ComponentMod, [], clientModules, {
+          filterStackFrame: filterStackFrameForError,
+          onError: serverComponentsErrorHandler,
+        })
+      )
+    const inlinedDataStream = createInlinedDataStream(
+      emptyReactServerResult.consumeAsStream(),
+      nonce,
+      formState
+    )
+    return continueStaticFallbackPrerender(htmlStream, {
+      inlinedDataStream,
+      getServerInsertedHTML,
+      getServerInsertedMetadata,
+      deploymentId,
+    })
+  }
+
+  const inlinedDataStream = createInlinedDataStream(
+    reactServerResult.consumeAsStream(),
+    nonce,
+    formState
+  )
+  return continueStaticPrerender(htmlStream, {
+    inlinedDataStream,
+    getServerInsertedHTML,
+    getServerInsertedMetadata,
+    deploymentId,
+  })
 }
 
 async function prerenderToStream(
@@ -7314,6 +7327,10 @@ async function prerenderToStream(
   )
 
   let reactServerPrerenderResult: null | ReactServerPrerenderResult = null
+  let reactServerPrerenderResultIsDynamic: null | boolean = null
+  let reactServerPrerenderResumeDataCache: null | PrerenderResumeDataCache =
+    null
+  let reactServerPrerenderStore: null | PrerenderStore = null
   const setMetadataHeader = (name: string) => {
     metadata.headers ??= {}
     metadata.headers[name] = res.getHeader(name)
@@ -7339,229 +7356,75 @@ async function prerenderToStream(
 
   let prerenderStore: PrerenderStore | null = null
 
-  const prerenderWithCacheComponents = async (
-    getPayload: () => Promise<InitialRSCPayload>,
-    validateStaticShell = true
-  ): Promise<PrerenderToStreamResult> => {
-    /**
-     * cacheComponents with PPR
-     *
-     * The general approach is to render the RSC stream first allowing any cache reads to resolve.
-     * Once we have settled all cache reads we restart the render and abort after a single Task.
-     *
-     * Unlike with the non PPR case we can't synchronously abort the render when a dynamic API is used
-     * during the initial render because we need to ensure all caches can be filled as part of the initial Task
-     * and a synchronous abort might prevent us from filling all caches.
-     *
-     * Once the render is complete we allow the SSR render to finish and use a combination of the postponed state
-     * and the reactServerIsDynamic value to determine how to treat the resulting render
-     */
+  try {
+    if (cacheComponents) {
+      /**
+       * cacheComponents with PPR
+       *
+       * The general approach is to render the RSC stream first allowing any cache reads to resolve.
+       * Once we have settled all cache reads we restart the render and abort after a single Task.
+       *
+       * Unlike with the non PPR case we can't synchronously abort the render when a dynamic API is used
+       * during the initial render because we need to ensure all caches can be filled as part of the initial Task
+       * and a synchronous abort might prevent us from filling all caches.
+       *
+       * Once the render is complete we allow the SSR render to finish and use a combination of the postponed state
+       * and the reactServerIsDynamic value to determine how to treat the resulting render
+       */
 
-    // The prerender controller represents the lifetime of the prerender. It
-    // will be aborted when a task is complete or a synchronously aborting API
-    // is called. Notably, during prospective prerenders, this does not
-    // actually terminate the prerender itself, which will continue until all
-    // caches are filled.
-    const initialServerPrerenderController = new AbortController()
+      // The prerender controller represents the lifetime of the prerender. It
+      // will be aborted when a task is complete or a synchronously aborting API
+      // is called. Notably, during prospective prerenders, this does not
+      // actually terminate the prerender itself, which will continue until all
+      // caches are filled.
+      const initialServerPrerenderController = new AbortController()
 
-    // This controller is used to abort the React prerender.
-    const initialServerReactController = new AbortController()
+      // This controller is used to abort the React prerender.
+      const initialServerReactController = new AbortController()
 
-    // This controller represents the lifetime of the React prerender. Its
-    // signal can be used for any I/O operation to abort the I/O and/or to
-    // reject, when prerendering aborts. This includes our own hanging
-    // promises for accessing request data, and for fetch calls. It might be
-    // replaced in the future by React.cacheSignal(). It's aborted after the
-    // React controller, so that no pending I/O can register abort listeners
-    // that are called before React's abort listener is called. This ensures
-    // that pending I/O is not rejected too early when aborting the prerender.
-    // Notably, during the prospective prerender, it is different from the
-    // prerender controller because we don't want to end the React prerender
-    // until all caches are filled.
-    const initialServerRenderController = new AbortController()
+      // This controller represents the lifetime of the React prerender. Its
+      // signal can be used for any I/O operation to abort the I/O and/or to
+      // reject, when prerendering aborts. This includes our own hanging
+      // promises for accessing request data, and for fetch calls. It might be
+      // replaced in the future by React.cacheSignal(). It's aborted after the
+      // React controller, so that no pending I/O can register abort listeners
+      // that are called before React's abort listener is called. This ensures
+      // that pending I/O is not rejected too early when aborting the prerender.
+      // Notably, during the prospective prerender, it is different from the
+      // prerender controller because we don't want to end the React prerender
+      // until all caches are filled.
+      const initialServerRenderController = new AbortController()
 
-    // The cacheSignal helps us track whether caches are still filling or we are ready
-    // to cut the render off.
-    const cacheSignal = new CacheSignal()
+      // The cacheSignal helps us track whether caches are still filling or we are ready
+      // to cut the render off.
+      const cacheSignal = new CacheSignal()
 
-    // Always start with a fresh prerender RDC so warmup can fill misses,
-    // even when we have a prefilled render RDC to seed from.
-    const prerenderResumeDataCache = createPrerenderResumeDataCache()
-    let renderResumeDataCache: RenderResumeDataCache | null =
-      renderOpts.renderResumeDataCache ?? null
+      // Always start with a fresh prerender RDC so warmup can fill misses,
+      // even when we have a prefilled render RDC to seed from.
+      const prerenderResumeDataCache = createPrerenderResumeDataCache()
+      reactServerPrerenderResultIsDynamic = null
+      reactServerPrerenderResumeDataCache = prerenderResumeDataCache
+      reactServerPrerenderStore = null
+      let renderResumeDataCache: RenderResumeDataCache | null =
+        renderOpts.renderResumeDataCache ?? null
 
-    const initialServerPayloadPrerenderStore: PrerenderStore = {
-      type: 'prerender',
-      phase: 'render',
-      rootParams,
-      fallbackRouteParams,
-      implicitTags,
-      // While this render signal isn't going to be used to abort a React render while getting the RSC payload
-      // various request data APIs bind to this controller to reject after completion.
-      renderSignal: initialServerRenderController.signal,
-      // When we generate the RSC payload we might abort this controller due to sync IO
-      // but we don't actually care about sync IO in this phase so we use a throw away controller
-      // that isn't connected to anything
-      controller: new AbortController(),
-      // During the initial prerender we need to track all cache reads to ensure
-      // we render long enough to fill every cache it is possible to visit during
-      // the final prerender.
-      cacheSignal,
-      dynamicTracking: null,
-      allowEmptyStaticShell,
-      revalidate: INFINITE_CACHE,
-      expire: INFINITE_CACHE,
-      stale: INFINITE_CACHE,
-      tags: [...implicitTags.tags],
-      prerenderResumeDataCache,
-      renderResumeDataCache,
-      hmrRefreshHash: undefined,
-      // We don't track vary params during initial prerender, only the final one
-      varyParamsAccumulator: null,
-    }
-
-    // We're not going to use the result of this render because the only time it could be used
-    // is if it completes in a microtask and that's likely very rare for any non-trivial app
-    const initialServerPayload = await workUnitAsyncStorage.run(
-      initialServerPayloadPrerenderStore,
-      getPayload
-    )
-
-    const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
-      type: 'prerender',
-      phase: 'render',
-      rootParams,
-      fallbackRouteParams,
-      implicitTags,
-      renderSignal: initialServerRenderController.signal,
-      controller: initialServerPrerenderController,
-      // During the initial prerender we need to track all cache reads to ensure
-      // we render long enough to fill every cache it is possible to visit during
-      // the final prerender.
-      cacheSignal,
-      dynamicTracking: null,
-      allowEmptyStaticShell,
-      revalidate: INFINITE_CACHE,
-      expire: INFINITE_CACHE,
-      stale: INFINITE_CACHE,
-      tags: [...implicitTags.tags],
-      prerenderResumeDataCache,
-      renderResumeDataCache,
-      hmrRefreshHash: undefined,
-      // We don't track vary params during initial prerender, only the final one
-      varyParamsAccumulator: null,
-    })
-
-    const initialPrerenderOptions = {
-      filterStackFrame,
-      onError: (err: unknown) => {
-        const digest = getDigestForWellKnownError(err)
-
-        if (digest) {
-          return digest
-        }
-
-        if (isReactLargeShellError(err)) {
-          // TODO: Aggregate
-          console.error(err)
-          return undefined
-        }
-
-        if (initialServerPrerenderController.signal.aborted) {
-          // The render aborted before this error was handled which indicates
-          // the error is caused by unfinished components within the render
-          return
-        } else if (
-          process.env.NEXT_DEBUG_BUILD ||
-          process.env.__NEXT_VERBOSE_LOGGING
-        ) {
-          printDebugThrownValueForProspectiveRender(
-            err,
-            workStore.route,
-            Phase.ProspectiveRender
-          )
-        }
-      },
-      // We don't want to stop rendering until the cacheSignal is complete so we pass
-      // a different signal to this render call than is used by dynamic APIs to signify
-      // transitioning out of the prerender environment
-      signal: initialServerReactController.signal,
-    }
-
-    const pendingInitialServerResult = workUnitAsyncStorage.run(
-      initialServerPrerenderStore,
-      getServerPrerender(ComponentMod),
-      initialServerPayload,
-      clientModules,
-      initialPrerenderOptions
-    )
-
-    // The listener to abort our own render controller must be added after
-    // React has added its listener, to ensure that pending I/O is not
-    // aborted/rejected too early.
-    initialServerReactController.signal.addEventListener(
-      'abort',
-      () => {
-        initialServerRenderController.abort()
-        initialServerPrerenderController.abort()
-      },
-      { once: true }
-    )
-
-    // Wait for all caches to be finished filling and for async imports to resolve
-    trackPendingModules(cacheSignal)
-    await cacheSignal.cacheReady()
-
-    initialServerReactController.abort()
-
-    // We don't need to continue the prerender process if we already
-    // detected invalid dynamic usage in the initial prerender phase.
-    if (workStore.invalidDynamicUsageError) {
-      logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
-      throw new StaticGenBailoutError()
-    }
-
-    let initialServerResult
-    try {
-      initialServerResult = await createReactServerPrerenderResult(
-        pendingInitialServerResult
-      )
-    } catch (err) {
-      if (
-        initialServerReactController.signal.aborted ||
-        initialServerPrerenderController.signal.aborted
-      ) {
-        // These are expected errors that might error the prerender. we ignore them.
-      } else if (
-        process.env.NEXT_DEBUG_BUILD ||
-        process.env.__NEXT_VERBOSE_LOGGING
-      ) {
-        // We don't normally log these errors because we are going to retry anyway but
-        // it can be useful for debugging Next.js itself to get visibility here when needed
-        printDebugThrownValueForProspectiveRender(
-          err,
-          workStore.route,
-          Phase.ProspectiveRender
-        )
-      }
-    }
-
-    if (initialServerResult) {
-      const initialClientPrerenderController = new AbortController()
-      const initialClientReactController = new AbortController()
-      const initialClientRenderController = new AbortController()
-
-      const initialClientPrerenderStore: PrerenderStore = {
-        type: 'prerender-client',
+      const initialServerPayloadPrerenderStore: PrerenderStore = {
+        type: 'prerender',
         phase: 'render',
         rootParams,
         fallbackRouteParams,
         implicitTags,
-        renderSignal: initialClientRenderController.signal,
-        controller: initialClientPrerenderController,
-        // For HTML Generation the only cache tracked activity
-        // is module loading, which has it's own cache signal
-        cacheSignal: null,
+        // While this render signal isn't going to be used to abort a React render while getting the RSC payload
+        // various request data APIs bind to this controller to reject after completion.
+        renderSignal: initialServerRenderController.signal,
+        // When we generate the RSC payload we might abort this controller due to sync IO
+        // but we don't actually care about sync IO in this phase so we use a throw away controller
+        // that isn't connected to anything
+        controller: new AbortController(),
+        // During the initial prerender we need to track all cache reads to ensure
+        // we render long enough to fill every cache it is possible to visit during
+        // the final prerender.
+        cacheSignal,
         dynamicTracking: null,
         allowEmptyStaticShell,
         revalidate: INFINITE_CACHE,
@@ -7571,72 +7434,123 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        // Client prerenders don't track server param access
+        // We don't track vary params during initial prerender, only the final one
         varyParamsAccumulator: null,
       }
 
-      const pendingInitialClientResult = workUnitAsyncStorage.run(
-        initialClientPrerenderStore,
-        getClientPrerender,
-        // eslint-disable-next-line @next/internal/no-ambiguous-jsx
-        <App
-          reactServerStream={initialServerResult.asUnclosingStream()}
-          reactDebugStream={undefined}
-          debugEndTime={undefined}
-          preinitScripts={preinitScripts}
-          ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
-          nonce={nonce}
-          images={ctx.renderOpts.images}
-        />,
-        {
-          signal: initialClientReactController.signal,
-          onError: (err: unknown) => {
-            const digest = getDigestForWellKnownError(err)
+      // We're not going to use the result of this render because the only time it could be used
+      // is if it completes in a microtask and that's likely very rare for any non-trivial app
+      const initialServerPayload = await workUnitAsyncStorage.run(
+        initialServerPayloadPrerenderStore,
+        getRSCPayload,
+        tree,
+        ctx,
+        { is404: res.statusCode === 404 }
+      )
 
-            if (digest) {
-              return digest
-            }
+      const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
+        type: 'prerender',
+        phase: 'render',
+        rootParams,
+        fallbackRouteParams,
+        implicitTags,
+        renderSignal: initialServerRenderController.signal,
+        controller: initialServerPrerenderController,
+        // During the initial prerender we need to track all cache reads to ensure
+        // we render long enough to fill every cache it is possible to visit during
+        // the final prerender.
+        cacheSignal,
+        dynamicTracking: null,
+        allowEmptyStaticShell,
+        revalidate: INFINITE_CACHE,
+        expire: INFINITE_CACHE,
+        stale: INFINITE_CACHE,
+        tags: [...implicitTags.tags],
+        prerenderResumeDataCache,
+        renderResumeDataCache,
+        hmrRefreshHash: undefined,
+        // We don't track vary params during initial prerender, only the final one
+        varyParamsAccumulator: null,
+      })
 
-            if (isReactLargeShellError(err)) {
-              // TODO: Aggregate
-              console.error(err)
-              return undefined
-            }
+      const initialPrerenderOptions = {
+        filterStackFrame,
+        onError: (err: unknown) => {
+          const digest = getDigestForWellKnownError(err)
 
-            if (initialClientReactController.signal.aborted) {
-              // These are expected errors that might error the prerender. we ignore them.
-            } else if (
-              process.env.NEXT_DEBUG_BUILD ||
-              process.env.__NEXT_VERBOSE_LOGGING
-            ) {
-              // We don't normally log these errors because we are going to retry anyway but
-              // it can be useful for debugging Next.js itself to get visibility here when needed
-              printDebugThrownValueForProspectiveRender(
-                err,
-                workStore.route,
-                Phase.ProspectiveRender
-              )
-            }
-          },
-          bootstrapScripts: [bootstrapScript],
-        }
+          if (digest) {
+            return digest
+          }
+
+          if (isReactLargeShellError(err)) {
+            // TODO: Aggregate
+            console.error(err)
+            return undefined
+          }
+
+          if (initialServerPrerenderController.signal.aborted) {
+            // The render aborted before this error was handled which indicates
+            // the error is caused by unfinished components within the render
+            return
+          } else if (
+            process.env.NEXT_DEBUG_BUILD ||
+            process.env.__NEXT_VERBOSE_LOGGING
+          ) {
+            printDebugThrownValueForProspectiveRender(
+              err,
+              workStore.route,
+              Phase.ProspectiveRender
+            )
+          }
+        },
+        // We don't want to stop rendering until the cacheSignal is complete so we pass
+        // a different signal to this render call than is used by dynamic APIs to signify
+        // transitioning out of the prerender environment
+        signal: initialServerReactController.signal,
+      }
+
+      const pendingInitialServerResult = workUnitAsyncStorage.run(
+        initialServerPrerenderStore,
+        getServerPrerender(ComponentMod),
+        initialServerPayload,
+        clientModules,
+        initialPrerenderOptions
       )
 
       // The listener to abort our own render controller must be added after
       // React has added its listener, to ensure that pending I/O is not
       // aborted/rejected too early.
-      initialClientReactController.signal.addEventListener(
+      initialServerReactController.signal.addEventListener(
         'abort',
         () => {
-          initialClientRenderController.abort()
+          initialServerRenderController.abort()
+          initialServerPrerenderController.abort()
         },
         { once: true }
       )
 
-      pendingInitialClientResult.catch((err: unknown) => {
+      // Wait for all caches to be finished filling and for async imports to resolve
+      trackPendingModules(cacheSignal)
+      await cacheSignal.cacheReady()
+
+      initialServerReactController.abort()
+
+      // We don't need to continue the prerender process if we already
+      // detected invalid dynamic usage in the initial prerender phase.
+      if (workStore.invalidDynamicUsageError) {
+        logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
+        throw new StaticGenBailoutError()
+      }
+
+      let initialServerResult
+      try {
+        initialServerResult = await createReactServerPrerenderResult(
+          pendingInitialServerResult
+        )
+      } catch (err) {
         if (
-          initialClientReactController.signal.aborted ||
-          isPrerenderInterruptedError(err)
+          initialServerReactController.signal.aborted ||
+          initialServerPrerenderController.signal.aborted
         ) {
           // These are expected errors that might error the prerender. we ignore them.
         } else if (
@@ -7651,217 +7565,43 @@ async function prerenderToStream(
             Phase.ProspectiveRender
           )
         }
-      })
-
-      // This is mostly needed for dynamic `import()`s in client components.
-      // Promises passed to client were already awaited above (assuming that they came from cached functions)
-      trackPendingModules(cacheSignal)
-      await cacheSignal.cacheReady()
-      initialClientReactController.abort()
-    }
-
-    if (renderOpts.renderResumeDataCache) {
-      // Swap to the warmed cache so the final render uses entries produced during warmup.
-      renderResumeDataCache = createRenderResumeDataCache(
-        prerenderResumeDataCache
-      )
-    }
-
-    const finalServerReactController = new AbortController()
-    const finalServerRenderController = new AbortController()
-
-    const varyParamsAccumulator = createResponseVaryParamsAccumulator()
-
-    const finalServerPayloadPrerenderStore: PrerenderStore = {
-      type: 'prerender',
-      phase: 'render',
-      rootParams,
-      fallbackRouteParams,
-      implicitTags,
-      // While this render signal isn't going to be used to abort a React render while getting the RSC payload
-      // various request data APIs bind to this controller to reject after completion.
-      renderSignal: finalServerRenderController.signal,
-      // When we generate the RSC payload we might abort this controller due to sync IO
-      // but we don't actually care about sync IO in this phase so we use a throw away controller
-      // that isn't connected to anything
-      controller: new AbortController(),
-      // All caches we could read must already be filled so no tracking is necessary
-      cacheSignal: null,
-      dynamicTracking: null,
-      allowEmptyStaticShell,
-      revalidate: INFINITE_CACHE,
-      expire: INFINITE_CACHE,
-      stale: INFINITE_CACHE,
-      tags: [...implicitTags.tags],
-      prerenderResumeDataCache,
-      renderResumeDataCache,
-      hmrRefreshHash: undefined,
-      varyParamsAccumulator,
-    }
-
-    const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
-      finalServerPayloadPrerenderStore,
-      getPayload
-    )
-
-    let staleTimeIterable: StaleTimeIterable | undefined
-    if (cachedNavigations) {
-      staleTimeIterable = new StaleTimeIterable()
-      finalAttemptRSCPayload.s = staleTimeIterable
-    }
-
-    const serverDynamicTracking = createDynamicTrackingState(
-      isDebugDynamicAccesses
-    )
-    let serverIsDynamic = false
-
-    const finalServerPrerenderStore: PrerenderStore = (prerenderStore = {
-      type: 'prerender',
-      phase: 'render',
-      rootParams,
-      fallbackRouteParams,
-      implicitTags,
-      renderSignal: finalServerRenderController.signal,
-      controller: finalServerReactController,
-      // All caches we could read must already be filled so no tracking is necessary
-      cacheSignal: null,
-      dynamicTracking: serverDynamicTracking,
-      allowEmptyStaticShell,
-      revalidate: INFINITE_CACHE,
-      expire: INFINITE_CACHE,
-      stale: INFINITE_CACHE,
-      tags: [...implicitTags.tags],
-      prerenderResumeDataCache,
-      renderResumeDataCache,
-      hmrRefreshHash: undefined,
-      varyParamsAccumulator,
-    })
-
-    if (staleTimeIterable !== undefined) {
-      trackStaleTime(
-        finalServerPrerenderStore,
-        staleTimeIterable,
-        selectStaleTime
-      )
-    }
-
-    let prerenderIsPending = true
-    const finalRSCPrerenderOptions = {
-      filterStackFrame,
-      onError: (err: unknown) => {
-        return serverComponentsErrorHandler(err)
-      },
-      signal: finalServerReactController.signal,
-    }
-    const finalRSCAbortCallback = async () => {
-      // Now that the prerendering is complete, we know the final stale
-      // time and vary params. Close the stale time iterable and resolve
-      // the vary params thenable so Flight can serialize their values
-      // into the stream. The timing here is important: both were
-      // included in the Flight payload, but they can only be serialized
-      // at the very end, after all the components have finished.
-      //
-      // We resolve these directly here instead of reading from the work
-      // unit store because this callback runs in a separate task (via
-      // setTimeout) and may not have access to the async storage context.
-      const pendingFinishes: Promise<void>[] = [
-        finishAccumulatingVaryParams(varyParamsAccumulator),
-      ]
-      if (staleTimeIterable !== undefined) {
-        pendingFinishes.push(finishStaleTimeTracking(staleTimeIterable))
-      }
-      await Promise.all(pendingFinishes)
-
-      if (finalServerReactController.signal.aborted) {
-        // If the server controller is already aborted we must have called something
-        // that required aborting the prerender synchronously such as with new Date()
-        serverIsDynamic = true
-        return
       }
 
-      if (prerenderIsPending) {
-        // If prerenderIsPending then we have blocked for longer than a Task and we assume
-        // there is something unfinished.
-        serverIsDynamic = true
-      }
+      if (initialServerResult) {
+        const initialClientPrerenderController = new AbortController()
+        const initialClientReactController = new AbortController()
+        const initialClientRenderController = new AbortController()
 
-      finalServerReactController.abort()
-    }
-    const finalRSCPrerenderFn = async () => {
-      const pendingPrerenderResult = workUnitAsyncStorage.run(
-        // The store to scope
-        finalServerPrerenderStore,
-        // The function to run
-        getServerPrerender(ComponentMod),
-        // ... the arguments for the function to run
-        finalAttemptRSCPayload,
-        clientModules,
-        finalRSCPrerenderOptions
-      )
+        const initialClientPrerenderStore: PrerenderStore = {
+          type: 'prerender-client',
+          phase: 'render',
+          rootParams,
+          fallbackRouteParams,
+          implicitTags,
+          renderSignal: initialClientRenderController.signal,
+          controller: initialClientPrerenderController,
+          // For HTML Generation the only cache tracked activity
+          // is module loading, which has it's own cache signal
+          cacheSignal: null,
+          dynamicTracking: null,
+          allowEmptyStaticShell,
+          revalidate: INFINITE_CACHE,
+          expire: INFINITE_CACHE,
+          stale: INFINITE_CACHE,
+          tags: [...implicitTags.tags],
+          prerenderResumeDataCache,
+          renderResumeDataCache,
+          hmrRefreshHash: undefined,
+          // Client prerenders don't track server param access
+          varyParamsAccumulator: null,
+        }
 
-      // The listener to abort our own render controller must be added
-      // after React has added its listener, to ensure that pending I/O
-      // is not aborted/rejected too early.
-      finalServerReactController.signal.addEventListener(
-        'abort',
-        () => {
-          finalServerRenderController.abort()
-        },
-        { once: true }
-      )
-
-      const prerenderResult = await pendingPrerenderResult
-      prerenderIsPending = false
-
-      return prerenderResult
-    }
-    const reactServerResult = (reactServerPrerenderResult =
-      await createReactServerPrerenderResult(
-        runInSequentialTasks(finalRSCPrerenderFn, finalRSCAbortCallback)
-      ))
-
-    const clientDynamicTracking = createDynamicTrackingState(
-      isDebugDynamicAccesses
-    )
-
-    const finalClientReactController = new AbortController()
-    const finalClientRenderController = new AbortController()
-
-    const finalClientPrerenderStore: PrerenderStore = {
-      type: 'prerender-client',
-      phase: 'render',
-      rootParams,
-      fallbackRouteParams,
-      implicitTags,
-      renderSignal: finalClientRenderController.signal,
-      controller: finalClientReactController,
-      // No APIs require a cacheSignal through the workUnitStore during the HTML prerender
-      cacheSignal: null,
-      dynamicTracking: clientDynamicTracking,
-      allowEmptyStaticShell,
-      revalidate: INFINITE_CACHE,
-      expire: INFINITE_CACHE,
-      stale: INFINITE_CACHE,
-      tags: [...implicitTags.tags],
-      prerenderResumeDataCache,
-      renderResumeDataCache,
-      hmrRefreshHash: undefined,
-      // Client prerenders don't track server param access
-      varyParamsAccumulator: null,
-    }
-
-    let dynamicValidation = createDynamicValidationState()
-
-    const finalClientOnHeaders = createOnHeadersCallback(appendHeader)
-
-    let { prelude: unprocessedPrelude, postponed } = await runInSequentialTasks(
-      () => {
-        const pendingFinalClientResult = workUnitAsyncStorage.run(
-          finalClientPrerenderStore,
+        const pendingInitialClientResult = workUnitAsyncStorage.run(
+          initialClientPrerenderStore,
           getClientPrerender,
           // eslint-disable-next-line @next/internal/no-ambiguous-jsx
           <App
-            reactServerStream={reactServerResult.asUnclosingStream()}
+            reactServerStream={initialServerResult.asUnclosingStream()}
             reactDebugStream={undefined}
             debugEndTime={undefined}
             preinitScripts={preinitScripts}
@@ -7870,55 +7610,367 @@ async function prerenderToStream(
             images={ctx.renderOpts.images}
           />,
           {
-            signal: finalClientReactController.signal,
-            onError: (err: unknown, errorInfo: ErrorInfo) => {
-              if (
-                isPrerenderInterruptedError(err) ||
-                finalClientReactController.signal.aborted
-              ) {
-                const componentStack: string | undefined = (errorInfo as any)
-                  .componentStack
-                if (typeof componentStack === 'string') {
-                  trackAllowedDynamicAccess(
-                    workStore,
-                    componentStack,
-                    dynamicValidation,
-                    clientDynamicTracking
-                  )
-                }
-                return
+            signal: initialClientReactController.signal,
+            onError: (err: unknown) => {
+              const digest = getDigestForWellKnownError(err)
+
+              if (digest) {
+                return digest
               }
 
-              return htmlRendererErrorHandler(err, errorInfo)
+              if (isReactLargeShellError(err)) {
+                // TODO: Aggregate
+                console.error(err)
+                return undefined
+              }
+
+              if (initialClientReactController.signal.aborted) {
+                // These are expected errors that might error the prerender. we ignore them.
+              } else if (
+                process.env.NEXT_DEBUG_BUILD ||
+                process.env.__NEXT_VERBOSE_LOGGING
+              ) {
+                // We don't normally log these errors because we are going to retry anyway but
+                // it can be useful for debugging Next.js itself to get visibility here when needed
+                printDebugThrownValueForProspectiveRender(
+                  err,
+                  workStore.route,
+                  Phase.ProspectiveRender
+                )
+              }
             },
-            onHeaders: finalClientOnHeaders,
-            maxHeadersLength: reactMaxHeadersLength,
             bootstrapScripts: [bootstrapScript],
           }
         )
 
-        // The listener to abort our own render controller must be added
-        // after React has added its listener, to ensure that pending I/O is
-        // not aborted/rejected too early.
-        finalClientReactController.signal.addEventListener(
+        // The listener to abort our own render controller must be added after
+        // React has added its listener, to ensure that pending I/O is not
+        // aborted/rejected too early.
+        initialClientReactController.signal.addEventListener(
           'abort',
           () => {
-            finalClientRenderController.abort()
+            initialClientRenderController.abort()
           },
           { once: true }
         )
 
-        return pendingFinalClientResult
-      },
-      () => {
-        finalClientReactController.abort()
+        pendingInitialClientResult.catch((err: unknown) => {
+          if (
+            initialClientReactController.signal.aborted ||
+            isPrerenderInterruptedError(err)
+          ) {
+            // These are expected errors that might error the prerender. we ignore them.
+          } else if (
+            process.env.NEXT_DEBUG_BUILD ||
+            process.env.__NEXT_VERBOSE_LOGGING
+          ) {
+            // We don't normally log these errors because we are going to retry anyway but
+            // it can be useful for debugging Next.js itself to get visibility here when needed
+            printDebugThrownValueForProspectiveRender(
+              err,
+              workStore.route,
+              Phase.ProspectiveRender
+            )
+          }
+        })
+
+        // This is mostly needed for dynamic `import()`s in client components.
+        // Promises passed to client were already awaited above (assuming that they came from cached functions)
+        trackPendingModules(cacheSignal)
+        await cacheSignal.cacheReady()
+        initialClientReactController.abort()
       }
-    )
 
-    const { prelude, preludeIsEmpty } =
-      await processPreludeOp(unprocessedPrelude)
+      if (renderOpts.renderResumeDataCache) {
+        // Swap to the warmed cache so the final render uses entries produced during warmup.
+        renderResumeDataCache = createRenderResumeDataCache(
+          prerenderResumeDataCache
+        )
+      }
 
-    if (validateStaticShell) {
+      const finalServerReactController = new AbortController()
+      const finalServerRenderController = new AbortController()
+
+      const varyParamsAccumulator = createResponseVaryParamsAccumulator()
+
+      const finalServerPayloadPrerenderStore: PrerenderStore = {
+        type: 'prerender',
+        phase: 'render',
+        rootParams,
+        fallbackRouteParams,
+        implicitTags,
+        // While this render signal isn't going to be used to abort a React render while getting the RSC payload
+        // various request data APIs bind to this controller to reject after completion.
+        renderSignal: finalServerRenderController.signal,
+        // When we generate the RSC payload we might abort this controller due to sync IO
+        // but we don't actually care about sync IO in this phase so we use a throw away controller
+        // that isn't connected to anything
+        controller: new AbortController(),
+        // All caches we could read must already be filled so no tracking is necessary
+        cacheSignal: null,
+        dynamicTracking: null,
+        allowEmptyStaticShell,
+        revalidate: INFINITE_CACHE,
+        expire: INFINITE_CACHE,
+        stale: INFINITE_CACHE,
+        tags: [...implicitTags.tags],
+        prerenderResumeDataCache,
+        renderResumeDataCache,
+        hmrRefreshHash: undefined,
+        varyParamsAccumulator,
+      }
+
+      const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
+        finalServerPayloadPrerenderStore,
+        getRSCPayload,
+        tree,
+        ctx,
+        { is404: res.statusCode === 404 }
+      )
+
+      let staleTimeIterable: StaleTimeIterable | undefined
+      if (cachedNavigations) {
+        staleTimeIterable = new StaleTimeIterable()
+        finalAttemptRSCPayload.s = staleTimeIterable
+      }
+
+      const serverDynamicTracking = createDynamicTrackingState(
+        isDebugDynamicAccesses
+      )
+      let serverIsDynamic = false
+
+      const finalServerPrerenderStore: PrerenderStore = (prerenderStore = {
+        type: 'prerender',
+        phase: 'render',
+        rootParams,
+        fallbackRouteParams,
+        implicitTags,
+        renderSignal: finalServerRenderController.signal,
+        controller: finalServerReactController,
+        // All caches we could read must already be filled so no tracking is necessary
+        cacheSignal: null,
+        dynamicTracking: serverDynamicTracking,
+        allowEmptyStaticShell,
+        revalidate: INFINITE_CACHE,
+        expire: INFINITE_CACHE,
+        stale: INFINITE_CACHE,
+        tags: [...implicitTags.tags],
+        prerenderResumeDataCache,
+        renderResumeDataCache,
+        hmrRefreshHash: undefined,
+        varyParamsAccumulator,
+      })
+
+      if (staleTimeIterable !== undefined) {
+        trackStaleTime(
+          finalServerPrerenderStore,
+          staleTimeIterable,
+          selectStaleTime
+        )
+      }
+
+      let prerenderIsPending = true
+      const finalRSCPrerenderOptions = {
+        filterStackFrame,
+        onError: (err: unknown) => {
+          return serverComponentsErrorHandler(err)
+        },
+        signal: finalServerReactController.signal,
+      }
+      const finalRSCAbortCallback = async () => {
+        // Now that the prerendering is complete, we know the final stale
+        // time and vary params. Close the stale time iterable and resolve
+        // the vary params thenable so Flight can serialize their values
+        // into the stream. The timing here is important: both were
+        // included in the Flight payload, but they can only be serialized
+        // at the very end, after all the components have finished.
+        //
+        // We resolve these directly here instead of reading from the work
+        // unit store because this callback runs in a separate task (via
+        // setTimeout) and may not have access to the async storage context.
+        const pendingFinishes: Promise<void>[] = [
+          finishAccumulatingVaryParams(varyParamsAccumulator),
+        ]
+        if (staleTimeIterable !== undefined) {
+          pendingFinishes.push(finishStaleTimeTracking(staleTimeIterable))
+        }
+        await Promise.all(pendingFinishes)
+
+        if (finalServerReactController.signal.aborted) {
+          // If the server controller is already aborted we must have called something
+          // that required aborting the prerender synchronously such as with new Date()
+          serverIsDynamic = true
+          return
+        }
+
+        if (prerenderIsPending) {
+          // If prerenderIsPending then we have blocked for longer than a Task and we assume
+          // there is something unfinished.
+          serverIsDynamic = true
+        }
+
+        finalServerReactController.abort()
+      }
+      const finalRSCPrerenderFn = async () => {
+        const pendingPrerenderResult = workUnitAsyncStorage.run(
+          // The store to scope
+          finalServerPrerenderStore,
+          // The function to run
+          getServerPrerender(ComponentMod),
+          // ... the arguments for the function to run
+          finalAttemptRSCPayload,
+          clientModules,
+          finalRSCPrerenderOptions
+        )
+
+        // The listener to abort our own render controller must be added
+        // after React has added its listener, to ensure that pending I/O
+        // is not aborted/rejected too early.
+        finalServerReactController.signal.addEventListener(
+          'abort',
+          () => {
+            finalServerRenderController.abort()
+          },
+          { once: true }
+        )
+
+        const prerenderResult = await pendingPrerenderResult
+        prerenderIsPending = false
+
+        return prerenderResult
+      }
+      const reactServerResult = (reactServerPrerenderResult =
+        await createReactServerPrerenderResult(
+          runInSequentialTasks(finalRSCPrerenderFn, finalRSCAbortCallback)
+        ))
+      reactServerPrerenderResultIsDynamic = serverIsDynamic
+      reactServerPrerenderStore = finalServerPrerenderStore
+
+      if (shouldGenerateStaticFlightData(workStore)) {
+        metadata.flightData = await streamToBuffer(
+          cachedNavigations
+            ? prependIsPartialByte(
+                reactServerResult.asStream(),
+                serverIsDynamic
+              )
+            : reactServerResult.asStream()
+        )
+
+        // collectSegmentData needs the raw flight data without the marker byte.
+        const flightData = cachedNavigations
+          ? metadata.flightData.subarray(1)
+          : metadata.flightData
+
+        await collectSegmentData(
+          flightData,
+          finalServerPrerenderStore,
+          ComponentMod,
+          renderOpts,
+          ctx.pagePath,
+          metadata
+        )
+      }
+
+      const clientDynamicTracking = createDynamicTrackingState(
+        isDebugDynamicAccesses
+      )
+
+      const finalClientReactController = new AbortController()
+      const finalClientRenderController = new AbortController()
+
+      const finalClientPrerenderStore: PrerenderStore = {
+        type: 'prerender-client',
+        phase: 'render',
+        rootParams,
+        fallbackRouteParams,
+        implicitTags,
+        renderSignal: finalClientRenderController.signal,
+        controller: finalClientReactController,
+        // No APIs require a cacheSignal through the workUnitStore during the HTML prerender
+        cacheSignal: null,
+        dynamicTracking: clientDynamicTracking,
+        allowEmptyStaticShell,
+        revalidate: INFINITE_CACHE,
+        expire: INFINITE_CACHE,
+        stale: INFINITE_CACHE,
+        tags: [...implicitTags.tags],
+        prerenderResumeDataCache,
+        renderResumeDataCache,
+        hmrRefreshHash: undefined,
+        // Client prerenders don't track server param access
+        varyParamsAccumulator: null,
+      }
+
+      let dynamicValidation = createDynamicValidationState()
+
+      const finalClientOnHeaders = createOnHeadersCallback(appendHeader)
+
+      let { prelude: unprocessedPrelude, postponed } =
+        await runInSequentialTasks(
+          () => {
+            const pendingFinalClientResult = workUnitAsyncStorage.run(
+              finalClientPrerenderStore,
+              getClientPrerender,
+              // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+              <App
+                reactServerStream={reactServerResult.asUnclosingStream()}
+                reactDebugStream={undefined}
+                debugEndTime={undefined}
+                preinitScripts={preinitScripts}
+                ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+                nonce={nonce}
+                images={ctx.renderOpts.images}
+              />,
+              {
+                signal: finalClientReactController.signal,
+                onError: (err: unknown, errorInfo: ErrorInfo) => {
+                  if (
+                    isPrerenderInterruptedError(err) ||
+                    finalClientReactController.signal.aborted
+                  ) {
+                    const componentStack: string | undefined = (
+                      errorInfo as any
+                    ).componentStack
+                    if (typeof componentStack === 'string') {
+                      trackAllowedDynamicAccess(
+                        workStore,
+                        componentStack,
+                        dynamicValidation,
+                        clientDynamicTracking
+                      )
+                    }
+                    return
+                  }
+
+                  return htmlRendererErrorHandler(err, errorInfo)
+                },
+                onHeaders: finalClientOnHeaders,
+                maxHeadersLength: reactMaxHeadersLength,
+                bootstrapScripts: [bootstrapScript],
+              }
+            )
+
+            // The listener to abort our own render controller must be added
+            // after React has added its listener, to ensure that pending I/O is
+            // not aborted/rejected too early.
+            finalClientReactController.signal.addEventListener(
+              'abort',
+              () => {
+                finalClientRenderController.abort()
+              },
+              { once: true }
+            )
+
+            return pendingFinalClientResult
+          },
+          () => {
+            finalClientReactController.abort()
+          }
+        )
+
+      const { prelude, preludeIsEmpty } =
+        await processPreludeOp(unprocessedPrelude)
+
       throwIfDisallowedDynamic(
         workStore,
         preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
@@ -7926,98 +7978,56 @@ async function prerenderToStream(
         serverDynamicTracking,
         allowEmptyStaticShell
       )
-    }
 
-    const getServerInsertedHTML = makeGetServerInsertedHTML({
-      polyfills,
-      renderServerInsertedHTML,
-      serverCapturedErrors: allCapturedErrors,
-      basePath,
-      tracingMetadata: tracingMetadata,
-    })
-
-    metadata.flightData = await streamToBuffer(
-      cachedNavigations
-        ? prependIsPartialByte(reactServerResult.asStream(), serverIsDynamic)
-        : reactServerResult.asStream()
-    )
-
-    // collectSegmentData needs the raw flight data without the marker byte.
-    const flightData = cachedNavigations
-      ? metadata.flightData.subarray(1)
-      : metadata.flightData
-
-    await collectSegmentData(
-      flightData,
-      finalServerPrerenderStore,
-      ComponentMod,
-      renderOpts,
-      ctx.pagePath,
-      metadata
-    )
-
-    if (serverIsDynamic) {
-      // Dynamic case
-      // We will always need to perform a "resume" render of some kind when this route is accessed
-      // because the RSC data itself is dynamic. We determine if there are any HTML holes or not
-      // but generally this is a "partial" prerender in that there will be a per-request compute
-      // concatenated to the static shell.
-      if (postponed != null) {
-        // Dynamic HTML case
-        metadata.postponed = await getDynamicHTMLPostponedState(
-          postponed,
-          preludeIsEmpty
-            ? DynamicHTMLPreludeState.Empty
-            : DynamicHTMLPreludeState.Full,
-          fallbackRouteParams,
-          prerenderResumeDataCache,
-          cacheComponents
-        )
-      } else {
-        // Dynamic Data case
-        metadata.postponed = await getDynamicDataPostponedState(
-          prerenderResumeDataCache,
-          cacheComponents
-        )
-      }
-      reactServerResult.consume()
-      const continueDynamicPrerenderOpts = {
-        getServerInsertedHTML,
-        getServerInsertedMetadata,
-        deploymentId: ctx.sharedContext.deploymentId,
-      }
-      return {
-        digestErrorsMap: reactServerErrorsByDigest,
-        ssrErrors: allCapturedErrors,
-        stream: await continueDynamicPrerender(
-          prelude,
-          continueDynamicPrerenderOpts
-        ),
-        dynamicAccess: consumeDynamicAccess(
-          serverDynamicTracking,
-          clientDynamicTracking
-        ),
-        // TODO: Should this include the SSR pass?
-        collectedRevalidate: finalServerPrerenderStore.revalidate,
-        collectedExpire: finalServerPrerenderStore.expire,
-        collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
-        collectedTags: finalServerPrerenderStore.tags,
-        renderResumeDataCache: createRenderResumeDataCache(
-          prerenderResumeDataCache
-        ),
-      }
-    } else {
-      // Static case
-      // We will not perform resumption per request. The result can be served statically to the requestor
-      // and if there was anything dynamic it will only be rendered in the browser.
-      if (workStore.forceDynamic) {
-        throw new StaticGenBailoutError(
-          'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
-        )
-      }
+      const getServerInsertedHTML = makeGetServerInsertedHTML({
+        polyfills,
+        renderServerInsertedHTML,
+        serverCapturedErrors: allCapturedErrors,
+        basePath,
+        tracingMetadata: tracingMetadata,
+      })
 
       let htmlStream: AnyStream = prelude
-      if (postponed != null) {
+      if (serverIsDynamic) {
+        if (postponed != null) {
+          metadata.postponed = await getDynamicHTMLPostponedState(
+            postponed,
+            preludeIsEmpty
+              ? DynamicHTMLPreludeState.Empty
+              : DynamicHTMLPreludeState.Full,
+            fallbackRouteParams,
+            prerenderResumeDataCache,
+            cacheComponents
+          )
+        } else {
+          metadata.postponed = await getDynamicDataPostponedState(
+            prerenderResumeDataCache,
+            cacheComponents
+          )
+        }
+        reactServerResult.consume()
+        return {
+          digestErrorsMap: reactServerErrorsByDigest,
+          ssrErrors: allCapturedErrors,
+          stream: await continueDynamicPrerender(htmlStream, {
+            getServerInsertedHTML,
+            getServerInsertedMetadata,
+            deploymentId: ctx.sharedContext.deploymentId,
+          }),
+          dynamicAccess: consumeDynamicAccess(
+            serverDynamicTracking,
+            clientDynamicTracking
+          ),
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: finalServerPrerenderStore.revalidate,
+          collectedExpire: finalServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
+          collectedTags: finalServerPrerenderStore.tags,
+          renderResumeDataCache: createRenderResumeDataCache(
+            prerenderResumeDataCache
+          ),
+        }
+      } else if (postponed != null) {
         // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
         // so we can set all the postponed boundaries to client render mode before we store the HTML response
         const foreverStream = createPendingStream()
@@ -8045,66 +8055,37 @@ async function prerenderToStream(
         htmlStream = chainStreams(prelude, resumePrelude)
       }
 
-      let finalStream
-      const hasFallbackRouteParams =
-        fallbackRouteParams && fallbackRouteParams.size > 0
-      if (hasFallbackRouteParams) {
-        // This is a "static fallback" prerender: although the page didn't
-        // access any runtime params in a Server Component, it may have
-        // accessed a runtime param in a client segment.
-        //
-        // TODO: If there were no client segments, we can use the fully static
-        // path instead.
-        //
-        // Rather than use a dynamic server resume to fill in the params,
-        // we can rely on the client to parse the params from the URL and use
-        // that to hydrate the page.
-        //
-        // Send an empty InitialRSCPayload to the server component renderer
-        // The data will be fetched by the client instead.
-        // TODO: In the future, rather than defer the entire hydration payload
-        // to be fetched by the client, we should only defer the client
-        // segments, since those are the only ones whose data is not complete.
-        const emptyReactServerResult =
-          await createReactServerPrerenderResultFromRender(
-            renderFlightStream(ComponentMod, [], clientModules, {
-              filterStackFrame,
-              onError: serverComponentsErrorHandler,
-            })
-          )
-        finalStream = await continueStaticFallbackPrerender(htmlStream, {
-          inlinedDataStream: createInlinedDataStream(
-            emptyReactServerResult.consumeAsStream(),
-            nonce,
-            formState
-          ),
-          getServerInsertedHTML,
-          getServerInsertedMetadata,
-          deploymentId: ctx.sharedContext.deploymentId,
-        })
-      } else {
-        // Normal static prerender case, no fallback param handling needed
-        finalStream = await continueStaticPrerender(htmlStream, {
-          inlinedDataStream: createInlinedDataStream(
-            reactServerResult.consumeAsStream(),
-            nonce,
-            formState
-          ),
-          getServerInsertedHTML,
-          getServerInsertedMetadata,
-          deploymentId: ctx.sharedContext.deploymentId,
-        })
+      if (workStore.forceDynamic) {
+        throw new StaticGenBailoutError(
+          'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
+        )
       }
+
+      const stream = await continueStaticPrerenderWithInlinedData(
+        htmlStream,
+        reactServerResult,
+        fallbackRouteParams,
+        createInlinedDataStream,
+        formState,
+        nonce,
+        getServerInsertedHTML,
+        getServerInsertedMetadata,
+        ctx.sharedContext.deploymentId,
+        ComponentMod,
+        renderFlightStream,
+        clientModules,
+        filterStackFrame,
+        serverComponentsErrorHandler
+      )
 
       return {
         digestErrorsMap: reactServerErrorsByDigest,
         ssrErrors: allCapturedErrors,
-        stream: finalStream,
+        stream,
         dynamicAccess: consumeDynamicAccess(
           serverDynamicTracking,
           clientDynamicTracking
         ),
-        // TODO: Should this include the SSR pass?
         collectedRevalidate: finalServerPrerenderStore.revalidate,
         collectedExpire: finalServerPrerenderStore.expire,
         collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
@@ -8113,20 +8094,12 @@ async function prerenderToStream(
           prerenderResumeDataCache
         ),
       }
-    }
-  }
-
-  try {
-    if (cacheComponents) {
-      return await prerenderWithCacheComponents(() =>
-        getRSCPayload(tree, ctx, { is404: res.statusCode === 404 })
-      )
     } else if (experimental.isRoutePPREnabled) {
       // We're statically generating with PPR and need to do dynamic tracking
       let dynamicTracking = createDynamicTrackingState(isDebugDynamicAccesses)
 
       const prerenderResumeDataCache = createPrerenderResumeDataCache()
-      const reactServerPrerenderStore: PrerenderStore = (prerenderStore = {
+      const pprReactServerPrerenderStore: PrerenderStore = (prerenderStore = {
         type: 'prerender-ppr',
         phase: 'render',
         rootParams,
@@ -8140,7 +8113,7 @@ async function prerenderToStream(
         prerenderResumeDataCache,
       })
       const RSCPayload = await workUnitAsyncStorage.run(
-        reactServerPrerenderStore,
+        pprReactServerPrerenderStore,
         getRSCPayload,
         tree,
         ctx,
@@ -8150,7 +8123,7 @@ async function prerenderToStream(
       reactServerResult = reactServerPrerenderResult =
         await createReactServerPrerenderResultFromRender(
           workUnitAsyncStorage.run(
-            reactServerPrerenderStore,
+            pprReactServerPrerenderStore,
             renderFlightStream,
             ComponentMod,
             RSCPayload,
@@ -8275,10 +8248,10 @@ async function prerenderToStream(
           stream: await continueDynamicPrerender(prelude, pprDynamicOpts),
           dynamicAccess: dynamicTracking.dynamicAccesses,
           // TODO: Should this include the SSR pass?
-          collectedRevalidate: reactServerPrerenderStore.revalidate,
-          collectedExpire: reactServerPrerenderStore.expire,
-          collectedStale: selectStaleTime(reactServerPrerenderStore.stale),
-          collectedTags: reactServerPrerenderStore.tags,
+          collectedRevalidate: pprReactServerPrerenderStore.revalidate,
+          collectedExpire: pprReactServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(pprReactServerPrerenderStore.stale),
+          collectedTags: pprReactServerPrerenderStore.tags,
         }
       } else if (fallbackRouteParams && fallbackRouteParams.size > 0) {
         // Rendering the fallback case.
@@ -8301,10 +8274,10 @@ async function prerenderToStream(
           ),
           dynamicAccess: dynamicTracking.dynamicAccesses,
           // TODO: Should this include the SSR pass?
-          collectedRevalidate: reactServerPrerenderStore.revalidate,
-          collectedExpire: reactServerPrerenderStore.expire,
-          collectedStale: selectStaleTime(reactServerPrerenderStore.stale),
-          collectedTags: reactServerPrerenderStore.tags,
+          collectedRevalidate: pprReactServerPrerenderStore.revalidate,
+          collectedExpire: pprReactServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(pprReactServerPrerenderStore.stale),
+          collectedTags: pprReactServerPrerenderStore.tags,
         }
       } else {
         // Static case
@@ -8357,10 +8330,10 @@ async function prerenderToStream(
           }),
           dynamicAccess: dynamicTracking.dynamicAccesses,
           // TODO: Should this include the SSR pass?
-          collectedRevalidate: reactServerPrerenderStore.revalidate,
-          collectedExpire: reactServerPrerenderStore.expire,
-          collectedStale: selectStaleTime(reactServerPrerenderStore.stale),
-          collectedTags: reactServerPrerenderStore.tags,
+          collectedRevalidate: pprReactServerPrerenderStore.revalidate,
+          collectedExpire: pprReactServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(pprReactServerPrerenderStore.stale),
+          collectedTags: pprReactServerPrerenderStore.tags,
         }
       }
     } else {
@@ -8501,12 +8474,14 @@ async function prerenderToStream(
       throw err
     }
     let errorType: MetadataErrorType | 'redirect' | undefined
+    const isHTTPAccessFallback = isHTTPAccessFallbackError(err)
+    const isRedirect = isRedirectError(err)
 
-    if (isHTTPAccessFallbackError(err)) {
+    if (isHTTPAccessFallback) {
       res.statusCode = getAccessFallbackHTTPStatus(err)
       metadata.statusCode = res.statusCode
       errorType = getAccessFallbackErrorTypeByStatus(res.statusCode)
-    } else if (isRedirectError(err)) {
+    } else if (isRedirect) {
       errorType = 'redirect'
       res.statusCode = getRedirectStatusCodeFromError(err)
       metadata.statusCode = res.statusCode
@@ -8514,9 +8489,13 @@ async function prerenderToStream(
       const redirectUrl = addPathPrefix(getURLFromRedirectError(err), basePath)
 
       setHeader('location', redirectUrl)
-    } else if (!shouldBailoutToCSR) {
+    } else {
       res.statusCode = 500
       metadata.statusCode = res.statusCode
+    }
+
+    if (cacheComponents && !isHTTPAccessFallback && !isRedirect) {
+      throw reactServerErrorsByDigest.get((err as any).digest) ?? err
     }
 
     const [errorPreinitScripts, errorBootstrapScript] = getRequiredScripts(
@@ -8529,89 +8508,59 @@ async function prerenderToStream(
       '/_not-found/page'
     )
 
-    let prerenderHTTPError: PrerenderHTTPErrorState | undefined
-    if (cacheComponents && isHTTPAccessFallbackError(err)) {
-      const triggeredStatus = getAccessFallbackHTTPStatus(
-        err
-      ) as HTTPAccessErrorStatusCode
-      const boundaryTree = findPrerenderHTTPErrorBoundaryTree(
-        tree,
-        triggeredStatus,
-        ctx.renderOpts.experimental.authInterrupts
-      )
-
-      if (boundaryTree) {
-        prerenderHTTPError = {
-          boundaryTree,
-          triggeredStatus,
-        }
-      }
-    }
-
     if (cacheComponents) {
       const originalFlightPrerenderResult = reactServerPrerenderResult
-
-      // Route the recovery render through the Cache Components prerender helper
-      // to prerender with CC semantics. Segment-scoped HTTP fallback recovery
-      // intentionally skips static shell validation so fallback UIs that were
-      // previously tolerated do not start failing builds.
-      if (prerenderHTTPError) {
-        try {
-          return await prerenderWithCacheComponents(
-            () =>
-              getRSCPayload(tree, ctx, {
-                is404: prerenderHTTPError.triggeredStatus === 404,
-                prerenderHTTPError,
-              }),
-            // validateStaticShell: false. This recovery render should not turn
-            // fallback UI shell validation into a build failure.
-            false
-          )
-        } catch (recoveryErr) {
-          // If the segment-scoped HTTP fallback recovery throws another
-          // control-flow error (e.g. the matched boundary's subtree re-throws
-          // `notFound()` because the boundary was actually above where the
-          // original notFound() was called), fall through to the final recovery
-          // below.
-          if (isDynamicServerError(recoveryErr)) {
-            throw new InvariantError(
-              'Cache Components HTTP fallback recovery unexpectedly produced a DynamicServerError',
-              { cause: recoveryErr }
-            )
-          }
-
-          if (
-            !isHTTPAccessFallbackError(recoveryErr) &&
-            !isStaticGenBailoutError(recoveryErr) &&
-            !isBailoutToCSRError(recoveryErr)
-          ) {
-            throw recoveryErr
-          }
-        }
-      }
+      const originalFlightPrerenderResultIsDynamic =
+        reactServerPrerenderResultIsDynamic
+      const originalPrerenderResumeDataCache =
+        reactServerPrerenderResumeDataCache
+      const originalPrerenderStore =
+        reactServerPrerenderStore as PrerenderStore | null
 
       if (originalFlightPrerenderResult === null) {
         throw new InvariantError(
           'Cache Components error recovery expected an original Flight prerender result'
         )
       }
+      if (originalFlightPrerenderResultIsDynamic === null) {
+        throw new InvariantError(
+          'Cache Components error recovery expected to know whether the original Flight prerender result was dynamic'
+        )
+      }
+      if (originalPrerenderResumeDataCache === null) {
+        throw new InvariantError(
+          'Cache Components error recovery expected an original prerender resume data cache'
+        )
+      }
+      if (originalPrerenderStore === null) {
+        throw new InvariantError(
+          'Cache Components error recovery expected an original prerender store'
+        )
+      }
+      const originalCollectedStale = selectStaleTime(
+        originalPrerenderStore.stale
+      )
 
-      // The final recovery still belongs to Cache Components, but it must
-      // preserve the original Flight stream. The static error shell is only the
-      // HTML fallback; the client still needs the original route tree so HTTP
-      // fallback boundaries can recover during hydration.
-      const errorPrerenderController = new AbortController()
-      const errorRenderController = new AbortController()
+      // The final recovery still belongs to Cache Components. Render the error
+      // payload with the same prerender APIs as the normal path so not-found
+      // metadata can participate in static, dynamic-data, and dynamic-HTML
+      // outcomes instead of being dropped from the recovery shell.
+      const errorPrerenderResumeDataCache = createPrerenderResumeDataCache()
+      const errorServerReactController = new AbortController()
+      const errorServerRenderController = new AbortController()
+      const errorServerDynamicTracking = createDynamicTrackingState(
+        isDebugDynamicAccesses
+      )
       const errorPrerenderStore: PrerenderStore = {
         type: 'prerender',
         phase: 'render',
         rootParams,
         fallbackRouteParams,
         implicitTags,
-        renderSignal: errorRenderController.signal,
-        controller: errorPrerenderController,
+        renderSignal: errorServerRenderController.signal,
+        controller: errorServerReactController,
         cacheSignal: null,
-        dynamicTracking: null,
+        dynamicTracking: errorServerDynamicTracking,
         allowEmptyStaticShell,
         revalidate:
           typeof prerenderStore?.revalidate !== 'undefined'
@@ -8626,7 +8575,7 @@ async function prerenderToStream(
             ? prerenderStore.stale
             : INFINITE_CACHE,
         tags: [...(prerenderStore?.tags || implicitTags.tags)],
-        prerenderResumeDataCache: null,
+        prerenderResumeDataCache: errorPrerenderResumeDataCache,
         renderResumeDataCache: renderOpts.renderResumeDataCache ?? null,
         hmrRefreshHash: undefined,
         varyParamsAccumulator: null,
@@ -8641,89 +8590,255 @@ async function prerenderToStream(
         errorType
       )
 
-      const errorServerStream = workUnitAsyncStorage.run(
-        errorPrerenderStore,
-        renderFlightStream,
-        ComponentMod,
-        errorRSCPayload,
-        clientModules,
-        {
-          filterStackFrame,
-          onError: serverComponentsErrorHandler,
-        }
+      const errorServerResult = await createReactServerPrerenderResult(
+        runInSequentialTasks(
+          async () => {
+            const pendingErrorServerResult = workUnitAsyncStorage.run(
+              errorPrerenderStore,
+              getServerPrerender(ComponentMod),
+              errorRSCPayload,
+              clientModules,
+              {
+                filterStackFrame,
+                signal: errorServerReactController.signal,
+                onError: (rscError: unknown) => {
+                  return serverComponentsErrorHandler(rscError)
+                },
+              }
+            )
+
+            // The listener to abort our own render controller must be added
+            // after React has added its listener, to ensure that pending I/O
+            // is not aborted/rejected too early.
+            errorServerReactController.signal.addEventListener(
+              'abort',
+              () => {
+                errorServerRenderController.abort()
+              },
+              { once: true }
+            )
+
+            const prerenderResult = await pendingErrorServerResult
+            return prerenderResult
+          },
+          () => {
+            if (!errorServerReactController.signal.aborted) {
+              errorServerReactController.abort()
+            }
+          }
+        )
       )
 
       try {
-        const { stream: errorHtmlStream } = await workUnitAsyncStorage.run(
-          errorPrerenderStore,
-          renderFizzStream,
-          // eslint-disable-next-line @next/internal/no-ambiguous-jsx
-          <ErrorApp
-            reactServerStream={errorServerStream}
-            ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
-            preinitScripts={errorPreinitScripts}
-            nonce={nonce}
-            images={ctx.renderOpts.images}
-          />,
-          {
-            nonce,
-            bootstrapScripts: [errorBootstrapScript],
-            formState,
+        const errorClientReactController = new AbortController()
+        const errorClientRenderController = new AbortController()
+        const errorClientDynamicTracking = createDynamicTrackingState(
+          isDebugDynamicAccesses
+        )
+        const errorDynamicValidation = createDynamicValidationState()
+        const errorClientPrerenderStore: PrerenderStore = {
+          type: 'prerender-client',
+          phase: 'render',
+          rootParams,
+          fallbackRouteParams,
+          implicitTags,
+          renderSignal: errorClientRenderController.signal,
+          controller: errorClientReactController,
+          cacheSignal: null,
+          dynamicTracking: errorClientDynamicTracking,
+          allowEmptyStaticShell,
+          revalidate: errorPrerenderStore.revalidate,
+          expire: errorPrerenderStore.expire,
+          stale: errorPrerenderStore.stale,
+          tags: [...(errorPrerenderStore.tags || implicitTags.tags)],
+          prerenderResumeDataCache: errorPrerenderResumeDataCache,
+          renderResumeDataCache: renderOpts.renderResumeDataCache ?? null,
+          hmrRefreshHash: undefined,
+          varyParamsAccumulator: null,
+        }
+
+        const {
+          prelude: unprocessedErrorHtmlStream,
+          postponed: errorPostponed,
+        } = await runInSequentialTasks(
+          () => {
+            const pendingErrorHtmlResult = workUnitAsyncStorage.run(
+              errorClientPrerenderStore,
+              getClientPrerender,
+              // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+              <ErrorApp
+                reactServerStream={errorServerResult.asUnclosingStream()}
+                ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+                preinitScripts={errorPreinitScripts}
+                nonce={nonce}
+                images={ctx.renderOpts.images}
+              />,
+              {
+                nonce,
+                bootstrapScripts: [errorBootstrapScript],
+                formState,
+                signal: errorClientReactController.signal,
+                onError: (clientError: unknown, errorInfo: ErrorInfo) => {
+                  if (
+                    isPrerenderInterruptedError(clientError) ||
+                    errorClientReactController.signal.aborted
+                  ) {
+                    const componentStack: string | undefined = (
+                      errorInfo as any
+                    ).componentStack
+                    if (typeof componentStack === 'string') {
+                      trackAllowedDynamicAccess(
+                        workStore,
+                        componentStack,
+                        errorDynamicValidation,
+                        errorClientDynamicTracking
+                      )
+                    }
+                    return
+                  }
+
+                  return htmlRendererErrorHandler(clientError, errorInfo)
+                },
+              }
+            )
+
+            // The listener to abort our own render controller must be added
+            // after React has added its listener, to ensure that pending I/O
+            // is not aborted/rejected too early.
+            errorClientReactController.signal.addEventListener(
+              'abort',
+              () => {
+                errorClientRenderController.abort()
+              },
+              { once: true }
+            )
+
+            return pendingErrorHtmlResult
           },
-          { waitForAllReady: true }
+          () => {
+            errorClientReactController.abort()
+          }
         )
 
-        if (shouldGenerateStaticFlightData(workStore)) {
-          metadata.flightData = await streamToBuffer(
-            cachedNavigations
-              ? prependIsPartialByte(
-                  originalFlightPrerenderResult.asStream(),
-                  false
-                )
-              : originalFlightPrerenderResult.asStream()
+        const { prelude, preludeIsEmpty } = await processPreludeOp(
+          unprocessedErrorHtmlStream
+        )
+
+        if (preludeIsEmpty) {
+          console.error(
+            `Route "${workStore.route}" did not produce a static shell while rendering its error page.`
           )
+          throwIfDisallowedDynamic(
+            workStore,
+            PreludeState.Empty,
+            errorDynamicValidation,
+            errorServerDynamicTracking,
+            false
+          )
+          throw new StaticGenBailoutError()
+        }
 
-          // collectSegmentData needs the raw flight data without the marker byte.
-          const flightData = cachedNavigations
-            ? metadata.flightData.subarray(1)
-            : metadata.flightData
+        const getServerInsertedHTML = makeGetServerInsertedHTML({
+          polyfills,
+          renderServerInsertedHTML,
+          serverCapturedErrors: [],
+          basePath,
+          tracingMetadata: tracingMetadata,
+        })
 
-          await collectSegmentData(
-            flightData,
+        let errorHtmlStream: AnyStream = prelude
+        if (originalFlightPrerenderResultIsDynamic) {
+          metadata.postponed = await getDynamicDataPostponedState(
+            originalPrerenderResumeDataCache,
+            cacheComponents
+          )
+          originalFlightPrerenderResult.consume()
+          errorServerResult.consume()
+          return {
+            digestErrorsMap: reactServerErrorsByDigest,
+            ssrErrors: allCapturedErrors,
+            stream: await continueDynamicPrerender(errorHtmlStream, {
+              getServerInsertedHTML,
+              getServerInsertedMetadata,
+              deploymentId: ctx.sharedContext.deploymentId,
+            }),
+            dynamicAccess: consumeDynamicAccess(
+              errorServerDynamicTracking,
+              errorClientDynamicTracking
+            ),
+            collectedRevalidate: originalPrerenderStore.revalidate,
+            collectedExpire: originalPrerenderStore.expire,
+            collectedStale: originalCollectedStale,
+            collectedTags: originalPrerenderStore.tags,
+            renderResumeDataCache: createRenderResumeDataCache(
+              originalPrerenderResumeDataCache
+            ),
+          }
+        } else if (errorPostponed != null) {
+          // We postponed but nothing dynamic was used. Resume the error shell
+          // and immediately abort it so postponed client boundaries are marked
+          // for browser rendering before the static response is stored.
+          const foreverStream = createPendingStream()
+          const resumePrelude = await workUnitAsyncStorage.run(
             errorPrerenderStore,
-            ComponentMod,
-            renderOpts,
-            ctx.pagePath,
-            metadata
+            resumeAndAbort,
+            // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+            <ErrorApp
+              reactServerStream={foreverStream}
+              ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+              preinitScripts={() => {}}
+              nonce={nonce}
+              images={ctx.renderOpts.images}
+            />,
+            JSON.parse(JSON.stringify(errorPostponed)),
+            {
+              signal: createRenderInBrowserAbortSignal(),
+              onError: htmlRendererErrorHandler,
+              nonce,
+            }
+          )
+          errorHtmlStream = chainStreams(prelude, resumePrelude)
+        }
+
+        if (workStore.forceDynamic) {
+          throw new StaticGenBailoutError(
+            'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
           )
         }
 
+        const stream = await continueStaticPrerenderWithInlinedData(
+          errorHtmlStream,
+          originalFlightPrerenderResult,
+          fallbackRouteParams,
+          createInlinedDataStream,
+          formState,
+          nonce,
+          getServerInsertedHTML,
+          getServerInsertedMetadata,
+          ctx.sharedContext.deploymentId,
+          ComponentMod,
+          renderFlightStream,
+          clientModules,
+          filterStackFrame,
+          serverComponentsErrorHandler
+        )
+
+        errorServerResult.consume()
         return {
           digestErrorsMap: reactServerErrorsByDigest,
           ssrErrors: allCapturedErrors,
-          stream: await continueFizzStream(errorHtmlStream, {
-            inlinedDataStream: createInlinedDataStream(
-              originalFlightPrerenderResult.consumeAsStream(),
-              nonce,
-              formState
-            ),
-            isStaticGeneration: true,
-            getServerInsertedHTML: makeGetServerInsertedHTML({
-              polyfills,
-              renderServerInsertedHTML,
-              serverCapturedErrors: [],
-              basePath,
-              tracingMetadata: tracingMetadata,
-            }),
-            getServerInsertedMetadata,
-            validateRootLayout: !!process.env.__NEXT_DEV_SERVER,
-            deploymentId: ctx.sharedContext.deploymentId,
-          }),
-          dynamicAccess: null,
-          collectedRevalidate: errorPrerenderStore.revalidate,
-          collectedExpire: errorPrerenderStore.expire,
-          collectedStale: selectStaleTime(errorPrerenderStore.stale),
-          collectedTags: errorPrerenderStore.tags,
+          stream,
+          dynamicAccess: consumeDynamicAccess(
+            errorServerDynamicTracking,
+            errorClientDynamicTracking
+          ),
+          collectedRevalidate: originalPrerenderStore.revalidate,
+          collectedExpire: originalPrerenderStore.expire,
+          collectedStale: originalCollectedStale,
+          collectedTags: originalPrerenderStore.tags,
+          renderResumeDataCache: createRenderResumeDataCache(
+            originalPrerenderResumeDataCache
+          ),
         }
       } catch (finalErr: any) {
         if (

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -8549,18 +8549,12 @@ async function prerenderToStream(
     }
 
     if (cacheComponents) {
+      const originalFlightPrerenderResult = reactServerPrerenderResult
+
       // Route the recovery render through the Cache Components prerender helper
       // to prerender with CC semantics. Segment-scoped HTTP fallback recovery
       // intentionally skips static shell validation so fallback UIs that were
-      // previously tolerated do not start failing builds. For recoveries that
-      // render the synthetic error shell from `getErrorRSCPayload` (generic
-      // `Error`, `RedirectError`, `HTTPAccessFallbackError` with no matching
-      // boundary, or fall-through from the segment-scoped recovery below), the
-      // helper still runs but no user code participates in the SSR —
-      // `global-error.tsx` is plumbed into the payload but its
-      // `RootErrorBoundary` is never triggered because the synthetic shell can't
-      // throw. We still route synthetic-shell recoveries through the helper so
-      // legacy prerendering is never used when Cache Components is on.
+      // previously tolerated do not start failing builds.
       if (prerenderHTTPError) {
         try {
           return await prerenderWithCacheComponents(
@@ -8577,8 +8571,8 @@ async function prerenderToStream(
           // If the segment-scoped HTTP fallback recovery throws another
           // control-flow error (e.g. the matched boundary's subtree re-throws
           // `notFound()` because the boundary was actually above where the
-          // original notFound() was called), fall through to the generic
-          // synthetic-shell recovery below.
+          // original notFound() was called), fall through to the final recovery
+          // below.
           if (isDynamicServerError(recoveryErr)) {
             throw new InvariantError(
               'Cache Components HTTP fallback recovery unexpectedly produced a DynamicServerError',
@@ -8596,14 +8590,152 @@ async function prerenderToStream(
         }
       }
 
-      return await prerenderWithCacheComponents(() =>
-        getErrorRSCPayload(
-          tree,
-          ctx,
-          reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
-          errorType
+      if (originalFlightPrerenderResult === null) {
+        throw new InvariantError(
+          'Cache Components error recovery expected an original Flight prerender result'
         )
+      }
+
+      // The final recovery still belongs to Cache Components, but it must
+      // preserve the original Flight stream. The static error shell is only the
+      // HTML fallback; the client still needs the original route tree so HTTP
+      // fallback boundaries can recover during hydration.
+      const errorPrerenderController = new AbortController()
+      const errorRenderController = new AbortController()
+      const errorPrerenderStore: PrerenderStore = {
+        type: 'prerender',
+        phase: 'render',
+        rootParams,
+        fallbackRouteParams,
+        implicitTags,
+        renderSignal: errorRenderController.signal,
+        controller: errorPrerenderController,
+        cacheSignal: null,
+        dynamicTracking: null,
+        allowEmptyStaticShell,
+        revalidate:
+          typeof prerenderStore?.revalidate !== 'undefined'
+            ? prerenderStore.revalidate
+            : INFINITE_CACHE,
+        expire:
+          typeof prerenderStore?.expire !== 'undefined'
+            ? prerenderStore.expire
+            : INFINITE_CACHE,
+        stale:
+          typeof prerenderStore?.stale !== 'undefined'
+            ? prerenderStore.stale
+            : INFINITE_CACHE,
+        tags: [...(prerenderStore?.tags || implicitTags.tags)],
+        prerenderResumeDataCache: null,
+        renderResumeDataCache: renderOpts.renderResumeDataCache ?? null,
+        hmrRefreshHash: undefined,
+        varyParamsAccumulator: null,
+      }
+
+      const errorRSCPayload = await workUnitAsyncStorage.run(
+        errorPrerenderStore,
+        getErrorRSCPayload,
+        tree,
+        ctx,
+        reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
+        errorType
       )
+
+      const errorServerStream = workUnitAsyncStorage.run(
+        errorPrerenderStore,
+        renderFlightStream,
+        ComponentMod,
+        errorRSCPayload,
+        clientModules,
+        {
+          filterStackFrame,
+          onError: serverComponentsErrorHandler,
+        }
+      )
+
+      try {
+        const { stream: errorHtmlStream } = await workUnitAsyncStorage.run(
+          errorPrerenderStore,
+          renderFizzStream,
+          // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+          <ErrorApp
+            reactServerStream={errorServerStream}
+            ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+            preinitScripts={errorPreinitScripts}
+            nonce={nonce}
+            images={ctx.renderOpts.images}
+          />,
+          {
+            nonce,
+            bootstrapScripts: [errorBootstrapScript],
+            formState,
+          },
+          { waitForAllReady: true }
+        )
+
+        if (shouldGenerateStaticFlightData(workStore)) {
+          metadata.flightData = await streamToBuffer(
+            cachedNavigations
+              ? prependIsPartialByte(
+                  originalFlightPrerenderResult.asStream(),
+                  false
+                )
+              : originalFlightPrerenderResult.asStream()
+          )
+
+          // collectSegmentData needs the raw flight data without the marker byte.
+          const flightData = cachedNavigations
+            ? metadata.flightData.subarray(1)
+            : metadata.flightData
+
+          await collectSegmentData(
+            flightData,
+            errorPrerenderStore,
+            ComponentMod,
+            renderOpts,
+            ctx.pagePath,
+            metadata
+          )
+        }
+
+        return {
+          digestErrorsMap: reactServerErrorsByDigest,
+          ssrErrors: allCapturedErrors,
+          stream: await continueFizzStream(errorHtmlStream, {
+            inlinedDataStream: createInlinedDataStream(
+              originalFlightPrerenderResult.consumeAsStream(),
+              nonce,
+              formState
+            ),
+            isStaticGeneration: true,
+            getServerInsertedHTML: makeGetServerInsertedHTML({
+              polyfills,
+              renderServerInsertedHTML,
+              serverCapturedErrors: [],
+              basePath,
+              tracingMetadata: tracingMetadata,
+            }),
+            getServerInsertedMetadata,
+            validateRootLayout: !!process.env.__NEXT_DEV_SERVER,
+            deploymentId: ctx.sharedContext.deploymentId,
+          }),
+          dynamicAccess: null,
+          collectedRevalidate: errorPrerenderStore.revalidate,
+          collectedExpire: errorPrerenderStore.expire,
+          collectedStale: selectStaleTime(errorPrerenderStore.stale),
+          collectedTags: errorPrerenderStore.tags,
+        }
+      } catch (finalErr: any) {
+        if (
+          process.env.__NEXT_DEV_SERVER &&
+          isHTTPAccessFallbackError(finalErr)
+        ) {
+          const { bailOnRootNotFound } =
+            require('../../client/components/dev-root-http-access-fallback-boundary') as typeof import('../../client/components/dev-root-http-access-fallback-boundary')
+          bailOnRootNotFound()
+        }
+        throw finalErr
+      }
     }
 
     const prerenderLegacyStore: PrerenderStore = {

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -44,13 +44,6 @@ import {
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
 import { RenderStage, type StagedRenderingController } from './staged-rendering'
 
-type HTTPAccessErrorStatusCode = 404 | 403 | 401
-
-export type PrerenderHTTPErrorState = {
-  boundaryTree: LoaderTree
-  triggeredStatus: HTTPAccessErrorStatusCode
-}
-
 /**
  * Use the provided loader tree to create the React Component tree.
  */
@@ -69,7 +62,6 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   MetadataOutlet: ComponentType
-  prerenderHTTPError?: PrerenderHTTPErrorState
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -107,7 +99,6 @@ async function createComponentTreeInternal(
     preloadCallbacks,
     authInterrupts,
     MetadataOutlet,
-    prerenderHTTPError,
   }: {
     loaderTree: LoaderTree
     parentParams: Params
@@ -122,7 +113,6 @@ async function createComponentTreeInternal(
     preloadCallbacks: PreloadCallbacks
     authInterrupts: boolean
     MetadataOutlet: ComponentType | null
-    prerenderHTTPError?: PrerenderHTTPErrorState
   },
   isRoot: boolean
 ): Promise<CacheNodeSeedData> {
@@ -602,46 +592,6 @@ async function createComponentTreeInternal(
             }
           }
 
-          // The outer prerender catch already found the deepest segment whose
-          // HTTP fallback should replace the throwing page. When we reach that
-          // segment's `children` slot, render the fallback directly instead of
-          // descending back into the subtree that threw during deserialization.
-
-          // Like the other segment-level boundary props below, HTTP access
-          // fallbacks are attached to the default `children` slot, not to named
-          // parallel routes.
-          const shouldRenderPrerenderHTTPFallback =
-            prerenderHTTPError?.boundaryTree === tree && isChildrenRouteKey
-
-          if (shouldRenderPrerenderHTTPFallback) {
-            let fallbackElement: React.ReactNode | undefined
-            switch (prerenderHTTPError.triggeredStatus) {
-              case 404:
-                fallbackElement = notFoundElement
-                break
-              case 403:
-                fallbackElement = forbiddenElement
-                break
-              case 401:
-                fallbackElement = unauthorizedElement
-                break
-              default:
-                break
-            }
-
-            if (fallbackElement) {
-              childCacheNodeSeedData = createSeedData(
-                ctx,
-                fallbackElement,
-                {},
-                null,
-                isPossiblyPartialResponse,
-                false,
-                emptyVaryParamsAccumulator
-              )
-            }
-          }
-
           if (childCacheNodeSeedData === null) {
             const seedData = await createComponentTreeInternal(
               {
@@ -661,7 +611,6 @@ async function createComponentTreeInternal(
                 // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
                 // but we only want to throw on the first one.
                 MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
-                prerenderHTTPError,
               },
               false
             )

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
@@ -2,7 +2,7 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
 describe('Cache Components HTTP Access Fallback Prerender', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/http-access-fallback-prerender',
     skipStart: !isNextDev,
     skipDeployment: true,
@@ -82,7 +82,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
       await next.build({ args })
     }
 
-    const expectStaticRouteArtifacts = async (route: string) => {
+    const expectStaticRouteArtifacts = async (route: string, status = 404) => {
       const meta = JSON.parse(
         await next.readFile(`.next/server/app/${route}.meta`)
       )
@@ -90,7 +90,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
       expect(await next.readFile(`.next/server/app/${route}.html`)).toEqual(
         expect.any(String)
       )
-      expect(meta.status).toBe(404)
+      expect(meta.status).toBe(status)
       expect(meta.segmentPaths).toContain('/_tree')
       expect(
         await next.readFile(
@@ -112,7 +112,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           )
         })
       } else {
-        it('should log the fallback dynamic error without failing the build', async () => {
+        it('should skip static shell validation during fallback recovery', async () => {
           await prerender(pagePath)
 
           const output = getPrerenderOutput(
@@ -120,136 +120,8 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
             { isMinified: !isDebugPrerender }
           )
 
-          if (isTurbopack) {
-            if (isDebugPrerender) {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at NotFound (app/not-found/[slug]/not-found.tsx:6:39)
-                 4 |
-                 5 | export default function NotFound() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                                       ^
-                 7 |
-                 8 |   return <p>not found {searchParams.get('foo')}</p>
-                 9 | }
-               To debug the issue, start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error."
-              `)
-            } else {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at <unknown> (app/not-found/[slug]/not-found.tsx:6:24)
-                   at body (<anonymous>)
-                   at html (<anonymous>)
-                 4 |
-                 5 | export default function NotFound() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                        ^
-                 7 |
-                 8 |   return <p>not found {searchParams.get('foo')}</p>
-                 9 | }
-               To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                 - Start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error.
-                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
-              `)
-            }
-          } else {
-            if (isDebugPrerender) {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at NotFound (webpack:///app/not-found/[slug]/not-found.tsx:6:39)
-                 4 |
-                 5 | export default function NotFound() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                                       ^
-                 7 |
-                 8 |   return <p>not found {searchParams.get('foo')}</p>
-                 9 | }
-               To debug the issue, start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error."
-              `)
-            } else {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at a (<next-dist-dir>)
-                   at b (<next-dist-dir>)
-                   at c (<next-dist-dir>)
-                   at d (<next-dist-dir>)
-                   at e (<next-dist-dir>)
-                   at f (<next-dist-dir>)
-                   at g (<next-dist-dir>)
-                   at h (<next-dist-dir>)
-                   at i (<next-dist-dir>)
-                   at j (<next-dist-dir>)
-                   at k (<next-dist-dir>)
-                   at l (<next-dist-dir>)
-                   at m (<next-dist-dir>)
-                   at n (<next-dist-dir>)
-                   at o (<next-dist-dir>)
-                   at p (<next-dist-dir>)
-                   at q (<next-dist-dir>)
-                   at r (<next-dist-dir>)
-                   at s (<next-dist-dir>)
-                   at t (<next-dist-dir>)
-                   at u (<next-dist-dir>)
-                   at v (<next-dist-dir>)
-                   at w (<next-dist-dir>)
-                   at x (<next-dist-dir>)
-                   at y (<next-dist-dir>)
-                   at z (<next-dist-dir>)
-                   at a (<next-dist-dir>)
-                   at b (<next-dist-dir>)
-                   at c (<next-dist-dir>)
-                   at d (<next-dist-dir>)
-                   at e (<next-dist-dir>)
-                   at f (<next-dist-dir>)
-                   at g (<next-dist-dir>)
-                   at body (<anonymous>)
-                   at html (<anonymous>)
-               To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                 - Start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error.
-                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
-              `)
-            }
-          }
+          expect(output).toMatchInlineSnapshot(`""`)
+          await expectStaticRouteArtifacts('not-found/not-found')
         })
       }
     })
@@ -267,7 +139,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           )
         })
       } else {
-        it('should log the fallback dynamic error without failing the build', async () => {
+        it('should skip static shell validation during fallback recovery', async () => {
           await prerender(pagePath)
 
           const output = getPrerenderOutput(
@@ -275,136 +147,8 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
             { isMinified: !isDebugPrerender }
           )
 
-          if (isTurbopack) {
-            if (isDebugPrerender) {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at Forbidden (app/forbidden/[slug]/forbidden.tsx:6:39)
-                 4 |
-                 5 | export default function Forbidden() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                                       ^
-                 7 |
-                 8 |   return <p>forbidden {searchParams.get('foo')}</p>
-                 9 | }
-               To debug the issue, start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error."
-              `)
-            } else {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at <unknown> (app/forbidden/[slug]/forbidden.tsx:6:24)
-                   at body (<anonymous>)
-                   at html (<anonymous>)
-                 4 |
-                 5 | export default function Forbidden() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                        ^
-                 7 |
-                 8 |   return <p>forbidden {searchParams.get('foo')}</p>
-                 9 | }
-               To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                 - Start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error.
-                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
-              `)
-            }
-          } else {
-            if (isDebugPrerender) {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at Forbidden (webpack:///app/forbidden/[slug]/forbidden.tsx:6:39)
-                 4 |
-                 5 | export default function Forbidden() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                                       ^
-                 7 |
-                 8 |   return <p>forbidden {searchParams.get('foo')}</p>
-                 9 | }
-               To debug the issue, start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error."
-              `)
-            } else {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at a (<next-dist-dir>)
-                   at b (<next-dist-dir>)
-                   at c (<next-dist-dir>)
-                   at d (<next-dist-dir>)
-                   at e (<next-dist-dir>)
-                   at f (<next-dist-dir>)
-                   at g (<next-dist-dir>)
-                   at h (<next-dist-dir>)
-                   at i (<next-dist-dir>)
-                   at j (<next-dist-dir>)
-                   at k (<next-dist-dir>)
-                   at l (<next-dist-dir>)
-                   at m (<next-dist-dir>)
-                   at n (<next-dist-dir>)
-                   at o (<next-dist-dir>)
-                   at p (<next-dist-dir>)
-                   at q (<next-dist-dir>)
-                   at r (<next-dist-dir>)
-                   at s (<next-dist-dir>)
-                   at t (<next-dist-dir>)
-                   at u (<next-dist-dir>)
-                   at v (<next-dist-dir>)
-                   at w (<next-dist-dir>)
-                   at x (<next-dist-dir>)
-                   at y (<next-dist-dir>)
-                   at z (<next-dist-dir>)
-                   at a (<next-dist-dir>)
-                   at b (<next-dist-dir>)
-                   at c (<next-dist-dir>)
-                   at d (<next-dist-dir>)
-                   at e (<next-dist-dir>)
-                   at f (<next-dist-dir>)
-                   at g (<next-dist-dir>)
-                   at body (<anonymous>)
-                   at html (<anonymous>)
-               To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                 - Start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error.
-                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
-              `)
-            }
-          }
+          expect(output).toMatchInlineSnapshot(`""`)
+          await expectStaticRouteArtifacts('forbidden/forbidden', 403)
         })
       }
     })
@@ -422,7 +166,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           )
         })
       } else {
-        it('should log the fallback dynamic error without failing the build', async () => {
+        it('should skip static shell validation during fallback recovery', async () => {
           await prerender(pagePath)
 
           const output = getPrerenderOutput(
@@ -430,136 +174,8 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
             { isMinified: !isDebugPrerender }
           )
 
-          if (isTurbopack) {
-            if (isDebugPrerender) {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at Unauthorized (app/unauthorized/[slug]/unauthorized.tsx:6:39)
-                 4 |
-                 5 | export default function Unauthorized() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                                       ^
-                 7 |
-                 8 |   return <p>unauthorized {searchParams.get('foo')}</p>
-                 9 | }
-               To debug the issue, start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error."
-              `)
-            } else {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at <unknown> (app/unauthorized/[slug]/unauthorized.tsx:6:24)
-                   at body (<anonymous>)
-                   at html (<anonymous>)
-                 4 |
-                 5 | export default function Unauthorized() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                        ^
-                 7 |
-                 8 |   return <p>unauthorized {searchParams.get('foo')}</p>
-                 9 | }
-               To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                 - Start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error.
-                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
-              `)
-            }
-          } else {
-            if (isDebugPrerender) {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at Unauthorized (webpack:///app/unauthorized/[slug]/unauthorized.tsx:6:39)
-                 4 |
-                 5 | export default function Unauthorized() {
-               > 6 |   const searchParams = useSearchParams()
-                   |                                       ^
-                 7 |
-                 8 |   return <p>unauthorized {searchParams.get('foo')}</p>
-                 9 | }
-               To debug the issue, start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error."
-              `)
-            } else {
-              expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
-
-               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
-
-               Ways to fix this:
-                 - Cache the data access with \`"use cache"\`
-                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
-                 - Set \`export const instant = false\` to allow a blocking route
-
-               Learn more: https://nextjs.org/docs/messages/blocking-route
-                   at a (<next-dist-dir>)
-                   at b (<next-dist-dir>)
-                   at c (<next-dist-dir>)
-                   at d (<next-dist-dir>)
-                   at e (<next-dist-dir>)
-                   at f (<next-dist-dir>)
-                   at g (<next-dist-dir>)
-                   at h (<next-dist-dir>)
-                   at i (<next-dist-dir>)
-                   at j (<next-dist-dir>)
-                   at k (<next-dist-dir>)
-                   at l (<next-dist-dir>)
-                   at m (<next-dist-dir>)
-                   at n (<next-dist-dir>)
-                   at o (<next-dist-dir>)
-                   at p (<next-dist-dir>)
-                   at q (<next-dist-dir>)
-                   at r (<next-dist-dir>)
-                   at s (<next-dist-dir>)
-                   at t (<next-dist-dir>)
-                   at u (<next-dist-dir>)
-                   at v (<next-dist-dir>)
-                   at w (<next-dist-dir>)
-                   at x (<next-dist-dir>)
-                   at y (<next-dist-dir>)
-                   at z (<next-dist-dir>)
-                   at a (<next-dist-dir>)
-                   at b (<next-dist-dir>)
-                   at c (<next-dist-dir>)
-                   at d (<next-dist-dir>)
-                   at e (<next-dist-dir>)
-                   at f (<next-dist-dir>)
-                   at g (<next-dist-dir>)
-                   at body (<anonymous>)
-                   at html (<anonymous>)
-               To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                 - Start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error.
-                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
-              `)
-            }
-          }
+          expect(output).toMatchInlineSnapshot(`""`)
+          await expectStaticRouteArtifacts('unauthorized/unauthorized', 401)
         })
       }
     })

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
@@ -123,7 +123,17 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at NotFound (app/not-found/[slug]/not-found.tsx:6:39)
                  4 |
                  5 | export default function NotFound() {
@@ -131,54 +141,112 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                    |                                       ^
                  7 |
                  8 |   return <p>not found {searchParams.get('foo')}</p>
-                 9 | } {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 9 | }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error."
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at <unknown> (app/not-found/[slug]/not-found.tsx:6:24)
+                   at body (<anonymous>)
+                   at html (<anonymous>)
                  4 |
                  5 | export default function NotFound() {
                > 6 |   const searchParams = useSearchParams()
                    |                        ^
                  7 |
                  8 |   return <p>not found {searchParams.get('foo')}</p>
-                 9 | } {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 9 | }
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
               `)
             }
           } else {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
-                   at useDynamicSearchParams (webpack:///<next-src>)
-                   at useSearchParams (webpack:///<next-src>)
+               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at NotFound (webpack:///app/not-found/[slug]/not-found.tsx:6:39)
-                 707 |         return
-                 708 |       }
-               > 709 |       throw new BailoutToCSRError(expression)
-                     |             ^
-                 710 |     }
-                 711 |     case 'prerender':
-                 712 |     case 'prerender-runtime': {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 4 |
+                 5 | export default function NotFound() {
+               > 6 |   const searchParams = useSearchParams()
+                   |                                       ^
+                 7 |
+                 8 |   return <p>not found {searchParams.get('foo')}</p>
+                 9 | }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error."
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/not-found/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at a (<next-dist-dir>)
                    at b (<next-dist-dir>)
-                   at c (<next-dist-dir>) {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                   at c (<next-dist-dir>)
+                   at d (<next-dist-dir>)
+                   at e (<next-dist-dir>)
+                   at f (<next-dist-dir>)
+                   at g (<next-dist-dir>)
+                   at h (<next-dist-dir>)
+                   at i (<next-dist-dir>)
+                   at j (<next-dist-dir>)
+                   at k (<next-dist-dir>)
+                   at l (<next-dist-dir>)
+                   at m (<next-dist-dir>)
+                   at n (<next-dist-dir>)
+                   at o (<next-dist-dir>)
+                   at p (<next-dist-dir>)
+                   at q (<next-dist-dir>)
+                   at r (<next-dist-dir>)
+                   at s (<next-dist-dir>)
+                   at t (<next-dist-dir>)
+                   at u (<next-dist-dir>)
+                   at v (<next-dist-dir>)
+                   at w (<next-dist-dir>)
+                   at x (<next-dist-dir>)
+                   at y (<next-dist-dir>)
+                   at z (<next-dist-dir>)
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>)
+                   at c (<next-dist-dir>)
+                   at d (<next-dist-dir>)
+                   at e (<next-dist-dir>)
+                   at f (<next-dist-dir>)
+                   at g (<next-dist-dir>)
+                   at body (<anonymous>)
+                   at html (<anonymous>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/not-found/[slug]" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
               `)
             }
           }
@@ -210,7 +278,17 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at Forbidden (app/forbidden/[slug]/forbidden.tsx:6:39)
                  4 |
                  5 | export default function Forbidden() {
@@ -218,54 +296,112 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                    |                                       ^
                  7 |
                  8 |   return <p>forbidden {searchParams.get('foo')}</p>
-                 9 | } {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 9 | }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error."
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at <unknown> (app/forbidden/[slug]/forbidden.tsx:6:24)
+                   at body (<anonymous>)
+                   at html (<anonymous>)
                  4 |
                  5 | export default function Forbidden() {
                > 6 |   const searchParams = useSearchParams()
                    |                        ^
                  7 |
                  8 |   return <p>forbidden {searchParams.get('foo')}</p>
-                 9 | } {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 9 | }
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
               `)
             }
           } else {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
-                   at useDynamicSearchParams (webpack:///<next-src>)
-                   at useSearchParams (webpack:///<next-src>)
+               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at Forbidden (webpack:///app/forbidden/[slug]/forbidden.tsx:6:39)
-                 707 |         return
-                 708 |       }
-               > 709 |       throw new BailoutToCSRError(expression)
-                     |             ^
-                 710 |     }
-                 711 |     case 'prerender':
-                 712 |     case 'prerender-runtime': {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 4 |
+                 5 | export default function Forbidden() {
+               > 6 |   const searchParams = useSearchParams()
+                   |                                       ^
+                 7 |
+                 8 |   return <p>forbidden {searchParams.get('foo')}</p>
+                 9 | }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error."
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/forbidden/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at a (<next-dist-dir>)
                    at b (<next-dist-dir>)
-                   at c (<next-dist-dir>) {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                   at c (<next-dist-dir>)
+                   at d (<next-dist-dir>)
+                   at e (<next-dist-dir>)
+                   at f (<next-dist-dir>)
+                   at g (<next-dist-dir>)
+                   at h (<next-dist-dir>)
+                   at i (<next-dist-dir>)
+                   at j (<next-dist-dir>)
+                   at k (<next-dist-dir>)
+                   at l (<next-dist-dir>)
+                   at m (<next-dist-dir>)
+                   at n (<next-dist-dir>)
+                   at o (<next-dist-dir>)
+                   at p (<next-dist-dir>)
+                   at q (<next-dist-dir>)
+                   at r (<next-dist-dir>)
+                   at s (<next-dist-dir>)
+                   at t (<next-dist-dir>)
+                   at u (<next-dist-dir>)
+                   at v (<next-dist-dir>)
+                   at w (<next-dist-dir>)
+                   at x (<next-dist-dir>)
+                   at y (<next-dist-dir>)
+                   at z (<next-dist-dir>)
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>)
+                   at c (<next-dist-dir>)
+                   at d (<next-dist-dir>)
+                   at e (<next-dist-dir>)
+                   at f (<next-dist-dir>)
+                   at g (<next-dist-dir>)
+                   at body (<anonymous>)
+                   at html (<anonymous>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/forbidden/[slug]" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
               `)
             }
           }
@@ -297,7 +433,17 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at Unauthorized (app/unauthorized/[slug]/unauthorized.tsx:6:39)
                  4 |
                  5 | export default function Unauthorized() {
@@ -305,54 +451,112 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                    |                                       ^
                  7 |
                  8 |   return <p>unauthorized {searchParams.get('foo')}</p>
-                 9 | } {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 9 | }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error."
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at <unknown> (app/unauthorized/[slug]/unauthorized.tsx:6:24)
+                   at body (<anonymous>)
+                   at html (<anonymous>)
                  4 |
                  5 | export default function Unauthorized() {
                > 6 |   const searchParams = useSearchParams()
                    |                        ^
                  7 |
                  8 |   return <p>unauthorized {searchParams.get('foo')}</p>
-                 9 | } {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 9 | }
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
               `)
             }
           } else {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
-                   at useDynamicSearchParams (webpack:///<next-src>)
-                   at useSearchParams (webpack:///<next-src>)
+               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at Unauthorized (webpack:///app/unauthorized/[slug]/unauthorized.tsx:6:39)
-                 707 |         return
-                 708 |       }
-               > 709 |       throw new BailoutToCSRError(expression)
-                     |             ^
-                 710 |     }
-                 711 |     case 'prerender':
-                 712 |     case 'prerender-runtime': {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                 4 |
+                 5 | export default function Unauthorized() {
+               > 6 |   const searchParams = useSearchParams()
+                   |                                       ^
+                 7 |
+                 8 |   return <p>unauthorized {searchParams.get('foo')}</p>
+                 9 | }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error."
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Bail out to client-side rendering: useSearchParams()
+               "Error: Route "/unauthorized/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - Cache the data access with \`"use cache"\`
+                 - Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - If the runtime data is \`params\` and they're known, prerender them with \`generateStaticParams\`
+                 - Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route
                    at a (<next-dist-dir>)
                    at b (<next-dist-dir>)
-                   at c (<next-dist-dir>) {
-                 reason: 'useSearchParams()',
-                 digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }"
+                   at c (<next-dist-dir>)
+                   at d (<next-dist-dir>)
+                   at e (<next-dist-dir>)
+                   at f (<next-dist-dir>)
+                   at g (<next-dist-dir>)
+                   at h (<next-dist-dir>)
+                   at i (<next-dist-dir>)
+                   at j (<next-dist-dir>)
+                   at k (<next-dist-dir>)
+                   at l (<next-dist-dir>)
+                   at m (<next-dist-dir>)
+                   at n (<next-dist-dir>)
+                   at o (<next-dist-dir>)
+                   at p (<next-dist-dir>)
+                   at q (<next-dist-dir>)
+                   at r (<next-dist-dir>)
+                   at s (<next-dist-dir>)
+                   at t (<next-dist-dir>)
+                   at u (<next-dist-dir>)
+                   at v (<next-dist-dir>)
+                   at w (<next-dist-dir>)
+                   at x (<next-dist-dir>)
+                   at y (<next-dist-dir>)
+                   at z (<next-dist-dir>)
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>)
+                   at c (<next-dist-dir>)
+                   at d (<next-dist-dir>)
+                   at e (<next-dist-dir>)
+                   at f (<next-dist-dir>)
+                   at g (<next-dist-dir>)
+                   at body (<anonymous>)
+                   at html (<anonymous>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/unauthorized/[slug]" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces."
               `)
             }
           }

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
@@ -72,6 +72,33 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
       await next.build({ args })
     }
 
+    const buildPath = async (pathname: string) => {
+      const args = ['--debug-build-paths', `app${pathname}/page.tsx`]
+
+      if (isDebugPrerender) {
+        args.push('--debug-prerender')
+      }
+
+      await next.build({ args })
+    }
+
+    const expectStaticRouteArtifacts = async (route: string) => {
+      const meta = JSON.parse(
+        await next.readFile(`.next/server/app/${route}.meta`)
+      )
+
+      expect(await next.readFile(`.next/server/app/${route}.html`)).toEqual(
+        expect.any(String)
+      )
+      expect(meta.status).toBe(404)
+      expect(meta.segmentPaths).toContain('/_tree')
+      expect(
+        await next.readFile(
+          `.next/server/app/${route}.segments/_tree.segment.rsc`
+        )
+      ).toEqual(expect.any(String))
+    }
+
     describe('notFound()', () => {
       const pagePath = '/not-found/[slug]'
       const visitUrl = '/not-found/not-found'
@@ -85,12 +112,8 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           )
         })
       } else {
-        it('should error the build with a blocking-route error', async () => {
-          try {
-            await prerender(pagePath)
-          } catch {
-            // we expect the build to fail
-          }
+        it('should log the fallback dynamic error without failing the build', async () => {
+          await prerender(pagePath)
 
           const output = getPrerenderOutput(
             next.cliOutput.slice(cliOutputLength),
@@ -111,11 +134,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  9 | } {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/not-found/not-found". Read more: https://nextjs.org/docs/messages/prerender-error
-
-               > Export encountered errors on 1 path:
-               	/not-found/[slug]/page: /not-found/not-found"
+               }"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
@@ -130,9 +149,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  9 | } {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/not-found/not-found". Read more: https://nextjs.org/docs/messages/prerender-error
-               Export encountered an error on /not-found/[slug]/page: /not-found/not-found, exiting the build."
+               }"
               `)
             }
           } else {
@@ -151,11 +168,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  712 |     case 'prerender-runtime': {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/not-found/not-found". Read more: https://nextjs.org/docs/messages/prerender-error
-
-               > Export encountered errors on 1 path:
-               	/not-found/[slug]/page: /not-found/not-found"
+               }"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
@@ -165,9 +178,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                    at c (<next-dist-dir>) {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/not-found/not-found". Read more: https://nextjs.org/docs/messages/prerender-error
-               Export encountered an error on /not-found/[slug]/page: /not-found/not-found, exiting the build."
+               }"
               `)
             }
           }
@@ -188,12 +199,8 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           )
         })
       } else {
-        it('should error the build with a blocking-route error', async () => {
-          try {
-            await prerender(pagePath)
-          } catch {
-            // we expect the build to fail
-          }
+        it('should log the fallback dynamic error without failing the build', async () => {
+          await prerender(pagePath)
 
           const output = getPrerenderOutput(
             next.cliOutput.slice(cliOutputLength),
@@ -214,11 +221,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  9 | } {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/forbidden/forbidden". Read more: https://nextjs.org/docs/messages/prerender-error
-
-               > Export encountered errors on 1 path:
-               	/forbidden/[slug]/page: /forbidden/forbidden"
+               }"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
@@ -233,9 +236,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  9 | } {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/forbidden/forbidden". Read more: https://nextjs.org/docs/messages/prerender-error
-               Export encountered an error on /forbidden/[slug]/page: /forbidden/forbidden, exiting the build."
+               }"
               `)
             }
           } else {
@@ -254,11 +255,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  712 |     case 'prerender-runtime': {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/forbidden/forbidden". Read more: https://nextjs.org/docs/messages/prerender-error
-
-               > Export encountered errors on 1 path:
-               	/forbidden/[slug]/page: /forbidden/forbidden"
+               }"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
@@ -268,9 +265,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                    at c (<next-dist-dir>) {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/forbidden/forbidden". Read more: https://nextjs.org/docs/messages/prerender-error
-               Export encountered an error on /forbidden/[slug]/page: /forbidden/forbidden, exiting the build."
+               }"
               `)
             }
           }
@@ -291,12 +286,8 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
           )
         })
       } else {
-        it('should error the build with a blocking-route error', async () => {
-          try {
-            await prerender(pagePath)
-          } catch {
-            // we expect the build to fail
-          }
+        it('should log the fallback dynamic error without failing the build', async () => {
+          await prerender(pagePath)
 
           const output = getPrerenderOutput(
             next.cliOutput.slice(cliOutputLength),
@@ -317,11 +308,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  9 | } {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/unauthorized/unauthorized". Read more: https://nextjs.org/docs/messages/prerender-error
-
-               > Export encountered errors on 1 path:
-               	/unauthorized/[slug]/page: /unauthorized/unauthorized"
+               }"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
@@ -336,9 +323,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  9 | } {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/unauthorized/unauthorized". Read more: https://nextjs.org/docs/messages/prerender-error
-               Export encountered an error on /unauthorized/[slug]/page: /unauthorized/unauthorized, exiting the build."
+               }"
               `)
             }
           } else {
@@ -357,11 +342,7 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                  712 |     case 'prerender-runtime': {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/unauthorized/unauthorized". Read more: https://nextjs.org/docs/messages/prerender-error
-
-               > Export encountered errors on 1 path:
-               	/unauthorized/[slug]/page: /unauthorized/unauthorized"
+               }"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
@@ -371,12 +352,19 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
                    at c (<next-dist-dir>) {
                  reason: 'useSearchParams()',
                  digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
-               }
-               Error occurred prerendering page "/unauthorized/unauthorized". Read more: https://nextjs.org/docs/messages/prerender-error
-               Export encountered an error on /unauthorized/[slug]/page: /unauthorized/unauthorized, exiting the build."
+               }"
               `)
             }
           }
+        })
+      }
+    })
+
+    describe('notFound() above the matching not-found boundary', () => {
+      if (!isNextDev) {
+        it('should emit static artifacts', async () => {
+          await buildPath('/not-found-above-boundary/child')
+          await expectStaticRouteArtifacts('not-found-above-boundary/child')
         })
       }
     })

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
@@ -126,6 +126,24 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
       }
     })
 
+    describe('notFound() with root client params during recovery', () => {
+      const pagePath = '/not-found-use-params/[slug]'
+
+      if (!isNextDev) {
+        it('should fall through from the resume-abort recovery and emit static artifacts', async () => {
+          await prerender(pagePath)
+
+          const output = getPrerenderOutput(
+            next.cliOutput.slice(cliOutputLength),
+            { isMinified: !isDebugPrerender }
+          )
+
+          expect(output).toMatchInlineSnapshot(`""`)
+          await expectStaticRouteArtifacts('not-found-use-params/not-found')
+        })
+      }
+    })
+
     describe('forbidden()', () => {
       const pagePath = '/forbidden/[slug]'
       const visitUrl = '/forbidden/forbidden'

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.http-access-fallback-prerender.test.ts
@@ -91,6 +91,28 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
         expect.any(String)
       )
       expect(meta.status).toBe(status)
+      expect(meta.postponed).toBeUndefined()
+      expect(meta.segmentPaths).toContain('/_tree')
+      expect(
+        await next.readFile(
+          `.next/server/app/${route}.segments/_tree.segment.rsc`
+        )
+      ).toEqual(expect.any(String))
+    }
+
+    const expectPartiallyStaticErrorArtifacts = async (
+      route: string,
+      status = 404
+    ) => {
+      const meta = JSON.parse(
+        await next.readFile(`.next/server/app/${route}.meta`)
+      )
+
+      expect(await next.readFile(`.next/server/app/${route}.html`)).toEqual(
+        expect.any(String)
+      )
+      expect(meta.status).toBe(status)
+      expect(meta.postponed).toEqual(expect.any(String))
       expect(meta.segmentPaths).toContain('/_tree')
       expect(
         await next.readFile(
@@ -140,6 +162,44 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
 
           expect(output).toMatchInlineSnapshot(`""`)
           await expectStaticRouteArtifacts('not-found-use-params/not-found')
+        })
+      }
+    })
+
+    describe('notFound() with static RSC data', () => {
+      const pagePath = '/not-found-static-flight/[slug]'
+
+      if (!isNextDev) {
+        it('should preserve the original static Flight data during recovery', async () => {
+          await prerender(pagePath)
+
+          const output = getPrerenderOutput(
+            next.cliOutput.slice(cliOutputLength),
+            { isMinified: !isDebugPrerender }
+          )
+
+          expect(output).toMatchInlineSnapshot(`""`)
+          await expectStaticRouteArtifacts('not-found-static-flight/not-found')
+        })
+      }
+    })
+
+    describe('notFound() with dynamic RSC data', () => {
+      const pagePath = '/not-found-dynamic-flight/[slug]'
+
+      if (!isNextDev) {
+        it('should preserve the original dynamic Flight data during recovery', async () => {
+          await prerender(pagePath)
+
+          const output = getPrerenderOutput(
+            next.cliOutput.slice(cliOutputLength),
+            { isMinified: !isDebugPrerender }
+          )
+
+          expect(output).toMatchInlineSnapshot(`""`)
+          await expectPartiallyStaticErrorArtifacts(
+            'not-found-dynamic-flight/not-found'
+          )
         })
       }
     })

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-above-boundary/child/not-found.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-above-boundary/child/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <p>child not found</p>
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-above-boundary/child/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-above-boundary/child/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>child page</p>
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-above-boundary/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-above-boundary/layout.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Layout() {
+  notFound()
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/@parallel/default.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/@parallel/default.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Default() {
+  notFound()
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  parallel,
+}: {
+  children: React.ReactNode
+  parallel: React.ReactNode
+}) {
+  return (
+    <>
+      {children}
+      {parallel}
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/not-found.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <p>not found after dynamic flight</p>
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-dynamic-flight/[slug]/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export function generateStaticParams() {
+  return [{ slug: 'not-found' }]
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>loading dynamic flight</p>}>
+      <DynamicCookieValue />
+    </Suspense>
+  )
+}
+
+async function DynamicCookieValue() {
+  const value =
+    (await cookies()).get('http-access-fallback-prerender')?.value ?? 'missing'
+
+  return <p>dynamic cookie value: {value}</p>
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/@parallel/default.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/@parallel/default.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Default() {
+  notFound()
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  parallel,
+}: {
+  children: React.ReactNode
+  parallel: React.ReactNode
+}) {
+  return (
+    <>
+      {children}
+      {parallel}
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/not-found.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <p>not found after static flight</p>
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-static-flight/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export function generateStaticParams() {
+  return [{ slug: 'not-found' }]
+}
+
+export default function Page() {
+  return <p>static flight</p>
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-use-params/[slug]/not-found.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-use-params/[slug]/not-found.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function NotFound() {
+  const params = useParams<{ slug: string }>()
+
+  return <p>not found {params.slug}</p>
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-use-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/http-access-fallback-prerender/app/not-found-use-params/[slug]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation'
+
+export function generateStaticParams() {
+  return [{ slug: 'found' }, { slug: 'not-found' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  if (slug === 'found') {
+    return <p>hello world</p>
+  }
+
+  notFound()
+}


### PR DESCRIPTION
Effectively

Relands #93988
Reverts #92231

Prerendering the notFound loaderTree turns out to not be the correct behavior in many cases. The original motivation of 92231 as to solve the connection closed problem caused by statically prerendering an incomplete HTTP event like notFound() when cacheComponents is enabled because it would leave holes in the inlined flight data that never resolved and led to reported errors on hydration.

This change now continues to fork the CC behavior of the error handler but it treats the error page as a resumable page so fresh hydration data is generated if it wasn't able to be entirely static.

This is good for correctness but it also means the page is not going to statically prerender the notFound UI. This will be handled in a followup