### PR TITLE
test: unflake instant-navs-devtools test

### DIFF
--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -7,6 +7,18 @@ describe('instant-nav-panel', () => {
   })
 
   const targetPage = '/target-page/my-post?search=foo'
+  let cleanupBrowser: Playwright | undefined
+
+  async function openBrowser(pathname: string) {
+    const browser = await next.browser(pathname)
+    cleanupBrowser = browser
+    return browser
+  }
+
+  afterEach(async () => {
+    await cleanupBrowser?.deleteCookies()
+    cleanupBrowser = undefined
+  })
 
   async function waitForPanelRouterTransition() {
     // Run all the necessary CSS transitions
@@ -240,7 +252,7 @@ describe('instant-nav-panel', () => {
 
   async function openHomeWithTargetPageWarmup() {
     const [browser] = await Promise.all([
-      next.browser('/'),
+      openBrowser('/'),
       isNextDev && !isTurbopack
         ? // warmup target page compilation before clicking Start, to avoid extra flakiness.
           next.render(targetPage).catch(() => {})
@@ -254,7 +266,7 @@ describe('instant-nav-panel', () => {
 
   describe('idle state', () => {
     it('should open panel in the idle state', async () => {
-      const browser = await next.browser('/')
+      const browser = await openBrowser('/')
       await clearInstantModeCookie(browser)
       await browser.waitForElementByCss('[data-testid="home-title"]')
 
@@ -277,7 +289,7 @@ describe('instant-nav-panel', () => {
     })
 
     it('should not set cookie when closing panel from idle state', async () => {
-      const browser = await next.browser('/')
+      const browser = await openBrowser('/')
       await clearInstantModeCookie(browser)
       await browser.waitForElementByCss('[data-testid="home-title"]')
 
@@ -300,7 +312,7 @@ describe('instant-nav-panel', () => {
 
   describe('awaiting navigation state', () => {
     it('should reset the panel and app when pressing the close button from awaiting navigation', async () => {
-      const browser = await next.browser('/')
+      const browser = await openBrowser('/')
       await clearInstantModeCookie(browser)
       await browser.waitForElementByCss('[data-testid="home-title"]')
 
@@ -321,7 +333,7 @@ describe('instant-nav-panel', () => {
 
   describe('MPA captures', () => {
     it('should show page load state after clicking Start and refreshing', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await openBrowser(targetPage)
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)
@@ -334,7 +346,7 @@ describe('instant-nav-panel', () => {
     })
 
     it('should auto-open panel on page load when cookie is already set', async () => {
-      const browser = await next.browser('/')
+      const browser = await openBrowser('/')
       await clearInstantModeCookie(browser)
       await browser.waitForElementByCss('[data-testid="home-title"]')
 
@@ -357,7 +369,7 @@ describe('instant-nav-panel', () => {
     })
 
     it('should reset the panel and app when pressing the close button from captured MPA state', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await openBrowser(targetPage)
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)
@@ -377,7 +389,7 @@ describe('instant-nav-panel', () => {
     })
 
     it('should keep params and searchParams RSC content suspended for a captured MPA page load', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await openBrowser(targetPage)
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)
@@ -390,7 +402,7 @@ describe('instant-nav-panel', () => {
     })
 
     it('should show MPA state after clicking a link that crosses root layouts', async () => {
-      const browser = await next.browser('/')
+      const browser = await openBrowser('/')
       await clearInstantModeCookie(browser)
       await browser.waitForElementByCss('[data-testid="home-title"]')
       await waitForAppHydration(browser)
@@ -416,7 +428,7 @@ describe('instant-nav-panel', () => {
     })
 
     it('should re-arm capture and return to awaiting navigation after Continue Rendering from MPA state', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await openBrowser(targetPage)
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -1,8 +1,7 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { retry, toggleDevToolsIndicatorPopover } from 'next-test-utils'
 
-// FIXME: Skipped due to flakiness. Reenable when fixed
-describe.skip('instant-nav-panel', () => {
+describe('instant-nav-panel', () => {
   const { isNextDev, isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
@@ -69,26 +68,16 @@ describe.skip('instant-nav-panel', () => {
     }, href)
   }
 
+  function getInstantNavPanel(browser: Playwright) {
+    return browser.elementByCss('.instant-nav-panel')
+  }
+
   async function getInstantNavPanelText(browser: Playwright): Promise<string> {
-    return browser.elementByCssInstant('.instant-nav-panel').text()
+    return getInstantNavPanel(browser).text()
   }
 
   async function closePanelViaHeader(browser: Playwright) {
     return browser.elementByCss('#_next-devtools-panel-close').click()
-  }
-
-  async function hasInstantNavPanelOpen(browser: Playwright): Promise<void> {
-    await browser.elementByCssInstant('.instant-nav-panel')
-  }
-
-  async function waitForInstantNavPanelOpen(browser: Playwright) {
-    await retry(
-      async () => {
-        await hasInstantNavPanelOpen(browser)
-      },
-      5_000,
-      500
-    )
   }
 
   async function waitForAppHydration(browser: Playwright) {
@@ -102,7 +91,7 @@ describe.skip('instant-nav-panel', () => {
     await waitForPanelRouterTransition()
     await clickInstantNavMenuItem(browser)
 
-    await waitForInstantNavPanelOpen(browser)
+    await getInstantNavPanel(browser)
     await waitForPanelRouterTransition()
   }
 
@@ -149,7 +138,7 @@ describe.skip('instant-nav-panel', () => {
       5_000,
       250
     )
-    await waitForInstantNavPanelOpen(browser)
+    await getInstantNavPanel(browser)
     await waitForPanelRouterTransition()
   }
 
@@ -339,7 +328,7 @@ describe.skip('instant-nav-panel', () => {
 
       await clickStartCapturing(browser)
       await browser.refresh()
-      await waitForInstantNavPanelOpen(browser)
+      await getInstantNavPanel(browser)
 
       await expectMpaPanel(browser)
     })
@@ -358,7 +347,6 @@ describe.skip('instant-nav-panel', () => {
       await browser.waitForElementByCss('[data-testid="home-title"]')
 
       await retry(async () => {
-        await hasInstantNavPanelOpen(browser)
         const text = await getInstantNavPanelText(browser)
         expect(text).toContain('Page load')
         expect(text).toContain('prerendered UI')
@@ -375,7 +363,7 @@ describe.skip('instant-nav-panel', () => {
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
       await browser.refresh()
-      await waitForInstantNavPanelOpen(browser)
+      await getInstantNavPanel(browser)
       await expectMpaPanel(browser)
       await expectTargetPageMpaShell(browser)
 
@@ -395,7 +383,7 @@ describe.skip('instant-nav-panel', () => {
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
       await browser.refresh()
-      await waitForInstantNavPanelOpen(browser)
+      await getInstantNavPanel(browser)
       await expectMpaPanel(browser)
 
       await expectTargetPageMpaShell(browser)
@@ -416,7 +404,7 @@ describe.skip('instant-nav-panel', () => {
           .click()
       })
       await browser.waitForElementByCss('[data-testid="mpa-target-title"]')
-      await waitForInstantNavPanelOpen(browser)
+      await getInstantNavPanel(browser)
 
       await expectMpaPanel(browser)
       await browser
@@ -434,7 +422,7 @@ describe.skip('instant-nav-panel', () => {
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
       await browser.refresh()
-      await waitForInstantNavPanelOpen(browser)
+      await getInstantNavPanel(browser)
       await expectMpaPanel(browser)
       await expectTargetPageMpaShell(browser)
       await waitForAppHydration(browser)
@@ -553,7 +541,7 @@ describe.skip('instant-nav-panel', () => {
       await browser.refresh()
       await browser.waitForElementByCss('[data-testid="home-title"]')
       await waitForAppHydration(browser)
-      await waitForInstantNavPanelOpen(browser)
+      await getInstantNavPanel(browser)
       await expectMpaPanel(browser)
 
       await clickLink(browser, targetPage)
@@ -570,7 +558,7 @@ describe.skip('instant-nav-panel', () => {
       await expectSpaPanel(browser)
 
       await browser.refresh()
-      await waitForInstantNavPanelOpen(browser)
+      await getInstantNavPanel(browser)
 
       const initialPanelText = await getInstantNavPanelText(browser)
       expect(initialPanelText).toContain('Page load')


### PR DESCRIPTION
The `elementByCssInstant` call seems flaky (shows up in failed test runs 500 times today: [see datadog](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.status%3A%22fail%22%20%40test.suite%3Ainstant-nav-panel%20%40error.message%3A%2ATimeout%5C%2010ms%5C%20exceeded.%2A&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1779311563529&end=1779916363529&paused=true)). It doesn't seem to be load bearing (the test suite still passes after replacing it with a normal `elementByCss`), so i'm gonna get rid of this. This also lets us remove a unecessary retry loop.