### PR TITLE
docs: update Contributor Covenant link to HTTPS

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,5 +49,5 @@ members of the project's leadership.
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
 available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct/][version]
 
-[homepage]: http://contributor-covenant.org
+[homepage]: https://www.contributor-covenant.org
 [version]: https://www.contributor-covenant.org/version/2/1


### PR DESCRIPTION
### What
Updates the Contributor Covenant homepage reference in `CODE_OF_CONDUCT.md` from HTTP to HTTPS.

### Why
The same file already references the specific Contributor Covenant version over HTTPS. This keeps the homepage reference consistent and avoids an outdated insecure link in the root Code of Conduct.

### Verification
- `git diff --check`
- Verified `CODE_OF_CONDUCT.md` no longer contains `http://contributor-covenant.org`
