### PR TITLE
test(typed-routes): improve ApiRouteConfig test coverage and cleanup

### DIFF
--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -333,9 +333,12 @@ describe('typed-routes-validator', () => {
             `
       )
 
-      const { exitCode } = await next.build()
-      await next.deleteFile('pages/api/valid-api.ts')
-      expect(exitCode).toBe(0)
+      try {
+        const { exitCode } = await next.build()
+        expect(exitCode).toBe(0)
+      } finally {
+        await next.deleteFile('pages/api/valid-api.ts')
+      }
     })
 
     it('should pass type checking when sizeLimit is a number', async () => {

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -5,6 +5,19 @@ import { getDistDir, retry } from 'next-test-utils'
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
+/** Asserts the CLI output contains an ApiRouteConfig type-check failure. */
+function expectApiRouteConfigTypeError(cliOutput: string) {
+  if (strictRouteTypes) {
+    expect(cliOutput).toMatch(
+      /Type error: Type 'typeof import\(.*' does not satisfy the expected type 'ApiRouteConfig'/
+    )
+  } else {
+    expect(cliOutput).toMatch(
+      /Type error: Type 'typeof import\(.*' does not satisfy the constraint 'ApiRouteConfig'/
+    )
+  }
+}
+
 describe('typed-routes-validator', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
@@ -313,14 +326,46 @@ describe('typed-routes-validator', () => {
 
     export const config = {
       api: {
-        bodyParser: true,
+        bodyParser: false,
+        responseLimit: '4mb',
       },
     }
             `
       )
 
       const { exitCode } = await next.build()
+      await next.deleteFile('pages/api/valid-api.ts')
       expect(exitCode).toBe(0)
+    })
+
+    it('should pass type checking when sizeLimit is a number', async () => {
+      await next.patchFile(
+        'pages/api/valid-size-limit.ts',
+        `
+    import type { NextApiRequest, NextApiResponse } from 'next'
+    import type { PageConfig } from 'next'
+
+    export default function handler(
+      req: NextApiRequest,
+      res: NextApiResponse
+    ) {
+      res.status(200).json({ message: 'OK' })
+    }
+
+    export const config: PageConfig = {
+      api: {
+        bodyParser: { sizeLimit: 1024 },
+      },
+    }
+            `
+      )
+
+      try {
+        const { exitCode } = await next.build()
+        expect(exitCode).toBe(0)
+      } finally {
+        await next.deleteFile('pages/api/valid-size-limit.ts')
+      }
     })
 
     it('should fail type checking with invalid API route exports', async () => {
@@ -332,20 +377,16 @@ describe('typed-routes-validator', () => {
             `
       )
 
-      const { exitCode, cliOutput } = await next.build()
-      // clean up before assertion just in case it fails
-      await next.deleteFile('pages/api/invalid-api.ts')
+      let exitCode: number | undefined
+      let cliOutput: string | undefined
+      try {
+        ;({ exitCode, cliOutput } = await next.build())
+      } finally {
+        await next.deleteFile('pages/api/invalid-api.ts')
+      }
 
       expect(exitCode).toBe(1)
-      if (strictRouteTypes) {
-        expect(cliOutput).toMatch(
-          /Type error: Type 'typeof import\(.*' does not satisfy the expected type 'ApiRouteConfig'/
-        )
-      } else {
-        expect(cliOutput).toMatch(
-          /Type error: Type 'typeof import\(.*' does not satisfy the constraint 'ApiRouteConfig'/
-        )
-      }
+      expectApiRouteConfigTypeError(cliOutput!)
     })
   }
 })


### PR DESCRIPTION
## What?

Improves the E2E test suite for the typed-routes validator around Pages Router API routes.

> **Note:** The upstream `sizeLimit?: number | string` fix was already present in `canary`. This PR focuses on test-layer improvements surfaced during investigation of #83946.

## Changes

### `test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts`

1. **Extract helper** — Add `expectApiRouteConfigTypeError(cliOutput)` to deduplicate the `strictRouteTypes` branching assertion block that appeared in every API route failure test.

2. **Guaranteed cleanup via `try/finally`** — Wrap `next.build()` + assertions in `try/finally` so `deleteFile()` always runs even if an assertion throws, preventing leaked fixture files from affecting subsequent tests.

3. **Regression test** — New test `should pass type checking when sizeLimit is a number` explicitly verifies that `bodyParser: { sizeLimit: 1024 }` (numeric `SizeLimit`) passes the validator, directly covering the scenario from #83946.

## Test Plan

All changes are in `test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts`.

Relates to #83946