### PR TITLE
Switch `TotalOrderF64` to `f64` in `ConstantNumber` to correctly handle `NaN === NaN` and `0 === -0` inside the Turbopack analyzer

### DIFF
--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -847,9 +847,9 @@ async fn parse_config_value(
             };
 
             match value {
-                JsValue::Constant(ConstantValue::Num(ConstantNumber(val))) if *val >= 0.0 => {
+                JsValue::Constant(ConstantValue::Num(ConstantNumber(val))) if val >= 0.0 => {
                     config.revalidate = Some(NextRevalidate::Frequency {
-                        seconds: *val as u32,
+                        seconds: val as u32,
                     });
                 }
                 JsValue::Constant(ConstantValue::False) => {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -106,7 +106,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 let JsValue::Constant(ConstantValue::Num(num)) = arg else {
                     return false;
                 };
-                sum += *num.0;
+                sum += num.0;
             }
             *value = JsValue::Constant(ConstantValue::Num(sum.into()));
             true

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
@@ -160,7 +160,7 @@ impl EvalContext {
                 op: op!(unary, "-"),
                 arg: box Expr::Lit(Lit::Num(n)),
                 ..
-            }) => JsValue::Constant(ConstantValue::Num(ConstantNumber((-n.value)))),
+            }) => JsValue::Constant(ConstantValue::Num(ConstantNumber(-n.value))),
 
             Expr::Unary(UnaryExpr {
                 op: op!("!"), arg, ..

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
@@ -160,7 +160,7 @@ impl EvalContext {
                 op: op!(unary, "-"),
                 arg: box Expr::Lit(Lit::Num(n)),
                 ..
-            }) => JsValue::Constant(ConstantValue::Num(ConstantNumber((-n.value).into()))),
+            }) => JsValue::Constant(ConstantValue::Num(ConstantNumber((-n.value)))),
 
             Expr::Unary(UnaryExpr {
                 op: op!("!"), arg, ..

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/constants.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/constants.rs
@@ -12,14 +12,13 @@ use swc_core::{
     ecma::{ast::Lit, atoms::Atom},
 };
 use turbo_rcstr::RcStr;
-use turbopack_core::compile_time_info::TotalOrderF64;
 
 use crate::{
     analyzer::{JsValue, imports::ImportAnnotations},
     utils::StringifyJs,
 };
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq)]
 pub enum ObjectPart {
     KeyValue(JsValue, JsValue),
     Spread(JsValue),
@@ -31,15 +30,22 @@ impl Default for ObjectPart {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ConstantNumber(pub TotalOrderF64);
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConstantNumber(pub f64);
 
 impl ConstantNumber {
     pub fn as_u32_index(&self) -> Option<usize> {
-        let index: u32 = *self.0 as u32;
-        (index as f64 == *self.0).then_some(index as usize)
+        let index: u32 = self.0 as u32;
+        (index as f64 == self.0).then_some(index as usize)
     }
 }
+
+impl Hash for ConstantNumber {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_ne_bytes().hash(state);
+    }
+}
+
 impl From<f64> for ConstantNumber {
     fn from(value: f64) -> Self {
         ConstantNumber(value.into())
@@ -123,7 +129,7 @@ impl From<RcStr> for ConstantString {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Hash)]
 pub enum ConstantValue {
     #[default]
     Undefined,
@@ -157,7 +163,7 @@ impl ConstantValue {
             Self::Undefined | Self::False | Self::Null => false,
             Self::True | Self::Regex(..) => true,
             Self::Str(s) => !s.is_empty(),
-            Self::Num(ConstantNumber(n)) => **n != 0.0,
+            Self::Num(ConstantNumber(n)) => *n != 0.0,
             Self::BigInt(n) => !n.is_zero(),
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/constants.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/constants.rs
@@ -48,7 +48,7 @@ impl Hash for ConstantNumber {
 
 impl From<f64> for ConstantNumber {
     fn from(value: f64) -> Self {
-        ConstantNumber(value.into())
+        ConstantNumber(value)
     }
 }
 
@@ -221,7 +221,7 @@ impl From<Lit> for ConstantValue {
                 }
             }
             Lit::Null(_) => ConstantValue::Null,
-            Lit::Num(v) => ConstantValue::Num(ConstantNumber(v.value.into())),
+            Lit::Num(v) => ConstantValue::Num(ConstantNumber(v.value)),
             Lit::BigInt(v) => ConstantValue::BigInt(v.value),
             Lit::Regex(v) => ConstantValue::Regex(Box::new((v.exp, v.flags))),
             Lit::JSXText(v) => ConstantValue::Str(ConstantString::Atom(v.value)),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
@@ -464,7 +464,7 @@ impl From<Box<BigInt>> for JsValue {
 
 impl From<f64> for JsValue {
     fn from(v: f64) -> Self {
-        ConstantValue::Num(ConstantNumber(v.into())).into()
+        ConstantValue::Num(ConstantNumber(v)).into()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
@@ -96,7 +96,7 @@ fn pretty_join(
 /// - Replace all built-in functions with their values when they are compile-time constant.
 /// - For optimization, any nested operations are replaced with [JsValue::Unknown]. So only one
 ///   layer of operation remains. Any remaining operation or placeholder can be treated as unknown.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq)]
 pub enum JsValue {
     // LEAF VALUES
     // ----------------------------
@@ -213,7 +213,7 @@ pub enum JsValue {
 /// (`MemberCall(total, obj, prop, [args])`) by writing obj/prop/args as siblings inside the
 /// parent's `debug_tuple`. This keeps fixture snapshots identical to the 4-tuple-payload
 /// version without forcing a hand-written `Debug` on every `JsValue` arm.
-#[derive(Default, Clone, Hash, PartialEq, Eq)]
+#[derive(Default, Clone, Hash, PartialEq)]
 pub struct MemberCallList(Vec<JsValue>);
 
 impl fmt::Debug for MemberCallList {
@@ -338,7 +338,7 @@ impl MemberCallList {
 ///
 /// The custom `Debug` impl re-emits the pre-refactor `(callee, [args])` shape so fixture
 /// snapshots remain identical to the 3-tuple-payload version.
-#[derive(Default, Clone, Hash, PartialEq, Eq)]
+#[derive(Default, Clone, Hash, PartialEq)]
 pub struct CallList(Vec<JsValue>);
 
 impl fmt::Debug for CallList {
@@ -500,7 +500,7 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
             CompileTimeDefineValue::Undefined => ConstantValue::Undefined,
             CompileTimeDefineValue::Null => ConstantValue::Null,
             CompileTimeDefineValue::Bool(b) => (*b).into(),
-            CompileTimeDefineValue::Number(n) => ConstantValue::Num(ConstantNumber(*n)),
+            CompileTimeDefineValue::Number(n) => ConstantValue::Num(ConstantNumber(**n)),
             CompileTimeDefineValue::BigInt(n) => ConstantValue::BigInt(n.clone()),
             CompileTimeDefineValue::String(s) => s.as_str().into(),
             CompileTimeDefineValue::Regex(pattern, flags) => {
@@ -548,7 +548,7 @@ impl TryFrom<&ConstantValue> for CompileTimeDefineValue {
             ConstantValue::Null => CompileTimeDefineValue::Null,
             ConstantValue::True => CompileTimeDefineValue::Bool(true),
             ConstantValue::False => CompileTimeDefineValue::Bool(false),
-            ConstantValue::Num(n) => CompileTimeDefineValue::Number(n.0),
+            ConstantValue::Num(n) => CompileTimeDefineValue::Number(n.0.into()),
             ConstantValue::Str(s) => CompileTimeDefineValue::String(s.as_rcstr()),
             ConstantValue::BigInt(n) => CompileTimeDefineValue::BigInt(n.clone()),
             ConstantValue::Regex(regex) => CompileTimeDefineValue::Regex(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -39,7 +39,7 @@ const LIMIT_NODE_SIZE: u32 = 100;
 const LIMIT_IN_PROGRESS_NODES: u32 = 500;
 const LIMIT_LINK_STEPS: u32 = 1500;
 
-#[derive(Debug, Hash, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 enum Step {
     /// Take all children out of the value (replacing temporarily with unknown) and queue them
     /// for processing using individual `Enter`s.

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/kinds.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/kinds.rs
@@ -151,7 +151,7 @@ impl WellKnownObjectKind {
 }
 
 /// A list of well-known functions that have special meaning in the analysis.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq)]
 pub enum WellKnownFunctionKind {
     ArrayFilter,
     ArrayForEach,

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -112,11 +112,9 @@ impl ModuleReference for WebpackChunkAssetReference {
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         let runtime = self.runtime.await?;
         Ok(match &*runtime {
-            WebpackRuntime::Webpack5 {
-                chunk_request_expr: _,
-                context_path,
-            } => {
-                // TODO determine filename from chunk_request_expr
+            WebpackRuntime::Webpack5 { context_path } => {
+                // TODO: Determine the filename from the chunk filename in `webpack_runtime()`,
+                // refer to `is_webpack_runtime()` in https://github.com/vercel/next.js/commit/f6d8529af54b78e913f0f743ab6cace851b32e4f for a partial implentation
                 let chunk_id = match &self.chunk_id {
                     Lit::Str(str) => str.value.to_string_lossy().into_owned(),
                     Lit::Num(num) => format!("{num}"),

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -31,7 +31,6 @@ pub enum WebpackRuntime {
         /// There is a [JsValue]::FreeVar("chunkId") that need to be replaced
         /// before converting to string
         #[turbo_tasks(trace_ignore)]
-        chunk_request_expr: JsValue,
         context_path: FileSystemPath,
     },
     None,
@@ -209,34 +208,14 @@ pub async fn webpack_runtime(
     )
     .await?;
     match &*parsed {
-        ParseResult::Ok {
-            program,
-            eval_context,
-            globals,
-            ..
-        } => {
+        ParseResult::Ok { program, .. } => {
             if let Some(stmts) = program_iife(program)
                 && stmts.iter().any(is_webpack_require_decl)
             {
-                // extract webpack/runtime/get javascript chunk filename
-                let chunk_filename = GLOBALS.set(globals, || {
-                    get_javascript_chunk_filename(stmts, eval_context)
-                });
-
-                let prefix_path = get_require_prefix(stmts);
-
-                if let (Some(chunk_filename), Some(prefix_path)) = (chunk_filename, prefix_path) {
-                    let value = JsValue::concat(vec![
-                        JsValue::Constant(prefix_path.into()),
-                        chunk_filename,
-                    ]);
-
-                    return Ok(WebpackRuntime::Webpack5 {
-                        chunk_request_expr: value,
-                        context_path: source.ident().await?.path.parent(),
-                    }
-                    .cell());
+                return Ok(WebpackRuntime::Webpack5 {
+                    context_path: source.ident().await?.path.parent(),
                 }
+                .cell());
             }
         }
         ParseResult::Unparsable { .. } | ParseResult::NotFound => {}

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -1,16 +1,6 @@
-use std::borrow::Cow;
-
 use anyhow::Result;
-use swc_core::{
-    common::GLOBALS,
-    ecma::{
-        ast::{
-            ArrowExpr, AssignOp, AssignTarget, BinExpr, BinaryOp, CallExpr, Callee, Expr,
-            ExprOrSpread, ExprStmt, FnExpr, Lit, Module, ModuleItem, Program, Script,
-            SimpleAssignTarget, Stmt,
-        },
-        visit::{Visit, VisitWith},
-    },
+use swc_core::ecma::ast::{
+    ArrowExpr, CallExpr, Callee, Expr, ExprStmt, FnExpr, Module, ModuleItem, Program, Script, Stmt,
 };
 use turbo_rcstr::rcstr;
 use turbo_tasks::Vc;
@@ -19,7 +9,6 @@ use turbopack_core::{compile_time_info::CompileTimeInfo, source::Source};
 
 use crate::{
     EcmascriptInputTransforms, EcmascriptModuleAssetType,
-    analyzer::{JsValue, graph::EvalContext},
     parse::{ParseResult, parse},
     utils::unparen,
 };
@@ -27,12 +16,7 @@ use crate::{
 #[turbo_tasks::value(shared, serialization = "skip")]
 #[derive(Debug)]
 pub enum WebpackRuntime {
-    Webpack5 {
-        /// There is a [JsValue]::FreeVar("chunkId") that need to be replaced
-        /// before converting to string
-        #[turbo_tasks(trace_ignore)]
-        context_path: FileSystemPath,
-    },
+    Webpack5 { context_path: FileSystemPath },
     None,
 }
 
@@ -77,56 +61,6 @@ fn is_webpack_require_decl(stmt: &Stmt) -> bool {
     false
 }
 
-fn get_assign_target_identifier(expr: &AssignTarget) -> Option<Cow<'_, str>> {
-    match expr.as_simple()? {
-        SimpleAssignTarget::Ident(ident) => Some(Cow::Borrowed(&*ident.sym)),
-        SimpleAssignTarget::Member(member) => {
-            if let Some(obj_name) = get_expr_identifier(&member.obj)
-                && let Some(ident) = member.prop.as_ident()
-            {
-                return Some(Cow::Owned(obj_name.into_owned() + "." + &*ident.sym));
-            }
-            None
-        }
-        SimpleAssignTarget::Paren(p) => get_expr_identifier(&p.expr),
-
-        _ => None,
-    }
-}
-
-fn get_expr_identifier(expr: &Expr) -> Option<Cow<'_, str>> {
-    let expr = unparen(expr);
-    if let Some(ident) = expr.as_ident() {
-        return Some(Cow::Borrowed(&*ident.sym));
-    }
-    if let Some(member) = expr.as_member()
-        && let Some(ident) = member.prop.as_ident()
-        && let Some(obj_name) = get_expr_identifier(&member.obj)
-    {
-        return Some(Cow::Owned(obj_name.into_owned() + "." + &*ident.sym));
-    }
-    None
-}
-
-fn get_assignment<'a>(stmts: &'a Vec<Stmt>, property: &str) -> Option<&'a Expr> {
-    for stmt in stmts {
-        if let Some(stmts) = iife(stmt)
-            && let Some(result) = get_assignment(stmts, property)
-        {
-            return Some(result);
-        }
-        if let Some(expr_stmt) = stmt.as_expr()
-            && let Some(assign) = unparen(&expr_stmt.expr).as_assign()
-            && assign.op == AssignOp::Assign
-            && let Some(name) = get_assign_target_identifier(&assign.left)
-            && name == property
-        {
-            return Some(unparen(&assign.right));
-        }
-    }
-    None
-}
-
 fn get_fn_body(expr: &Expr) -> Option<&Vec<Stmt>> {
     let expr = unparen(expr);
     if let Some(FnExpr { function, .. }) = expr.as_fn_expr()
@@ -138,49 +72,6 @@ fn get_fn_body(expr: &Expr) -> Option<&Vec<Stmt>> {
         && let Some(block) = body.as_block_stmt()
     {
         return Some(&block.stmts);
-    }
-    None
-}
-
-fn get_javascript_chunk_filename(stmts: &Vec<Stmt>, eval_context: &EvalContext) -> Option<JsValue> {
-    if let Some(expr) = get_assignment(stmts, "__webpack_require__.u")
-        && let Some(stmts) = get_fn_body(expr)
-        && let Some(ret) = stmts.iter().find_map(|stmt| stmt.as_return_stmt())
-        && let Some(expr) = &ret.arg
-    {
-        return Some(eval_context.eval(expr));
-    }
-    None
-}
-
-struct RequirePrefixVisitor {
-    result: Option<Lit>,
-}
-
-impl Visit for RequirePrefixVisitor {
-    fn visit_call_expr(&mut self, call: &CallExpr) {
-        if let Some(expr) = call.callee.as_expr()
-            && let Some(name) = get_expr_identifier(expr)
-            && name == "require"
-            && let [ExprOrSpread { spread: None, expr }] = &call.args[..]
-            && let Some(BinExpr {
-                op: BinaryOp::Add,
-                left,
-                ..
-            }) = expr.as_bin()
-        {
-            self.result = left.as_lit().cloned();
-            return;
-        }
-        call.visit_children_with(self);
-    }
-}
-
-fn get_require_prefix(stmts: &Vec<Stmt>) -> Option<Lit> {
-    if let Some(expr) = get_assignment(stmts, "__webpack_require__.f.require") {
-        let mut visitor = RequirePrefixVisitor { result: None };
-        expr.visit_children_with(&mut visitor);
-        return visitor.result;
     }
     None
 }

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
@@ -37,9 +37,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
@@ -7,9 +7,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
@@ -6,9 +6,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -325,9 +323,7 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -370,9 +366,7 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        2.0,
-                    ),
+                    2.0,
                 ),
             ),
         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
@@ -4,9 +4,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -31,9 +29,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    1.0,
-                                ),
+                                1.0,
                             ),
                         ),
                     ),
@@ -70,9 +66,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -125,9 +119,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -146,9 +138,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            2.0,
-                        ),
+                        2.0,
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph.snapshot
@@ -7,9 +7,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            3.0,
-                        ),
+                        3.0,
                     ),
                 ),
             ),
@@ -23,9 +21,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            3.0,
-                        ),
+                        3.0,
                     ),
                 ),
             ),
@@ -39,9 +35,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -55,9 +49,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -71,9 +63,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            2.0,
-                        ),
+                        2.0,
                     ),
                 ),
             ),
@@ -87,9 +77,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -103,9 +91,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            2.0,
-                        ),
+                        2.0,
                     ),
                 ),
             ),
@@ -119,9 +105,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            2.0,
-                        ),
+                        2.0,
                     ),
                 ),
             ),
@@ -135,9 +119,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -151,9 +133,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            2.0,
-                        ),
+                        2.0,
                     ),
                 ),
             ),
@@ -212,9 +192,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            4.0,
-                        ),
+                        4.0,
                     ),
                 ),
             ),
@@ -283,9 +261,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            4.0,
-                        ),
+                        4.0,
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
@@ -41,9 +41,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -64,9 +62,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -87,18 +83,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -114,18 +106,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -141,18 +129,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
@@ -59,9 +59,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -127,9 +125,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            2.0,
-                        ),
+                        2.0,
                     ),
                 ),
             ),
@@ -195,9 +191,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            2.0,
-                        ),
+                        2.0,
                     ),
                 ),
             ),
@@ -263,9 +257,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -279,27 +271,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -321,27 +307,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -363,27 +343,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                8.0,
-                            ),
+                            8.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
@@ -51,9 +51,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        123.0,
-                    ),
+                    123.0,
                 ),
             ),
         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
@@ -6135,9 +6135,7 @@
                                                                 Constant(
                                                                     Num(
                                                                         ConstantNumber(
-                                                                            TotalOrderF64(
-                                                                                493.0,
-                                                                            ),
+                                                                            493.0,
                                                                         ),
                                                                     ),
                                                                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
@@ -111,9 +111,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -292,9 +290,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
@@ -90,9 +90,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),
@@ -111,9 +109,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
@@ -90,9 +90,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),
@@ -111,9 +109,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph.snapshot
@@ -20,9 +20,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-effects.snapshot
@@ -99,9 +99,7 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                1.0,
-                                            ),
+                                            1.0,
                                         ),
                                     ),
                                 ),
@@ -110,9 +108,7 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                1.0,
-                                            ),
+                                            1.0,
                                         ),
                                     ),
                                 ),
@@ -385,9 +381,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -396,9 +390,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -532,9 +524,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -543,9 +533,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph.snapshot
@@ -71,27 +71,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -114,18 +108,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1.0,
-                                    ),
+                                    1.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        2.0,
-                                    ),
+                                    2.0,
                                 ),
                             ),
                         ),
@@ -137,18 +127,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -191,18 +177,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -212,18 +194,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -239,27 +217,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -269,9 +241,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
@@ -447,9 +447,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -680876936.0,
-                            ),
+                            -680876936.0,
                         ),
                     ),
                 ),
@@ -691,9 +689,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -389564586.0,
-                            ),
+                            -389564586.0,
                         ),
                     ),
                 ),
@@ -1177,9 +1173,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1044525330.0,
-                            ),
+                            -1044525330.0,
                         ),
                     ),
                 ),
@@ -1421,9 +1415,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -176418897.0,
-                            ),
+                            -176418897.0,
                         ),
                     ),
                 ),
@@ -1907,9 +1899,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1473231341.0,
-                            ),
+                            -1473231341.0,
                         ),
                     ),
                 ),
@@ -2151,9 +2141,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -45705983.0,
-                            ),
+                            -45705983.0,
                         ),
                     ),
                 ),
@@ -2637,9 +2625,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1958414417.0,
-                            ),
+                            -1958414417.0,
                         ),
                     ),
                 ),
@@ -2881,9 +2867,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -42063.0,
-                            ),
+                            -42063.0,
                         ),
                     ),
                 ),
@@ -3125,9 +3109,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1990404162.0,
-                            ),
+                            -1990404162.0,
                         ),
                     ),
                 ),
@@ -3611,9 +3593,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -40341101.0,
-                            ),
+                            -40341101.0,
                         ),
                     ),
                 ),
@@ -3855,9 +3835,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1502002290.0,
-                            ),
+                            -1502002290.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
@@ -184,9 +184,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -440,9 +438,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -538,9 +534,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -676,9 +670,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
@@ -690,9 +682,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -788,9 +778,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -926,9 +914,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
@@ -940,9 +926,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -951,9 +935,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                606105819.0,
-                            ),
+                            606105819.0,
                         ),
                     ),
                 ),
@@ -1038,9 +1020,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -1176,9 +1156,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -1190,9 +1168,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -1288,9 +1264,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -1426,9 +1400,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            4.0,
-                                        ),
+                                        4.0,
                                     ),
                                 ),
                             ),
@@ -1440,9 +1412,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -1538,9 +1508,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -1676,9 +1644,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            5.0,
-                                        ),
+                                        5.0,
                                     ),
                                 ),
                             ),
@@ -1690,9 +1656,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -1701,9 +1665,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1200080426.0,
-                            ),
+                            1200080426.0,
                         ),
                     ),
                 ),
@@ -1788,9 +1750,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -1926,9 +1886,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            6.0,
-                                        ),
+                                        6.0,
                                     ),
                                 ),
                             ),
@@ -1940,9 +1898,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -2038,9 +1994,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -2176,9 +2130,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            7.0,
-                                        ),
+                                        7.0,
                                     ),
                                 ),
                             ),
@@ -2190,9 +2142,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -2288,9 +2238,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                8.0,
-                            ),
+                            8.0,
                         ),
                     ),
                 ),
@@ -2426,9 +2374,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            8.0,
-                                        ),
+                                        8.0,
                                     ),
                                 ),
                             ),
@@ -2440,9 +2386,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -2451,9 +2395,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1770035416.0,
-                            ),
+                            1770035416.0,
                         ),
                     ),
                 ),
@@ -2538,9 +2480,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -2676,9 +2616,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            9.0,
-                                        ),
+                                        9.0,
                                     ),
                                 ),
                             ),
@@ -2690,9 +2628,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -2788,9 +2724,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -2926,9 +2860,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            10.0,
-                                        ),
+                                        10.0,
                                     ),
                                 ),
                             ),
@@ -2940,9 +2872,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -3038,9 +2968,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -3176,9 +3104,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            11.0,
-                                        ),
+                                        11.0,
                                     ),
                                 ),
                             ),
@@ -3190,9 +3116,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -3288,9 +3212,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -3426,9 +3348,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            12.0,
-                                        ),
+                                        12.0,
                                     ),
                                 ),
                             ),
@@ -3440,9 +3360,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -3451,9 +3369,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1804603682.0,
-                            ),
+                            1804603682.0,
                         ),
                     ),
                 ),
@@ -3538,9 +3454,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                13.0,
-                            ),
+                            13.0,
                         ),
                     ),
                 ),
@@ -3676,9 +3590,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            13.0,
-                                        ),
+                                        13.0,
                                     ),
                                 ),
                             ),
@@ -3690,9 +3602,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -3788,9 +3698,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -3926,9 +3834,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            14.0,
-                                        ),
+                                        14.0,
                                     ),
                                 ),
                             ),
@@ -3940,9 +3846,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -4038,9 +3942,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -4176,9 +4078,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            15.0,
-                                        ),
+                                        15.0,
                                     ),
                                 ),
                             ),
@@ -4190,9 +4090,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -4201,9 +4099,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1236535329.0,
-                            ),
+                            1236535329.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -69,9 +69,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -680876936.0,
-                                    ),
+                                    -680876936.0,
                                 ),
                             ),
                         ),
@@ -147,9 +145,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -176418897.0,
-                                    ),
+                                    -176418897.0,
                                 ),
                             ),
                         ),
@@ -333,9 +329,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -271733879.0,
-                            ),
+                            -271733879.0,
                         ),
                     ),
                 ),
@@ -409,9 +403,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1044525330.0,
-                                    ),
+                                    -1044525330.0,
                                 ),
                             ),
                         ),
@@ -487,9 +479,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -45705983.0,
-                                    ),
+                                    -45705983.0,
                                 ),
                             ),
                         ),
@@ -565,9 +555,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1990404162.0,
-                                    ),
+                                    -1990404162.0,
                                 ),
                             ),
                         ),
@@ -675,9 +663,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1732584194.0,
-                            ),
+                            -1732584194.0,
                         ),
                     ),
                 ),
@@ -827,9 +813,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1473231341.0,
-                                    ),
+                                    -1473231341.0,
                                 ),
                             ),
                         ),
@@ -905,9 +889,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -42063.0,
-                                    ),
+                                    -42063.0,
                                 ),
                             ),
                         ),
@@ -983,9 +965,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1502002290.0,
-                                    ),
+                                    -1502002290.0,
                                 ),
                             ),
                         ),
@@ -1084,9 +1064,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -389564586.0,
-                                    ),
+                                    -389564586.0,
                                 ),
                             ),
                         ),
@@ -1238,9 +1216,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1958414417.0,
-                                    ),
+                                    -1958414417.0,
                                 ),
                             ),
                         ),
@@ -1316,9 +1292,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -40341101.0,
-                                    ),
+                                    -40341101.0,
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -7,9 +7,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1732584193.0,
-                            ),
+                            1732584193.0,
                         ),
                     ),
                 ),
@@ -64,9 +62,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
@@ -134,9 +130,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    4.0,
-                                                ),
+                                                4.0,
                                             ),
                                         ),
                                     ),
@@ -146,9 +140,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
@@ -216,9 +208,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    8.0,
-                                                ),
+                                                8.0,
                                             ),
                                         ),
                                     ),
@@ -228,18 +218,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1770035416.0,
-                                    ),
+                                    1770035416.0,
                                 ),
                             ),
                         ),
@@ -298,9 +284,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    12.0,
-                                                ),
+                                                12.0,
                                             ),
                                         ),
                                     ),
@@ -310,18 +294,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1804603682.0,
-                                    ),
+                                    1804603682.0,
                                 ),
                             ),
                         ),
@@ -412,9 +392,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    3.0,
-                                                ),
+                                                3.0,
                                             ),
                                         ),
                                     ),
@@ -424,9 +402,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
@@ -494,9 +470,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    7.0,
-                                                ),
+                                                7.0,
                                             ),
                                         ),
                                     ),
@@ -506,9 +480,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
@@ -576,9 +548,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    11.0,
-                                                ),
+                                                11.0,
                                             ),
                                         ),
                                     ),
@@ -588,9 +558,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
@@ -658,9 +626,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    15.0,
-                                                ),
+                                                15.0,
                                             ),
                                         ),
                                     ),
@@ -670,18 +636,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1236535329.0,
-                                    ),
+                                    1236535329.0,
                                 ),
                             ),
                         ),
@@ -772,9 +734,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    2.0,
-                                                ),
+                                                2.0,
                                             ),
                                         ),
                                     ),
@@ -784,18 +744,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        606105819.0,
-                                    ),
+                                    606105819.0,
                                 ),
                             ),
                         ),
@@ -854,9 +810,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    6.0,
-                                                ),
+                                                6.0,
                                             ),
                                         ),
                                     ),
@@ -866,9 +820,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
@@ -936,9 +888,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    10.0,
-                                                ),
+                                                10.0,
                                             ),
                                         ),
                                     ),
@@ -948,9 +898,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
@@ -1018,9 +966,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    14.0,
-                                                ),
+                                                14.0,
                                             ),
                                         ),
                                     ),
@@ -1030,9 +976,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
@@ -1066,9 +1010,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                271733878.0,
-                            ),
+                            271733878.0,
                         ),
                     ),
                 ),
@@ -1125,9 +1067,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    1.0,
-                                                ),
+                                                1.0,
                                             ),
                                         ),
                                     ),
@@ -1137,9 +1077,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
@@ -1207,9 +1145,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    5.0,
-                                                ),
+                                                5.0,
                                             ),
                                         ),
                                     ),
@@ -1219,18 +1155,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1200080426.0,
-                                    ),
+                                    1200080426.0,
                                 ),
                             ),
                         ),
@@ -1289,9 +1221,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    9.0,
-                                                ),
+                                                9.0,
                                             ),
                                         ),
                                     ),
@@ -1301,9 +1231,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
@@ -1371,9 +1299,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    13.0,
-                                                ),
+                                                13.0,
                                             ),
                                         ),
                                     ),
@@ -1383,9 +1309,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
@@ -1431,9 +1355,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -1449,9 +1371,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        16.0,
-                                    ),
+                                    16.0,
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
@@ -2781,9 +2781,7 @@
                                                 Constant(
                                                     Num(
                                                         ConstantNumber(
-                                                            TotalOrderF64(
-                                                                0.0,
-                                                            ),
+                                                            0.0,
                                                         ),
                                                     ),
                                                 ),
@@ -5493,9 +5491,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -6141,9 +6137,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -6325,9 +6319,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            0.0,
-                                        ),
+                                        0.0,
                                     ),
                                 ),
                             ),
@@ -6339,9 +6331,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -6483,9 +6473,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -6667,9 +6655,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
@@ -6681,9 +6667,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -6825,9 +6809,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -7009,9 +6991,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
@@ -7023,9 +7003,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -7034,9 +7012,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                606105819.0,
-                            ),
+                            606105819.0,
                         ),
                     ),
                 ),
@@ -7167,9 +7143,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -7351,9 +7325,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -7365,9 +7337,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -7509,9 +7479,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -7693,9 +7661,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            4.0,
-                                        ),
+                                        4.0,
                                     ),
                                 ),
                             ),
@@ -7707,9 +7673,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -7851,9 +7815,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -8035,9 +7997,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            5.0,
-                                        ),
+                                        5.0,
                                     ),
                                 ),
                             ),
@@ -8049,9 +8009,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -8060,9 +8018,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1200080426.0,
-                            ),
+                            1200080426.0,
                         ),
                     ),
                 ),
@@ -8193,9 +8149,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -8377,9 +8331,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            6.0,
-                                        ),
+                                        6.0,
                                     ),
                                 ),
                             ),
@@ -8391,9 +8343,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -8535,9 +8485,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -8719,9 +8667,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            7.0,
-                                        ),
+                                        7.0,
                                     ),
                                 ),
                             ),
@@ -8733,9 +8679,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -8877,9 +8821,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                8.0,
-                            ),
+                            8.0,
                         ),
                     ),
                 ),
@@ -9061,9 +9003,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            8.0,
-                                        ),
+                                        8.0,
                                     ),
                                 ),
                             ),
@@ -9075,9 +9015,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -9086,9 +9024,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1770035416.0,
-                            ),
+                            1770035416.0,
                         ),
                     ),
                 ),
@@ -9219,9 +9155,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -9403,9 +9337,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            9.0,
-                                        ),
+                                        9.0,
                                     ),
                                 ),
                             ),
@@ -9417,9 +9349,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -9561,9 +9491,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -9745,9 +9673,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            10.0,
-                                        ),
+                                        10.0,
                                     ),
                                 ),
                             ),
@@ -9759,9 +9685,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -9903,9 +9827,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -10087,9 +10009,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            11.0,
-                                        ),
+                                        11.0,
                                     ),
                                 ),
                             ),
@@ -10101,9 +10021,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -10245,9 +10163,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -10429,9 +10345,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            12.0,
-                                        ),
+                                        12.0,
                                     ),
                                 ),
                             ),
@@ -10443,9 +10357,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -10454,9 +10366,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1804603682.0,
-                            ),
+                            1804603682.0,
                         ),
                     ),
                 ),
@@ -10587,9 +10497,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                13.0,
-                            ),
+                            13.0,
                         ),
                     ),
                 ),
@@ -10771,9 +10679,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            13.0,
-                                        ),
+                                        13.0,
                                     ),
                                 ),
                             ),
@@ -10785,9 +10691,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -10929,9 +10833,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -11113,9 +11015,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            14.0,
-                                        ),
+                                        14.0,
                                     ),
                                 ),
                             ),
@@ -11127,9 +11027,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                17.0,
-                            ),
+                            17.0,
                         ),
                     ),
                 ),
@@ -11271,9 +11169,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -11455,9 +11351,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            15.0,
-                                        ),
+                                        15.0,
                                     ),
                                 ),
                             ),
@@ -11469,9 +11363,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                22.0,
-                            ),
+                            22.0,
                         ),
                     ),
                 ),
@@ -11480,9 +11372,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1236535329.0,
-                            ),
+                            1236535329.0,
                         ),
                     ),
                 ),
@@ -11613,9 +11503,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -11797,9 +11685,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
@@ -11811,9 +11697,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -11955,9 +11839,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -12139,9 +12021,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            6.0,
-                                        ),
+                                        6.0,
                                     ),
                                 ),
                             ),
@@ -12153,9 +12033,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -12297,9 +12175,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -12481,9 +12357,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            11.0,
-                                        ),
+                                        11.0,
                                     ),
                                 ),
                             ),
@@ -12495,9 +12369,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -12506,9 +12378,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                643717713.0,
-                            ),
+                            643717713.0,
                         ),
                     ),
                 ),
@@ -12639,9 +12509,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -12823,9 +12691,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            0.0,
-                                        ),
+                                        0.0,
                                     ),
                                 ),
                             ),
@@ -12837,9 +12703,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                20.0,
-                            ),
+                            20.0,
                         ),
                     ),
                 ),
@@ -12981,9 +12845,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -13165,9 +13027,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            5.0,
-                                        ),
+                                        5.0,
                                     ),
                                 ),
                             ),
@@ -13179,9 +13039,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -13323,9 +13181,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -13507,9 +13363,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            10.0,
-                                        ),
+                                        10.0,
                                     ),
                                 ),
                             ),
@@ -13521,9 +13375,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -13532,9 +13384,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                38016083.0,
-                            ),
+                            38016083.0,
                         ),
                     ),
                 ),
@@ -13665,9 +13515,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -13849,9 +13697,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            15.0,
-                                        ),
+                                        15.0,
                                     ),
                                 ),
                             ),
@@ -13863,9 +13709,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -14007,9 +13851,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -14191,9 +14033,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            4.0,
-                                        ),
+                                        4.0,
                                     ),
                                 ),
                             ),
@@ -14205,9 +14045,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                20.0,
-                            ),
+                            20.0,
                         ),
                     ),
                 ),
@@ -14349,9 +14187,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -14533,9 +14369,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            9.0,
-                                        ),
+                                        9.0,
                                     ),
                                 ),
                             ),
@@ -14547,9 +14381,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -14558,9 +14390,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                568446438.0,
-                            ),
+                            568446438.0,
                         ),
                     ),
                 ),
@@ -14691,9 +14521,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -14875,9 +14703,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            14.0,
-                                        ),
+                                        14.0,
                                     ),
                                 ),
                             ),
@@ -14889,9 +14715,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -15033,9 +14857,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -15217,9 +15039,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -15231,9 +15051,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -15375,9 +15193,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                8.0,
-                            ),
+                            8.0,
                         ),
                     ),
                 ),
@@ -15559,9 +15375,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            8.0,
-                                        ),
+                                        8.0,
                                     ),
                                 ),
                             ),
@@ -15573,9 +15387,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                20.0,
-                            ),
+                            20.0,
                         ),
                     ),
                 ),
@@ -15584,9 +15396,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1163531501.0,
-                            ),
+                            1163531501.0,
                         ),
                     ),
                 ),
@@ -15717,9 +15527,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                13.0,
-                            ),
+                            13.0,
                         ),
                     ),
                 ),
@@ -15901,9 +15709,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            13.0,
-                                        ),
+                                        13.0,
                                     ),
                                 ),
                             ),
@@ -15915,9 +15721,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -16059,9 +15863,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -16243,9 +16045,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
@@ -16257,9 +16057,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -16401,9 +16199,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -16585,9 +16381,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            7.0,
-                                        ),
+                                        7.0,
                                     ),
                                 ),
                             ),
@@ -16599,9 +16393,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -16610,9 +16402,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1735328473.0,
-                            ),
+                            1735328473.0,
                         ),
                     ),
                 ),
@@ -16743,9 +16533,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -16927,9 +16715,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            12.0,
-                                        ),
+                                        12.0,
                                     ),
                                 ),
                             ),
@@ -16941,9 +16727,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                20.0,
-                            ),
+                            20.0,
                         ),
                     ),
                 ),
@@ -17085,9 +16869,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -17269,9 +17051,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            5.0,
-                                        ),
+                                        5.0,
                                     ),
                                 ),
                             ),
@@ -17283,9 +17063,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -17427,9 +17205,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                8.0,
-                            ),
+                            8.0,
                         ),
                     ),
                 ),
@@ -17611,9 +17387,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            8.0,
-                                        ),
+                                        8.0,
                                     ),
                                 ),
                             ),
@@ -17625,9 +17399,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -17769,9 +17541,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -17953,9 +17723,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            11.0,
-                                        ),
+                                        11.0,
                                     ),
                                 ),
                             ),
@@ -17967,9 +17735,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                16.0,
-                            ),
+                            16.0,
                         ),
                     ),
                 ),
@@ -17978,9 +17744,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1839030562.0,
-                            ),
+                            1839030562.0,
                         ),
                     ),
                 ),
@@ -18111,9 +17875,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -18295,9 +18057,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            14.0,
-                                        ),
+                                        14.0,
                                     ),
                                 ),
                             ),
@@ -18309,9 +18069,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                23.0,
-                            ),
+                            23.0,
                         ),
                     ),
                 ),
@@ -18453,9 +18211,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -18637,9 +18393,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
@@ -18651,9 +18405,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -18795,9 +18547,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -18979,9 +18729,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            4.0,
-                                        ),
+                                        4.0,
                                     ),
                                 ),
                             ),
@@ -18993,9 +18741,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -19004,9 +18750,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1272893353.0,
-                            ),
+                            1272893353.0,
                         ),
                     ),
                 ),
@@ -19137,9 +18881,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -19321,9 +19063,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            7.0,
-                                        ),
+                                        7.0,
                                     ),
                                 ),
                             ),
@@ -19335,9 +19075,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                16.0,
-                            ),
+                            16.0,
                         ),
                     ),
                 ),
@@ -19479,9 +19217,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -19663,9 +19399,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            10.0,
-                                        ),
+                                        10.0,
                                     ),
                                 ),
                             ),
@@ -19677,9 +19411,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                23.0,
-                            ),
+                            23.0,
                         ),
                     ),
                 ),
@@ -19821,9 +19553,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                13.0,
-                            ),
+                            13.0,
                         ),
                     ),
                 ),
@@ -20005,9 +19735,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            13.0,
-                                        ),
+                                        13.0,
                                     ),
                                 ),
                             ),
@@ -20019,9 +19747,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -20030,9 +19756,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                681279174.0,
-                            ),
+                            681279174.0,
                         ),
                     ),
                 ),
@@ -20163,9 +19887,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -20347,9 +20069,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            0.0,
-                                        ),
+                                        0.0,
                                     ),
                                 ),
                             ),
@@ -20361,9 +20081,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -20505,9 +20223,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -20689,9 +20405,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -20703,9 +20417,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                16.0,
-                            ),
+                            16.0,
                         ),
                     ),
                 ),
@@ -20847,9 +20559,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -21031,9 +20741,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            6.0,
-                                        ),
+                                        6.0,
                                     ),
                                 ),
                             ),
@@ -21045,9 +20753,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                23.0,
-                            ),
+                            23.0,
                         ),
                     ),
                 ),
@@ -21056,9 +20762,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                76029189.0,
-                            ),
+                            76029189.0,
                         ),
                     ),
                 ),
@@ -21189,9 +20893,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -21373,9 +21075,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            9.0,
-                                        ),
+                                        9.0,
                                     ),
                                 ),
                             ),
@@ -21387,9 +21087,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -21531,9 +21229,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -21715,9 +21411,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            12.0,
-                                        ),
+                                        12.0,
                                     ),
                                 ),
                             ),
@@ -21729,9 +21423,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -21873,9 +21565,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -22057,9 +21747,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            15.0,
-                                        ),
+                                        15.0,
                                     ),
                                 ),
                             ),
@@ -22071,9 +21759,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                16.0,
-                            ),
+                            16.0,
                         ),
                     ),
                 ),
@@ -22082,9 +21768,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                530742520.0,
-                            ),
+                            530742520.0,
                         ),
                     ),
                 ),
@@ -22215,9 +21899,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -22399,9 +22081,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
@@ -22413,9 +22093,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                23.0,
-                            ),
+                            23.0,
                         ),
                     ),
                 ),
@@ -22557,9 +22235,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -22741,9 +22417,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            0.0,
-                                        ),
+                                        0.0,
                                     ),
                                 ),
                             ),
@@ -22755,9 +22429,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -22899,9 +22571,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                7.0,
-                            ),
+                            7.0,
                         ),
                     ),
                 ),
@@ -23083,9 +22753,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            7.0,
-                                        ),
+                                        7.0,
                                     ),
                                 ),
                             ),
@@ -23097,9 +22765,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -23108,9 +22774,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1126891415.0,
-                            ),
+                            1126891415.0,
                         ),
                     ),
                 ),
@@ -23241,9 +22905,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                14.0,
-                            ),
+                            14.0,
                         ),
                     ),
                 ),
@@ -23425,9 +23087,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            14.0,
-                                        ),
+                                        14.0,
                                     ),
                                 ),
                             ),
@@ -23439,9 +23099,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -23583,9 +23241,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -23767,9 +23423,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            5.0,
-                                        ),
+                                        5.0,
                                     ),
                                 ),
                             ),
@@ -23781,9 +23435,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                21.0,
-                            ),
+                            21.0,
                         ),
                     ),
                 ),
@@ -23925,9 +23577,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                12.0,
-                            ),
+                            12.0,
                         ),
                     ),
                 ),
@@ -24109,9 +23759,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            12.0,
-                                        ),
+                                        12.0,
                                     ),
                                 ),
                             ),
@@ -24123,9 +23771,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -24134,9 +23780,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1700485571.0,
-                            ),
+                            1700485571.0,
                         ),
                     ),
                 ),
@@ -24267,9 +23911,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -24451,9 +24093,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -24465,9 +24105,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -24609,9 +24247,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -24793,9 +24429,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            10.0,
-                                        ),
+                                        10.0,
                                     ),
                                 ),
                             ),
@@ -24807,9 +24441,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -24951,9 +24583,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -25135,9 +24765,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
@@ -25149,9 +24777,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                21.0,
-                            ),
+                            21.0,
                         ),
                     ),
                 ),
@@ -25293,9 +24919,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                8.0,
-                            ),
+                            8.0,
                         ),
                     ),
                 ),
@@ -25477,9 +25101,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            8.0,
-                                        ),
+                                        8.0,
                                     ),
                                 ),
                             ),
@@ -25491,9 +25113,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -25502,9 +25122,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1873313359.0,
-                            ),
+                            1873313359.0,
                         ),
                     ),
                 ),
@@ -25635,9 +25253,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -25819,9 +25435,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            15.0,
-                                        ),
+                                        15.0,
                                     ),
                                 ),
                             ),
@@ -25833,9 +25447,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -25977,9 +25589,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -26161,9 +25771,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            6.0,
-                                        ),
+                                        6.0,
                                     ),
                                 ),
                             ),
@@ -26175,9 +25783,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -26319,9 +25925,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                13.0,
-                            ),
+                            13.0,
                         ),
                     ),
                 ),
@@ -26503,9 +26107,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            13.0,
-                                        ),
+                                        13.0,
                                     ),
                                 ),
                             ),
@@ -26517,9 +26119,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                21.0,
-                            ),
+                            21.0,
                         ),
                     ),
                 ),
@@ -26528,9 +26128,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1309151649.0,
-                            ),
+                            1309151649.0,
                         ),
                     ),
                 ),
@@ -26661,9 +26259,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -26845,9 +26441,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            4.0,
-                                        ),
+                                        4.0,
                                     ),
                                 ),
                             ),
@@ -26859,9 +26453,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -27003,9 +26595,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                11.0,
-                            ),
+                            11.0,
                         ),
                     ),
                 ),
@@ -27187,9 +26777,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            11.0,
-                                        ),
+                                        11.0,
                                     ),
                                 ),
                             ),
@@ -27201,9 +26789,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                10.0,
-                            ),
+                            10.0,
                         ),
                     ),
                 ),
@@ -27345,9 +26931,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -27529,9 +27113,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
@@ -27543,9 +27125,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                15.0,
-                            ),
+                            15.0,
                         ),
                     ),
                 ),
@@ -27554,9 +27134,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                718787259.0,
-                            ),
+                            718787259.0,
                         ),
                     ),
                 ),
@@ -27687,9 +27265,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                9.0,
-                            ),
+                            9.0,
                         ),
                     ),
                 ),
@@ -27871,9 +27447,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            9.0,
-                                        ),
+                                        9.0,
                                     ),
                                 ),
                             ),
@@ -27885,9 +27459,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                21.0,
-                            ),
+                            21.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
@@ -6340,9 +6340,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -680876936.0,
-                            ),
+                            -680876936.0,
                         ),
                     ),
                 ),
@@ -6676,9 +6674,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -389564586.0,
-                            ),
+                            -389564586.0,
                         ),
                     ),
                 ),
@@ -7346,9 +7342,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1044525330.0,
-                            ),
+                            -1044525330.0,
                         ),
                     ),
                 ),
@@ -7682,9 +7676,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -176418897.0,
-                            ),
+                            -176418897.0,
                         ),
                     ),
                 ),
@@ -8352,9 +8344,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1473231341.0,
-                            ),
+                            -1473231341.0,
                         ),
                     ),
                 ),
@@ -8688,9 +8678,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -45705983.0,
-                            ),
+                            -45705983.0,
                         ),
                     ),
                 ),
@@ -9358,9 +9346,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1958414417.0,
-                            ),
+                            -1958414417.0,
                         ),
                     ),
                 ),
@@ -9694,9 +9680,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -42063.0,
-                            ),
+                            -42063.0,
                         ),
                     ),
                 ),
@@ -10030,9 +10014,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1990404162.0,
-                            ),
+                            -1990404162.0,
                         ),
                     ),
                 ),
@@ -10700,9 +10682,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -40341101.0,
-                            ),
+                            -40341101.0,
                         ),
                     ),
                 ),
@@ -11036,9 +11016,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1502002290.0,
-                            ),
+                            -1502002290.0,
                         ),
                     ),
                 ),
@@ -11706,9 +11684,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -165796510.0,
-                            ),
+                            -165796510.0,
                         ),
                     ),
                 ),
@@ -12042,9 +12018,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1069501632.0,
-                            ),
+                            -1069501632.0,
                         ),
                     ),
                 ),
@@ -12712,9 +12686,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -373897302.0,
-                            ),
+                            -373897302.0,
                         ),
                     ),
                 ),
@@ -13048,9 +13020,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -701558691.0,
-                            ),
+                            -701558691.0,
                         ),
                     ),
                 ),
@@ -13718,9 +13688,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -660478335.0,
-                            ),
+                            -660478335.0,
                         ),
                     ),
                 ),
@@ -14054,9 +14022,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -405537848.0,
-                            ),
+                            -405537848.0,
                         ),
                     ),
                 ),
@@ -14724,9 +14690,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1019803690.0,
-                            ),
+                            -1019803690.0,
                         ),
                     ),
                 ),
@@ -15060,9 +15024,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -187363961.0,
-                            ),
+                            -187363961.0,
                         ),
                     ),
                 ),
@@ -15730,9 +15692,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1444681467.0,
-                            ),
+                            -1444681467.0,
                         ),
                     ),
                 ),
@@ -16066,9 +16026,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -51403784.0,
-                            ),
+                            -51403784.0,
                         ),
                     ),
                 ),
@@ -16736,9 +16694,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1926607734.0,
-                            ),
+                            -1926607734.0,
                         ),
                     ),
                 ),
@@ -17072,9 +17028,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -378558.0,
-                            ),
+                            -378558.0,
                         ),
                     ),
                 ),
@@ -17408,9 +17362,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -2022574463.0,
-                            ),
+                            -2022574463.0,
                         ),
                     ),
                 ),
@@ -18078,9 +18030,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -35309556.0,
-                            ),
+                            -35309556.0,
                         ),
                     ),
                 ),
@@ -18414,9 +18364,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1530992060.0,
-                            ),
+                            -1530992060.0,
                         ),
                     ),
                 ),
@@ -19084,9 +19032,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -155497632.0,
-                            ),
+                            -155497632.0,
                         ),
                     ),
                 ),
@@ -19420,9 +19366,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1094730640.0,
-                            ),
+                            -1094730640.0,
                         ),
                     ),
                 ),
@@ -20090,9 +20034,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -358537222.0,
-                            ),
+                            -358537222.0,
                         ),
                     ),
                 ),
@@ -20426,9 +20368,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -722521979.0,
-                            ),
+                            -722521979.0,
                         ),
                     ),
                 ),
@@ -21096,9 +21036,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -640364487.0,
-                            ),
+                            -640364487.0,
                         ),
                     ),
                 ),
@@ -21432,9 +21370,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -421815835.0,
-                            ),
+                            -421815835.0,
                         ),
                     ),
                 ),
@@ -22102,9 +22038,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -995338651.0,
-                            ),
+                            -995338651.0,
                         ),
                     ),
                 ),
@@ -22438,9 +22372,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -198630844.0,
-                            ),
+                            -198630844.0,
                         ),
                     ),
                 ),
@@ -23108,9 +23040,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1416354905.0,
-                            ),
+                            -1416354905.0,
                         ),
                     ),
                 ),
@@ -23444,9 +23374,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -57434055.0,
-                            ),
+                            -57434055.0,
                         ),
                     ),
                 ),
@@ -24114,9 +24042,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1894986606.0,
-                            ),
+                            -1894986606.0,
                         ),
                     ),
                 ),
@@ -24450,9 +24376,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1051523.0,
-                            ),
+                            -1051523.0,
                         ),
                     ),
                 ),
@@ -24786,9 +24710,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -2054922799.0,
-                            ),
+                            -2054922799.0,
                         ),
                     ),
                 ),
@@ -25456,9 +25378,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -30611744.0,
-                            ),
+                            -30611744.0,
                         ),
                     ),
                 ),
@@ -25792,9 +25712,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1560198380.0,
-                            ),
+                            -1560198380.0,
                         ),
                     ),
                 ),
@@ -26462,9 +26380,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -145523070.0,
-                            ),
+                            -145523070.0,
                         ),
                     ),
                 ),
@@ -26798,9 +26714,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1120210379.0,
-                            ),
+                            -1120210379.0,
                         ),
                     ),
                 ),
@@ -27468,9 +27382,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -343485551.0,
-                            ),
+                            -343485551.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -434,9 +434,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -680876936.0,
-                                    ),
+                                    -680876936.0,
                                 ),
                             ),
                         ),
@@ -512,9 +510,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -176418897.0,
-                                    ),
+                                    -176418897.0,
                                 ),
                             ),
                         ),
@@ -742,9 +738,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -165796510.0,
-                                    ),
+                                    -165796510.0,
                                 ),
                             ),
                         ),
@@ -820,9 +814,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -701558691.0,
-                                    ),
+                                    -701558691.0,
                                 ),
                             ),
                         ),
@@ -974,9 +966,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1444681467.0,
-                                    ),
+                                    -1444681467.0,
                                 ),
                             ),
                         ),
@@ -1052,9 +1042,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -378558.0,
-                                    ),
+                                    -378558.0,
                                 ),
                             ),
                         ),
@@ -1130,9 +1118,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1530992060.0,
-                                    ),
+                                    -1530992060.0,
                                 ),
                             ),
                         ),
@@ -1284,9 +1270,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -640364487.0,
-                                    ),
+                                    -640364487.0,
                                 ),
                             ),
                         ),
@@ -1362,9 +1346,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -198630844.0,
-                                    ),
+                                    -198630844.0,
                                 ),
                             ),
                         ),
@@ -1592,9 +1574,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -145523070.0,
-                                    ),
+                                    -145523070.0,
                                 ),
                             ),
                         ),
@@ -1663,9 +1643,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -271733879.0,
-                            ),
+                            -271733879.0,
                         ),
                     ),
                 ),
@@ -1739,9 +1717,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1044525330.0,
-                                    ),
+                                    -1044525330.0,
                                 ),
                             ),
                         ),
@@ -1817,9 +1793,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -45705983.0,
-                                    ),
+                                    -45705983.0,
                                 ),
                             ),
                         ),
@@ -1895,9 +1869,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1990404162.0,
-                                    ),
+                                    -1990404162.0,
                                 ),
                             ),
                         ),
@@ -2049,9 +2021,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -373897302.0,
-                                    ),
+                                    -373897302.0,
                                 ),
                             ),
                         ),
@@ -2127,9 +2097,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -405537848.0,
-                                    ),
+                                    -405537848.0,
                                 ),
                             ),
                         ),
@@ -2281,9 +2249,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1926607734.0,
-                                    ),
+                                    -1926607734.0,
                                 ),
                             ),
                         ),
@@ -2359,9 +2325,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -35309556.0,
-                                    ),
+                                    -35309556.0,
                                 ),
                             ),
                         ),
@@ -2437,9 +2401,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1094730640.0,
-                                    ),
+                                    -1094730640.0,
                                 ),
                             ),
                         ),
@@ -2591,9 +2553,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -995338651.0,
-                                    ),
+                                    -995338651.0,
                                 ),
                             ),
                         ),
@@ -2669,9 +2629,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -57434055.0,
-                                    ),
+                                    -57434055.0,
                                 ),
                             ),
                         ),
@@ -2747,9 +2705,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -2054922799.0,
-                                    ),
+                                    -2054922799.0,
                                 ),
                             ),
                         ),
@@ -2901,9 +2857,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -343485551.0,
-                                    ),
+                                    -343485551.0,
                                 ),
                             ),
                         ),
@@ -3000,9 +2954,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                -1732584194.0,
-                            ),
+                            -1732584194.0,
                         ),
                     ),
                 ),
@@ -3152,9 +3104,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1473231341.0,
-                                    ),
+                                    -1473231341.0,
                                 ),
                             ),
                         ),
@@ -3230,9 +3180,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -42063.0,
-                                    ),
+                                    -42063.0,
                                 ),
                             ),
                         ),
@@ -3308,9 +3256,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1502002290.0,
-                                    ),
+                                    -1502002290.0,
                                 ),
                             ),
                         ),
@@ -3462,9 +3408,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -660478335.0,
-                                    ),
+                                    -660478335.0,
                                 ),
                             ),
                         ),
@@ -3540,9 +3484,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -187363961.0,
-                                    ),
+                                    -187363961.0,
                                 ),
                             ),
                         ),
@@ -3770,9 +3712,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -155497632.0,
-                                    ),
+                                    -155497632.0,
                                 ),
                             ),
                         ),
@@ -3848,9 +3788,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -722521979.0,
-                                    ),
+                                    -722521979.0,
                                 ),
                             ),
                         ),
@@ -4002,9 +3940,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1416354905.0,
-                                    ),
+                                    -1416354905.0,
                                 ),
                             ),
                         ),
@@ -4080,9 +4016,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1051523.0,
-                                    ),
+                                    -1051523.0,
                                 ),
                             ),
                         ),
@@ -4158,9 +4092,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1560198380.0,
-                                    ),
+                                    -1560198380.0,
                                 ),
                             ),
                         ),
@@ -4397,9 +4329,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -389564586.0,
-                                    ),
+                                    -389564586.0,
                                 ),
                             ),
                         ),
@@ -4551,9 +4481,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1958414417.0,
-                                    ),
+                                    -1958414417.0,
                                 ),
                             ),
                         ),
@@ -4629,9 +4557,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -40341101.0,
-                                    ),
+                                    -40341101.0,
                                 ),
                             ),
                         ),
@@ -4707,9 +4633,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1069501632.0,
-                                    ),
+                                    -1069501632.0,
                                 ),
                             ),
                         ),
@@ -4861,9 +4785,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1019803690.0,
-                                    ),
+                                    -1019803690.0,
                                 ),
                             ),
                         ),
@@ -4939,9 +4861,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -51403784.0,
-                                    ),
+                                    -51403784.0,
                                 ),
                             ),
                         ),
@@ -5017,9 +4937,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -2022574463.0,
-                                    ),
+                                    -2022574463.0,
                                 ),
                             ),
                         ),
@@ -5171,9 +5089,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -358537222.0,
-                                    ),
+                                    -358537222.0,
                                 ),
                             ),
                         ),
@@ -5249,9 +5165,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -421815835.0,
-                                    ),
+                                    -421815835.0,
                                 ),
                             ),
                         ),
@@ -5403,9 +5317,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1894986606.0,
-                                    ),
+                                    -1894986606.0,
                                 ),
                             ),
                         ),
@@ -5481,9 +5393,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -30611744.0,
-                                    ),
+                                    -30611744.0,
                                 ),
                             ),
                         ),
@@ -5559,9 +5469,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        -1120210379.0,
-                                    ),
+                                    -1120210379.0,
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -360,9 +360,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1732584193.0,
-                            ),
+                            1732584193.0,
                         ),
                     ),
                 ),
@@ -419,9 +417,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    0.0,
-                                                ),
+                                                0.0,
                                             ),
                                         ),
                                     ),
@@ -431,9 +427,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
@@ -501,9 +495,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    4.0,
-                                                ),
+                                                4.0,
                                             ),
                                         ),
                                     ),
@@ -513,9 +505,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
@@ -583,9 +573,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    8.0,
-                                                ),
+                                                8.0,
                                             ),
                                         ),
                                     ),
@@ -595,18 +583,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1770035416.0,
-                                    ),
+                                    1770035416.0,
                                 ),
                             ),
                         ),
@@ -665,9 +649,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    12.0,
-                                                ),
+                                                12.0,
                                             ),
                                         ),
                                     ),
@@ -677,18 +659,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1804603682.0,
-                                    ),
+                                    1804603682.0,
                                 ),
                             ),
                         ),
@@ -747,9 +725,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    1.0,
-                                                ),
+                                                1.0,
                                             ),
                                         ),
                                     ),
@@ -759,9 +735,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        5.0,
-                                    ),
+                                    5.0,
                                 ),
                             ),
                         ),
@@ -829,9 +803,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    5.0,
-                                                ),
+                                                5.0,
                                             ),
                                         ),
                                     ),
@@ -841,9 +813,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        5.0,
-                                    ),
+                                    5.0,
                                 ),
                             ),
                         ),
@@ -911,9 +881,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    9.0,
-                                                ),
+                                                9.0,
                                             ),
                                         ),
                                     ),
@@ -923,18 +891,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        5.0,
-                                    ),
+                                    5.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        568446438.0,
-                                    ),
+                                    568446438.0,
                                 ),
                             ),
                         ),
@@ -993,9 +957,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    13.0,
-                                                ),
+                                                13.0,
                                             ),
                                         ),
                                     ),
@@ -1005,9 +967,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        5.0,
-                                    ),
+                                    5.0,
                                 ),
                             ),
                         ),
@@ -1075,9 +1035,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    5.0,
-                                                ),
+                                                5.0,
                                             ),
                                         ),
                                     ),
@@ -1087,9 +1045,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        4.0,
-                                    ),
+                                    4.0,
                                 ),
                             ),
                         ),
@@ -1157,9 +1113,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    1.0,
-                                                ),
+                                                1.0,
                                             ),
                                         ),
                                     ),
@@ -1169,9 +1123,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        4.0,
-                                    ),
+                                    4.0,
                                 ),
                             ),
                         ),
@@ -1239,9 +1191,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    13.0,
-                                                ),
+                                                13.0,
                                             ),
                                         ),
                                     ),
@@ -1251,18 +1201,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        4.0,
-                                    ),
+                                    4.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        681279174.0,
-                                    ),
+                                    681279174.0,
                                 ),
                             ),
                         ),
@@ -1321,9 +1267,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    9.0,
-                                                ),
+                                                9.0,
                                             ),
                                         ),
                                     ),
@@ -1333,9 +1277,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        4.0,
-                                    ),
+                                    4.0,
                                 ),
                             ),
                         ),
@@ -1403,9 +1345,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    0.0,
-                                                ),
+                                                0.0,
                                             ),
                                         ),
                                     ),
@@ -1415,9 +1355,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        6.0,
-                                    ),
+                                    6.0,
                                 ),
                             ),
                         ),
@@ -1485,9 +1423,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    12.0,
-                                                ),
+                                                12.0,
                                             ),
                                         ),
                                     ),
@@ -1497,18 +1433,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        6.0,
-                                    ),
+                                    6.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1700485571.0,
-                                    ),
+                                    1700485571.0,
                                 ),
                             ),
                         ),
@@ -1567,9 +1499,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    8.0,
-                                                ),
+                                                8.0,
                                             ),
                                         ),
                                     ),
@@ -1579,18 +1509,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        6.0,
-                                    ),
+                                    6.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1873313359.0,
-                                    ),
+                                    1873313359.0,
                                 ),
                             ),
                         ),
@@ -1649,9 +1575,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    4.0,
-                                                ),
+                                                4.0,
                                             ),
                                         ),
                                     ),
@@ -1661,9 +1585,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        6.0,
-                                    ),
+                                    6.0,
                                 ),
                             ),
                         ),
@@ -1800,9 +1722,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    3.0,
-                                                ),
+                                                3.0,
                                             ),
                                         ),
                                     ),
@@ -1812,9 +1732,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
@@ -1882,9 +1800,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    7.0,
-                                                ),
+                                                7.0,
                                             ),
                                         ),
                                     ),
@@ -1894,9 +1810,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
@@ -1964,9 +1878,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    11.0,
-                                                ),
+                                                11.0,
                                             ),
                                         ),
                                     ),
@@ -1976,9 +1888,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
@@ -2046,9 +1956,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    15.0,
-                                                ),
+                                                15.0,
                                             ),
                                         ),
                                     ),
@@ -2058,18 +1966,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        22.0,
-                                    ),
+                                    22.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1236535329.0,
-                                    ),
+                                    1236535329.0,
                                 ),
                             ),
                         ),
@@ -2128,9 +2032,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    0.0,
-                                                ),
+                                                0.0,
                                             ),
                                         ),
                                     ),
@@ -2140,9 +2042,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        20.0,
-                                    ),
+                                    20.0,
                                 ),
                             ),
                         ),
@@ -2210,9 +2110,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    4.0,
-                                                ),
+                                                4.0,
                                             ),
                                         ),
                                     ),
@@ -2222,9 +2120,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        20.0,
-                                    ),
+                                    20.0,
                                 ),
                             ),
                         ),
@@ -2292,9 +2188,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    8.0,
-                                                ),
+                                                8.0,
                                             ),
                                         ),
                                     ),
@@ -2304,18 +2198,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        20.0,
-                                    ),
+                                    20.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1163531501.0,
-                                    ),
+                                    1163531501.0,
                                 ),
                             ),
                         ),
@@ -2374,9 +2264,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    12.0,
-                                                ),
+                                                12.0,
                                             ),
                                         ),
                                     ),
@@ -2386,9 +2274,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        20.0,
-                                    ),
+                                    20.0,
                                 ),
                             ),
                         ),
@@ -2456,9 +2342,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    14.0,
-                                                ),
+                                                14.0,
                                             ),
                                         ),
                                     ),
@@ -2468,9 +2352,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        23.0,
-                                    ),
+                                    23.0,
                                 ),
                             ),
                         ),
@@ -2538,9 +2420,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    10.0,
-                                                ),
+                                                10.0,
                                             ),
                                         ),
                                     ),
@@ -2550,9 +2430,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        23.0,
-                                    ),
+                                    23.0,
                                 ),
                             ),
                         ),
@@ -2620,9 +2498,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    6.0,
-                                                ),
+                                                6.0,
                                             ),
                                         ),
                                     ),
@@ -2632,18 +2508,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        23.0,
-                                    ),
+                                    23.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        76029189.0,
-                                    ),
+                                    76029189.0,
                                 ),
                             ),
                         ),
@@ -2702,9 +2574,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    2.0,
-                                                ),
+                                                2.0,
                                             ),
                                         ),
                                     ),
@@ -2714,9 +2584,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        23.0,
-                                    ),
+                                    23.0,
                                 ),
                             ),
                         ),
@@ -2784,9 +2652,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    5.0,
-                                                ),
+                                                5.0,
                                             ),
                                         ),
                                     ),
@@ -2796,9 +2662,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        21.0,
-                                    ),
+                                    21.0,
                                 ),
                             ),
                         ),
@@ -2866,9 +2730,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    1.0,
-                                                ),
+                                                1.0,
                                             ),
                                         ),
                                     ),
@@ -2878,9 +2740,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        21.0,
-                                    ),
+                                    21.0,
                                 ),
                             ),
                         ),
@@ -2948,9 +2808,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    13.0,
-                                                ),
+                                                13.0,
                                             ),
                                         ),
                                     ),
@@ -2960,18 +2818,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        21.0,
-                                    ),
+                                    21.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1309151649.0,
-                                    ),
+                                    1309151649.0,
                                 ),
                             ),
                         ),
@@ -3030,9 +2884,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    9.0,
-                                                ),
+                                                9.0,
                                             ),
                                         ),
                                     ),
@@ -3042,9 +2894,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        21.0,
-                                    ),
+                                    21.0,
                                 ),
                             ),
                         ),
@@ -3209,9 +3059,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    2.0,
-                                                ),
+                                                2.0,
                                             ),
                                         ),
                                     ),
@@ -3221,18 +3069,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        606105819.0,
-                                    ),
+                                    606105819.0,
                                 ),
                             ),
                         ),
@@ -3291,9 +3135,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    6.0,
-                                                ),
+                                                6.0,
                                             ),
                                         ),
                                     ),
@@ -3303,9 +3145,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
@@ -3373,9 +3213,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    10.0,
-                                                ),
+                                                10.0,
                                             ),
                                         ),
                                     ),
@@ -3385,9 +3223,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
@@ -3455,9 +3291,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    14.0,
-                                                ),
+                                                14.0,
                                             ),
                                         ),
                                     ),
@@ -3467,9 +3301,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        17.0,
-                                    ),
+                                    17.0,
                                 ),
                             ),
                         ),
@@ -3537,9 +3369,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    11.0,
-                                                ),
+                                                11.0,
                                             ),
                                         ),
                                     ),
@@ -3549,18 +3379,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        14.0,
-                                    ),
+                                    14.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        643717713.0,
-                                    ),
+                                    643717713.0,
                                 ),
                             ),
                         ),
@@ -3619,9 +3445,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    15.0,
-                                                ),
+                                                15.0,
                                             ),
                                         ),
                                     ),
@@ -3631,9 +3455,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        14.0,
-                                    ),
+                                    14.0,
                                 ),
                             ),
                         ),
@@ -3701,9 +3523,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    3.0,
-                                                ),
+                                                3.0,
                                             ),
                                         ),
                                     ),
@@ -3713,9 +3533,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        14.0,
-                                    ),
+                                    14.0,
                                 ),
                             ),
                         ),
@@ -3783,9 +3601,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    7.0,
-                                                ),
+                                                7.0,
                                             ),
                                         ),
                                     ),
@@ -3795,18 +3611,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        14.0,
-                                    ),
+                                    14.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1735328473.0,
-                                    ),
+                                    1735328473.0,
                                 ),
                             ),
                         ),
@@ -3865,9 +3677,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    11.0,
-                                                ),
+                                                11.0,
                                             ),
                                         ),
                                     ),
@@ -3877,18 +3687,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        16.0,
-                                    ),
+                                    16.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1839030562.0,
-                                    ),
+                                    1839030562.0,
                                 ),
                             ),
                         ),
@@ -3947,9 +3753,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    7.0,
-                                                ),
+                                                7.0,
                                             ),
                                         ),
                                     ),
@@ -3959,9 +3763,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        16.0,
-                                    ),
+                                    16.0,
                                 ),
                             ),
                         ),
@@ -4029,9 +3831,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    3.0,
-                                                ),
+                                                3.0,
                                             ),
                                         ),
                                     ),
@@ -4041,9 +3841,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        16.0,
-                                    ),
+                                    16.0,
                                 ),
                             ),
                         ),
@@ -4111,9 +3909,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    15.0,
-                                                ),
+                                                15.0,
                                             ),
                                         ),
                                     ),
@@ -4123,18 +3919,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        16.0,
-                                    ),
+                                    16.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        530742520.0,
-                                    ),
+                                    530742520.0,
                                 ),
                             ),
                         ),
@@ -4193,9 +3985,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    14.0,
-                                                ),
+                                                14.0,
                                             ),
                                         ),
                                     ),
@@ -4205,9 +3995,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        15.0,
-                                    ),
+                                    15.0,
                                 ),
                             ),
                         ),
@@ -4275,9 +4063,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    10.0,
-                                                ),
+                                                10.0,
                                             ),
                                         ),
                                     ),
@@ -4287,9 +4073,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        15.0,
-                                    ),
+                                    15.0,
                                 ),
                             ),
                         ),
@@ -4357,9 +4141,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    6.0,
-                                                ),
+                                                6.0,
                                             ),
                                         ),
                                     ),
@@ -4369,9 +4151,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        15.0,
-                                    ),
+                                    15.0,
                                 ),
                             ),
                         ),
@@ -4439,9 +4219,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    2.0,
-                                                ),
+                                                2.0,
                                             ),
                                         ),
                                     ),
@@ -4451,18 +4229,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        15.0,
-                                    ),
+                                    15.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        718787259.0,
-                                    ),
+                                    718787259.0,
                                 ),
                             ),
                         ),
@@ -4549,9 +4323,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                271733878.0,
-                            ),
+                            271733878.0,
                         ),
                     ),
                 ),
@@ -4608,9 +4380,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    1.0,
-                                                ),
+                                                1.0,
                                             ),
                                         ),
                                     ),
@@ -4620,9 +4390,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
@@ -4690,9 +4458,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    5.0,
-                                                ),
+                                                5.0,
                                             ),
                                         ),
                                     ),
@@ -4702,18 +4468,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1200080426.0,
-                                    ),
+                                    1200080426.0,
                                 ),
                             ),
                         ),
@@ -4772,9 +4534,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    9.0,
-                                                ),
+                                                9.0,
                                             ),
                                         ),
                                     ),
@@ -4784,9 +4544,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
@@ -4854,9 +4612,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    13.0,
-                                                ),
+                                                13.0,
                                             ),
                                         ),
                                     ),
@@ -4866,9 +4622,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        12.0,
-                                    ),
+                                    12.0,
                                 ),
                             ),
                         ),
@@ -4936,9 +4690,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    6.0,
-                                                ),
+                                                6.0,
                                             ),
                                         ),
                                     ),
@@ -4948,9 +4700,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),
@@ -5018,9 +4768,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    10.0,
-                                                ),
+                                                10.0,
                                             ),
                                         ),
                                     ),
@@ -5030,18 +4778,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        38016083.0,
-                                    ),
+                                    38016083.0,
                                 ),
                             ),
                         ),
@@ -5100,9 +4844,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    14.0,
-                                                ),
+                                                14.0,
                                             ),
                                         ),
                                     ),
@@ -5112,9 +4854,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),
@@ -5182,9 +4922,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    2.0,
-                                                ),
+                                                2.0,
                                             ),
                                         ),
                                     ),
@@ -5194,9 +4932,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),
@@ -5264,9 +5000,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    8.0,
-                                                ),
+                                                8.0,
                                             ),
                                         ),
                                     ),
@@ -5276,9 +5010,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        11.0,
-                                    ),
+                                    11.0,
                                 ),
                             ),
                         ),
@@ -5346,9 +5078,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    4.0,
-                                                ),
+                                                4.0,
                                             ),
                                         ),
                                     ),
@@ -5358,18 +5088,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        11.0,
-                                    ),
+                                    11.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1272893353.0,
-                                    ),
+                                    1272893353.0,
                                 ),
                             ),
                         ),
@@ -5428,9 +5154,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    0.0,
-                                                ),
+                                                0.0,
                                             ),
                                         ),
                                     ),
@@ -5440,9 +5164,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        11.0,
-                                    ),
+                                    11.0,
                                 ),
                             ),
                         ),
@@ -5510,9 +5232,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    12.0,
-                                                ),
+                                                12.0,
                                             ),
                                         ),
                                     ),
@@ -5522,9 +5242,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        11.0,
-                                    ),
+                                    11.0,
                                 ),
                             ),
                         ),
@@ -5592,9 +5310,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    7.0,
-                                                ),
+                                                7.0,
                                             ),
                                         ),
                                     ),
@@ -5604,18 +5320,14 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        10.0,
-                                    ),
+                                    10.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1126891415.0,
-                                    ),
+                                    1126891415.0,
                                 ),
                             ),
                         ),
@@ -5674,9 +5386,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    3.0,
-                                                ),
+                                                3.0,
                                             ),
                                         ),
                                     ),
@@ -5686,9 +5396,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        10.0,
-                                    ),
+                                    10.0,
                                 ),
                             ),
                         ),
@@ -5756,9 +5464,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    15.0,
-                                                ),
+                                                15.0,
                                             ),
                                         ),
                                     ),
@@ -5768,9 +5474,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        10.0,
-                                    ),
+                                    10.0,
                                 ),
                             ),
                         ),
@@ -5838,9 +5542,7 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                TotalOrderF64(
-                                                    11.0,
-                                                ),
+                                                11.0,
                                             ),
                                         ),
                                     ),
@@ -5850,9 +5552,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        10.0,
-                                    ),
+                                    10.0,
                                 ),
                             ),
                         ),
@@ -5967,9 +5667,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -5990,9 +5688,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        16.0,
-                                    ),
+                                    16.0,
                                 ),
                             ),
                         ),
@@ -6170,9 +5866,7 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        0.0,
-                                    ),
+                                    0.0,
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
@@ -9,9 +9,7 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -115,9 +113,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -126,9 +122,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -137,9 +131,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -151,27 +143,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        8.0,
-                                    ),
+                                    8.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),
@@ -243,27 +229,21 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -276,9 +256,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),
@@ -338,27 +316,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1.0,
-                                    ),
+                                    1.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        2.0,
-                                    ),
+                                    2.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        3.0,
-                                    ),
+                                    3.0,
                                 ),
                             ),
                         ),
@@ -371,9 +343,7 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        0.0,
-                    ),
+                    0.0,
                 ),
             ),
         ),
@@ -486,27 +456,21 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -519,9 +483,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),
@@ -541,27 +503,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        4.0,
-                                    ),
+                                    4.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        5.0,
-                                    ),
+                                    5.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        6.0,
-                                    ),
+                                    6.0,
                                 ),
                             ),
                         ),
@@ -616,27 +572,21 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -649,9 +599,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),
@@ -711,27 +659,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1.0,
-                                    ),
+                                    1.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        2.0,
-                                    ),
+                                    2.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        3.0,
-                                    ),
+                                    3.0,
                                 ),
                             ),
                         ),
@@ -744,9 +686,7 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        0.0,
-                    ),
+                    0.0,
                 ),
             ),
         ),
@@ -848,27 +788,21 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),
@@ -881,9 +815,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),
@@ -900,9 +832,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
@@ -911,9 +841,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -922,9 +850,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -976,9 +902,7 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -1085,27 +1009,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        8.0,
-                                    ),
+                                    8.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
@@ -7,27 +7,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -46,27 +40,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        1.0,
-                                    ),
+                                    1.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        2.0,
-                                    ),
+                                    2.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        3.0,
-                                    ),
+                                    3.0,
                                 ),
                             ),
                         ),
@@ -79,27 +67,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        4.0,
-                                    ),
+                                    4.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        5.0,
-                                    ),
+                                    5.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        6.0,
-                                    ),
+                                    6.0,
                                 ),
                             ),
                         ),
@@ -131,27 +113,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),
@@ -161,27 +137,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        8.0,
-                                    ),
+                                    8.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),
@@ -233,27 +203,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        7.0,
-                                    ),
+                                    7.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        8.0,
-                                    ),
+                                    8.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        9.0,
-                                    ),
+                                    9.0,
                                 ),
                             ),
                         ),
@@ -276,9 +240,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -297,9 +259,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            1.0,
-                        ),
+                        1.0,
                     ),
                 ),
             ),
@@ -320,27 +280,21 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                1.0,
-                                            ),
+                                            1.0,
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                2.0,
-                                            ),
+                                            2.0,
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                3.0,
-                                            ),
+                                            3.0,
                                         ),
                                     ),
                                 ),
@@ -353,9 +307,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -374,27 +326,21 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        4.0,
-                                    ),
+                                    4.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        5.0,
-                                    ),
+                                    5.0,
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    TotalOrderF64(
-                                        6.0,
-                                    ),
+                                    6.0,
                                 ),
                             ),
                         ),
@@ -422,27 +368,21 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                1.0,
-                                            ),
+                                            1.0,
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                2.0,
-                                            ),
+                                            2.0,
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            TotalOrderF64(
-                                                3.0,
-                                            ),
+                                            3.0,
                                         ),
                                     ),
                                 ),
@@ -455,9 +395,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -473,27 +411,21 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                4.0,
-                            ),
+                            4.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                6.0,
-                            ),
+                            6.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
@@ -144,9 +144,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -205,9 +203,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -218,9 +214,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -269,9 +263,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),
@@ -385,9 +377,7 @@
                                         Constant(
                                             Num(
                                                 ConstantNumber(
-                                                    TotalOrderF64(
-                                                        1.0,
-                                                    ),
+                                                    1.0,
                                                 ),
                                             ),
                                         ),
@@ -618,9 +608,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
@@ -121,9 +121,7 @@
                                             Constant(
                                                 Num(
                                                     ConstantNumber(
-                                                        TotalOrderF64(
-                                                            1.0,
-                                                        ),
+                                                        1.0,
                                                     ),
                                                 ),
                                             ),
@@ -134,9 +132,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
@@ -163,9 +159,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    1.0,
-                                ),
+                                1.0,
                             ),
                         ),
                     ),
@@ -175,9 +169,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -198,9 +190,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph.snapshot
@@ -89,9 +89,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -101,9 +99,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -113,9 +109,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -125,9 +119,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -137,9 +129,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),
@@ -149,9 +139,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        1.0,
-                    ),
+                    1.0,
                 ),
             ),
         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
@@ -181,9 +181,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
@@ -22,9 +22,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        2.0,
-                    ),
+                    2.0,
                 ),
             ),
         ),
@@ -70,18 +68,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -97,9 +91,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -117,9 +109,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        3.0,
-                    ),
+                    3.0,
                 ),
             ),
         ),
@@ -139,9 +129,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),
@@ -154,9 +142,7 @@
         Constant(
             Num(
                 ConstantNumber(
-                    TotalOrderF64(
-                        2.0,
-                    ),
+                    2.0,
                 ),
             ),
         ),
@@ -181,9 +167,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -199,18 +183,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5.0,
-                            ),
+                            5.0,
                         ),
                     ),
                 ),
@@ -226,18 +206,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                3.0,
-                            ),
+                            3.0,
                         ),
                     ),
                 ),
@@ -253,18 +229,14 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
@@ -547,9 +547,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    1.0,
-                                ),
+                                1.0,
                             ),
                         ),
                     ),
@@ -565,9 +563,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    2.0,
-                                ),
+                                2.0,
                             ),
                         ),
                     ),
@@ -583,9 +579,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    3.0,
-                                ),
+                                3.0,
                             ),
                         ),
                     ),
@@ -610,9 +604,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    1.0,
-                                ),
+                                1.0,
                             ),
                         ),
                     ),
@@ -624,9 +616,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    2.0,
-                                ),
+                                2.0,
                             ),
                         ),
                     ),
@@ -642,9 +632,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    3.0,
-                                ),
+                                3.0,
                             ),
                         ),
                     ),
@@ -656,9 +644,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    4.0,
-                                ),
+                                4.0,
                             ),
                         ),
                     ),
@@ -674,9 +660,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    5.0,
-                                ),
+                                5.0,
                             ),
                         ),
                     ),
@@ -701,9 +685,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    11.0,
-                                ),
+                                11.0,
                             ),
                         ),
                     ),
@@ -727,9 +709,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    22.0,
-                                ),
+                                22.0,
                             ),
                         ),
                     ),
@@ -754,9 +734,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    1.0,
-                                ),
+                                1.0,
                             ),
                         ),
                     ),
@@ -777,9 +755,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    2.0,
-                                ),
+                                2.0,
                             ),
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph-effects.snapshot
@@ -1184,9 +1184,7 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        TotalOrderF64(
-                            0.0,
-                        ),
+                        0.0,
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
@@ -50,9 +50,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),
@@ -105,9 +103,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                0.0,
-                            ),
+                            0.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pattern-assignment/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pattern-assignment/graph.snapshot
@@ -58,9 +58,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    0.0,
-                                ),
+                                0.0,
                             ),
                         ),
                     ),
@@ -104,9 +102,7 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                TotalOrderF64(
-                                    0.0,
-                                ),
+                                0.0,
                             ),
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
@@ -7,9 +7,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
                         ),
                     ),
                 ),
@@ -29,9 +27,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                2.0,
-                            ),
+                            2.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
@@ -1348,9 +1348,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                200.0,
-                            ),
+                            200.0,
                         ),
                     ),
                 ),
@@ -1661,9 +1659,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                200.0,
-                            ),
+                            200.0,
                         ),
                     ),
                 ),
@@ -1822,9 +1818,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                200.0,
-                            ),
+                            200.0,
                         ),
                     ),
                 ),
@@ -2528,9 +2522,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5166.0,
-                            ),
+                            5166.0,
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
@@ -75,9 +75,7 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            TotalOrderF64(
-                                5166.0,
-                            ),
+                            5166.0,
                         ),
                     ),
                 ),
@@ -233,9 +231,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            1.0,
-                                        ),
+                                        1.0,
                                     ),
                                 ),
                             ),
@@ -257,9 +253,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            2.0,
-                                        ),
+                                        2.0,
                                     ),
                                 ),
                             ),
@@ -281,9 +275,7 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        TotalOrderF64(
-                                            3.0,
-                                        ),
+                                        3.0,
                                     ),
                                 ),
                             ),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/ieee754/input/else.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/ieee754/input/else.js
@@ -1,0 +1,1 @@
+exports.value = 'else'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/ieee754/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/ieee754/input/index.js
@@ -1,0 +1,87 @@
+/* These tests test that Turbopack's analyzer correctly 
+   handles NaN === NaN and 0 === -0. These are handled 
+   differently by Rust compared to JavaScript, see: 
+   https://github.com/rust-lang/rust/issues/1084.
+
+   Turbopack's analyzer should line up with JavaScript.
+*/
+
+it('NaN === NaN is not folded to truthy', () => {
+  let mod
+  if (NaN === NaN) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('else')
+})
+
+it('NaN !== NaN is not folded to falsy', () => {
+  let mod
+  if (NaN !== NaN) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('then')
+})
+
+it('NaN == NaN is not folded to truthy', () => {
+  let mod
+  if (NaN == NaN) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('else')
+})
+
+it('NaN != NaN is not folded to falsy', () => {
+  let mod
+  if (NaN != NaN) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('then')
+})
+
+it('0 === -0 is not folded to falsy', () => {
+  let mod
+  if (0 === -0) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('then')
+})
+
+it('0 !== -0 is not folded to truthy', () => {
+  let mod
+  if (0 !== -0) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('else')
+})
+
+it('0 == -0 is not folded to falsy', () => {
+  let mod
+  if (0 == -0) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('then')
+})
+
+it('0 != -0 is not folded to truthy', () => {
+  let mod
+  if (0 != -0) {
+    mod = require('./then')
+  } else {
+    mod = require('./else')
+  }
+  expect(mod.value).toBe('else')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/ieee754/input/then.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/ieee754/input/then.js
@@ -1,0 +1,1 @@
+exports.value = 'then'


### PR DESCRIPTION
This is how JavaScript handles them:

<img width="112" height="78" alt="Screenshot 2026-05-27 at 2 08 08 PM" src="https://github.com/user-attachments/assets/21313410-7600-489a-a8bb-4e76d8052d23" />

However, we were using `TotalOrderF64` which did not follow this. This PR switches to us to using `f64` in `ConstantNumber`. 

This PR also adds execution tests that were previously failing but now pass. A large amount of changes in this PR are changes in snapshot tests, eg:

```diff
 Constant(
     Num(
         ConstantNumber(
-                            TotalOrderF64(
-                                1.0,
-                            ),
+                            1.0,
         ),
     ),
 ),
```

The other use of `TotalOrderF64` was in `CompileTimeDefineValue` which has now been switched to `serde_json::Number` in a stacked PR: https://github.com/vercel/next.js/pull/94177.