### PR TITLE
feat(eslint-plugin): add no-unallowed-tags-in-head rule

### DIFF
--- a/errors/no-unallowed-tags-in-head.mdx
+++ b/errors/no-unallowed-tags-in-head.mdx
@@ -1,0 +1,67 @@
+---
+title: No Unallowed Tags in Head
+---
+
+> Prevent usage of invalid HTML tags in `next/head` component.
+
+## Why This Error Occurred
+
+An invalid HTML element (e.g., `<html>`, `<body>`, `<div>`, `<main>`, `<section>`) was used inside the `next/head` component. Only elements valid inside the HTML `<head>` section are allowed as children of `<Head>`: `title`, `meta`, `link`, `style`, `script`, `base`, `noscript`, and `template`.
+
+When invalid elements are rendered inside `<head>`, the browser silently moves them (and all subsequent content) to the `<body>`, causing head tags to not be applied correctly during client-side navigation. This previously resulted in the misleading error: `"next-head-count is missing"`.
+
+## Possible Ways to Fix It
+
+Remove the invalid element from `<Head>` and place it in the appropriate location.
+
+### Before
+
+```jsx filename="pages/index.js"
+import Head from 'next/head'
+
+export default function Page() {
+  return (
+    <Head>
+      <html lang="en" />
+      <title>My Page</title>
+    </Head>
+  )
+}
+```
+
+### After
+
+```jsx filename="pages/index.js"
+import Head from 'next/head'
+
+export default function Page() {
+  return (
+    <Head>
+      <title>My Page</title>
+    </Head>
+  )
+}
+```
+
+For the `lang` attribute, use a [custom `_document`](/docs/pages/building-your-application/routing/custom-document) instead:
+
+```jsx filename="pages/_document.js"
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}
+```
+
+## Useful Links
+
+- [next/head API Reference](/docs/pages/api-reference/components/head)
+- [Custom Document](/docs/pages/building-your-application/routing/custom-document)

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -21,6 +21,7 @@ import noStyledJsxInDocument from './rules/no-styled-jsx-in-document'
 import noSyncScripts from './rules/no-sync-scripts'
 import noTitleInDocumentHead from './rules/no-title-in-document-head'
 import noTypos from './rules/no-typos'
+import noUnallowedTagsInHead from './rules/no-unallowed-tags-in-head'
 import noUnwantedPolyfillio from './rules/no-unwanted-polyfillio'
 
 const recommendedRules = {
@@ -40,6 +41,7 @@ const recommendedRules = {
   '@next/next/no-sync-scripts': 'warn',
   '@next/next/no-title-in-document-head': 'warn',
   '@next/next/no-typos': 'warn',
+  '@next/next/no-unallowed-tags-in-head': 'warn',
   '@next/next/no-unwanted-polyfillio': 'warn',
   // errors
   '@next/next/inline-script-id': 'error',
@@ -82,6 +84,7 @@ const plugin = {
     'no-sync-scripts': noSyncScripts,
     'no-title-in-document-head': noTitleInDocumentHead,
     'no-typos': noTypos,
+    'no-unallowed-tags-in-head': noUnallowedTagsInHead,
     'no-unwanted-polyfillio': noUnwantedPolyfillio,
   } satisfies Record<string, Rule.RuleModule>,
   configs: {} as ESLintPluginConfigs,

--- a/packages/eslint-plugin-next/src/rules/no-unallowed-tags-in-head.ts
+++ b/packages/eslint-plugin-next/src/rules/no-unallowed-tags-in-head.ts
@@ -43,23 +43,33 @@ export default defineRule({
 
         // Check if this is a <Head> component
         const tagName = node.openingElement?.name
-        if (!tagName || (tagName.type === 'Identifier' && tagName.name !== 'Head')) {
+        if (
+          !tagName ||
+          (tagName.type === 'JSXIdentifier' && tagName.name !== 'Head')
+        ) {
           return
         }
 
         const checkChildren = (children: any[], depth: number) => {
           for (const child of children) {
+            // Handle JSXFragment shorthand (<>...</>)
+            if (child.type === 'JSXFragment') {
+              if (depth < 1) {
+                checkChildren(child.children || [], depth + 1)
+              }
+              continue
+            }
+
             if (child.type === 'JSXElement') {
               const childTagName = child.openingElement?.name
 
               if (!childTagName) continue
 
-              // Handle React.Fragment (<>, <Fragment>, <React.Fragment>)
+              // Handle named Fragment (<Fragment>, <React.Fragment>)
               if (
-                childTagName.type === 'JSXFragment' ||
-                (childTagName.type === 'Identifier' &&
-                  (childTagName.name === 'Fragment' ||
-                    childTagName.name === 'ReactFragment'))
+                childTagName.type === 'JSXIdentifier' &&
+                (childTagName.name === 'Fragment' ||
+                  childTagName.name === 'ReactFragment')
               ) {
                 if (depth < 1) {
                   checkChildren(child.children || [], depth + 1)
@@ -69,7 +79,7 @@ export default defineRule({
 
               // Skip custom React components (PascalCase)
               if (
-                childTagName.type === 'Identifier' &&
+                childTagName.type === 'JSXIdentifier' &&
                 childTagName.name[0] === childTagName.name[0].toUpperCase() &&
                 childTagName.name[0] !== childTagName.name[0].toLowerCase()
               ) {
@@ -78,7 +88,7 @@ export default defineRule({
 
               // Check if it's a lowercase HTML tag that's not in the valid set
               if (
-                childTagName.type === 'Identifier' &&
+                childTagName.type === 'JSXIdentifier' &&
                 !VALID_HEAD_TAGS.has(childTagName.name)
               ) {
                 context.report({

--- a/packages/eslint-plugin-next/src/rules/no-unallowed-tags-in-head.ts
+++ b/packages/eslint-plugin-next/src/rules/no-unallowed-tags-in-head.ts
@@ -1,0 +1,98 @@
+import { defineRule } from '../utils/define-rule'
+
+const url = 'https://nextjs.org/docs/messages/no-unallowed-tags-in-head'
+
+// Tags that are valid inside <head> per HTML spec
+const VALID_HEAD_TAGS = new Set([
+  'title',
+  'meta',
+  'link',
+  'style',
+  'script',
+  'base',
+  'noscript',
+  'template',
+])
+
+export default defineRule({
+  meta: {
+    docs: {
+      description:
+        'Prevent invalid HTML tags from being used in `next/head` component.',
+      recommended: true,
+      url,
+    },
+    type: 'problem',
+    schema: [],
+    messages: {
+      invalidTag:
+        'Do not use `<{{tag}}>` inside `<Head>` from `next/head`. Only tags valid in `<head>` are allowed: `title`, `meta`, `link`, `style`, `script`, `base`, `noscript`, and `template`. See: {{url}}',
+    },
+  },
+  create(context) {
+    let isNextHeadImported = false
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'next/head') {
+          isNextHeadImported = true
+        }
+      },
+      JSXElement(node) {
+        if (!isNextHeadImported) return
+
+        // Check if this is a <Head> component
+        const tagName = node.openingElement?.name
+        if (!tagName || (tagName.type === 'Identifier' && tagName.name !== 'Head')) {
+          return
+        }
+
+        const checkChildren = (children: any[], depth: number) => {
+          for (const child of children) {
+            if (child.type === 'JSXElement') {
+              const childTagName = child.openingElement?.name
+
+              if (!childTagName) continue
+
+              // Handle React.Fragment (<>, <Fragment>, <React.Fragment>)
+              if (
+                childTagName.type === 'JSXFragment' ||
+                (childTagName.type === 'Identifier' &&
+                  (childTagName.name === 'Fragment' ||
+                    childTagName.name === 'ReactFragment'))
+              ) {
+                if (depth < 1) {
+                  checkChildren(child.children || [], depth + 1)
+                }
+                continue
+              }
+
+              // Skip custom React components (PascalCase)
+              if (
+                childTagName.type === 'Identifier' &&
+                childTagName.name[0] === childTagName.name[0].toUpperCase() &&
+                childTagName.name[0] !== childTagName.name[0].toLowerCase()
+              ) {
+                continue
+              }
+
+              // Check if it's a lowercase HTML tag that's not in the valid set
+              if (
+                childTagName.type === 'Identifier' &&
+                !VALID_HEAD_TAGS.has(childTagName.name)
+              ) {
+                context.report({
+                  node: child,
+                  messageId: 'invalidTag',
+                  data: { tag: childTagName.name, url },
+                })
+              }
+            }
+          }
+        }
+
+        checkChildren(node.children || [], 0)
+      },
+    }
+  },
+})

--- a/test/unit/eslint-plugin-next/no-unallowed-tags-in-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-unallowed-tags-in-head.test.ts
@@ -1,0 +1,184 @@
+import { RuleTester } from 'eslint'
+import { rules } from '@next/eslint-plugin-next'
+
+const NextESLintRule = rules['no-unallowed-tags-in-head']
+
+const url = 'https://nextjs.org/docs/messages/no-unallowed-tags-in-head'
+
+const tests = {
+  valid: [
+    // Valid head tags
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><title>My Title</title></Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><meta name="desc" content="hello" /></Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><link rel="icon" href="/favicon.ico" /></Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><style>{'body { color: red }'}</style></Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><base href="/" /></Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    // Fragment wrapping is OK
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><><title>My Title</title><meta name="desc" content="hello" /></></Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    // Custom component (PascalCase) is OK
+    {
+      code: `import Head from 'next/head'
+        const MyMeta = () => <meta name="custom" content="val" />
+        export default function Page() {
+          return <Head><MyMeta /></Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    // No next/head import — should not trigger
+    {
+      code: `export default function Page() {
+          return <head><html lang="en" /></head>
+        }`,
+      filename: 'pages/index.js',
+    },
+    // Multiple valid tags
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head>
+            <title>My Page</title>
+            <meta name="viewport" content="width=device-width" />
+            <link rel="stylesheet" href="/styles.css" />
+            <noscript>Your browser does not support JavaScript.</noscript>
+          </Head>
+        }`,
+      filename: 'pages/index.js',
+    },
+  ],
+
+  invalid: [
+    // <html> inside <Head>
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><html lang="en" /><title>My Title</title></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [
+        {
+          messageId: 'invalidTag',
+          data: { tag: 'html', url },
+        },
+      ],
+    },
+    // <body> inside <Head>
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><body><title>My Title</title></body></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [
+        {
+          messageId: 'invalidTag',
+          data: { tag: 'body', url },
+        },
+      ],
+    },
+    // <div> inside <Head>
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><div>content</div></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [{ messageId: 'invalidTag' }],
+    },
+    // <main> inside <Head>
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><main>content</main></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [{ messageId: 'invalidTag' }],
+    },
+    // <section> inside <Head>
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><section>content</section></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [{ messageId: 'invalidTag' }],
+    },
+    // Multiple invalid tags
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><html lang="en" /><body className="dark"></body></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [{ messageId: 'invalidTag' }, { messageId: 'invalidTag' }],
+    },
+    // Invalid tag inside Fragment
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><><div>content</div><title>My Title</title></></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [{ messageId: 'invalidTag' }],
+    },
+    // <h1> inside <Head>
+    {
+      code: `import Head from 'next/head'
+        export default function Page() {
+          return <Head><h1>My Title</h1></Head>
+        }`,
+      filename: 'pages/index.js',
+      errors: [{ messageId: 'invalidTag' }],
+    },
+  ],
+}
+
+describe('no-unallowed-tags-in-head', () => {
+  new RuleTester({
+    languageOptions: {
+      ecmaVersion: 2018,
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          modules: true,
+          jsx: true,
+        },
+      },
+    },
+  }).run('eslint', NextESLintRule, tests)
+})


### PR DESCRIPTION
## What?

Adds a new ESLint rule `no-unallowed-tags-in-head` that detects and warns when invalid HTML elements (e.g., `<html>`, `<body>`, `<div>`, `<main>`, `<section>`) are used as children of `<Head>` from `next/head`.

This prevents the misleading `"next-head-count is missing"` error at its root cause by catching invalid tags at lint time.

**Before (runtime error):**
```
Warning: next-head-count is missing. https://nextjs.org/docs/messages/next-head-count-missing
```

**After (lint warning):**
```
Do not use `<html>` inside `<Head>` from `next/head`. Only tags valid in `<head>` are allowed: `title`, `meta`, `link`, `style`, `script`, `base`, `noscript`, and `template`. See: https://nextjs.org/docs/messages/no-unallowed-tags-in-head
```

## Why?

When invalid HTML elements are placed inside `<Head>`, the browser silently moves them (and all subsequent content) from `<head>` to `<body>`. This causes the `next-head-count` meta tag to be displaced, resulting in a confusing error message that does not point to the actual cause. Issue: #20924

As suggested by @timneutkens, this should be an ESLint rule rather than a runtime fix.

## How?

- Created `packages/eslint-plugin-next/src/rules/no-unallowed-tags-in-head.ts`
- Registered the rule in `packages/eslint-plugin-next/src/index.ts` (added to recommended)
- Added comprehensive test suite in `test/unit/eslint-plugin-next/no-unallowed-tags-in-head.test.ts`
- Added error documentation in `errors/no-unallowed-tags-in-head.mdx`

The rule:
- Only triggers when `next/head` is imported (avoids false positives)
- Allows `React.Fragment` wrapping (1 level deep, matching Next.js behavior)
- Skips custom React components (PascalCase) that may render valid head tags internally
- Reports on lowercase HTML tags that are not in the valid `<head>` tag set
- Set to `warn` in the recommended config

Fixes #20924

<!-- NEXT_JS_LLM_PR -->