### PR TITLE
ServerActionsGraph: pass ModuleGraphLayer as OperationVc

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -17,7 +17,8 @@ use rustc_hash::FxHashMap;
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    CollectiblesSource, FxIndexMap, FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
+    CollectiblesSource, FxIndexMap, FxIndexSet, OperationVc, ResolvedVc, TryFlatJoinIterExt,
+    TryJoinIterExt, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -256,9 +257,8 @@ impl ServerActionsGraphs {
         let server_actions = async {
             graphs_ref
                 .iter()
-                .map(|graph| {
-                    ServerActionsGraph::new_with_entries(graph.connect(), is_single_page)
-                        .to_resolved()
+                .map(|&graph| {
+                    ServerActionsGraph::new_with_entries(graph, is_single_page).to_resolved()
                 })
                 .try_join()
                 .await
@@ -320,14 +320,14 @@ impl ServerActionsGraphs {
 impl ServerActionsGraph {
     #[turbo_tasks::function]
     pub async fn new_with_entries(
-        graph: ResolvedVc<ModuleGraphLayer>,
+        graph: OperationVc<ModuleGraphLayer>,
         is_single_page: bool,
     ) -> Result<Vc<Self>> {
-        let mapped = map_server_actions(*graph);
+        let mapped = map_server_actions(graph);
 
         Ok(ServerActionsGraph {
             is_single_page,
-            graph,
+            graph: graph.connect().to_resolved().await?,
             data: mapped.to_resolved().await?,
         }
         .cell())

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -21,7 +21,7 @@ use swc_core::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc, trace::TraceRawVcs,
+    FxIndexMap, NonLocalValue, OperationVc, ResolvedVc, TryFlatJoinIterExt, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
@@ -524,8 +524,9 @@ pub struct AllModuleActions(
 
 #[turbo_tasks::function]
 pub async fn map_server_actions(
-    graph: ResolvedVc<ModuleGraphLayer>,
+    graph: OperationVc<ModuleGraphLayer>,
 ) -> Result<Vc<AllModuleActions>> {
+    let graph = graph.connect();
     let actions = graph
         .await?
         .iter_reachable_modules()?


### PR DESCRIPTION
### What?

Threads the layer module graph through `ServerActionsGraph` and `map_server_actions` as an `OperationVc` instead of a resolved `Vc`, calling `connect()` at each consumer.

### Why?

Fixes the invalidation priority of `map_server_actions` so it is executed after the module graph on incremental builds. Previously, because the graph was resolved at construction time, the dependency ordering caused `map_server_actions` to be re-run before the module graph on incremental rebuilds.

### How?

By passing the layer graph as an `OperationVc` and calling `connect()` within each consumer task, the graph is resolved within the consuming task rather than at construction time. This restores the intended invalidation/scheduling order between the module graph and `map_server_actions`.

<!-- NEXT_JS_LLM_PR -->