### PR TITLE
fix(cache): skip disk writes for app 404 responses

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -362,6 +362,14 @@ export default class FileSystemCache implements CacheHandler {
 
     if (!this.flushToDisk || !data) return
 
+    if (
+      (data.kind === CachedRouteKind.APP_PAGE ||
+        data.kind === CachedRouteKind.APP_ROUTE) &&
+      data.status === 404
+    ) {
+      return
+    }
+
     // Create a new writer that will prepare to write all the files to disk
     // after their containing directory is created.
     const writer = new MultiFileWriter(this.fs)

--- a/test/production/app-dir/isr-not-found-static-files/app/isr-not-found/[slug]/page.tsx
+++ b/test/production/app-dir/isr-not-found-static-files/app/isr-not-found/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation'
+
+export const revalidate = 60
+export const dynamicParams = true
+
+export function generateStaticParams() {
+  return [{ slug: 'valid' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  if (slug !== 'valid') {
+    notFound()
+  }
+
+  return <p>Valid ISR slug: {slug}</p>
+}

--- a/test/production/app-dir/isr-not-found-static-files/app/layout.tsx
+++ b/test/production/app-dir/isr-not-found-static-files/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/isr-not-found-static-files/isr-not-found-static-files.test.ts
+++ b/test/production/app-dir/isr-not-found-static-files/isr-not-found-static-files.test.ts
@@ -1,0 +1,50 @@
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+
+describe('app-dir ISR notFound static files', () => {
+  if (!isNextStart || process.env.__NEXT_CACHE_COMPONENTS) {
+    it('skipped outside next start or with cache components', () => {})
+    return
+  }
+
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    buildCommand: 'node node_modules/next/dist/bin/next build',
+    startCommand: 'node node_modules/next/dist/bin/next start',
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  const missingArtifacts = [
+    '.next/server/app/isr-not-found/missing.html',
+    '.next/server/app/isr-not-found/missing.rsc',
+    '.next/server/app/isr-not-found/missing.meta',
+    '.next/server/app/isr-not-found/missing.segments',
+  ]
+
+  it('does not persist generated notFound() ISR responses to disk', async () => {
+    expect(
+      await next.hasFile('.next/server/app/isr-not-found/valid.html')
+    ).toBe(true)
+
+    for (const artifact of missingArtifacts) {
+      expect(await next.hasFile(artifact)).toBe(false)
+    }
+
+    const firstResponse = await next.fetch('/isr-not-found/missing')
+    expect(firstResponse.status).toBe(404)
+    expect(await firstResponse.text()).toContain('This page could not be found')
+
+    for (const artifact of missingArtifacts) {
+      expect(await next.hasFile(artifact)).toBe(false)
+    }
+
+    const secondResponse = await next.fetch('/isr-not-found/missing')
+    expect(secondResponse.status).toBe(404)
+    expect(secondResponse.headers.get('x-nextjs-cache')).toBe('HIT')
+
+    for (const artifact of missingArtifacts) {
+      expect(await next.hasFile(artifact)).toBe(false)
+    }
+  })
+})

--- a/test/unit/incremental-cache/file-system-cache.test.ts
+++ b/test/unit/incremental-cache/file-system-cache.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import FileSystemCache from 'next/dist/server/lib/incremental-cache/file-system-cache'
 import { nodeFs } from 'next/dist/server/lib/node-fs-methods'
@@ -8,6 +9,15 @@ import {
 } from 'next/dist/server/response-cache'
 
 const cacheDir = fileURLToPath(new URL('./cache', import.meta.url))
+
+async function hasCacheFile(...segments: string[]) {
+  try {
+    await fs.access(path.join(cacheDir, ...segments))
+    return true
+  } catch {
+    return false
+  }
+}
 
 describe('FileSystemCache', () => {
   it('set image route', async () => {
@@ -51,6 +61,57 @@ describe('FileSystemCache', () => {
       status: 200,
       kind: IncrementalCacheKind.APP_ROUTE,
     })
+  })
+
+  it('does not write app 404 responses to disk', async () => {
+    const pageKey = `missing-page-${Date.now()}`
+    const routeKey = `missing-route-${Date.now()}`
+    const fsCache = new FileSystemCache({
+      _requestHeaders: {},
+      flushToDisk: true,
+      fs: nodeFs,
+      serverDistDir: cacheDir,
+      revalidatedTags: [],
+      maxMemoryCacheSize: 0,
+    })
+
+    await fsCache.set(
+      pageKey,
+      {
+        kind: CachedRouteKind.APP_PAGE,
+        html: '<html><body>missing</body></html>',
+        rscData: Buffer.from('missing'),
+        headers: {},
+        status: 404,
+        postponed: undefined,
+        segmentData: new Map([['/_tree', Buffer.from('segment')]]),
+      },
+      {
+        cacheControl: { revalidate: 1, expire: undefined },
+      }
+    )
+
+    await fsCache.set(
+      routeKey,
+      {
+        kind: CachedRouteKind.APP_ROUTE,
+        body: Buffer.from('missing'),
+        headers: {},
+        status: 404,
+      },
+      {
+        cacheControl: { revalidate: 1, expire: undefined },
+      }
+    )
+
+    await expect(hasCacheFile('app', `${pageKey}.html`)).resolves.toBe(false)
+    await expect(hasCacheFile('app', `${pageKey}.rsc`)).resolves.toBe(false)
+    await expect(hasCacheFile('app', `${pageKey}.meta`)).resolves.toBe(false)
+    await expect(
+      hasCacheFile('app', `${pageKey}.segments`, '_tree.segment.rsc')
+    ).resolves.toBe(false)
+    await expect(hasCacheFile('app', `${routeKey}.body`)).resolves.toBe(false)
+    await expect(hasCacheFile('app', `${routeKey}.meta`)).resolves.toBe(false)
   })
 })
 


### PR DESCRIPTION
Closes #73101

## Summary

- Keep app page and app route 404 cache entries in memory but skip writing those generated 404 responses to disk.
- Add unit coverage for the cache writer and a production ISR regression test that confirms `notFound()` responses do not create static artifacts.

## Testing

- `PATH=./node_modules/.bin:/Users/c543982/.npm/_npx/179a5fd3f63fede5/node_modules/.bin:$PATH ./node_modules/.bin/jest --runInBand test/unit/incremental-cache/file-system-cache.test.ts`
- `PATH=./node_modules/.bin:/Users/c543982/.npm/_npx/179a5fd3f63fede5/node_modules/.bin:$PATH scripts/run-jest.sh --mode=start --bundler=webpack --headless -- test/production/app-dir/isr-not-found-static-files/isr-not-found-static-files.test.ts`
- `git diff --check`
- `./node_modules/.bin/prettier --check packages/next/src/server/lib/incremental-cache/file-system-cache.ts test/unit/incremental-cache/file-system-cache.test.ts test/production/app-dir/isr-not-found-static-files/isr-not-found-static-files.test.ts 'test/production/app-dir/isr-not-found-static-files/app/isr-not-found/[slug]/page.tsx' test/production/app-dir/isr-not-found-static-files/app/layout.tsx`

<!-- NEXT_JS_LLM_PR -->
