### PR TITLE
fix(next): return 405 for POST to static pages in dev

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2048,6 +2048,16 @@ export default abstract class Server<
     const hasServerProps = !!components.getServerSideProps
     const isPossibleServerAction = getIsPossibleServerAction(req)
     let isSSG = !!components.getStaticProps
+    const isDevAutoExportPage =
+      this.dev &&
+      !isAppPath &&
+      !isDynamicRoute(pathname) &&
+      !isSSG &&
+      !hasServerProps &&
+      typeof components.Component !== 'string' &&
+      !(components.Component as any).getInitialProps &&
+      components.App.getInitialProps ===
+        (components.App as any).origGetInitialProps
     // NOTE: Don't delete headers[RSC] yet, it still needs to be used in renderToHTML later
     const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
 
@@ -2286,7 +2296,7 @@ export default abstract class Server<
       pathname !== '/_error' &&
       req.method !== 'HEAD' &&
       req.method !== 'GET' &&
-      (typeof components.Component === 'string' || isSSG)
+      (typeof components.Component === 'string' || isSSG || isDevAutoExportPage)
     ) {
       res.statusCode = 405
       res.setHeader('Allow', ['GET', 'HEAD'])

--- a/test/development/pages-dir/request-methods/request-methods.test.ts
+++ b/test/development/pages-dir/request-methods/request-methods.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('Pages Router request methods', () => {
+  const { next } = nextTestSetup({
+    startServerTimeout: 30_000,
+    startCommand: 'node node_modules/next/dist/bin/next dev',
+    files: {
+      'pages/index.js': `
+        export default function Page() {
+          return <p>hello world</p>
+        }
+      `,
+    },
+  })
+
+  it('should respond with 405 for POST to an auto-static page', async () => {
+    const res = await next.fetch('/', { method: 'POST' })
+    const allow = res.headers.get('allow') || ''
+
+    expect(res.status).toBe(405)
+    expect(allow).toContain('GET')
+    expect(allow).toContain('HEAD')
+    expect(await res.text()).toContain('Method Not Allowed')
+  })
+})


### PR DESCRIPTION
### What?

Return `405 Method Not Allowed` for non-GET/HEAD requests to auto-static Pages Router pages in development.

### Why?

Static pages already return 405 for unsupported methods in production-like paths, but in `next dev` a POST to an auto-static page could render successfully instead.

Closes #38863

### How?

- Detect dev-only auto-exportable Pages Router pages before render.
- Reuse the existing 405 response path for non-GET/HEAD requests.
- Add a focused dev regression test for POSTing to `/`.

### Testing

- `pnpm test-dev-webpack test/development/pages-dir/request-methods/request-methods.test.ts`
- `git diff --check`
- `prettier --check` on touched files

<!-- NEXT_JS_LLM_PR -->
