### PR TITLE
fix(eslint-plugin): support pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -96,18 +96,13 @@ export default defineRule({
         ? nextSettings.pageExtensions
         : parsePageExtensions(ruleOptions)
 
-    const extensionRegex = new RegExp(
-      `(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
-    )
-    const indexRegex = new RegExp(
-      `^index(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
-    )
-    const pageRegex = new RegExp(
-      `^page(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
-    )
-    const layoutRegex = new RegExp(
-      `^layout(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
-    )
+    // Build extension pattern string (not RegExp) so it serializes properly
+    // for the memoize cache key. Individual extensions are escaped to prevent
+    // regex special characters (e.g., dots in "custom.ext") from causing
+    // false-positive matches.
+    const extPattern = pageExtensions
+      .map((ext) => ext.replace(/^\./, ''))
+      .join('|')
 
     const rootDirs = getRootDirs(context)
 
@@ -144,8 +139,8 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, extensionRegex, indexRegex)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, extensionRegex, pageRegex, layoutRegex)
+    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, extPattern)
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, extPattern)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -10,6 +10,21 @@ import {
   getUrlFromAppDirectory,
 } from '../utils/url'
 
+const defaultPageExtensions = ['js', 'jsx', 'ts', 'tsx']
+
+function parsePageExtensions(options: (string | string[])[]): string[] {
+  // Options can be: 'pagesDir' or ['pagesDir', { pageExtensions: [...] }]
+  const secondOption = options[1]
+  if (secondOption && typeof secondOption === 'object' && !Array.isArray(secondOption)) {
+    const exts = secondOption.pageExtensions
+    if (Array.isArray(exts) && exts.length > 0) {
+      return exts
+    }
+  }
+  // Also check eslint settings
+  return defaultPageExtensions
+}
+
 const pagesDirWarning = execOnce((pagesDirs) => {
   console.warn(
     `Pages directory cannot be found at ${pagesDirs.join(' or ')}. ` +
@@ -72,6 +87,28 @@ export default defineRule({
     const ruleOptions: (string | string[])[] = context.options
     const [customPagesDirectory] = ruleOptions
 
+    // Check settings for pageExtensions
+    const nextSettings: { pageExtensions?: string[] } =
+      (context.settings.next || {}) as { pageExtensions?: string[] }
+
+    const pageExtensions =
+      nextSettings.pageExtensions && nextSettings.pageExtensions.length > 0
+        ? nextSettings.pageExtensions
+        : parsePageExtensions(ruleOptions)
+
+    const extensionRegex = new RegExp(
+      `(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+    const indexRegex = new RegExp(
+      `^index(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+    const pageRegex = new RegExp(
+      `^page(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+    const layoutRegex = new RegExp(
+      `^layout(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+
     const rootDirs = getRootDirs(context)
 
     const pagesDirs = (
@@ -107,8 +144,8 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, extensionRegex, indexRegex)
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, extensionRegex, pageRegex, layoutRegex)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -24,7 +24,12 @@ function parseUrlForPages(
     withFileTypes: true,
   })
   const res = []
-  const escaped = extPattern ? escapeRegExp(extPattern) : '(j|t)sx?'
+  // Escape each individual extension so that special chars (e.g. dots) are
+  // treated as literals, then join with "|" for alternation.  We must NOT
+  // escape the "|" separator itself — that would break the alternation.
+  const escaped = extPattern
+    ? extPattern.split('|').map(escapeRegExp).join('|')
+    : '(j|t)sx?'
   const extRegex = new RegExp('(\\.(' + escaped + '))$')
   const idxRegex = new RegExp('^index(\\.(' + escaped + '))$')
   fsReadDirSyncCache[directory].forEach((dirent) => {
@@ -57,7 +62,12 @@ function parseUrlForAppDir(
     withFileTypes: true,
   })
   const res = []
-  const escaped = extPattern ? escapeRegExp(extPattern) : '(j|t)sx?'
+  // Escape each individual extension so that special chars (e.g. dots) are
+  // treated as literals, then join with "|" for alternation.  We must NOT
+  // escape the "|" separator itself — that would break the alternation.
+  const escaped = extPattern
+    ? extPattern.split('|').map(escapeRegExp).join('|')
+    : '(j|t)sx?'
   const extRegex = new RegExp('(\\.(' + escaped + '))$')
   const pRegex = new RegExp('^page(\\.(' + escaped + '))$')
   const lRegex = new RegExp('^layout(\\.(' + escaped + '))$')

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -6,21 +6,27 @@ import * as fs from 'fs'
 const fsReadDirSyncCache = {}
 
 /**
+ * Escapes special regex characters in a string so it can be safely used in a RegExp.
+ */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
  * Recursively parse directory for page URLs.
  */
 function parseUrlForPages(
   urlprefix: string,
   directory: string,
-  extensionRegex?: RegExp
+  extPattern?: string
 ) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
-  const extRegex = extensionRegex || /(\.(j|t)sx?)$/
-  const idxRegex = extensionRegex
-    ? new RegExp(`^index(${extensionRegex.source})$`)
-    : /^index(\.(j|t)sx?)$/
+  const escaped = extPattern ? escapeRegExp(extPattern) : '(j|t)sx?'
+  const extRegex = new RegExp('(\\.(' + escaped + '))$')
+  const idxRegex = new RegExp('^index(\\.(' + escaped + '))$')
   fsReadDirSyncCache[directory].forEach((dirent) => {
     if (extRegex.test(dirent.name)) {
       if (idxRegex.test(dirent.name)) {
@@ -32,7 +38,7 @@ function parseUrlForPages(
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensionRegex))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extPattern))
       }
     }
   })
@@ -45,17 +51,16 @@ function parseUrlForPages(
 function parseUrlForAppDir(
   urlprefix: string,
   directory: string,
-  extensionRegex?: RegExp,
-  pageRegex?: RegExp,
-  layoutRegex?: RegExp
+  extPattern?: string
 ) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
-  const extRegex = extensionRegex || /(\.(j|t)sx?)$/
-  const pRegex = pageRegex || /^page(\.(j|t)sx?)$/
-  const lRegex = layoutRegex || /^layout(\.(j|t)sx?)$/
+  const escaped = extPattern ? escapeRegExp(extPattern) : '(j|t)sx?'
+  const extRegex = new RegExp('(\\.(' + escaped + '))$')
+  const pRegex = new RegExp('^page(\\.(' + escaped + '))$')
+  const lRegex = new RegExp('^layout(\\.(' + escaped + '))$')
   fsReadDirSyncCache[directory].forEach((dirent) => {
     if (extRegex.test(dirent.name)) {
       if (pRegex.test(dirent.name)) {
@@ -66,7 +71,7 @@ function parseUrlForAppDir(
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensionRegex))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extPattern))
       }
     }
   })
@@ -150,14 +155,13 @@ export function normalizeAppPath(route: string) {
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
   directories: string[],
-  extensionRegex?: RegExp,
-  indexRegex?: RegExp
+  extPattern?: string
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, extensionRegex))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, extPattern))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -172,15 +176,13 @@ export function getUrlFromPagesDirectories(
 export function getUrlFromAppDirectory(
   urlPrefix: string,
   directories: string[],
-  extensionRegex?: RegExp,
-  pageRegex?: RegExp,
-  layoutRegex?: RegExp
+  extPattern?: string
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory, extensionRegex, pageRegex, layoutRegex))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, extPattern))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -8,25 +8,31 @@ const fsReadDirSyncCache = {}
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  extensionRegex?: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = extensionRegex || /(\.(j|t)sx?)$/
+  const idxRegex = extensionRegex
+    ? new RegExp(`^index(${extensionRegex.source})$`)
+    : /^index(\.(j|t)sx?)$/
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (extRegex.test(dirent.name)) {
+      if (idxRegex.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(idxRegex, '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensionRegex))
       }
     }
   })
@@ -36,24 +42,31 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  extensionRegex?: RegExp,
+  pageRegex?: RegExp,
+  layoutRegex?: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = extensionRegex || /(\.(j|t)sx?)$/
+  const pRegex = pageRegex || /^page(\.(j|t)sx?)$/
+  const lRegex = layoutRegex || /^layout(\.(j|t)sx?)$/
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      if (pRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pRegex, '')}`)
+      } else if (!lRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensionRegex))
       }
     }
   })
@@ -136,13 +149,15 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensionRegex?: RegExp,
+  indexRegex?: RegExp
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, extensionRegex))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +171,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensionRegex?: RegExp,
+  pageRegex?: RegExp,
+  layoutRegex?: RegExp
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, extensionRegex, pageRegex, layoutRegex))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.


### PR DESCRIPTION
Fixes #53473

The @next/next/no-html-link-for-pages ESLint rule was hardcoded to only recognize .js, .jsx, .ts, .tsx file extensions. When users configure custom pageExtensions in next.config.js, the rule produces false positives and false negatives.

Changes:
- Modified parseUrlForPages and parseUrlForAppDir to accept custom extension regex
- Added support for settings.next.pageExtensions
- Removed TODO comments about page extensions