### PR TITLE
test: fix next-after-app-static

### DIFF
--- a/test/e2e/app-dir/next-after-app-static/build-time/app/static/route/route.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time/app/static/route/route.ts
@@ -7,5 +7,5 @@ export async function GET() {
   after(() => {
     cliLog({ source: '[route] /static/route' })
   })
-  return new Response()
+  return new Response('hello')
 }

--- a/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts
@@ -51,7 +51,7 @@ _describe('after() in static pages', () => {
     }
 
     resetLogs()
-    await next.start()
+    await next.start({ skipBuild: true })
 
     {
       const res = await next.fetch('/static/dynamic-error')
@@ -71,17 +71,10 @@ _describe('after() in static pages', () => {
     await setTimeout(1000) // no other good way to make sure any possible afters ran
 
     {
-      // after should not run at runtime
+      // all the pages/routes have been statically prerendered, so
+      // we should not observe any after()s at runtime
       const logsFromAfter = Log.readCliLogs(getLogs())
-      expect(logsFromAfter).not.toContainEqual({
-        source: '[page] /static/dynamic-error',
-      })
-      expect(logsFromAfter).not.toContainEqual({
-        source: '[page] /static/dynamic-force-static',
-      })
-      expect(logsFromAfter).not.toContainEqual({
-        source: '[page] /static/route',
-      })
+      expect(logsFromAfter).toHaveLength(0)
     }
   })
 })


### PR DESCRIPTION
This test has been flaking in weird ways, but i also noticed that it's a bit broken
- we were running build twice, because `next.start()` does that. this affected what was in the logs that we assert on
- The assertion on the route was incorrect (it checked for `[page] /static/route` instead of `[route] /static/route`, which would never be emitted)
- ...which was hiding the fact that actually the thing *was* getting logged due to a bug unrelated to after()

The idea in the test was essentially to assert that no after()s run at runtime if the page/route is statically prerendered (which implicitly also asserts that `after` itself does not make it dynamic). But it appears that returning a `new Response()` from a static handler is unsupported (bug imho) because it logs `Failed to update prerender cache for /static/route Error: LRUCache: calculateSize returned 0, but size must be > 0. Items with size 0 would never be evicted, causing unbounded cache growth.`. As a workaround, i just gave it a non-empty body

I don't know if this will fix the flakes we've been seeing in CI. Those, bizarrely, fail here
```
Error: can not run export while server is running, use next.stop() first
    at NextStartInstance.build (/__w/next.js/next.js/test/lib/next-modes/next-start.ts:255:13)
    at Object.build (/__w/next.js/next.js/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts:36:36)
 ```
 https://github.com/vercel/next.js/blob/1bc1da711cd0699b620716b204b480485274ff05/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts#L36
 
 We do `skipStart` in `nextTestSetup`, and there's no other tests running, so i have no idea what "running server" that error is referring to