### PR TITLE
fix(client): resolve hydration deadlock on HMR WebSocket failure

### DIFF
--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -173,3 +173,16 @@ export function createDebugChannel(
 
   return { readable }
 }
+
+export function closeAllDebugChannels(): void {
+  for (const pair of pairs.values()) {
+    try {
+      pair.writer.ready.then(() => pair.writer.close()).catch(() => {})
+    } catch {}
+  }
+  pairs.clear()
+}
+
+export function resetDebugChannelState(): void {
+  initialDocumentDebugChunks = []
+}

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -15,6 +15,10 @@ import {
 import { logQueue } from '../../../../next-devtools/userspace/app/forward-logs'
 import { InvariantError } from '../../../../shared/lib/invariant-error'
 import { WEB_SOCKET_MAX_RECONNECTIONS } from '../../../../lib/constants'
+import {
+  closeAllDebugChannels,
+  resetDebugChannelState,
+} from '../../debug-channel'
 
 let reconnections = 0
 let reloading = false
@@ -46,6 +50,8 @@ export function createWebSocket(
     if (webSocket) {
       webSocket.close()
     }
+
+    resetDebugChannelState()
 
     const newWebSocket = new window.WebSocket(
       `${getSocketUrl(assetPrefix)}/_next/hmr?id=${self.__next_r}`
@@ -116,6 +122,7 @@ export function createWebSocket(
     }
 
     function handleDisconnect() {
+      closeAllDebugChannels()
       newWebSocket.onerror = null
       newWebSocket.onclose = null
       newWebSocket.close()


### PR DESCRIPTION
### Fix Turbopack Hydration Deadlock on HMR WebSocket Failure

#### Issue
React hydration hangs indefinitely in environments (like cross-origin WebViews) where the HMR WebSocket connection fails to open or is closed.

#### Root Cause
With Turbopack debug telemetry enabled, React enters dual-stream mode. If the HMR WebSocket connection fails to open or is terminated, the debug telemetry stream never receives its terminating chunk and remains pending indefinitely. This blocks the main server response from resolving and prevents hydration from executing.

#### Solution
* Added lifecycle hook `closeAllDebugChannels()` in `debug-channel.ts` to safely close all active debug stream writers and clear the registry.
* Added lifecycle hook `resetDebugChannelState()` to clear the initial document chunks buffer.
* Wired these hooks directly into `web-socket.ts`:
  * `resetDebugChannelState()` is invoked inside `init()` prior to WebSocket creation.
  * `closeAllDebugChannels()` is invoked inside `handleDisconnect()` to immediately close unresolved debug streams on connection failure/disconnect.

This ensures graceful degradation. If the HMR WebSocket fails or drops, active debug streams are closed and the page hydrates successfully.

<!-- NEXT_JS_LLM_PR -->
