### PR TITLE
Use Chromium-only Playwright CI image

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -103,24 +103,30 @@ on:
         default: 'yes'
       playwrightDockerImage:
         description: >
-          Docker image to use on Linux runners that need Playwright. Pinned to
-          the same version as the `playwright` dependency in `package.json`;
-          the image ships Chromium/Firefox/WebKit and all system deps
-          preinstalled, so the per-job install step is skipped on Linux.
-          Use the `-noble` (Ubuntu 24.04) variant so its glibc (>=2.39)
-          matches the `ubuntu-latest` host runners that build the
-          `next-swc.linux-x64-gnu.node` native binary; an older base (e.g.
-          `-jammy`) fails to dlopen the native binary at runtime with
-          `GLIBC_2.39 not found`.
+          Deprecated. Use `playwrightChromiumDockerImage` for Chromium
+          container jobs. Non-Chromium jobs run directly on the runner and
+          install Playwright browsers at runtime.
         required: false
         type: string
         default: 'mcr.microsoft.com/playwright:v1.58.2-noble'
+      playwrightChromiumDockerImage:
+        description: >
+          Chromium-only Docker image to use for the default Chromium Linux
+          test jobs. This image is maintained in this repository and also
+          includes jq, unzip, and build-essential so container jobs do not need
+          to apt-install them on every run. The trailing revision suffix should
+          be bumped together with IMAGE_REVISION in
+          playwright_chromium_image.yml when the image Dockerfile changes
+          without a Playwright version bump.
+        required: false
+        type: string
+        default: 'ghcr.io/vercel/next.js-playwright-chromium:v1.58.2-noble-r1'
       usePlaywrightContainer:
         description: >
           When 'no', run the job directly on the Linux runner and install
           Playwright at runtime instead of wrapping the job in
-          `playwrightDockerImage`. Use this for jobs that need tooling not
-          shipped in the container image (e.g. `rustup` for the wasm tests).
+          `playwrightChromiumDockerImage`. Use this for jobs that need tooling
+          not shipped in the container image (e.g. `rustup` for the wasm tests).
         required: false
         type: string
         default: 'yes'
@@ -179,17 +185,19 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     runs-on: ${{ fromJson(inputs.runs_on_labels) }}
 
-    # Run inside Microsoft's prebuilt Playwright image on Linux when the job
-    # actually needs browsers, so the per-job "Install Playwright browsers"
-    # step (download + apt-based `--with-deps`) disappears entirely. When the
-    # expression evaluates to '', GitHub Actions runs the job directly on the
-    # runner (Windows jobs, build-only jobs, and any job that opts out via
-    # `needsPlaywright: 'no'` or `skipInstallBuild: 'yes'`).
+    # Run Chromium jobs inside a smaller Next.js-owned Chromium-only image on
+    # Linux, so the per-job "Install Playwright browsers" step (download +
+    # apt-based `--with-deps`) disappears for the common case. Firefox/WebKit
+    # jobs run directly on the runner and install Playwright at runtime, like
+    # Windows jobs. When the expression evaluates to '', GitHub Actions runs the
+    # job directly on the runner (Windows jobs, build-only jobs, non-Chromium
+    # jobs, and any job that opts out via `needsPlaywright: 'no'` or
+    # `skipInstallBuild: 'yes'`).
     container:
-      image: ${{ (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows')) && inputs.playwrightDockerImage || '' }}
+      image: ${{ (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && inputs.browser == 'chromium' && !contains(inputs.runs_on_labels, 'windows')) && inputs.playwrightChromiumDockerImage || '' }}
       # --ipc=host avoids Chromium running out of memory in /dev/shm.
       # --init reaps zombie browser processes properly.
-      options: --ipc=host --init
+      options: --ipc=host --init --user pwuser
       env:
         # The Next.js standalone server template binds to
         # `process.env.HOSTNAME || '0.0.0.0'` (see
@@ -234,32 +242,6 @@ jobs:
           else
             echo "fnm not found."
             echo "found=false" >> $GITHUB_OUTPUT
-          fi
-
-      # The Microsoft Playwright image is browser-focused and does not ship
-      # `jq`/`unzip` (required by the fnm install + `fnm env --json` parse
-      # below) or `build-essential` (required by `node-gyp` when test
-      # fixtures install native modules like `node-pty`). Install them
-      # unconditionally inside the container.
-      - name: Install container build dependencies (Linux container)
-        if: ${{ runner.os == 'Linux' && inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows') }}
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends jq unzip build-essential
-
-      # GitHub Actions sets `HOME=/github/home` for every step in a
-      # container job and overrides anything set via `container.env`.
-      # Playwright's GitHub Actions example runs the container as a
-      # non-root user, but this reusable workflow needs root so it can
-      # install jq/unzip/build-essential from the upstream image before
-      # bootstrapping. Firefox still requires $HOME to be owned by the
-      # current user, so re-own GitHub's mounted home directory in the
-      # Playwright container before tests run.
-      - name: Take ownership of /github/home (Linux container)
-        if: ${{ runner.os == 'Linux' && inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows') }}
-        run: |
-          if [ "$(id -u)" = "0" ] && [ -d /github/home ]; then
-            chown -R root:root /github/home
           fi
 
       - name: Install fnm
@@ -318,19 +300,12 @@ jobs:
         with:
           fetch-depth: 25
 
-      - name: Mark workspace as safe for Git (Linux container)
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          if [ "$(id -u)" = "0" ]; then
-            git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          fi
-
       # Cache pnpm store on GitHub-hosted runners (self-hosted runners have
       # their own persistent storage). Also fire inside the Playwright
       # container since the container filesystem is always ephemeral, even
       # when the host runner is persistent.
       - name: Get pnpm store directory
-        if: ${{ runner.environment == 'github-hosted' || (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows')) }}
+        if: ${{ runner.environment == 'github-hosted' || (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && inputs.browser == 'chromium' && !contains(inputs.runs_on_labels, 'windows')) }}
         id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
@@ -403,7 +378,7 @@ jobs:
         # risk caching an incomplete store
         # If keep conditions in sync breaks, we can split into restore and save
         # steps where saving runs based on the outcome of the install step
-        if: ${{ (runner.environment == 'github-hosted' || (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows'))) && (inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes') }}
+        if: ${{ (runner.environment == 'github-hosted' || (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && inputs.browser == 'chromium' && !contains(inputs.runs_on_labels, 'windows'))) && (inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes') }}
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         timeout-minutes: 5
         id: cache-pnpm-store
@@ -424,7 +399,7 @@ jobs:
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
       - name: Install Playwright browsers
-        if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' && (runner.os == 'Windows' || inputs.usePlaywrightContainer == 'no') }}
+        if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' && (runner.os == 'Windows' || inputs.usePlaywrightContainer == 'no' || (runner.os == 'Linux' && inputs.browser != 'chromium')) }}
         run: pnpm playwright install --with-deps ${{ inputs.browser }}
 
       - name: Download pre-built test timings


### PR DESCRIPTION
### What?

Use the Chromium-only Playwright image from #94051 for Linux Chromium CI jobs.

### Why?

The image must be published first, then this stacked PR can switch CI to it. That avoids pulling the full Playwright browser image for Chromium jobs and removes the per-job apt install for container build dependencies.

### How?

- Add `playwrightChromiumDockerImage` with the published GHCR tag.
- Run only Chromium Linux jobs in the container, as `pwuser`.
- Run Firefox/WebKit Linux jobs directly on the runner and install browsers at runtime like Windows.
- Remove the old root-only container apt install, `/github/home` ownership, and Git safe-directory workarounds.

### Verification

- `git diff --cached --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_reusable.yml")'`
- Not run: full CI is expected to need the #94051 image published to GHCR before this top PR can pass.
- Not run: `pnpm prettier --with-node-modules --ignore-path .prettierignore --write .github/workflows/build_reusable.yml` (`prettier` command is not available in this checkout)

<!-- NEXT_JS_LLM_PR -->
