### PR TITLE
test: skip flaky instant-nav-panel tests

### DIFF
--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -1,7 +1,8 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { retry, toggleDevToolsIndicatorPopover } from 'next-test-utils'
 
-describe('instant-nav-panel', () => {
+// FIXME: Skipped due to flakiness. Reenable when fixed
+describe.skip('instant-nav-panel', () => {
   const { isNextDev, isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })


### PR DESCRIPTION
The tests in `test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts` seem to be failing a lot. According to [datadog](https://app.datadoghq.com/ci/test/flaky?query=%40test.name%3Ainstant-nav-panel%2A&sort=-pipelines_failed&viewMode=flaky), the worst offender fails 40% of runs. 
<img width="762" height="458" alt="Screenshot 2026-05-28 at 14 58 46" src="https://github.com/user-attachments/assets/148b8122-e5d4-407c-89cf-12101297f189" />
I'm disabling them to avoid disrupting people's CI runs too much

I'm taking a stab at unflaking them here https://github.com/vercel/next.js/pull/94171, but no luck so far
