### PR TITLE
Turbopack's analyzer: always treat promises as truth-y and non-nullish

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -2430,6 +2430,7 @@ impl JsValue {
             JsValue::Url(..)
             | JsValue::Array { .. }
             | JsValue::Object { .. }
+            | JsValue::Promise(..)
             | JsValue::WellKnownObject(..)
             | JsValue::WellKnownFunction(..)
             | JsValue::Function(..) => Some(true),
@@ -2515,6 +2516,7 @@ impl JsValue {
             | JsValue::WellKnownFunction(..)
             | JsValue::Not(..)
             | JsValue::Binary(..)
+            | JsValue::Promise(..)
             | JsValue::Function(..) => Some(false),
             JsValue::Alternatives {
                 total_nodes: _,
@@ -4017,7 +4019,7 @@ mod tests {
     };
 
     use super::{
-        JsValue,
+        ConstantValue, JsValue,
         graph::{ConditionalKind, Effect, EffectArg, EvalContext, VarGraph, create_graph},
         linker::link,
     };
@@ -4684,6 +4686,46 @@ mod tests {
             None,
             "expected to be unable to determine whether '{}' is not-nullish",
             input
+        );
+    }
+
+    #[rstest]
+    #[case(JsValue::from(1.0))]
+    #[case(JsValue::from("hi"))]
+    #[case(ConstantValue::True.into())]
+    #[case(JsValue::promise(ConstantValue::Null.into()))]
+    fn is_truthy_positive(#[case] v: JsValue) {
+        assert_eq!(v.is_truthy(), Some(true), "expected '{v}' to be truthy");
+    }
+
+    #[rstest]
+    #[case(JsValue::from(0.0))]
+    #[case(JsValue::from(""))]
+    #[case(ConstantValue::False.into())]
+    #[case(ConstantValue::Null.into())]
+    #[case(ConstantValue::Undefined.into())]
+    fn is_truthy_negative(#[case] v: JsValue) {
+        assert_eq!(v.is_truthy(), Some(false), "expected '{v}' to be falsy");
+    }
+
+    #[rstest]
+    #[case(ConstantValue::Null.into())]
+    #[case(ConstantValue::Undefined.into())]
+    fn is_nullish_positive(#[case] v: JsValue) {
+        assert_eq!(v.is_nullish(), Some(true), "expected '{v}' to be nullish");
+    }
+
+    #[rstest]
+    #[case(JsValue::from(0.0))]
+    #[case(JsValue::from(""))]
+    #[case(JsValue::from("hi"))]
+    #[case(ConstantValue::True.into())]
+    #[case(JsValue::promise(ConstantValue::Null.into()))]
+    fn is_nullish_negative(#[case] v: JsValue) {
+        assert_eq!(
+            v.is_nullish(),
+            Some(false),
+            "expected '{v}' not to be nullish"
         );
     }
 }


### PR DESCRIPTION
Promises are not included in the list of JavaScript's falsy values, therefore, they are always truthy. See https://developer.mozilla.org/en-US/docs/Glossary/Truthy. Additionally, promises are neither `null` or `undefined` so they are not nullish: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing.

This PR updates Turbopack's analyzer to reflect this + adds unit tests for `is_truthy` and `is_nullish`.