### PR TITLE
next-routing: remove unanchored has.value fallback

### DIFF
--- a/packages/next-routing/src/__tests__/conditions.test.ts
+++ b/packages/next-routing/src/__tests__/conditions.test.ts
@@ -69,6 +69,43 @@ describe('Has conditions', () => {
     expect(result.resolvedPathname).toBe('/admin-dashboard')
   })
 
+  it('should NOT match substring values in has conditions', async () => {
+    const headers = new Headers({
+      'x-role': 'not-admin',
+    })
+
+    const params = createBaseParams({
+      url: new URL('https://example.com/dashboard'),
+      headers,
+      routes: {
+        beforeMiddleware: [],
+        beforeFiles: [
+          {
+            sourceRegex: '^/dashboard$',
+            destination: '/admin',
+            has: [
+              {
+                type: 'header',
+                key: 'x-role',
+                value: 'admin',
+              },
+            ],
+          },
+        ],
+        afterFiles: [],
+        dynamicRoutes: [],
+        onMatch: [],
+        fallback: [],
+      },
+      pathnames: ['/dashboard', '/admin'],
+    })
+
+    const result = await resolveRoutes(params)
+
+    expect(result.resolvedPathname).toBe('/dashboard')
+    expect(result.invocationTarget?.pathname).toBe('/dashboard')
+  })
+
   it('should match route with cookie condition', async () => {
     const headers = new Headers({
       cookie: 'session=abc123; theme=dark',

--- a/packages/next-routing/src/matchers.ts
+++ b/packages/next-routing/src/matchers.ts
@@ -25,9 +25,7 @@ function matchesCondition(
   // Try to match as regex first
   try {
     const exactRegex = new RegExp(`^(?:${conditionValue})$`)
-    const fallbackRegex = new RegExp(conditionValue)
-    const match =
-      actualValue.match(exactRegex) ?? actualValue.match(fallbackRegex)
+    const match = actualValue.match(exactRegex)
     if (match) {
       const namedCaptures: Record<string, string> = {}
       if (match.groups) {


### PR DESCRIPTION
## Summary

This keeps `@next/routing` aligned with existing Next.js `has.value` matching semantics.

`packages/next-routing/src/matchers.ts` currently tries an anchored regex first and then falls back to an unanchored regex. That allows a rule like `value: 'admin'` to match `not-admin`, which is broader than the existing resolver.

This change removes the unanchored fallback and adds a regression test covering the `not-admin` case.

Related: #94109 was auto-closed by the issue template bot because it did not include a reproduction repository link.

## Testing

- runtime verification of exact match vs substring non-match in `packages/next-routing`
- runtime verification that named capture regexes still resolve correctly
- added a regression test in `packages/next-routing/src/__tests__/conditions.test.ts`

## Why

The goal here is compatibility. `@next/routing` is reimplementing subtle resolver behavior, so matcher semantics should stay as close as possible to the existing Next.js resolver.
