### PR TITLE
fix: await ensureInstrumentationRegistered in RouteModule.prepare

### DIFF
--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -671,7 +671,7 @@ export abstract class RouteModule<
       )
       // ensure instrumentation is registered and pass
       // onRequestError below
-      ensureInstrumentationRegistered(absoluteProjectDir, this.distDir)
+      await ensureInstrumentationRegistered(absoluteProjectDir, this.distDir)
     }
     const manifests = this.loadManifests(srcPage, absoluteProjectDir)
     const { routesManifest, prerenderManifest, serverFilesManifest } = manifests


### PR DESCRIPTION
### What?

`RouteModule.prepare()` called `ensureInstrumentationRegistered()` without `await`ing it, then proceeded to load manifests and handle the request. This adds the missing `await`.

### Why?

The function is async and registers the instrumentation hook (including `onRequestError`). Without awaiting, request handling can begin before registration completes, so early request errors may not reach `onRequestError`. Every other call site already awaits it — `next-server.ts`, `next-dev-server.ts`, and `web/adapter.ts` — so this was the only inconsistent path. The inline comment ("ensure instrumentation is registered and pass onRequestError below") confirms the intent was to complete registration first.

### How?

Add `await` to the call in `route-module.ts`. `ensureInstrumentationRegistered()` memoizes its promise (`registerInstrumentationPromise`), so after the first request this awaits an already-resolved promise — effectively free.

### Verification

- `pnpm --filter=next build`
- `pnpm --filter=next types`
- `pnpm prettier --write` + `eslint --fix` on the changed file (clean)
- `pnpm test-dev-turbo test/e2e/instrumentation-hook/instrumentation-hook.test.ts` (9 passed, 1 skipped)
- `pnpm test-dev-turbo test/e2e/app-dir/instrumentation-order` (passed)
- Not adding a dedicated unit test: the change fixes a registration race that is not feasible to assert deterministically. Coverage is via the existing instrumentation e2e suites above, and the change makes this call site consistent with every other one.

Fixes #93993

<!-- NEXT_JS_LLM_PR -->