### PR TITLE
fix(dev): restore no-store for dev HTML responses to prevent bfcache hydration failures

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1526,7 +1526,7 @@ export async function handler(
 
       // In dev, we should not cache pages for any reason.
       if (routeModule.isDev) {
-        res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        res.setHeader('Cache-Control', 'no-store, must-revalidate')
       }
 
       if (!cacheEntry) {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1810,8 +1810,11 @@ export default abstract class Server<
       const { generateEtags, poweredByHeader } = this.renderOpts
 
       // In dev, we should not cache pages for any reason.
+      // no-store (not no-cache) is required to prevent Chrome from serving stale HTML
+      // on back/forward navigation via bfcache/disk cache, which causes hydration failures
+      // with stale __next_f.push() chunks (see https://github.com/vercel/next.js/issues/94036).
       if (this.dev) {
-        res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        res.setHeader('Cache-Control', 'no-store, must-revalidate')
         cacheControl = undefined
       }
 

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -720,7 +720,7 @@ export const getHandler = ({
 
         // In dev, we should not cache pages for any reason.
         if (routeModule.isDev) {
-          res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+          res.setHeader('Cache-Control', 'no-store, must-revalidate')
         }
 
         // Draft mode should never be cached

--- a/test/development/dev-cache-control-no-cache/dev-cache-control-no-cache.test.ts
+++ b/test/development/dev-cache-control-no-cache/dev-cache-control-no-cache.test.ts
@@ -5,13 +5,13 @@ describe('dev Cache-Control header', () => {
     files: __dirname,
   })
 
-  it('should use no-cache for pages router', async () => {
+  it('should use no-store for pages router', async () => {
     const res = await next.fetch('/pages-route')
-    expect(res.headers.get('Cache-Control')).toBe('no-cache, must-revalidate')
+    expect(res.headers.get('Cache-Control')).toBe('no-store, must-revalidate')
   })
 
-  it('should use no-cache for app router', async () => {
+  it('should use no-store for app router', async () => {
     const res = await next.fetch('/app-route')
-    expect(res.headers.get('Cache-Control')).toBe('no-cache, must-revalidate')
+    expect(res.headers.get('Cache-Control')).toBe('no-store, must-revalidate')
   })
 })

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -387,7 +387,7 @@ describe('Client Navigation rendering', () => {
       responses.forEach((res) => {
         try {
           expect(res.headers.get('Cache-Control')).toBe(
-            'no-cache, must-revalidate'
+            'no-store, must-revalidate'
           )
         } catch (err) {
           err.message = res.url + ' ' + err.message

--- a/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+++ b/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
@@ -15,14 +15,14 @@ describe('custom-cache-control', () => {
   it('should have custom cache-control for app-ssg prerendered', async () => {
     const res = await next.fetch('/app-ssg/first')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-cache, must-revalidate' : 's-maxage=30'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=30'
     )
   })
 
   it('should have custom cache-control for app-ssg lazy', async () => {
     const res = await next.fetch('/app-ssg/lazy')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-cache, must-revalidate' : 's-maxage=31'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=31'
     )
   })
   ;(process.env.__NEXT_CACHE_COMPONENTS ? it.skip : it)(
@@ -32,7 +32,7 @@ describe('custom-cache-control', () => {
       // eslint-disable-next-line jest/no-standalone-expect
       expect(res.headers.get('cache-control')).toBe(
         isNextDev
-          ? 'no-cache, must-revalidate'
+          ? 'no-store, must-revalidate'
           : 's-maxage=120, stale-while-revalidate=31535880'
       )
     }
@@ -41,28 +41,28 @@ describe('custom-cache-control', () => {
   it('should have custom cache-control for app-ssr', async () => {
     const res = await next.fetch('/app-ssr')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-cache, must-revalidate' : 's-maxage=32'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=32'
     )
   })
 
   it('should have custom cache-control for auto static page', async () => {
     const res = await next.fetch('/pages-auto-static')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-cache, must-revalidate' : 's-maxage=33'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=33'
     )
   })
 
   it('should have custom cache-control for pages-ssg prerendered', async () => {
     const res = await next.fetch('/pages-ssg/first')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-cache, must-revalidate' : 's-maxage=34'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=34'
     )
   })
 
   it('should have custom cache-control for pages-ssg lazy', async () => {
     const res = await next.fetch('/pages-ssg/lazy')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-cache, must-revalidate' : 's-maxage=35'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=35'
     )
   })
 
@@ -70,7 +70,7 @@ describe('custom-cache-control', () => {
     const res = await next.fetch('/pages-ssg/another')
     expect(res.headers.get('cache-control')).toBe(
       isNextDev
-        ? 'no-cache, must-revalidate'
+        ? 'no-store, must-revalidate'
         : 's-maxage=120, stale-while-revalidate=31535880'
     )
   })
@@ -78,7 +78,7 @@ describe('custom-cache-control', () => {
   it('should have default cache-control for pages-ssr', async () => {
     const res = await next.fetch('/pages-ssr')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-cache, must-revalidate' : 's-maxage=36'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=36'
     )
   })
 })

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -691,7 +691,7 @@ describe('app dir - metadata', () => {
       expect(res.headers.get('content-type')).toBe('image/x-icon')
       expect(res.headers.get('cache-control')).toBe(
         isNextDev
-          ? 'no-cache, must-revalidate'
+          ? 'no-store, must-revalidate'
           : 'public, max-age=0, must-revalidate'
       )
     })
@@ -706,14 +706,14 @@ describe('app dir - metadata', () => {
       expect(resAppleIcon.headers.get('content-type')).toBe('image/png')
       expect(resAppleIcon.headers.get('cache-control')).toBe(
         isNextDev
-          ? 'no-cache, must-revalidate'
+          ? 'no-store, must-revalidate'
           : 'public, max-age=0, must-revalidate'
       )
       expect(resIcon.status).toBe(200)
       expect(resIcon.headers.get('content-type')).toBe('image/png')
       expect(resIcon.headers.get('cache-control')).toBe(
         isNextDev
-          ? 'no-cache, must-revalidate'
+          ? 'no-store, must-revalidate'
           : 'public, max-age=0, must-revalidate'
       )
     })

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -192,7 +192,7 @@ describe.skip('ppr-full', () => {
           if (isNextDeploy) {
             expect(cacheControl).toEqual('public, max-age=0, must-revalidate')
           } else if (isNextDev) {
-            expect(cacheControl).toEqual('no-cache, must-revalidate')
+            expect(cacheControl).toEqual('no-store, must-revalidate')
           } else if (dynamic === false || dynamic === 'force-static') {
             expect(cacheControl).toEqual(
               revalidate === undefined

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -2059,8 +2059,8 @@
   },
   "test/development/dev-cache-control-no-cache/dev-cache-control-no-cache.test.ts": {
     "passed": [
-      "dev Cache-Control header should use no-cache for app router",
-      "dev Cache-Control header should use no-cache for pages router"
+      "dev Cache-Control header should use no-store for app router",
+      "dev Cache-Control header should use no-store for pages router"
     ],
     "failed": [],
     "pending": [],


### PR DESCRIPTION
## What?

Restores `no-store, must-revalidate` as the dev server `Cache-Control` header value for HTML document responses, reverting the behavioral change introduced in #91503 (which hard-coded `no-cache, must-revalidate`).

Fixes #94036

## Why?

Chrome's bfcache (back/forward cache) and disk cache can serve `no-cache` responses **without revalidating** on back/forward navigation. This is a known browser behavior: back/forward navigations are treated differently from regular fetches, and `no-cache` does not reliably force revalidation in that path.

In practice this means:
1. User visits a Next.js dev page → server sends HTML with `no-cache, must-revalidate`  
2. Chrome stores the response in its disk/bfcache
3. HMR updates JS chunks on the dev server
4. User clicks Back/Forward → Chrome restores the **old** HTML from bfcache without revalidating
5. The stale HTML's `__next_f.push()` chunks reference build IDs/URLs from a previous build
6. Turbopack hydration silently fails — the page looks rendered but is un-hydrated

## How?

Change `'no-cache, must-revalidate'` → `'no-store, must-revalidate'` in the three dev HTML render paths:
- `packages/next/src/server/base-server.ts` (main render path)
- `packages/next/src/build/templates/app-page.ts` (app router)
- `packages/next/src/server/route-modules/pages/pages-handler.ts` (pages router)

`no-store` prevents the browser from storing the HTML in any cache (including bfcache), so back/forward navigation always results in a fresh request to the dev server. This eliminates the stale-chunk hydration failure.

Note: The static asset path (`/_next/static/`) is unaffected — it correctly uses `public, max-age=31536000, immutable` in prod and `no-cache, must-revalidate` in dev, since JS chunks are fingerprinted by content hash and stale-chunk issues don't apply there.

Update all tests that previously expected `no-cache, must-revalidate` in dev mode.