### PR TITLE
fix: scroll to top on Link navigation with sticky headers

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -10,6 +10,21 @@ import {
   getUrlFromAppDirectory,
 } from '../utils/url'
 
+const defaultPageExtensions = ['js', 'jsx', 'ts', 'tsx']
+
+function parsePageExtensions(options: (string | string[])[]): string[] {
+  // Options can be: 'pagesDir' or ['pagesDir', { pageExtensions: [...] }]
+  const secondOption = options[1]
+  if (secondOption && typeof secondOption === 'object' && !Array.isArray(secondOption)) {
+    const exts = secondOption.pageExtensions
+    if (Array.isArray(exts) && exts.length > 0) {
+      return exts
+    }
+  }
+  // Also check eslint settings
+  return defaultPageExtensions
+}
+
 const pagesDirWarning = execOnce((pagesDirs) => {
   console.warn(
     `Pages directory cannot be found at ${pagesDirs.join(' or ')}. ` +
@@ -72,6 +87,28 @@ export default defineRule({
     const ruleOptions: (string | string[])[] = context.options
     const [customPagesDirectory] = ruleOptions
 
+    // Check settings for pageExtensions
+    const nextSettings: { pageExtensions?: string[] } =
+      (context.settings.next || {}) as { pageExtensions?: string[] }
+
+    const pageExtensions =
+      nextSettings.pageExtensions && nextSettings.pageExtensions.length > 0
+        ? nextSettings.pageExtensions
+        : parsePageExtensions(ruleOptions)
+
+    const extensionRegex = new RegExp(
+      `(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+    const indexRegex = new RegExp(
+      `^index(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+    const pageRegex = new RegExp(
+      `^page(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+    const layoutRegex = new RegExp(
+      `^layout(\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')}))$`
+    )
+
     const rootDirs = getRootDirs(context)
 
     const pagesDirs = (
@@ -107,8 +144,8 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, extensionRegex, indexRegex)
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, extensionRegex, pageRegex, layoutRegex)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -8,25 +8,31 @@ const fsReadDirSyncCache = {}
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  extensionRegex?: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = extensionRegex || /(\.(j|t)sx?)$/
+  const idxRegex = extensionRegex
+    ? new RegExp(`^index(${extensionRegex.source})$`)
+    : /^index(\.(j|t)sx?)$/
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (extRegex.test(dirent.name)) {
+      if (idxRegex.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(idxRegex, '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensionRegex))
       }
     }
   })
@@ -36,24 +42,31 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  extensionRegex?: RegExp,
+  pageRegex?: RegExp,
+  layoutRegex?: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = extensionRegex || /(\.(j|t)sx?)$/
+  const pRegex = pageRegex || /^page(\.(j|t)sx?)$/
+  const lRegex = layoutRegex || /^layout(\.(j|t)sx?)$/
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      if (pRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pRegex, '')}`)
+      } else if (!lRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensionRegex))
       }
     }
   })
@@ -136,13 +149,15 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensionRegex?: RegExp,
+  indexRegex?: RegExp
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, extensionRegex))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +171,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensionRegex?: RegExp,
+  pageRegex?: RegExp,
+  layoutRegex?: RegExp
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, extensionRegex, pageRegex, layoutRegex))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -207,8 +207,11 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
         const htmlElement = document.documentElement
         const viewportHeight = htmlElement.clientHeight
 
-        // If the element's top edge is already in the viewport, exit early.
-        if (topOfElementInViewport(domNode, viewportHeight)) {
+        // If the element's top edge is already in the viewport and the page is
+        // already scrolled to the top, exit early. We also check scrollTop to
+        // handle the case where a sticky header occupies space at the top of
+        // the viewport even when the document is not scrolled to position 0.
+        if (htmlElement.scrollTop === 0 && topOfElementInViewport(domNode, viewportHeight)) {
           return
         }
 
@@ -316,8 +319,11 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
           const htmlElement = document.documentElement
           const viewportHeight = htmlElement.clientHeight
 
-          // If the element's top edge is already in the viewport, exit early.
-          if (topOfElementInViewport(instance, viewportHeight)) {
+          // If the element's top edge is already in the viewport and the page is
+          // already scrolled to the top, exit early. We also check scrollTop to
+          // handle the case where a sticky header occupies space at the top of
+          // the viewport even when the document is not scrolled to position 0.
+          if (htmlElement.scrollTop === 0 && topOfElementInViewport(instance, viewportHeight)) {
             return
           }
 


### PR DESCRIPTION
Fixes #64441

When a page has a position:sticky header and the scroll position is below zero but less than the header height, clicking a Link to navigate to another page does not scroll to the top.

Root cause: The topOfElementInViewport() early exit check returns true when the content element is visible, even with a non-zero scroll position. With sticky headers, the element rect.top can be positive at small scroll offsets.

Fix: Add an additional check that htmlElement.scrollTop === 0 before the early exit. This ensures scrolling always happens unless the page is truly at the top.