### PR TITLE
Fix default regex for `require.context` in Turbopack analyzer

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3686,7 +3686,7 @@ pub fn parse_require_context(args: &[JsValue]) -> Result<RequireContextOptions> 
         // https://webpack.js.org/api/module-methods/#requirecontext
         // > optional, default /^\.\/.*$/, any file
         static DEFAULT_REGEX: LazyLock<EsRegex> =
-            LazyLock::new(|| EsRegex::new(r"^\\./.*$", "").unwrap());
+            LazyLock::new(|| EsRegex::new(r"^\./.*$", "").unwrap());
 
         DEFAULT_REGEX.clone()
     };

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-context-default-filter/input/deps/bar.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-context-default-filter/input/deps/bar.js
@@ -1,0 +1,1 @@
+exports.value = 'bar'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-context-default-filter/input/deps/foo.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-context-default-filter/input/deps/foo.js
@@ -1,0 +1,1 @@
+exports.value = 'foo'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-context-default-filter/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-context-default-filter/input/index.js
@@ -1,0 +1,12 @@
+// When require.context is called without an explicit filter regex,
+// the default /^\.\/.*$/ should be used (matches any file).
+it('require.context() uses the default filter when none is provided', () => {
+  const ctx = require.context('./deps', true)
+  expect(ctx.keys().sort()).toEqual(['./bar.js', './foo.js'])
+  expect(
+    ctx
+      .keys()
+      .map((k) => ctx(k).value)
+      .sort()
+  ).toEqual(['bar', 'foo'])
+})


### PR DESCRIPTION
Here is the original bug found by Claude:

```
static DEFAULT_REGEX: LazyLock<EsRegex> =
      LazyLock::new(|| EsRegex::new(r"^\\./.*$", "").unwrap());

  The raw string is the literal ^\\./.*$. Regex parses \\ as a single backslash,
   so this matches paths starting with \<any>/…. The comment correctly cites
  webpack's default /^\.\/.*$/ ("any file"); the Rust raw string should be
  r"^\./.*$" (single backslash). Today, every default require.context filter
  rejects valid relative paths.
```

This PR makes the suggested change + adds a unit test that was previously failing but now succeeds.