### PR TITLE
Fix Firefox refresh loop on initial load of streaming pages in dev mode

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -916,10 +916,12 @@ jobs:
           test/production/chunk-load-failure/chunk-load-failure.test.ts
 
         TURBOPACK_DEV=1 NEXT_TEST_MODE=dev BROWSER_NAME=firefox node run-tests.js \
-          test/e2e/app-dir/scss/hmr-module/hmr-module.test.ts
+          test/e2e/app-dir/scss/hmr-module/hmr-module.test.ts \
+          test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
 
         TURBOPACK_DEV=1 NEXT_TEST_MODE=dev BROWSER_NAME=safari node run-tests.js \
-          test/e2e/app-dir/scss/hmr-module/hmr-module.test.ts
+          test/e2e/app-dir/scss/hmr-module/hmr-module.test.ts \
+          test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
 
         TURBOPACK_BUILD=1 NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js \
           test/production/pages-dir/production/test/index.test.ts \

--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -51,7 +51,36 @@ function wasServedFromCache(): boolean {
     // There is exactly one PerformanceNavigationTiming entry per page load.
     const entry = performance.getEntriesByType('navigation')[0]
 
-    return entry?.transferSize === 0
+    if (!entry) {
+      return false
+    }
+
+    // HTTP cache restore detection isn't uniform across browsers, so we combine
+    // two signals:
+    //
+    //   1. type === 'back_forward' — set on browser-history navigations
+    //      (back/forward) in all three browsers, and on tab duplication in
+    //      Chrome and Firefox. This only matters when scripts actually
+    //      re-execute; a bfcache restore preserves the entire JS context and
+    //      never reaches this code. The HMR WebSocket disqualifies bfcache in
+    //      Chrome and Firefox, so back/forward falls back to an HTTP cache
+    //      restore and we land here with this type set. Safari is more lenient
+    //      and often still uses bfcache for back/forward despite the WebSocket,
+    //      in which case this function isn't called and no recovery is needed.
+    //   2. responseStart === 0 && responseEnd > 0 — Safari uses type='navigate'
+    //      on tab duplication. It sets responseStart to 0 when no
+    //      first-body-byte arrived over the network; fresh loads always have
+    //      responseStart > 0.
+    //
+    // Neither fires on Firefox's fresh streaming load, where transferSize is
+    // transiently 0. That case has type='navigate' with a non-zero
+    // responseStart, so it correctly returns false and avoids a
+    // location.reload() loop that earlier (transferSize-only) versions of this
+    // check triggered.
+    return (
+      entry.type === 'back_forward' ||
+      (entry.responseStart === 0 && entry.responseEnd > 0)
+    )
   } catch {
     return false
   }

--- a/test/e2e/app-dir/bfcache-regression/app/layout.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/layout.tsx
@@ -2,7 +2,12 @@ import { ReactNode } from 'react'
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <p>
+          <a href="/target-page">MPA Link</a>
+        </p>
+        <main>{children}</main>
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/bfcache-regression/app/page.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/page.tsx
@@ -11,9 +11,6 @@ export default function Page() {
       <button id="increment" onClick={() => setCount((c) => c + 1)}>
         Increment
       </button>
-      <p>
-        <a href="/target-page">MPA Link</a>
-      </p>
     </div>
   )
 }

--- a/test/e2e/app-dir/bfcache-regression/app/streaming/page.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/streaming/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function DynamicContent() {
+  await connection()
+  // Delay so that the streamed body has not arrived by the time the
+  // bootstrap script reads PerformanceNavigationTiming.transferSize.
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return <p id="dynamic-content">Dynamic content</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Streaming page</h1>
+      <Suspense fallback={<p id="dynamic-fallback">Loading...</p>}>
+        <DynamicContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
+++ b/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
@@ -46,4 +46,40 @@ describe('bfcache-regression', () => {
 
     await assertNoConsoleErrors(browser)
   })
+
+  // Regression test for an infinite refresh loop on the initial load of a
+  // streaming page. wasServedFromCache() in debug-channel.ts must not treat
+  // a still-in-flight streaming response as an HTTP cache restore, or it
+  // calls location.reload() and the next load hits the same condition. The
+  // bug only manifests in browsers where PerformanceNavigationTiming
+  // reports transferSize/encodedBodySize as 0 until the body finishes
+  // arriving — Firefox in practice. Chrome and Safari report non-zero
+  // values during streaming and aren't affected.
+  it('should not enter a refresh loop on initial load of a page with streaming dynamic content', async () => {
+    let loadCount = 0
+    const browser = await next.browser('/streaming', {
+      pushErrorAsConsoleLog: true,
+      beforePageLoad: async (page) => {
+        // Increments on every load event for /streaming (including any
+        // location.reload() triggered by the bug), so loadCount > 1 means a
+        // reload happened. URL-filtered to skip the about:blank load Firefox
+        // emits when Playwright creates the page.
+        page.on('load', () => {
+          if (page.url().endsWith('/streaming')) {
+            loadCount++
+          }
+        })
+      },
+    })
+
+    await retry(async () => {
+      expect(await browser.elementById('dynamic-content').text()).toBe(
+        'Dynamic content'
+      )
+    })
+
+    expect(loadCount).toBe(1)
+
+    await assertNoConsoleErrors(browser)
+  })
 })


### PR DESCRIPTION
Follow-up to #92892 and #93486. Those PRs introduced `wasServedFromCache()` to detect HTTP cache restores so the dev-mode debug channel could be replayed from `sessionStorage` (or, as a fallback, the document could be force-reloaded). The check used `PerformanceNavigationTiming.transferSize === 0` as the sole signal.

In Firefox, `transferSize` stays at `0` for the entire window while a streaming response body is still arriving. On the initial load of a page that uses `Suspense` + dynamic content, the bootstrap ran before the body had finished streaming, `wasServedFromCache()` returned `true`, no `sessionStorage` entry existed for the request, and the `location.reload()` safety net fired — only to land in the same condition again, producing an infinite refresh loop. Chrome and Safari report a non-zero `transferSize` during streaming, so they were unaffected.

`wasServedFromCache()` now combines two signals that fire on a real cache restore but not on a streaming load:

- `type === 'back_forward'` for browser-history navigation (in all three browsers) and for tab duplication in Chrome and Firefox.
- `responseStart === 0 && responseEnd > 0` for Safari tab duplication, where `type` stays `'navigate'` and `responseStart` is `0` when no first-body-byte arrived over the network.

A regression test under `test/e2e/app-dir/bfcache-regression` covers a streaming page and asserts that no extra `load` event fires after the initial navigation. The test is also wired into the Firefox and Safari dev jobs in CI so future regressions are caught there. Tab duplication cannot be simulated in Playwright and was verified manually across all three browsers, same as in the original PR.