### PR TITLE
Refine error overlay insight pagination

### DIFF
--- a/packages/next/.storybook/fixtures/errors.ts
+++ b/packages/next/.storybook/fixtures/errors.ts
@@ -648,3 +648,58 @@ export const instantClientMathRandomErrors: ReadyRuntimeError[] = [
     type: 'runtime',
   },
 ]
+
+export const mixedIssueAndInsightErrors: ReadyRuntimeError[] = [
+  runtimeErrors[0],
+  runtimeErrors[1],
+  {
+    id: 120,
+    runtime: true,
+    error: Object.assign(
+      new Error(
+        'Route "/nav-cookies-under-suspense": Next.js encountered runtime data during the initial render or a navigation.\n\n`cookies()`, `headers()`, `params`, or `searchParams` accessed under `<Suspense>` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.\n\nWays to fix this:\n  - Use `generateStaticParams` to make route params static\n  - Provide a placeholder with `<Suspense fallback={...}>` around the data access\n  - Set `export const instant = false` to allow a blocking route\n\nLearn more: https://nextjs.org/docs/messages/blocking-route'
+      ),
+      { __NEXT_ERROR_CODE: 'E1247' }
+    ),
+    frames: createStoryFrames({
+      reason:
+        'Route "/nav-cookies-under-suspense": Next.js encountered runtime data during the initial render or a navigation.',
+      file: 'app/nav-cookies-under-suspense/page.tsx',
+      methodName: 'Page',
+      line: 5,
+      column: 15,
+      codeFrame: instantCodeFrame({
+        beforeLine: "import { cookies } from 'next/headers'",
+        line: 'const c = await cookies()',
+        markerLine: 5,
+        pointerColumn: 11,
+      }),
+    }),
+    type: 'runtime',
+  },
+  {
+    id: 121,
+    runtime: true,
+    error: Object.assign(
+      new Error(
+        'Route "/nav-fetch-under-suspense": Next.js encountered uncached data during the initial render or a navigation.\n\n`fetch(...)` or `connection()` accessed under `<Suspense>` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.\n\nWays to fix this:\n  - Cache the data access with `"use cache"`\n  - Provide a placeholder with `<Suspense fallback={...}>` around the data access\n  - Set `export const instant = false` to allow a blocking route\n\nLearn more: https://nextjs.org/docs/messages/blocking-route'
+      ),
+      { __NEXT_ERROR_CODE: 'E1246' }
+    ),
+    frames: createStoryFrames({
+      reason:
+        'Route "/nav-fetch-under-suspense": Next.js encountered uncached data during the initial render or a navigation.',
+      file: 'app/nav-fetch-under-suspense/page.tsx',
+      methodName: 'Page',
+      line: 6,
+      column: 21,
+      codeFrame: instantCodeFrame({
+        beforeLine: 'export default async function Page() {',
+        line: 'const res = await fetch("http://example.com", { cache: "no-store" })',
+        markerLine: 6,
+        pointerColumn: 21,
+      }),
+    }),
+    type: 'runtime',
+  },
+]

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -18,6 +18,7 @@ import {
   ErrorOverlayNav,
   styles as floatingHeaderStyles,
 } from '../error-overlay-nav/error-overlay-nav'
+import type { ErrorOverlayTabBarRenderer } from '../error-overlay-pagination/error-overlay-pagination'
 
 import { ErrorOverlayDialog, DIALOG_STYLES } from '../dialog/dialog'
 import {
@@ -38,7 +39,11 @@ export interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   errorType: ErrorType
   children?: React.ReactNode
   headerChildren?: React.ReactNode
-  tabBar?: React.ReactNode
+  renderTabBar?: ErrorOverlayTabBarRenderer
+  canGoPrevious?: boolean
+  canGoNext?: boolean
+  onPrevious?: () => void
+  onNext?: () => void
   errorCode?: string
   error: ReadyRuntimeError['error']
   debugInfo?: DebugInfo
@@ -57,7 +62,11 @@ export function ErrorOverlayLayout({
   errorType,
   children,
   headerChildren,
-  tabBar,
+  renderTabBar,
+  canGoPrevious,
+  canGoNext,
+  onPrevious,
+  onNext,
   errorCode,
   errorCount: _errorCount,
   error,
@@ -113,12 +122,16 @@ export function ErrorOverlayLayout({
           runtimeErrors={runtimeErrors}
           activeIdx={activeIdx}
           setActiveIndex={setActiveIndex}
+          canGoPrevious={canGoPrevious}
+          canGoNext={canGoNext}
+          onPrevious={onPrevious}
+          onNext={onNext}
           versionInfo={versionInfo}
           error={error}
           debugInfo={debugInfo}
           generateErrorInfo={generateErrorInfo}
+          renderTabBar={renderTabBar}
         />
-        {tabBar}
         <ErrorOverlayDialog onClose={onClose} data-has-footer={hasFooter}>
           <Resizer
             ref={dialogResizerRef}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-nav/error-overlay-nav.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-nav/error-overlay-nav.tsx
@@ -1,7 +1,10 @@
 import type { DebugInfo } from '../../../../shared/types'
 import type { VersionInfo } from '../../../../../server/dev/parse-version-info'
 
-import { ErrorOverlayPagination } from '../error-overlay-pagination/error-overlay-pagination'
+import {
+  ErrorOverlayPagination,
+  type ErrorOverlayTabBarRenderer,
+} from '../error-overlay-pagination/error-overlay-pagination'
 import { ErrorOverlayToolbar } from '../error-overlay-toolbar/error-overlay-toolbar'
 import type { ReadyRuntimeError } from '../../../utils/get-error-by-type'
 
@@ -9,20 +12,30 @@ type ErrorOverlayNavProps = {
   runtimeErrors?: ReadyRuntimeError[]
   activeIdx?: number
   setActiveIndex?: (index: number) => void
+  canGoPrevious?: boolean
+  canGoNext?: boolean
+  onPrevious?: () => void
+  onNext?: () => void
   versionInfo?: VersionInfo
   error: ReadyRuntimeError['error']
   debugInfo?: DebugInfo
   generateErrorInfo: () => Promise<string>
+  renderTabBar?: ErrorOverlayTabBarRenderer
 }
 
 export function ErrorOverlayNav({
   runtimeErrors,
   activeIdx,
   setActiveIndex,
+  canGoPrevious,
+  canGoNext,
+  onPrevious,
+  onNext,
   versionInfo,
   error,
   debugInfo,
   generateErrorInfo,
+  renderTabBar,
 }: ErrorOverlayNavProps) {
   const bundlerName = (process.env.__NEXT_BUNDLER || 'Turbopack') as
     | 'Turbopack'
@@ -36,6 +49,11 @@ export function ErrorOverlayNav({
           runtimeErrors={runtimeErrors ?? []}
           activeIdx={activeIdx ?? 0}
           onActiveIndexChange={setActiveIndex ?? (() => {})}
+          canGoPrevious={canGoPrevious}
+          canGoNext={canGoNext}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          renderTabBar={renderTabBar}
         />
       </NavItem>
       <NavItem side="right">

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
@@ -9,18 +9,38 @@ import { LeftArrow } from '../../../icons/left-arrow'
 import { RightArrow } from '../../../icons/right-arrow'
 import type { ReadyRuntimeError } from '../../../utils/get-error-by-type'
 
+export type ErrorOverlayPaginationControls = {
+  previousButton: React.ReactNode
+  nextButton: React.ReactNode
+  createCount: (activeIdx: number, total: number) => React.ReactNode
+}
+
+export type ErrorOverlayTabBarRenderer = (
+  controls: ErrorOverlayPaginationControls
+) => React.ReactNode
+
 type ErrorPaginationProps = {
   runtimeErrors: ReadyRuntimeError[]
   activeIdx: number
   onActiveIndexChange: (index: number) => void
+  canGoPrevious?: boolean
+  canGoNext?: boolean
+  onPrevious?: () => void
+  onNext?: () => void
+  renderTabBar?: ErrorOverlayTabBarRenderer
 }
 
 export function ErrorOverlayPagination({
   runtimeErrors,
   activeIdx,
   onActiveIndexChange,
+  canGoPrevious,
+  canGoNext,
+  onPrevious,
+  onNext,
+  renderTabBar,
 }: ErrorPaginationProps) {
-  const handlePrevious = useCallback(
+  const handlePreviousWithinGroup = useCallback(
     () =>
       startTransition(() => {
         if (activeIdx > 0) {
@@ -30,7 +50,7 @@ export function ErrorOverlayPagination({
     [activeIdx, onActiveIndexChange]
   )
 
-  const handleNext = useCallback(
+  const handleNextWithinGroup = useCallback(
     () =>
       startTransition(() => {
         if (activeIdx < runtimeErrors.length - 1) {
@@ -41,6 +61,13 @@ export function ErrorOverlayPagination({
       }),
     [activeIdx, runtimeErrors.length, onActiveIndexChange]
   )
+
+  const canNavigatePrevious = canGoPrevious ?? activeIdx > 0
+  const canNavigateNext =
+    canGoNext ?? activeIdx < runtimeErrors.length - 1
+
+  const handlePrevious = onPrevious ?? handlePreviousWithinGroup
+  const handleNext = onNext ?? handleNextWithinGroup
 
   const buttonLeft = useRef<HTMLButtonElement | null>(null)
   const buttonRight = useRef<HTMLButtonElement | null>(null)
@@ -94,59 +121,69 @@ export function ErrorOverlayPagination({
     if (root instanceof ShadowRoot) {
       const a = root.activeElement
 
-      if (activeIdx === 0) {
+      if (!canNavigatePrevious) {
         if (buttonLeft.current && a === buttonLeft.current) {
           buttonLeft.current.blur()
         }
-      } else if (activeIdx === runtimeErrors.length - 1) {
+      } else if (!canNavigateNext) {
         if (buttonRight.current && a === buttonRight.current) {
           buttonRight.current.blur()
         }
       }
     }
-  }, [nav, activeIdx, runtimeErrors.length])
+  }, [nav, canNavigateNext, canNavigatePrevious])
+
+  const previousButton = (
+    <button
+      ref={buttonLeft}
+      type="button"
+      disabled={!canNavigatePrevious}
+      aria-disabled={!canNavigatePrevious}
+      onClick={handlePrevious}
+      data-nextjs-dialog-error-previous
+      className="error-overlay-pagination-button"
+    >
+      <LeftArrow title="previous" className="error-overlay-pagination-button-icon" />
+    </button>
+  )
+
+  const createCount = (currentActiveIdx: number, total: number) => (
+    <div className="error-overlay-pagination-count">
+      <span data-nextjs-dialog-error-index={currentActiveIdx}>
+        {total === 0 ? 0 : currentActiveIdx + 1}/
+      </span>
+      <span data-nextjs-dialog-header-total-count>{total}</span>
+    </div>
+  )
+
+  const nextButton = (
+    <button
+      ref={buttonRight}
+      type="button"
+      disabled={!canNavigateNext}
+      aria-disabled={!canNavigateNext}
+      onClick={handleNext}
+      data-nextjs-dialog-error-next
+      className="error-overlay-pagination-button"
+    >
+      <RightArrow title="next" className="error-overlay-pagination-button-icon" />
+    </button>
+  )
 
   return (
     <nav
       className="error-overlay-pagination dialog-exclude-closing-from-outside-click"
       ref={onNav}
     >
-      <button
-        ref={buttonLeft}
-        type="button"
-        disabled={activeIdx === 0}
-        aria-disabled={activeIdx === 0}
-        onClick={handlePrevious}
-        data-nextjs-dialog-error-previous
-        className="error-overlay-pagination-button"
-      >
-        <LeftArrow
-          title="previous"
-          className="error-overlay-pagination-button-icon"
-        />
-      </button>
-      <div className="error-overlay-pagination-count">
-        <span data-nextjs-dialog-error-index={activeIdx}>{activeIdx + 1}/</span>
-        <span data-nextjs-dialog-header-total-count>
-          {/* Display 1 out of 1 if there are no errors (e.g. for build errors). */}
-          {runtimeErrors.length || 1}
-        </span>
-      </div>
-      <button
-        ref={buttonRight}
-        type="button"
-        // If no errors or the last error is active, disable the button.
-        disabled={activeIdx >= runtimeErrors.length - 1}
-        aria-disabled={activeIdx >= runtimeErrors.length - 1}
-        onClick={handleNext}
-        data-nextjs-dialog-error-next
-        className="error-overlay-pagination-button"
-      >
-        <RightArrow
-          title="next"
-          className="error-overlay-pagination-button-icon"
-        />
-      </button>
+      {renderTabBar
+        ? renderTabBar({ previousButton, createCount, nextButton })
+        : (
+            <>
+              {previousButton}
+              {createCount(activeIdx, runtimeErrors.length || 1)}
+              {nextButton}
+            </>
+          )}
     </nav>
   )
 }
@@ -168,9 +205,11 @@ export const styles = `
   }
 
   .error-overlay-pagination-count {
-    color: var(--color-gray-900);
+    display: flex;
+    align-items: center;
+    color: inherit;
     text-align: center;
-    font-size: var(--size-14);
+    font-size: var(--size-13);
     font-family: var(--font-mono);
     line-height: var(--size-16);
     font-variant-numeric: tabular-nums;

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
@@ -67,8 +67,7 @@ export function ErrorOverlayPagination({
   )
 
   const canNavigatePrevious = canGoPrevious ?? activeIdx > 0
-  const canNavigateNext =
-    canGoNext ?? activeIdx < runtimeErrors.length - 1
+  const canNavigateNext = canGoNext ?? activeIdx < runtimeErrors.length - 1
 
   const handlePrevious = onPrevious ?? handlePreviousWithinGroup
   const handleNext = onNext ?? handleNextWithinGroup
@@ -147,7 +146,10 @@ export function ErrorOverlayPagination({
       data-nextjs-dialog-error-previous
       className="error-overlay-pagination-button"
     >
-      <LeftArrow title="previous" className="error-overlay-pagination-button-icon" />
+      <LeftArrow
+        title="previous"
+        className="error-overlay-pagination-button-icon"
+      />
     </button>
   )
 
@@ -182,7 +184,10 @@ export function ErrorOverlayPagination({
       data-nextjs-dialog-error-next
       className="error-overlay-pagination-button"
     >
-      <RightArrow title="next" className="error-overlay-pagination-button-icon" />
+      <RightArrow
+        title="next"
+        className="error-overlay-pagination-button-icon"
+      />
     </button>
   )
 
@@ -191,15 +196,15 @@ export function ErrorOverlayPagination({
       className="error-overlay-pagination dialog-exclude-closing-from-outside-click"
       ref={onNav}
     >
-      {renderTabBar
-        ? renderTabBar({ previousButton, createCount, nextButton })
-        : (
-            <>
-              {previousButton}
-              {createCount(activeIdx, runtimeErrors.length || 1)}
-              {nextButton}
-            </>
-          )}
+      {renderTabBar ? (
+        renderTabBar({ previousButton, createCount, nextButton })
+      ) : (
+        <>
+          {previousButton}
+          {createCount(activeIdx, runtimeErrors.length || 1)}
+          {nextButton}
+        </>
+      )}
     </nav>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
@@ -12,7 +12,11 @@ import type { ReadyRuntimeError } from '../../../utils/get-error-by-type'
 export type ErrorOverlayPaginationControls = {
   previousButton: React.ReactNode
   nextButton: React.ReactNode
-  createCount: (activeIdx: number, total: number) => React.ReactNode
+  createCount: (
+    activeIdx: number,
+    total: number,
+    isActive?: boolean
+  ) => React.ReactNode
 }
 
 export type ErrorOverlayTabBarRenderer = (
@@ -147,12 +151,24 @@ export function ErrorOverlayPagination({
     </button>
   )
 
-  const createCount = (currentActiveIdx: number, total: number) => (
+  const createCount = (
+    currentActiveIdx: number,
+    total: number,
+    isActive: boolean = true
+  ) => (
     <div className="error-overlay-pagination-count">
-      <span data-nextjs-dialog-error-index={currentActiveIdx}>
+      <span
+        {...(isActive
+          ? { 'data-nextjs-dialog-error-index': currentActiveIdx }
+          : {})}
+      >
         {total === 0 ? 0 : currentActiveIdx + 1}/
       </span>
-      <span data-nextjs-dialog-header-total-count>{total}</span>
+      <span
+        {...(isActive ? { 'data-nextjs-dialog-header-total-count': '' } : {})}
+      >
+        {total}
+      </span>
     </div>
   )
 

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
@@ -14,6 +14,7 @@ import {
   instantUncachedDataErrors,
   instantViewportErrors,
   instantViewportUncachedErrors,
+  mixedIssueAndInsightErrors,
   runtimeErrors,
 } from '../../../../.storybook/fixtures/errors'
 
@@ -59,6 +60,13 @@ export const VeryLongErrorMessage: Story = {
         error: Object.assign(new Error(lorem)),
       },
     ],
+  },
+}
+
+export const MixedIssuesAndInsights: Story = {
+  args: {
+    ...Default.args,
+    runtimeErrors: mixedIssueAndInsightErrors,
   },
 }
 

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -1,4 +1,11 @@
-import React, { useMemo, useRef, Suspense, useCallback, useState } from 'react'
+import React, {
+  startTransition,
+  Suspense,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import type { DebugInfo } from '../../shared/types'
 import { Overlay, OverlayBackdrop } from '../components/overlay'
 import { RuntimeError } from './runtime-error'
@@ -33,6 +40,7 @@ import { CodeFrame } from '../components/code-frame/code-frame'
 import { ErrorOverlayCallStack } from '../components/errors/error-overlay-call-stack/error-overlay-call-stack'
 import { ErrorCause } from './runtime-error/error-cause'
 import { useFrames } from '../utils/get-error-by-type'
+import type { ErrorOverlayPaginationControls } from '../components/errors/error-overlay-pagination/error-overlay-pagination'
 
 interface ErrorsProps extends ErrorBaseProps {
   getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
@@ -397,14 +405,25 @@ export function ErrorTabBar({
   onTabChange,
   errorCount,
   instantCount,
+  errorActiveIdx,
+  instantActiveIdx,
+  previousButton,
+  nextButton,
+  createCount,
 }: {
   activeTab: ErrorTab
   onTabChange: (tab: ErrorTab) => void
   errorCount: number
   instantCount: number
+  errorActiveIdx: number
+  instantActiveIdx: number
+  previousButton: React.ReactNode
+  nextButton: React.ReactNode
+  createCount: (activeIdx: number, total: number) => React.ReactNode
 }) {
   return (
     <div className="error-overlay-tab-bar" data-nextjs-error-overlay-tab-bar>
+      {previousButton}
       <button
         type="button"
         className="error-overlay-tab"
@@ -413,8 +432,11 @@ export function ErrorTabBar({
         onClick={() => onTabChange('errors')}
       >
         Issues
-        <span className="error-overlay-tab-count" data-variant="errors">
-          {errorCount}
+        <span
+          className="error-overlay-tab-count"
+          data-active={activeTab === 'errors'}
+        >
+          {createCount(errorActiveIdx, errorCount)}
         </span>
       </button>
       <button
@@ -425,10 +447,14 @@ export function ErrorTabBar({
         onClick={() => onTabChange('instant')}
       >
         Insights
-        <span className="error-overlay-tab-count" data-variant="instant">
-          {instantCount}
+        <span
+          className="error-overlay-tab-count"
+          data-active={activeTab === 'instant'}
+        >
+          {createCount(instantActiveIdx, instantCount)}
         </span>
       </button>
+      {nextButton}
     </div>
   )
 }
@@ -458,8 +484,30 @@ export function Errors({
   const [activeTab, setActiveTab] = useState<ErrorTab>(() =>
     normalErrors.length > 0 ? 'errors' : 'instant'
   )
-
-  const activeErrors = activeTab === 'instant' ? instantErrors : normalErrors
+  const [activeIndices, setActiveIndices] = useState<Record<ErrorTab, number>>({
+    errors: 0,
+    instant: 0,
+  })
+  const effectiveActiveTab =
+    activeTab === 'errors'
+      ? normalErrors.length > 0
+        ? 'errors'
+        : 'instant'
+      : instantErrors.length > 0
+        ? 'instant'
+        : 'errors'
+  const activeErrors =
+    effectiveActiveTab === 'instant' ? instantErrors : normalErrors
+  const errorActiveIdx = Math.max(
+    0,
+    Math.min(activeIndices.errors, Math.max(0, normalErrors.length - 1))
+  )
+  const instantActiveIdx = Math.max(
+    0,
+    Math.min(activeIndices.instant, Math.max(0, instantErrors.length - 1))
+  )
+  const activeIdxForTab =
+    effectiveActiveTab === 'instant' ? instantActiveIdx : errorActiveIdx
 
   const {
     isLoading,
@@ -472,6 +520,13 @@ export function Errors({
   } = useActiveRuntimeError({
     runtimeErrors: activeErrors,
     getSquashedHydrationErrorDetails,
+    activeIdx: activeIdxForTab,
+    setActiveIndex: (index) => {
+      setActiveIndices((previous) => ({
+        ...previous,
+        [effectiveActiveTab]: index,
+      }))
+    },
   })
 
   const generateErrorInfo = useCallback(async () => {
@@ -579,17 +634,86 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
   // Show the tab bar whenever there are instant errors so the user
   // knows they're looking at an insight, even if the other tab is empty.
   const showTabBar = instantErrors.length > 0
-  const tabBar = showTabBar ? (
-    <ErrorTabBar
-      activeTab={activeTab}
-      onTabChange={(tab) => {
-        setActiveTab(tab)
-        setActiveIndex(0)
-      }}
-      errorCount={normalErrors.length}
-      instantCount={instantErrors.length}
-    />
-  ) : null
+  const renderTabBar = showTabBar
+    ? ({ previousButton, createCount, nextButton }: ErrorOverlayPaginationControls) => (
+        <ErrorTabBar
+          activeTab={effectiveActiveTab}
+          onTabChange={(tab) => {
+            setActiveTab(tab)
+          }}
+          errorCount={normalErrors.length}
+          instantCount={instantErrors.length}
+          errorActiveIdx={errorActiveIdx}
+          instantActiveIdx={instantActiveIdx}
+          previousButton={previousButton}
+          nextButton={nextButton}
+          createCount={createCount}
+        />
+      )
+    : undefined
+
+  const canGoPrevious = showTabBar
+    ? effectiveActiveTab === 'errors'
+      ? errorActiveIdx > 0
+      : instantActiveIdx > 0 || normalErrors.length > 0
+    : activeIdx > 0
+  const canGoNext = showTabBar
+    ? effectiveActiveTab === 'errors'
+      ? errorActiveIdx < normalErrors.length - 1 || instantErrors.length > 0
+      : instantActiveIdx < instantErrors.length - 1
+    : activeIdx < activeErrors.length - 1
+
+  const handlePrevious = showTabBar
+    ? () => {
+        startTransition(() => {
+          if (effectiveActiveTab === 'errors') {
+            if (errorActiveIdx > 0) {
+              setActiveIndex(errorActiveIdx - 1)
+            }
+            return
+          }
+
+          if (instantActiveIdx > 0) {
+            setActiveIndex(instantActiveIdx - 1)
+            return
+          }
+
+          if (normalErrors.length > 0) {
+            setActiveTab('errors')
+            setActiveIndices((previous) => ({
+              ...previous,
+              errors: Math.max(0, normalErrors.length - 1),
+            }))
+          }
+        })
+      }
+    : undefined
+
+  const handleNext = showTabBar
+    ? () => {
+        startTransition(() => {
+          if (effectiveActiveTab === 'errors') {
+            if (errorActiveIdx < normalErrors.length - 1) {
+              setActiveIndex(errorActiveIdx + 1)
+              return
+            }
+
+            if (instantErrors.length > 0) {
+              setActiveTab('instant')
+              setActiveIndices((previous) => ({
+                ...previous,
+                instant: 0,
+              }))
+            }
+            return
+          }
+
+          if (instantActiveIdx < instantErrors.length - 1) {
+            setActiveIndex(instantActiveIdx + 1)
+          }
+        })
+      }
+    : undefined
 
   let errorMessage: React.ReactNode
   let maybeNotes: React.ReactNode = null
@@ -659,7 +783,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               }
             />
           }
-          tabBar={tabBar}
+          renderTabBar={renderTabBar}
+          canGoPrevious={canGoPrevious}
+          canGoNext={canGoNext}
+          onPrevious={handlePrevious}
+          onNext={handleNext}
           onClose={isServerError ? undefined : onClose}
           debugInfo={debugInfo}
           error={error}
@@ -700,7 +828,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
             )
           }
           headerChildren={<InstantHeaderExplanation kind="metadata" />}
-          tabBar={tabBar}
+          renderTabBar={renderTabBar}
+          canGoPrevious={canGoPrevious}
+          canGoNext={canGoNext}
+          onPrevious={handlePrevious}
+          onNext={handleNext}
           onClose={isServerError ? undefined : onClose}
           debugInfo={debugInfo}
           error={error}
@@ -742,7 +874,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
             )
           }
           headerChildren={<InstantHeaderExplanation kind="viewport" />}
-          tabBar={tabBar}
+          renderTabBar={renderTabBar}
+          canGoPrevious={canGoPrevious}
+          canGoNext={canGoNext}
+          onPrevious={handlePrevious}
+          onNext={handleNext}
           onClose={isServerError ? undefined : onClose}
           debugInfo={debugInfo}
           error={error}
@@ -782,7 +918,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               docsUrl={SYNC_IO_DOCS[errorDetails.cause]}
             />
           }
-          tabBar={tabBar}
+          renderTabBar={renderTabBar}
+          canGoPrevious={canGoPrevious}
+          canGoNext={canGoNext}
+          onPrevious={handlePrevious}
+          onNext={handleNext}
           onClose={isServerError ? undefined : onClose}
           debugInfo={debugInfo}
           error={error}
@@ -823,7 +963,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               docsUrl={SYNC_IO_CLIENT_DOCS[errorDetails.cause]}
             />
           }
-          tabBar={tabBar}
+          renderTabBar={renderTabBar}
+          canGoPrevious={canGoPrevious}
+          canGoNext={canGoNext}
+          onPrevious={handlePrevious}
+          onNext={handleNext}
           onClose={isServerError ? undefined : onClose}
           debugInfo={debugInfo}
           error={error}
@@ -859,7 +1003,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
       errorCode={errorCode}
       errorType={errorType}
       errorMessage={errorMessage}
-      tabBar={tabBar}
+      renderTabBar={renderTabBar}
+      canGoPrevious={canGoPrevious}
+      canGoNext={canGoNext}
+      onPrevious={handlePrevious}
+      onNext={handleNext}
       onClose={isServerError ? undefined : onClose}
       debugInfo={debugInfo}
       error={error}
@@ -954,12 +1102,10 @@ export const styles = `
 
   .error-overlay-tab-bar {
     display: flex;
-    gap: 0;
+    gap: 6px;
     translate: var(--next-dialog-border-width) 0;
     max-width: var(--next-dialog-max-width);
     width: 100%;
-    border-bottom: 1px solid var(--color-gray-400);
-    background: var(--color-background-100);
     position: relative;
     z-index: 1;
   }
@@ -967,33 +1113,24 @@ export const styles = `
   .error-overlay-tab {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 8px 16px;
+    gap: 2px;
+    padding: 0 4px;
     border: none;
     background: none;
-    color: var(--color-gray-700);
-    font-size: var(--size-14);
+    color: var(--color-gray-800);
+    font-size: var(--size-13);
     font-family: var(--font-stack-sans);
     cursor: pointer;
     position: relative;
     transition: color 0.15s ease;
 
     &:hover {
-      color: var(--color-gray-900);
+      color: var(--color-gray-1000);
     }
 
     &[data-active='true'] {
       color: var(--color-gray-1000);
-    }
-
-    &[data-active='true']::after {
-      content: '';
-      position: absolute;
-      bottom: -1px;
-      left: 0;
-      right: 0;
-      height: 2px;
-      background: var(--color-gray-1000);
+      font-weight: 500;
     }
 
     &:disabled {
@@ -1003,28 +1140,15 @@ export const styles = `
   }
 
   .error-overlay-tab-count {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    justify-content: center;
-    min-width: 20px;
-    height: 20px;
-    padding: 0 6px;
-    border-radius: var(--rounded-full);
-    font-size: var(--size-12);
-    font-family: var(--font-mono);
-    font-variant-numeric: tabular-nums;
-    line-height: 1;
-    background: var(--color-gray-alpha-100);
-    color: var(--color-gray-900);
+    color: inherit;
 
-    &[data-variant='errors'] {
-      background: var(--color-red-100);
-      color: var(--color-red-900);
-    }
-
-    &[data-variant='instant'] {
-      background: var(--color-amber-100);
-      color: var(--color-amber-900);
+    &[data-active='true'] {
+      .error-overlay-pagination-count {
+        font-weight: 500;
+      }
     }
   }
+
 `

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -639,7 +639,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
   // knows they're looking at an insight, even if the other tab is empty.
   const showTabBar = instantErrors.length > 0
   const renderTabBar = showTabBar
-    ? ({ previousButton, createCount, nextButton }: ErrorOverlayPaginationControls) => (
+    ? ({
+        previousButton,
+        createCount,
+        nextButton,
+      }: ErrorOverlayPaginationControls) => (
         <ErrorTabBar
           activeTab={effectiveActiveTab}
           onTabChange={(tab) => {

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -419,7 +419,11 @@ export function ErrorTabBar({
   instantActiveIdx: number
   previousButton: React.ReactNode
   nextButton: React.ReactNode
-  createCount: (activeIdx: number, total: number) => React.ReactNode
+  createCount: (
+    activeIdx: number,
+    total: number,
+    isActive?: boolean
+  ) => React.ReactNode
 }) {
   return (
     <div className="error-overlay-tab-bar" data-nextjs-error-overlay-tab-bar>
@@ -436,7 +440,7 @@ export function ErrorTabBar({
           className="error-overlay-tab-count"
           data-active={activeTab === 'errors'}
         >
-          {createCount(errorActiveIdx, errorCount)}
+          {createCount(errorActiveIdx, errorCount, activeTab === 'errors')}
         </span>
       </button>
       <button
@@ -451,7 +455,7 @@ export function ErrorTabBar({
           className="error-overlay-tab-count"
           data-active={activeTab === 'instant'}
         >
-          {createCount(instantActiveIdx, instantCount)}
+          {createCount(instantActiveIdx, instantCount, activeTab === 'instant')}
         </span>
       </button>
       {nextButton}

--- a/packages/next/src/next-devtools/dev-overlay/hooks/use-active-runtime-error.ts
+++ b/packages/next/src/next-devtools/dev-overlay/hooks/use-active-runtime-error.ts
@@ -16,7 +16,8 @@ export function useActiveRuntimeError({
   activeIdx?: number
   setActiveIndex?: (index: number) => void
 }) {
-  const [uncontrolledActiveIdx, setUncontrolledActiveIndex] = useState<number>(0)
+  const [uncontrolledActiveIdx, setUncontrolledActiveIndex] =
+    useState<number>(0)
   const activeIdx = controlledActiveIdx ?? uncontrolledActiveIdx
   const setActiveIndex = controlledSetActiveIndex ?? setUncontrolledActiveIndex
 

--- a/packages/next/src/next-devtools/dev-overlay/hooks/use-active-runtime-error.ts
+++ b/packages/next/src/next-devtools/dev-overlay/hooks/use-active-runtime-error.ts
@@ -8,11 +8,17 @@ import { extractNextErrorCode } from '../../../lib/error-telemetry-utils'
 export function useActiveRuntimeError({
   runtimeErrors,
   getSquashedHydrationErrorDetails,
+  activeIdx: controlledActiveIdx,
+  setActiveIndex: controlledSetActiveIndex,
 }: {
   runtimeErrors: ReadyRuntimeError[]
   getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
+  activeIdx?: number
+  setActiveIndex?: (index: number) => void
 }) {
-  const [activeIdx, setActiveIndex] = useState<number>(0)
+  const [uncontrolledActiveIdx, setUncontrolledActiveIndex] = useState<number>(0)
+  const activeIdx = controlledActiveIdx ?? uncontrolledActiveIdx
+  const setActiveIndex = controlledSetActiveIndex ?? setUncontrolledActiveIndex
 
   const isLoading = useMemo<boolean>(() => {
     return runtimeErrors.length === 0

--- a/test/development/app-dir/instant-insights-tab-overlay/instant-insights-tab-overlay.test.ts
+++ b/test/development/app-dir/instant-insights-tab-overlay/instant-insights-tab-overlay.test.ts
@@ -39,31 +39,30 @@ describe('instant insights tab overlay', () => {
     return evalInPortal(browser, (root) => {
       const bar = root.querySelector('[data-nextjs-error-overlay-tab-bar]')
       if (!bar) return null
+      const tabs = bar.querySelectorAll('.error-overlay-tab')
+      const parseTotal = (tab: Element | undefined) => {
+        const totalEl = tab?.querySelector(
+          '.error-overlay-pagination-count > span:last-child'
+        )
+        return parseInt(totalEl?.textContent || '0', 10)
+      }
       return {
-        errors: parseInt(
-          bar.querySelector('.error-overlay-tab-count[data-variant="errors"]')
-            ?.textContent || '0',
-          10
-        ),
-        instant: parseInt(
-          bar.querySelector('.error-overlay-tab-count[data-variant="instant"]')
-            ?.textContent || '0',
-          10
-        ),
+        errors: parseTotal(tabs[0]),
+        instant: parseTotal(tabs[1]),
       }
     })
   }
 
   function getActiveErrorOverlayTab(browser: Playwright) {
     return evalInPortal(browser, (root) => {
-      const active = root.querySelector(
-        '[data-nextjs-error-overlay-tab-bar] .error-overlay-tab[data-active="true"]'
+      const bar = root.querySelector('[data-nextjs-error-overlay-tab-bar]')
+      if (!bar) return null
+      const tabs = [...bar.querySelectorAll('.error-overlay-tab')]
+      const activeIndex = tabs.findIndex(
+        (tab) => tab.getAttribute('data-active') === 'true'
       )
-      return (
-        active
-          ?.querySelector('.error-overlay-tab-count')
-          ?.getAttribute('data-variant') ?? null
-      )
+      if (activeIndex === -1) return null
+      return activeIndex === 0 ? 'errors' : 'instant'
     })
   }
 
@@ -71,11 +70,10 @@ describe('instant insights tab overlay', () => {
     return evalInPortal(browser, (root) => {
       const bar = root.querySelector('[data-nextjs-error-overlay-tab-bar]')
       if (!bar) return null
+      const variants = ['errors', 'instant'] as const
       return [...bar.querySelectorAll('.error-overlay-tab')].map(
-        (tab: any) => ({
-          variant: tab
-            .querySelector('.error-overlay-tab-count')
-            ?.getAttribute('data-variant'),
+        (tab: any, index: number) => ({
+          variant: variants[index],
           disabled: tab.disabled === true,
           active: tab.getAttribute('data-active') === 'true',
         })


### PR DESCRIPTION
### What?

Refines the new Errors/Insights tab treatment in the dev overlay and adds a Storybook scenario for exercising both tabs.

### Why?

The follow-up makes the pagination feel more coherent when switching between issues and insights, and gives us a reliable Storybook case for iterating on the tabbed UI.

### How?

- move the tab bar into the pagination area
- keep per-tab counts visible and let arrows page across tab boundaries
- thread the custom previous/next behavior through the overlay nav/pagination components
- add a mixed issues/insights Storybook fixture and story

### Verification

- `pnpm --filter=next types`
- Not run: `pnpm storybook` (`not run in this session`)

<!-- NEXT_JS_LLM_PR -->