### PR TITLE
Fix create-next-app to use pnpm allowBuilds syntax

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -340,13 +340,13 @@ export const installTemplate = async ({
     const pnpmMajorVersion = getPnpmMajorVersion();
     if (pnpmMajorVersion === null || pnpmMajorVersion >= 10) {
       const pnpmWorkspaceYaml = [
-        "ignoredBuiltDependencies:",
+        "allowBuilds:",
         // Sharp has prebuilt binaries for the platforms next-swc has binaries.
         // If it needs to build binaries from source, next-swc wouldn't work either.
         // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
-        "  - sharp",
+        "  sharp: true",
         // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
-        "  - unrs-resolver",
+        "  unrs-resolver: true",
         "",
       ].join(os.EOL);
       await fs.writeFile(


### PR DESCRIPTION
Fixes `ERR_PNPM_IGNORED_BUILDS` error that aborts `pnpm create next-app` with pnpm v11 by updating the `pnpm-workspace.yaml` template to use `allowBuilds`.