### PR TITLE
[ci] Disable hanging node 24 typescript tests on 16.2 backport branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -661,7 +661,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        # HACK: node 24 is hanging during `pnpm install` on this backport
+        # branch, only enable node 22 on this branch:
+        # https://vercel.slack.com/archives/C0B0LKK5QD7/p1779825011578549
+        node: [22]
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -683,7 +686,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        # HACK: node 24 is hanging during `pnpm install` on this backport
+        # branch, only enable node 22 on this branch:
+        # https://vercel.slack.com/archives/C0B0LKK5QD7/p1779825011578549
+        node: [22]
 
     uses: ./.github/workflows/build_reusable.yml
     with:


### PR DESCRIPTION
https://vercel.slack.com/archives/C0B0LKK5QD7/p1779825011578549

> I'm not having any luck reproducing this locally, and there's no useful logs from GitHub Actions. Looking at the timestamps, it successfully completes `pnpm install` and then hangs for 30m until it times out.

> I'm not seeing these failures in the `canary` branch, and this only happens with node 24. I'm just going to disable this job on the `next-16-2` branch. The failure doesn't appear to be indicative of any real issue on our end, it's more likely an issue with node or pnpm.

Example failure: https://github.com/vercel/next.js/actions/runs/26503905088/job/78051437920