### PR TITLE
[feat] updated the documentation for deployment to point to new next.js Docker official guide.

### DIFF
--- a/docs/01-app/01-getting-started/17-deploying.mdx
+++ b/docs/01-app/01-getting-started/17-deploying.mdx
@@ -39,7 +39,7 @@ Node.js deployments support all Next.js features. Learn how to [configure them](
 
 ## Docker
 
-Next.js can be deployed to any provider that supports [Docker](https://www.docker.com/) containers. This includes container orchestrators like Kubernetes or a cloud provider that runs Docker. For containerization best practices, see the [Docker guide for React.js](https://docs.docker.com/guides/reactjs/).
+Next.js can be deployed to any provider that supports [Docker](https://www.docker.com/) containers. This includes container orchestrators like Kubernetes or a cloud provider that runs Docker. For best practices on containerizing your app, refer to Docker's official [Next.js](https://docs.docker.com/guides/nextjs) and [React.js](https://docs.docker.com/guides/reactjs) guides.
 
 Docker deployments support all Next.js features. Learn how to [configure them](/docs/app/guides/self-hosting) for your infrastructure.
 


### PR DESCRIPTION
## What?

Updates the Docker section in the deploying guide.

- Rewrites the Docker intro sentence to be more concise and adds a link to Docker's official [React.js guide](https://docs.docker.com/guides/reactjs) alongside the existing [Next.js guide](https://docs.docker.com/guides/nextjs).

## Why?
Add reference to new Next.js Docker guide in the deploying docs.

## How?

Documentation-only change. No code changes.

CC: @icyJoseph 