### PR TITLE
Tweak error overlay nav overflow

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-nav/error-overlay-nav.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-nav/error-overlay-nav.tsx
@@ -76,6 +76,7 @@ export const styles = `
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     flex-shrink: 0;
 
     width: 100%;
@@ -98,6 +99,19 @@ export const styles = `
 
       &[data-side='right'] {
         padding-left: 0;
+      }
+    }
+  }
+
+  @media (max-width: 767px) {
+    [data-nextjs-error-overlay-nav] {
+      overflow-x: auto;
+      overflow-y: hidden;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+
+      &::-webkit-scrollbar {
+        display: none;
       }
     }
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/version-staleness-info/version-staleness-info.tsx
@@ -56,6 +56,8 @@ export const styles = `
     justify-content: center;
     align-items: center;
     gap: 4px;
+    white-space: nowrap;
+    flex-shrink: 0;
 
     height: var(--size-24);
     padding: 6px 8px 6px 6px;


### PR DESCRIPTION
### What?

Tweaks the mobile behavior of the error overlay nav so the controls can scroll horizontally without breaking the version badge into multiple lines.

https://github.com/user-attachments/assets/c3e91d6c-a303-4a04-9655-0ec005e2e9e7

### Why?

On narrow screens the nav content can overflow, and the Next.js version badge was wrapping internally instead of staying intact while the nav scrolled.

### How?

- allow the error overlay nav row to scroll horizontally on mobile
- add a small gap between the left and right nav groups
- keep the version status badge on a single line with `white-space: nowrap`

### Verification

- `pnpm prettier --check packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-nav/error-overlay-nav.tsx packages/next/src/next-devtools/dev-overlay/components/version-staleness-info/version-staleness-info.tsx`
- Not run: `pnpm --filter=next types` (`not needed for these CSS-only tweaks`)

<!-- NEXT_JS_LLM_PR -->