### PR TITLE
fix(app-dir): handle not-found pageExtensions manifest

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -134,6 +134,14 @@ const pluginState = getProxiedPluginState({
 const POSSIBLE_SHARED_CONVENTIONS = ['template', 'layout']
 const STANDALONE_BUNDLE_CONVENTION = 'global-not-found'
 
+function isAppConventionBundlePath(bundlePath: string, convention: string) {
+  const appConventionPath = `app/${convention}`
+  return (
+    bundlePath === appConventionPath ||
+    bundlePath.startsWith(`${appConventionPath}.`)
+  )
+}
+
 function deduplicateCSSImportsForEntry(mergedCSSimports: CssImports) {
   // If multiple entry module connections are having the same CSS import,
   // we only need to have one module to keep track of that CSS import.
@@ -431,7 +439,7 @@ export class FlightClientEntryPlugin {
         // TODO-APP: This could be better handled, however Turbopack does not have the same problem as we resolve client components in a single graph.
         if (
           name === `app${UNDERSCORE_NOT_FOUND_ROUTE_ENTRY}` &&
-          bundlePath === 'app/not-found'
+          isAppConventionBundlePath(bundlePath, 'not-found')
         ) {
           clientEntriesToInject.push({
             compiler,
@@ -445,7 +453,7 @@ export class FlightClientEntryPlugin {
 
         if (
           name === `app${UNDERSCORE_NOT_FOUND_ROUTE_ENTRY}` &&
-          bundlePath === 'app/global-not-found'
+          isAppConventionBundlePath(bundlePath, 'global-not-found')
         ) {
           clientEntriesToInject.push({
             compiler,

--- a/test/production/app-dir/not-found-page-extension/app/layout.page.js
+++ b/test/production/app-dir/not-found-page-extension/app/layout.page.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/not-found-page-extension/app/not-found.page.js
+++ b/test/production/app-dir/not-found-page-extension/app/not-found.page.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <p id="not-found">custom not found</p>
+}

--- a/test/production/app-dir/not-found-page-extension/app/page.page.js
+++ b/test/production/app-dir/not-found-page-extension/app/page.page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home page</p>
+}

--- a/test/production/app-dir/not-found-page-extension/next.config.js
+++ b/test/production/app-dir/not-found-page-extension/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['page.jsx', 'page.js'],
+}

--- a/test/production/app-dir/not-found-page-extension/not-found-page-extension.test.ts
+++ b/test/production/app-dir/not-found-page-extension/not-found-page-extension.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app dir - not-found with compound pageExtensions', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    buildCommand: 'node node_modules/next/dist/bin/next build',
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  beforeAll(async () => {
+    await next.build()
+  })
+
+  it('should prerender /_not-found and emit its client reference manifest', async () => {
+    expect(next.cliOutput).toContain('Compiled successfully')
+
+    const appPathsManifest = JSON.parse(
+      await next.readFile('.next/server/app-paths-manifest.json')
+    )
+    expect(appPathsManifest).toHaveProperty('/_not-found/page')
+
+    const clientReferenceManifest = await next.readFile(
+      '.next/server/app/_not-found/page_client-reference-manifest.js'
+    )
+    expect(clientReferenceManifest).toContain(
+      '__RSC_MANIFEST["/_not-found/page"]'
+    )
+    expect(clientReferenceManifest).toContain('"clientModules"')
+  })
+})


### PR DESCRIPTION
Closes #65447

## Summary

- Treat compound app convention bundle paths like `app/not-found.page` as the `not-found` convention.
- Add production coverage for `pageExtensions` with an app `not-found` route and verify the client reference manifest is emitted.

## Testing

- `PATH=./node_modules/.bin:/Users/c543982/.npm/_npx/179a5fd3f63fede5/node_modules/.bin:$PATH scripts/run-jest.sh --mode=start --bundler=webpack --headless -- test/production/app-dir/not-found-page-extension/not-found-page-extension.test.ts`
- `git diff --check`
- `./node_modules/.bin/prettier --check packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts test/production/app-dir/not-found-page-extension/not-found-page-extension.test.ts test/production/app-dir/not-found-page-extension/app/layout.page.js test/production/app-dir/not-found-page-extension/app/page.page.js test/production/app-dir/not-found-page-extension/app/not-found.page.js test/production/app-dir/not-found-page-extension/next.config.js`

<!-- NEXT_JS_LLM_PR -->
