### PR TITLE
[skills] Add next-feedback

### DIFF
--- a/skills/next-feedback/SKILL.md
+++ b/skills/next-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: next-feedback
-description: Files Next.js framework feedback as a prefilled report the user reviews and submits. Invoke with /next-feedback, optionally with a focus.
+description: Files Next.js framework feedback. Reach for it whenever Next.js surprised you during a task — or invoke directly to file specific feedback.
 ---
 
 # next-feedback

--- a/skills/next-feedback/SKILL.md
+++ b/skills/next-feedback/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: next-feedback
-description: >
-  Invoke at the end of every Next.js dev session, including when the user
-  signals they're wrapping up. Drafts a framework-issue report if one
-  surfaced; silent exit otherwise. Don't defer to later.
+description: Files Next.js framework feedback as a prefilled report the user reviews and submits. Invoke with /next-feedback, optionally with a focus.
 ---
 
 # next-feedback
+
+Reflect on the session (or the focus, if given) for Next.js friction worth
+surfacing to the team — surprising behavior, doc gaps, version footguns,
+workarounds. If nothing is worth filing, say so and stop.
 
 ## Fields
 

--- a/skills/next-feedback/SKILL.md
+++ b/skills/next-feedback/SKILL.md
@@ -29,7 +29,7 @@ const url = `https://nextjs.org/agent-feedback?report=${b64}`
 ```
 
 ```bash
-agent-browser open "$URL" --headed --session-name next-feedback
+agent-browser open "$url" --headed --session-name next-feedback
 ```
 
 Never auto-click submit.

--- a/skills/next-feedback/SKILL.md
+++ b/skills/next-feedback/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: next-feedback
+description: >
+  Invoke at the end of every Next.js dev session, including when the user
+  signals they're wrapping up. Drafts a framework-issue report if one
+  surfaced; silent exit otherwise. Don't defer to later.
+---
+
+# next-feedback
+
+## Fields
+
+- **`title`** — one-line summary.
+- **`body`** — markdown, free-form. Whatever you saw. Repros optional.
+- **`nextVersion`** — from `packages/next/package.json`.
+- **`agent`** — your identifier.
+
+**Sanitize.** Strip anything identifying the user, their project, or containing secrets/PII. Can't describe it without leaking? Stop and tell the user.
+
+## Submit
+
+Requires `agent-browser` (`npm i -g agent-browser`).
+
+```js
+const b64 = Buffer.from(
+  JSON.stringify({ title, body, nextVersion, agent })
+).toString('base64url')
+const url = `https://nextjs.org/agent-feedback?report=${b64}`
+```
+
+```bash
+agent-browser open "$URL" --headed --session-name next-feedback
+```
+
+Never auto-click submit.


### PR DESCRIPTION
Adds the `next-feedback` skill: drafts framework feedback at the end of a Next.js dev session and opens a prefilled submission form in agent-browser for the user to review. Sends to `nextjs.org/agent-feedback`.