### PR TITLE
[ci] Increase TEST_CONCURRENCY from 8 to 12

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -131,7 +131,7 @@ env:
   NODE_LTS_VERSION: 20.9.0
   # run-tests.js reads `TEST_CONCURRENCY` if no explicit `--concurrency` or `-c`
   # argument is provided
-  TEST_CONCURRENCY: 8
+  TEST_CONCURRENCY: 12
   # overrides `turbo_tasks::parallel::available_parallelism`. Smaller values are more CPU and memory
   # efficient, but won't fully utilize all available CPU cores. A small value here makes sense since
   # we're running many tests in parallel.


### PR DESCRIPTION
We're using 16 core machines, our `TEST_CONCURRENCY` of 8 is arbitrary. This tries increasing that to 12.

- GH Actions for 8 (control, #94142): https://github.com/vercel/next.js/actions/workflows/build_and_test.yml?query=branch%3Abgw%2Ftest-concurrency-8
- GH Actions for 12 (this branch): https://github.com/vercel/next.js/actions/workflows/build_and_test.yml?query=branch%3Abgw%2Ftest-concurrency-12
- GH Actions for 16 (#94133): https://github.com/vercel/next.js/actions/workflows/build_and_test.yml?query=branch%3Abgw%2Ftest-concurrency-16

It appeared that (across a couple of runs) that `TEST_CONCURRENCY=16` *may* lead to more test failures. Plausibly this could be due to timeouts. `TEST_CONCURRENCY=12` does not appear to be causing noticeably more failures than usual, and seems to be slightly speeding things up.

Datadog SQL:

```
SELECT
  SUM(duration) / 1000 / 1000 / 1000 / 60 as minutes,
  branch,
  ci_pipeline_id
FROM dd.ci_pipelines(
    columns => ARRAY ['@ci.pipeline.id', '@duration', '@git.branch'],
    event_type => 'step',
    filter => '@git.repository.id_v2:github.com/vercel/next.js @ci.pipeline.name:build-and-test @ci.provider.instance:github-actions @ci.pipeline.id:(26473602379-1 OR 26484229016-1 OR 26485947297-1 OR 26493064901-1 OR 26492002693-1 OR 26485986756-1 OR 26485929595-1 OR 26484214883-1 OR 26480156826-1)',
    from_timestamp => now() - INTERVAL '30 days',
    to_timestamp => now()
  ) AS (
    ci_pipeline_id VARCHAR,
    duration BIGINT,
    branch VARCHAR
  )
GROUP BY branch, ci_pipeline_id ORDER BY branch;
```

<img width="1193" height="807" alt="Screenshot 2026-05-26 at 11 07 05 PM" src="https://github.com/user-attachments/assets/bbd75ee1-9766-48a8-90da-6225908de251" />

