### PR TITLE
Map next routing results to live resolver shape

### DIFF
--- a/packages/next/src/server/lib/router-utils/next-routing-adapter.ts
+++ b/packages/next/src/server/lib/router-utils/next-routing-adapter.ts
@@ -1,13 +1,22 @@
 import type { NextConfigRuntime } from '../../config-shared'
 import type { Header, Redirect, Rewrite } from '../../../lib/load-custom-routes'
-import type { FilesystemDynamicRoute, setupFsCheck } from './filesystem'
+import type {
+  FilesystemDynamicRoute,
+  FsOutput,
+  setupFsCheck,
+} from './filesystem'
+import type { NextUrlWithParsedQuery } from '../../request-meta'
 
 import {
   convertHeaders,
   convertRedirects,
   convertRewrites,
 } from 'next/dist/compiled/@vercel/routing-utils'
-import { getRedirectStatus } from '../../../lib/redirect-status'
+import {
+  allowedStatusCodes,
+  getRedirectStatus,
+} from '../../../lib/redirect-status'
+import { parseUrl } from '../../../shared/lib/router/utils/parse-url'
 
 type FsChecker = Awaited<ReturnType<typeof setupFsCheck>>
 
@@ -52,6 +61,33 @@ export type NextRoutingServerState = {
   i18n?: NextRoutingI18nConfig
   pathnames: string[]
   routes: NextRoutingRouteConfig
+}
+
+export type NextRoutingResolveResult = {
+  middlewareResponded?: boolean
+  externalRewrite?: URL
+  redirect?: {
+    url: URL
+    status: number
+  }
+  resolvedPathname?: string
+  resolvedQuery?: Record<string, string | string[]>
+  invocationTarget?: {
+    pathname: string
+    query: Record<string, string | string[]>
+  }
+  resolvedHeaders?: Headers
+  status?: number
+  routeMatches?: Record<string, string>
+}
+
+export type NextRoutingMappedResult = {
+  finished: boolean
+  statusCode?: number
+  bodyStream?: ReadableStream | null
+  resHeaders: Record<string, string | string[]> | null
+  parsedUrl: NextUrlWithParsedQuery
+  matchedOutput?: FsOutput | null
 }
 
 type LiveHeaderRoute = Header & { regex?: string; internal?: boolean }
@@ -251,5 +287,139 @@ export function createNextRoutingServerState(
         : fsChecker.rewrites.fallback.map(createNextRoutingRewriteRoute),
       shouldNormalizeNextData,
     },
+  }
+}
+
+function headersToRecord(
+  headers: Headers | undefined
+): Record<string, string | string[]> {
+  const record: Record<string, string | string[]> = {}
+
+  if (!headers) {
+    return record
+  }
+
+  headers.forEach((value, key) => {
+    record[key] = value
+  })
+
+  const setCookie = (
+    headers as Headers & { getSetCookie?: () => string[] }
+  ).getSetCookie?.()
+  if (setCookie?.length) {
+    record['set-cookie'] = setCookie
+  }
+
+  return record
+}
+
+function getRelativeUrl(url: URL, initUrl: URL) {
+  if (url.origin === initUrl.origin) {
+    return `${url.pathname}${url.search}${url.hash}`
+  }
+
+  return url.toString()
+}
+
+function parseRedirectDestination(destination: string) {
+  const parsedUrl = parseUrl(destination) as NextUrlWithParsedQuery
+
+  // Live custom-route redirects assign `search` from `stringifyQuery()`,
+  // which intentionally omits the leading `?`.
+  if (parsedUrl.search?.startsWith('?')) {
+    parsedUrl.search = parsedUrl.search.slice(1)
+  }
+
+  return parsedUrl
+}
+
+function setParsedUrlInvocationTarget(
+  parsedUrl: NextUrlWithParsedQuery,
+  invocationTarget: NonNullable<NextRoutingResolveResult['invocationTarget']>
+) {
+  parsedUrl.pathname = invocationTarget.pathname
+  parsedUrl.query = { ...invocationTarget.query }
+}
+
+export async function mapNextRoutingResultToResolveRoutesResult({
+  result,
+  fsChecker,
+  initUrl,
+  requestUrl,
+  invokedOutputs,
+}: {
+  result: NextRoutingResolveResult
+  fsChecker: Pick<FsChecker, 'getItem'>
+  initUrl: URL
+  requestUrl: string
+  invokedOutputs?: Set<string>
+}): Promise<NextRoutingMappedResult> {
+  const resHeaders = headersToRecord(result.resolvedHeaders)
+  const parsedUrl = parseUrl(requestUrl) as NextUrlWithParsedQuery
+
+  if (result.middlewareResponded) {
+    return {
+      finished: true,
+      parsedUrl,
+      resHeaders,
+      statusCode: result.status,
+    }
+  }
+
+  if (result.externalRewrite) {
+    return {
+      finished: true,
+      parsedUrl: parseUrl(
+        result.externalRewrite.toString()
+      ) as NextUrlWithParsedQuery,
+      resHeaders,
+      statusCode: result.status,
+    }
+  }
+
+  if (result.redirect) {
+    return {
+      finished: true,
+      parsedUrl: parseRedirectDestination(
+        getRelativeUrl(result.redirect.url, initUrl)
+      ),
+      resHeaders: null,
+      statusCode: result.redirect.status,
+    }
+  }
+
+  const location = result.resolvedHeaders?.get('location')
+  if (result.status && location && allowedStatusCodes.has(result.status)) {
+    return {
+      finished: true,
+      parsedUrl: parseRedirectDestination(location),
+      resHeaders: null,
+      statusCode: result.status,
+    }
+  }
+
+  if (result.invocationTarget) {
+    setParsedUrlInvocationTarget(parsedUrl, result.invocationTarget)
+  } else if (result.resolvedPathname) {
+    parsedUrl.pathname = result.resolvedPathname
+    if (result.resolvedQuery) {
+      parsedUrl.query = { ...result.resolvedQuery }
+    }
+  }
+
+  let matchedOutput: FsOutput | null = null
+  if (
+    result.resolvedPathname &&
+    !invokedOutputs?.has(result.resolvedPathname)
+  ) {
+    matchedOutput = await fsChecker.getItem(result.resolvedPathname)
+  }
+
+  return {
+    finished: !!matchedOutput,
+    parsedUrl,
+    resHeaders,
+    matchedOutput,
+    statusCode: result.status,
   }
 }

--- a/test/unit/server-routing-equivalence/next-routing-adapter.test.ts
+++ b/test/unit/server-routing-equivalence/next-routing-adapter.test.ts
@@ -9,6 +9,7 @@ const {
 } = require('../../../packages/next/src/server/lib/router-utils/filesystem')
 const {
   createNextRoutingServerState,
+  mapNextRoutingResultToResolveRoutesResult,
 } = require('../../../packages/next/src/server/lib/router-utils/next-routing-adapter')
 const {
   getRouteMatcher,
@@ -65,6 +66,7 @@ function createFsChecker({
   appFiles = [],
   pageFiles = [],
   nextDataRoutes = [],
+  outputs = {},
   buildId = 'BUILD_ID',
 }: {
   headers?: any[]
@@ -75,8 +77,11 @@ function createFsChecker({
   appFiles?: string[]
   pageFiles?: string[]
   nextDataRoutes?: string[]
+  outputs?: Record<string, { type: 'pageFile'; itemPath: string }>
   buildId?: string
 } = {}) {
+  const outputMap = new Map(Object.entries(outputs))
+
   return {
     headers,
     redirects,
@@ -93,6 +98,9 @@ function createFsChecker({
     nextDataRoutes: new Set(nextDataRoutes),
     getDynamicRoutes() {
       return dynamicRoutes
+    },
+    async getItem(pathname: string) {
+      return outputMap.get(pathname) ?? null
     },
   } as unknown as FsChecker
 }
@@ -314,5 +322,125 @@ describe('next routing server adapter', () => {
     expect(result.resolvedHeaders?.get('cache-control')).toBe(
       'public, max-age=31536000'
     )
+  })
+
+  it('maps @next/routing resolved outputs to live resolver results', async () => {
+    const matchedOutput = { type: 'pageFile' as const, itemPath: '/page' }
+    const fsChecker = createFsChecker({
+      outputs: {
+        '/page': matchedOutput,
+      },
+    })
+
+    const result = await mapNextRoutingResultToResolveRoutesResult({
+      result: {
+        resolvedPathname: '/page',
+        invocationTarget: {
+          pathname: '/page',
+          query: {
+            draft: '1',
+          },
+        },
+        resolvedHeaders: new Headers({
+          'x-route': 'matched',
+        }),
+      },
+      fsChecker,
+      initUrl: new URL('https://example.com/source?draft=1'),
+      requestUrl: '/source?draft=1',
+    })
+
+    expect(result).toMatchObject({
+      finished: true,
+      matchedOutput,
+      resHeaders: {
+        'x-route': 'matched',
+      },
+    })
+    expect(result.parsedUrl.pathname).toBe('/page')
+    expect(result.parsedUrl.query).toEqual({ draft: '1' })
+  })
+
+  it('maps @next/routing no-match results without finishing', async () => {
+    const fsChecker = createFsChecker()
+
+    const result = await mapNextRoutingResultToResolveRoutesResult({
+      result: {
+        resolvedHeaders: new Headers(),
+      },
+      fsChecker,
+      initUrl: new URL('https://example.com/missing'),
+      requestUrl: '/missing',
+    })
+
+    expect(result.finished).toBe(false)
+    expect(result.matchedOutput).toBeNull()
+    expect(result.parsedUrl.pathname).toBe('/missing')
+  })
+
+  it('maps @next/routing redirect results to live redirect results', async () => {
+    const fsChecker = createFsChecker()
+
+    const result = await mapNextRoutingResultToResolveRoutesResult({
+      result: {
+        redirect: {
+          url: new URL('https://example.com/new?from=1'),
+          status: 308,
+        },
+      },
+      fsChecker,
+      initUrl: new URL('https://example.com/old?from=1'),
+      requestUrl: '/old?from=1',
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBe(308)
+    expect(result.resHeaders).toBeNull()
+    expect(result.parsedUrl.pathname).toBe('/new')
+    expect(result.parsedUrl.search).toBe('from=1')
+  })
+
+  it('maps @next/routing status plus location headers as redirects', async () => {
+    const fsChecker = createFsChecker()
+
+    const result = await mapNextRoutingResultToResolveRoutesResult({
+      result: {
+        status: 307,
+        resolvedHeaders: new Headers({
+          location: '/temporary?from=1',
+        }),
+      },
+      fsChecker,
+      initUrl: new URL('https://example.com/old?from=1'),
+      requestUrl: '/old?from=1',
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.statusCode).toBe(307)
+    expect(result.resHeaders).toBeNull()
+    expect(result.parsedUrl.pathname).toBe('/temporary')
+    expect(result.parsedUrl.search).toBe('from=1')
+  })
+
+  it('maps @next/routing external rewrites to finished live results', async () => {
+    const fsChecker = createFsChecker()
+
+    const result = await mapNextRoutingResultToResolveRoutesResult({
+      result: {
+        externalRewrite: new URL('https://backend.example.test/api'),
+        resolvedHeaders: new Headers({
+          'x-proxy': '1',
+        }),
+      },
+      fsChecker,
+      initUrl: new URL('https://example.com/proxy'),
+      requestUrl: '/proxy',
+    })
+
+    expect(result.finished).toBe(true)
+    expect(result.resHeaders).toEqual({ 'x-proxy': '1' })
+    expect(result.parsedUrl.protocol).toBe('https:')
+    expect(result.parsedUrl.hostname).toBe('backend.example.test')
+    expect(result.parsedUrl.pathname).toBe('/api')
   })
 })


### PR DESCRIPTION
## What?

Adds a mapper from `@next/routing` resolve results back into the live `getResolveRoutes()` result shape.

## Why?

This isolates the compatibility boundary needed before any live server route phase can delegate to `@next/routing`.

## How?

- Converts resolved headers, redirects, external rewrites, resolved outputs, and no-match results into the current live resolver contract.
- Looks up matched outputs through the existing filesystem checker.
- Adds focused unit coverage for the mapped result shapes.

<!-- NEXT_JS_LLM_PR -->