### PR TITLE
Add Chromium-only Playwright image publisher

### DIFF
--- a/.github/images/playwright-chromium/Dockerfile
+++ b/.github/images/playwright-chromium/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker.io/docker/dockerfile:1
+FROM ubuntu:noble
+
+ARG NODE_VERSION=20.9.0
+ARG PLAYWRIGHT_VERSION
+ARG IMAGE_NAME_TEMPLATE=ghcr.io/vercel/next.js-playwright-chromium:v%version%-noble-r1
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV FNM_DIR=/usr/local/share/fnm
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PATH=/usr/local/share/fnm:$PATH
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ENV TZ=Etc/UTC
+
+RUN apt-get update && \
+    test -n "${NODE_VERSION}" && \
+    test -n "${PLAYWRIGHT_VERSION}" && \
+    apt-get install -y --no-install-recommends \
+      bash \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      openssh-client \
+      unzip \
+      wget && \
+    curl -fsSL https://fnm.vercel.app/install | bash && \
+    fnm install "${NODE_VERSION}" && \
+    fnm default "${NODE_VERSION}" && \
+    eval "$(fnm env)" && \
+    npm install -g yarn && \
+    mkdir -p /ms-playwright /ms-playwright-agent && \
+    cd /ms-playwright-agent && \
+    npm init -y && \
+    npm i "playwright-core@${PLAYWRIGHT_VERSION}" && \
+    npm exec --no -- playwright-core mark-docker-image "${IMAGE_NAME_TEMPLATE}" && \
+    npm exec --no -- playwright-core install --with-deps chromium && \
+    rm -rf /var/lib/apt/lists/* /ms-playwright-agent ~/.npm && \
+    chmod -R 777 /ms-playwright && \
+    useradd --uid 1001 --create-home --shell /bin/bash pwuser && \
+    chown -R pwuser:pwuser "${FNM_DIR}" /home/pwuser

--- a/.github/workflows/playwright_chromium_image.yml
+++ b/.github/workflows/playwright_chromium_image.yml
@@ -1,0 +1,72 @@
+name: build-playwright-chromium-image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - canary
+    paths:
+      - '.github/images/playwright-chromium/**'
+      - '.github/workflows/playwright_chromium_image.yml'
+      - '.github/workflows/build_reusable.yml'
+      - 'package.json'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/vercel/next.js-playwright-chromium
+  IMAGE_REVISION: 1
+
+jobs:
+  build:
+    if: github.repository == 'vercel/next.js'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.0
+
+      - name: Resolve Playwright version
+        id: version
+        run: |
+          version="$(yq -r '.devDependencies.playwright' package.json)"
+          node_version="$(yq -r '.env.NODE_LTS_VERSION' .github/workflows/build_reusable.yml)"
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "Unable to resolve Playwright version from package.json"
+            exit 1
+          fi
+          if [ -z "$node_version" ] || [ "$node_version" = "null" ]; then
+            echo "Unable to resolve Node.js version from build_reusable.yml"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "node_version=${node_version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}-noble-r${IMAGE_REVISION}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+      - name: Build and push Chromium image
+        env:
+          IMAGE_TAG: ${{ steps.version.outputs.tag }}
+          NODE_VERSION: ${{ steps.version.outputs.node_version }}
+          PLAYWRIGHT_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx create --use --name nextjs-playwright-builder
+          # Keep this GHCR package public: job containers are pulled before any
+          # workflow step can authenticate to a private registry.
+          docker buildx build \
+            --file .github/images/playwright-chromium/Dockerfile \
+            --build-arg NODE_VERSION="$NODE_VERSION" \
+            --build-arg PLAYWRIGHT_VERSION="$PLAYWRIGHT_VERSION" \
+            --build-arg IMAGE_NAME_TEMPLATE="$IMAGE_NAME:v%version%-noble-r$IMAGE_REVISION" \
+            --tag "$IMAGE_NAME:$IMAGE_TAG" \
+            --platform linux/amd64 \
+            --push \
+            .github/images/playwright-chromium


### PR DESCRIPTION
### What?

Add the Next.js-owned Chromium-only Playwright image definition and a workflow that builds and pushes it to GHCR.

### Why?

This needs to merge before the reusable CI workflow starts using the image, so the GHCR tag exists when job containers are initialized.

### How?

- Add a Noble-based Chromium image with the CI build dependencies, Playwright Chromium, and the repository's Node.js LTS version preinstalled.
- Add a manual/canary-only publisher workflow that derives Playwright from `package.json`, Node.js from `build_reusable.yml`, and tags images with a Next.js-owned revision suffix.
- Keep the image revision in the publisher workflow so Dockerfile-only changes can publish a distinct immutable tag.

### Verification

- `git diff --cached --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/playwright_chromium_image.yml")'`
- Not run: `docker buildx build --check --build-arg PLAYWRIGHT_VERSION=1.58.2 .github/images/playwright-chromium` (Docker daemon is not running locally)
- Not run: `pnpm prettier --with-node-modules --ignore-path .prettierignore --write .github/workflows/playwright_chromium_image.yml .github/images/playwright-chromium/Dockerfile` (`prettier` command is not available in this checkout)

<!-- NEXT_JS_LLM_PR -->
