### PR TITLE
[turbopack] Enable Effects to be evicted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9847,6 +9847,7 @@ name = "turbo-tasks-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "auto-hash-map",
  "bincode 2.0.1",
  "bitfield",
@@ -9869,6 +9870,7 @@ dependencies = [
  "serde_path_to_error",
  "smallvec",
  "tempfile",
+ "thiserror 1.0.69",
  "thread_local",
  "tokio",
  "tracing",
@@ -9948,6 +9950,7 @@ name = "turbo-tasks-fs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "auto-hash-map",
  "bincode 2.0.1",
  "bitflags 1.3.2",

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -13,7 +13,8 @@ use next_api::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Effects, ReadConsistency, ReadRef, ResolvedVc, TransientInstance, TurboTasks, Vc, take_effects,
+    Effects, ReadConsistency, ReadRef, ResolvedVc, TransientInstance, TurboTasks, Vc,
+    read_strongly_consistent_and_apply_effects, take_effects,
 };
 use turbo_tasks_backend::TurboTasksBackend;
 use turbo_tasks_malloc::TurboMalloc;
@@ -275,13 +276,9 @@ async fn endpoint_write_to_disk_with_apply(
     }
 
     let op = inner_operation_with_effects(endpoint);
-    let WithEffects {
-        output_paths,
-        effects,
-    } = &*op.read_strongly_consistent().await?;
-    effects.apply().await?;
+    let read = read_strongly_consistent_and_apply_effects(op, |v| &v.effects).await?;
 
-    Ok(output_paths.clone())
+    Ok(read.output_paths.clone())
 }
 
 async fn hmr(

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -14,7 +14,9 @@ use next_api::{
 };
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, Effects, OperationVc, ReadRef, Vc};
+use turbo_tasks::{
+    Completion, Effects, OperationVc, ReadRef, Vc, read_strongly_consistent_and_apply_effects,
+};
 use turbopack_core::issue::{IssueFilter, PlainIssue};
 
 use crate::next_api::utils::{
@@ -156,14 +158,14 @@ pub async fn endpoint_write_to_disk(
         .run(async move {
             let written_entrypoint_with_issues_op =
                 get_written_endpoint_with_issues_operation(endpoint_op);
+            let read = read_strongly_consistent_and_apply_effects(
+                written_entrypoint_with_issues_op,
+                |v| &v.effects,
+            )
+            .await?;
             let WrittenEndpointWithIssues {
-                written,
-                issues,
-                effects,
-            } = &*written_entrypoint_with_issues_op
-                .read_strongly_consistent()
-                .await?;
-            effects.apply().await?;
+                written, issues, ..
+            } = &*read;
 
             Ok((written.clone(), issues.clone()))
         })
@@ -190,8 +192,9 @@ pub fn endpoint_server_changed_subscribe(
         move || {
             async move {
                 let issues_and_diags_op = subscribe_issues_and_diags_operation(endpoint, issues);
-                let result = issues_and_diags_op.read_strongly_consistent().await?;
-                result.effects.apply().await?;
+                let result =
+                    read_strongly_consistent_and_apply_effects(issues_and_diags_op, |v| &v.effects)
+                        .await?;
                 Ok(result)
             }
             .instrument(tracing::info_span!("server changes subscription"))

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -51,7 +51,7 @@ use turbo_tasks::{
     TransientInstance, TryJoinIterExt, TurboTasksApi, TurboTasksCallApi, UpdateInfo, Vc,
     mark_top_level_task,
     message_queue::{CompilationEvent, Severity},
-    take_effects,
+    read_strongly_consistent_and_apply_effects, take_effects,
     trace::TraceRawVcs,
     unmark_top_level_task_may_leak_eventually_consistent_state,
 };
@@ -1406,17 +1406,16 @@ pub async fn project_write_all_entrypoints_to_disk(
                 first_phase,
             );
 
-            // Read and compile the files
+            let read =
+                read_strongly_consistent_and_apply_effects(entrypoints_with_issues_op, |v| {
+                    &v.effects
+                })
+                .await?;
             let AllWrittenEntrypointsWithIssues {
                 entrypoints,
                 issues,
-                effects,
-            } = &*entrypoints_with_issues_op
-                .read_strongly_consistent()
-                .await?;
-
-            // Apply phase side effects. Asset emission is performed once at the end.
-            effects.apply().await?;
+                ..
+            } = &*read;
 
             Ok((
                 entrypoints.clone(),
@@ -1471,16 +1470,16 @@ pub async fn project_write_all_entrypoints_to_disk(
                     EntrypointsWritePhase::Deferred,
                 );
 
+                let read =
+                    read_strongly_consistent_and_apply_effects(entrypoints_with_issues_op, |v| {
+                        &v.effects
+                    })
+                    .await?;
                 let AllWrittenEntrypointsWithIssues {
                     entrypoints,
                     issues,
-                    effects,
-                } = &*entrypoints_with_issues_op
-                    .read_strongly_consistent()
-                    .await?;
-
-                // Apply phase side effects. Asset emission is performed once at the end.
-                effects.apply().await?;
+                    ..
+                } = &*read;
 
                 Ok((
                     entrypoints.clone(),
@@ -1503,17 +1502,16 @@ pub async fn project_write_all_entrypoints_to_disk(
                 app_dir_only,
                 has_deferred_entrypoints,
             );
-            let OperationResult { issues, effects } =
-                &*emit_result_op.read_strongly_consistent().await?;
+            let read =
+                read_strongly_consistent_and_apply_effects(emit_result_op, |v| &v.effects).await?;
+            let OperationResult { issues, .. } = &*read;
 
-            effects.apply().await?;
-
-            Ok(issues.iter().cloned().collect::<Vec<_>>())
+            Ok(issues.clone())
         })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await?;
 
-    issues.extend(emit_issues);
+    issues.extend(emit_issues.iter().cloned());
 
     Ok(TurbopackResult {
         result: if let Some(entrypoints) = entrypoints {
@@ -1745,15 +1743,16 @@ pub fn project_entrypoints_subscribe(
         move || {
             async move {
                 let entrypoints_with_issues_op = get_entrypoints_with_issues_operation(container);
+                let read =
+                    read_strongly_consistent_and_apply_effects(entrypoints_with_issues_op, |v| {
+                        &v.effects
+                    })
+                    .await?;
                 let EntrypointsWithIssues {
                     entrypoints,
                     issues,
-                    effects,
-                } = &*entrypoints_with_issues_op
-                    .read_strongly_consistent()
-                    .await?;
-
-                effects.apply().await?;
+                    ..
+                } = &*read;
                 Ok((entrypoints.clone(), issues.clone()))
             }
             .instrument(tracing::info_span!("entrypoints subscription"))
@@ -1865,17 +1864,14 @@ pub fn project_hmr_events(
                         state,
                         hmr_target,
                     );
-                    let update = update_op.read_strongly_consistent().await?;
-                    let HmrUpdateWithIssues {
-                        update,
-                        issues,
-                        effects,
-                    } = &*update;
                     // HACK(bgw): Remove this mark call
                     mark_top_level_task();
-                    effects.apply().await?;
+                    let read =
+                        read_strongly_consistent_and_apply_effects(update_op, |v| &v.effects)
+                            .await?;
                     // HACK(bgw): Remove this unmark call
                     unmark_top_level_task_may_leak_eventually_consistent_state();
+                    let HmrUpdateWithIssues { update, issues, .. } = &*read;
                     match &**update {
                         Update::Missing | Update::None => {}
                         Update::Total(TotalUpdate { to }) => {
@@ -1987,14 +1983,16 @@ pub fn project_hmr_chunk_names_subscribe(
         move || async move {
             let hmr_chunk_names_with_issues_op =
                 get_hmr_chunk_names_with_issues_operation(container, hmr_target);
+            let read =
+                read_strongly_consistent_and_apply_effects(hmr_chunk_names_with_issues_op, |v| {
+                    &v.effects
+                })
+                .await?;
             let HmrChunkNamesWithIssues {
                 chunk_names,
                 issues,
-                effects,
-            } = &*hmr_chunk_names_with_issues_op
-                .read_strongly_consistent()
-                .await?;
-            effects.apply().await?;
+                ..
+            } = &*read;
 
             Ok((chunk_names.clone(), issues.clone()))
         },
@@ -2453,11 +2451,10 @@ pub async fn project_write_analyze_data(
         .turbo_tasks()
         .run_once(async move {
             let analyze_data_op = write_analyze_data_with_issues_operation(container, app_dir_only);
-            let WriteAnalyzeResult { issues, effects } =
-                &*analyze_data_op.read_strongly_consistent().await?;
-
             // Write the files to disk
-            effects.apply().await?;
+            let read =
+                read_strongly_consistent_and_apply_effects(analyze_data_op, |v| &v.effects).await?;
+            let WriteAnalyzeResult { issues, .. } = &*read;
             Ok(issues.clone())
         })
         .await

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -64,12 +64,14 @@ turbo-tasks-malloc = { workspace = true, default-features = false }
 thread_local = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 futures = { workspace = true }
 indoc = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
 triomphe = { workspace = true }
+thiserror = { workspace = true }
 turbo-tasks-malloc = { workspace = true , features = ["custom_allocator"]}
 rstest = { workspace = true }
 turbo-tasks-testing = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/tests/effects.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/effects.rs
@@ -1,0 +1,736 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use rustc_hash::FxHashMap;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{
+    ApplyError, CapturedEffect, Effect, EffectExt, EffectStateStorage, Effects, EffectsError,
+    NonLocalValue, OperationValue, ReadRef, ResolvedVc, State, TurboTasks, Vc, take_effects,
+    trace::TraceRawVcs,
+};
+use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
+
+/// Per-test counters + `EffectStateStorage`. Tests assert against
+/// `applies_by_key` to check how many times each effect ran.
+///
+/// A single `SharedState` can be associated with multiple `TestInput` cells (each
+/// representing a separate producer task); they then share the same
+/// `EffectStateStorage`, mirroring how on disk two producers writing the
+/// same path contend on the same per-key state entry.
+#[derive(TraceRawVcs, NonLocalValue)]
+struct SharedState {
+    #[turbo_tasks(trace_ignore)]
+    applies_by_key: Mutex<FxHashMap<RcStr, u64>>,
+    #[turbo_tasks(trace_ignore)]
+    total_applies: AtomicU64,
+    /// Counts captures that materialized content (i.e. those where
+    /// `EffectStateStorage::matches_applied` returned false). Lets tests
+    /// assert that capture skipped content materialization on re-runs.
+    #[turbo_tasks(trace_ignore)]
+    captures_with_content: AtomicU64,
+    /// Shared `EffectStateStorage` used by both `matches_applied` (in `capture`)
+    /// and `run_apply` (in `apply`).
+    #[turbo_tasks(trace_ignore)]
+    state_storage: EffectStateStorage,
+}
+
+impl SharedState {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            applies_by_key: Mutex::new(Default::default()),
+            total_applies: AtomicU64::new(0),
+            captures_with_content: AtomicU64::new(0),
+            state_storage: EffectStateStorage::default(),
+        })
+    }
+
+    fn applies_for(&self, key: &RcStr) -> u64 {
+        self.applies_by_key.lock().get(key).copied().unwrap_or(0)
+    }
+
+    fn total(&self) -> u64 {
+        self.total_applies.load(Ordering::Relaxed)
+    }
+
+    fn captures_with_content(&self) -> u64 {
+        self.captures_with_content.load(Ordering::Relaxed)
+    }
+}
+// Emit-side effect. A `#[turbo_tasks::value]` cell implementing the `Effect` value_trait. Marked
+// `serialization = "skip"` because it holds `Arc<SharedState>` (counters + storage, not
+// serializable) — these tests use `noop_backing_storage`, so persistence isn't exercised.
+#[turbo_tasks::value(serialization = "skip", cell = "new", eq = "manual")]
+struct TestEffect {
+    key: RcStr,
+    value_hash: u128,
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    shared: Arc<SharedState>,
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl Effect for TestEffect {
+    async fn capture(&self) -> Result<Box<dyn CapturedEffect>> {
+        // Consult storage. If the per-key state already records `Applied { value_hash }`
+        // matching our hash, elide content materialization (`content = false`). Otherwise
+        // bump the captures-with-content counter (the test's stand-in for a `ReadRef` /
+        // disk-read at this point).
+        let content = if self
+            .shared
+            .state_storage
+            .matches_applied(self.key.as_bytes(), self.value_hash)
+        {
+            false
+        } else {
+            self.shared
+                .captures_with_content
+                .fetch_add(1, Ordering::Relaxed);
+            true
+        };
+        Ok(Box::new(TestEffectCaptured {
+            key: self.key.clone(),
+            value_hash: self.value_hash,
+            content,
+            shared: self.shared.clone(),
+        }) as Box<dyn CapturedEffect>)
+    }
+}
+
+// Post-capture effect — session-only plain struct.
+#[derive(TraceRawVcs, NonLocalValue)]
+struct TestEffectCaptured {
+    key: RcStr,
+    value_hash: u128,
+    /// Whether `capture` materialized content. When `false`, `apply` passes `None` to
+    /// `run_apply`; a non-matching storage state then triggers `ApplyOutcome::Retry`.
+    content: bool,
+    shared: Arc<SharedState>,
+}
+
+#[async_trait]
+impl CapturedEffect for TestEffectCaptured {
+    fn key(&self) -> Box<[u8]> {
+        self.key.as_bytes().into()
+    }
+
+    fn value_hash(&self) -> u128 {
+        self.value_hash
+    }
+
+    async fn apply(&self) -> Result<(), ApplyError> {
+        let body = if self.content {
+            Some(|| async {
+                self.shared.total_applies.fetch_add(1, Ordering::Relaxed);
+                *self
+                    .shared
+                    .applies_by_key
+                    .lock()
+                    .entry(self.key.clone())
+                    .or_insert(0) += 1;
+                Ok::<(), TestError>(())
+            })
+        } else {
+            None
+        };
+        self.shared
+            .state_storage
+            .run_apply::<TestError, _, _>(self.key(), self.value_hash, body)
+            .await
+    }
+}
+
+#[derive(Debug, thiserror::Error, TraceRawVcs, NonLocalValue)]
+enum TestError {}
+
+/// Spec for what the producer should emit: a list of `(key, value_hash)`
+/// pairs. Stored inside `State<EmitSpec>` so mutating it invalidates the
+/// producer.
+#[derive(Clone, Default, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue, OperationValue)]
+struct EmitSpec {
+    pairs: Vec<(RcStr, u128)>,
+}
+
+/// Input cell. Holds an `Arc<Shared>` (counters + `EffectStateStorage`) plus
+/// its own `Arc<State<EmitSpec>>` driving what *this* producer emits. The
+/// spec lives in an `Arc<State<…>>` rather than in the cell value so the
+/// test body can mutate it from top-level via the handle returned by
+/// `TestInput::new`, without going through a cached operation. Mutating from
+/// inside a cached operation would make the operation non-deterministic.
+///
+/// Multiple `TestInput`s can share one `Arc<Shared>` (so they contend on the
+/// same `EffectStateStorage`) while each carries its own independent spec —
+/// this is what lets us simulate two sibling producers writing the same key
+/// in the retry test.
+#[turbo_tasks::value(eq = "manual", serialization = "skip")]
+#[derive(Clone)]
+struct TestInput {
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    shared: Arc<SharedState>,
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    spec: Arc<State<EmitSpec>>,
+    /// Side-channel `State` for invalidating the producer without changing
+    /// `spec`. Lets tests simulate upstream input changes that don't affect
+    /// emitted hashes (e.g. a comment edit that recompiles to identical bytes).
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    tick: Arc<State<u64>>,
+}
+
+impl PartialEq for TestInput {
+    fn eq(&self, _other: &Self) -> bool {
+        false
+    }
+}
+
+impl TestInput {
+    /// Construct a fresh `TestInput` cell with a fresh `Shared`.
+    fn new() -> (ResolvedVc<Self>, Self) {
+        Self::new_with_shared(SharedState::new())
+    }
+
+    /// Construct a fresh `TestInput` cell that shares an existing `Shared`.
+    /// The new input has its own independent spec.
+    fn new_with_shared(shared: Arc<SharedState>) -> (ResolvedVc<Self>, Self) {
+        let spec = Arc::new(State::new(EmitSpec::default()));
+        let tick = Arc::new(State::new(0u64));
+        let input = Self { shared, spec, tick };
+
+        (input.clone().resolved_cell(), input)
+    }
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn producer_operation(input: ResolvedVc<TestInput>) -> Result<()> {
+    let input = input.await?;
+    let shared = input.shared.clone();
+    let spec = input.spec.get().clone();
+    // Track `tick` so callers can force a producer rerun without mutating `spec`.
+    let _tick: u64 = *input.tick.get();
+    for (key, value_hash) in spec.pairs {
+        TestEffect {
+            key,
+            value_hash,
+            shared: shared.clone(),
+        }
+        .resolved_cell()
+        .emit();
+    }
+    Ok(())
+}
+
+/// Read the current spec from `input` and emit the corresponding effects,
+/// returning the captured `Effects`. State mutation must happen OUTSIDE this
+/// operation (at top-level via the spec handle), otherwise the operation
+/// becomes non-deterministic and turbo-tasks may re-run it with stale inputs.
+#[turbo_tasks::function(operation, root)]
+async fn extract_effects(input: ResolvedVc<TestInput>) -> Result<Vc<Effects>> {
+    let producer = producer_operation(input);
+    let _ = producer.resolve().strongly_consistent().await?;
+    Ok(take_effects(producer).await?.cell())
+}
+
+/// Mutate the spec via its top-level handle and return the resulting
+/// `Effects`. State mutation is synchronous at top-level (so it doesn't make
+/// any operation non-deterministic); only the `take_effects` step runs
+/// inside an operation root so it gets strongly-consistent read semantics.
+async fn emit_and_take(
+    spec: &State<EmitSpec>,
+    input: ResolvedVc<TestInput>,
+    pairs: Vec<(RcStr, u128)>,
+) -> Result<ReadRef<Effects>> {
+    spec.set(EmitSpec { pairs });
+    extract_effects(input).read_strongly_consistent().await
+}
+
+// =============================================================================
+// Test harness
+// =============================================================================
+
+fn create_tt() -> Arc<TurboTasks<TurboTasksBackend>> {
+    TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions::default(),
+        noop_backing_storage(),
+    ))
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/// A duplicate sequential `.apply_for_testing()` on the same `Effects` must run each
+/// underlying side-effect exactly once. The first call populates the per-key
+/// `EffectStateStorage` with `Applied { value_hash }`; the second call sees
+/// `Effects.captured == None` and falls through `apply_post_drop` where every
+/// state entry is `Applied` with a matching hash → no `dyn_apply` invocation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn duplicate_apply_runs_once() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (input, TestInput { shared, spec, .. }) = TestInput::new();
+
+        let effects = emit_and_take(&spec, input, vec![(rcstr!("foo"), 0xAAAA)]).await?;
+
+        effects.apply_for_testing().await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            1,
+            "first apply runs the effect"
+        );
+
+        effects.apply_for_testing().await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            1,
+            "second apply on the same Effects must not re-run"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Re-running the producer (e.g. because something upstream invalidated it)
+/// with the same `(key, value_hash)` set produces a fresh `Effects` value
+/// whose identity multiset matches the previous one. `.apply_for_testing()` on the new
+/// `Effects` short-circuits through the per-key state machine because each
+/// `EffectStateEntry` is still `Applied { value_hash: matching }`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reemit_unchanged_hash_does_not_reapply() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (input, TestInput { shared, spec, .. }) = TestInput::new();
+
+        emit_and_take(
+            &spec,
+            input,
+            vec![(rcstr!("foo"), 0xAAAA), (rcstr!("bar"), 0xBBBB)],
+        )
+        .await?
+        .apply_for_testing()
+        .await?;
+        assert_eq!(shared.total(), 2, "first emit runs both effects");
+
+        // Re-set with the same value. `State::set` is a no-op when the value
+        // hasn't changed (PartialEq), but the second `extract_effects` invocation
+        // is still a fresh root task — it re-takes the producer's collectibles.
+        emit_and_take(
+            &spec,
+            input,
+            vec![(rcstr!("foo"), 0xAAAA), (rcstr!("bar"), 0xBBBB)],
+        )
+        .await?
+        .apply_for_testing()
+        .await?;
+        assert_eq!(
+            shared.total(),
+            2,
+            "re-emit with same (key, hash) must not re-run any apply"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Changing one effect's hash re-runs only that effect; the sibling stays
+/// short-circuited by its `Applied { value_hash: matching }` state entry.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hash_change_reapplies_only_changed_key() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (input, TestInput { shared, spec, .. }) = TestInput::new();
+
+        emit_and_take(
+            &spec,
+            input,
+            vec![(rcstr!("foo"), 0xAAAA), (rcstr!("bar"), 0xBBBB)],
+        )
+        .await?
+        .apply_for_testing()
+        .await?;
+        assert_eq!(shared.applies_for(&rcstr!("foo")), 1);
+        assert_eq!(shared.applies_for(&rcstr!("bar")), 1);
+
+        // Change key 1's hash; leave key 2 alone.
+        emit_and_take(
+            &spec,
+            input,
+            vec![(rcstr!("foo"), 0xCCCC), (rcstr!("bar"), 0xBBBB)],
+        )
+        .await?
+        .apply_for_testing()
+        .await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            2,
+            "key 1 hash changed; apply must run again"
+        );
+        assert_eq!(
+            shared.applies_for(&rcstr!("bar")),
+            1,
+            "key 2 unchanged; apply must short-circuit"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Adding a brand-new effect to the emitted set only runs the new key's
+/// apply; the pre-existing keys stay short-circuited.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn adding_effect_only_runs_new_key() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (input, TestInput { shared, spec, .. }) = TestInput::new();
+
+        emit_and_take(&spec, input, vec![(rcstr!("foo"), 0xAAAA)])
+            .await?
+            .apply_for_testing()
+            .await?;
+        assert_eq!(shared.total(), 1);
+
+        // Add a new effect, key 2.
+        emit_and_take(
+            &spec,
+            input,
+            vec![(rcstr!("foo"), 0xAAAA), (rcstr!("bar"), 0xBBBB)],
+        )
+        .await?
+        .apply_for_testing()
+        .await?;
+
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            1,
+            "key 1 already applied"
+        );
+        assert_eq!(shared.applies_for(&rcstr!("bar")), 1, "key 2 newly added");
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Removing an effect from the emitted set must not re-run the surviving
+/// effect, and the removed effect's apply must not fire again either.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn removing_effect_does_not_reapply_survivors() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (input, TestInput { shared, spec, .. }) = TestInput::new();
+
+        emit_and_take(
+            &spec,
+            input,
+            vec![(rcstr!("foo"), 0xAAAA), (rcstr!("bar"), 0xBBBB)],
+        )
+        .await?
+        .apply_for_testing()
+        .await?;
+        assert_eq!(shared.total(), 2);
+
+        // Drop key 2.
+        emit_and_take(&spec, input, vec![(rcstr!("foo"), 0xAAAA)])
+            .await?
+            .apply_for_testing()
+            .await?;
+
+        assert_eq!(shared.applies_for(&rcstr!("foo")), 1, "key 1 stays cached");
+        assert_eq!(
+            shared.applies_for(&rcstr!("bar")),
+            1,
+            "key 2 was removed; its apply must not run again"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// When sibling producers write the same key with different hashes, A's
+/// re-apply (on the same `Effects` value) re-fires A's side effect because
+/// the per-key state machine sees `Applied { H_B } != H_A` → break into
+/// InProgress, run body, write back `Applied { H_A }`. Captured effects are
+/// kept alive for the lifetime of the cell so re-apply always has a body to
+/// run; there is no Retry signal in this scenario because the test effects
+/// don't elide content at capture time.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sibling_producer_overwrites_state_reapplies_on_call() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (
+            input_a,
+            TestInput {
+                shared,
+                spec: spec_a,
+                ..
+            },
+        ) = TestInput::new();
+        let (input_b, TestInput { spec: spec_b, .. }) = TestInput::new_with_shared(shared.clone());
+
+        // Step 1: A emits and applies (key=1, hash=H1).
+        spec_a.set(EmitSpec {
+            pairs: vec![(rcstr!("foo"), 0xAAAA)],
+        });
+        let op_a = extract_effects(input_a);
+        let effects_a = op_a.read_strongly_consistent().await?;
+        effects_a.apply_for_testing().await?;
+        assert_eq!(shared.applies_for(&rcstr!("foo")), 1, "A's first apply ran");
+
+        // Step 2: B emits and applies (key=1, hash=H2). Different hash for the
+        // same key overwrites the per-key state entry.
+        emit_and_take(&spec_b, input_b, vec![(rcstr!("foo"), 0xBBBB)])
+            .await?
+            .apply_for_testing()
+            .await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            2,
+            "B's apply for the same key ran"
+        );
+
+        // Step 3: re-apply A's original Effects. Captured slice is still alive
+        // (Effects keeps captured for the cell's lifetime; cell="new" drops it
+        // when the producer reruns), so the state machine breaks into InProgress
+        // and re-runs A's body, then writes back Applied{H_A}.
+        effects_a.apply_for_testing().await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            3,
+            "A's re-apply against stomped state re-fires its body"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// When `Effects::apply` is called twice in sequence on the same value, the
+/// second call short-circuits via the per-key dedup hit. This works because
+/// `Effects` keeps `captured` alive for the lifetime of the cell, so every
+/// apply re-enters the state machine; with storage `Applied{H_A}` matching
+/// the captured hash H_A, the state machine returns the cached result
+/// without invoking the body a second time.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repeated_apply_after_unchanged_state_dedupes() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (input, TestInput { shared, spec, .. }) = TestInput::new();
+
+        spec.set(EmitSpec {
+            pairs: vec![(rcstr!("foo"), 0xAAAA)],
+        });
+        let op = extract_effects(input);
+        let effects = op.read_strongly_consistent().await?;
+        effects.apply_for_testing().await?;
+        assert_eq!(shared.applies_for(&rcstr!("foo")), 1);
+
+        effects.apply_for_testing().await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            1,
+            "second apply with unchanged state must dedup-hit",
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Holding on to `effects_a`, deliberately suppress the test from holding
+/// `ReadRef` references that would prevent eviction. We confirm referential
+/// behavior: after a sibling stomps storage and A is invalidated and re-read,
+/// the new `Effects` cell is a different value (cell = "new").
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cell_new_produces_distinct_effects_per_producer_run() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (input, TestInput { spec, .. }) = TestInput::new();
+
+        spec.set(EmitSpec {
+            pairs: vec![(rcstr!("foo"), 0xAAAA)],
+        });
+        let op = extract_effects(input);
+        let effects_v1 = op.read_strongly_consistent().await?;
+
+        // Mutate spec to invalidate the producer.
+        spec.set(EmitSpec {
+            pairs: vec![(rcstr!("foo"), 0xBBBB)],
+        });
+        let effects_v2 = op.read_strongly_consistent().await?;
+
+        assert!(
+            !ReadRef::ptr_eq(&effects_v1, &effects_v2),
+            "cell = \"new\" must allocate a fresh cell value on producer rerun"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// When the producer reruns with the same `(key, value_hash)` after the first
+/// apply succeeded, `capture` observes storage `Applied{matching}` and elides
+/// content materialization. The apply-side state machine still dedup-hits
+/// because storage is unchanged, so the side effect does not re-fire.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capture_skips_content_when_storage_matches() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (
+            input,
+            TestInput {
+                shared, spec, tick, ..
+            },
+        ) = TestInput::new();
+
+        spec.set(EmitSpec {
+            pairs: vec![(rcstr!("foo"), 0xAAAA)],
+        });
+        let op = extract_effects(input);
+        op.read_strongly_consistent()
+            .await?
+            .apply_for_testing()
+            .await?;
+        assert_eq!(shared.applies_for(&rcstr!("foo")), 1, "first apply ran");
+        assert_eq!(
+            shared.captures_with_content(),
+            1,
+            "first capture had to materialize (storage was empty)"
+        );
+
+        // Force the producer to rerun without changing what it emits (simulates
+        // an upstream input change that doesn't affect the output). Storage
+        // still holds `Applied{0xAAAA}` so capture's `matches_applied` returns
+        // true and we skip content materialization. Apply dedup-hits via the
+        // state machine.
+        tick.set(1);
+        op.read_strongly_consistent()
+            .await?
+            .apply_for_testing()
+            .await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            1,
+            "re-emit with unchanged state must not re-run apply",
+        );
+        assert_eq!(
+            shared.captures_with_content(),
+            1,
+            "second capture must skip content materialization",
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Race scenario: A's capture observed `Applied{H_A}` and elided content
+/// materialization. Before A's apply runs, B applies a different hash for the
+/// same key, stomping storage to `Applied{H_B}`. A's apply now sees the
+/// mismatch but has no content — `ApplyOutcome::Retry` propagates as
+/// `EffectsError::Retry`. The producer's invalidator fires; re-reading A
+/// produces a fresh `Effects` whose `capture` sees the mismatch and
+/// materializes content this time, so the second apply succeeds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capture_skip_then_stomp_signals_retry() {
+    let tt = create_tt();
+    tt.run_once(async move {
+        let (
+            input_a,
+            TestInput {
+                shared,
+                spec: spec_a,
+                tick: tick_a,
+            },
+        ) = TestInput::new();
+        let (input_b, TestInput { spec: spec_b, .. }) = TestInput::new_with_shared(shared.clone());
+
+        // T1: A applies (key=1, H_A). Storage = Applied{H_A}. Capture had to
+        // materialize (storage was empty).
+        spec_a.set(EmitSpec {
+            pairs: vec![(rcstr!("foo"), 0xAAAA)],
+        });
+        let op_a = extract_effects(input_a);
+        op_a.read_strongly_consistent()
+            .await?
+            .apply_for_testing()
+            .await?;
+        assert_eq!(shared.applies_for(&rcstr!("foo")), 1);
+        assert_eq!(shared.captures_with_content(), 1);
+
+        // T2: Force the producer to rerun by bumping `tick` (simulates an upstream
+        // input change that doesn't affect the emitted hashes). Storage still
+        // holds Applied{H_A}, so capture's matches_applied returns true and we
+        // elide content materialization.
+        tick_a.set(1);
+        let effects_a_skipped = op_a.read_strongly_consistent().await?;
+        assert_eq!(
+            shared.captures_with_content(),
+            1,
+            "second capture skipped materialization",
+        );
+
+        // T3: B applies (key=1, H_B). Different hash, so B's capture materializes
+        // and writes back Applied{H_B}.
+        emit_and_take(&spec_b, input_b, vec![(rcstr!("foo"), 0xBBBB)])
+            .await?
+            .apply_for_testing()
+            .await?;
+        assert_eq!(shared.applies_for(&rcstr!("foo")), 2);
+
+        // T4: A's apply on the content-elided Effects. State is Applied{H_B} ≠
+        // H_A; capture had no content → run_apply returns Retry.
+        let err = effects_a_skipped
+            .apply_for_testing()
+            .await
+            .expect_err("expected Retry");
+        assert!(
+            matches!(err, EffectsError::Retry { .. }),
+            "expected EffectsError::Retry, got {err:?}"
+        );
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            2,
+            "Retry path must not run A's side effect",
+        );
+
+        // T5: Re-read A. capture sees Applied{H_B} ≠ H_A so it materializes
+        // content. Apply succeeds and writes back Applied{H_A}.
+        op_a.read_strongly_consistent()
+            .await?
+            .apply_for_testing()
+            .await?;
+        assert_eq!(
+            shared.applies_for(&rcstr!("foo")),
+            3,
+            "fresh capture with content recovers A's apply",
+        );
+        assert!(
+            shared.captures_with_content() >= 2,
+            "recovery capture had to materialize at least once (storage diverged); got {}",
+            shared.captures_with_content(),
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -24,6 +24,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 bincode = { workspace = true }
 bitflags = "1.3.2"

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -65,8 +65,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     CapturedEffect, Completion, Effect, EffectExt, EffectStateStorage, InvalidationReason,
     NonLocalValue, ReadRef, ResolvedVc, TurboTasksApi, ValueToString, ValueToStringRef, Vc,
-    debug::ValueDebugFormat, parallel, spawn, trace::TraceRawVcs, turbo_tasks_weak, turbobail,
-    turbofmt,
+    debug::ValueDebugFormat, parallel, trace::TraceRawVcs, turbo_tasks_weak, turbobail, turbofmt,
 };
 use turbo_tasks_hash::{
     DeterministicHash, DeterministicHasher, HashAlgorithm, deterministic_hash, hash_xxh3_hash64,
@@ -1004,20 +1003,13 @@ impl FileSystem for DiskFileSystem {
             }
 
             async fn apply(&self) -> Result<(), turbo_tasks::ApplyError> {
-                // Run the whole apply (state-machine coordination + the actual write) on its own
-                // spawned task so that multiple pending write effects can execute in parallel
-                // rather than serially on the caller's future (see #94140).
-                let this = self.clone();
-                spawn(async move {
-                    let body = this.content.as_ref().map(|content| {
-                        || async { this.apply_inner(content).await.map_err(AnyhowWrapper::from) }
-                    });
-                    this.inner
-                        .effect_state_storage
-                        .run_apply::<AnyhowWrapper, _, _>(this.key(), this.content_hash, body)
-                        .await
-                })
-                .await
+                let body = self.content.as_ref().map(|content| {
+                    || async { self.apply_inner(content).await.map_err(AnyhowWrapper::from) }
+                });
+                self.inner
+                    .effect_state_storage
+                    .run_apply::<AnyhowWrapper, _, _>(self.key(), self.content_hash, body)
+                    .await
             }
         }
 
@@ -1229,20 +1221,13 @@ impl FileSystem for DiskFileSystem {
             }
 
             async fn apply(&self) -> Result<(), turbo_tasks::ApplyError> {
-                // Run the whole apply (state-machine coordination + the actual symlink write) on
-                // its own spawned task so multiple pending effects can execute in parallel rather
-                // than serially on the caller's future (see #94140).
-                let this = self.clone();
-                spawn(async move {
-                    let body = this.content.as_ref().map(|content| {
-                        || async { this.apply_inner(content).await.map_err(AnyhowWrapper::from) }
-                    });
-                    this.inner
-                        .effect_state_storage
-                        .run_apply::<AnyhowWrapper, _, _>(this.key(), this.content_hash, body)
-                        .await
-                })
-                .await
+                let body = self.content.as_ref().map(|content| {
+                    || async { self.apply_inner(content).await.map_err(AnyhowWrapper::from) }
+                });
+                self.inner
+                    .effect_state_storage
+                    .run_apply::<AnyhowWrapper, _, _>(self.key(), self.content_hash, body)
+                    .await
             }
         }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -46,6 +46,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
 use auto_hash_map::{AutoMap, AutoSet};
 use bincode::{Decode, Encode};
 use bitflags::bitflags;
@@ -62,9 +63,10 @@ use tokio::{
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, Effect, EffectStateStorage, InvalidationReason, NonLocalValue, ReadRef, ResolvedVc,
-    TurboTasksApi, ValueToString, ValueToStringRef, Vc, debug::ValueDebugFormat, emit_effect,
-    parallel, spawn, trace::TraceRawVcs, turbo_tasks_weak, turbobail, turbofmt,
+    CapturedEffect, Completion, Effect, EffectExt, EffectStateStorage, InvalidationReason,
+    NonLocalValue, ReadRef, ResolvedVc, TurboTasksApi, ValueToString, ValueToStringRef, Vc,
+    debug::ValueDebugFormat, parallel, spawn, trace::TraceRawVcs, turbo_tasks_weak, turbobail,
+    turbofmt,
 };
 use turbo_tasks_hash::{
     DeterministicHash, DeterministicHasher, HashAlgorithm, deterministic_hash, hash_xxh3_hash64,
@@ -916,37 +918,83 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs)]
-    async fn write(&self, fs_path: FileSystemPath, content: Vc<FileContent>) -> Result<()> {
+    async fn write(
+        self: ResolvedVc<Self>,
+        fs_path: FileSystemPath,
+        content: ResolvedVc<FileContent>,
+    ) -> Result<()> {
+        let this = self.await?;
         // You might be tempted to use `session_dependent` here, but `write` purely declares a side
         // effect and does not need to be reexecuted in the next session. All side effects are
         // reexecuted in general.
 
         // Check if path is denied - if so, return an error
-        if self.inner.is_path_denied(&fs_path) {
+        if this.inner.is_path_denied(&fs_path) {
             turbobail!("Cannot write to denied path: {fs_path}");
         }
-        let full_path = self.to_sys_path(&fs_path);
+        let full_path = this.to_sys_path(&fs_path);
 
         // Persist the file content so it is stored in the persistent cache.
         // Since FileContent uses serialization = "hash", persisting it here ensures the full
         // content is available in the persistent cache (via PersistedFileContent) and does not
         // require recomputing the content on cache restore — avoiding unnecessary downstream
         // recomputation.
-        let content = content.persist().await?;
+        let content = content.persist().to_resolved().await?;
+        let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content.await?));
 
-        let inner = self.inner.clone();
-
-        #[derive(TraceRawVcs, NonLocalValue, Clone)]
+        #[turbo_tasks::value(eq = "manual", cell = "new")]
         struct WriteEffect {
-            full_path: Arc<Path>,
-            inner: Arc<DiskFileSystemInner>,
-            content: ReadRef<PersistedFileContent>,
+            full_path: Arc<PathBuf>,
+            fs: ResolvedVc<DiskFileSystem>,
+            content: ResolvedVc<PersistedFileContent>,
             content_hash: u128,
         }
 
+        #[async_trait]
+        #[turbo_tasks::value_impl]
         impl Effect for WriteEffect {
-            type Error = AnyhowWrapper;
+            async fn capture(&self) -> Result<Box<dyn CapturedEffect>> {
+                // Untracked, a tracked read of this cell occurred in the write effect so if it
+                // somehow changes the effect will be re-emitted
+                let inner = (*self.fs).untracked().await?.inner.clone();
 
+                // If the per-key effect state already records `Applied { value_hash }` matching
+                // our hash, skip materializing the content (avoids a possible disk read +
+                // decompression via the persistent cache). The apply-time state machine will
+                // dedup-hit before touching content. If state diverged between this read and
+                // apply, `Effects::apply` will fire our producer's invalidator via the Retry
+                // pathway and the producer will rerun with a fresh capture.
+                let key_bytes: Box<[u8]> = self.full_path.as_os_str().as_encoded_bytes().into();
+                let content = if inner
+                    .effect_state_storage
+                    .matches_applied(&key_bytes, self.content_hash)
+                {
+                    None
+                } else {
+                    // Untracked: the content cell is already captured via `content_hash`, and
+                    // we don't want this `capture` to take a tracked dependency on the content
+                    // cell — that would pin it and defeat the eviction this refactor enables.
+                    Some((*self.content).untracked().await?)
+                };
+                Ok(Box::new(CapturedWriteEffect {
+                    full_path: self.full_path.clone(),
+                    inner,
+                    content,
+                    content_hash: self.content_hash,
+                }) as Box<dyn CapturedEffect>)
+            }
+        }
+
+        #[derive(TraceRawVcs, NonLocalValue, Clone)]
+        struct CapturedWriteEffect {
+            full_path: Arc<PathBuf>,
+            inner: Arc<DiskFileSystemInner>,
+            content: Option<ReadRef<PersistedFileContent>>,
+            content_hash: u128,
+        }
+
+        #[async_trait]
+        impl CapturedEffect for CapturedWriteEffect {
             fn key(&self) -> Box<[u8]> {
                 self.full_path.as_os_str().as_encoded_bytes().into()
             }
@@ -955,19 +1003,29 @@ impl FileSystem for DiskFileSystem {
                 self.content_hash
             }
 
-            fn state_storage(&self) -> &EffectStateStorage {
-                &self.inner.effect_state_storage
-            }
-
-            async fn apply(&self) -> Result<(), AnyhowWrapper> {
-                spawn(self.clone().apply_inner())
-                    .await
-                    .map_err(AnyhowWrapper::from)
+            async fn apply(&self) -> Result<(), turbo_tasks::ApplyError> {
+                // Run the whole apply (state-machine coordination + the actual write) on its own
+                // spawned task so that multiple pending write effects can execute in parallel
+                // rather than serially on the caller's future (see #94140).
+                let this = self.clone();
+                spawn(async move {
+                    let body = this.content.as_ref().map(|content| {
+                        || async { this.apply_inner(content).await.map_err(AnyhowWrapper::from) }
+                    });
+                    this.inner
+                        .effect_state_storage
+                        .run_apply::<AnyhowWrapper, _, _>(this.key(), this.content_hash, body)
+                        .await
+                })
+                .await
             }
         }
 
-        impl WriteEffect {
-            async fn apply_inner(self) -> anyhow::Result<()> {
+        impl CapturedWriteEffect {
+            async fn apply_inner(
+                &self,
+                content: &ReadRef<PersistedFileContent>,
+            ) -> anyhow::Result<()> {
                 let full_path = validate_path_length(&self.full_path)?;
 
                 let _lock = self.inner.lock_path(&full_path).await;
@@ -977,8 +1035,7 @@ impl FileSystem for DiskFileSystem {
                 // be freed immediately. Given this is an output file, it's unlikely any Turbo
                 // code will need to read the file from disk into a Vc<FileContent>, so we're
                 // not wasting cycles.
-                let compare = self
-                    .content
+                let compare = content
                     .streaming_compare(&full_path)
                     .instrument(tracing::info_span!("read file before write", name = ?full_path))
                     .concurrency_limited(&self.inner.read_semaphore)
@@ -987,9 +1044,9 @@ impl FileSystem for DiskFileSystem {
                     return Ok(());
                 }
 
-                match &*self.content {
+                match &**content {
                     PersistedFileContent::Content(..) => {
-                        let content = self.content.clone();
+                        let content = content.clone();
                         let full_path = full_path.into_owned();
                         async {
                             let do_write = || {
@@ -1086,44 +1143,83 @@ impl FileSystem for DiskFileSystem {
             }
         }
 
-        let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content));
-        emit_effect(WriteEffect {
-            full_path: Arc::from(full_path),
-            inner,
+        WriteEffect {
+            full_path: Arc::new(full_path),
+            fs: self,
             content,
             content_hash,
-        });
+        }
+        .resolved_cell()
+        .emit();
 
         Ok(())
     }
 
     #[turbo_tasks::function(fs)]
-    async fn write_link(&self, fs_path: FileSystemPath, target: Vc<LinkContent>) -> Result<()> {
+    async fn write_link(
+        self: ResolvedVc<Self>,
+        fs_path: FileSystemPath,
+        target: ResolvedVc<LinkContent>,
+    ) -> Result<()> {
         // You might be tempted to use `session_dependent` here, but we purely declare a side
         // effect and does not need to be re-executed in the next session. All side effects are
         // re-executed in general.
 
+        let this = self.await?;
         // Check if path is denied - if so, return an error
-        if self.inner.is_path_denied(&fs_path) {
+        if this.inner.is_path_denied(&fs_path) {
             turbobail!("Cannot write link to denied path: {fs_path}");
         }
+        let full_path = this.to_sys_path(&fs_path);
 
-        let content = target.await?;
+        let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*target.await?));
 
-        let full_path = self.to_sys_path(&fs_path);
-        let inner = self.inner.clone();
-
-        #[derive(TraceRawVcs, NonLocalValue, Clone)]
+        #[turbo_tasks::value(eq = "manual", cell = "new")]
         struct WriteLinkEffect {
-            full_path: Arc<Path>,
-            inner: Arc<DiskFileSystemInner>,
-            content: ReadRef<LinkContent>,
+            full_path: Arc<PathBuf>,
+            fs: ResolvedVc<DiskFileSystem>,
+            target: ResolvedVc<LinkContent>,
             content_hash: u128,
         }
 
+        #[async_trait]
+        #[turbo_tasks::value_impl]
         impl Effect for WriteLinkEffect {
-            type Error = AnyhowWrapper;
+            async fn capture(&self) -> Result<Box<dyn CapturedEffect>> {
+                let inner = (*self.fs).untracked().await?.inner.clone();
 
+                // Skip target materialization if the per-key effect state already records
+                // `Applied { value_hash }` matching our hash. See `WriteEffect::capture`.
+                let key_bytes: Box<[u8]> = self.full_path.as_os_str().as_encoded_bytes().into();
+                let content = if inner
+                    .effect_state_storage
+                    .matches_applied(&key_bytes, self.content_hash)
+                {
+                    None
+                } else {
+                    // Untracked — see `WriteEffect::capture`.
+                    Some((*self.target).untracked().await?)
+                };
+                Ok(Box::new(CapturedWriteLinkEffect {
+                    full_path: self.full_path.clone(),
+                    inner,
+                    content,
+                    content_hash: self.content_hash,
+                }) as Box<dyn CapturedEffect>)
+            }
+        }
+
+        // Post-capture effect — session-only plain struct.
+        #[derive(TraceRawVcs, NonLocalValue, Clone)]
+        struct CapturedWriteLinkEffect {
+            full_path: Arc<PathBuf>,
+            inner: Arc<DiskFileSystemInner>,
+            content: Option<ReadRef<LinkContent>>,
+            content_hash: u128,
+        }
+
+        #[async_trait]
+        impl CapturedEffect for CapturedWriteLinkEffect {
             fn key(&self) -> Box<[u8]> {
                 self.full_path.as_os_str().as_encoded_bytes().into()
             }
@@ -1132,19 +1228,26 @@ impl FileSystem for DiskFileSystem {
                 self.content_hash
             }
 
-            fn state_storage(&self) -> &EffectStateStorage {
-                &self.inner.effect_state_storage
-            }
-
-            async fn apply(&self) -> Result<(), AnyhowWrapper> {
-                spawn(self.clone().apply_inner())
-                    .await
-                    .map_err(AnyhowWrapper::from)
+            async fn apply(&self) -> Result<(), turbo_tasks::ApplyError> {
+                // Run the whole apply (state-machine coordination + the actual symlink write) on
+                // its own spawned task so multiple pending effects can execute in parallel rather
+                // than serially on the caller's future (see #94140).
+                let this = self.clone();
+                spawn(async move {
+                    let body = this.content.as_ref().map(|content| {
+                        || async { this.apply_inner(content).await.map_err(AnyhowWrapper::from) }
+                    });
+                    this.inner
+                        .effect_state_storage
+                        .run_apply::<AnyhowWrapper, _, _>(this.key(), this.content_hash, body)
+                        .await
+                })
+                .await
             }
         }
 
-        impl WriteLinkEffect {
-            async fn apply_inner(self) -> anyhow::Result<()> {
+        impl CapturedWriteLinkEffect {
+            async fn apply_inner(&self, content: &ReadRef<LinkContent>) -> anyhow::Result<()> {
                 let full_path = validate_path_length(&self.full_path)?;
 
                 let _lock = self.inner.lock_path(&full_path).await;
@@ -1159,7 +1262,7 @@ impl FileSystem for DiskFileSystem {
                     Invalid,
                 }
 
-                let os_specific_link_content = match &*self.content {
+                let os_specific_link_content = match &**content {
                     LinkContent::Link { target, link_type } => {
                         let is_directory = link_type.contains(LinkType::DIRECTORY);
                         let target_path = if link_type.contains(LinkType::ABSOLUTE) {
@@ -1369,13 +1472,14 @@ impl FileSystem for DiskFileSystem {
             }
         }
 
-        let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content));
-        emit_effect(WriteLinkEffect {
-            full_path: Arc::from(full_path),
-            inner,
-            content,
+        WriteLinkEffect {
+            full_path: Arc::new(full_path),
+            fs: self,
+            target,
             content_hash,
-        });
+        }
+        .resolved_cell()
+        .emit();
         Ok(())
     }
 
@@ -3161,7 +3265,7 @@ mod tests {
 
         use rand::{RngExt, SeedableRng};
         use turbo_rcstr::{RcStr, rcstr};
-        use turbo_tasks::{ResolvedVc, Vc};
+        use turbo_tasks::{ResolvedVc, Vc, read_strongly_consistent_and_apply_effects};
         use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
         use super::extract_effects_operation;
@@ -3233,14 +3337,14 @@ mod tests {
                     .await?;
                 let root_path = disk_file_system_root(fs);
 
-                extract_effects_operation(test_write_link_effect_operation(
-                    fs,
-                    root_path.clone(),
-                    rcstr!("subdir-a"),
-                ))
-                .read_strongly_consistent()
-                .await?
-                .apply()
+                read_strongly_consistent_and_apply_effects(
+                    extract_effects_operation(test_write_link_effect_operation(
+                        fs,
+                        root_path.clone(),
+                        rcstr!("subdir-a"),
+                    )),
+                    |e| e,
+                )
                 .await?;
 
                 assert_eq!(read_to_string(path.join("symlink-file")).unwrap(), "foo");
@@ -3250,14 +3354,14 @@ mod tests {
                 );
 
                 // Write the same links again but with different targets
-                extract_effects_operation(test_write_link_effect_operation(
-                    fs,
-                    root_path,
-                    rcstr!("subdir-b"),
-                ))
-                .read_strongly_consistent()
-                .await?
-                .apply()
+                read_strongly_consistent_and_apply_effects(
+                    extract_effects_operation(test_write_link_effect_operation(
+                        fs,
+                        root_path,
+                        rcstr!("subdir-b"),
+                    )),
+                    |e| e,
+                )
                 .await?;
 
                 assert_eq!(read_to_string(path.join("symlink-file")).unwrap(), "bar");
@@ -3348,14 +3452,14 @@ mod tests {
 
                 let initial_updates: Vec<(usize, usize)> =
                     (0..STRESS_SYMLINK_COUNT).map(|i| (i, 0)).collect();
-                extract_effects_operation(write_symlink_stress_batch(
-                    fs,
-                    symlinks_dir.clone(),
-                    initial_updates,
-                ))
-                .read_strongly_consistent()
-                .await?
-                .apply()
+                read_strongly_consistent_and_apply_effects(
+                    extract_effects_operation(write_symlink_stress_batch(
+                        fs,
+                        symlinks_dir.clone(),
+                        initial_updates,
+                    )),
+                    |e| e,
+                )
                 .await?;
 
                 let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
@@ -3368,14 +3472,14 @@ mod tests {
                     }
                     let updates: Vec<(usize, usize)> = updates_map.into_iter().collect();
 
-                    extract_effects_operation(write_symlink_stress_batch(
-                        fs,
-                        symlinks_dir.clone(),
-                        updates,
-                    ))
-                    .read_strongly_consistent()
-                    .await?
-                    .apply()
+                    read_strongly_consistent_and_apply_effects(
+                        extract_effects_operation(write_symlink_stress_batch(
+                            fs,
+                            symlinks_dir.clone(),
+                            updates,
+                        )),
+                        |e| e,
+                    )
                     .await?;
                 }
 
@@ -3398,7 +3502,7 @@ mod tests {
         };
 
         use turbo_rcstr::{RcStr, rcstr};
-        use turbo_tasks::{Effects, Vc, take_effects};
+        use turbo_tasks::{Effects, Vc, read_strongly_consistent_and_apply_effects, take_effects};
         use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
         use crate::{
@@ -3724,15 +3828,13 @@ mod tests {
                 const TEST_CONTENT: &str = "test content";
 
                 // Test 1: Writing to allowed directory should work
-                let effects = write_allowed_file_operation(
+                let effects_op = write_allowed_file_operation(
                     root.clone(),
                     denied_path.clone(),
                     RcStr::from(ALLOWED_FILE),
                     RcStr::from(TEST_CONTENT),
-                )
-                .read_strongly_consistent()
-                .await?;
-                effects.apply().await?;
+                );
+                read_strongly_consistent_and_apply_effects(effects_op, |e| e).await?;
 
                 // Verify the file was written to disk
                 let content = read_to_string(Path::new(root.as_str()).join(ALLOWED_FILE))?;

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -232,7 +232,10 @@ pub mod tests {
     };
 
     use turbo_rcstr::{RcStr, rcstr};
-    use turbo_tasks::{Completion, Effects, OperationVc, ReadRef, Vc, take_effects};
+    use turbo_tasks::{
+        Completion, Effects, OperationVc, ReadRef, Vc, read_strongly_consistent_and_apply_effects,
+        take_effects,
+    };
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
     use crate::{
@@ -560,11 +563,11 @@ pub mod tests {
                 .await?;
 
             // Delete a file that we shouldn't be tracking
-            extract_effects_operation(delete(root.join("dir/sub/.vim/.gitignore")?))
-                .read_strongly_consistent()
-                .await?
-                .apply()
-                .await?;
+            read_strongly_consistent_and_apply_effects(
+                extract_effects_operation(delete(root.join("dir/sub/.vim/.gitignore")?)),
+                |e| e,
+            )
+            .await?;
 
             let read_dir2 = track_star_star_glob(dir.clone())
                 .read_strongly_consistent()
@@ -572,11 +575,11 @@ pub mod tests {
             assert!(ReadRef::ptr_eq(&read_dir, &read_dir2));
 
             // Delete a file that we should be tracking
-            extract_effects_operation(delete(root.join("dir/foo")?))
-                .read_strongly_consistent()
-                .await?
-                .apply()
-                .await?;
+            read_strongly_consistent_and_apply_effects(
+                extract_effects_operation(delete(root.join("dir/foo")?)),
+                |e| e,
+            )
+            .await?;
 
             let read_dir2 = track_star_star_glob(dir.clone())
                 .read_strongly_consistent()
@@ -585,11 +588,14 @@ pub mod tests {
             assert!(!ReadRef::ptr_eq(&read_dir, &read_dir2));
 
             // Modify a symlink target file
-            extract_effects_operation(write(root.join("link_target.js")?, rcstr!("new_contents")))
-                .read_strongly_consistent()
-                .await?
-                .apply()
-                .await?;
+            read_strongly_consistent_and_apply_effects(
+                extract_effects_operation(write(
+                    root.join("link_target.js")?,
+                    rcstr!("new_contents"),
+                )),
+                |e| e,
+            )
+            .await?;
             let read_dir3 = track_star_star_glob(dir.clone())
                 .read_strongly_consistent()
                 .await?;

--- a/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
@@ -15,8 +15,8 @@ use rustc_hash::FxHashSet;
 use tokio::time::sleep;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Effects, NonLocalValue, OperationVc, ResolvedVc, TransientInstance, Vc, take_effects,
-    trace::TraceRawVcs,
+    Effects, NonLocalValue, OperationVc, ResolvedVc, TransientInstance, Vc,
+    read_strongly_consistent_and_apply_effects, take_effects, trace::TraceRawVcs,
 };
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{
@@ -142,7 +142,7 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
         let symlink_is_directory =
             symlink_mode.map(|m| m.to_link_type().contains(LinkType::DIRECTORY));
 
-        let effects = extract_effects_operation(read_or_write_all_paths_operation(
+        let effects_op = extract_effects_operation(read_or_write_all_paths_operation(
             invalidations.clone(),
             project_root.clone(),
             args.depth,
@@ -150,11 +150,9 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
             symlink_count,
             symlink_is_directory,
             track_writes,
-        ))
-        .read_strongly_consistent()
-        .await?;
+        ));
         if track_writes {
-            effects.apply().await?;
+            read_strongly_consistent_and_apply_effects(effects_op, |e| e).await?;
             let (total, mismatched) = verify_written_files(
                 &fs_root,
                 args.depth,
@@ -169,6 +167,8 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
                 }
             }
         } else {
+            // Still drive the computation (and propagate errors) without applying effects.
+            effects_op.read_strongly_consistent().await?;
             let invalidations = invalidations.0.lock().unwrap();
             println!("read all {} files", invalidations.len());
         }
@@ -228,7 +228,7 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
             // there's no way to know when we've received all the pending events from the operating
             // system, so just sleep and pray
             sleep(Duration::from_millis(args.notify_timeout_ms)).await;
-            let effects = extract_effects_operation(read_or_write_all_paths_operation(
+            let effects_op = extract_effects_operation(read_or_write_all_paths_operation(
                 invalidations.clone(),
                 project_root.clone(),
                 args.depth,
@@ -236,16 +236,14 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
                 symlink_count,
                 symlink_is_directory,
                 track_writes,
-            ))
-            .read_strongly_consistent()
-            .await?;
+            ));
             let symlink_info = if args.symlinks.is_some() {
                 " and symlinks"
             } else {
                 ""
             };
             if track_writes {
-                effects.apply().await?;
+                read_strongly_consistent_and_apply_effects(effects_op, |e| e).await?;
                 let (total, mismatched) = verify_written_files(
                     &fs_root,
                     args.depth,
@@ -268,6 +266,8 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
                     }
                 }
             } else {
+                // Still drive the computation (and propagate errors) without applying effects.
+                effects_op.read_strongly_consistent().await?;
                 let mut invalidations = invalidations.0.lock().unwrap();
                 println!(
                     "modified {} files{}. found {} invalidations",

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -8,7 +8,10 @@ const PROGRESS_INTERVAL: Duration = Duration::from_secs(1);
 use clap::Args;
 use rand::{RngExt, SeedableRng};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Effects, OperationVc, ResolvedVc, TryJoinIterExt, Vc, take_effects};
+use turbo_tasks::{
+    Effects, OperationVc, ResolvedVc, TryJoinIterExt, Vc,
+    read_strongly_consistent_and_apply_effects, take_effects,
+};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath, LinkContent, LinkType};
 
@@ -82,14 +85,14 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
 
         println!("creating {symlink_count} initial symlinks...");
 
-        extract_effects_operation(create_initial_symlinks_operation(
-            symlinks_path.clone(),
-            symlink_count,
-            initial_target,
-        ))
-        .read_strongly_consistent()
-        .await?
-        .apply()
+        read_strongly_consistent_and_apply_effects(
+            extract_effects_operation(create_initial_symlinks_operation(
+                symlinks_path.clone(),
+                symlink_count,
+                initial_target,
+            )),
+            |e| e,
+        )
         .await?;
 
         println!(
@@ -120,13 +123,13 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
                 .collect();
 
             // Execute writes in parallel via turbo-tasks
-            extract_effects_operation(write_symlinks_batch_operation(
-                symlinks_path.clone(),
-                updates,
-            ))
-            .read_strongly_consistent()
-            .await?
-            .apply()
+            read_strongly_consistent_and_apply_effects(
+                extract_effects_operation(write_symlinks_batch_operation(
+                    symlinks_path.clone(),
+                    updates,
+                )),
+                |e| e,
+            )
             .await?;
 
             total_writes += parallelism as u64;

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -22,6 +22,7 @@ use crate::{
         debug_assert_in_top_level_task, debug_assert_not_in_top_level_task, mark_top_level_task,
         unmark_top_level_task_may_leak_eventually_consistent_state, with_turbo_tasks,
     },
+    spawn,
     trace::TraceRawVcs,
 };
 
@@ -126,7 +127,7 @@ impl EffectStateStorage {
     /// Intended for use by [`Effect::capture`] to elide content materialization when the apply
     /// would dedup. Reading this from inside a turbo-tasks task is sound because
     /// [`Effects::apply`] re-checks at apply time and fires the producing task's invalidator on
-    /// mismatch (via the [`ApplyOutcome::Retry`] / [`EffectsError::Retry`] pathway).
+    /// mismatch (via the [`ApplyError::Retry`] / [`EffectsError::Retry`] pathway).
     pub fn matches_applied(&self, key: &[u8], target: u128) -> bool {
         let entry = self.effect_state.lock().get(key).cloned();
         let Some(entry) = entry else { return false };
@@ -150,14 +151,10 @@ impl EffectStateStorage {
 
     /// Coordinate an apply for `(key, value_hash)` against the per-key state machine.
     ///
-    /// On a dedup hit (`Applied { value_hash == target, result }`), short-circuits and returns the
-    /// cached result without calling `body`. Otherwise, transitions the entry to `InProgress`,
-    /// awaits any in-flight apply for the same key, calls `body` to perform the side effect, then
-    /// writes back the result as `Applied { value_hash, result }`.
-    ///
-    /// If `body` is `None` the captured effect has no materialized content (capture observed
-    /// matching storage and elided materialization). In that case, a non-matching state forces a
-    /// `Retry` — we have nothing to apply. The state entry is left in `Unapplied` for waiters.
+    /// Dedup hits (state already `Applied` with a matching hash) return the cached result without
+    /// running `body`. Otherwise `body` runs once under an `InProgress` guard and the result is
+    /// stored. A `None` `body` (capture elided content because storage matched, but it no longer
+    /// does) yields [`ApplyError::Retry`].
     pub async fn run_apply<E, F, Fut>(
         &self,
         key: Box<[u8]>,
@@ -343,14 +340,11 @@ pub enum EffectsError {
     Conflict(usize),
 
     #[error(
-        "effect state was reset for {}{}; producing task {task_name} invalidated, retry required",
+        "effect state diverged before apply for {}{}; producing task invalidated, retry required",
         keys.iter().take(MAX_KEYS_TO_DISPLAY).cloned().collect::<Vec<_>>().join(", "),
-        if keys.len() > MAX_KEYS_TO_DISPLAY { format!(", ... ({} more)", keys.len() - 100) } else { String::new() }
+        if keys.len() > MAX_KEYS_TO_DISPLAY { format!(", ... ({} more)", keys.len() - MAX_KEYS_TO_DISPLAY) } else { String::new() }
     )]
-    Retry {
-        task_name: String,
-        keys: Vec<String>,
-    },
+    Retry { keys: Vec<String> },
 }
 
 impl From<Arc<dyn EffectError>> for EffectsError {
@@ -449,10 +443,10 @@ impl Effects {
     /// `apply()` multiple times on the same `Effects` value runs each underlying side effect at
     /// most once per stored `(key, value_hash)` pair.
     ///
-    /// If any captured effect signals [`ApplyOutcome::Retry`] (its content was elided at capture
+    /// If any captured effect signals [`ApplyError::Retry`] (its content was elided at capture
     /// time and storage state diverged between capture and apply), the producing task is
     /// invalidated and [`EffectsError::Retry`] is returned after the remaining keys finish.
-    /// Side-effect failures (`ApplyOutcome::Failed`) propagate as [`EffectsError::Apply`]; the
+    /// Side-effect failures (`ApplyError::Failed`) propagate as [`EffectsError::Apply`]; the
     /// first such error wins.
     ///
     /// `apply` must only be used in a "top-level" task (e.g. [`run_once`][crate::run_once]),
@@ -463,8 +457,8 @@ impl Effects {
     ///
     /// **Do not call this directly.** External callers must go through
     /// [`read_strongly_consistent_and_apply_effects`] or
-    /// [`read_strongly_consistent_and_apply_effects_with`], which own the read+apply+retry loop
-    /// required to recover from [`EffectsError::Retry`]. Exposed publicly only as
+    /// [`resolve_strongly_consistent_and_take_and_apply_effects`], which own the read+apply+retry
+    /// loop required to recover from [`EffectsError::Retry`]. Exposed publicly only as
     /// [`Effects::apply_for_testing`] (`#[doc(hidden)]`) so integration tests can drive the apply
     /// state machine directly.
     async fn apply(&self) -> Result<(), EffectsError> {
@@ -491,9 +485,11 @@ impl Effects {
             let retry_keys = Mutex::new(Vec::<String>::new());
             let result: Result<(), EffectsError> = futures::stream::iter(unique.iter())
                 .map(Ok::<_, EffectsError>)
-                .try_for_each_concurrent(
-                    APPLY_EFFECTS_CONCURRENCY_LIMIT,
-                    async |idx| match captured[*idx].apply().await {
+                .try_for_each_concurrent(APPLY_EFFECTS_CONCURRENCY_LIMIT, async |idx| {
+                    // Run each apply on its own spawned task so that pending effects execute in
+                    // parallel rather than serially on this future (see #94140).
+                    let effect = captured[*idx].clone();
+                    match spawn(async move { effect.apply().await }).await {
                         Ok(()) => Ok(()),
                         Err(ApplyError::Failed(err)) => Err(EffectsError::Apply(err)),
                         Err(ApplyError::Retry) => {
@@ -503,8 +499,8 @@ impl Effects {
                                 .push(String::from_utf8_lossy(&key).into_owned());
                             Ok(())
                         }
-                    },
-                )
+                    }
+                })
                 .await;
 
             match result {
@@ -533,18 +529,13 @@ impl Effects {
     }
 
     /// Invalidate the producing task (if any) and return [`EffectsError::Retry`] carrying the
-    /// producing task's name and the `keys` that signaled [`ApplyOutcome::Retry`] (their capture
-    /// elided content materialization but storage state diverged before apply).
+    /// `keys` that signaled [`ApplyError::Retry`] (their capture elided content materialization but
+    /// storage state diverged before apply).
     fn signal_retry(&self, keys: Vec<String>) -> Result<(), EffectsError> {
-        let task_name = match self.invalidator {
-            Some(invalidator) => with_turbo_tasks(|tt| {
-                let name = tt.get_task_name(invalidator.task_id());
-                invalidator.invalidate(&**tt);
-                name
-            }),
-            None => "<unknown>".to_string(),
-        };
-        Err(EffectsError::Retry { task_name, keys })
+        if let Some(invalidator) = self.invalidator {
+            with_turbo_tasks(|tt| invalidator.invalidate(&**tt));
+        }
+        Err(EffectsError::Retry { keys })
     }
 }
 
@@ -626,24 +617,23 @@ where
 fn handle_apply_retry(err: EffectsError, attempts: &mut usize) -> Result<()> {
     const MAX_RETRIES: usize = 4; // chosen by a fair dice roll
     match err {
-        EffectsError::Retry { task_name, keys } if *attempts < MAX_RETRIES => {
+        EffectsError::Retry { keys } if *attempts < MAX_RETRIES => {
             *attempts += 1;
             // Warn on every retry after the first.
             if *attempts > 1 {
-                eprintln!(
-                    "BUG: {task_name} has retried {attempts} times to write an output: {keys:?}.  \
-                     This implies multiple routes are fighting to write one of these files.",
+                tracing::warn!(
                     attempts = *attempts,
+                    ?keys,
+                    "retrying effect application; this implies multiple routes are fighting to \
+                     write one of these files",
                 );
             }
             Ok(())
         }
-        // Retries exhausted: surface that we gave up after `MAX_RETRIES`, naming the task and the
-        // contended outputs.
-        EffectsError::Retry { task_name, keys } => anyhow::bail!(
-            "gave up applying effects for {task_name} after {MAX_RETRIES} retries; repeated \
-             effect-state divergence on: {keys:?}. This implies multiple routes are fighting to \
-             write one of these files."
+        EffectsError::Retry { keys } => anyhow::bail!(
+            "gave up applying effects after {MAX_RETRIES} retries; repeated effect-state \
+             divergence on: {keys:?}. This implies multiple routes are fighting to write one of \
+             these files."
         ),
         e => Err(e.into()),
     }

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -3,54 +3,85 @@ use std::{
     error::Error as StdError,
     future::Future,
     mem::{forget, replace},
-    pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::Arc,
 };
 
 use anyhow::Result;
+use async_trait::async_trait;
 use futures::{StreamExt, TryStreamExt};
 use parking_lot::{Mutex, MutexGuard};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use tracing::Instrument;
 
 use crate::{
-    self as turbo_tasks, CollectiblesSource, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt,
-    emit,
+    self as turbo_tasks, CollectiblesSource, NonLocalValue, OperationVc, ReadRef, ResolvedVc,
+    TryJoinIterExt, Upcast, VcRead, VcValueType, emit,
     event::Event,
-    manager::{debug_assert_in_top_level_task, debug_assert_not_in_top_level_task},
+    invalidation::{Invalidator, get_invalidator},
+    manager::{
+        debug_assert_in_top_level_task, debug_assert_not_in_top_level_task, mark_top_level_task,
+        unmark_top_level_task_may_leak_eventually_consistent_state, with_turbo_tasks,
+    },
     trace::TraceRawVcs,
 };
 
 const APPLY_EFFECTS_CONCURRENCY_LIMIT: usize = 1024;
 
-pub trait Effect: TraceRawVcs + NonLocalValue + Send + Sync + 'static {
-    /// The error type that an effect can return. We use `dyn std::error::Error` (instead of
-    /// [`anyhow::Error`] or [`SharedError`]) to encourage use of structured error types that can
-    /// potentially be transformed into `Issue`s.
+/// An IO Side effect to be computed by turbo tasks and then executed outside of turbo tasks.
+#[async_trait]
+#[turbo_tasks::value_trait]
+pub trait Effect {
+    /// Read any Vc data needed for `apply()` and return the [`CapturedEffect`] that performs it.
     ///
-    /// We can't require that the returned error implements `Issue`:
-    /// - `Issue` uses `FileSystemPath`
-    /// - `turbo-tasks-fs` returns effect errors that should be transformed into `Issue`s.
-    /// - It logically doesn't make sense to define `Issue` in `turbo-tasks-fs`, `Issue` can't be
-    ///   defined in a base crate either because it would form a circular crate dependency.
-    ///
-    /// So instead, we leave it up to the caller to figure out how to downcast these errors
-    /// themselves.
-    ///
-    /// [`SharedError`]: crate::util::SharedError
-    type Error: EffectError;
+    /// An implementation may elect to elide capturing data if the `EffectStateStorage` state is
+    /// already up to date.
+    async fn capture(&self) -> Result<Box<dyn CapturedEffect>>;
+}
 
+pub trait EffectExt {
+    fn emit(self);
+}
+
+impl<T> EffectExt for ResolvedVc<T>
+where
+    T: Upcast<Box<dyn Effect>>,
+{
+    fn emit(self) {
+        emit::<Box<dyn Effect>>(ResolvedVc::upcast_non_strict(self));
+    }
+}
+
+/// Post-capture effect. Holds data needed to perform the actual side effect in a top level context.
+///
+/// `apply()` is responsible for coordinating with [`EffectStateStorage`] via
+/// [`EffectStateStorage::run_apply`] (which handles the per-key state machine, in-progress
+/// coordination, dedup-hit short-circuit, and panic recovery).
+#[async_trait]
+pub trait CapturedEffect: TraceRawVcs + NonLocalValue + Send + Sync + 'static {
     /// Unique key identifying this effect's target (e.g., absolute path bytes).
     fn key(&self) -> Box<[u8]>;
 
     /// Extract the hash of the value part of this effect for comparison.
     fn value_hash(&self) -> u128;
 
-    /// Returns a reference to the state storage.
-    fn state_storage(&self) -> &EffectStateStorage;
+    /// Perform the side effect
+    ///
+    /// Implementations typically dispatch into [`EffectStateStorage::run_apply`].
+    async fn apply(&self) -> Result<(), ApplyError>;
+}
 
-    /// Perform the side effect (write file, create symlink, etc.).
-    fn apply(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+/// Outcome of [`CapturedEffect::apply`]. Distinguishes a side-effect failure (terminal) from a
+/// soft failure where the captured form had no content and storage state diverged between
+/// capture and apply (recoverable via [`Effects::apply`]'s invalidator path).
+#[derive(Debug)]
+pub enum ApplyError {
+    /// The side effect itself failed.
+    Failed(Arc<dyn EffectError>),
+    /// Capture short-circuited content materialization (observed `Applied { matching }` in
+    /// storage), but by apply time the storage state had diverged and we have no content to
+    /// re-apply. [`Effects::apply`] should invalidate the producing operation and return
+    /// [`EffectsError::Retry`].
+    Retry,
 }
 
 /// The error type that an effect can return. We use `dyn std::error::Error` (instead of
@@ -89,76 +120,138 @@ pub struct EffectStateStorage {
     effect_state: Mutex<FxHashMap<Box<[u8]>, EffectStateEntry>>,
 }
 
-// Private wrapper trait to allow dynamic dispatch of an `Effect`. This is similar to the pattern
-// that the dynosaur crate uses: https://github.com/spastorino/dynosaur
-trait DynEffect: TraceRawVcs + NonLocalValue + Send + Sync + 'static {
-    fn key(&self) -> Box<[u8]>;
-    fn value_hash(&self) -> u128;
-    fn state_storage(&self) -> &EffectStateStorage;
-    fn dyn_apply<'a>(&'a self) -> DynEffectApplyFuture<'a>;
-}
-
-impl<T> DynEffect for T
-where
-    T: Effect,
-{
-    fn key(&self) -> Box<[u8]> {
-        Effect::key(self)
+impl EffectStateStorage {
+    /// Returns true if the per-key state holds `Applied { value_hash == target, result: Ok(()) }`.
+    ///
+    /// Intended for use by [`Effect::capture`] to elide content materialization when the apply
+    /// would dedup. Reading this from inside a turbo-tasks task is sound because
+    /// [`Effects::apply`] re-checks at apply time and fires the producing task's invalidator on
+    /// mismatch (via the [`ApplyOutcome::Retry`] / [`EffectsError::Retry`] pathway).
+    pub fn matches_applied(&self, key: &[u8], target: u128) -> bool {
+        let entry = self.effect_state.lock().get(key).cloned();
+        let Some(entry) = entry else { return false };
+        matches!(
+            &*entry.lock(),
+            EffectLastApplied::Applied {
+                value_hash,
+                result: Ok(()),
+            } if *value_hash == target,
+        )
     }
 
-    fn value_hash(&self) -> u128 {
-        Effect::value_hash(self)
+    /// Look up or create the per-key state entry.
+    fn entry_for(&self, key: Box<[u8]>) -> EffectStateEntry {
+        self.effect_state
+            .lock()
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(EffectLastApplied::Unapplied)))
+            .clone()
     }
 
-    fn state_storage(&self) -> &EffectStateStorage {
-        Effect::state_storage(self)
-    }
+    /// Coordinate an apply for `(key, value_hash)` against the per-key state machine.
+    ///
+    /// On a dedup hit (`Applied { value_hash == target, result }`), short-circuits and returns the
+    /// cached result without calling `body`. Otherwise, transitions the entry to `InProgress`,
+    /// awaits any in-flight apply for the same key, calls `body` to perform the side effect, then
+    /// writes back the result as `Applied { value_hash, result }`.
+    ///
+    /// If `body` is `None` the captured effect has no materialized content (capture observed
+    /// matching storage and elided materialization). In that case, a non-matching state forces a
+    /// `Retry` — we have nothing to apply. The state entry is left in `Unapplied` for waiters.
+    pub async fn run_apply<E, F, Fut>(
+        &self,
+        key: Box<[u8]>,
+        value_hash: u128,
+        body: Option<F>,
+    ) -> Result<(), ApplyError>
+    where
+        E: EffectError,
+        F: FnOnce() -> Fut + Send,
+        Fut: Future<Output = Result<(), E>> + Send,
+    {
+        let entry = self.entry_for(key);
 
-    fn dyn_apply<'a>(&'a self) -> DynEffectApplyFuture<'a> {
-        Box::pin(async move { Effect::apply(self).await.map_err(|err| Arc::new(err) as _) })
-    }
-}
-
-type DynEffectApplyFuture<'a> =
-    Pin<Box<dyn Future<Output = Result<(), Arc<dyn EffectError>>> + Send + 'a>>;
-
-/// A trait to emit a task effect as collectible. This trait only has one implementation,
-/// `EffectInstance` and no other implementation is allowed. The trait is private to this module so
-/// that no other implementation can be added.
-#[turbo_tasks::value_trait]
-trait EffectCollectible {}
-
-/// The Effect instance collectible that is emitted for effects.
-#[turbo_tasks::value(serialization = "skip", evict = "last", cell = "new", eq = "manual")]
-struct EffectInstance {
-    #[turbo_tasks(debug_ignore)]
-    inner: Box<dyn DynEffect>,
-}
-
-impl EffectInstance {
-    fn new(effect: impl Effect) -> Self {
-        Self {
-            inner: Box::new(effect) as Box<dyn DynEffect>,
+        // If `body` panics or the future is dropped before completion, the guard's drop impl
+        // resets the per-key state to `Unapplied` and notifies other waiters via the `Event` it
+        // recovers from the previous `InProgress`, so they retry rather than deadlock or observe
+        // a stale "panic" cache entry.
+        struct EventGuard<'a> {
+            entry: &'a EffectStateEntry,
         }
+        impl Drop for EventGuard<'_> {
+            fn drop(&mut self) {
+                let prev_state = replace(&mut *self.entry.lock(), EffectLastApplied::Unapplied);
+                let EffectLastApplied::InProgress { write_event } = prev_state else {
+                    unreachable!("EventGuard: prev_state must be InProgress");
+                };
+                write_event.notify(usize::MAX);
+            }
+        }
+
+        let begin_in_progress = |mut last_applied_guard: MutexGuard<'_, _>| {
+            *last_applied_guard = EffectLastApplied::InProgress {
+                write_event: Event::new(|| || "effect application in progress".to_string()),
+            };
+            EventGuard { entry: &entry }
+        };
+
+        let event_guard = loop {
+            let listener;
+            {
+                let last_applied_guard = entry.lock();
+                match &*last_applied_guard {
+                    EffectLastApplied::Unapplied => {
+                        break begin_in_progress(last_applied_guard);
+                    }
+                    EffectLastApplied::Applied {
+                        value_hash: stored,
+                        result,
+                    } => {
+                        if value_hash == *stored {
+                            return result.clone().map_err(ApplyError::Failed);
+                        } else {
+                            break begin_in_progress(last_applied_guard);
+                        }
+                    }
+                    EffectLastApplied::InProgress { write_event } => {
+                        // Event::listen registers the listener immediately, so notifications
+                        // fired after we drop last_applied_guard cannot be missed.
+                        listener = write_event.listen();
+                    }
+                }
+            };
+            listener.await;
+        };
+
+        // We hold the InProgress guard. Either run the body, or — if we have no content to
+        // apply — release the guard (resetting state to Unapplied + waking waiters) and Retry.
+        let Some(body) = body else {
+            drop(event_guard);
+            return Err(ApplyError::Retry);
+        };
+
+        // Erase the body's concrete error type to `Arc<dyn EffectError>` so the cached result
+        // type is uniform across all callers of the same key.
+        let effect_result: Result<(), Arc<dyn EffectError>> = body()
+            .await
+            .map_err(|err| Arc::new(err) as Arc<dyn EffectError>);
+
+        let prev_state = replace(
+            &mut *entry.lock(),
+            EffectLastApplied::Applied {
+                value_hash,
+                result: effect_result.clone(),
+            },
+        );
+        forget(event_guard);
+
+        let EffectLastApplied::InProgress { write_event } = prev_state else {
+            unreachable!("Effect applied: prev_state must be InProgress");
+        };
+        write_event.notify(usize::MAX);
+
+        effect_result.map_err(ApplyError::Failed)
     }
-}
-
-#[turbo_tasks::value_impl]
-impl EffectCollectible for EffectInstance {}
-
-/// Emits an effect to be applied. The effect is executed once [`Effects::apply`] is called (see
-/// [`take_effects`]).
-///
-/// The effect will only executed once. The effect is executed outside of the current task
-/// and can't read any Vcs. These need to be read before. ReadRefs can be passed into the effect.
-///
-/// Effects are executed in parallel, so they might need to use async locking to avoid problems.
-/// Order of execution of multiple effects is not defined. You must not use multiple conflicting
-/// effects to avoid non-deterministic behavior.
-pub fn emit_effect(effect: impl Effect) {
-    emit::<Box<dyn EffectCollectible>>(ResolvedVc::upcast(
-        EffectInstance::new(effect).resolved_cell(),
-    ));
 }
 
 /// Capture effects. Call this from within a [turbo-tasks operation][crate::OperationVc].
@@ -185,7 +278,7 @@ pub fn emit_effect(effect: impl Effect) {
 /// # #[turbo_tasks::function(operation)]
 /// # fn some_turbo_tasks_operation(_args: Args) {}
 /// #
-/// #[turbo_tasks::value(serialization = "skip", evict = "last")]
+/// #[turbo_tasks::value(serialization = "skip")]
 /// struct OutputWithEffects {
 ///     output: ReadRef<Example>,
 ///     effects: Effects,
@@ -214,22 +307,21 @@ pub fn emit_effect(effect: impl Effect) {
 /// ```
 pub async fn take_effects(source: impl CollectiblesSource) -> Result<Effects> {
     debug_assert_not_in_top_level_task("take_effects");
-    let effects = source
-        .take_collectibles::<Box<dyn EffectCollectible>>()
+    let effects = source.take_collectibles::<Box<dyn Effect>>();
+
+    let captured: Vec<Box<dyn CapturedEffect>> = effects
         .into_iter()
-        .map(|effect| {
-            if let Some(effect) = ResolvedVc::try_downcast_type::<EffectInstance>(effect) {
-                effect
-            } else {
-                unreachable!("EffectCollectible must only be implemented by EffectInstance");
-            }
-        })
+        .map(async |effect_vc| effect_vc.into_trait_ref().await?.capture().await)
         .try_join()
         .await?;
-    Ok(Effects {
-        effects,
-        unique_indices: OnceLock::new(),
-    })
+
+    // detect duplicate keys
+    let unique_keys = build_unique_keys(&captured);
+
+    let invalidator = get_invalidator()
+        .expect("take_effects must be called from within a turbo-tasks task context");
+
+    Ok(Effects::new(captured, unique_keys, invalidator))
 }
 
 #[derive(thiserror::Error, Debug, TraceRawVcs, NonLocalValue)]
@@ -238,202 +330,350 @@ struct ConflictingEffectError {
     key_len: usize,
 }
 
-/// Cached result of grouping effects by key and dedup/conflict detection.
-/// Each entry is (index into `effects`, per-key state entry).
-/// The `EffectStateEntry` is resolved once and cached to avoid repeated map lookups on subsequent
-/// `apply()` calls.
-type UniqueEffectIndices = Result<Vec<(usize, EffectStateEntry)>, Arc<ConflictingEffectError>>;
+const MAX_KEYS_TO_DISPLAY: usize = 10;
+/// Error returned by [`Effects::apply`]. Callers should retry on `Retry`; everything else is
+/// terminal.
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum EffectsError {
+    /// A side effect failed during apply. Holds the first error encountered.
+    #[error(transparent)]
+    Apply(Arc<dyn EffectError>),
 
-/// Captured effects from an operation. This struct can be used to return Effects from a turbo-tasks
-/// function and apply them later.
-#[derive(Default)]
-#[turbo_tasks::value(shared, eq = "manual", serialization = "skip", evict = "last")]
-pub struct Effects {
-    #[turbo_tasks(debug_ignore)]
-    effects: Vec<ReadRef<EffectInstance>>,
-    /// Cached `(index, state_entry)` pairs after grouping by key and dedup/conflict detection.
-    /// Computed once on first `apply()` call; reused on subsequent calls to avoid repeated
-    /// key allocations and map lookups.
-    /// `Err` means a conflict was detected.
-    #[turbo_tasks(debug_ignore, trace_ignore)]
-    unique_indices: OnceLock<UniqueEffectIndices>,
+    #[error("conflicting effects for the same key (key length: {0} bytes)")]
+    Conflict(usize),
+
+    #[error(
+        "effect state was reset for {}{}; producing task {task_name} invalidated, retry required",
+        keys.iter().take(MAX_KEYS_TO_DISPLAY).cloned().collect::<Vec<_>>().join(", "),
+        if keys.len() > MAX_KEYS_TO_DISPLAY { format!(", ... ({} more)", keys.len() - 100) } else { String::new() }
+    )]
+    Retry {
+        task_name: String,
+        keys: Vec<String>,
+    },
 }
 
-impl PartialEq for Effects {
-    fn eq(&self, other: &Self) -> bool {
-        if self.effects.len() != other.effects.len() {
-            return false;
-        }
-        let effect_ptrs = self
-            .effects
-            .iter()
-            .map(ReadRef::ptr)
-            .collect::<FxHashSet<_>>();
-        other
-            .effects
-            .iter()
-            .all(|e| effect_ptrs.contains(&ReadRef::ptr(e)))
+impl From<Arc<dyn EffectError>> for EffectsError {
+    fn from(err: Arc<dyn EffectError>) -> Self {
+        EffectsError::Apply(err)
     }
 }
 
+/// Dedup'd indices into the captured Vec — one entry per unique key. Computed eagerly in
+/// [`take_effects`] purely from the captured effects (no [`EffectStateStorage`] interaction);
+/// the apply-side state machine in [`EffectStateStorage::run_apply`] handles per-key hash dedup.
+type UniqueKeys = Result<Vec<usize>, Arc<ConflictingEffectError>>;
+
+/// Slice of captured effects, individually Arc'd. Each effect is `Arc<dyn CapturedEffect>`
+/// so callers can cheaply clone a Send handle out across `.await` boundaries without holding
+/// the outer mutex.
+type CapturedSlice = Arc<[Arc<dyn CapturedEffect>]>;
+
+/// Captured effects from an operation. This struct can be used to return Effects from a turbo-tasks
+/// function and apply them later.
+///
+/// # Cell semantics
+///
+/// `Effects` uses `cell = "new"`: every producer re-execution allocates a fresh cell value and
+/// the prior cell is dropped. Cell-level dedup of `Effects` is given up; per-key dedup at apply
+/// time is provided by [`EffectStateStorage`]'s state machine (see
+/// [`EffectStateStorage::run_apply`]), which short-circuits when storage already holds
+/// `Applied { value_hash }` matching the new hash.
+///
+/// `Effects::apply` is idempotent and safe to call multiple times on the same value — the state
+/// machine in `run_apply` ensures each underlying side effect runs at most once per stored
+/// `(key, value_hash)` pair across all callers.
+#[turbo_tasks::value(shared, eq = "manual", serialization = "skip", cell = "new")]
+pub struct Effects {
+    /// Pre-resolved effects awaiting application. Lives for the lifetime of the cell — released
+    /// when the producer reruns and `cell = "new"` overwrites the cell, which is when any
+    /// upstream `ReadRef` strong-count cascades are naturally released.
+    #[turbo_tasks(debug_ignore, trace_ignore)]
+    captured: CapturedSlice,
+    /// Captured at `take_effects` time. `None` for `Effects::empty()` (nothing to retry).
+    #[turbo_tasks(debug_ignore, trace_ignore)]
+    invalidator: Option<Invalidator>,
+    /// Unique key info computed eagerly in `take_effects`. Holds one index into `captured` per
+    /// unique key, or a `ConflictingEffectError` if two captured effects share a key with
+    /// different hashes. No [`EffectStateStorage`] interaction here — that is deferred to
+    /// `apply()`.
+    #[turbo_tasks(debug_ignore, trace_ignore)]
+    unique_keys: Arc<UniqueKeys>,
+}
+
+/// `PartialEq`/`Eq` are compat shims so containing structs (which derive `PartialEq`/`Eq` via
+/// `turbo_tasks::value`) can still embed `Effects`. The actual cell-update strategy for `Effects`
+/// itself is `cell = "new"` — see the doc-comment above — so this `PartialEq` is not consulted
+/// for `Effects` cells. We always return `false` to match `cell = "new"` semantics for the
+/// wrapper structs (they should also refresh on every producer run).
+impl PartialEq for Effects {
+    fn eq(&self, _other: &Self) -> bool {
+        false
+    }
+}
 impl Eq for Effects {}
 
 impl Effects {
+    /// A test-only placeholder `Effects` value with no effects (and no producer to invalidate).
+    #[cfg(test)]
+    fn empty() -> Self {
+        Self {
+            captured: Arc::from(Vec::new()),
+            invalidator: None,
+            unique_keys: Arc::new(Ok(Vec::new())),
+        }
+    }
+
+    fn new(
+        captured: Vec<Box<dyn CapturedEffect>>,
+        unique_keys: UniqueKeys,
+        invalidator: Invalidator,
+    ) -> Self {
+        // Convert Box<dyn> into Arc<dyn> per slot. Each Arc is independently Send/Sync.
+        let captured: CapturedSlice = captured
+            .into_iter()
+            .map(Arc::<dyn CapturedEffect>::from)
+            .collect();
+        Self {
+            captured,
+            invalidator: Some(invalidator),
+            unique_keys: Arc::new(unique_keys),
+        }
+    }
+
     /// Applies all effects that have been captured.
     ///
-    /// On first call: groups effects by key, detects duplicates/conflicts, caches deduped indices.
-    /// On subsequent calls: skips grouping (reuses cached indices), only runs per-key state checks.
+    /// Dispatch goes through each captured effect's [`CapturedEffect::apply`] (via
+    /// [`EffectStateStorage::run_apply`]) which handles the per-key state machine, dedup hits,
+    /// in-progress coordination, and panic recovery. The dispatch is idempotent — calling
+    /// `apply()` multiple times on the same `Effects` value runs each underlying side effect at
+    /// most once per stored `(key, value_hash)` pair.
     ///
-    /// `apply` must only be used in a "top-level" task (e.g. [`run_once`][crate::run_once]), after
-    /// [`take_effects`] is called from an [operation read with strong
+    /// If any captured effect signals [`ApplyOutcome::Retry`] (its content was elided at capture
+    /// time and storage state diverged between capture and apply), the producing task is
+    /// invalidated and [`EffectsError::Retry`] is returned after the remaining keys finish.
+    /// Side-effect failures (`ApplyOutcome::Failed`) propagate as [`EffectsError::Apply`]; the
+    /// first such error wins.
+    ///
+    /// `apply` must only be used in a "top-level" task (e.g. [`run_once`][crate::run_once]),
+    /// after [`take_effects`] is called from an [operation read with strong
     /// consistency][crate::OperationVc::read_strongly_consistent].
     ///
     /// See [`take_effects`] for example usage.
-    pub async fn apply(&self) -> Result<(), Arc<dyn EffectError>> {
+    ///
+    /// **Do not call this directly.** External callers must go through
+    /// [`read_strongly_consistent_and_apply_effects`] or
+    /// [`read_strongly_consistent_and_apply_effects_with`], which own the read+apply+retry loop
+    /// required to recover from [`EffectsError::Retry`]. Exposed publicly only as
+    /// [`Effects::apply_for_testing`] (`#[doc(hidden)]`) so integration tests can drive the apply
+    /// state machine directly.
+    async fn apply(&self) -> Result<(), EffectsError> {
         debug_assert_in_top_level_task(
             "Effects::apply must be called from a top-level task to avoid unintended \
              re-executions due to eventual consistency",
         );
-        if self.effects.is_empty() {
+        let unique = match self.unique_keys.as_ref() {
+            Ok(unique) => unique.as_slice(),
+            Err(err) => return Err(EffectsError::Conflict(err.key_len)),
+        };
+        if unique.is_empty() {
             return Ok(());
         }
 
-        let span = tracing::info_span!("apply effects", count = self.effects.len());
+        let span = tracing::info_span!("apply effects", count = unique.len());
+        let captured = &self.captured;
 
         async {
-            // Compute unique (index, state_entry) pairs once; reuse on later calls.
-            // The EffectStateEntry is resolved from the state map on first call and cached
-            // here, so subsequent apply() calls bypass the map lookup entirely.
-            let unique_indices = self
-                .unique_indices
-                .get_or_init(|| {
-                    let mut by_key: FxHashMap<Box<[u8]>, usize> = FxHashMap::default();
-                    for (idx, effect) in self.effects.iter().enumerate() {
-                        match by_key.entry(effect.inner.key()) {
-                            hash_map::Entry::Vacant(entry) => {
-                                entry.insert(idx);
-                            }
-                            hash_map::Entry::Occupied(entry) => {
-                                if self.effects[*entry.get()].inner.value_hash()
-                                    != effect.inner.value_hash()
-                                {
-                                    return Err(Arc::new(ConflictingEffectError {
-                                        key_len: entry.key().len(),
-                                    }));
-                                }
-                            }
+            // Collect the keys of any effects that signaled `Retry` across the parallel apply so
+            // we invalidate at most once at the end of the batch and can report which outputs
+            // forced the retry. `Apply` errors still take precedence — they fail-fast through the
+            // `try_for_each_concurrent`.
+            let retry_keys = Mutex::new(Vec::<String>::new());
+            let result: Result<(), EffectsError> = futures::stream::iter(unique.iter())
+                .map(Ok::<_, EffectsError>)
+                .try_for_each_concurrent(
+                    APPLY_EFFECTS_CONCURRENCY_LIMIT,
+                    async |idx| match captured[*idx].apply().await {
+                        Ok(()) => Ok(()),
+                        Err(ApplyError::Failed(err)) => Err(EffectsError::Apply(err)),
+                        Err(ApplyError::Retry) => {
+                            let key = captured[*idx].key();
+                            retry_keys
+                                .lock()
+                                .push(String::from_utf8_lossy(&key).into_owned());
+                            Ok(())
                         }
+                    },
+                )
+                .await;
+
+            match result {
+                Err(e) => Err(e),
+                Ok(()) => {
+                    let retry_keys = retry_keys.into_inner();
+                    if retry_keys.is_empty() {
+                        Ok(())
+                    } else {
+                        self.signal_retry(retry_keys)
                     }
-
-                    let mut indices = Vec::with_capacity(by_key.len());
-                    for (key, effect_idx) in by_key {
-                        let state_storage = self.effects[effect_idx].inner.state_storage();
-                        // Look up or create the per-key state entry and cache the Arc directly.
-                        let entry = state_storage
-                            .effect_state
-                            .lock()
-                            .entry(key)
-                            .or_insert_with(|| Arc::new(Mutex::new(EffectLastApplied::Unapplied)))
-                            .clone();
-                        indices.push((effect_idx, entry));
-                    }
-                    Ok(indices)
-                })
-                .as_ref()
-                .map_err(|err| err.clone() as Arc<_>)?;
-
-            // Apply effects using cached (index, state_entry) pairs.
-            // Hot path: no map lookup — EffectStateEntry is cached in unique_indices.
-            futures::stream::iter(unique_indices.iter())
-                .map(Ok::<_, Arc<dyn EffectError>>)
-                .try_for_each_concurrent(APPLY_EFFECTS_CONCURRENCY_LIMIT, async |(idx, entry)| {
-                    let effect: &dyn DynEffect = &*self.effects[*idx].inner;
-
-                    // If `effect.dyn_apply` panics or the apply future is dropped before
-                    // completion, the guard's drop impl resets the per-key state to `Unapplied`
-                    // and notifies other waiters via the `Event` it recovers from the previous
-                    // `InProgress`, so they retry rather than deadlock or observe a stale
-                    // "panic" cache entry.
-                    struct EventGuard<'a> {
-                        entry: &'a EffectStateEntry,
-                    }
-                    impl Drop for EventGuard<'_> {
-                        fn drop(&mut self) {
-                            let prev_state =
-                                replace(&mut *self.entry.lock(), EffectLastApplied::Unapplied);
-                            let EffectLastApplied::InProgress { write_event } = prev_state else {
-                                unreachable!("EventGuard: prev_state must be InProgress");
-                            };
-                            write_event.notify(usize::MAX);
-                        }
-                    }
-
-                    let begin_in_progress = |mut last_applied_guard: MutexGuard<'_, _>| {
-                        *last_applied_guard = EffectLastApplied::InProgress {
-                            write_event: Event::new(|| {
-                                || "effect application in progress".to_string()
-                            }),
-                        };
-                        EventGuard { entry }
-                    };
-
-                    let event_guard = loop {
-                        let listener;
-                        {
-                            let last_applied_guard = entry.lock();
-                            match &*last_applied_guard {
-                                EffectLastApplied::Unapplied => {
-                                    break begin_in_progress(last_applied_guard);
-                                }
-                                EffectLastApplied::Applied { value_hash, result } => {
-                                    // Fast path: check if the stored value already matches
-                                    if effect.value_hash() == *value_hash {
-                                        return result.clone();
-                                    } else {
-                                        break begin_in_progress(last_applied_guard);
-                                    }
-                                }
-                                EffectLastApplied::InProgress { write_event } => {
-                                    // `Event::listen` registers the listener immediately, so
-                                    // notifications fired after we drop `last_applied_guard`
-                                    // cannot be missed.
-                                    listener = write_event.listen();
-                                }
-                            }
-                        };
-                        // We didn't break out of the loop: There's a concurrent in-progress
-                        // application. Wait for it to finish and then read `last_applied` again.
-                        listener.await;
-                    };
-
-                    // Apply the effect. InProgress is visible to concurrent readers, preventing
-                    // stale fast-path matches.
-                    let effect_result = effect.dyn_apply().await;
-
-                    // Update the state, clear the EventGuard
-                    let prev_state = replace(
-                        &mut *entry.lock(),
-                        EffectLastApplied::Applied {
-                            value_hash: effect.value_hash(),
-                            result: effect_result.clone(),
-                        },
-                    );
-                    // don't run the `Drop` impl on `EventGuard`. We'll do the notification
-                    // ourselves.
-                    forget(event_guard);
-
-                    let EffectLastApplied::InProgress { write_event } = prev_state else {
-                        unreachable!("Effect applied: prev_state must be InProgress");
-                    };
-                    write_event.notify(usize::MAX);
-
-                    effect_result
-                })
-                .await
+                }
+            }
         }
         .instrument(span)
         .await
     }
+
+    /// Test-only public alias for [`Effects::apply`]. Lets integration tests in other crates drive
+    /// the per-key apply state machine directly (e.g. asserting dedup counts or the raw
+    /// [`EffectsError::Retry`] signal). Production code must use
+    /// [`read_strongly_consistent_and_apply_effects`] instead, which owns the retry loop.
+    #[doc(hidden)]
+    pub async fn apply_for_testing(&self) -> Result<(), EffectsError> {
+        self.apply().await
+    }
+
+    /// Invalidate the producing task (if any) and return [`EffectsError::Retry`] carrying the
+    /// producing task's name and the `keys` that signaled [`ApplyOutcome::Retry`] (their capture
+    /// elided content materialization but storage state diverged before apply).
+    fn signal_retry(&self, keys: Vec<String>) -> Result<(), EffectsError> {
+        let task_name = match self.invalidator {
+            Some(invalidator) => with_turbo_tasks(|tt| {
+                let name = tt.get_task_name(invalidator.task_id());
+                invalidator.invalidate(&**tt);
+                name
+            }),
+            None => "<unknown>".to_string(),
+        };
+        Err(EffectsError::Retry { task_name, keys })
+    }
+}
+
+/// Strongly-consistent read of `op`, then apply its effects, retrying the whole read+apply on
+/// [`EffectsError::Retry`].
+///
+/// `get_effects` extracts the [`Effects`] from the read value (for a wrapper struct this is
+/// `|v| &v.effects`; for an `OperationVc<Effects>` it is `|e| e`).
+///
+/// On [`EffectsError::Retry`] the producing operation has already been invalidated by
+/// [`Effects::apply`], so the next
+/// [`read_strongly_consistent`][OperationVc::read_strongly_consistent] re-runs the producer and
+/// yields a fresh [`Effects`] whose `capture()` re-materializes content. Retries are bounded to
+/// avoid livelock when two producers perpetually stomp the same key; after the first retry a
+/// warning is logged on each subsequent attempt, and on exhaustion the last `Retry` surfaces as an
+/// error.
+///
+/// This is one of two public entry points for applying effects (see also
+/// [`read_strongly_consistent_and_apply_effects_with`]) — [`Effects::apply`] is private so the
+/// retry contract cannot be bypassed.
+pub async fn read_strongly_consistent_and_apply_effects<T, F>(
+    op: OperationVc<T>,
+    get_effects: F,
+) -> Result<ReadRef<T>>
+where
+    T: VcValueType,
+    F: Fn(&<<T as VcValueType>::Read as VcRead<T>>::Target) -> &Effects,
+{
+    let mut attempts = 0usize;
+    loop {
+        let value = op.read_strongly_consistent().await?;
+        // Deref the `ReadRef<T>` to the read target (`T` for non-transparent types).
+        let effects = get_effects(&*value);
+        match effects.apply().await {
+            Ok(()) => return Ok(value),
+            Err(e) => handle_apply_retry(e, &mut attempts)?,
+        }
+    }
+}
+
+/// AVOID CALLING THIS UNLESS DEEPLY REQUIRED
+///
+/// Like [`read_strongly_consistent_and_apply_effects`], but the [`Effects`] directly accessed by
+/// calling [`take_effects`] on the supplied operation.
+///
+/// Unlike [`read_strongly_consistent_and_apply_effects`], this may be called from *inside* a
+/// turbo-tasks task (it owns the `mark`/`unmark` around `apply`). The consequence is that the
+/// effects may be re-applied if that enclosing task is invalidated — acceptable for lazily-created
+/// resources.
+pub async fn resolve_strongly_consistent_and_take_and_apply_effects<T>(
+    op: OperationVc<T>,
+) -> Result<ResolvedVc<T>>
+where
+    T: VcValueType,
+{
+    let mut attempts = 0usize;
+    loop {
+        let value = op.resolve().strongly_consistent().await?;
+        // Run the callback while *not* marked top-level so it can `take_effects` / read Vcs.
+
+        let effects = take_effects(op).await?;
+        // `Effects::apply` asserts it runs at the top-level. Mark only around the apply, then
+        // unmark so any further work (including the next loop iteration's read) is unaffected.
+        mark_top_level_task();
+        let result = effects.apply().await;
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        match result {
+            Ok(()) => return Ok(value),
+            Err(e) => handle_apply_retry(e, &mut attempts)?,
+        }
+    }
+}
+
+/// Shared retry-decision for the two `read_strongly_consistent_and_apply_effects*` helpers.
+///
+/// Returns `Ok(())` to signal the caller should retry the read+apply loop (bounded by
+/// `MAX_RETRIES`). Returns `Err` for terminal outcomes: a non-`Retry` error, or `Retry` after the
+/// retry budget is exhausted.
+fn handle_apply_retry(err: EffectsError, attempts: &mut usize) -> Result<()> {
+    const MAX_RETRIES: usize = 4; // chosen by a fair dice roll
+    match err {
+        EffectsError::Retry { task_name, keys } if *attempts < MAX_RETRIES => {
+            *attempts += 1;
+            // Warn on every retry after the first.
+            if *attempts > 1 {
+                eprintln!(
+                    "BUG: {task_name} has retried {attempts} times to write an output: {keys:?}.  \
+                     This implies multiple routes are fighting to write one of these files.",
+                    attempts = *attempts,
+                );
+            }
+            Ok(())
+        }
+        // Retries exhausted: surface that we gave up after `MAX_RETRIES`, naming the task and the
+        // contended outputs.
+        EffectsError::Retry { task_name, keys } => anyhow::bail!(
+            "gave up applying effects for {task_name} after {MAX_RETRIES} retries; repeated \
+             effect-state divergence on: {keys:?}. This implies multiple routes are fighting to \
+             write one of these files."
+        ),
+        e => Err(e.into()),
+    }
+}
+
+/// Build the deduped per-key indices into the captured slice. Detects per-key value-hash
+/// conflicts. This is the eager half of effect deduplication — it inspects only the captured
+/// effects themselves (no [`EffectStateStorage`] interaction) and is therefore safe to call
+/// from inside a turbo-tasks task in [`take_effects`].
+fn build_unique_keys(captured: &[Box<dyn CapturedEffect>]) -> UniqueKeys {
+    let mut by_key: FxHashMap<Box<[u8]>, usize> = FxHashMap::default();
+    for (idx, effect) in captured.iter().enumerate() {
+        match by_key.entry(effect.key()) {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(idx);
+            }
+            hash_map::Entry::Occupied(entry) => {
+                if captured[*entry.get()].value_hash() != effect.value_hash() {
+                    return Err(Arc::new(ConflictingEffectError {
+                        key_len: entry.key().len(),
+                    }));
+                }
+            }
+        }
+    }
+
+    let mut keys: Vec<usize> = by_key.into_values().collect();
+    // Sort by idx so the order is deterministic — useful for stable tracing/logging.
+    keys.sort_unstable();
+    Ok(keys)
 }
 
 #[cfg(test)]
@@ -445,13 +685,7 @@ mod tests {
     fn is_send() {
         fn assert_send<T: Send>(_: T) {}
         fn check_effects_apply() {
-            assert_send(
-                Effects {
-                    effects: Vec::new(),
-                    unique_indices: Default::default(),
-                }
-                .apply(),
-            );
+            assert_send(Effects::empty().apply());
         }
         fn check_take_effects<T: CollectiblesSource + Send + Sync>(t: T) {
             assert_send(take_effects(t));

--- a/turbopack/crates/turbo-tasks/src/invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/invalidation.rs
@@ -33,6 +33,13 @@ pub struct Invalidator {
 }
 
 impl Invalidator {
+    /// The [`TaskId`] of the task this invalidator targets. Used for diagnostics
+    /// (e.g. resolving the producing task's name via
+    /// [`TurboTasksApi::get_task_name`][crate::TurboTasksApi::get_task_name]).
+    pub fn task_id(&self) -> TaskId {
+        self.task
+    }
+
     pub fn invalidate(self, turbo_tasks: &dyn TurboTasksApi) {
         turbo_tasks.invalidate(self.task);
     }

--- a/turbopack/crates/turbo-tasks/src/invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/invalidation.rs
@@ -33,13 +33,6 @@ pub struct Invalidator {
 }
 
 impl Invalidator {
-    /// The [`TaskId`] of the task this invalidator targets. Used for diagnostics
-    /// (e.g. resolving the producing task's name via
-    /// [`TurboTasksApi::get_task_name`][crate::TurboTasksApi::get_task_name]).
-    pub fn task_id(&self) -> TaskId {
-        self.task
-    }
-
     pub fn invalidate(self, turbo_tasks: &dyn TurboTasksApi) {
         turbo_tasks.invalidate(self.task);
     }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -83,7 +83,11 @@ pub use crate::{
     dyn_task_inputs::{
         DynTaskInputs, DynTaskInputsStorage, HeapDynTaskInputsStorage, StackDynTaskInputsStorage,
     },
-    effect::{Effect, EffectError, EffectStateStorage, Effects, emit_effect, take_effects},
+    effect::{
+        ApplyError, CapturedEffect, Effect, EffectError, EffectExt, EffectStateStorage, Effects,
+        EffectsError, read_strongly_consistent_and_apply_effects,
+        resolve_strongly_consistent_and_take_and_apply_effects, take_effects,
+    },
     error::PrettyPrintError,
     id::{
         ExecutionId, FunctionId, LocalTaskId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId,

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -162,6 +162,7 @@ impl_task_input! {
     u32,
     i32,
     u64,
+    u128,
     usize,
     RcStr,
     TaskId,

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -11,7 +11,7 @@ use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     Effects, OperationVc, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Vc,
-    take_effects,
+    read_strongly_consistent_and_apply_effects, take_effects,
 };
 use turbo_tasks_backend::{
     BackendOptions, GitVersionInfo, StartupCacheState, StorageMode, TurboTasksBackend,
@@ -158,10 +158,7 @@ impl TurbopackBuildBuilder {
                     self.scope_hoist,
                 ));
 
-                // Await the result to propagate any errors and capture effects.
-                let effects = wrapper_op.read_strongly_consistent().await?;
-
-                effects.apply().await?;
+                read_strongly_consistent_and_apply_effects(wrapper_op, |e| e).await?;
 
                 let issue_reporter: Vc<Box<dyn IssueReporter>> =
                     Vc::upcast(ConsoleUi::new(TransientInstance::new(LogOptions {

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -12,7 +12,7 @@ use hyper::{
 use mime::Mime;
 use turbo_tasks::{
     CollectiblesSource, Effects, OperationVc, ReadRef, ResolvedVc, TransientInstance, Vc,
-    take_effects, util::SharedError,
+    read_strongly_consistent_and_apply_effects, take_effects, util::SharedError,
 };
 use turbo_tasks_bytes::Bytes;
 use turbo_tasks_fs::FileContent;
@@ -106,12 +106,12 @@ pub async fn process_request_with_content_source(
     let request = http_request_to_source_request(request).await?;
     let wrapper_op =
         get_from_source_with_collectibles_operation(source, TransientInstance::new(request));
+    let read = read_strongly_consistent_and_apply_effects(wrapper_op, |v| &v.effects).await?;
     let GetFromSourceResultWithCollectibles {
         result,
-        effects,
         content_source_side_effects,
-    } = &*wrapper_op.read_strongly_consistent().await?;
-    effects.apply().await?;
+        ..
+    } = &*read;
     handle_issues(
         wrapper_op,
         issue_reporter,

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -30,8 +30,9 @@ use socket2::{Domain, Protocol, Socket, Type};
 use tokio::task::JoinHandle;
 use tracing::{Instrument, Level, Span, event, info_span};
 use turbo_tasks::{
-    Effects, NonLocalValue, OperationVc, PrettyPrintError, TurboTasksApi, Vc, run_once_with_reason,
-    take_effects, trace::TraceRawVcs, util::FormatDuration,
+    Effects, NonLocalValue, OperationVc, PrettyPrintError, TurboTasksApi, Vc,
+    read_strongly_consistent_and_apply_effects, run_once_with_reason, take_effects,
+    trace::TraceRawVcs, util::FormatDuration,
 };
 use turbopack_core::issue::{IssueReporter, IssueSeverity, handle_issues};
 
@@ -223,9 +224,12 @@ impl DevServerBuilder {
                             let path = uri.path().to_string();
                             let source_with_issues_op =
                                 get_source_with_issues_operation(source_provider.get_source());
-                            let ContentSourceWithIssues { source_op, effects } =
-                                &*source_with_issues_op.read_strongly_consistent().await?;
-                            effects.apply().await?;
+                            let read = read_strongly_consistent_and_apply_effects(
+                                source_with_issues_op,
+                                |v| &v.effects,
+                            )
+                            .await?;
+                            let ContentSourceWithIssues { source_op, .. } = &*read;
                             handle_issues(
                                 source_with_issues_op,
                                 issue_reporter,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -1,4 +1,4 @@
-use std::{iter, process::ExitStatus, sync::Arc, time::Duration};
+use std::{iter, process::ExitStatus, time::Duration};
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
@@ -10,8 +10,8 @@ use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, FxIndexMap, OperationVc, PrettyPrintError, ResolvedVc, TryJoinIterExt,
-    ValueToString, Vc, duration_span, fxindexmap, mark_top_level_task,
-    parallel::available_parallelism, take_effects, trace::TraceRawVcs,
+    ValueToString, Vc, duration_span, fxindexmap, parallel::available_parallelism,
+    resolve_strongly_consistent_and_take_and_apply_effects, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, to_sys_path};
@@ -179,7 +179,7 @@ async fn emit_evaluate_pool_assets_operation(
     Ok(EmittedEvaluatePoolAssets {
         bootstrap: bootstrap.to_resolved().await?,
         output_root,
-        entrypoint: entrypoint.clone(),
+        entrypoint,
     }
     .cell())
 }
@@ -191,17 +191,16 @@ async fn create_evaluate_pool_assets_operation(
     module_graph: ResolvedVc<ModuleGraph>,
 ) -> Result<Vc<EmittedEvaluatePoolAssets>> {
     let operation = emit_evaluate_pool_assets_operation(entries, chunking_context, module_graph);
-    let assets = operation.resolve().strongly_consistent().await?;
-    let effects = Arc::new(take_effects(operation).await?);
-
-    // HACK: `Effects::apply` normally panics if not called at the top-level. We want to apply most
-    // effects outside of turbo-task functions to avoid re-executing effects during invalidations.
+    // Apply the effects here (inside this producing task) via the bounded-retry helper, draining
+    // them from the nested emit operation. Returning the serializable `EmittedEvaluatePoolAssets`
+    // (rather than a `serialization = "skip"` wrapper carrying the effects) keeps this task's
+    // output restorable from the persistent cache, so a warm restart does not re-run the
+    // effect-producing tasks.
     //
-    // That's not possible here because we lazily create the pool, so instead, use
-    // `mark_top_level_task` to avoid the debug assertion. The consequence is that these effects
-    // might get evaluated more than once if this function is invalidated.
-    mark_top_level_task();
-    effects.apply().await?;
+    // HACK: applying effects from inside a task means they may get re-applied if this task is
+    // invalidated. That's acceptable because the pool is created lazily; we can't move the
+    // apply to a true top-level task without eagerly reading the operation.
+    let assets = resolve_strongly_consistent_and_take_and_apply_effects(operation).await?;
 
     Ok(*assets)
 }
@@ -228,6 +227,8 @@ pub async fn get_evaluate_pool(
     env_var_tracking: EnvVarTracking,
 ) -> Result<Vc<EvaluatePool>> {
     let assets_op = create_evaluate_pool_assets_operation(entries, chunking_context, module_graph);
+    // Effects are applied inside `create_evaluate_pool_assets_operation`; a plain strongly
+    // consistent read suffices here.
     let assets = assets_op.read_strongly_consistent().await?;
 
     let EmittedEvaluatePoolAssets {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -15,7 +15,8 @@ use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Effects, NonLocalValue, OperationVc, ReadRef, ResolvedVc, TurboTasks, Vc,
-    debug::ValueDebugFormat, fxindexmap, take_effects, trace::TraceRawVcs,
+    debug::ValueDebugFormat, fxindexmap, read_strongly_consistent_and_apply_effects, take_effects,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_env::CommandLineProcessEnv;
@@ -249,11 +250,9 @@ async fn run(resource: PathBuf, snapshot_mode: IssueSnapshotMode) -> Result<JsRe
     }
 
     tt.run_once(async move {
+        let op = run_inner_operation_with_effects(resource.to_str().unwrap().into(), snapshot_mode);
         let result_with_effects =
-            run_inner_operation_with_effects(resource.to_str().unwrap().into(), snapshot_mode)
-                .read_strongly_consistent()
-                .await?;
-        result_with_effects.effects.apply().await?;
+            read_strongly_consistent_and_apply_effects(op, |v| &v.effects).await?;
 
         Ok((*result_with_effects.result).clone())
     })

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -11,7 +11,10 @@ use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde_json::json;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Effects, OperationVc, ResolvedVc, TurboTasks, Vc, take_effects, turbofmt};
+use turbo_tasks::{
+    Effects, OperationVc, ResolvedVc, TurboTasks, Vc, read_strongly_consistent_and_apply_effects,
+    take_effects, turbofmt,
+};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
@@ -249,11 +252,11 @@ async fn run(resource: PathBuf) -> Result<()> {
             Ok(take_effects(op).await?.cell())
         }
 
-        extract_effects(inner_operation(resource.to_str().unwrap().into()))
-            .read_strongly_consistent()
-            .await?
-            .apply()
-            .await?;
+        read_strongly_consistent_and_apply_effects(
+            extract_effects(inner_operation(resource.to_str().unwrap().into())),
+            |e| e,
+        )
+        .await?;
 
         Ok(())
     })

--- a/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
@@ -3,7 +3,9 @@ use std::{fs, path::PathBuf};
 use criterion::{Bencher, BenchmarkId, Criterion};
 use regex::Regex;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Effects, OperationVc, TurboTasks, Vc, take_effects};
+use turbo_tasks::{
+    Effects, OperationVc, TurboTasks, Vc, read_strongly_consistent_and_apply_effects, take_effects,
+};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, NullFileSystem};
 use turbopack::{
@@ -129,11 +131,11 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                     .to_resolved()
                     .await?;
 
-                extract_effects_operation(emit_assets_into_dir_operation(assets, output_dir))
-                    .read_strongly_consistent()
-                    .await?
-                    .apply()
-                    .await?;
+                read_strongly_consistent_and_apply_effects(
+                    extract_effects_operation(emit_assets_into_dir_operation(assets, output_dir)),
+                    |e| e,
+                )
+                .await?;
 
                 Ok(())
             })

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -28,8 +28,8 @@ use serde::Serialize;
 use tokio::{process::Command, time::timeout};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Effects, ResolvedVc, TurboTasks, ValueToString, Vc, backend::Backend, take_effects,
-    trace::TraceRawVcs,
+    Effects, ResolvedVc, TurboTasks, ValueToString, Vc, backend::Backend,
+    read_strongly_consistent_and_apply_effects, take_effects, trace::TraceRawVcs,
 };
 use turbo_tasks_backend::TurboTasksBackend;
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
@@ -489,14 +489,13 @@ fn node_file_trace<B: Backend + 'static>(
             let directory = directory.clone();
             let task = async move {
                 let before_start = Instant::now();
-                let trace_result = node_file_trace_operation(
+                let trace_op = node_file_trace_operation(
                     package_root.clone(),
                     input.clone(),
                     directory.clone(),
-                )
-                .read_strongly_consistent()
-                .await?;
-                trace_result.effects.apply().await?;
+                );
+                let trace_result =
+                    read_strongly_consistent_and_apply_effects(trace_op, |v| &v.effects).await?;
                 let rebased = trace_result.rebased;
                 let duration = before_start.elapsed();
 


### PR DESCRIPTION
### What?
Enable Effects to be evicted.

Currently `EffectInstance` transitively holds a `ReadRef<PersistentFileContent>` which means eviction cannot not free the memory for the outputs.  Because the `ReadRefs` are captured by the task producing the `Effect` we cannot just drop them (otherwise we could need to somehow re-execute the write to recover them).  So instead we need a new 'effect processing phase'

Here is our new state machine:
 * Phase 1: `emit` effects.
      - At this point we capture the content as a `ResolvedVc` and the hash as a value.
      - In principle this means the hash and content can get out of sync, but only within an eventual consistency race which callers should be handling.
  * Phase 2: `take_effects`.
      - This will call `capture()` on all the effects which will conditionally read the content cell if the hash doesn't match the `EffectStateStorage`
  * Phase 3: `Effects::apply`.
      - This will apply the effects for all effects whose hashes don't match storage.
      - At this point we may discover that a hash in storage changed between `capture` and `apply` which will trigger a special `Retry` error and `invalidate` `Phase 2`.

To facilitate the `Retry` logic a `read_strongly_consistent_and_apply_effects` helper function handles it.  Which allows for a simple circuit breaker and some verbose warnings/errors when we retry too many times.

Specifically:
- Split the `Effect` trait into `Effect` (emit-side, returns a `Captured` payload) and `CapturedEffect` (apply-side). `
- Switch `Effects` to `cell = "new"`. Every producer re-execution allocates a fresh cell value; the prior cell (and its captured payload) drops on overwrite, cascade-releasing upstream `ReadRef<PersistedFileContent>` strong counts. The captured payload also drops naturally when the cell is evicted.
- Push the per-key state machine (`Unapplied` / `InProgress` / `Applied { value_hash, result }`, `EventGuard` panic recovery, `Event` listener coordination) down into `EffectStateStorage::run_apply`. `Effects::apply` becomes a thin aggregator over `dyn_apply()` calls.
- New `ApplyOutcome<E> { Failed(E), Retry }`. `CapturedEffect::apply` returns this; `Retry` signals "capture elided content but storage diverged before apply" — `Effects::apply` collects across the batch, fires the producer's invalidator once, and surfaces `EffectsError::Retry`.
- New `EffectStateStorage::matches_applied(key, hash)`. `WriteEffect::capture` / `WriteLinkEffect::capture` consult this and skip the `ReadRef<PersistedFileContent>` / `ReadRef<LinkContent>` materialization when storage already holds `Applied { matching, Ok(()) }` — avoiding the disk-read + decompression hit on producer re-runs that don't actually change output.
- 10 integration tests in `turbopack/crates/turbo-tasks-backend/tests/effects.rs` cover the new lifecycle: duplicate apply, sibling stomp re-apply, repeated apply with unchanged state dedupe, `cell = "new"` producing distinct cells per producer run, capture-skip on storage match, and the capture-skip-then-stomp race that exercises the `Retry` path.

### Why?

A memory audit showed `EffectInstance` cells accumulating the majority of the ram in an eviction session

#### Capture-time storage check (the perf story)

`Effect::capture` may consult `EffectStateStorage::matches_applied` and elide the content materialization when storage already records the target hash. `CapturedWriteEffect.content` becomes `Option<ReadRef<PersistedFileContent>>` — `None` means "capture observed `Applied { matching }`; no `body` to pass to `run_apply`". The apply-side state machine then either dedup-hits (storage still matches → cached `Ok`) or enters the no-body branch and returns `ApplyOutcome::Retry`.

Reading shared mutable `EffectStateStorage` from inside a turbo-tasks task is normally suspect (the state isn't a tracked input). It is sound here because the apply-time re-check fires the producer's invalidator on mismatch, turning the otherwise-untracked read into an explicitly-tracked one via the `Retry` pathway. The producer reruns, `capture` sees the new storage state, materializes content, and the next `apply` succeeds.

#### `ApplyOutcome::Retry` and the invalidator

`Effects::apply` collects `Retry` signals across the parallel batch via `AtomicBool`. `Failed(e)` errors fail-fast. After the batch, if any `Retry` fired (and no `Failed`), the producer's invalidator runs once and `EffectsError::Retry` propagates. Callers re-read the operation; the producer reruns; fresh `capture` either materializes content (storage diverged) or dedup-hits cleanly.

#### `turbo-tasks-fs`

`WriteEffect::capture` / `WriteLinkEffect::capture` call `matches_applied` first and conditionally `.await?` the content `ResolvedVc`. `CapturedWriteEffect::apply` / `CapturedWriteLinkEffect::apply` dispatch through `run_apply(key, hash, body)`, where `body` is `Some(closure)` iff content is `Some`. `apply_inner` takes the unwrapped `&ReadRef<…>` as a parameter so the option-unwrap is at the dispatch boundary (type-enforced).

### Risk: infinite retry loop

**Failure mode.** Two sibling producers A and B contend on the same key with different hashes (e.g. two routes that both want to write `chunks/foo.js` with different content). Each `Retry` from A's apply invalidates A's producer; each `Retry` from B's apply invalidates B's producer. In the worst case, A and B perpetually re-capture, race to apply, stomp each other's storage state, and re-trigger Retry — invalidating themselves on each cycle.

**Why we believe it terminates in practice.** A `Retry` only fires when (a) capture observed `Applied { matching }` and elided content, and (b) by apply time storage was stomped to a different hash. Each `Retry` invalidates only its own producer (no cross-producer invalidation), so without external input churn the system reaches a fixed point — whichever producer applies last wins, and subsequent re-runs of the loser's producer materialize content (because storage no longer matches) and apply cleanly. The pathological case requires a real, ongoing race fundamentally triggered by external invalidations (file edits).


<!-- NEXT_JS_LLM_PR -->