### PR TITLE
fix: improve error messaging for invalid param types in getStaticPaths

### DIFF
--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -167,10 +167,9 @@ export async function buildPagesStaticPaths({
           (!repeat && typeof paramValue !== 'string') ||
           typeof paramValue === 'undefined'
         ) {
-          throw new Error(
-            `A required parameter (${validParamKey}) was not provided as ${
-              repeat ? 'an array' : 'a string'
-            } received ${typeof paramValue} in getStaticPaths for ${page}`
+          const expectedType = repeat ? 'an array of strings' : 'a string'
+          throw new TypeError(
+            `A required parameter (${validParamKey}) was not provided as ${expectedType} in getStaticPaths for ${page}. Received ${typeof paramValue}. See: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
           )
         }
 

--- a/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
+++ b/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
@@ -290,7 +290,7 @@ describe('Dynamic Optional Routing - build validation', () => {
     )
     await next.build()
     expect(next.cliOutput).toMatch(
-      'A required parameter (slug) was not provided as an array received undefined in getStaticPaths for /invalid/[[...slug]]'
+      'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /invalid/[[...slug]]'
     )
     // Clean up
     await next.deleteFile('pages/invalid/[[...slug]].js')

--- a/test/production/prerender-invalid-catchall-params/index.test.ts
+++ b/test/production/prerender-invalid-catchall-params/index.test.ts
@@ -13,7 +13,7 @@ describe('Invalid Prerender Catchall Params', () => {
       const out = await next.build()
       expect(out.cliOutput).toMatch(`Build error occurred`)
       expect(out.cliOutput).toMatch(
-        'A required parameter (slug) was not provided as an array received string in getStaticPaths for /[...slug]'
+        'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /[...slug]'
       )
     })
   })


### PR DESCRIPTION
## What?

Improves the error message when `getStaticPaths` receives a parameter with an incorrect type (e.g., passing a `number` instead of a `string` for a dynamic route param, or passing a `string` instead of an array for a catch-all param).

**Before:**
```
Error: A required parameter (id) was not provided as a string received number in getStaticPaths for /[id]
```

**After:**
```
TypeError: A required parameter (id) was not provided as a string in getStaticPaths for /[id]. Received number. See: https://nextjs.org/docs/messages/invalid-getstaticpaths-value
```

## Why?

The original error message was grammatically awkward ("was not provided as a string received number") and used `Error` instead of `TypeError` for what is fundamentally a type mismatch. For catch-all params, it said "an array" instead of "an array of strings", which was imprecise. Issue: #41281

## How?

- Changed `Error` to `TypeError` in `packages/next/src/build/static-paths/pages.ts`
- Changed error message for catch-all params from "an array" to "an array of strings"
- Improved the message grammar (separated clauses with periods)
- Added a helpful link to the docs
- Updated existing test expectations to match the new message format

Fixes #41281

<!-- NEXT_JS_LLM_PR -->