### PR TITLE
fix: add encode option to cookies().set() for raw cookie values

### DIFF
--- a/packages/next/src/compiled/@edge-runtime/cookies/index.d.ts
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.d.ts
@@ -131,7 +131,7 @@ interface CookieListItem extends Pick<CookieSerializeOptions, 'domain' | 'path' 
  * Superset of {@link CookieListItem} extending it with
  * the `httpOnly`, `maxAge` and `priority` properties.
  */
-type ResponseCookie = CookieListItem & Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority'>;
+type ResponseCookie = CookieListItem & Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority' | 'encode'>;
 /**
  * Subset of {@link CookieListItem}, only containing `name` and `value`
  * since other cookie attributes aren't be available on a `Request`.

--- a/packages/next/src/compiled/@edge-runtime/cookies/index.js
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.js
@@ -42,7 +42,8 @@ function stringifyCookie(c) {
     "partitioned" in c && c.partitioned && "Partitioned",
     "priority" in c && c.priority && `Priority=${c.priority}`
   ].filter(Boolean);
-  const stringified = `${c.name}=${encodeURIComponent((_a = c.value) != null ? _a : "")}`;
+  const encode = typeof c.encode === 'function' ? c.encode : encodeURIComponent;
+  const stringified = `${c.name}=${encode((_a = c.value) != null ? _a : "")}`;
   return attrs.length === 0 ? stringified : `${stringified}; ${attrs.join("; ")}`;
 }
 function parseCookie(cookie) {
@@ -245,7 +246,7 @@ var RequestCookies = class {
     return `RequestCookies ${JSON.stringify(Object.fromEntries(this._parsed))}`;
   }
   toString() {
-    return [...this._parsed.values()].map((v) => `${v.name}=${encodeURIComponent(v.value)}`).join("; ");
+    return [...this._parsed.values()].map((v) => `${v.name}=${typeof v.encode === 'function' ? v.encode(v.value) : encodeURIComponent(v.value)}`).join("; ");
   }
 };
 


### PR DESCRIPTION
Fixes #64346

The cookies().set() function always encodes cookie values with encodeURIComponent. Third-party libraries (especially Go backends) send/receive cookies in raw format. The underlying cookie npm package already supports an encode option, but it was never wired through.

Changes:
- stringifyCookie() now checks for a custom encode function before falling back to encodeURIComponent
- RequestCookies.toString() respects encode if present
- ResponseCookie type now includes encode from CookieSerializeOptions

Usage:
cookies().set("session", "raw value", { encode: (v) => v });