### PR TITLE
Use `serde_json::Number` in `CompileTimeDefineValue` and remove `TotalOrderF64`

### DIFF
--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,9 +1,3 @@
-use std::{
-    fmt::Display,
-    hash::{Hash, Hasher},
-    ops::Deref,
-};
-
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use indexmap::Equivalent;
@@ -111,11 +105,15 @@ macro_rules! free_var_references {
 
 // TODO: replace with just a `serde_json::Value`
 // https://linear.app/vercel/issue/WEB-1641/compiletimedefinevalue-should-just-use-serde-jsonvalue
-#[derive(Debug, Clone, Hash, TraceRawVcs, NonLocalValue, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, TraceRawVcs, NonLocalValue, Encode, Decode, PartialEq, Eq, Hash)]
 pub enum CompileTimeDefineValue {
     Null,
     Bool(bool),
-    Number(TotalOrderF64),
+    Number(
+        #[bincode(with_serde)]
+        #[turbo_tasks(trace_ignore)]
+        serde_json::Number,
+    ),
     String(RcStr),
     BigInt(
         #[bincode(with_serde)]
@@ -127,37 +125,6 @@ pub enum CompileTimeDefineValue {
     Undefined,
     Evaluate(RcStr),
     Regex(RcStr, RcStr),
-}
-
-/// Wrapper around f64 that implements total Eq and Hash, based on total ordering.
-#[derive(Debug, Copy, Clone, TraceRawVcs, NonLocalValue, Encode, Decode)]
-pub struct TotalOrderF64(f64);
-impl PartialEq for TotalOrderF64 {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.total_cmp(&other.0) == std::cmp::Ordering::Equal
-    }
-}
-impl Eq for TotalOrderF64 {}
-impl Hash for TotalOrderF64 {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_le_bytes().hash(state);
-    }
-}
-impl From<f64> for TotalOrderF64 {
-    fn from(value: f64) -> Self {
-        Self(value)
-    }
-}
-impl Deref for TotalOrderF64 {
-    type Target = f64;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl Display for TotalOrderF64 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
 }
 
 impl From<bool> for CompileTimeDefineValue {
@@ -189,11 +156,7 @@ impl From<serde_json::Value> for CompileTimeDefineValue {
         match value {
             serde_json::Value::Null => Self::Null,
             serde_json::Value::Bool(b) => Self::Bool(b),
-            serde_json::Value::Number(n) => Self::Number(
-                n.as_f64()
-                    .expect("unreachable: serde-json has arbitrary_precision disabled")
-                    .into(),
-            ),
+            serde_json::Value::Number(n) => Self::Number(n),
             serde_json::Value::String(s) => Self::String(s.into()),
             serde_json::Value::Array(a) => Self::Array(a.into_iter().map(|i| i.into()).collect()),
             serde_json::Value::Object(m) => {

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -110,7 +110,7 @@ pub enum CompileTimeDefineValue {
     Null,
     Bool(bool),
     Number(
-        #[bincode(with_serde)]
+        #[bincode(with = "turbo_bincode::serde_self_describing")]
         #[turbo_tasks(trace_ignore)]
         serde_json::Number,
     ),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
@@ -500,7 +500,10 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
             CompileTimeDefineValue::Undefined => ConstantValue::Undefined,
             CompileTimeDefineValue::Null => ConstantValue::Null,
             CompileTimeDefineValue::Bool(b) => (*b).into(),
-            CompileTimeDefineValue::Number(n) => ConstantValue::Num(ConstantNumber(**n)),
+            CompileTimeDefineValue::Number(n) => ConstantValue::Num(ConstantNumber(
+                n.as_f64()
+                    .expect("unreachable: serde-json has arbitrary_precision disabled"),
+            )),
             CompileTimeDefineValue::BigInt(n) => ConstantValue::BigInt(n.clone()),
             CompileTimeDefineValue::String(s) => s.as_str().into(),
             CompileTimeDefineValue::Regex(pattern, flags) => {
@@ -548,7 +551,10 @@ impl TryFrom<&ConstantValue> for CompileTimeDefineValue {
             ConstantValue::Null => CompileTimeDefineValue::Null,
             ConstantValue::True => CompileTimeDefineValue::Bool(true),
             ConstantValue::False => CompileTimeDefineValue::Bool(false),
-            ConstantValue::Num(n) => CompileTimeDefineValue::Number(n.0.into()),
+            ConstantValue::Num(n) => CompileTimeDefineValue::Number(
+                serde_json::Number::from_f64(n.0)
+                    .ok_or_else(|| anyhow::anyhow!("NaN and Infinity cannot be represented"))?,
+            ),
             ConstantValue::Str(s) => CompileTimeDefineValue::String(s.as_rcstr()),
             ConstantValue::BigInt(n) => CompileTimeDefineValue::BigInt(n.clone()),
             ConstantValue::Regex(regex) => CompileTimeDefineValue::Regex(

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -67,7 +67,10 @@ fn value_to_expr(value: &CompileTimeDefineValue) -> Expr {
             quote!("(\"TURBOPACK compile-time value\", false)" as Expr)
         }
         CompileTimeDefineValue::Number(n) => {
-            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = (**n).into())
+            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = n
+                .as_f64()
+                .expect("unreachable: serde-json has arbitrary_precision disabled")
+                .into())
         }
         CompileTimeDefineValue::String(s) => {
             quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = s.as_str().into())


### PR DESCRIPTION
This is a follow-on to https://github.com/vercel/next.js/pull/94172, this allows us to remove `TotalOrderF64` from the codebase.