### PR TITLE
docs: fix "good first issue" label link by wrapping in quotes

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -39,7 +39,7 @@ Contributions to Next.js are welcome and highly appreciated. However, before you
 
 ### Good First Issues:
 
-We have a list of **[good first issues](https://github.com/vercel/next.js/labels/good%20first%20issue)** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
+We have a list of **[good first issues](https://github.com/vercel/next.js/labels/%22good%20first%20issue%22)** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
 
 ---
 ## Security


### PR DESCRIPTION
## Problem

The "good first issue" label link in the README points to `https://github.com/vercel/next.js/labels/good%20first%20issue` which doesn't work because GitHub interprets it as two separate labels ("good" and "first issue") instead of the single label "good first issue".

## Solution

Wrapped the label name in quotes so the URL correctly encodes the entire label name: `https://github.com/vercel/next.js/labels/%22good%20first%20issue%22`

Fixes #80472