### PR TITLE
Align issue triage guidance with automated behavior

### DIFF
--- a/.github/comments/invalid-reproduction.md
+++ b/.github/comments/invalid-reproduction.md
@@ -16,9 +16,9 @@ Ensure the link is pointing to a codebase that is accessible (e.g. not a private
 
 ### What happens if I don't provide a sufficient minimal reproduction?
 
-Issues with the `please add a complete reproduction` label that receives no meaningful activity (e.g. new comments with a reproduction link) are automatically closed and locked after **2** days.
+Issues with the `please add a complete reproduction` label that receives no meaningful activity (e.g. new comments with a reproduction link) are automatically closed after **2** days.
 
-If your issue has _not_ been resolved in that time and it has been closed/locked, please open a new issue with the required reproduction.
+If your issue has _not_ been resolved in that time and it has been closed, please open a new issue with the required reproduction.
 
 ### I did not open this issue, but it is relevant to me, what can I do to help?
 

--- a/.github/comments/simplify-reproduction.md
+++ b/.github/comments/simplify-reproduction.md
@@ -21,9 +21,9 @@ If you cannot create a clean reproduction, another way you can help the maintain
 
 ### What happens if I don't provide a sufficient minimal reproduction?
 
-Issues with the `please simplify reproduction` label that receive no meaningful activity (e.g. new comments with a simplified reproduction link) are automatically closed and locked after **14** days.
+Issues with the `please simplify reproduction` label that receive no meaningful activity (e.g. new comments with a simplified reproduction link) are automatically closed after **14** days.
 
-If your issue has _not_ been resolved in that time and it has been closed/locked, please open a new issue with the required reproduction.
+If your issue has _not_ been resolved in that time and it has been closed, please open a new issue with the required reproduction.
 
 ### I did not open this issue, but it is relevant to me, what can I do to help?
 

--- a/.github/comments/verify-canary.md
+++ b/.github/comments/verify-canary.md
@@ -18,9 +18,9 @@ Next.js does not backport bug fixes to older versions of Next.js. Instead, we ar
 
 ### What happens if I don't verify against the canary version of Next.js?
 
-An issue with the `please verify canary` that receives no meaningful activity (e.g. new comments that acknowledge verification against `canary`) will be automatically closed and locked after **14** days.
+An issue with the `please verify canary` that receives no meaningful activity (e.g. new comments that acknowledge verification against `canary`) will be automatically closed after **14** days.
 
-If your issue has not been resolved in that time and it has been closed/locked, please open a new issue, with the required reproduction, using `next@canary`.
+If your issue has not been resolved in that time and it has been closed, please open a new issue, with the required reproduction, using `next@canary`.
 
 ### I did not open this issue, but it is relevant to me, what can I do to help?
 

--- a/contributing/repository/triaging.md
+++ b/contributing/repository/triaging.md
@@ -26,19 +26,19 @@ A maintainer can also manually label an issue with one of the following labels, 
 
 1. `please add a complete reproduction`
 
-The provided reproduction is not enough for the maintainers to investigate. If sufficient reproduction is not provided for more than 30 days, the issue becomes stale and will be automatically closed. If a reproduction is provided within 30 days, a `needs triage` label is added, indicating that the issue needs another look from a maintainer.
+The provided reproduction is not enough for the maintainers to investigate. If a sufficient reproduction is not provided, the issue will be automatically closed after 2 days of inactivity.
 
 The issue will receive [this comment](https://github.com/vercel/next.js/blob/canary/.github/comments/invalid-reproduction.md)
 
 2. `please verify canary`
 
-The issue is not verified against the `next@canary` release. The canary version of Next.js ships daily and includes all features and fixes that have not been released to the stable version yet. Think of canary as a public beta. Some issues may already be fixed in the canary version, so please verify that your issue reproduces before opening a new issue. Issues not verified against `next@canary` will be closed after 30 days.
+The issue is not verified against the `next@canary` release. The canary version of Next.js ships daily and includes all features and fixes that have not been released to the stable version yet. Think of canary as a public beta. Some issues may already be fixed in the canary version, so please verify that your issue reproduces before opening a new issue. Issues not verified against `next@canary` will be automatically closed after 14 days of inactivity.
 
 The issue will receive [this comment](https://github.com/vercel/next.js/blob/canary/.github/comments/verify-canary.md)
 
 3. `please simplify reproduction`
 
-The provided reproduction is too complex or requires too many steps to reproduce. If a simplified reproduction is not provided for more than 30 days, the issue becomes stale and will be automatically closed. If a reproduction is provided within 30 days, a `needs triage` label is added, indicating that the issue needs another look from a maintainer.
+The provided reproduction is too complex or requires too many steps to reproduce. If a simplified reproduction is not provided, the issue will be automatically closed after 14 days of inactivity.
 The issue will receive [this comment](https://github.com/vercel/next.js/blob/canary/.github/comments/simplify-reproduction.md)
 
 4. `good first issue`
@@ -53,7 +53,7 @@ The issue will receive [this comment](https://github.com/vercel/next.js/blob/can
 
 ## Verified issues
 
-If an issue is verified, it will receive the `linear: next`, `linear: dx` or `linear: web` label and will be tracked by the maintainers. Additionally, one or more [label(s)](https://github.com/vercel/next.js/labels) can be added to indicate which part of Next.js is affected.
+If an issue is verified, it will receive the `linear: next`, `linear: turbopack` or `linear: docs` label and will be tracked by the maintainers. Additionally, one or more [label(s)](https://github.com/vercel/next.js/labels) can be added to indicate which part of Next.js is affected.
 
 Confirmed issues never become stale or are closed before resolution.
 


### PR DESCRIPTION
### What?

- Align the public triage guide with the issue workflows current response windows and confirmed-team labels.
- Update reproduction and canary response comments to describe automatic closure separately from the later lock workflow.

### Why?

The documented triage contract had drifted from the active automation: the guide described 30-day response windows and unsupported triage labeling, while automated comments implied that timed closure immediately locks issues. This sets inaccurate expectations for reporters and maintainers.

### How?

Update the four Markdown surfaces that explain manual triage and automated follow-up behavior to match the existing stale and lock workflows.

### Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --check contributing/repository/triaging.md .github/comments/invalid-reproduction.md .github/comments/simplify-reproduction.md .github/comments/verify-canary.md`
- `git diff --cached --check`
- Not run: `pnpm --filter=next build` (`documentation and GitHub comment text only; no framework source changes`)

<!-- NEXT_JS_LLM_PR -->