### PR TITLE
[backport] Propagate adapter preferred regions

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -754,6 +754,7 @@ export async function handleBuildComplete({
           wasmAssets: {},
           config: {
             env: page.env,
+            preferredRegion: page.regions,
           },
         }
 

--- a/test/production/adapter-config/adapter-config-export.test.ts
+++ b/test/production/adapter-config/adapter-config-export.test.ts
@@ -16,6 +16,7 @@ describe('adapter-config export', () => {
       'app/node-app/page.tsx',
       'app/node-route/route.ts',
       'app/edge-route/route.ts',
+      'app/preferred-region/route.ts',
       'app/isr-route/route.ts',
       'app/isr-route/[slug]/route.ts',
       'app/edge-app/page.tsx',

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -388,4 +388,17 @@ describe('adapter-config', () => {
       rsc: expect.toBeObject(),
     })
   })
+
+  it('should propagate preferredRegion to adapter output', async () => {
+    const { outputs }: Parameters<NextAdapter['onBuildComplete']>[0] =
+      await next.readJSON('build-complete.json')
+
+    const preferredRegionRoute = outputs.appRoutes.find(
+      (output) => output.pathname === '/docs/preferred-region'
+    )
+
+    expect(preferredRegionRoute).toBeDefined()
+    expect(preferredRegionRoute?.runtime).toBe('edge')
+    expect(preferredRegionRoute?.config.preferredRegion).toEqual(['cdg1'])
+  })
 })

--- a/test/production/adapter-config/app/preferred-region/route.ts
+++ b/test/production/adapter-config/app/preferred-region/route.ts
@@ -1,0 +1,7 @@
+export const runtime = 'edge'
+export const preferredRegion = ['cdg1']
+export const dynamic = 'force-dynamic'
+
+export function GET(_request: Request) {
+  return new Response('Hello, world!', { status: 200 })
+}


### PR DESCRIPTION
Backports [Propagate adapter preferred regions](https://github.com/vercel/next.js/pull/94123) to `next-16-2`.

<!-- NEXT_JS_LLM_PR -->