### PR TITLE
fix(build): add import.meta.dirname and import.meta.filename to DefinePlugin

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -297,6 +297,8 @@ export function getDefineEnv({
     ...getImageConfig(config, dev),
     'process.env.__NEXT_ROUTER_BASEPATH': config.basePath,
     'process.env.__NEXT_HAS_REWRITES': hasRewrites,
+    'import.meta.dirname': '__dirname',
+    'import.meta.filename': '__filename',
     'process.env.__NEXT_CONFIG_OUTPUT': config.output,
     'process.env.__NEXT_I18N_SUPPORT': !!config.i18n,
     'process.env.__NEXT_I18N_DOMAINS': config.i18n?.domains ?? false,

--- a/test/e2e/app-dir/import-meta/app/page.tsx
+++ b/test/e2e/app-dir/import-meta/app/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  const dirname = import.meta.dirname
+  const filename = import.meta.filename
+  return (
+    <div>
+      <p id="dirname">{dirname}</p>
+      <p id="filename">{filename}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/import-meta/import-meta.test.ts
+++ b/test/e2e/app-dir/import-meta/import-meta.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('import-meta', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should have import.meta.dirname defined', async () => {
+    const $ = await next.render$('/')
+    expect($('#dirname').text()).not.toBe('undefined')
+    expect($('#dirname').text()).toContain('/')
+  })
+
+  it('should have import.meta.filename defined', async () => {
+    const $ = await next.render$('/')
+    expect($('#filename').text()).not.toBe('undefined')
+    expect($('#filename').text()).toContain('/')
+  })
+})

--- a/test/e2e/app-dir/import-meta/next.config.js
+++ b/test/e2e/app-dir/import-meta/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+module.exports = nextConfig


### PR DESCRIPTION
## Description
This PR adds support for import.meta.dirname and import.meta.filename in Next.js pages when using the Webpack bundler.

## Problem
Webpack versions prior to 5.103.0 do not support import.meta.dirname and import.meta.filename. Since Next.js currently uses webpack 5.98.0, these properties are undefined in pages.

## Solution
Added import.meta.dirname and import.meta.filename to the Webpack DefinePlugin configuration in packages/next/src/build/define-env.ts, mapping them to __dirname and __filename respectively.

## Verification
- [x] LSP diagnostics clean on changed files
- [ ] Type check passed (requires pnpm install)
- [ ] Tests passed (requires pnpm install)

## Note
Turbopack still does not support these properties and will require a separate fix.

Closes #60879