### PR TITLE
fix(next/head): filter invalid html and body tags

### DIFF
--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -46,6 +46,18 @@ function onlyReactElement(
   return list.concat(child)
 }
 
+function isValidHeadChild(c: React.ReactElement<any>) {
+  if (c.type === 'html' || c.type === 'body') {
+    if (process.env.NODE_ENV === 'development') {
+      warnOnce(
+        `Do not add <${c.type}> tags using next/head. next/head can only handle tags inside the HTML <head> tag.`
+      )
+    }
+    return false
+  }
+  return true
+}
+
 const METATYPES = ['name', 'httpEquiv', 'charSet', 'itemProp']
 
 /*
@@ -121,6 +133,7 @@ function reduceComponents(
 ) {
   return headChildrenElements
     .reduce(onlyReactElement, [])
+    .filter(isValidHeadChild)
     .reverse()
     .concat(defaultHead().reverse())
     .filter(unique())

--- a/test/development/pages-dir/client-navigation/fixture/pages/head-invalid-elements.js
+++ b/test/development/pages-dir/client-navigation/fixture/pages/head-invalid-elements.js
@@ -1,0 +1,15 @@
+import Head from 'next/head'
+
+export default function HeadInvalidElementsPage() {
+  return (
+    <div>
+      <Head>
+        <html data-next-head-invalid="html" />
+        <body data-next-head-invalid="body" />
+        <title>Valid Head Title</title>
+        <meta name="valid-head" content="kept" />
+      </Head>
+      <h1>Invalid head elements</h1>
+    </div>
+  )
+}

--- a/test/development/pages-dir/client-navigation/rendering-head.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering-head.test.ts
@@ -170,6 +170,18 @@ describe('Client Navigation rendering <Head />', () => {
     expect(html).toContain('<meta content="meta fragment" data-next-head=""/>')
   })
 
+  test('header helper warns about and filters invalid html/body children', async () => {
+    const html = await render('/head-invalid-elements')
+
+    expect(html).toContain('<title data-next-head="">Valid Head Title</title>')
+    expect(html).toContain(
+      '<meta name="valid-head" content="kept" data-next-head=""/>'
+    )
+    expect(html).not.toContain('data-next-head-invalid')
+    expect(next.cliOutput).toContain('Do not add <html> tags using next/head')
+    expect(next.cliOutput).toContain('Do not add <body> tags using next/head')
+  })
+
   test('header helper renders boolean attributes correctly children', async () => {
     const html = await render('/head')
     expect(html).toContain(


### PR DESCRIPTION
### What?

Warn and filter invalid `<html>` and `<body>` children passed to `next/head`.

### Why?

`next/head` should only manage elements that belong inside the document `<head>`. Passing document-level tags can produce invalid output instead of a useful development warning.

Closes #20924

### How?

- Filter `<html>` and `<body>` React elements during head reduction.
- Emit a development-only warning with `warnOnce`.
- Add a regression fixture and assertion that valid head tags remain while invalid tags are excluded.

### Testing

- Focused dev regression was reported passing by the worker agent.
- Local rerun was blocked by the isolated dev harness spawning `pnpm` with `ENOENT` in this desktop environment after dependency install succeeded.
- `git diff --check`
- `prettier --check` on touched files

<!-- NEXT_JS_LLM_PR -->
