### PR TITLE
fix(dev): refresh generated interception rewrites

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -35,6 +35,7 @@ import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-s
 import { createClientRouterFilter } from '../../../lib/create-client-router-filter'
 import { absolutePathToPage } from '../../../shared/lib/page-path/absolute-path-to-page'
 import { generateInterceptionRoutesRewrites } from '../../../lib/generate-interception-routes-rewrites'
+import { isInterceptionRouteRewrite } from '../../../lib/is-interception-route-rewrite'
 
 import {
   CLIENT_STATIC_FILES_PATH,
@@ -993,7 +994,13 @@ async function startWatcher(
         )
       )
 
-      opts.fsChecker.rewrites.beforeFiles.push(...interceptionRoutes)
+      const beforeFilesRewrites = opts.fsChecker.rewrites.beforeFiles
+      for (let i = beforeFilesRewrites.length - 1; i >= 0; i--) {
+        if (isInterceptionRouteRewrite(beforeFilesRewrites[i])) {
+          beforeFilesRewrites.splice(i, 1)
+        }
+      }
+      beforeFilesRewrites.push(...interceptionRoutes)
 
       const exportPathMap =
         (typeof nextConfig.exportPathMap === 'function' &&

--- a/test/development/app-dir/interception-routes-rewrites-hmr/app/@slot/(.)photo/page.js
+++ b/test/development/app-dir/interception-routes-rewrites-hmr/app/@slot/(.)photo/page.js
@@ -1,0 +1,3 @@
+export default function SlotPhoto() {
+  return <h1>Slot photo</h1>
+}

--- a/test/development/app-dir/interception-routes-rewrites-hmr/app/@slot/default.js
+++ b/test/development/app-dir/interception-routes-rewrites-hmr/app/@slot/default.js
@@ -1,0 +1,3 @@
+export default function SlotDefault() {
+  return null
+}

--- a/test/development/app-dir/interception-routes-rewrites-hmr/app/layout.js
+++ b/test/development/app-dir/interception-routes-rewrites-hmr/app/layout.js
@@ -1,0 +1,10 @@
+export default function RootLayout({ children, slot }) {
+  return (
+    <html>
+      <body>
+        <main id="children">{children}</main>
+        <aside id="slot">{slot}</aside>
+      </body>
+    </html>
+  )
+}

--- a/test/development/app-dir/interception-routes-rewrites-hmr/app/page.js
+++ b/test/development/app-dir/interception-routes-rewrites-hmr/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Home</h1>
+}

--- a/test/development/app-dir/interception-routes-rewrites-hmr/app/photo/page.js
+++ b/test/development/app-dir/interception-routes-rewrites-hmr/app/photo/page.js
@@ -1,0 +1,3 @@
+export default function PhotoPage() {
+  return <h1>Full photo</h1>
+}

--- a/test/development/app-dir/interception-routes-rewrites-hmr/app/picture/page.js
+++ b/test/development/app-dir/interception-routes-rewrites-hmr/app/picture/page.js
@@ -1,0 +1,3 @@
+export default function PicturePage() {
+  return <h1>Full picture</h1>
+}

--- a/test/development/app-dir/interception-routes-rewrites-hmr/interception-routes-rewrites-hmr.test.ts
+++ b/test/development/app-dir/interception-routes-rewrites-hmr/interception-routes-rewrites-hmr.test.ts
@@ -1,0 +1,52 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
+  'interception-routes-rewrites-hmr',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      startCommand: 'node node_modules/next/dist/bin/next dev',
+      startServerTimeout: 30_000,
+    })
+
+    async function renderWithNextUrl(pathname: string) {
+      const res = await next.fetch(pathname, {
+        headers: {
+          'Next-URL': '/',
+        },
+      })
+
+      return res.text()
+    }
+
+    it('replaces generated interception rewrites when an intercepting route folder is renamed', async () => {
+      const initialHtml = await renderWithNextUrl('/photo')
+      expect(initialHtml).toContain('Slot photo')
+      expect(initialHtml).not.toContain('Full photo')
+
+      try {
+        await next.renameFolder('app/@slot/(.)photo', 'app/@slot/(.)picture')
+        await next.patchFile('app/@slot/(.)picture/page.js', (content) =>
+          content.replace('Slot photo', 'Slot picture')
+        )
+
+        await retry(async () => {
+          const pictureHtml = await renderWithNextUrl('/picture')
+          expect(pictureHtml).toContain('Slot picture')
+          expect(pictureHtml).not.toContain('Full picture')
+
+          const photoHtml = await renderWithNextUrl('/photo')
+          expect(photoHtml).toContain('Full photo')
+          expect(photoHtml).not.toContain('Slot photo')
+        })
+      } finally {
+        await next
+          .renameFolder('app/@slot/(.)picture', 'app/@slot/(.)photo')
+          .catch(() => {})
+        await next.patchFile('app/@slot/(.)photo/page.js', (content) =>
+          content.replace('Slot picture', 'Slot photo')
+        )
+      }
+    })
+  }
+)


### PR DESCRIPTION
Closes #73803

## Summary

- Remove stale generated interception rewrites before appending the current generated set in dev.
- Add a dev HMR regression test that renames an intercepted route and verifies the old rewrite no longer wins.

## Testing

- `PATH=./node_modules/.bin:/Users/c543982/.npm/_npx/179a5fd3f63fede5/node_modules/.bin:$PATH scripts/run-jest.sh --mode=dev --bundler=webpack --headless -- test/development/app-dir/interception-routes-rewrites-hmr/interception-routes-rewrites-hmr.test.ts`
- `git diff --check`
- `./node_modules/.bin/prettier --check packages/next/src/server/lib/router-utils/setup-dev-bundler.ts test/development/app-dir/interception-routes-rewrites-hmr/interception-routes-rewrites-hmr.test.ts test/development/app-dir/interception-routes-rewrites-hmr/app/layout.js test/development/app-dir/interception-routes-rewrites-hmr/app/page.js 'test/development/app-dir/interception-routes-rewrites-hmr/app/@slot/(.)photo/page.js' test/development/app-dir/interception-routes-rewrites-hmr/app/@slot/default.js test/development/app-dir/interception-routes-rewrites-hmr/app/photo/page.js test/development/app-dir/interception-routes-rewrites-hmr/app/picture/page.js`

<!-- NEXT_JS_LLM_PR -->
