### PR TITLE
fix(image-optimizer): respect updated upstream Cache-Control when reusing cached image

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -1164,7 +1164,7 @@ export async function imageOptimizer(
     return {
       buffer: previouslyCachedImage.buffer,
       contentType,
-      maxAge: opts?.previousCacheEntry?.cacheControl?.revalidate || maxAge,
+      maxAge,
       etag: previouslyCachedImage.etag,
       upstreamEtag: previouslyCachedImage.upstreamEtag,
     }

--- a/test/unit/image-optimizer/image-optimizer-max-age.test.ts
+++ b/test/unit/image-optimizer/image-optimizer-max-age.test.ts
@@ -1,0 +1,113 @@
+/* eslint-env jest */
+import { imageOptimizer, getImageEtag } from 'next/dist/server/image-optimizer'
+import {
+  CachedRouteKind,
+  IncrementalResponseCacheEntry,
+} from 'next/dist/server/response-cache/types'
+import { readFile } from 'fs-extra'
+import { join } from 'path'
+
+const nextConfig = {
+  experimental: {
+    imgOptConcurrency: null,
+    imgOptMaxInputPixels: undefined,
+    imgOptSequentialRead: null,
+    imgOptSkipMetadata: false,
+    imgOptTimeoutInSeconds: 7,
+  },
+  images: {
+    dangerouslyAllowSVG: false,
+    minimumCacheTTL: 60,
+  },
+} as unknown as Parameters<typeof imageOptimizer>[2]
+
+const paramsResult = {
+  href: 'https://example.com/test.jpg',
+  width: 64,
+  quality: 75,
+  mimeType: '',
+} as Parameters<typeof imageOptimizer>[1]
+
+describe('imageOptimizer maxAge with previously cached image', () => {
+  it('reflects the new upstream Cache-Control when reusing an unchanged cached image', async () => {
+    const buffer = await readFile(join(__dirname, './images/test.jpg'))
+    const upstreamEtag = getImageEtag(buffer)
+
+    // The previous cache entry was written when the upstream advertised a long
+    // TTL (1 year). The optimized etag differs from the upstream etag so the
+    // entry is eligible for reuse.
+    const previousCacheEntry = {
+      isStale: true,
+      isMiss: false,
+      isFallback: false,
+      revalidateAfter: 0,
+      cacheControl: { revalidate: 31536000, expire: undefined },
+      value: {
+        kind: CachedRouteKind.IMAGE,
+        upstreamEtag,
+        etag: 'optimized-etag',
+        buffer,
+        extension: 'jpeg',
+      },
+    } as unknown as IncrementalResponseCacheEntry
+
+    // On revalidation the upstream is re-fetched and now advertises a much
+    // shorter TTL. The source bytes are unchanged (same upstream etag) so the
+    // optimized buffer is reused, but the returned maxAge must reflect the new
+    // upstream header (300), not the stale persisted value (31536000).
+    const result = await imageOptimizer(
+      {
+        buffer,
+        contentType: 'image/jpeg',
+        cacheControl: 'max-age=300',
+        etag: upstreamEtag,
+      },
+      paramsResult,
+      nextConfig,
+      { silent: true, previousCacheEntry }
+    )
+
+    // Optimization was skipped: the previously optimized image is reused.
+    expect(result.etag).toBe('optimized-etag')
+    expect(result.upstreamEtag).toBe(upstreamEtag)
+    // The TTL reflects the freshly fetched upstream Cache-Control header.
+    expect(result.maxAge).toBe(300)
+  })
+
+  it('clamps the reused maxAge to minimumCacheTTL', async () => {
+    const buffer = await readFile(join(__dirname, './images/test.jpg'))
+    const upstreamEtag = getImageEtag(buffer)
+
+    const previousCacheEntry = {
+      isStale: true,
+      isMiss: false,
+      isFallback: false,
+      revalidateAfter: 0,
+      cacheControl: { revalidate: 31536000, expire: undefined },
+      value: {
+        kind: CachedRouteKind.IMAGE,
+        upstreamEtag,
+        etag: 'optimized-etag',
+        buffer,
+        extension: 'jpeg',
+      },
+    } as unknown as IncrementalResponseCacheEntry
+
+    // Upstream advertises a TTL below minimumCacheTTL (60), so the result is
+    // clamped up to minimumCacheTTL.
+    const result = await imageOptimizer(
+      {
+        buffer,
+        contentType: 'image/jpeg',
+        cacheControl: 'max-age=5',
+        etag: upstreamEtag,
+      },
+      paramsResult,
+      nextConfig,
+      { silent: true, previousCacheEntry }
+    )
+
+    expect(result.etag).toBe('optimized-etag')
+    expect(result.maxAge).toBe(60)
+  })
+})


### PR DESCRIPTION
### What?

When an optimized image is revalidated and the upstream source bytes are
unchanged (same upstream etag), Next.js reuses the previously optimized buffer
to skip re-encoding. This PR makes that path return the `maxAge` derived from
the **freshly re-fetched** upstream `Cache-Control` header, instead of the
`revalidate` value persisted in the previous cache entry.

### Why?

The optimized-image cache TTL was effectively frozen at the value computed on
the very first fetch. Because the reuse branch returned the *previous* entry's
`revalidate`, changing the upstream/CDN `Cache-Control` `max-age` was never
reflected as long as the source image bytes stayed identical — each
revalidation kept re-emitting the original TTL.

This reuse optimization was introduced in #67257; the buffer reuse itself is
correct (the optimized output is identical), but carrying over the old TTL was
an unintended side effect.

#### Reproduction

1. `images: { minimumCacheTTL: 0 }`, a remote/internal image whose upstream
   responds with `Cache-Control: max-age=2`.
2. `next build && next start`, request `/_next/image?url=...&w=64&q=75` →
   response `Cache-Control` reports `max-age=2`.
3. Let the cache entry go stale (> 2s).
4. Change the upstream to e.g. `Cache-Control: max-age=600` **without changing
   the image bytes**.
5. Request again → the response still reports `max-age=2`; the new value is
   never picked up.

(Originally observed under `output: 'standalone'`, but this is not specific to
standalone. The bug is in Next.js's built-in Image Optimization cache, which runs
on any self-hosted server (`next start` and `output: 'standalone'` alike). It does
not affect managed/minimal-mode deployments, where image optimization is handled
by the platform rather than this code path.)

### How?

In `imageOptimizer()`, the reuse branch returned
`opts?.previousCacheEntry?.cacheControl?.revalidate || maxAge`. The freshly
computed `maxAge` (already `Math.max(minimumCacheTTL, getMaxAge(upstream.cacheControl))`)
is now returned directly, so the buffer reuse / CPU optimization from #67257 is
preserved while the cache TTL tracks the current upstream header.

Added a unit test (`test/unit/image-optimizer/image-optimizer-max-age.test.ts`)
covering both the updated-`max-age` case and the `minimumCacheTTL` clamp. The
test fails before the change (`Received: 31536000`) and passes after.

<!-- NEXT_JS_LLM_PR -->
