### PR TITLE
Add server routing audit and contract tests

### DIFF
--- a/contributing/core/server-routing-audit.md
+++ b/contributing/core/server-routing-audit.md
@@ -1,0 +1,218 @@
+# Next.js Server Routing Audit
+
+This audit maps the current Next.js server routing paths and identifies a
+compatibility-first route toward making `@next/routing` the shared route
+resolution layer. It is an internal contributor artifact, not public
+documentation and not an API commitment.
+
+`@next/routing` is experimental and is documented as stabilizing with the
+adapters API. Any migration from the current server resolver must preserve
+`next dev`, `next start`, custom server, adapter, and standalone behavior unless
+a separate proposal explicitly approves a behavior change.
+
+## Baseline Findings
+
+- `@next/routing` exists in `packages/next-routing` and exposes a URL/Header
+  based `resolveRoutes()` API for adapters.
+- Public adapter docs already describe using `@next/routing` with
+  `onBuildComplete` routing data in
+  `docs/01-app/03-api-reference/07-adapters/05-routing-with-next-routing.mdx`
+  and route shape information in
+  `docs/01-app/03-api-reference/07-adapters/10-routing-information.mdx`.
+- The live `next` server does not import `@next/routing` today. The only
+  current references are the package itself and adapter documentation.
+- `next start`, `next dev`, and custom server all converge through
+  `packages/next/src/server/lib/router-server.ts`.
+- The live resolver in
+  `packages/next/src/server/lib/router-utils/resolve-routes.ts` owns more than
+  pure route matching. It mutates Node request headers and metadata, invokes
+  middleware through the render server, checks filesystem outputs, handles
+  `_next/data`, applies i18n metadata, sets RSC rewrite headers, and reports
+  matched outputs back to `router-server.ts`.
+- The `@next/routing` test baseline is green with
+  `pnpm --filter @next/routing test`: 10 suites, 255 tests.
+- Live resolver contract coverage lives in
+  `test/unit/server-routing-equivalence/resolve-routes.test.ts` and exercises
+  the main observable server-routing branches: custom headers, redirects,
+  before/after/fallback rewrites, external rewrites, dynamic routes, i18n,
+  basePath, `_next/data`, export path map routes, `minimalMode`, invoked output
+  skips, RSC rewrite headers, upgrade metadata, on-match headers, and
+  middleware response translation.
+
+## Entrypoint Map
+
+| Surface                     | Current path                                                                                                       | Main responsibilities                                                                                                                                                                                                                                   |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next start`                | `packages/next/src/cli/next-start.ts` -> `startServer()` -> `getRequestHandlers()` -> `router-server.initialize()` | Production CLI option parsing, reserved port checks, Node inspector setup, HTTP listener setup, production routing/rendering.                                                                                                                           |
+| `next dev`                  | `packages/next/src/cli/next-dev.ts` -> child process -> `startServer()` -> `router-server.initialize()`            | Dev CLI orchestration, restart handling, trace/telemetry, bundler selection, HTTPS dev server setup, HMR and dev overlay integration.                                                                                                                   |
+| Programmatic `next()`       | `packages/next/src/server/next.ts`                                                                                 | Public custom-server wrapper. `NextCustomServer.prepare()` calls `getRequestHandlers()` and routes `getRequestHandler()`, `render()`, and upgrades through the same router server.                                                                      |
+| Default server wrapper      | `packages/next/src/server/next.ts` -> `NextServer` -> `next-server.ts`                                             | Wrapper used by `next start` style APIs and render worker initialization. Preserves legacy methods such as `render`, `renderToHTML`, `renderError`, `render404`, and `revalidate`.                                                                      |
+| Router server               | `packages/next/src/server/lib/router-server.ts`                                                                    | Shared serverful request and upgrade coordinator. Loads config, builds filesystem checks, initializes dev bundler, initializes render server, filters internal headers, runs routing, serves static files, invokes render, and handles fallback errors. |
+| Render server               | `packages/next/src/server/lib/render-server.ts`                                                                    | Lazy bridge from the router server into `NextServer` / `NextDevServer` request handling. Owns render-worker style initialization and request handler metadata.                                                                                          |
+| Production render core      | `packages/next/src/server/next-server.ts` and `packages/next/src/server/base-server.ts`                            | Rendering, cache behavior, route module invocation, minimal-mode behavior, image handling, API/page/app route execution, error rendering, and custom-server compatibility methods.                                                                      |
+| Upgrade requests            | `router-server.ts` upgrade handler                                                                                 | Handles dev HMR upgrades first, then routes possible proxy upgrade requests. Page/app WebSocket handling is still intentionally not claimed by the router server.                                                                                       |
+| Standalone/minimal/adapters | `next.ts`, `base-server.ts`, build adapter docs and build outputs                                                  | Standalone output uses generated server output instead of `next start`; `minimalMode` changes routing/render assumptions; adapters consume build-time routing output and may invoke entrypoints directly.                                               |
+
+The important maintenance point is that the serverful path already has one
+shared coordinator, `router-server.ts`, but its responsibilities are broader
+than routing. A minimal future server should preserve that coordinator role
+while moving pure route resolution out of it.
+
+## Request Flow Today
+
+The serverful request path in `router-server.ts` currently follows this shape:
+
+1. Initialize process state, load config, run `setupFsCheck()`, optionally set up
+   the dev bundler, then initialize the render server.
+2. For each request, attach request metadata, filter internal headers, run i18n
+   locale detection redirects, set up compression, and run dev-only hot reloader
+   handling.
+3. Call the live `getResolveRoutes()` resolver with the Node request/response,
+   filesystem checker, render server, config, and optional middleware ensure
+   hook.
+4. Apply route response headers, redirects, middleware body responses, external
+   proxy rewrites, static asset serving, matched output rendering, and final
+   404/500 fallback rendering.
+5. For upgrade requests, first offer the request to HMR in dev, then reuse route
+   resolution to detect external proxy rewrites.
+
+This makes `router-server.ts` the correct place for an adoption seam, but not
+the right long-term home for the route matching algorithm itself.
+
+## Responsibility Map
+
+| Responsibility                            | Current owner                                                                   | Compatibility constraint                                                                                                                               |
+| ----------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| HTTP/HTTPS listener and graceful shutdown | `start-server.ts`                                                               | Must keep current CLI startup, retry, signal, and logging behavior.                                                                                    |
+| Internal header filtering                 | `router-server.ts` and `server-ipc/utils.ts`                                    | Security-sensitive. New internal headers must be filtered before any server code trusts them.                                                          |
+| Request URL and metadata normalization    | `router-server.ts`, `resolve-routes.ts`, `request-meta.ts`                      | `initURL`, `initQuery`, `initProtocol`, locale, data request, middleware, and invoke metadata are observable by render internals.                      |
+| Route matching phases                     | `router-utils/resolve-routes.ts` plus `filesystem.ts` route data                | Candidate for `@next/routing`, but only after equivalent phase ordering is proven.                                                                     |
+| Filesystem/output lookup                  | `router-utils/filesystem.ts`                                                    | Needs a stable interface for public files, static files, app/pages files, data routes, dev virtual files, and dynamic routes.                          |
+| Middleware invocation                     | `resolve-routes.ts` via render server                                           | `@next/routing` can model middleware results, but live invocation still needs Node request cloning, response capture, dev timing, and header mutation. |
+| Static asset serving                      | `router-server.ts` with `serveStatic()`                                         | Must preserve cache-control, method handling, conflicting public/page file errors, and static 404 short-circuits.                                      |
+| Rendering                                 | `router-server.ts` -> `render-server.ts` -> `next-server.ts` / `base-server.ts` | Route resolution must continue to produce the same `invokePath`, `invokeQuery`, `invokeOutput`, and status metadata.                                   |
+| Error fallback                            | `router-server.ts`, `next-server.ts`, `base-server.ts`                          | Must preserve `NoFallbackError`, 400 decode errors, 404 app not-found routing, and 500 fallback behavior.                                              |
+| Dev-only behavior                         | `setup-dev-bundler.ts`, hot reloaders, `next-dev-server.ts`                     | HMR, dev virtual FS items, overlay, dev logging, and ensure-before-render behavior should migrate last.                                                |
+| Custom server compatibility               | `next.ts` wrapper and public methods                                            | `getRequestHandler()`, `render()`, `renderToHTML()`, `renderError()`, `render404()`, and `revalidate()` must stay compatible.                          |
+| Adapter behavior                          | `@next/routing` docs and build adapter outputs                                  | The package is already adapter-facing; server adoption should reduce divergence, not force adapter API churn.                                          |
+
+## Resolver Comparison
+
+The live resolver is exported as `getResolveRoutes()` from
+`packages/next/src/server/lib/router-utils/resolve-routes.ts`. The package
+resolver is exported as `resolveRoutes()` from
+`packages/next-routing/src/resolve-routes.ts`.
+
+Shared concepts:
+
+- Both model the same high-level phase order: before-middleware work,
+  middleware, before-files rewrites, filesystem/static matching,
+  after-files rewrites, dynamic route matching, on-match headers, and fallback
+  rewrites.
+- Both handle redirects, rewrites, route headers, has/missing conditions,
+  external rewrite detection, dynamic route params, i18n, basePath, and
+  `_next/data` normalization.
+- Both need route data that is already available from manifests or
+  `setupFsCheck()`.
+
+Important differences before live adoption:
+
+- The live resolver accepts and mutates `IncomingMessage` and `ServerResponse`.
+  `@next/routing` accepts `URL`, `Headers`, `ReadableStream`, route arrays, and
+  a middleware callback.
+- The live resolver returns `matchedOutput` from `fsChecker.getItem()`.
+  `@next/routing` returns a resolved pathname, query, invocation target,
+  headers, route matches, redirects, or external rewrites.
+- The live resolver directly invokes middleware through the render server and
+  translates middleware response headers into Node request/response mutation.
+  `@next/routing` delegates middleware execution to `invokeMiddleware()`.
+- The live resolver has dev-specific behavior: middleware ensure hooks, dev
+  timing metadata, dev virtual FS items, dynamic page/app ensure callbacks, and
+  Turbopack test deployment-id checks.
+- The live resolver coordinates with `fsChecker` for public/static files,
+  app/page outputs, dynamic routes, `exportPathMap`, locales, and data routes.
+  `@next/routing` needs a server adapter layer that supplies equivalent
+  pathnames and route arrays and maps the result back to `FsOutput`.
+- The live resolver sets framework-specific response headers for RSC rewrites
+  (`NEXT_REWRITTEN_PATH_HEADER` and `NEXT_REWRITTEN_QUERY_HEADER`) under
+  specific safety checks.
+
+The migration should therefore avoid a direct file replacement. The safer target
+is a small server adapter that converts live server state into `@next/routing`
+inputs, invokes it, then maps the result back into the existing
+`router-server.ts` contract.
+
+## Compatibility Risk Inventory
+
+- i18n: Locale detection redirects, domain locales, default-locale internal
+  prefixing, API route locale stripping, and locale metadata must stay byte
+  compatible with current render behavior.
+- `basePath` and `assetPrefix`: Both are stripped or reapplied in different
+  phases for dev bundler, static assets, HMR, and route matching.
+- `_next/data`: Data URL normalization affects middleware matching, dynamic
+  route matching, locale handling, and `x-nextjs-data` metadata.
+- Middleware headers: Override headers, request header mutation,
+  `x-middleware-set-cookie`, refresh behavior, non-redirect `Location`, and
+  external rewrites are observable and security-sensitive.
+- Rewrites, redirects, and headers: Phase ordering, status handling, query
+  merging, set-cookie accumulation, and route condition captures need golden
+  coverage.
+- Dynamic routes: Matching must preserve data routes, route params, dynamic
+  fallback behavior, and app-dir locale exclusions.
+- Static assets: Public, legacy static, `.next/static`, metadata routes,
+  immutable cache-control, method handling, and static 404 behavior are not pure
+  route resolution.
+- `minimalMode`: Current server internals intentionally skip custom routes and
+  normalize some request forms differently. Treat this as a separate mode in
+  tests.
+- Standalone output: `next start` warns for `output: 'standalone'`; generated
+  standalone server output has different deployment assumptions.
+- Custom server APIs: Programmatic `next()` must keep the same request handler,
+  upgrade handler, and legacy render methods.
+- HMR upgrades: Dev HMR path handling depends on `basePath`/`assetPrefix` and
+  should stay in `router-server.ts` until routing equivalence is proven.
+- Adapter routing outputs: `@next/routing` is already an adapter contract. Live
+  server adoption should use the same route shapes where possible and should not
+  require adapter-facing churn.
+
+## Staged Migration Recommendation
+
+1. Build equivalence fixtures around the current live resolver before changing
+   behavior. Keep expanding the contract suite until every live resolver branch
+   and mode-specific edge case has a fixture, including redirects, headers,
+   before/after/fallback rewrites, middleware rewrites and redirects, i18n,
+   basePath, `_next/data`, dynamic routes, static assets, minimalMode, invoked
+   outputs, upgrade requests, and proxy rewrites.
+2. Add a translation layer that converts `fsChecker` and manifest-backed data
+   into the `@next/routing` route shape and maps `@next/routing` results back to
+   the existing `router-server.ts` result shape.
+3. Delegate a narrow production path first, preferably route phases that do not
+   invoke middleware or depend on dev-only ensure behavior.
+4. Expand to production middleware once middleware response translation has
+   golden coverage against the current Node mutation behavior.
+5. Expand to dev paths last, including dev virtual files, page/app ensure,
+   HMR-adjacent behavior, and dev overlay timing metadata.
+6. Delete legacy route-resolution branches only after the equivalent
+   `@next/routing` path is default, covered in both webpack and Turbopack modes,
+   and no longer needed by minimal/custom-server flows.
+
+## Non-Goals For This Milestone
+
+- Do not change `next dev`, `next start`, custom server, standalone, minimal
+  mode, or adapter behavior.
+- Do not mark `@next/routing` stable.
+- Do not remove legacy route branches or bypass `router-server.ts`.
+- Do not change public types, manifests, route output shape, or adapter docs
+  beyond future separately reviewed work.
+
+## Verification Notes
+
+- Re-run `pnpm --filter @next/routing test` after changes that affect
+  `packages/next-routing`.
+- Re-run
+  `pnpm testonly test/unit/server-routing-equivalence/resolve-routes.test.ts`
+  after changes that affect the live server resolver contract.
+- For live server adoption work, run focused start/dev tests in both webpack and
+  Turbopack modes, matching CI environment variables when reproducing failures.
+- Treat this audit as a map for future implementation PRs, not as sufficient
+  proof for deleting existing compatibility paths.

--- a/test/unit/server-routing-equivalence/resolve-routes.test.ts
+++ b/test/unit/server-routing-equivalence/resolve-routes.test.ts
@@ -1,0 +1,975 @@
+/* eslint-env jest */
+
+import type { IncomingHttpHeaders } from 'http'
+
+const {
+  NEXT_REWRITTEN_PATH_HEADER,
+  NEXT_REWRITTEN_QUERY_HEADER,
+  RSC_HEADER,
+} = require('../../../packages/next/src/client/components/app-router-headers')
+const {
+  defaultConfig,
+} = require('../../../packages/next/src/server/config-shared')
+const {
+  createRequestResponseMocks,
+} = require('../../../packages/next/src/server/lib/mock-request')
+const {
+  buildCustomRoute,
+} = require('../../../packages/next/src/server/lib/router-utils/filesystem')
+const {
+  getResolveRoutes,
+} = require('../../../packages/next/src/server/lib/router-utils/resolve-routes')
+const {
+  getRequestMeta,
+} = require('../../../packages/next/src/server/request-meta')
+const {
+  getRouteMatcher,
+} = require('../../../packages/next/src/shared/lib/router/utils/route-matcher')
+const {
+  getNamedRouteRegex,
+} = require('../../../packages/next/src/shared/lib/router/utils/route-regex')
+
+type NextConfigRuntime = any
+type FilesystemDynamicRoute = any
+type FsOutput = any
+type FsChecker = any
+type ResolveRoutesOptions = any
+
+type FsCheckerOverrides = {
+  headers?: any[]
+  redirects?: any[]
+  rewrites?: Record<string, any[]>
+  outputs?: Record<string, FsOutput>
+  dynamicRoutes?: FilesystemDynamicRoute[]
+  onMatchHeaders?: any[]
+  exportPathMapRoutes?: any
+  middlewareMatcher?: any
+  handleLocale?: (pathname: string) => { pathname: string; locale?: string }
+  buildId?: string
+}
+
+function createConfig(
+  overrides: Partial<NextConfigRuntime> = {}
+): NextConfigRuntime {
+  const baseConfig = defaultConfig as unknown as NextConfigRuntime
+  return {
+    ...baseConfig,
+    ...overrides,
+    experimental: {
+      ...baseConfig.experimental,
+      ...overrides.experimental,
+    },
+  }
+}
+
+function createOutput(
+  itemPath: string,
+  type: string = 'pageFile',
+  extra: Record<string, any> = {}
+): FsOutput {
+  return { type, itemPath, ...extra }
+}
+
+function createDynamicRoute(page: string): FilesystemDynamicRoute {
+  const routeRegex = getNamedRouteRegex(page, {
+    prefixRouteKeys: true,
+  })
+  return {
+    page,
+    regex: routeRegex.re.toString(),
+    namedRegex: routeRegex.namedRegex,
+    routeKeys: routeRegex.routeKeys,
+    match: getRouteMatcher(routeRegex),
+  }
+}
+
+function createMiddlewareMatcher(
+  predicate: (pathname: string) => boolean = () => true
+) {
+  return function middlewareMatcher(pathname: string) {
+    return predicate(pathname)
+  }
+}
+
+function createFsChecker({
+  headers = [],
+  redirects = [],
+  rewrites = {},
+  outputs = {},
+  dynamicRoutes = [],
+  onMatchHeaders = [],
+  exportPathMapRoutes,
+  middlewareMatcher,
+  handleLocale = (pathname: string) => ({ pathname, locale: undefined }),
+  buildId = 'BUILD_ID',
+}: FsCheckerOverrides = {}) {
+  const outputMap = new Map(Object.entries(outputs))
+  const getItem = jest.fn(async (pathname: string) => {
+    return outputMap.get(pathname) ?? null
+  })
+
+  const fsChecker = {
+    headers,
+    redirects,
+    rewrites: {
+      beforeFiles: [],
+      afterFiles: [],
+      fallback: [],
+      ...rewrites,
+    },
+    onMatchHeaders,
+    buildId,
+    handleLocale,
+    appFiles: new Set<string>(),
+    pageFiles: new Set<string>(),
+    staticMetadataFiles: new Map<string, string>(),
+    dynamicRoutes,
+    nextDataRoutes: new Set<string>(),
+    exportPathMapRoutes,
+    devVirtualFsItems: new Set<string>(),
+    previewProps: {
+      previewModeId: 'preview-id',
+      previewModeSigningKey: 'preview-signing-key',
+      previewModeEncryptionKey: 'preview-encryption-key',
+    },
+    middlewareMatcher,
+    ensureCallback() {},
+    getItem,
+    getDynamicRoutes() {
+      return dynamicRoutes
+    },
+    getMiddlewareMatchers() {
+      return middlewareMatcher
+    },
+  } as unknown as FsChecker
+
+  return {
+    fsChecker,
+    getItem,
+  }
+}
+
+async function resolveLiveRoute({
+  url,
+  headers,
+  config = createConfig(),
+  fsChecker,
+  opts = {},
+  renderServerOpts = {
+    dir: '/app',
+    port: 3000,
+    dev: false,
+    hostname: 'localhost',
+    onDevServerCleanup: undefined,
+    serverFields: {},
+    experimentalTestProxy: false,
+    experimentalHttpsServer: false,
+    distDir: '.next',
+    experimentalFeatures: [],
+    cacheComponents: false,
+  },
+  isUpgradeReq = false,
+  invokedOutputs,
+  middlewareResponse,
+  middlewareError,
+  ensureMiddleware = jest.fn(async () => {}),
+}: {
+  url: string
+  headers?: IncomingHttpHeaders
+  config?: NextConfigRuntime
+  fsChecker: FsChecker
+  opts?: Partial<ResolveRoutesOptions>
+  renderServerOpts?: any
+  isUpgradeReq?: boolean
+  invokedOutputs?: Set<string>
+  middlewareResponse?: Response
+  middlewareError?: unknown
+  ensureMiddleware?: (url?: string) => Promise<void>
+}) {
+  const { req, res } = createRequestResponseMocks({
+    url,
+    headers,
+  })
+  const requestHandler = jest.fn(async () => {
+    if (middlewareError) {
+      throw middlewareError
+    }
+    if (middlewareResponse) {
+      const middlewareResult = new Error('middleware response') as Error & {
+        result: { response: Response }
+      }
+      middlewareResult.result = { response: middlewareResponse }
+      throw middlewareResult
+    }
+  })
+  const renderServer = {
+    initialize: jest.fn(async () => ({ requestHandler })),
+    clearModuleContext: jest.fn(),
+    propagateServerField: jest.fn(),
+    getServerField: jest.fn(),
+  } as any
+
+  const resolveRoutes = getResolveRoutes(
+    fsChecker,
+    config,
+    {
+      dir: '/app',
+      dev: false,
+      hostname: 'localhost',
+      onDevServerCleanup: undefined,
+      port: 3000,
+      ...opts,
+    },
+    renderServer,
+    renderServerOpts,
+    ensureMiddleware
+  )
+
+  const result = await resolveRoutes({
+    req,
+    res,
+    isUpgradeReq,
+    signal: new AbortController().signal,
+    invokedOutputs,
+  })
+
+  return {
+    result,
+    req,
+    res,
+    renderServer,
+    requestHandler,
+    ensureMiddleware,
+  }
+}
+
+describe('live server route resolver contract', () => {
+  it('normalizes repeated slashes before route matching', async () => {
+    const { fsChecker, getItem } = createFsChecker()
+
+    const { result } = await resolveLiveRoute({
+      url: '/docs//intro?from=test',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBe(308)
+    expect(result.parsedUrl.pathname).toBe('/docs/intro')
+    expect(result.parsedUrl.query).toEqual({ from: 'test' })
+    expect(getItem).not.toHaveBeenCalled()
+  })
+
+  it('records the request metadata used by later server phases', async () => {
+    const { fsChecker } = createFsChecker()
+
+    const { req } = await resolveLiveRoute({
+      url: '/meta?x=1',
+      headers: {
+        'x-forwarded-proto': 'https',
+      },
+      fsChecker,
+    })
+
+    expect(getRequestMeta(req, 'initURL')).toBe(
+      'https://localhost:3000/meta?x=1'
+    )
+    expect(getRequestMeta(req, 'initQuery')).toEqual({ x: '1' })
+    expect(getRequestMeta(req, 'initProtocol')).toBe('https')
+    expect(getRequestMeta(req, 'clonableBody')).toBeDefined()
+  })
+
+  it('does not attach clonable request bodies for upgrade requests', async () => {
+    const { fsChecker } = createFsChecker()
+
+    const { req } = await resolveLiveRoute({
+      url: '/_next/webpack-hmr',
+      fsChecker,
+      isUpgradeReq: true,
+    })
+
+    expect(getRequestMeta(req, 'initURL')).toBe(
+      'http://localhost:3000/_next/webpack-hmr'
+    )
+    expect(getRequestMeta(req, 'clonableBody')).toBeUndefined()
+  })
+
+  it('keeps custom headers when resolving a filesystem output', async () => {
+    const matchedOutput = createOutput('/with-header')
+    const { fsChecker, getItem } = createFsChecker({
+      headers: [
+        buildCustomRoute('header', {
+          source: '/with-header',
+          headers: [
+            { key: 'x-route-header', value: 'yes' },
+            { key: 'set-cookie', value: 'one=1' },
+            { key: 'set-cookie', value: 'two=2' },
+          ],
+        }),
+      ],
+      outputs: {
+        '/with-header': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/with-header',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(result.resHeaders).toEqual({
+      'x-route-header': 'yes',
+      'set-cookie': ['one=1', 'two=2'],
+    })
+    expect(getItem).toHaveBeenCalledWith('/with-header')
+  })
+
+  it('applies has and missing predicates before custom route params', async () => {
+    const { fsChecker } = createFsChecker({
+      headers: [
+        buildCustomRoute('header', {
+          source: '/conditional',
+          has: [
+            {
+              type: 'header',
+              key: 'x-auth',
+              value: '(?<token>allowed)',
+            },
+          ],
+          missing: [{ type: 'query', key: 'skip' }],
+          headers: [{ key: 'x-token', value: ':token' }],
+        }),
+      ],
+    })
+
+    const { result: positive } = await resolveLiveRoute({
+      url: '/conditional',
+      headers: {
+        'x-auth': 'allowed',
+      },
+      fsChecker,
+    })
+    const { result: negative } = await resolveLiveRoute({
+      url: '/conditional?skip=1',
+      headers: {
+        'x-auth': 'allowed',
+      },
+      fsChecker,
+    })
+
+    expect(positive.resHeaders).toEqual({ 'x-token': 'allowed' })
+    expect(negative.resHeaders).toEqual({})
+  })
+
+  it('returns redirect responses with normalized destinations', async () => {
+    const { fsChecker } = createFsChecker({
+      redirects: [
+        buildCustomRoute('redirect', {
+          source: '/old/:slug',
+          destination: '/new//:slug',
+          permanent: true,
+        }),
+      ],
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/old/post?keep=1',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBe(308)
+    expect(result.resHeaders).toBeNull()
+    expect(result.parsedUrl.pathname).toBe('/new/post')
+    expect(result.parsedUrl.search).toBe('keep=1')
+  })
+
+  it('keeps direct static outputs even when page filesystem routes are disabled', async () => {
+    const publicOutput = createOutput('/robots.txt', 'publicFolder')
+    const pageOutput = createOutput('/page')
+    const config = createConfig({ useFileSystemPublicRoutes: false })
+    const { fsChecker } = createFsChecker({
+      outputs: {
+        '/robots.txt': publicOutput,
+        '/page': pageOutput,
+      },
+    })
+
+    const { result: publicResult } = await resolveLiveRoute({
+      url: '/robots.txt',
+      config,
+      fsChecker,
+    })
+    const { result: pageResult } = await resolveLiveRoute({
+      url: '/page',
+      config,
+      fsChecker,
+    })
+
+    expect(publicResult.finished).toBe(true)
+    expect(publicResult.matchedOutput).toBe(publicOutput)
+    expect(pageResult.finished).toBe(false)
+    expect(pageResult.matchedOutput).toBeNull()
+  })
+
+  it('resolves beforeFiles rewrites before checking filesystem outputs', async () => {
+    const matchedOutput = createOutput('/page/intro')
+    const { fsChecker } = createFsChecker({
+      rewrites: {
+        beforeFiles: [
+          buildCustomRoute('before_files_rewrite', {
+            source: '/docs/:slug',
+            destination: '/page/:slug',
+          }),
+        ],
+      },
+      outputs: {
+        '/page/intro': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/docs/intro?draft=1',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(result.parsedUrl.pathname).toBe('/page/intro')
+    expect(result.parsedUrl.query).toEqual({
+      draft: '1',
+    })
+  })
+
+  it('prefers direct filesystem outputs over afterFiles rewrites', async () => {
+    const directOutput = createOutput('/legacy')
+    const rewrittenOutput = createOutput('/modern')
+    const { fsChecker } = createFsChecker({
+      rewrites: {
+        afterFiles: [
+          buildCustomRoute('rewrite', {
+            source: '/legacy',
+            destination: '/modern',
+          }),
+        ],
+      },
+      outputs: {
+        '/legacy': directOutput,
+        '/modern': rewrittenOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/legacy',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/legacy')
+    expect(result.matchedOutput).toBe(directOutput)
+  })
+
+  it('resolves afterFiles rewrites when the original pathname is missing', async () => {
+    const matchedOutput = createOutput('/modern')
+    const { fsChecker } = createFsChecker({
+      rewrites: {
+        afterFiles: [
+          buildCustomRoute('rewrite', {
+            source: '/legacy',
+            destination: '/modern',
+          }),
+        ],
+      },
+      outputs: {
+        '/modern': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/legacy',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/modern')
+    expect(result.matchedOutput).toBe(matchedOutput)
+  })
+
+  it('resolves fallback rewrites after dynamic and filesystem misses', async () => {
+    const matchedOutput = createOutput('/fallback')
+    const { fsChecker } = createFsChecker({
+      rewrites: {
+        fallback: [
+          buildCustomRoute('rewrite', {
+            source: '/missing',
+            destination: '/fallback',
+          }),
+        ],
+      },
+      outputs: {
+        '/fallback': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/missing',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/fallback')
+    expect(result.matchedOutput).toBe(matchedOutput)
+  })
+
+  it('returns immediately for external rewrites', async () => {
+    const { fsChecker } = createFsChecker({
+      rewrites: {
+        afterFiles: [
+          buildCustomRoute('rewrite', {
+            source: '/proxy',
+            destination: 'https://example.com/proxy',
+          }),
+        ],
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/proxy',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.resHeaders).toBeNull()
+    expect(result.parsedUrl.protocol).toBe('https:')
+    expect(result.parsedUrl.hostname).toBe('example.com')
+    expect(result.parsedUrl.pathname).toBe('/proxy')
+  })
+
+  it('sets rewritten RSC headers for internal rewrites', async () => {
+    const matchedOutput = createOutput('/target')
+    const { fsChecker } = createFsChecker({
+      rewrites: {
+        beforeFiles: [
+          buildCustomRoute('before_files_rewrite', {
+            source: '/rsc',
+            destination: '/target?x=1',
+          }),
+        ],
+      },
+      outputs: {
+        '/target': matchedOutput,
+      },
+    })
+
+    const { result, res } = await resolveLiveRoute({
+      url: '/rsc',
+      headers: {
+        [RSC_HEADER]: '1',
+      },
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(res.getHeader(NEXT_REWRITTEN_PATH_HEADER)).toBe('/target')
+    expect(res.getHeader(NEXT_REWRITTEN_QUERY_HEADER)).toBe('x=1')
+  })
+
+  it('matches dynamic routes through the filesystem checker', async () => {
+    const matchedOutput = createOutput('/blog/[slug]')
+    const dynamicRoute = createDynamicRoute('/blog/[slug]')
+    const { fsChecker, getItem } = createFsChecker({
+      dynamicRoutes: [dynamicRoute],
+      outputs: {
+        '/blog/[slug]': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/blog/hello',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(result.parsedUrl.pathname).toBe('/blog/hello')
+    expect(getItem).toHaveBeenCalledWith('/blog/[slug]')
+  })
+
+  it('checks dynamic route outputs with the configured basePath', async () => {
+    const matchedOutput = createOutput('/docs/blog/[slug]')
+    const dynamicRoute = createDynamicRoute('/blog/[slug]')
+    const config = createConfig({ basePath: '/docs' })
+    const { fsChecker, getItem } = createFsChecker({
+      dynamicRoutes: [dynamicRoute],
+      outputs: {
+        '/docs/blog/[slug]': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/docs/blog/hello',
+      config,
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(getItem).toHaveBeenCalledWith('/docs/blog/[slug]')
+  })
+
+  it('prefixes the default locale for i18n filesystem lookup', async () => {
+    const matchedOutput = createOutput('/en/about', 'pageFile', {
+      locale: 'en',
+    })
+    const config = createConfig({
+      i18n: {
+        locales: ['en', 'fr'],
+        defaultLocale: 'en',
+      },
+    })
+    const { fsChecker } = createFsChecker({
+      outputs: {
+        '/en/about': matchedOutput,
+      },
+    })
+
+    const { result, req } = await resolveLiveRoute({
+      url: '/about',
+      config,
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/en/about')
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(getRequestMeta(req, 'defaultLocale')).toBe('en')
+    expect(getRequestMeta(req, 'locale')).toBe('en')
+  })
+
+  it('preserves detected i18n locales for localized filesystem lookup', async () => {
+    const matchedOutput = createOutput('/fr/about', 'pageFile', {
+      locale: 'fr',
+    })
+    const config = createConfig({
+      i18n: {
+        locales: ['en', 'fr'],
+        defaultLocale: 'en',
+      },
+    })
+    const { fsChecker } = createFsChecker({
+      outputs: {
+        '/fr/about': matchedOutput,
+      },
+    })
+
+    const { result, req } = await resolveLiveRoute({
+      url: '/fr/about',
+      config,
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/fr/about')
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(getRequestMeta(req, 'locale')).toBe('fr')
+  })
+
+  it('normalizes _next/data requests before middleware and dynamic lookup', async () => {
+    const matchedOutput = createOutput('/blog/[slug]')
+    const dynamicRoute = createDynamicRoute('/blog/[slug]')
+    const { fsChecker } = createFsChecker({
+      dynamicRoutes: [dynamicRoute],
+      middlewareMatcher: createMiddlewareMatcher(() => false),
+      outputs: {
+        '/blog/[slug]': matchedOutput,
+      },
+    })
+
+    const { result, req } = await resolveLiveRoute({
+      url: '/_next/data/BUILD_ID/blog/hello.json',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/blog/hello')
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(getRequestMeta(req, 'isNextDataReq')).toBe(true)
+    expect(req.headers['x-nextjs-data']).toBe('1')
+  })
+
+  it('runs exportPathMap routes at the beforeFiles boundary', async () => {
+    const matchedOutput = createOutput('/mapped')
+    const { fsChecker } = createFsChecker({
+      exportPathMapRoutes: [
+        buildCustomRoute('rewrite', {
+          source: '/exported',
+          destination: '/mapped',
+        }),
+      ],
+      outputs: {
+        '/mapped': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/exported',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/mapped')
+    expect(result.matchedOutput).toBe(matchedOutput)
+  })
+
+  it('applies onMatchHeaders after resolving an output', async () => {
+    const matchedOutput = createOutput('/asset', 'nextStaticFolder')
+    const { fsChecker } = createFsChecker({
+      onMatchHeaders: [
+        buildCustomRoute('header', {
+          source: '/asset',
+          headers: [
+            { key: 'cache-control', value: 'public, max-age=31536000' },
+          ],
+        }),
+      ],
+      outputs: {
+        '/asset': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/asset',
+      fsChecker,
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(result.resHeaders).toEqual({
+      'cache-control': 'public, max-age=31536000',
+    })
+  })
+
+  it('skips outputs that are already being invoked', async () => {
+    const matchedOutput = createOutput('/again')
+    const { fsChecker } = createFsChecker({
+      outputs: {
+        '/again': matchedOutput,
+      },
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/again',
+      fsChecker,
+      invokedOutputs: new Set(['/again']),
+    })
+
+    expect(result.finished).toBe(false)
+    expect(result.matchedOutput).toBeNull()
+  })
+
+  it('keeps minimal mode to filesystem checks only', async () => {
+    const matchedOutput = createOutput('/minimal')
+    const { fsChecker } = createFsChecker({
+      headers: [
+        buildCustomRoute('header', {
+          source: '/minimal',
+          headers: [{ key: 'x-minimal-header', value: 'ignored' }],
+        }),
+      ],
+      redirects: [
+        buildCustomRoute('redirect', {
+          source: '/minimal',
+          destination: '/redirected',
+          permanent: false,
+        }),
+      ],
+      rewrites: {
+        beforeFiles: [
+          buildCustomRoute('before_files_rewrite', {
+            source: '/minimal',
+            destination: '/rewritten',
+          }),
+        ],
+      },
+      middlewareMatcher: createMiddlewareMatcher(() => true),
+      outputs: {
+        '/minimal': matchedOutput,
+        '/rewritten': createOutput('/rewritten'),
+      },
+    })
+
+    const { result, renderServer } = await resolveLiveRoute({
+      url: '/minimal',
+      fsChecker,
+      opts: { minimalMode: true },
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBeUndefined()
+    expect(result.parsedUrl.pathname).toBe('/minimal')
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(result.resHeaders).toEqual({})
+    expect(renderServer.initialize).not.toHaveBeenCalled()
+  })
+
+  it('turns middleware redirects into relative locations', async () => {
+    const { fsChecker } = createFsChecker({
+      middlewareMatcher: createMiddlewareMatcher(() => true),
+    })
+    const ensureMiddleware = jest.fn(async () => {})
+
+    const { result, requestHandler } = await resolveLiveRoute({
+      url: '/from',
+      fsChecker,
+      middlewareResponse: new Response(null, {
+        status: 307,
+        headers: {
+          location: 'http://localhost:3000/login',
+        },
+      }),
+      ensureMiddleware,
+    })
+
+    expect(ensureMiddleware).toHaveBeenCalledWith('/from')
+    expect(requestHandler).toHaveBeenCalled()
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBe(307)
+    expect(result.resHeaders).toEqual({ location: '/login' })
+    expect(result.parsedUrl.pathname).toBe('/login')
+  })
+
+  it('continues route resolution after internal middleware rewrites', async () => {
+    const matchedOutput = createOutput('/rewritten')
+    const { fsChecker } = createFsChecker({
+      middlewareMatcher: createMiddlewareMatcher(() => true),
+      outputs: {
+        '/rewritten': matchedOutput,
+      },
+    })
+
+    const { result, req } = await resolveLiveRoute({
+      url: '/from',
+      fsChecker,
+      middlewareResponse: new Response(null, {
+        headers: {
+          'x-middleware-rewrite': 'http://localhost:3000/rewritten?m=1',
+          'x-visible': 'visible',
+        },
+      }),
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.parsedUrl.pathname).toBe('/rewritten')
+    expect(result.parsedUrl.query).toEqual({ m: '1' })
+    expect(result.matchedOutput).toBe(matchedOutput)
+    expect(result.resHeaders).toEqual({
+      'x-middleware-rewrite': '/rewritten?m=1',
+      'x-visible': 'visible',
+    })
+    expect(req.headers['x-visible']).toBe('visible')
+  })
+
+  it('returns immediately for external middleware rewrites', async () => {
+    const { fsChecker } = createFsChecker({
+      middlewareMatcher: createMiddlewareMatcher(() => true),
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/from',
+      fsChecker,
+      middlewareResponse: new Response(null, {
+        headers: {
+          'x-middleware-rewrite': 'https://external.test/path',
+        },
+      }),
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.resHeaders).toEqual({
+      'x-middleware-rewrite': 'https://external.test/path',
+    })
+    expect(result.parsedUrl.protocol).toBe('https:')
+    expect(result.parsedUrl.hostname).toBe('external.test')
+    expect(result.parsedUrl.pathname).toBe('/path')
+  })
+
+  it('passes through non-redirect middleware Location responses', async () => {
+    const { fsChecker } = createFsChecker({
+      middlewareMatcher: createMiddlewareMatcher(() => true),
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/from',
+      fsChecker,
+      middlewareResponse: new Response('created', {
+        status: 201,
+        headers: {
+          location: '/created',
+        },
+      }),
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBe(201)
+    expect(result.bodyStream).toBeDefined()
+    expect(result.resHeaders).toEqual({
+      'content-type': 'text/plain;charset=UTF-8',
+      location: '/created',
+    })
+    expect(result.parsedUrl.pathname).toBe('/from')
+  })
+
+  it('finishes middleware responses that request a refresh', async () => {
+    const { fsChecker } = createFsChecker({
+      middlewareMatcher: createMiddlewareMatcher(() => true),
+    })
+
+    const { result } = await resolveLiveRoute({
+      url: '/from',
+      fsChecker,
+      middlewareResponse: new Response(null, {
+        status: 204,
+      }),
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBe(204)
+    expect(result.bodyStream).toBeDefined()
+    expect(result.resHeaders).toEqual({})
+  })
+
+  it('applies middleware request header overrides without exposing set-cookie', async () => {
+    const { fsChecker } = createFsChecker({
+      middlewareMatcher: createMiddlewareMatcher(() => true),
+    })
+
+    const { result, req } = await resolveLiveRoute({
+      url: '/from',
+      headers: {
+        'x-keep': 'old',
+        'x-remove': 'remove',
+      },
+      fsChecker,
+      middlewareResponse: new Response(null, {
+        headers: {
+          'x-middleware-next': '1',
+          'x-middleware-override-headers': 'x-keep,x-added',
+          'x-middleware-request-x-keep': 'new',
+          'x-middleware-request-x-added': 'yes',
+          'x-middleware-set-cookie': 'middleware=1',
+          'x-visible': 'visible',
+        },
+      }),
+    })
+
+    expect(result.finished).toBe(false)
+    expect(result.resHeaders).toEqual({ 'x-visible': 'visible' })
+    expect(req.headers['x-keep']).toBe('new')
+    expect(req.headers['x-added']).toBe('yes')
+    expect(req.headers['x-remove']).toBeUndefined()
+    expect(req.headers['x-middleware-set-cookie']).toBe('middleware=1')
+    expect(result.resHeaders?.['x-middleware-set-cookie']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What?

Adds an internal server routing audit and a live resolver contract test suite.

## Why?

This establishes a compatibility-first baseline before exploring whether `@next/routing` can become the shared route-resolution layer for the Next.js server.

## How?

- Documents the current `next dev`, `next start`, custom server, standalone/minimal-mode, upgrade, and adapter-related server paths.
- Maps live resolver responsibilities and compatibility risks.
- Adds unit coverage for the main observable `getResolveRoutes()` routing branches.

<!-- NEXT_JS_LLM_PR -->