### PR TITLE
Remove dead code from `JsValue::Binary` in `is_truthy`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -2460,25 +2460,6 @@ impl JsValue {
                         JsValue::Constant(b),
                     ) if a.is_value_type() => Some(a == b),
                     (
-                        PositiveBinaryOperator::StrictEqual,
-                        JsValue::Constant(a),
-                        JsValue::Constant(b),
-                    ) if a.is_value_type() => {
-                        let same_type = {
-                            use ConstantValue::*;
-                            matches!(
-                                (a, b),
-                                (Num(_), Num(_))
-                                    | (Str(_), Str(_))
-                                    | (BigInt(_), BigInt(_))
-                                    | (True | False, True | False)
-                                    | (Undefined, Undefined)
-                                    | (Null, Null)
-                            )
-                        };
-                        if same_type { Some(a == b) } else { None }
-                    }
-                    (
                         PositiveBinaryOperator::Equal,
                         JsValue::Constant(ConstantValue::Str(a)),
                         JsValue::Constant(ConstantValue::Str(b)),


### PR DESCRIPTION
This is another thing flagged by @bgw's Claude:

```
  3. Dead duplicate match arm in is_truthy for StrictEqual (lines 2469–2494)

  ( … StrictEqual, Constant(a), Constant(b)) if a.is_value_type() => Some(a ==
  b),
  ( … StrictEqual, Constant(a), Constant(b)) if a.is_value_type() => { /* 
  same-type check */ }

  Identical pattern + guard. The second arm — the only one that handles
  cross-type equality conservatively — is unreachable. Looks like a half-applied
   fix.
``` 

I've removed the second arm with a double type check. Tests appear to still pass and I can't think of a case where we'd hit the second arm.

