### PR TITLE
Turbopack: Fix unsound IntoIterator for ReadRef<T>

### DIFF
--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -376,7 +376,7 @@ pub async fn analyze_output_assets(output_assets: Vc<OutputAssets>) -> Result<Vc
 
     // Process the output assets and extract chunk parts.
     // Also creates sources for the chunk parts.
-    for &asset in output_assets.await? {
+    for asset in output_assets.await? {
         let filename = asset.path().to_string().owned().await?;
         if filename.ends_with(".map") || filename.ends_with(".nft.json") {
             // Skip source maps.
@@ -385,7 +385,7 @@ pub async fn analyze_output_assets(output_assets: Vc<OutputAssets>) -> Result<Vc
 
         let output_file_index = builder.add_output_file(AnalyzeOutputFile { filename });
         let chunk_parts = split_output_asset_into_parts(*asset).await?;
-        for chunk_part in chunk_parts {
+        for chunk_part in &chunk_parts {
             let decoded_source = urlencoding::decode(&chunk_part.source)?;
             let source = if let Some(stripped) = decoded_source.strip_prefix(&prefix) {
                 Cow::Borrowed(stripped)
@@ -439,7 +439,7 @@ pub async fn analyze_module_graphs(module_graphs: Vc<ModuleGraphs>) -> Result<Vc
     let mut all_modules = FxIndexSet::default();
     let mut all_edges = FxIndexSet::default();
     let mut all_async_edges = FxIndexSet::default();
-    for &module_graph in module_graphs.await? {
+    for module_graph in module_graphs.await? {
         let module_graph = module_graph.await?;
         module_graph.traverse_edges_unordered(|parent, node| {
             if let Some((parent_node, reference)) = parent {

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1471,7 +1471,7 @@ impl AppEndpoint {
             )
             .to_resolved()
             .await?;
-        server_assets.extend(app_entry_chunks.all_assets().await?.into_iter());
+        server_assets.extend(app_entry_chunks.all_assets().await?);
         let app_entry_chunk_group_ref = app_entry_chunks.await?;
         let app_entry_chunks = app_entry_chunk_group_ref.assets;
         let app_entry_chunks_ref = app_entry_chunks.await?;

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -902,7 +902,7 @@ impl AppProject {
                     let client_shared_entries = client_shared_entries
                         .await?
                         .into_iter()
-                        .map(|m| ResolvedVc::upcast(*m))
+                        .map(ResolvedVc::upcast)
                         .collect();
 
                     // SEGMENT: client_shared_entries and server utils shared by the layout segments
@@ -1471,7 +1471,7 @@ impl AppEndpoint {
             )
             .to_resolved()
             .await?;
-        server_assets.extend(app_entry_chunks.all_assets().await?.into_iter().copied());
+        server_assets.extend(app_entry_chunks.all_assets().await?.into_iter());
         let app_entry_chunk_group_ref = app_entry_chunks.await?;
         let app_entry_chunks = app_entry_chunk_group_ref.assets;
         let app_entry_chunks_ref = app_entry_chunks.await?;
@@ -1553,20 +1553,26 @@ impl AppEndpoint {
 
                 let node_root_value = node_root.clone();
 
-                file_paths_from_root
-                    .extend(get_js_paths_from_root(&node_root_value, &middleware_assets).await?);
-                file_paths_from_root
-                    .extend(get_js_paths_from_root(&node_root_value, &app_entry_chunks_ref).await?);
+                file_paths_from_root.extend(
+                    get_js_paths_from_root(&node_root_value, middleware_assets.iter().copied())
+                        .await?,
+                );
+                file_paths_from_root.extend(
+                    get_js_paths_from_root(&node_root_value, app_entry_chunks_ref.iter().copied())
+                        .await?,
+                );
 
                 let all_output_assets = all_assets_from_entries(*app_entry_chunks).await?;
 
                 wasm_paths_from_root
-                    .extend(get_wasm_paths_from_root(&node_root_value, &middleware_assets).await?);
-                wasm_paths_from_root
-                    .extend(get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?);
+                    .extend(get_wasm_paths_from_root(&node_root_value, middleware_assets).await?);
+                wasm_paths_from_root.extend(
+                    get_wasm_paths_from_root(&node_root_value, all_output_assets.iter().copied())
+                        .await?,
+                );
 
                 let all_assets =
-                    get_asset_paths_from_root(&node_root_value, &all_output_assets).await?;
+                    get_asset_paths_from_root(&node_root_value, all_output_assets).await?;
 
                 let entry_file = rcstr!("app-edge-has-no-entrypoint");
 
@@ -1595,7 +1601,7 @@ impl AppEndpoint {
 
                     server_assets.extend(loadable_manifest_output.iter().copied());
                     file_paths_from_root.extend(
-                        get_js_paths_from_root(&node_root_value, &loadable_manifest_output).await?,
+                        get_js_paths_from_root(&node_root_value, loadable_manifest_output).await?,
                     );
                 }
                 if emit_manifests != EmitManifests::None {

--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -59,7 +59,7 @@ impl Asset for FontManifest {
         // `_next` gets added again later, so we "strip" it here via
         // `get_font_paths_from_root`.
         let font_paths: Vec<String> =
-            get_font_paths_from_root(client_root, &all_client_output_assets)
+            get_font_paths_from_root(client_root, all_client_output_assets)
                 .await?
                 .iter()
                 .filter_map(|p| p.split("_next/").last().map(|f| f.to_string()))

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -148,7 +148,7 @@ impl InstrumentationEndpoint {
             let node_root_value = node_root.clone();
 
             let file_paths_from_root =
-                get_js_paths_from_root(&node_root_value, &edge_chunk_group.await?.assets.await?)
+                get_js_paths_from_root(&node_root_value, edge_chunk_group.await?.assets.await?)
                     .await?;
 
             let mut output_assets = edge_chunk_group.all_assets().owned().await?;

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -263,7 +263,7 @@ impl MiddlewareEndpoint {
             let edge_assets = edge_chunk_group_ref.assets.await?;
 
             let file_paths_from_root =
-                get_js_paths_from_root(&node_root_value, &edge_assets).await?;
+                get_js_paths_from_root(&node_root_value, edge_assets.iter().copied()).await?;
             let entrypoint_asset = *edge_assets
                 .last()
                 .context("expected assets for edge middleware endpoint")?;
@@ -278,7 +278,7 @@ impl MiddlewareEndpoint {
                 get_wasm_paths_from_root(&node_root_value, edge_all_assets.await?).await?;
 
             let all_assets =
-                get_asset_paths_from_root(&node_root_value, &edge_all_assets.await?).await?;
+                get_asset_paths_from_root(&node_root_value, edge_all_assets.await?).await?;
 
             let regions = if let Some(regions) = config.preferred_region.as_ref() {
                 if regions.len() == 1 {

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -107,7 +107,6 @@ impl NextDynamicGraphs {
                             .get_next_dynamic_imports_for_endpoint(entry)
                             .await?
                             .into_iter()
-                            .map(|(k, v)| (*k, *v))
                             // TODO remove this collect and return an iterator instead
                             .collect::<Vec<_>>())
                     })

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -215,7 +215,7 @@ impl ServerNftJsonAsset {
         // These are used by packages/next/src/server/require-hook.ts
         let shared_entries = ["styled-jsx", "styled-jsx/style", "styled-jsx/style.js"];
 
-        let cache_handler_entries = cache_handler.into_iter().chain(cache_handlers).map(|f| {
+        let cache_handler_entries = cache_handler.iter().chain(cache_handlers.iter()).map(|f| {
             asset_context
                 .process(
                     Vc::upcast(FileSource::new(f.clone())),

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1430,8 +1430,9 @@ impl PageEndpoint {
                     let pages_structure = this.pages_structure.await?;
                     if pages_structure.should_create_pages_entries {
                         server_assets.extend(assets_ref.iter().copied());
-                        file_paths_from_root
-                            .extend(get_js_paths_from_root(&node_root, &assets_ref).await?);
+                        file_paths_from_root.extend(
+                            get_js_paths_from_root(&node_root, assets_ref.iter().copied()).await?,
+                        );
                     }
 
                     if emit_manifests == EmitManifests::Full {
@@ -1445,28 +1446,30 @@ impl PageEndpoint {
                         if pages_structure.should_create_pages_entries {
                             server_assets.extend(loadable_manifest_output.iter().copied());
                             file_paths_from_root.extend(
-                                get_js_paths_from_root(&node_root, &loadable_manifest_output)
+                                get_js_paths_from_root(&node_root, loadable_manifest_output)
                                     .await?,
                             );
                         }
                     }
 
-                    let (wasm_paths_from_root, all_assets) =
-                        if pages_structure.should_create_pages_entries {
-                            let all_output_assets = all_assets_from_entries(all_assets).await?;
+                    let (wasm_paths_from_root, all_assets) = if pages_structure
+                        .should_create_pages_entries
+                    {
+                        let all_output_assets = all_assets_from_entries(all_assets).await?;
 
-                            let mut wasm_paths_from_root = fxindexset![];
-                            wasm_paths_from_root.extend(
-                                get_wasm_paths_from_root(&node_root, &all_output_assets).await?,
-                            );
+                        let mut wasm_paths_from_root = fxindexset![];
+                        wasm_paths_from_root.extend(
+                            get_wasm_paths_from_root(&node_root, all_output_assets.iter().copied())
+                                .await?,
+                        );
 
-                            let all_assets =
-                                get_asset_paths_from_root(&node_root, &all_output_assets).await?;
+                        let all_assets =
+                            get_asset_paths_from_root(&node_root, all_output_assets).await?;
 
-                            (wasm_paths_from_root, all_assets)
-                        } else {
-                            (fxindexset![], vec![])
-                        };
+                        (wasm_paths_from_root, all_assets)
+                    } else {
+                        (fxindexset![], vec![])
+                    };
 
                     let named_regex = get_named_middleware_regex(&this.pathname).into();
                     let matchers = ProxyMatcher {

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -96,7 +96,7 @@ pub async fn all_paths_in_root(
     assets: Vc<OutputAssets>,
     root: FileSystemPath,
 ) -> Result<Vc<Vec<RcStr>>> {
-    let all_assets = &*all_assets_from_entries(assets).await?;
+    let all_assets = all_assets_from_entries(assets).await?;
 
     Ok(Vc::cell(
         get_paths_from_root(&root, all_assets, |_| true).await?,
@@ -105,12 +105,12 @@ pub async fn all_paths_in_root(
 
 pub(crate) async fn get_paths_from_root(
     root: &FileSystemPath,
-    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
+    output_assets: impl IntoIterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
     filter: impl FnOnce(&str) -> bool + Copy,
 ) -> Result<Vec<RcStr>> {
     output_assets
         .into_iter()
-        .map(move |&file| async move {
+        .map(move |file| async move {
             let path = &*file.path().await?;
             let Some(relative) = root.get_path_to(path) else {
                 return Ok(None);
@@ -128,18 +128,18 @@ pub(crate) async fn get_paths_from_root(
 
 pub(crate) async fn get_js_paths_from_root(
     root: &FileSystemPath,
-    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
+    output_assets: impl IntoIterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<RcStr>> {
     get_paths_from_root(root, output_assets, |path| path.ends_with(".js")).await
 }
 
 pub(crate) async fn get_wasm_paths_from_root(
     root: &FileSystemPath,
-    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
+    output_assets: impl IntoIterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<(RcStr, ResolvedVc<Box<dyn OutputAsset>>)>> {
     output_assets
         .into_iter()
-        .map(move |&file| async move {
+        .map(move |file| async move {
             let path = &*file.path().await?;
             let Some(relative) = root.get_path_to(path) else {
                 return Ok(None);
@@ -157,7 +157,7 @@ pub(crate) async fn get_wasm_paths_from_root(
 
 pub(crate) async fn get_asset_paths_from_root(
     root: &FileSystemPath,
-    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
+    output_assets: impl IntoIterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<RcStr>> {
     get_paths_from_root(root, output_assets, |path| {
         !path.ends_with(".js") && !path.ends_with(".map") && !path.ends_with(".wasm")
@@ -167,7 +167,7 @@ pub(crate) async fn get_asset_paths_from_root(
 
 pub(crate) async fn get_font_paths_from_root(
     root: &FileSystemPath,
-    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
+    output_assets: impl IntoIterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<RcStr>> {
     get_paths_from_root(root, output_assets, |path| {
         path.ends_with(".woff")

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -2696,10 +2696,7 @@ async fn any_output_changed(
     server: bool,
 ) -> Result<Vc<Completion>> {
     let all_assets = expand_output_assets(
-        roots
-            .await?
-            .into_iter()
-            .map(|&a| ExpandOutputAssetsInput::Asset(a)),
+        roots.await?.into_iter().map(ExpandOutputAssetsInput::Asset),
         true,
     )
     .await?;

--- a/crates/next-api/src/project_asset_hashes_manifest.rs
+++ b/crates/next-api/src/project_asset_hashes_manifest.rs
@@ -68,11 +68,7 @@ pub async fn endpoints_outputs(endpoints: Vc<Endpoints>) -> Result<Vc<OutputAsse
         .map(async |endpoint| endpoint.output().await?.output_assets.await)
         .try_join()
         .await?;
-    let set = all_outputs
-        .into_iter()
-        .flatten()
-        .copied()
-        .collect::<FxIndexSet<_>>();
+    let set = all_outputs.into_iter().flatten().collect::<FxIndexSet<_>>();
     Ok(Vc::cell(set.into_iter().collect()))
 }
 
@@ -105,7 +101,7 @@ pub async fn expand_outputs(
             .await?
             .into_iter()
             .flatten()
-            .map(|asset| ExpandOutputAssetsInput::Asset(*asset)),
+            .map(ExpandOutputAssetsInput::Asset),
         true,
     )
     .await?;
@@ -138,7 +134,7 @@ impl Asset for AssetHashesManifestAsset {
         let output_assets = expand_outputs(*self.project, self.asset_root.clone()).await?;
 
         let asset_paths = output_assets
-            .into_iter()
+            .iter()
             .map(async |(asset, path)| {
                 Ok((
                     path,

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -176,7 +176,6 @@ async fn module_graphs_of_endpoints(
         .try_flat_join()
         .await?
         .into_iter()
-        .copied()
         .collect::<FxIndexSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();

--- a/crates/next-api/src/routes_hashes_manifest.rs
+++ b/crates/next-api/src/routes_hashes_manifest.rs
@@ -131,7 +131,7 @@ pub async fn sources_hash(module_graph: Vc<ModuleGraph>, modules: Vc<Modules>) -
     let module_graph = module_graph.await?;
 
     module_graph.traverse_nodes_dfs(
-        modules.into_iter(),
+        modules,
         &mut all_modules,
         |module, all_modules| {
             all_modules.insert(*module);

--- a/crates/next-api/src/routes_hashes_manifest.rs
+++ b/crates/next-api/src/routes_hashes_manifest.rs
@@ -154,8 +154,8 @@ pub async fn sources_hash(module_graph: Vc<ModuleGraph>, modules: Vc<Modules>) -
 }
 
 #[derive(Serialize)]
-struct RoutesHashesManifest {
-    pub routes: FxIndexMap<String, EndpointHashStrings>,
+struct RoutesHashesManifest<'l> {
+    pub routes: FxIndexMap<&'l str, EndpointHashStrings>,
 }
 
 #[derive(Serialize)]
@@ -210,7 +210,7 @@ impl Asset for RoutesHashesManifestAsset {
                     outputs_hash(endpoints_outputs(endpoints)),
                 )
             };
-            entrypoint_hashes.insert(key.as_str().to_string(), entry);
+            entrypoint_hashes.insert(key.as_str(), entry);
         }
 
         let entrypoint_hashes_values = entrypoint_hashes

--- a/crates/next-api/src/routes_hashes_manifest.rs
+++ b/crates/next-api/src/routes_hashes_manifest.rs
@@ -57,11 +57,7 @@ pub async fn endpoints_outputs(endpoints: Vc<Endpoints>) -> Result<Vc<OutputAsse
         .map(async |endpoint| Ok(endpoint.output().await?.output_assets.await?))
         .try_join()
         .await?;
-    let set = all_outputs
-        .into_iter()
-        .flatten()
-        .copied()
-        .collect::<FxIndexSet<_>>();
+    let set = all_outputs.into_iter().flatten().collect::<FxIndexSet<_>>();
     Ok(Vc::cell(set.into_iter().collect()))
 }
 
@@ -71,7 +67,7 @@ pub async fn outputs_hash(outputs: Vc<OutputAssets>) -> Result<Vc<u64>> {
         outputs
             .await?
             .into_iter()
-            .map(|asset| ExpandOutputAssetsInput::Asset(*asset)),
+            .map(ExpandOutputAssetsInput::Asset),
         true,
     )
     .await?;
@@ -89,12 +85,11 @@ pub async fn endpoint_entry_modules(
     base_module_graph: Vc<ModuleGraph>,
     endpoint: Vc<Box<dyn Endpoint>>,
 ) -> Result<Vc<Modules>> {
-    let entries = endpoint.entries();
-    let additional_entries = endpoint.additional_entries(base_module_graph);
+    let entries = endpoint.entries().await?;
+    let additional_entries = endpoint.additional_entries(base_module_graph).await?;
     let modules = entries
-        .await?
-        .into_iter()
-        .chain(additional_entries.await?)
+        .iter()
+        .chain(additional_entries.iter())
         .flat_map(|e| e.entries())
         .collect::<FxIndexSet<_>>();
     Ok(Vc::cell(modules.into_iter().collect()))
@@ -116,11 +111,11 @@ pub async fn endpoints_entry_modules(
         .try_join()
         .await?;
     let modules = entries_and_additional_entries
-        .into_iter()
+        .iter()
         .flat_map(|(entries, additional_entries)| {
             entries
-                .into_iter()
-                .chain(additional_entries)
+                .iter()
+                .chain(additional_entries.iter())
                 .flat_map(|e| e.entries())
         })
         .collect::<FxIndexSet<_>>();
@@ -136,7 +131,7 @@ pub async fn sources_hash(module_graph: Vc<ModuleGraph>, modules: Vc<Modules>) -
     let module_graph = module_graph.await?;
 
     module_graph.traverse_nodes_dfs(
-        modules.into_iter().copied(),
+        modules.into_iter(),
         &mut all_modules,
         |module, all_modules| {
             all_modules.insert(*module);
@@ -159,8 +154,8 @@ pub async fn sources_hash(module_graph: Vc<ModuleGraph>, modules: Vc<Modules>) -
 }
 
 #[derive(Serialize)]
-struct RoutesHashesManifest<'l> {
-    pub routes: FxIndexMap<&'l str, EndpointHashStrings>,
+struct RoutesHashesManifest {
+    pub routes: FxIndexMap<String, EndpointHashStrings>,
 }
 
 #[derive(Serialize)]
@@ -196,7 +191,7 @@ impl Asset for RoutesHashesManifestAsset {
 
         let entrypoint_groups = self.project.get_all_endpoint_groups(false).await?;
 
-        for (key, EndpointGroup { primary, .. }) in entrypoint_groups {
+        for (key, EndpointGroup { primary, .. }) in &entrypoint_groups {
             let entry = if let &[entry] = &primary.as_slice() {
                 (
                     sources_hash(
@@ -215,7 +210,7 @@ impl Asset for RoutesHashesManifestAsset {
                     outputs_hash(endpoints_outputs(endpoints)),
                 )
             };
-            entrypoint_hashes.insert(key.as_str(), entry);
+            entrypoint_hashes.insert(key.as_str().to_string(), entry);
         }
 
         let entrypoint_hashes_values = entrypoint_hashes

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -305,14 +305,16 @@ async fn hmr(
         .await?;
 
     let start = Instant::now();
-    for ident in idents {
+    for ident in &idents {
         if !ident.ends_with(".js") {
             continue;
         }
         let session = session.clone();
         let start = Instant::now();
+        let ident_for_task = ident.clone();
         let task = tt.spawn_root_task(move || {
             let session = session.clone();
+            let ident = ident_for_task.clone();
             async move {
                 let project = project.project();
                 let state = project.hmr_version_state(ident.clone(), HmrTarget::Client, session);

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -53,7 +53,6 @@ impl OutputAssetsReference for BuildManifest {
         let references = chunks
             .into_iter()
             .flatten()
-            .copied()
             .chain(root_main_files)
             .chain(self.polyfill_files.iter().copied())
             .collect();

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::{self, Debug, Display},
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::transmute_copy,
     ops::Deref,
 };
 
@@ -141,6 +140,7 @@ where
     }
 }
 
+/// Iterate by reference over a [`ReadRef`].
 impl<'a, T, I, J: Iterator<Item = I>> IntoIterator for &'a ReadRef<T>
 where
     T: VcValueType,
@@ -155,44 +155,63 @@ where
     }
 }
 
-impl<T, I: 'static, J: Iterator<Item = I>> IntoIterator for ReadRef<T>
+impl<T, I, J> IntoIterator for ReadRef<T>
 where
     T: VcValueType,
-    &'static VcReadTarget<T>: IntoIterator<Item = I, IntoIter = J>,
+    I: Copy + 'static,
+    J: Iterator<Item = &'static I> + 'static,
+    &'static VcReadTarget<T>: IntoIterator<Item = &'static I, IntoIter = J>,
 {
     type Item = I;
-
     type IntoIter = ReadRefIter<T, I, J>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let r = &*self;
-        // # Safety
-        // The reference will we valid as long as the ReadRef is valid.
-        let r = unsafe { transmute_copy::<&'_ VcReadTarget<T>, &'static VcReadTarget<T>>(&r) };
+        let r: &VcReadTarget<T> = &self;
+        // SAFETY: The `&'static` reference fabricated here is only stored in
+        // `iter`, which lives inside the returned `ReadRefIter` alongside the
+        // `ReadRef` that owns the data. The public `Iterator::next` only
+        // returns `Copy`-ed-out values — no reference (with the fake `'static`
+        // lifetime or otherwise) ever leaves the iterator. Struct-field drop
+        // order (`iter` then `_read_ref`) drops any references still held by
+        // `iter` before the backing storage.
+        let r = unsafe { std::mem::transmute::<&VcReadTarget<T>, &'static VcReadTarget<T>>(r) };
         ReadRefIter {
-            read_ref: self,
             iter: r.into_iter(),
+            _read_ref: self,
         }
     }
 }
 
-pub struct ReadRefIter<T, I: 'static, J: Iterator<Item = I>>
+/// Consuming iteration over a [`ReadRef`], yielding items by **copy**.
+///
+/// `Iterator::Item` is a fixed associated type — it cannot borrow from
+/// `&mut self`.
+///
+/// The iterator owns the original [`ReadRef`], borrows into the underlying value, and
+/// `Iterator::next` simply copies each element out of that borrow. This restricts the impl to
+/// element types that are [`Copy`] — typically `ResolvedVc<_>`, integer ids, etc. For
+/// non-`Copy` element types (or if you want zero-copy iteration over
+/// borrows), iterate by reference instead: `for item in &read_ref { ... }`.
+pub struct ReadRefIter<T, I, J>
 where
     T: VcValueType,
+    I: Copy + 'static,
+    J: Iterator<Item = &'static I>,
 {
     iter: J,
-    #[allow(dead_code)]
-    read_ref: ReadRef<T>,
+    _read_ref: ReadRef<T>,
 }
 
-impl<T, I: 'static, J: Iterator<Item = I>> Iterator for ReadRefIter<T, I, J>
+impl<T, I, J> Iterator for ReadRefIter<T, I, J>
 where
     T: VcValueType,
+    I: Copy + 'static,
+    J: Iterator<Item = &'static I>,
 {
     type Item = I;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+    fn next(&mut self) -> Option<I> {
+        self.iter.next().copied()
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -119,9 +119,9 @@ impl EcmascriptBrowserChunkContent {
 
         let content = this.content.await?;
         let chunk_items = content.chunk_item_code_and_ids().await?;
-        for item in chunk_items {
-            for (id, item_code) in item {
-                write!(code, "\n{}, ", StringifyJs(&id))?;
+        for item in &chunk_items {
+            for (id, item_code) in &**item {
+                write!(code, "\n{}, ", StringifyJs(id))?;
                 code.push_code(item_code);
                 write!(code, ",")?;
             }

--- a/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
@@ -107,7 +107,7 @@ impl AvailableModules {
             match idents {
                 IdentStrings::Single(ident) => hasher.write_value(ident),
                 IdentStrings::Multiple(idents) => {
-                    for ident in idents {
+                    for ident in &idents {
                         hasher.write_value(ident);
                     }
                 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -232,7 +232,7 @@ async fn batch_chunk_items_with_info(
 ) -> Result<Vc<BatchChunkItemsWithInfo>> {
     let split_batch_group = batch_group.split_by_chunk_type().await?;
     if split_batch_group.len() == 1 {
-        let &(ty, batch) = split_batch_group.into_iter().next().unwrap();
+        let (ty, batch) = split_batch_group.into_iter().next().unwrap();
         Ok(batch_chunk_items_with_info_with_type(
             *batch,
             *ty,
@@ -241,9 +241,7 @@ async fn batch_chunk_items_with_info(
     } else {
         let maps = split_batch_group
             .into_iter()
-            .map(|&(ty, batch)| {
-                batch_chunk_items_with_info_with_type(*batch, *ty, chunking_context)
-            })
+            .map(|(ty, batch)| batch_chunk_items_with_info_with_type(*batch, *ty, chunking_context))
             .try_join()
             .await?;
         Ok(Vc::cell(

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -197,13 +197,11 @@ impl ChunkGroupResult {
                     .await?
                     .into_iter()
                     .chain(self.referenced_assets.await?)
-                    .copied()
                     .map(ExpandOutputAssetsInput::Asset)
                     .chain(
                         self.references
                             .await?
                             .into_iter()
-                            .copied()
                             .map(ExpandOutputAssetsInput::Reference),
                     ),
                 false,
@@ -226,13 +224,11 @@ impl ChunkGroupResult {
                 self.referenced_assets
                     .await?
                     .into_iter()
-                    .copied()
                     .map(ExpandOutputAssetsInput::Asset)
                     .chain(
                         self.references
                             .await?
                             .into_iter()
-                            .copied()
                             .map(ExpandOutputAssetsInput::Reference),
                     ),
                 false,

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -25,7 +25,7 @@ pub async fn compute_async_module_info(
     // Layout segment optimization, we can individually compute the async modules for each graph.
     let mut result = None;
     for graph in graphs.iter_graphs().await? {
-        result = Some(compute_async_module_info_single(*graph, result));
+        result = Some(compute_async_module_info_single(graph, result));
     }
     Ok(result
         .context("There must be at least one single graph in the module graph")?

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -134,7 +134,7 @@ async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferenc
                     Ok(path) => {
                         results.insert(path.clone());
                     }
-                    Err(e) => bail!(e.as_error_message(&file, &realpath).await?),
+                    Err(e) => bail!(e.as_error_message(file, &realpath).await?),
                 }
             }
             PatternMatch::Directory(..) => {}

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -134,7 +134,7 @@ async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferenc
                     Ok(path) => {
                         results.insert(path.clone());
                     }
-                    Err(e) => bail!(e.as_error_message(file, &realpath).await?),
+                    Err(e) => bail!(e.as_error_message(&file, &realpath).await?),
                 }
             }
             PatternMatch::Directory(..) => {}

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -138,12 +138,12 @@ impl OutputAssetsWithReferenced {
                 .await?
                 .into_iter()
                 .chain(self.referenced_assets.await?)
-                .map(|&asset| ExpandOutputAssetsInput::Asset(asset))
+                .map(ExpandOutputAssetsInput::Asset)
                 .chain(
                     self.references
                         .await?
                         .into_iter()
-                        .map(|&reference| ExpandOutputAssetsInput::Reference(reference)),
+                        .map(ExpandOutputAssetsInput::Reference),
                 ),
             inner_output_assets,
         )
@@ -224,13 +224,11 @@ impl OutputAssetsWithReferenced {
                 self.referenced_assets
                     .await?
                     .into_iter()
-                    .copied()
                     .map(ExpandOutputAssetsInput::Asset)
                     .chain(
                         self.references
                             .await?
                             .into_iter()
-                            .copied()
                             .map(ExpandOutputAssetsInput::Reference),
                     ),
                 false,
@@ -259,12 +257,12 @@ async fn get_referenced_assets(
         .await?
         .into_iter()
         .chain(refs.referenced_assets.await?)
-        .map(|&asset| ExpandOutputAssetsInput::Asset(asset))
+        .map(ExpandOutputAssetsInput::Asset)
         .chain(
             refs.references
                 .await?
                 .into_iter()
-                .map(|&reference| ExpandOutputAssetsInput::Reference(reference)),
+                .map(ExpandOutputAssetsInput::Reference),
         );
     Ok(Either::Right(assets))
 }

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -258,7 +258,7 @@ pub async fn all_assets_from_entries(
             entries
                 .await?
                 .into_iter()
-                .map(|&asset| ExpandOutputAssetsInput::Asset(asset)),
+                .map(ExpandOutputAssetsInput::Asset),
             true,
         )
         .await?,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1470,7 +1470,7 @@ async fn find_package(
                 let matches =
                     read_matches(dir.clone(), rcstr!(""), true, package_name_with_extensions)
                         .await?;
-                for m in matches {
+                for m in &matches {
                     if let PatternMatch::File(_, package_file) = m {
                         packages.push(FindPackageItem::PackageFile {
                             name: get_package_name(dir, package_file)?,

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -226,7 +226,7 @@ impl OutputAssetsReference for CssModuleChunkItem {
     async fn references(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
         let mut references = Vec::new();
         if let ParseCssResult::Ok { url_references, .. } = &*self.module.parse_css().await? {
-            for (_, reference) in url_references.await? {
+            for (_, reference) in &*url_references.await? {
                 if let ReferencedAsset::Some(asset) = *reference
                     .get_referenced_asset(*self.chunking_context)
                     .await?

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -137,7 +137,7 @@ async fn expand(
             .await?
             .into_iter()
             .chain(refs.referenced_assets.await?);
-        for &asset in ref_assets {
+        for asset in ref_assets {
             if assets_set.insert(asset) {
                 let path = asset.path().await?;
                 if let Some(sub_path) = root_path.get_path_to(&path) {

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -146,9 +146,9 @@ async fn resolve_reference_from_dir(
     };
 
     let matches = abs_matches
-        .into_iter()
+        .iter()
         .flatten()
-        .chain(rel_matches.into_iter().flatten());
+        .chain(rel_matches.iter().flatten());
 
     let mut affecting_sources = Vec::new();
     let mut results = Vec::new();
@@ -168,7 +168,7 @@ async fn resolve_reference_from_dir(
                 results.push((
                     RequestKey::new(matched_path.clone()),
                     ResolvedVc::upcast(
-                        RawModule::new(Vc::upcast(FileSource::new(path)))
+                        RawModule::new(Vc::upcast(FileSource::new(path.clone())))
                             .to_resolved()
                             .await?,
                     ),

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -52,7 +52,7 @@ pub async fn node_file_trace(
     }
 
     println!("FILELIST:");
-    for a in result {
+    for a in &result {
         println!("{a}");
     }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -69,9 +69,9 @@ impl EcmascriptBuildNodeChunkContent {
 
         let content = self.content.await?;
         let chunk_items = content.chunk_item_code_and_ids().await?;
-        for item in chunk_items {
-            for (id, item_code) in item {
-                write!(code, "\n{}, ", StringifyJs(&id))?;
+        for item in &chunk_items {
+            for (id, item_code) in &**item {
+                write!(code, "\n{}, ", StringifyJs(id))?;
                 code.push_code(item_code);
                 write!(code, ",")?;
             }


### PR DESCRIPTION
### What?

Replaces the unsound by-value `IntoIterator` impl for `ReadRef<T>` in `turbo-tasks` with a sound clone-free variant, and adapts the callers across `turbopack-*` and `next-api`.

### Why?

The previous impl used `transmute_copy` to fabricate `&'static`-typed items so it could expose them through the standard `Iterator` trait. Those references were only really valid as long as the `ReadRef` inside the iterator stayed alive — but `Iterator::Item` is a fixed associated type, so once the items were stashed in futures, `Vec`s, or `serde_json` map keys, the lifetime was completely unenforced.

This produced a latent use-after-free whenever something else (turbo-tasks cell eviction, an intermediate `Drop`, etc.) released the underlying storage between the iteration site and the next dereference. The observed symptom was a panic in `RcStr::as_str` during JSON serialization of `AssetHashesManifestAsset`'s manifest:

```
thread 'tokio-rt-worker' panicked at turbopack/crates/turbo-rcstr/src/lib.rs:132:52:
range end index 13 out of range for slice of length 7
```

The byte read at the inline-length position was junk left over from freed/reused memory — `len = 13` is unreachable for any legitimately-constructed inline `RcStr` (max inline length is 7 on 64-bit). The bug site was `crates/next-api/src/project_asset_hashes_manifest.rs`, which consumed an `OutputAssetsWithPaths` `ReadRef`, kept `&RcStr` references in `asset_paths` past the `try_join` that dropped the iterator, then serialized them.

### How?

**`turbopack/crates/turbo-tasks/src/read_ref.rs`** — new by-value impl:

```rust
pub struct ReadRefIter<T, I, J>
where
    T: VcValueType,
    I: Copy + 'static,
    J: Iterator<Item = &'static I>,
{
    iter: J,
    _read_ref: ReadRef<T>,
}

impl<T, I, J> Iterator for ReadRefIter<T, I, J> /* … */ {
    type Item = I;
    fn next(&mut self) -> Option<I> { self.iter.next().copied() }
}

impl<T, I, J> IntoIterator for ReadRef<T>
where
    T: VcValueType,
    I: Copy + 'static,
    J: Iterator<Item = &'static I> + 'static,
    &'static VcReadTarget<T>: IntoIterator<Item = &'static I, IntoIter = J>,
{
    type Item = I;
    type IntoIter = ReadRefIter<T, I, J>;
    fn into_iter(self) -> Self::IntoIter {
        let r: &VcReadTarget<T> = &self;
        // SAFETY: the fabricated `&'static` reference is only stored inside
        // `iter`, which lives inside the returned `ReadRefIter` alongside
        // the `ReadRef` that owns the data. `next()` only ever yields
        // `Copy`-ed-out values — no reference (with the fake `'static`
        // lifetime or otherwise) ever leaves the iterator. Struct-field drop
        // order (`iter` then `_read_ref`) drops the borrow before the
        // backing storage.
        let r = unsafe { std::mem::transmute::<&VcReadTarget<T>, &'static VcReadTarget<T>>(r) };
        ReadRefIter { iter: r.into_iter(), _read_ref: self }
    }
}
```

Key properties:
- **No cloning.** Setup is one borrow + `transmute`; `next()` is `Option::copied()` (bitwise copy via the `Copy` bound), not `Clone::clone`. Nothing in the iterator clones the backing collection or its elements.
- **Contained `unsafe`.** The fake `'static` reference never leaves `ReadRefIter`. `Iterator::next` yields `I` by value, so the lifetime never escapes into futures, `Vec`s, or other persistence outside the iterator.
- **Drop order safe.** Struct fields drop in declaration order: `iter` (and any borrows it holds) drops before `_read_ref` (the backing `Arc`).
- **`Copy` bound.** The impl is restricted to element types that are `Copy` — `ResolvedVc<_>`, integer ids, owned-tuple-of-`Copy`, etc. For non-`Copy` element types (`RcStr`, `FileSystemPath`, `PatternMatch`, `(String, _)`, `(ModuleId, ReadRef<_>)`, …) callers iterate by reference via the existing `IntoIterator for &'a ReadRef<T>` impl (`for x in &read_ref` or `read_ref.iter()`).

The original buggy site in `project_asset_hashes_manifest.rs` now uses `output_assets.iter()` and keeps `&'a RcStr` references in the manifest struct. The borrow checker now enforces the lifetime that used to be faked via `transmute` — `output_assets` outlives the references because nothing consumes it, and there are no clones at the call site either.

**Caller adjustments.** Touching the impl forced a sweep of all call sites that were implicitly leaning on the unsound shape (yielding `&'static`-typed items as a stand-in for owned items). The fixes fall into a small number of categories:

- Drop redundant `.copied()` / `.cloned()` / `|&x| f(x)` patterns after `into_iter()` (items are owned `Copy` values now, no need to deref-and-copy).
- Switch non-`Copy` element iteration to `&read_ref` / `read_ref.iter()` (e.g. `PatternMatches`, `CodeAndIds`, `UnresolvedUrlReferences`, `GraphEntries`, `Vec<RcStr>`).
- Reshape `crates/next-api/src/paths.rs` helpers from `impl IntoIterator<Item = &ResolvedVc<_>>` to `impl IntoIterator<Item = ResolvedVc<_>>` — `ResolvedVc` is `Copy`, so by-value is the natural shape and it composes directly with the new by-value `ReadRef::into_iter`. Callers in `app.rs`, `pages.rs`, `middleware.rs`, `instrumentation.rs`, `font.rs` updated to match (either passing the `ReadRef`/`Vec` directly, or `.iter().copied()` for borrowed sources).
- A few small follow-ups: `for (key, EndpointGroup { primary, .. }) in &entrypoint_groups` in `routes_hashes_manifest.rs` (with a borrowed `&'l str` key in the manifest); `compute_async_module_info_single(graph, result)` (no `*graph`, it's already `Copy`); `&(ty, batch)` → `(ty, batch)` destructures in `chunking/mod.rs`.

### Testing

- `cac` clean across the workspace.
- `ca clippy --all-targets` clean.
- `ca test -p turbo-tasks-backend` — all unit + integration tests pass.
- `ca test -p turbopack-tests --tests` — execution snapshot suite (218 passed, 0 failed, 1 ignored) and snapshot suite (87 passed, 0 failed).

Closes NEXT-
Fixes #