### PR TITLE
[ci] Fix the playwright-chromium Dockerfile

### DIFF
--- a/.github/images/playwright-chromium/Dockerfile
+++ b/.github/images/playwright-chromium/Dockerfile
@@ -1,4 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1
+# Loosely based on:
+# https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.noble
+
 FROM ubuntu:noble
 
 ARG NODE_VERSION=20.9.0
@@ -12,10 +15,13 @@ ENV LC_ALL=C.UTF-8
 ENV PATH=/usr/local/share/fnm:$PATH
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV TZ=Etc/UTC
+ENV FNM_VERSION=v1.39.0
+ENV FNM_SHA256=7807664f39d39fc518da1c35ba0181e4b3267603c4b1dedeb4b5fc6ae440a224
+ENV FNM_PATH=/usr/bin/fnm
 
-RUN apt-get update && \
-    test -n "${NODE_VERSION}" && \
+RUN test -n "${NODE_VERSION}" && \
     test -n "${PLAYWRIGHT_VERSION}" && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
       bash \
       build-essential \
@@ -26,18 +32,25 @@ RUN apt-get update && \
       openssh-client \
       unzip \
       wget && \
-    curl -fsSL https://fnm.vercel.app/install | bash && \
-    fnm install "${NODE_VERSION}" && \
-    fnm default "${NODE_VERSION}" && \
-    eval "$(fnm env)" && \
+    curl -L --fail --retry 2 -o /tmp/fnm-linux.zip \
+      "https://github.com/Schniz/fnm/releases/download/$FNM_VERSION/fnm-linux.zip" && \
+    echo "$FNM_SHA256  /tmp/fnm-linux.zip" | sha256sum --check --status && \
+    unzip /tmp/fnm-linux.zip fnm  -d "$(dirname "$FNM_PATH")" && \
+    rm /tmp/fnm-linux.zip && \
+    chmod +x "$FNM_PATH" && \
+    fnm install "$NODE_VERSION" && \
+    fnm default "$NODE_VERSION"
+
+# put chrome in a separate layer to get some benefits from parallel pulling
+RUN eval "$(fnm env)" && \
     npm install -g yarn && \
     mkdir -p /ms-playwright /ms-playwright-agent && \
     cd /ms-playwright-agent && \
     npm init -y && \
-    npm i "playwright-core@${PLAYWRIGHT_VERSION}" && \
-    npm exec --no -- playwright-core mark-docker-image "${IMAGE_NAME_TEMPLATE}" && \
+    npm i "playwright-core@$PLAYWRIGHT_VERSION" && \
+    npm exec --no -- playwright-core mark-docker-image "$IMAGE_NAME_TEMPLATE" && \
     npm exec --no -- playwright-core install --with-deps chromium && \
     rm -rf /var/lib/apt/lists/* /ms-playwright-agent ~/.npm && \
     chmod -R 777 /ms-playwright && \
     useradd --uid 1001 --create-home --shell /bin/bash pwuser && \
-    chown -R pwuser:pwuser "${FNM_DIR}" /home/pwuser
+    chown -R pwuser:pwuser "$FNM_DIR" /home/pwuser


### PR DESCRIPTION
Added in https://github.com/vercel/next.js/pull/94051

Failing in canary: https://github.com/vercel/next.js/actions/runs/26311675098

Successful `workflow_dispatch` job here: https://github.com/vercel/next.js/actions/runs/26319776612/job/77486403513

Tested locally with

```
podman build . --build-arg=NODE_VERSION=20.9.0 --build-arg=PLAYWRIGHT_VERSION=1.58.2
```

If you're on arm64, you need to change the url from `fnm-linux.zip` to `fnm-arm64.zip` and update the checksum.