### PR TITLE
docs: rework dynamic segments intro section

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dynamic Route Segments
 nav_title: Dynamic Segments
-description: Dynamic Route Segments can be used to programmatically generate route segments from dynamic data.
+description: Use Dynamic Segments to read URL path params and generate routes from dynamic data.
 related:
   title: Next Steps
   description: For more information on what to do next, we recommend the following sections
@@ -9,7 +9,9 @@ related:
     - app/api-reference/functions/generate-static-params
 ---
 
-When you don't know the exact route segment names ahead of time and want to create routes from dynamic data, you can use Dynamic Segments that are filled in at request time or prerendered at build time.
+A URL path is a sequence of path segments. In the App Router, a segment may be **static** (a literal value matched exactly) or **dynamic** (a placeholder that captures a value from the URL). When you don't know a segment's value ahead of time, define a Dynamic Segment to create routes from dynamic data. Next.js passes the captured values to your page via the path `params` prop, either filled in at request time or prerendered at build time.
+
+> **Good to know**: Dynamic Segments are often referred to as path params, route params, or URL params.
 
 ## Convention
 


### PR DESCRIPTION
We don't refer to these as `path params` anymore, rather called them `dynamic segments`, which causes a drop-off when people search for "nextjs path params". 

While looking at this, I also noticed that we don't really mention what a segment, people don't know this necessarily. 

We'll have to come back to this point later on because, params are just placeholders, the dynamic qualifier is too broad, dynamic at build and runtime is what we mean today, but arguably params known via generateStaticParams, are no longer dynamic params, they are known set of params. 