### PR TITLE
[Skills] Mark backport-pr and create-pr as internal

### DIFF
--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -7,6 +7,8 @@ description: >
   finding the merged PR commit, creating a backport branch from the target
   release branch, cherry-picking from canary, validating, and opening the PR
   with the release branch as the base.
+metadata:
+  internal: true
 ---
 
 # Backport PR

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -6,6 +6,8 @@ description: >
   PR or draft PR, publish a pull request, or recover from gh pr create / PR
   template issues. Covers .github/pull_request_template.md, --body formatting,
   NEXT_JS_LLM_PR, codex/ branch names, and Codex app git directives.
+metadata:
+  internal: true
 ---
 
 # Create PR


### PR DESCRIPTION
Adds `metadata.internal: true` to `backport-pr` and `create-pr` so they aren't published alongside the user-facing Next.js skills in `/skills`. These are maintainer workflows, not for app developers consuming Next.js.

<!-- NEXT_JS_LLM_PR -->