### PR TITLE
docs: bodySizeLimit measures raw HTTP body

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -39,6 +39,8 @@ module.exports = {
 }
 ```
 
+The limit applies to the raw HTTP request body, including the bytes that `multipart/form-data` adds for boundaries, part headers, and field metadata. If you expect uploads close to the configured value, add a small allowance for that overhead; roughly 16 KB is comfortable headroom for typical multipart shapes.
+
 ## Enabling Server Actions (v13)
 
 Server Actions became a stable feature in Next.js 14, and are enabled by default. However, if you are using an earlier version of Next.js, you can enable them by setting `experimental.serverActions` to `true`.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -39,7 +39,7 @@ module.exports = {
 }
 ```
 
-The limit applies to the raw HTTP request body, including the bytes that `multipart/form-data` adds for boundaries, part headers, and field metadata. If you expect uploads close to the configured value, add a small allowance for that overhead; roughly 16 KB is comfortable headroom for typical multipart shapes.
+The limit applies to the raw HTTP request body, including the bytes that `multipart/form-data` adds for boundaries, part headers, and field metadata. If you expect uploads close to the configured value, leave some room for this overhead. For typical multipart uploads, an additional 10–20 KB is a reasonable rule of thumb.
 
 ## Enabling Server Actions (v13)
 


### PR DESCRIPTION
Started from https://github.com/vercel/next.js/discussions/93989 

Noticed we even have a test helper to account for overhead:

https://github.com/vercel/next.js/blob/fa4c0def823447e75366153690abeda79c7c4ec2/test/e2e/app-dir/actions/account-for-overhead.js#L1-L11

Let's document that the flag controls the raw http body size, overhead + data