### PR TITLE
fix(next): type AppType generic as app props

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<any> & P
 >
 
 export type AppTreeType = ComponentType<

--- a/test/e2e/typescript/pages/_app.tsx
+++ b/test/e2e/typescript/pages/_app.tsx
@@ -1,7 +1,15 @@
 import type { AppType } from 'next/app'
 
-const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
-  return <Component {...pageProps} />
+const MyApp: AppType<{ foo: string }> = ({ Component, pageProps, foo }) => {
+  // @ts-expect-error AppType's parameter applies to app props, not page props.
+  type _PageFoo = typeof pageProps.foo
+
+  return (
+    <>
+      <p id="app-prop">{foo}</p>
+      <Component {...pageProps} />
+    </>
+  )
 }
 
 MyApp.getInitialProps = () => ({ foo: 'bar' })

--- a/test/e2e/typescript/typescript.test.ts
+++ b/test/e2e/typescript/typescript.test.ts
@@ -12,6 +12,7 @@ describe('TypeScript Features', () => {
 
   it('should render the page', async () => {
     const $ = await next.render$('/hello')
+    expect($('#app-prop').text()).toBe('bar')
     expect($('body').text()).toMatch(/Hello World/)
     expect($('body').text()).toMatch(/1000000000000/)
   })


### PR DESCRIPTION
### What?

Update `AppType<P>` so its generic parameter augments app props instead of `pageProps`.

### Why?

The current type applies `P` to `pageProps`, which makes custom app-level props inferred from `getInitialProps` harder to type and does not match the apparent intent of the exported helper.

Closes #42846

### How?

- Change `AppType<P>` to compose `P` with `AppPropsType<any>`.
- Extend the TypeScript e2e fixture to verify custom app props are available and not treated as `pageProps`.

### Testing

- Focused `tsc` check for `test/e2e/typescript/pages/_app.tsx`
- `git diff --check`
- `prettier --check` on touched files

<!-- NEXT_JS_LLM_PR -->
