### PR TITLE
fix(app-router): extract RouterContent to prevent hooks error

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -163,6 +163,27 @@ function Router({
   staticIndicatorState: StaticIndicatorState | undefined
 }) {
   const state = useActionQueue(actionQueue)
+  return (
+    <RouterContent
+      state={state}
+      globalError={globalError}
+      webSocket={webSocket}
+      staticIndicatorState={staticIndicatorState}
+    />
+  )
+}
+
+function RouterContent({
+  state,
+  globalError,
+  webSocket,
+  staticIndicatorState,
+}: {
+  state: AppRouterState
+  globalError: GlobalErrorState
+  webSocket: WebSocket | undefined
+  staticIndicatorState: StaticIndicatorState | undefined
+}) {
   const { canonicalUrl } = state
   // Add memoized pathname/query for useSearchParams and usePathname.
   const { searchParams, pathname } = useMemo(() => {


### PR DESCRIPTION
## Description
This PR fixes the 'Rendered more hooks than during the previous render' error that occurs in the App Router during navigation and redirects.

## Problem
The Router component calls useActionQueue followed by useMemo and other hooks. When the state returned by useActionQueue changes between renders (e.g., during redirects or navigation), the hook count can become inconsistent, causing React errors.

## Solution
Extracted the content after useActionQueue into a separate RouterContent component. This ensures that hooks are always called in the same order within each component, preventing the hooks error.

## Verification
- [x] LSP diagnostics clean on changed files
- [ ] Type check passed (requires pnpm install)
- [ ] Tests passed (requires pnpm install)

## Related
- Fixes #63121
- Related React issue: facebook/react#33580
- Community patch: https://github.com/vercel/next.js/issues/63121#issuecomment-4184781636