### PR TITLE
test: untangle global playwright state

### DIFF
--- a/test/e2e/dynamic-routing/shared.ts
+++ b/test/e2e/dynamic-routing/shared.ts
@@ -124,11 +124,9 @@ export function runTests(ctx: {
           window.uncaught.push(err)
         })
       })()`)
-      const curFrames = [...(await browser.websocketFrames())]
+      const initialFrames = [...browser.websocketFrames]
       await retry(async () => {
-        const frames = await browser.websocketFrames()
-        const newFrames = frames.slice(curFrames.length)
-
+        const newFrames = browser.websocketFrames.slice(initialFrames.length)
         const found = newFrames.some((frame) => {
           try {
             const data = JSON.parse('' + frame.payload)

--- a/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 
 describe('Build Error Tests for basePath', () => {
   const { next } = nextTestSetup({
@@ -38,15 +38,14 @@ describe('Static Image Component Tests for basePath', () => {
   })
   if (skipped) return
 
-  let browser: Playwright
   let html: string
 
   beforeAll(async () => {
     html = await next.render('/docs/static-img')
-    browser = await next.browser('/docs/static-img')
   })
 
   it('Should allow an image with a static src to omit height and width', async () => {
+    const browser = await next.browser('/docs/static-img')
     expect(await browser.elementById('basic-static')).toBeTruthy()
     expect(await browser.elementById('blur-png')).toBeTruthy()
     expect(await browser.elementById('blur-webp')).toBeTruthy()
@@ -60,6 +59,7 @@ describe('Static Image Component Tests for basePath', () => {
   })
 
   it('Should use immutable cache-control header for static import', async () => {
+    const browser = await next.browser('/docs/static-img')
     await browser.eval(
       `document.getElementById("basic-static").scrollIntoView()`
     )
@@ -75,6 +75,7 @@ describe('Static Image Component Tests for basePath', () => {
 
   if (!isNextDev) {
     it('Should use immutable cache-control header even when unoptimized', async () => {
+      const browser = await next.browser('/docs/static-img')
       await browser.eval(
         `document.getElementById("static-unoptimized").scrollIntoView()`
       )

--- a/test/e2e/next-image-legacy/default/default-static.test.ts
+++ b/test/e2e/next-image-legacy/default/default-static.test.ts
@@ -1,10 +1,5 @@
 /* eslint-disable jest/no-standalone-expect */
-import {
-  nextTestSetup,
-  isNextDev,
-  isNextStart,
-  type Playwright,
-} from 'e2e-utils'
+import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import cheerio from 'cheerio'
 
 describe('Build Error Tests', () => {
@@ -48,15 +43,14 @@ describe('Static Image Component Tests', () => {
   })
   if (skipped) return
 
-  let browser: Playwright
   let html: string
 
   beforeAll(async () => {
     html = await next.render('/static-img')
-    browser = await next.browser('/static-img')
   })
 
   it('Should allow an image with a static src to omit height and width', async () => {
+    const browser = await next.browser('/static-img')
     expect(await browser.elementById('basic-static')).toBeTruthy()
     expect(await browser.elementById('blur-png')).toBeTruthy()
     expect(await browser.elementById('blur-webp')).toBeTruthy()
@@ -71,6 +65,7 @@ describe('Static Image Component Tests', () => {
   ;(isNextStart ? it : it.skip)(
     'Should use immutable cache-control header for static import',
     async () => {
+      const browser = await next.browser('/static-img')
       await browser.eval(
         `document.getElementById("basic-static").scrollIntoView()`
       )
@@ -87,6 +82,7 @@ describe('Static Image Component Tests', () => {
   ;(isNextStart ? it : it.skip)(
     'Should use immutable cache-control header even when unoptimized',
     async () => {
+      const browser = await next.browser('/static-img')
       await browser.eval(
         `document.getElementById("static-unoptimized").scrollIntoView()`
       )
@@ -158,6 +154,7 @@ describe('Static Image Component Tests', () => {
   })
 
   it('should load direct imported image', async () => {
+    const browser = await next.browser('/static-img')
     const src = await browser.elementById('basic-static').getAttribute('src')
     expect(src).toMatch(
       /_next\/image\?url=%2F_next%2Fstatic%2F(immutable%2F)?media%2Ftest-rect(.+)\.jpg&w=828&q=75/
@@ -168,6 +165,7 @@ describe('Static Image Component Tests', () => {
   })
 
   it('should load staticprops imported image', async () => {
+    const browser = await next.browser('/static-img')
     const src = await browser
       .elementById('basic-staticprop')
       .getAttribute('src')

--- a/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
+++ b/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 import cheerio from 'cheerio'
 
 // The fixture page intentionally renders an uncached `await setTimeout(0)`
@@ -52,16 +52,15 @@ import cheerio from 'cheerio'
     })
     if (skipped) return
 
-    let browser: Playwright
     let $: ReturnType<typeof cheerio.load>
 
     beforeAll(async () => {
       const html = await next.render('/static-img')
       $ = cheerio.load(html)
-      browser = await next.browser('/static-img')
     })
 
     it('Should allow an image with a static src to omit height and width', async () => {
+      const browser = await next.browser('/static-img')
       expect(await browser.elementById('basic-static')).toBeTruthy()
       expect(await browser.elementById('blur-png')).toBeTruthy()
       expect(await browser.elementById('blur-webp')).toBeTruthy()
@@ -80,6 +79,7 @@ import cheerio from 'cheerio'
 
     if (!isNextDev) {
       it('Should use immutable cache-control header for static import', async () => {
+        const browser = await next.browser('/static-img')
         await browser.eval(
           `document.getElementById("basic-static").scrollIntoView()`
         )
@@ -96,6 +96,7 @@ import cheerio from 'cheerio'
       })
 
       it('Should use immutable cache-control header even when unoptimized', async () => {
+        const browser = await next.browser('/static-img')
         await browser.eval(
           `document.getElementById("static-unoptimized").scrollIntoView()`
         )
@@ -258,6 +259,7 @@ import cheerio from 'cheerio'
     })
 
     it('should load direct imported image', async () => {
+      const browser = await next.browser('/static-img')
       const src = await browser.elementById('basic-static').getAttribute('src')
       expect(src).toMatch(
         /_next\/image\?url=%2F_next%2Fstatic(%2Fimmutable)?%2Fmedia%2Ftest-rect(.+)\.jpg&w=828&q=75/

--- a/test/e2e/next-image-new/app-dir/app-dir.test.ts
+++ b/test/e2e/next-image-new/app-dir/app-dir.test.ts
@@ -1434,21 +1434,20 @@ describe('Image Component App Dir Tests', () => {
   })
 
   describe('Fill-mode tests', () => {
-    let browser
-    beforeAll(async () => {
-      browser = await next.browser('/fill')
-    })
     it('should include a data-attribute on fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(
         await browser.elementById('fill-image-1').getAttribute('data-nimg')
       ).toBe('fill')
     })
     it('should add position:absolute to fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(await getComputedStyle(browser, 'fill-image-1', 'position')).toBe(
         'absolute'
       )
     })
     it('should add 100% width and height to fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(
         await browser.eval(
           `document.getElementById("fill-image-1").style.height`
@@ -1461,6 +1460,7 @@ describe('Image Component App Dir Tests', () => {
       ).toBe('100%')
     })
     it('should add position styles to fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(
         await browser.eval(
           `document.getElementById("fill-image-1").getAttribute('style')`
@@ -1471,6 +1471,7 @@ describe('Image Component App Dir Tests', () => {
     })
     if (isNextDev) {
       it('should not log incorrect warnings', async () => {
+        const browser = await next.browser('/fill')
         await new Promise((r) => setTimeout(r, 1000))
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1481,7 +1482,7 @@ describe('Image Component App Dir Tests', () => {
         )
       })
       it('should log warnings when using fill mode incorrectly', async () => {
-        browser = await next.browser('/fill-warnings')
+        const browser = await next.browser('/fill-warnings')
         await new Promise((r) => setTimeout(r, 1000))
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1500,7 +1501,7 @@ describe('Image Component App Dir Tests', () => {
         )
       })
       it('should not log warnings when image unmounts', async () => {
-        browser = await next.browser('/should-not-warn-unmount')
+        const browser = await next.browser('/should-not-warn-unmount')
         await new Promise((r) => setTimeout(r, 1000))
         const warnings = (await browser.log())
           .map((log) => log.message)

--- a/test/e2e/next-image-new/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-new/base-path/base-path-static.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 import cheerio from 'cheerio'
 
 describe('Build Error Tests', () => {
@@ -45,16 +45,15 @@ describe('Static Image Component Tests for basePath', () => {
   })
   if (skipped) return
 
-  let browser: Playwright
   let $: ReturnType<typeof cheerio.load>
 
   beforeAll(async () => {
     const html = await next.render('/docs/static-img')
     $ = cheerio.load(html)
-    browser = await next.browser('/docs/static-img')
   })
 
   it('Should allow an image with a static src to omit height and width', async () => {
+    const browser = await next.browser('/docs/static-img')
     expect(await browser.elementById('basic-static')).toBeTruthy()
     expect(await browser.elementById('blur-png')).toBeTruthy()
     expect(await browser.elementById('blur-webp')).toBeTruthy()
@@ -69,6 +68,7 @@ describe('Static Image Component Tests for basePath', () => {
 
   if (!isNextDev) {
     it('Should use immutable cache-control header for static import', async () => {
+      const browser = await next.browser('/docs/static-img')
       await browser.eval(
         `document.getElementById("basic-static").scrollIntoView()`
       )
@@ -83,6 +83,7 @@ describe('Static Image Component Tests for basePath', () => {
     })
 
     it('Should use immutable cache-control header even when unoptimized', async () => {
+      const browser = await next.browser('/docs/static-img')
       await browser.eval(
         `document.getElementById("static-unoptimized").scrollIntoView()`
       )

--- a/test/e2e/next-image-new/default/default-static.test.ts
+++ b/test/e2e/next-image-new/default/default-static.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 import cheerio from 'cheerio'
 
 describe('Build Error Tests', () => {
@@ -43,16 +43,15 @@ describe('Static Image Component Tests', () => {
   })
   if (skipped) return
 
-  let browser: Playwright
   let $: ReturnType<typeof cheerio.load>
 
   beforeAll(async () => {
     const html = await next.render('/static-img')
     $ = cheerio.load(html)
-    browser = await next.browser('/static-img')
   })
 
   it('Should allow an image with a static src to omit height and width', async () => {
+    const browser = await next.browser('/static-img')
     expect(await browser.elementById('basic-static')).toBeTruthy()
     expect(await browser.elementById('blur-png')).toBeTruthy()
     expect(await browser.elementById('blur-webp')).toBeTruthy()
@@ -71,6 +70,7 @@ describe('Static Image Component Tests', () => {
 
   if (!isNextDev) {
     it('Should use immutable cache-control header for static import', async () => {
+      const browser = await next.browser('/static-img')
       await browser.eval(
         `document.getElementById("basic-static").scrollIntoView()`
       )
@@ -85,6 +85,7 @@ describe('Static Image Component Tests', () => {
     })
 
     it('Should use immutable cache-control header even when unoptimized', async () => {
+      const browser = await next.browser('/static-img')
       await browser.eval(
         `document.getElementById("static-unoptimized").scrollIntoView()`
       )
@@ -245,6 +246,7 @@ describe('Static Image Component Tests', () => {
   })
 
   it('should load direct imported image', async () => {
+    const browser = await next.browser('/static-img')
     const src = await browser.elementById('basic-static').getAttribute('src')
     expect(normalizeURL(src)).toEqual(
       '/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest-rect.HASH.jpg&w=828&q=75'
@@ -255,6 +257,7 @@ describe('Static Image Component Tests', () => {
   })
 
   it('should load staticprops imported image', async () => {
+    const browser = await next.browser('/static-img')
     const src = await browser
       .elementById('basic-staticprop')
       .getAttribute('src')

--- a/test/e2e/next-image-new/default/default.test.ts
+++ b/test/e2e/next-image-new/default/default.test.ts
@@ -1440,21 +1440,20 @@ describe('Image Component Default Tests', () => {
   })
 
   describe('Fill-mode tests', () => {
-    let browser
-    beforeAll(async () => {
-      browser = await next.browser('/fill')
-    })
     it('should include a data-attribute on fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(
         await browser.elementById('fill-image-1').getAttribute('data-nimg')
       ).toBe('fill')
     })
     it('should add position:absolute to fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(await getComputedStyle(browser, 'fill-image-1', 'position')).toBe(
         'absolute'
       )
     })
     it('should add 100% width and height to fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(
         await browser.eval(
           `document.getElementById("fill-image-1").style.height`
@@ -1467,6 +1466,7 @@ describe('Image Component Default Tests', () => {
       ).toBe('100%')
     })
     it('should add position styles to fill images', async () => {
+      const browser = await next.browser('/fill')
       expect(
         await browser.eval(
           `document.getElementById("fill-image-1").getAttribute('style')`
@@ -1477,6 +1477,7 @@ describe('Image Component Default Tests', () => {
     })
     if (isNextDev) {
       it('should not log incorrect warnings', async () => {
+        const browser = await next.browser('/fill')
         await new Promise((r) => setTimeout(r, 1000))
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1487,7 +1488,7 @@ describe('Image Component Default Tests', () => {
         )
       })
       it('should log warnings when using fill mode incorrectly', async () => {
-        browser = await next.browser('/fill-warnings')
+        const browser = await next.browser('/fill-warnings')
         await new Promise((r) => setTimeout(r, 1000))
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1506,7 +1507,7 @@ describe('Image Component Default Tests', () => {
         )
       })
       it('should not log warnings when image unmounts', async () => {
-        browser = await next.browser('/should-not-warn-unmount')
+        const browser = await next.browser('/should-not-warn-unmount')
         await new Promise((r) => setTimeout(r, 1000))
         const warnings = (await browser.log())
           .map((log) => log.message)

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -22,13 +22,46 @@ type PageLog = { source: string; message: string; args: unknown[] }
 
 export type Permissions = BrowserContextOptions['permissions']
 
-let page: Page
-let browser: Browser | undefined
-let context: BrowserContext | undefined
-let contextHasJSEnabled: boolean = true
-let contextPermissions: Permissions = undefined
-let pageLogs: Array<Promise<PageLog> | PageLog> = []
-let websocketFrames: Array<{ payload: string | Buffer }> = []
+export function getDeviceOptionsByName(deviceName: string | undefined) {
+  if (!deviceName) {
+    return undefined
+  }
+  if (!(deviceName in devices)) {
+    throw new Error(`Invalid playwright device name ${deviceName}`)
+  }
+  return devices[deviceName as keyof typeof devices]
+}
+
+export async function launchBrowserProcess(
+  browserName: string,
+  launchOptions: { headless: boolean }
+) {
+  if (browserName === 'safari') {
+    return await webkit.launch(launchOptions)
+  } else if (browserName === 'firefox') {
+    return await firefox.launch({
+      ...launchOptions,
+      firefoxUserPrefs: {
+        // The "fission.webContentIsolationStrategy" pref must be
+        // set to 1 on Firefox due to the bug where a new history
+        // state is pushed on a page reload.
+        // See https://github.com/microsoft/playwright/issues/22640
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1832341
+        'fission.webContentIsolationStrategy': 1,
+      },
+    })
+  } else {
+    let launchArgs: string[] = []
+    if (!launchOptions.headless) {
+      launchArgs.push('--auto-open-devtools-for-tabs')
+    }
+    return await chromium.launch({
+      ...launchOptions,
+      args: launchArgs,
+      ignoreDefaultArgs: ['--disable-back-forward-cache'],
+    })
+  }
+}
 
 const tracePlaywright = process.env.TRACE_PLAYWRIGHT
 
@@ -37,25 +70,6 @@ const defaultTimeout = process.env.NEXT_E2E_TEST_TIMEOUT
   : // In development mode, compilation can take longer due to lower CPU
     // availability in GitHub Actions.
     60 * 1000
-
-// loose global to register teardown functions before quitting the browser instance.
-// This is due to `quit` can be called anytime outside of Playwright's lifecycle,
-// which can create corrupted state by terminating the context.
-// [TODO] global `quit` might need to be removed, instead should introduce per-instance teardown
-const pendingTeardown: Array<() => Promise<void>> = []
-export async function quit() {
-  await Promise.all(pendingTeardown.map((fn) => fn()))
-  await context?.close()
-  await browser?.close()
-  context = undefined
-  browser = undefined
-}
-
-async function teardown(tearDownFn: () => Promise<void>) {
-  pendingTeardown.push(tearDownFn)
-  await tearDownFn()
-  pendingTeardown.splice(pendingTeardown.indexOf(tearDownFn), 1)
-}
 
 interface ElementHandleExt extends ElementHandle {
   getComputedCss(prop: string): Promise<string>
@@ -83,21 +97,45 @@ export type PlaywrightNavigationWaitUntil =
   | 'commit'
 
 export class Playwright<TCurrent = undefined> {
+  context: BrowserContext
+
+  _page: Page | null = null
+  get page() {
+    const page = this._page
+    if (!page) {
+      throw new Error('Expected a page to be loaded')
+    }
+    return page
+  }
+
+  constructor(context: BrowserContext) {
+    this.context = context
+  }
+
   private activeTrace?: string
   private eventCallbacks: Record<EventType, Set<(...args: any[]) => void>> = {
     request: new Set(),
     response: new Set(),
   }
-  private async initContextTracing(url: string, context: BrowserContext) {
+
+  private pageLogs: Array<Promise<PageLog> | PageLog> = []
+  private websocketFrames: Array<{ payload: string | Buffer }> = []
+
+  static async create(browser: Browser, options: BrowserContextOptions) {
+    const context = await browser.newContext(options)
+    return new Playwright(context)
+  }
+
+  private async initContextTracing(url: string) {
     if (!tracePlaywright) {
       return
     }
 
     try {
       // Clean up if any previous traces are still active
-      await teardown(this.teardownTracing.bind(this))
+      await this.teardownTracing()
 
-      await context.tracing.start({
+      await this.context.tracing.start({
         screenshots: true,
         snapshots: true,
         sources: true,
@@ -124,7 +162,7 @@ export class Playwright<TCurrent = undefined> {
       )
 
       await fs.remove(traceOutputPath)
-      await context!.tracing.stop({
+      await this.context.tracing.stop({
         path: traceOutputPath,
       })
     } catch (e) {
@@ -165,102 +203,30 @@ export class Playwright<TCurrent = undefined> {
     this.eventCallbacks[event]?.delete(cb)
   }
 
-  async setup(
-    browserName: string,
-    locale: string,
-    javaScriptEnabled: boolean,
-    ignoreHTTPSErrors: boolean,
-    headless: boolean,
-    userAgent: string | undefined,
-    permissions: Permissions
-  ) {
-    let device
-
-    if (process.env.DEVICE_NAME) {
-      device = devices[process.env.DEVICE_NAME]
-
-      if (!device) {
-        throw new Error(
-          `Invalid playwright device name ${process.env.DEVICE_NAME}`
-        )
-      }
-    }
-
-    if (browser) {
-      if (
-        contextHasJSEnabled !== javaScriptEnabled ||
-        // Even triggers on same set of permissions, but we don't want to deal
-        // with the complexity of diffing them, so we just always recreate the
-        // context when permissions are set.
-        contextPermissions !== permissions
-      ) {
-        // If we have switched from having JS enable/disabled we need to recreate the context.
-        await teardown(this.teardownTracing.bind(this))
-        await context?.close()
-        context = await browser.newContext({
-          locale,
-          javaScriptEnabled,
-          ignoreHTTPSErrors,
-          ...(userAgent ? { userAgent } : {}),
-          ...device,
-          permissions,
-        })
-        contextHasJSEnabled = javaScriptEnabled
-        contextPermissions = permissions
-      }
-      return
-    }
-
-    browser = await this.launchBrowser(browserName, { headless })
-    context = await browser.newContext({
-      locale,
-      javaScriptEnabled,
-      ignoreHTTPSErrors,
-      ...(userAgent ? { userAgent } : {}),
-      ...device,
-      permissions,
-    })
-    contextHasJSEnabled = javaScriptEnabled
-  }
-
   async close(): Promise<void> {
-    await teardown(this.teardownTracing.bind(this))
-    await page?.close()
+    await this.teardownTracing()
+
+    const page = this._page
+    if (page) {
+      this._page = null
+      this.pageLogs = []
+      this.websocketFrames = []
+      await page.close()
+    }
+
+    // clean-up other existing pages
+    for (const oldPage of this.context.pages()) {
+      await oldPage.close()
+    }
   }
 
-  async launchBrowser(
-    browserName: string,
-    launchOptions: { headless: boolean }
-  ) {
-    if (browserName === 'safari') {
-      return await webkit.launch(launchOptions)
-    } else if (browserName === 'firefox') {
-      return await firefox.launch({
-        ...launchOptions,
-        firefoxUserPrefs: {
-          // The "fission.webContentIsolationStrategy" pref must be
-          // set to 1 on Firefox due to the bug where a new history
-          // state is pushed on a page reload.
-          // See https://github.com/microsoft/playwright/issues/22640
-          // See https://bugzilla.mozilla.org/show_bug.cgi?id=1832341
-          'fission.webContentIsolationStrategy': 1,
-        },
-      })
-    } else {
-      let launchArgs: string[] = []
-      if (!launchOptions.headless) {
-        launchArgs.push('--auto-open-devtools-for-tabs')
-      }
-      return await chromium.launch({
-        ...launchOptions,
-        args: launchArgs,
-        ignoreDefaultArgs: ['--disable-back-forward-cache'],
-      })
-    }
+  async destroy() {
+    await this.close()
+    await this.context.close()
   }
 
   async get(url: string): Promise<void> {
-    await page.goto(url)
+    await this.page.goto(url)
   }
 
   async loadPage(
@@ -279,13 +245,15 @@ export class Playwright<TCurrent = undefined> {
   ) {
     await this.close()
 
-    // clean-up existing pages
-    for (const oldPage of context!.pages()) {
-      await oldPage.close()
-    }
+    await this.initContextTracing(url)
 
-    await this.initContextTracing(url, context!)
-    page = await context!.newPage()
+    const page = await this.context.newPage()
+    const pageLogs: typeof this.pageLogs = []
+    const websocketFrames: typeof this.websocketFrames = []
+
+    this._page = page
+    this.pageLogs = pageLogs
+    this.websocketFrames = websocketFrames
 
     page.setDefaultTimeout(defaultTimeout)
     page.setDefaultNavigationTimeout(defaultTimeout)
@@ -293,9 +261,6 @@ export class Playwright<TCurrent = undefined> {
     if (extraHTTPHeaders !== undefined) {
       page.setExtraHTTPHeaders(extraHTTPHeaders)
     }
-
-    pageLogs = []
-    websocketFrames = []
 
     page.on('console', (msg) => {
       debugPrint('Browser Log:', msg)
@@ -313,7 +278,11 @@ export class Playwright<TCurrent = undefined> {
       console.error('page error', error)
 
       if (opts?.pushErrorAsConsoleLog) {
-        pageLogs.push({ source: 'error', message: error.message, args: [] })
+        pageLogs.push({
+          source: 'error',
+          message: error.message,
+          args: [],
+        })
       }
     })
     page.on('request', (req) => {
@@ -325,12 +294,12 @@ export class Playwright<TCurrent = undefined> {
 
     if (opts?.disableCache) {
       // TODO: this doesn't seem to work (dev tools does not check the box as expected)
-      const session = await context!.newCDPSession(page)
+      const session = await this.context.newCDPSession(page)
       session.send('Network.setCacheDisabled', { cacheDisabled: true })
     }
 
     if (opts?.cpuThrottleRate) {
-      const session = await context!.newCDPSession(page)
+      const session = await this.context.newCDPSession(page)
       // https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setCPUThrottlingRate
       session.send('Emulation.setCPUThrottlingRate', {
         rate: opts.cpuThrottleRate,
@@ -374,42 +343,43 @@ export class Playwright<TCurrent = undefined> {
   back(options?: Parameters<Page['goBack']>[0]) {
     // do not preserve the previous chained value, it might be invalid after a navigation.
     return this.startChain(async () => {
-      await page.goBack(options)
+      await this.page.goBack(options)
     })
   }
   forward(options?: Parameters<Page['goForward']>[0]) {
     // do not preserve the previous chained value, it might be invalid after a navigation.
     return this.startChain(async () => {
-      await page.goForward(options)
+      await this.page.goForward(options)
     })
   }
   refresh() {
     // do not preserve the previous chained value, it's likely to be invalid after a reload.
     return this.startChain(async () => {
-      await page.reload()
+      await this.page.reload()
     })
   }
   setDimensions({ width, height }: { height: number; width: number }) {
     return this.startOrPreserveChain(() =>
-      page.setViewportSize({ width, height })
+      this.page.setViewportSize({ width, height })
     )
   }
   addCookie(opts: { name: string; value: string }) {
     return this.startOrPreserveChain(async () =>
-      context!.addCookies([
+      this.context.addCookies([
         {
           path: '/',
-          domain: await page.evaluate('window.location.hostname'),
+          domain: await this.page.evaluate('window.location.hostname'),
           ...opts,
         },
       ])
     )
   }
   deleteCookies() {
-    return this.startOrPreserveChain(async () => context!.clearCookies())
+    return this.startOrPreserveChain(async () => this.context.clearCookies())
   }
 
   private wrapElement(el: ElementHandle, selector: string): ElementHandleExt {
+    const { page } = this
     function getComputedCss(prop: string) {
       return page.evaluate(
         function (args) {
@@ -444,7 +414,7 @@ export class Playwright<TCurrent = undefined> {
   }
 
   hasElementByCss(selector: string) {
-    return this.startChain(() => page.locator(selector).isVisible())
+    return this.startChain(() => this.page.locator(selector).isVisible())
   }
 
   elementById(id: string) {
@@ -486,11 +456,11 @@ export class Playwright<TCurrent = undefined> {
   }
 
   keydown(key: string) {
-    return this.startOrPreserveChain(() => page.keyboard.down(key))
+    return this.startOrPreserveChain(() => this.page.keyboard.down(key))
   }
 
   keyup(key: string) {
-    return this.startOrPreserveChain(() => page.keyboard.up(key))
+    return this.startOrPreserveChain(() => this.page.keyboard.up(key))
   }
 
   click(this: Playwright<ElementHandleExt>) {
@@ -509,7 +479,7 @@ export class Playwright<TCurrent = undefined> {
 
   elementsByCss(selector: string) {
     return this.startChain(() =>
-      page.$$(selector).then((els) => {
+      this.page.$$(selector).then((els) => {
         return els.map((el) => {
           const origGetAttribute = el.getAttribute.bind(el)
           el.getAttribute = (name) => {
@@ -544,6 +514,7 @@ export class Playwright<TCurrent = undefined> {
     } = typeof opts === 'number' ? { timeout: opts } : opts
 
     return this.startChain(async () => {
+      const { page } = this
       const el = await page.waitForSelector(selector, {
         timeout,
         state,
@@ -564,7 +535,7 @@ export class Playwright<TCurrent = undefined> {
 
   waitForCondition(snippet: string, timeout?: number) {
     return this.startOrPreserveChain(async () => {
-      await page.waitForFunction(snippet, { timeout })
+      await this.page.waitForFunction(snippet, { timeout })
     })
   }
 
@@ -583,8 +554,9 @@ export class Playwright<TCurrent = undefined> {
     fn: string | ((...args: any[]) => any),
     ...args: any[]
   ): Playwright<any> & Promise<any> {
-    return this.startChain(async () =>
-      page
+    return this.startChain(async () => {
+      const { page } = this
+      return page
         .evaluate(fn, ...args)
         .catch((err) => {
           // TODO: gross, why are we doing this
@@ -594,15 +566,15 @@ export class Playwright<TCurrent = undefined> {
         .finally(async () => {
           await page.waitForLoadState()
         })
-    )
+    })
   }
 
   async log<T extends boolean = false>(options?: { includeArgs?: T }) {
     return this.startChain(
       () =>
         options?.includeArgs
-          ? Promise.all(pageLogs)
-          : Promise.all(pageLogs).then((logs) =>
+          ? Promise.all(this.pageLogs)
+          : Promise.all(this.pageLogs).then((logs) =>
               logs.map(({ source, message }) => ({ source, message }))
             )
       // TODO: Starting with TypeScript 5.8 we might not need this type cast.
@@ -613,39 +585,37 @@ export class Playwright<TCurrent = undefined> {
     >
   }
 
-  async websocketFrames() {
-    return this.startChain(() => websocketFrames)
-  }
-
   async url() {
-    return this.startChain(() => page.url())
+    return this.startChain(() => this.page.url())
   }
 
   async waitForIdleNetwork() {
     return this.startOrPreserveChain(() => {
-      return page.waitForLoadState('networkidle')
+      return this.page.waitForLoadState('networkidle')
     })
   }
 
   getByRole(
-    role: Parameters<(typeof page)['getByRole']>[0],
-    options?: Parameters<(typeof page)['getByRole']>[1]
+    role: Parameters<Page['getByRole']>[0],
+    options?: Parameters<Page['getByRole']>[1]
   ) {
-    return page.getByRole(role, options)
+    return this.page.getByRole(role, options)
   }
 
   locateRedbox(): Locator {
-    return page.locator(
+    return this.page.locator(
       'nextjs-portal [aria-labelledby="nextjs__container_errors_label"]'
     )
   }
 
   locateDevToolsIndicator(): Locator {
-    return page.locator('nextjs-portal [data-nextjs-dev-tools-button]:visible')
+    return this.page.locator(
+      'nextjs-portal [data-nextjs-dev-tools-button]:visible'
+    )
   }
 
-  locator(selector: string, options?: Parameters<(typeof page)['locator']>[1]) {
-    return page.locator(selector, options)
+  locator(selector: string, options?: Parameters<Page['locator']>[1]) {
+    return this.page.locator(selector, options)
   }
 
   /** A call that expects to be chained after a previous call, because it needs its value. */

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -4,8 +4,10 @@ import {
   Permissions,
   Playwright,
   PlaywrightNavigationWaitUntil,
+  getDeviceOptionsByName,
+  launchBrowserProcess,
 } from './browsers/playwright'
-import { Page } from 'playwright'
+import { Page, Browser } from 'playwright'
 
 export type { Playwright }
 
@@ -33,18 +35,66 @@ if (isBrowserStack) {
   }
 }
 
-let browserTeardown: (() => Promise<void>)[] = []
-let browserQuit: (() => Promise<void>) | undefined
+let browserProcesses = new Map<string, Browser>()
+
+async function launchOrReuseBrowserProcess(
+  ...args: Parameters<typeof launchBrowserProcess>
+) {
+  const key = JSON.stringify(args)
+  let browserProcess = browserProcesses.get(key)
+  if (!browserProcess) {
+    browserProcess = await launchBrowserProcess(...args)
+    browserProcesses.set(key, browserProcess)
+  }
+  return browserProcess
+}
+
+async function closeActiveBrowserProcesses() {
+  const currentBrowserProcesses = browserProcesses
+  browserProcesses = new Map()
+
+  await Promise.all(
+    [...currentBrowserProcesses.values()].map((browserProcess) =>
+      browserProcess
+        .close()
+        .catch((err) =>
+          console.error('error while closing browser process:', err)
+        )
+    )
+  )
+}
+
+/**
+ * Despite generally calling them "browsers" (as per `next.browser()`),
+ * these really correspond to playwright's "browser contexts".
+ * We can create multiple browser contexts in the same browser process
+ * (generally one per test), but the browser process is generally shared across
+ * the whole test suite (unless some options result in us creating a second one)
+ */
+let browserInstances = new Set<Playwright>()
+
+async function closeActiveBrowserInstances() {
+  const currentPlaywrightInstances = browserInstances
+  browserInstances = new Set()
+
+  await Promise.all(
+    [...currentPlaywrightInstances].map((browser) =>
+      browser
+        .destroy()
+        .catch((err) => console.error('error while destroying browser:', err))
+    )
+  )
+}
 
 if (typeof afterAll === 'function') {
   afterAll(async () => {
-    await Promise.all(browserTeardown.map((f) => f())).catch((e) =>
-      console.error('browser teardown', e)
-    )
+    await closeActiveBrowserProcesses()
+  })
+}
 
-    if (browserQuit) {
-      await browserQuit()
-    }
+if (typeof afterEach === 'function') {
+  afterEach(async () => {
+    await closeActiveBrowserInstances()
   })
 }
 
@@ -113,25 +163,19 @@ export interface WebdriverOptions {
 export default async function webdriver(
   appPortOrUrl: string | number,
   url: string,
-  options?: WebdriverOptions
+  options: WebdriverOptions = {}
 ): Promise<Playwright> {
-  const defaultOptions = {
-    waitHydration: true,
-    retryWaitHydration: false,
-    disableCache: false,
-  }
-  options = Object.assign(defaultOptions, options)
   const {
-    waitHydration,
-    retryWaitHydration,
-    disableCache,
+    waitHydration = true,
+    retryWaitHydration = false,
+    disableCache = false,
     beforePageLoad,
     extraHTTPHeaders,
     locale,
     disableJavaScript,
     permissions,
     ignoreHTTPSErrors,
-    headless,
+    headless = !!process.env.HEADLESS,
     cpuThrottleRate,
     pushErrorAsConsoleLog,
     userAgent,
@@ -142,22 +186,26 @@ export default async function webdriver(
     appPortOrUrl = baseUrl
   }
 
-  const { Playwright, quit } = await import('./browsers/playwright')
-  browserQuit = quit
-
-  const browser = new Playwright()
   const browserName = process.env.BROWSER_NAME || 'chrome'
-  await browser.setup(
-    browserName,
-    locale!,
-    !disableJavaScript,
-    Boolean(ignoreHTTPSErrors),
-    // allow headless to be overwritten for a particular test
-    typeof headless !== 'undefined' ? headless : !!process.env.HEADLESS,
-    userAgent,
-    permissions
-  )
+  // Some tests rely on this being set
   ;(global as any).browserName = browserName
+
+  const deviceName = process.env.DEVICE_NAME
+
+  const browserProcess = await launchOrReuseBrowserProcess(browserName, {
+    headless,
+  })
+
+  const deviceOptions = getDeviceOptionsByName(deviceName)
+  const browser = await Playwright.create(browserProcess, {
+    locale: locale!,
+    javaScriptEnabled: !disableJavaScript,
+    ignoreHTTPSErrors: Boolean(ignoreHTTPSErrors),
+    userAgent,
+    permissions,
+    ...deviceOptions,
+  })
+  browserInstances.add(browser)
 
   const fullUrl = getFullUrl(
     appPortOrUrl,
@@ -176,8 +224,6 @@ export default async function webdriver(
     waitUntil,
   })
   debugPrint(`Loaded browser with ${fullUrl}`)
-
-  browserTeardown.push(browser.close.bind(browser))
 
   // Wait for application to hydrate
   if (!disableJavaScript && waitHydration) {

--- a/test/production/next-image-legacy/basic/basic.test.ts
+++ b/test/production/next-image-legacy/basic/basic.test.ts
@@ -39,44 +39,48 @@ describe('Image Component Tests', () => {
     return false
   }
 
-  function runTests(browser: () => Browser) {
+  function runTests(getBrowser: () => Promise<Browser>) {
     it('should render an image tag', async () => {
-      expect(await browser().hasElementByCssSelector('img')).toBeTruthy()
+      const browser = await getBrowser()
+      expect(await browser.hasElementByCssSelector('img')).toBeTruthy()
     })
     it('should support passing through arbitrary attributes', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().hasElementByCssSelector('img#attribute-test')
+        await browser.hasElementByCssSelector('img#attribute-test')
       ).toBeTruthy()
       expect(
-        await browser()
+        await browser
           .elementByCss('img#attribute-test')
           .getAttribute('data-demo')
       ).toBe('demo-value')
     })
     it('should modify src with the loader', async () => {
-      expect(
-        await browser().elementById('basic-image').getAttribute('src')
-      ).toBe(
+      const browser = await getBrowser()
+      expect(await browser.elementById('basic-image').getAttribute('src')).toBe(
         'https://example.com/myaccount/foo.jpg?auto=format&fit=max&w=1024&q=60'
       )
     })
     it('should correctly generate src even if preceding slash is included in prop', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('preceding-slash-image').getAttribute('src')
+        await browser.elementById('preceding-slash-image').getAttribute('src')
       ).toBe(
         'https://example.com/myaccount/fooslash.jpg?auto=format&fit=max&w=1024'
       )
     })
     it('should add a srcset based on the loader', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('basic-image').getAttribute('srcset')
+        await browser.elementById('basic-image').getAttribute('srcset')
       ).toBe(
         'https://example.com/myaccount/foo.jpg?auto=format&fit=max&w=480&q=60 1x, https://example.com/myaccount/foo.jpg?auto=format&fit=max&w=1024&q=60 2x'
       )
     })
     it('should add a srcset even with preceding slash in prop', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser()
+        await browser
           .elementById('preceding-slash-image')
           .getAttribute('srcset')
       ).toBe(
@@ -84,82 +88,87 @@ describe('Image Component Tests', () => {
       )
     })
     it('should use imageSizes when width matches, not deviceSizes from next.config.js', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('icon-image-16').getAttribute('src')
+        await browser.elementById('icon-image-16').getAttribute('src')
       ).toBe('https://example.com/myaccount/icon.png?auto=format&fit=max&w=32')
       expect(
-        await browser().elementById('icon-image-16').getAttribute('srcset')
+        await browser.elementById('icon-image-16').getAttribute('srcset')
       ).toBe(
         'https://example.com/myaccount/icon.png?auto=format&fit=max&w=16 1x, https://example.com/myaccount/icon.png?auto=format&fit=max&w=32 2x'
       )
       expect(
-        await browser().elementById('icon-image-32').getAttribute('src')
+        await browser.elementById('icon-image-32').getAttribute('src')
       ).toBe('https://example.com/myaccount/icon.png?auto=format&fit=max&w=64')
       expect(
-        await browser().elementById('icon-image-32').getAttribute('srcset')
+        await browser.elementById('icon-image-32').getAttribute('srcset')
       ).toBe(
         'https://example.com/myaccount/icon.png?auto=format&fit=max&w=32 1x, https://example.com/myaccount/icon.png?auto=format&fit=max&w=64 2x'
       )
     })
     it('should support the unoptimized attribute', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('unoptimized-image').getAttribute('src')
+        await browser.elementById('unoptimized-image').getAttribute('src')
       ).toBe('https://arbitraryurl.com/foo.jpg')
     })
     it('should not add a srcset if unoptimized attribute present', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('unoptimized-image').getAttribute('srcset')
+        await browser.elementById('unoptimized-image').getAttribute('srcset')
       ).toBeFalsy()
     })
     it('should keep auto parameter if already set', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('image-with-param-auto').getAttribute('src')
+        await browser.elementById('image-with-param-auto').getAttribute('src')
       ).toBe(
         'https://example.com/myaccount/foo.png?auto=compress&fit=max&w=1024'
       )
     })
     it('should keep width parameter if already set', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser()
-          .elementById('image-with-param-width')
-          .getAttribute('src')
+        await browser.elementById('image-with-param-width').getAttribute('src')
       ).toBe('https://example.com/myaccount/foo.png?auto=format&w=500&fit=max')
     })
     it('should keep fit parameter if already set', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('image-with-param-fit').getAttribute('src')
+        await browser.elementById('image-with-param-fit').getAttribute('src')
       ).toBe(
         'https://example.com/myaccount/foo.png?auto=format&fit=crop&w=300&h=300'
       )
     })
   }
 
-  function lazyLoadingTests(browser: () => Browser) {
+  function lazyLoadingTests(getBrowser: () => Promise<Browser>) {
     it('should have loaded the first image immediately', async () => {
-      expect(await browser().elementById('lazy-top').getAttribute('src')).toBe(
+      const browser = await getBrowser()
+      expect(await browser.elementById('lazy-top').getAttribute('src')).toBe(
         'https://example.com/myaccount/lazy1.jpg?auto=format&fit=max&w=2000'
       )
-      expect(
-        await browser().elementById('lazy-top').getAttribute('srcset')
-      ).toBe(
+      expect(await browser.elementById('lazy-top').getAttribute('srcset')).toBe(
         'https://example.com/myaccount/lazy1.jpg?auto=format&fit=max&w=1024 1x, https://example.com/myaccount/lazy1.jpg?auto=format&fit=max&w=2000 2x'
       )
     })
     it('should not have loaded the second image immediately', async () => {
-      expect(await browser().elementById('lazy-mid').getAttribute('src')).toBe(
+      const browser = await getBrowser()
+      expect(await browser.elementById('lazy-mid').getAttribute('src')).toBe(
         emptyImage
       )
       expect(
-        await browser().elementById('lazy-mid').getAttribute('srcset')
+        await browser.elementById('lazy-mid').getAttribute('srcset')
       ).toBeFalsy()
     })
     it('should pass through classes on a lazy loaded image', async () => {
-      expect(
-        await browser().elementById('lazy-mid').getAttribute('class')
-      ).toBe('exampleclass')
+      const browser = await getBrowser()
+      expect(await browser.elementById('lazy-mid').getAttribute('class')).toBe(
+        'exampleclass'
+      )
     })
     it('should load the second image after scrolling down', async () => {
-      const b = browser()
+      const b = await getBrowser()
       let viewportHeight = await b.eval(`window.innerHeight`)
       let topOfMidImage = await b.eval(
         `document.getElementById('lazy-mid').parentElement.offsetTop`
@@ -182,15 +191,16 @@ describe('Image Component Tests', () => {
       })
     })
     it('should not have loaded the third image after scrolling down', async () => {
+      const browser = await getBrowser()
+      expect(await browser.elementById('lazy-bottom').getAttribute('src')).toBe(
+        emptyImage
+      )
       expect(
-        await browser().elementById('lazy-bottom').getAttribute('src')
-      ).toBe(emptyImage)
-      expect(
-        await browser().elementById('lazy-bottom').getAttribute('srcset')
+        await browser.elementById('lazy-bottom').getAttribute('srcset')
       ).toBeFalsy()
     })
     it('should load the third image, which is unoptimized, after scrolling further down', async () => {
-      const b = browser()
+      const b = await getBrowser()
       let viewportHeight = await b.eval(`window.innerHeight`)
       let topOfBottomImage = await b.eval(
         `document.getElementById('lazy-bottom').parentElement.offsetTop`
@@ -208,7 +218,7 @@ describe('Image Component Tests', () => {
       ).toBeFalsy()
     })
     it('should load the fourth image lazily after scrolling down', async () => {
-      const b = browser()
+      const b = await getBrowser()
       expect(
         await b.elementById('lazy-without-attribute').getAttribute('src')
       ).toBe(emptyImage)
@@ -237,18 +247,19 @@ describe('Image Component Tests', () => {
     })
 
     it('should load the fifth image eagerly, without scrolling', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('eager-loading').getAttribute('src')
+        await browser.elementById('eager-loading').getAttribute('src')
       ).toBe(
         'https://example.com/myaccount/lazy5.jpg?auto=format&fit=max&w=2000'
       )
       expect(
-        await browser().elementById('eager-loading').getAttribute('srcset')
+        await browser.elementById('eager-loading').getAttribute('srcset')
       ).toBeTruthy()
     })
 
     it('should load the sixth image, which has lazyBoundary property after scrolling down', async () => {
-      const b = browser()
+      const b = await getBrowser()
       expect(await b.elementById('lazy-boundary').getAttribute('src')).toBe(
         emptyImage
       )
@@ -287,13 +298,11 @@ describe('Image Component Tests', () => {
   }
 
   describe('SSR Image Component Tests', () => {
-    let browser: Playwright
-    beforeAll(async () => {
-      browser = await next.browser('/')
-    })
-    runTests(() => browser)
+    const getBrowser = () => next.browser('/')
+    runTests(getBrowser)
 
     it('should add a preload tag for a priority image', async () => {
+      const browser = await getBrowser()
       expect(
         await hasPreloadLinkMatchingUrl(
           browser,
@@ -302,6 +311,7 @@ describe('Image Component Tests', () => {
       ).toBe(true)
     })
     it('should add a preload tag for a priority image with preceding slash', async () => {
+      const browser = await getBrowser()
       expect(
         await hasPreloadLinkMatchingUrl(
           browser,
@@ -310,6 +320,7 @@ describe('Image Component Tests', () => {
       ).toBe(true)
     })
     it('should add a preload tag for a priority image, with arbitrary host', async () => {
+      const browser = await getBrowser()
       expect(
         await hasPreloadLinkMatchingUrl(
           browser,
@@ -318,6 +329,7 @@ describe('Image Component Tests', () => {
       ).toBe(true)
     })
     it('should add a preload tag for a priority image, with quality', async () => {
+      const browser = await getBrowser()
       expect(
         await hasPreloadLinkMatchingUrl(
           browser,
@@ -326,9 +338,11 @@ describe('Image Component Tests', () => {
       ).toBe(true)
     })
     it('should not create any preload tags higher up the page than CSS preload tags', async () => {
+      const browser = await getBrowser()
       expect(await hasImagePreloadBeforeCSSPreload(browser)).toBe(false)
     })
     it('should add data-nimg data attribute based on layout', async () => {
+      const browser = await getBrowser()
       expect(
         await browser.elementById('image-with-sizes').getAttribute('data-nimg')
       ).toBe('responsive')
@@ -352,15 +366,16 @@ describe('Image Component Tests', () => {
   })
 
   describe('Client-side Image Component Tests', () => {
-    let browser: Playwright
-    beforeAll(async () => {
-      browser = await next.browser('/')
+    const getBrowser = async () => {
+      const browser = await next.browser('/')
       await browser.waitForElementByCss('#clientlink').click()
-    })
-    runTests(() => browser)
+      return browser
+    }
+    runTests(getBrowser)
 
     // FIXME: this test
     it.skip('should NOT add a preload tag for a priority image', async () => {
+      const browser = await getBrowser()
       expect(
         await hasPreloadLinkMatchingUrl(
           browser,
@@ -369,6 +384,7 @@ describe('Image Component Tests', () => {
       ).toBe(false)
     })
     it('should only be loaded once if `sizes` is set', async () => {
+      const browser = await getBrowser()
       const numRequests = await browser.eval(`(function() {
         const entries = window.performance.getEntries()
         return entries.filter(function(entry) {
@@ -379,7 +395,8 @@ describe('Image Component Tests', () => {
       expect(numRequests).toBe(1)
     })
     describe('Client-side Errors', () => {
-      beforeAll(async () => {
+      it('Should not log an error when an unregistered host is used in production', async () => {
+        const browser = await getBrowser()
         await browser.eval(`(function() {
           window.gotHostError = false
           const origError = console.error
@@ -391,8 +408,6 @@ describe('Image Component Tests', () => {
           }
         })()`)
         await browser.waitForElementByCss('#errorslink').click()
-      })
-      it('Should not log an error when an unregistered host is used in production', async () => {
         const foundError = await browser.eval('window.gotHostError')
         expect(foundError).toBe(false)
       })
@@ -400,20 +415,17 @@ describe('Image Component Tests', () => {
   })
 
   describe('SSR Lazy Loading Tests', () => {
-    let browser: Playwright
-    beforeAll(async () => {
-      browser = await next.browser('/lazy')
-    })
-    lazyLoadingTests(() => browser)
+    const getBrowser = () => next.browser('/lazy')
+    lazyLoadingTests(getBrowser)
   })
 
   describe('Client-side Lazy Loading Tests', () => {
-    let browser: Playwright
-    beforeAll(async () => {
-      browser = await next.browser('/')
+    const getBrowser = async () => {
+      const browser = await next.browser('/')
       await browser.waitForElementByCss('#lazylink').click()
       await new Promise((r) => setTimeout(r, 500))
-    })
-    lazyLoadingTests(() => browser)
+      return browser
+    }
+    lazyLoadingTests(getBrowser)
   })
 })

--- a/test/production/next-image-legacy/custom-resolver/custom-resolver.test.ts
+++ b/test/production/next-image-legacy/custom-resolver/custom-resolver.test.ts
@@ -6,39 +6,34 @@ describe('Custom Resolver Tests', () => {
   })
   type Browser = Playwright
 
-  function runTests(browser: () => Browser) {
+  function runTests(getBrowser: () => Promise<Browser>) {
     it('Should use a custom resolver for image URL', async () => {
-      expect(
-        await browser().elementById('basic-image').getAttribute('src')
-      ).toBe('https://customresolver.com/foo.jpg?w~~1024,q~~60')
+      const browser = await getBrowser()
+      expect(await browser.elementById('basic-image').getAttribute('src')).toBe(
+        'https://customresolver.com/foo.jpg?w~~1024,q~~60'
+      )
     })
     it('should add a srcset based on the custom resolver', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('basic-image').getAttribute('srcset')
+        await browser.elementById('basic-image').getAttribute('srcset')
       ).toBe(
         'https://customresolver.com/foo.jpg?w~~480,q~~60 1x, https://customresolver.com/foo.jpg?w~~1024,q~~60 2x'
       )
     })
     it('should support the unoptimized attribute', async () => {
+      const browser = await getBrowser()
       expect(
-        await browser().elementById('unoptimized-image').getAttribute('src')
+        await browser.elementById('unoptimized-image').getAttribute('src')
       ).toBe('https://arbitraryurl.com/foo.jpg')
     })
   }
 
   describe('SSR Custom Loader Tests', () => {
-    let browser: Playwright
-    beforeAll(async () => {
-      browser = await next.browser('/')
-    })
-    runTests(() => browser)
+    runTests(() => next.browser('/'))
   })
 
   describe('Client-side Custom Loader Tests', () => {
-    let browser: Playwright
-    beforeAll(async () => {
-      browser = await next.browser('/client-side')
-    })
-    runTests(() => browser)
+    runTests(() => next.browser('/client-side'))
   })
 })


### PR DESCRIPTION
The Playwright class relies on a bunch of stuff stored on globals (notably `page`, but also `browser` and `context`). This is messy and unnecessary. I've moved `context` and `page` into instance properties of `Playwright`. 

We still need to store what used to be `browser` (the playwright one, not the result of `next.browser()`) globally, because we re-use it across a test suite (and create new *browser contexts* for each `next.browser()` call). This is now done in `next-webdriver`. I've also reorganized the (strange) teardown logic. We now stop tracing and destroy the browsing context after each test.