### PR TITLE
Add next routing server adapter input builder

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1300,5 +1300,6 @@
   "1299": "Route \"%s\": Next.js encountered uncached or runtime data during prerendering.\\n\\n\\`fetch(...)\\`, \\`cookies()\\`, \\`headers()\\`, \\`params\\`, \\`searchParams\\`, or \\`connection()\\` accessed outside of \\`<Suspense>\\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.\\n\\nWays to fix this:\\n  - [cache] Cache the data access with \\`\"use cache\"\\`\\n    https://nextjs.org/docs/messages/blocking-prerender-dynamic#cache-the-component-or-data\\n  - [stream] Provide a placeholder with \\`<Suspense fallback={...}>\\` around the data access\\n    https://nextjs.org/docs/messages/blocking-prerender-dynamic#wrap-in-or-move-into-suspense\\n  - [cache] If the runtime data is \\`params\\` and they're known, prerender them with \\`generateStaticParams\\`\\n    https://nextjs.org/docs/messages/blocking-prerender-runtime#for-known-params-prerender\\n  - [block] Set \\`export const unstable_instant = false\\` to silence this warning and allow a blocking route\\n    https://nextjs.org/docs/messages/blocking-prerender-dynamic#allow-blocking-route",
   "1300": "A render that hasn't started yet cannot be abandoned",
   "1301": "Cannot determine late/early stage before starting the render",
-  "1302": "Attempted to advance to stage %s but the render is limited to %s"
+  "1302": "Attempted to advance to stage %s but the render is limited to %s",
+  "1303": "Expected live route to include a compiled regex"
 }

--- a/packages/next/src/server/lib/router-utils/next-routing-adapter.ts
+++ b/packages/next/src/server/lib/router-utils/next-routing-adapter.ts
@@ -34,10 +34,22 @@ export type NextRoutingRouteConfig = {
   shouldNormalizeNextData: boolean
 }
 
+type NextRoutingI18nConfig = {
+  defaultLocale: string
+  domains?: Array<{
+    defaultLocale: string
+    domain: string
+    http?: true
+    locales?: string[]
+  }>
+  localeDetection?: false
+  locales: string[]
+}
+
 export type NextRoutingServerState = {
   buildId: string
   basePath: string
-  i18n?: NextConfigRuntime['i18n']
+  i18n?: NextRoutingI18nConfig
   pathnames: string[]
   routes: NextRoutingRouteConfig
 }
@@ -74,6 +86,26 @@ function getDestinationQuery(routeKeys: Record<string, string> | undefined) {
   }
 
   return `?${items.map(([key, value]) => `${value}=$${key}`).join('&')}`
+}
+
+function createNextRoutingI18nConfig(
+  i18n: NextConfigRuntime['i18n']
+): NextRoutingI18nConfig | undefined {
+  if (!i18n) {
+    return undefined
+  }
+
+  return {
+    defaultLocale: i18n.defaultLocale,
+    domains: i18n.domains?.map((domain) => ({
+      defaultLocale: domain.defaultLocale,
+      domain: domain.domain,
+      http: domain.http,
+      locales: domain.locales ? [...domain.locales] : undefined,
+    })),
+    localeDetection: i18n.localeDetection,
+    locales: [...i18n.locales],
+  }
 }
 
 export function createNextRoutingHeaderRoute(
@@ -190,7 +222,7 @@ export function createNextRoutingServerState(
   return {
     buildId: fsChecker.buildId,
     basePath: config.basePath || '',
-    i18n: config.i18n,
+    i18n: createNextRoutingI18nConfig(config.i18n),
     pathnames: createNextRoutingPathnames(fsChecker, {
       additionalPathnames,
       invokedOutputs,

--- a/packages/next/src/server/lib/router-utils/next-routing-adapter.ts
+++ b/packages/next/src/server/lib/router-utils/next-routing-adapter.ts
@@ -1,0 +1,223 @@
+import type { NextConfigRuntime } from '../../config-shared'
+import type { Header, Redirect, Rewrite } from '../../../lib/load-custom-routes'
+import type { FilesystemDynamicRoute, setupFsCheck } from './filesystem'
+
+import {
+  convertHeaders,
+  convertRedirects,
+  convertRewrites,
+} from 'next/dist/compiled/@vercel/routing-utils'
+import { getRedirectStatus } from '../../../lib/redirect-status'
+
+type FsChecker = Awaited<ReturnType<typeof setupFsCheck>>
+
+export type NextRoutingRoute = {
+  source?: string
+  sourceRegex: string
+  destination?: string
+  headers?: Record<string, string>
+  has?: Header['has']
+  missing?: Header['missing']
+  status?: number
+  priority?: boolean
+}
+
+export type NextRoutingRouteConfig = {
+  caseSensitive?: boolean
+  beforeMiddleware: NextRoutingRoute[]
+  middlewareMatchers: NextRoutingRoute[]
+  beforeFiles: NextRoutingRoute[]
+  afterFiles: NextRoutingRoute[]
+  dynamicRoutes: NextRoutingRoute[]
+  onMatch: NextRoutingRoute[]
+  fallback: NextRoutingRoute[]
+  shouldNormalizeNextData: boolean
+}
+
+export type NextRoutingServerState = {
+  buildId: string
+  basePath: string
+  i18n?: NextConfigRuntime['i18n']
+  pathnames: string[]
+  routes: NextRoutingRouteConfig
+}
+
+type LiveHeaderRoute = Header & { regex?: string; internal?: boolean }
+type LiveRedirectRoute = Redirect & { regex?: string; internal?: boolean }
+type LiveRewriteRoute = Rewrite & { regex?: string; internal?: boolean }
+
+export function normalizeNextRoutingSourceRegex(regex: string): string {
+  // Some live manifest routes can carry a RegExp string from `.toString()`,
+  // while @next/routing expects the pattern passed to `new RegExp()`.
+  if (regex.startsWith('/')) {
+    const lastSlash = regex.lastIndexOf('/')
+    if (lastSlash > 0) {
+      return regex.slice(1, lastSlash)
+    }
+  }
+
+  return regex
+}
+
+function routeSourceRegex(route: { regex?: string }): string {
+  if (!route.regex) {
+    throw new Error('Expected live route to include a compiled regex')
+  }
+
+  return normalizeNextRoutingSourceRegex(route.regex)
+}
+
+function getDestinationQuery(routeKeys: Record<string, string> | undefined) {
+  const items = Object.entries(routeKeys ?? {})
+  if (items.length === 0) {
+    return ''
+  }
+
+  return `?${items.map(([key, value]) => `${value}=$${key}`).join('&')}`
+}
+
+export function createNextRoutingHeaderRoute(
+  route: LiveHeaderRoute
+): NextRoutingRoute {
+  const converted = convertHeaders([route])[0]
+
+  return {
+    source: route.source,
+    sourceRegex: normalizeNextRoutingSourceRegex(
+      converted.src || routeSourceRegex(route)
+    ),
+    headers: 'headers' in converted ? converted.headers || {} : {},
+    has: route.has,
+    missing: route.missing,
+    priority: route.internal || undefined,
+  }
+}
+
+export function createNextRoutingRedirectRoute(
+  route: LiveRedirectRoute
+): NextRoutingRoute {
+  const converted = convertRedirects([route], 307)[0]
+
+  return {
+    source: route.source,
+    sourceRegex: normalizeNextRoutingSourceRegex(
+      converted.src || routeSourceRegex(route)
+    ),
+    headers: 'headers' in converted ? converted.headers || {} : {},
+    status: converted.status || getRedirectStatus(route),
+    has: route.has,
+    missing: route.missing,
+    priority: route.internal || undefined,
+  }
+}
+
+export function createNextRoutingRewriteRoute(
+  route: LiveRewriteRoute
+): NextRoutingRoute {
+  const converted = convertRewrites([route], ['nextInternalLocale'])[0]
+
+  return {
+    source: route.source,
+    sourceRegex: normalizeNextRoutingSourceRegex(
+      converted.src || routeSourceRegex(route)
+    ),
+    destination: converted.dest || route.destination,
+    has: route.has,
+    missing: route.missing,
+    priority: route.internal || undefined,
+  }
+}
+
+export function createNextRoutingDynamicRoute(
+  route: FilesystemDynamicRoute
+): NextRoutingRoute {
+  return {
+    source: route.page,
+    sourceRegex: normalizeNextRoutingSourceRegex(
+      route.namedRegex || route.regex
+    ),
+    destination: `${route.page}${getDestinationQuery(route.routeKeys)}`,
+  }
+}
+
+export function createNextRoutingPathnames(
+  fsChecker: Pick<
+    FsChecker,
+    'appFiles' | 'pageFiles' | 'nextDataRoutes' | 'getDynamicRoutes'
+  >,
+  {
+    additionalPathnames = [],
+    invokedOutputs,
+  }: {
+    additionalPathnames?: Iterable<string>
+    invokedOutputs?: Set<string>
+  } = {}
+): string[] {
+  const pathnames = new Set<string>()
+
+  for (const pathname of [
+    ...fsChecker.appFiles,
+    ...fsChecker.pageFiles,
+    ...fsChecker.nextDataRoutes,
+    ...fsChecker.getDynamicRoutes().map((route) => route.page),
+    ...additionalPathnames,
+  ]) {
+    if (!invokedOutputs?.has(pathname)) {
+      pathnames.add(pathname)
+    }
+  }
+
+  return [...pathnames]
+}
+
+export function createNextRoutingServerState(
+  fsChecker: FsChecker,
+  config: NextConfigRuntime,
+  {
+    additionalPathnames,
+    invokedOutputs,
+    minimalMode = false,
+    middlewareMatchers = [],
+    shouldNormalizeNextData = middlewareMatchers.length > 0,
+  }: {
+    additionalPathnames?: Iterable<string>
+    invokedOutputs?: Set<string>
+    minimalMode?: boolean
+    middlewareMatchers?: NextRoutingRoute[]
+    shouldNormalizeNextData?: boolean
+  } = {}
+): NextRoutingServerState {
+  return {
+    buildId: fsChecker.buildId,
+    basePath: config.basePath || '',
+    i18n: config.i18n,
+    pathnames: createNextRoutingPathnames(fsChecker, {
+      additionalPathnames,
+      invokedOutputs,
+    }),
+    routes: {
+      caseSensitive: config.experimental.caseSensitiveRoutes,
+      beforeMiddleware: minimalMode
+        ? []
+        : [
+            ...fsChecker.headers.map(createNextRoutingHeaderRoute),
+            ...fsChecker.redirects.map(createNextRoutingRedirectRoute),
+          ],
+      middlewareMatchers,
+      beforeFiles: minimalMode
+        ? []
+        : fsChecker.rewrites.beforeFiles.map(createNextRoutingRewriteRoute),
+      afterFiles: minimalMode
+        ? []
+        : fsChecker.rewrites.afterFiles.map(createNextRoutingRewriteRoute),
+      dynamicRoutes: fsChecker
+        .getDynamicRoutes()
+        .map(createNextRoutingDynamicRoute),
+      onMatch: fsChecker.onMatchHeaders.map(createNextRoutingHeaderRoute),
+      fallback: minimalMode
+        ? []
+        : fsChecker.rewrites.fallback.map(createNextRoutingRewriteRoute),
+      shouldNormalizeNextData,
+    },
+  }
+}

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -813,8 +813,12 @@ declare module 'next/dist/compiled/ws' {
   export = m
 }
 declare module 'next/dist/compiled/@vercel/routing-utils' {
-  import m from '@vercel/routing-utils/dist/superstatic'
-  export = m
+  export function convertHeaders(routes: any[]): any[]
+  export function convertRedirects(routes: any[], defaultStatus?: number): any[]
+  export function convertRewrites(
+    routes: any[],
+    internalParamNames?: string[]
+  ): any[]
 }
 
 declare module 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp' {

--- a/test/unit/server-routing-equivalence/next-routing-adapter.test.ts
+++ b/test/unit/server-routing-equivalence/next-routing-adapter.test.ts
@@ -1,19 +1,25 @@
 /* eslint-env jest */
 
-import type { NextConfigRuntime } from '../../../packages/next/src/server/config-shared'
-import type {
-  FilesystemDynamicRoute,
-  setupFsCheck,
-} from '../../../packages/next/src/server/lib/router-utils/filesystem'
-
 import { resolveRoutes } from '../../../packages/next-routing/src/resolve-routes'
-import { defaultConfig } from '../../../packages/next/src/server/config-shared'
-import { buildCustomRoute } from '../../../packages/next/src/server/lib/router-utils/filesystem'
-import { createNextRoutingServerState } from '../../../packages/next/src/server/lib/router-utils/next-routing-adapter'
-import { getRouteMatcher } from '../../../packages/next/src/shared/lib/router/utils/route-matcher'
-import { getNamedRouteRegex } from '../../../packages/next/src/shared/lib/router/utils/route-regex'
+const {
+  defaultConfig,
+} = require('../../../packages/next/src/server/config-shared')
+const {
+  buildCustomRoute,
+} = require('../../../packages/next/src/server/lib/router-utils/filesystem')
+const {
+  createNextRoutingServerState,
+} = require('../../../packages/next/src/server/lib/router-utils/next-routing-adapter')
+const {
+  getRouteMatcher,
+} = require('../../../packages/next/src/shared/lib/router/utils/route-matcher')
+const {
+  getNamedRouteRegex,
+} = require('../../../packages/next/src/shared/lib/router/utils/route-regex')
 
-type FsChecker = Awaited<ReturnType<typeof setupFsCheck>>
+type NextConfigRuntime = any
+type FilesystemDynamicRoute = any
+type FsChecker = any
 
 function createConfig(
   overrides: Partial<NextConfigRuntime> = {}
@@ -61,10 +67,10 @@ function createFsChecker({
   nextDataRoutes = [],
   buildId = 'BUILD_ID',
 }: {
-  headers?: FsChecker['headers']
-  redirects?: FsChecker['redirects']
-  rewrites?: Partial<FsChecker['rewrites']>
-  onMatchHeaders?: FsChecker['onMatchHeaders']
+  headers?: any[]
+  redirects?: any[]
+  rewrites?: Record<string, any[]>
+  onMatchHeaders?: any[]
   dynamicRoutes?: FilesystemDynamicRoute[]
   appFiles?: string[]
   pageFiles?: string[]

--- a/test/unit/server-routing-equivalence/next-routing-adapter.test.ts
+++ b/test/unit/server-routing-equivalence/next-routing-adapter.test.ts
@@ -1,0 +1,312 @@
+/* eslint-env jest */
+
+import type { NextConfigRuntime } from '../../../packages/next/src/server/config-shared'
+import type {
+  FilesystemDynamicRoute,
+  setupFsCheck,
+} from '../../../packages/next/src/server/lib/router-utils/filesystem'
+
+import { resolveRoutes } from '../../../packages/next-routing/src/resolve-routes'
+import { defaultConfig } from '../../../packages/next/src/server/config-shared'
+import { buildCustomRoute } from '../../../packages/next/src/server/lib/router-utils/filesystem'
+import { createNextRoutingServerState } from '../../../packages/next/src/server/lib/router-utils/next-routing-adapter'
+import { getRouteMatcher } from '../../../packages/next/src/shared/lib/router/utils/route-matcher'
+import { getNamedRouteRegex } from '../../../packages/next/src/shared/lib/router/utils/route-regex'
+
+type FsChecker = Awaited<ReturnType<typeof setupFsCheck>>
+
+function createConfig(
+  overrides: Partial<NextConfigRuntime> = {}
+): NextConfigRuntime {
+  const baseConfig = defaultConfig as unknown as NextConfigRuntime
+  return {
+    ...baseConfig,
+    ...overrides,
+    experimental: {
+      ...baseConfig.experimental,
+      ...overrides.experimental,
+    },
+  }
+}
+
+function createReadableStream(): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      controller.close()
+    },
+  })
+}
+
+function createDynamicRoute(page: string): FilesystemDynamicRoute {
+  const routeRegex = getNamedRouteRegex(page, {
+    prefixRouteKeys: true,
+  })
+  return {
+    page,
+    regex: routeRegex.re.toString(),
+    namedRegex: routeRegex.namedRegex,
+    routeKeys: routeRegex.routeKeys,
+    match: getRouteMatcher(routeRegex),
+  }
+}
+
+function createFsChecker({
+  headers = [],
+  redirects = [],
+  rewrites = {},
+  onMatchHeaders = [],
+  dynamicRoutes = [],
+  appFiles = [],
+  pageFiles = [],
+  nextDataRoutes = [],
+  buildId = 'BUILD_ID',
+}: {
+  headers?: FsChecker['headers']
+  redirects?: FsChecker['redirects']
+  rewrites?: Partial<FsChecker['rewrites']>
+  onMatchHeaders?: FsChecker['onMatchHeaders']
+  dynamicRoutes?: FilesystemDynamicRoute[]
+  appFiles?: string[]
+  pageFiles?: string[]
+  nextDataRoutes?: string[]
+  buildId?: string
+} = {}) {
+  return {
+    headers,
+    redirects,
+    rewrites: {
+      beforeFiles: [],
+      afterFiles: [],
+      fallback: [],
+      ...rewrites,
+    },
+    onMatchHeaders,
+    buildId,
+    appFiles: new Set(appFiles),
+    pageFiles: new Set(pageFiles),
+    nextDataRoutes: new Set(nextDataRoutes),
+    getDynamicRoutes() {
+      return dynamicRoutes
+    },
+  } as unknown as FsChecker
+}
+
+async function resolveWithNextRouting(
+  state: ReturnType<typeof createNextRoutingServerState>,
+  pathname: string,
+  headers = new Headers()
+) {
+  return resolveRoutes({
+    url: new URL(pathname, 'https://example.com'),
+    buildId: state.buildId,
+    basePath: state.basePath,
+    i18n: state.i18n,
+    requestBody: createReadableStream(),
+    headers,
+    pathnames: state.pathnames,
+    routes: state.routes,
+    invokeMiddleware: async () => ({}),
+  })
+}
+
+describe('next routing server adapter', () => {
+  it('translates live header routes into @next/routing beforeMiddleware routes', async () => {
+    const fsChecker = createFsChecker({
+      headers: [
+        buildCustomRoute('header', {
+          source: '/docs/:slug',
+          headers: [{ key: 'x-doc-slug', value: ':slug' }],
+        }),
+      ],
+      pageFiles: ['/docs/intro'],
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig())
+    const result = await resolveWithNextRouting(state, '/docs/intro')
+
+    expect(result.resolvedPathname).toBe('/docs/intro')
+    expect(result.resolvedHeaders?.get('x-doc-slug')).toBe('intro')
+  })
+
+  it('translates live redirect routes into @next/routing redirect headers', async () => {
+    const fsChecker = createFsChecker({
+      redirects: [
+        buildCustomRoute('redirect', {
+          source: '/old/:slug',
+          destination: '/new/:slug',
+          permanent: true,
+        }),
+      ],
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig())
+    const result = await resolveWithNextRouting(state, '/old/post?from=1')
+
+    expect(result.status).toBe(308)
+    expect(result.resolvedHeaders?.get('location')).toBe('/new/post?from=1')
+  })
+
+  it('translates live beforeFiles rewrites into @next/routing rewrite routes', async () => {
+    const fsChecker = createFsChecker({
+      rewrites: {
+        beforeFiles: [
+          buildCustomRoute('before_files_rewrite', {
+            source: '/docs/:slug',
+            destination: '/page/:slug',
+          }),
+        ],
+      },
+      pageFiles: ['/page/intro'],
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig())
+    const result = await resolveWithNextRouting(state, '/docs/intro?draft=1')
+
+    expect(result.resolvedPathname).toBe('/page/intro')
+    expect(result.invocationTarget).toEqual({
+      pathname: '/page/intro',
+      query: {
+        draft: '1',
+      },
+    })
+  })
+
+  it('translates live afterFiles and fallback external rewrites', async () => {
+    const fsChecker = createFsChecker({
+      rewrites: {
+        afterFiles: [
+          buildCustomRoute('rewrite', {
+            source: '/proxy',
+            destination: 'https://backend.example.test/api',
+          }),
+        ],
+        fallback: [
+          buildCustomRoute('rewrite', {
+            source: '/fallback-proxy',
+            destination: 'https://fallback.example.test/api',
+          }),
+        ],
+      },
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig())
+    const afterFilesResult = await resolveWithNextRouting(state, '/proxy')
+    const fallbackResult = await resolveWithNextRouting(
+      state,
+      '/fallback-proxy'
+    )
+
+    expect(afterFilesResult.externalRewrite?.toString()).toBe(
+      'https://backend.example.test/api'
+    )
+    expect(fallbackResult.externalRewrite?.toString()).toBe(
+      'https://fallback.example.test/api'
+    )
+  })
+
+  it('translates filesystem dynamic routes with invocation query params', async () => {
+    const dynamicRoute = createDynamicRoute('/blog/[slug]')
+    const fsChecker = createFsChecker({
+      dynamicRoutes: [dynamicRoute],
+      pageFiles: ['/blog/[slug]'],
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig())
+    const result = await resolveWithNextRouting(state, '/blog/hello?draft=1')
+
+    expect(result.resolvedPathname).toBe('/blog/[slug]')
+    expect(result.invocationTarget).toEqual({
+      pathname: '/blog/hello',
+      query: {
+        draft: '1',
+        nxtPslug: 'hello',
+      },
+    })
+  })
+
+  it('collects pathnames from route outputs and skips invoked outputs', () => {
+    const fsChecker = createFsChecker({
+      appFiles: ['/app'],
+      pageFiles: ['/page'],
+      nextDataRoutes: ['/data-page'],
+      dynamicRoutes: [createDynamicRoute('/blog/[slug]')],
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig(), {
+      additionalPathnames: ['/public.txt', '/app'],
+      invokedOutputs: new Set(['/page']),
+    })
+
+    expect(state.pathnames).toEqual([
+      '/app',
+      '/data-page',
+      '/blog/[slug]',
+      '/public.txt',
+    ])
+  })
+
+  it('keeps custom routes out of minimal mode routing input', () => {
+    const fsChecker = createFsChecker({
+      headers: [
+        buildCustomRoute('header', {
+          source: '/minimal',
+          headers: [{ key: 'x-minimal', value: 'ignored' }],
+        }),
+      ],
+      redirects: [
+        buildCustomRoute('redirect', {
+          source: '/minimal',
+          destination: '/redirected',
+          permanent: false,
+        }),
+      ],
+      rewrites: {
+        beforeFiles: [
+          buildCustomRoute('before_files_rewrite', {
+            source: '/minimal',
+            destination: '/rewritten',
+          }),
+        ],
+        fallback: [
+          buildCustomRoute('rewrite', {
+            source: '/minimal-fallback',
+            destination: '/fallback',
+          }),
+        ],
+      },
+      dynamicRoutes: [createDynamicRoute('/dynamic/[slug]')],
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig(), {
+      minimalMode: true,
+    })
+
+    expect(state.routes.beforeMiddleware).toEqual([])
+    expect(state.routes.beforeFiles).toEqual([])
+    expect(state.routes.afterFiles).toEqual([])
+    expect(state.routes.fallback).toEqual([])
+    expect(state.routes.dynamicRoutes).toHaveLength(1)
+  })
+
+  it('translates onMatch headers for resolved outputs', async () => {
+    const fsChecker = createFsChecker({
+      onMatchHeaders: [
+        buildCustomRoute('header', {
+          source: '/asset',
+          headers: [
+            { key: 'cache-control', value: 'public, max-age=31536000' },
+          ],
+        }),
+      ],
+      pageFiles: ['/asset'],
+    })
+
+    const state = createNextRoutingServerState(fsChecker, createConfig())
+    const result = await resolveWithNextRouting(state, '/asset')
+
+    expect(result.resolvedPathname).toBe('/asset')
+    expect(result.resolvedHeaders?.get('cache-control')).toBe(
+      'public, max-age=31536000'
+    )
+  })
+})


### PR DESCRIPTION
## What?

Adds an internal server adapter input builder that converts the live `fsChecker` route data into `@next/routing`-compatible route arrays and pathnames.

## Why?

This is the next compatibility-first layer after the audit and contract tests: it lets future work compare or delegate selected route phases to `@next/routing` without changing live request handling yet.

## How?

- Converts live header, redirect, and rewrite routes using the same routing-utils conversion helpers used by adapter build output.
- Converts filesystem dynamic routes and output pathnames into the shape expected by `@next/routing`.
- Adds focused unit tests that run the generated inputs through `@next/routing.resolveRoutes()`.

<!-- NEXT_JS_LLM_PR -->