### PR TITLE
fix(dev): enable polling for file watching in Docker containers

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -7,6 +7,7 @@ import path from 'path'
 import fs from 'fs'
 
 import { getDefineEnv } from './define-env'
+import { isDocker } from '../lib/is-docker'
 import { escapeStringRegexp } from '../shared/lib/escape-regexp'
 import { WEBPACK_LAYERS, WEBPACK_RESOURCE_QUERIES } from '../lib/constants'
 import type { WebpackLayerName } from '../lib/constants'
@@ -147,6 +148,7 @@ const nodePathList = (process.env.NODE_PATH || '')
 
 const baseWatchOptions: webpack.Configuration['watchOptions'] = Object.freeze({
   aggregateTimeout: 5,
+  poll: isDocker() ? 1000 : undefined,
   ignored:
     // Matches **/node_modules/**, **/.git/** and **/.next/**
     /^((?:[^/]*(?:\/|$))*)(\.(git|next)|node_modules)(\/((?:[^/]*(?:\/|$))*)(?:$|\/))?/,

--- a/packages/next/src/lib/is-docker.test.ts
+++ b/packages/next/src/lib/is-docker.test.ts
@@ -1,0 +1,33 @@
+import { isDocker } from './is-docker'
+import fs from 'fs'
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}))
+
+describe('isDocker', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns true when /.dockerenv exists', () => {
+    ;(fs.existsSync as jest.Mock).mockReturnValue(true)
+    ;(fs.readFileSync as jest.Mock).mockReturnValue('')
+    expect(isDocker()).toBe(true)
+  })
+
+  it('returns true when /proc/self/cgroup contains docker', () => {
+    ;(fs.existsSync as jest.Mock).mockReturnValue(false)
+    ;(fs.readFileSync as jest.Mock).mockReturnValue('docker')
+    expect(isDocker()).toBe(true)
+  })
+
+  it('returns false when not in docker', () => {
+    ;(fs.existsSync as jest.Mock).mockReturnValue(false)
+    ;(fs.readFileSync as jest.Mock).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+    expect(isDocker()).toBe(false)
+  })
+})

--- a/packages/next/src/lib/is-docker.ts
+++ b/packages/next/src/lib/is-docker.ts
@@ -1,0 +1,12 @@
+import fs from 'fs'
+
+export function isDocker(): boolean {
+  try {
+    return (
+      fs.existsSync('/.dockerenv') ||
+      fs.readFileSync('/proc/self/cgroup', 'utf8').includes('docker')
+    )
+  } catch {
+    return false
+  }
+}

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -28,6 +28,7 @@ import type {
   NodeJsPartialHmrUpdate,
 } from '../../build/swc/types'
 import { createDefineEnv, getBindingsSync, HmrTarget } from '../../build/swc'
+import { isDocker } from '../../lib/is-docker'
 import * as Log from '../../build/output/log'
 import { BLOCKED_PAGES } from '../../shared/lib/constants'
 import {
@@ -386,7 +387,7 @@ export async function createHotReloaderTurbopack(
       nextConfig: opts.nextConfig,
       watch: {
         enable: dev,
-        pollIntervalMs: nextConfig.watchOptions?.pollIntervalMs,
+        pollIntervalMs: nextConfig.watchOptions?.pollIntervalMs ?? (isDocker() ? 1000 : undefined),
       },
       dev,
       env: process.env as Record<string, string>,


### PR DESCRIPTION
## Description
This PR adds automatic Docker environment detection and enables polling mode for file watching when running inside Docker containers.

## Problem
Next.js 15 changed the file watching mechanism, which broke hot reload inside Docker containers. Users had to manually set WATCHPACK_POLLING=true or configure webpackDevMiddleware as workarounds.

## Solution
- Added isDocker() utility function that detects Docker environment by checking for /.dockerenv file or docker in /proc/self/cgroup
- Updated Webpack aseWatchOptions to automatically enable polling (1000ms interval) when running in Docker
- Updated Turbopack pollIntervalMs to automatically enable polling when running in Docker
- Added unit tests for Docker detection

## Verification
- [x] LSP diagnostics clean on changed files
- [ ] Type check passed (requires pnpm install)
- [ ] Tests passed (requires pnpm install)

Closes #71622