### PR TITLE
fix(middleware): match basePath root for catch-all matcher

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.test.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.test.ts
@@ -86,5 +86,21 @@ describe('get-page-static-infos', () => {
         regex.test('/index.segments/$c$children/__PAGE__.segment.rsc')
       ).toBe(true)
     })
+
+    it('matches the basePath root for catch-all matchers that match root', () => {
+      const regex = new RegExp(
+        getMiddlewareMatchers(
+          '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+          { i18n: undefined, basePath: '/test' }
+        )[0].regexp
+      )
+
+      expect(regex.test('/test')).toBe(true)
+      expect(regex.test('/test/')).toBe(true)
+      expect(regex.test('/')).toBe(true)
+      expect(regex.test('/test/dashboard')).toBe(true)
+      expect(regex.test('/test/api')).toBe(false)
+      expect(regex.test('/testing')).toBe(false)
+    })
   })
 })

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -122,6 +122,17 @@ const ROOT_APP_ROUTE_TRANSPORT_MATCHER = `/?index(?:${APP_ROUTE_TRANSPORT_SUFFIX
 const MIDDLEWARE_DATA_SUFFIX_MATCHER = `\\.json|${APP_ROUTE_TRANSPORT_SUFFIX_MATCHER}`
 const OPTIONAL_MIDDLEWARE_NEXT_DATA_PREFIX = '/:nextData(_next/data/[^/]{1,})?'
 
+function doesMiddlewareSourceMatchRoot(source: string) {
+  const regexStr = tryToParsePath(source).regexStr
+  return regexStr ? new RegExp(regexStr).test('/') : false
+}
+
+function addBasePathRootToRegexp(regexp: string, basePath: string) {
+  return `^(?:${escapeStringRegexp(basePath)}[\\/#\\?]?|/?|${regexp
+    .replace(/^\^/, '')
+    .replace(/\$$/, '')})$`
+}
+
 const CLIENT_MODULE_LABEL =
   /\/\* __next_internal_client_entry_do_not_use__ ([^ ]*) (cjs|auto) \*\//
 
@@ -491,6 +502,7 @@ export function getMiddlewareMatchers(
         : `{(${MIDDLEWARE_DATA_SUFFIX_MATCHER})}?`
     }`
     source = `${OPTIONAL_MIDDLEWARE_NEXT_DATA_PREFIX}${source}${sourceSuffix}`
+    const sourceWithoutBasePath = source
 
     if (nextConfig.basePath) {
       source = `${nextConfig.basePath}${source}`
@@ -507,11 +519,24 @@ export function getMiddlewareMatchers(
       process.exit(1)
     }
 
+    const regexp = tryToParsePath(result.data).regexStr!
+    const sourceMatchesRoot =
+      Boolean(nextConfig.basePath) &&
+      doesMiddlewareSourceMatchRoot(sourceWithoutBasePath)
+    // A matcher that catches `/` should also catch the bare basePath, e.g.
+    // `/docs`.
+    const normalizedRegexp =
+      nextConfig.basePath &&
+      sourceMatchesRoot &&
+      !new RegExp(regexp).test(nextConfig.basePath)
+        ? addBasePathRootToRegexp(regexp, nextConfig.basePath)
+        : regexp
+
     return {
       ...rest,
       // We know that parsed.regexStr is not undefined because we already
       // checked that the source is valid.
-      regexp: tryToParsePath(result.data).regexStr!,
+      regexp: normalizedRegexp,
       originalSource: originalSource || source,
     }
   })

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -410,6 +410,61 @@ describe.each([
   }
 )
 
+describe('using a catch-all matcher with basePath', () => {
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        export default function Page() {
+          return <p>root page</p>
+        }
+      `,
+      'pages/api/hello.js': `
+        export default function handler(req, res) {
+          res.status(200).json({ hello: 'world' })
+        }
+      `,
+      'middleware.js': `
+        import { NextResponse } from 'next/server'
+
+        export const config = {
+          matcher: '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+        }
+
+        export default function middleware() {
+          const res = NextResponse.next()
+          res.headers.set('X-From-Middleware', 'true')
+          return res
+        }
+      `,
+      'next.config.js': `
+        module.exports = {
+          basePath: '/test',
+        }
+      `,
+    },
+    buildCommand: 'node node_modules/next/dist/bin/next build',
+    startCommand: (global as any).isNextDev
+      ? 'node node_modules/next/dist/bin/next dev'
+      : 'node node_modules/next/dist/bin/next start',
+    startServerTimeout: 30_000,
+    dependencies: {},
+  })
+
+  it('adds the header for the basePath root without a trailing slash', async () => {
+    const response = await fetchViaHTTP(next.url, '/test')
+
+    expect(response.headers.get('X-From-Middleware')).toBe('true')
+    expect(await response.text()).toContain('root page')
+  })
+
+  it('does not add the header for an excluded path', async () => {
+    const response = await fetchViaHTTP(next.url, '/test/api/hello')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-From-Middleware')).toBeNull()
+  })
+})
+
 describe('using root matcher', () => {
   const { next } = nextTestSetup({
     files: {


### PR DESCRIPTION
Closes #73786

## Summary

- Preserve the bare `basePath` root as a match when a middleware matcher also matches `/`.
- Add unit coverage for the generated regexp and e2e coverage for a catch-all matcher with `basePath`.

## Testing

- `PATH=./node_modules/.bin:/Users/c543982/.npm/_npx/179a5fd3f63fede5/node_modules/.bin:$PATH ./node_modules/.bin/jest --runInBand packages/next/src/build/analysis/get-page-static-info.test.ts`
- `PATH=./node_modules/.bin:/Users/c543982/.npm/_npx/179a5fd3f63fede5/node_modules/.bin:$PATH scripts/run-jest.sh --mode=dev --bundler=webpack --headless -- test/e2e/middleware-matcher/index.test.ts -t "using a catch-all matcher with basePath"`
- `git diff --check`
- `./node_modules/.bin/prettier --check packages/next/src/build/analysis/get-page-static-info.ts packages/next/src/build/analysis/get-page-static-info.test.ts test/e2e/middleware-matcher/index.test.ts`

<!-- NEXT_JS_LLM_PR -->
