### PR TITLE
[Skills] next-dev-loop: persist login state across loops

### DIFF
--- a/skills/next-dev-loop/SKILL.md
+++ b/skills/next-dev-loop/SKILL.md
@@ -62,6 +62,7 @@ Once per session, confirm both views are live.
    you can't add `--enable react-devtools` after the session is
    open, and `cookies set` on a not-yet-opened session creates a
    sessionless cookie that silently fails to apply.
+
 2. POST `tools/list` to `/_next/mcp`. Send
    `Accept: application/json, text/event-stream`; responses are
    SSE-framed, strip the `data: ` prefix before parsing JSON.

--- a/skills/next-dev-loop/SKILL.md
+++ b/skills/next-dev-loop/SKILL.md
@@ -47,13 +47,18 @@ at the versions above.
 
 Once per session, confirm both views are live.
 
-1. **Open the user's `agent-browser` session at the target URL
-   with `--headed` and react-devtools enabled, then pause.** The
-   browser is the user's, not yours; `agent-browser open` is
-   headless by default, so `--headed` is required. If the page is
-   behind login, gated by a feature flag, or needs specific state,
-   the user drives that — log in, set state, navigate. Continue
-   only after they confirm. Session state is sticky per session:
+1. **Open `agent-browser` at the target URL, restoring saved
+   login state when present.** Build the `open` command from:
+   - `--session-name <slug>` where `<slug>` is the project
+     directory basename.
+   - `--state ~/.agent-browser/sessions/<slug>-default.json` if
+     that file exists. Omit on first run — a missing path fails
+     the open.
+   - `--headed --enable react-devtools`.
+
+   The browser is the user's. If state was not restored (first
+   run, expired session) and the page is gated, the user drives
+   the login — pause until they confirm. Session state is sticky:
    you can't add `--enable react-devtools` after the session is
    open, and `cookies set` on a not-yet-opened session creates a
    sessionless cookie that silently fails to apply.
@@ -127,8 +132,9 @@ get_compilation_issues       Turbopack only; errors on webpack
 
 ## teardown
 
-Close the `agent-browser` session. Leave `next dev` up for the next
-loop.
+Close the `agent-browser` session — `--session-name` writes state
+to disk so the next loop's `--state` restores login. Leave
+`next dev` up for the next loop.
 
 ---
 


### PR DESCRIPTION
## Summary

The `next-dev-loop` skill currently asks the user to log in at the start of every preflight when the target page is gated. With `agent-browser` 0.27.0's `--state <path>` flag and `--session-name <slug>` auto-save, the saved login can carry from one loop to the next.

This patch updates `skills/next-dev-loop/SKILL.md`:

- **Preflight** — open with `--session-name <slug>` (auto-save on close) and `--state ~/.agent-browser/sessions/<slug>-default.json` when that file already exists (omit on first run; a missing path fails the open).
- **Teardown** — note that `--session-name` writes the state on close, so the next loop's `--state` restores login.

No code changes; doc only.

## Test plan

Verified end-to-end with a headless `claude -p` invocation in a real logged-in Next.js project:

- The fresh agent reads the updated skill, opens `agent-browser` with `--session-name <slug> --state <path>`, and finds itself behind the login — no user input needed.
- After close, the state file's `mtime` advances (auto-save fired).
- Daemon `env` at PID confirms `AGENT_BROWSER_SESSION_NAME` and `AGENT_BROWSER_STATE` are set correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)