### PR TITLE
Turbopack: show codeframe when tracing too much

### DIFF
--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -121,25 +121,30 @@ impl Asset for ServerNftJsonAsset {
         )
         .connect();
 
-        let mut server_output_assets =
-            traced_modules_for_entries(module_graph, self.entries(), Some(self.ignores()), true)
-                .await?
-                .iter()
-                .map(async |m| {
-                    Ok((
-                        base_dir
-                            .get_relative_path_to(&m.ident().await?.path)
-                            .context("failed to compute relative path for server NFT JSON")?,
-                        m.source()
-                            .await?
-                            .context("NFT module has no content")?
-                            .content()
-                            .hash(HashAlgorithm::Xxh3Hash128Hex)
-                            .await?,
-                    ))
-                })
-                .try_join()
-                .await?;
+        let mut server_output_assets = traced_modules_for_entries(
+            module_graph,
+            self.entries(),
+            Some(self.ignores()),
+            true,
+            None,
+        )
+        .await?
+        .iter()
+        .map(async |m| {
+            Ok((
+                base_dir
+                    .get_relative_path_to(&m.ident().await?.path)
+                    .context("failed to compute relative path for server NFT JSON")?,
+                m.source()
+                    .await?
+                    .context("NFT module has no content")?
+                    .content()
+                    .hash(HashAlgorithm::Xxh3Hash128Hex)
+                    .await?,
+            ))
+        })
+        .try_join()
+        .await?;
 
         let next_dir = get_next_package(this.project.project_path().owned().await?).await?;
         for ty in ["app-page", "pages"] {

--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeSet, VecDeque};
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use next_core::{app_structure::FileSystemPathVec, next_config::NextConfig};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
 };
@@ -16,9 +17,12 @@ use turbo_tasks_hash::HashAlgorithm;
 use turbopack_core::{
     asset::Asset,
     chunk::{ChunkingType, TracedMode},
+    file_source::FileSource,
     ident::AssetIdent,
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     module::{Module, Modules},
     module_graph::{GraphTraversalAction, ModuleGraph},
+    raw_module::RawModule,
 };
 
 use crate::project::Project;
@@ -75,6 +79,7 @@ pub async fn trace_endpoint(
                 .await?
                 .map(|v| *v),
             false,
+            Some(next_config.config_file_path(project_path.clone())),
         )
         .await?;
 
@@ -262,6 +267,7 @@ pub async fn traced_modules_for_entries(
     entry_modules: Vc<Modules>,
     exclude_glob: Option<Vc<Glob>>,
     entries_are_traced: bool,
+    forbidden_path: Option<Vc<FileSystemPath>>,
 ) -> Result<Vc<Modules>> {
     let exclude_glob_and_module_idents = if let Some(exclude_glob) = exclude_glob {
         let exclude_glob = exclude_glob.await?;
@@ -270,6 +276,18 @@ pub async fn traced_modules_for_entries(
     } else {
         None
     };
+
+    let forbidden_module = if let Some(forbidden_path) = forbidden_path {
+        Some(ResolvedVc::upcast(
+            RawModule::new(Vc::upcast(FileSource::new(forbidden_path.owned().await?)))
+                .to_resolved()
+                .await?,
+        ))
+    } else {
+        None
+    };
+
+    let mut forbidden_issues = vec![];
 
     let mut traced_modules = FxIndexSet::default();
     module_graph.await?.traverse_edges_dfs(
@@ -282,6 +300,10 @@ pub async fn traced_modules_for_entries(
                 }
                 return Ok(GraphTraversalAction::Continue);
             };
+
+            if forbidden_module.is_some_and(|m| m == target) {
+                forbidden_issues.push((parent, ref_data.reference));
+            }
 
             if should_visit_for_tracing(&ref_data.chunking_type, traced_modules.contains(&parent)) {
                 if let Some((exclude_glob, module_idents)) = &exclude_glob_and_module_idents
@@ -302,6 +324,16 @@ pub async fn traced_modules_for_entries(
         |_, _, _| Ok(()),
         true,
     )?;
+
+    for (parent, reference) in forbidden_issues {
+        ForbiddenTracedFileIssue::new(
+            parent.ident().await?.path.clone(),
+            reference.into_trait_ref().await?.source(),
+        )
+        .to_resolved()
+        .await?
+        .emit();
+    }
 
     Ok(Vc::cell(traced_modules.into_iter().collect()))
 }
@@ -391,4 +423,94 @@ pub async fn traced_module_data_for_graph(
         hashes: ResolvedVc::cell(hashes),
     }
     .cell())
+}
+
+#[turbo_tasks::value(shared)]
+struct ForbiddenTracedFileIssue {
+    parent: FileSystemPath,
+    issue_source: Option<IssueSource>,
+}
+
+#[turbo_tasks::value_impl]
+impl ForbiddenTracedFileIssue {
+    #[turbo_tasks::function]
+    pub async fn new(
+        parent: FileSystemPath,
+        issue_source: Option<IssueSource>,
+    ) -> Result<Vc<Self>> {
+        Ok(Self {
+            parent,
+            issue_source,
+        }
+        .cell())
+    }
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl Issue for ForbiddenTracedFileIssue {
+    fn severity(&self) -> IssueSeverity {
+        // Ideally this would be an error, but for now we keep it a warning to avoid breaking
+        // existing apps
+        IssueSeverity::Warning
+    }
+
+    fn stage(&self) -> IssueStage {
+        IssueStage::Misc
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        self.issue_source
+    }
+
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.parent.clone())
+    }
+
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Encountered unexpected file in NFT list"
+        )))
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        let stack = vec![
+            StyledString::Text(rcstr!(
+                "This import traced the next.config.js file which indicates that the whole \
+                 project was traced unintentionally. Somewhere in the import trace below, there \
+                 are:"
+            )),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("- filesystem operations (like ")),
+                StyledString::Code(rcstr!("path.join")),
+                StyledString::Text(rcstr!(", ")),
+                StyledString::Code(rcstr!("path.resolve")),
+                StyledString::Text(rcstr!(" or ")),
+                StyledString::Code(rcstr!("fs.readFile")),
+                StyledString::Text(rcstr!("), or")),
+            ]),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("- very dynamic requires (like ")),
+                StyledString::Code(rcstr!("require('./' + foo)")),
+                StyledString::Text(rcstr!(").")),
+            ]),
+            StyledString::Text(rcstr!("To resolve this, you can")),
+            StyledString::Text(rcstr!("- remove them if possible, or")),
+            StyledString::Text(rcstr!("- only use them in development, or")),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!(
+                    "- make sure they are statically scoped to some subfolder: "
+                )),
+                StyledString::Code(rcstr!("path.join(process.cwd(), 'data', bar)")),
+                StyledString::Text(rcstr!(", or")),
+            ]),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("- add ignore comments: ")),
+                StyledString::Code(rcstr!(
+                    "path.join(/*turbopackIgnore: true*/ process.cwd(), bar)"
+                )),
+            ]),
+        ];
+        Ok(Some(StyledString::Stack(stack)))
+    }
 }

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -1,9 +1,8 @@
 use anyhow::{Context, Result, bail};
-use async_trait::async_trait;
 use either::Either;
 use serde_json::json;
 use tracing::{Instrument, Level, Span};
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{
     ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal, Visit},
@@ -13,7 +12,6 @@ use turbo_tasks_fs::{File, FileContent, FileSystem, FileSystemPath, glob::Glob};
 use turbo_tasks_hash::HashAlgorithm;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     module::Module,
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
 };
@@ -121,11 +119,6 @@ impl Asset for NftJsonAsset {
             let output_root_ref = this.project.output_fs().root().await?;
             let project_root_ref = this.project.project_fs().root().await?;
             let next_config = this.project.next_config();
-            let next_config_path = this
-                .project
-                .next_config()
-                .config_file_path(project_path.clone())
-                .await?;
 
             let client_root = this.project.client_fs().root();
             let client_root = client_root.owned().await?;
@@ -200,18 +193,6 @@ impl Asset for NftJsonAsset {
                         Either::Left(p) => &**p,
                         Either::Right(p) => p,
                     };
-
-                    if let AssetOrModule::Module(_) = referenced
-                        && referenced_chunk_path == &*next_config_path
-                    {
-                        // If next.config.js was traced, assume that the whole project was traced
-                        // (unintentionally). Print a message in this case to avoid deploying
-                        // unnecessary files.
-                        ForbiddenTracedFileIssue::new(referenced_chunk_path.clone())
-                            .to_resolved()
-                            .await?
-                            .emit();
-                    }
 
                     if referenced_chunk_path.has_extension(".map") {
                         return Ok(None);
@@ -348,83 +329,6 @@ async fn all_assets_from_entries_filtered(
             .map(|n| n.0)
             .collect(),
     ))
-}
-
-#[turbo_tasks::value(shared)]
-struct ForbiddenTracedFileIssue {
-    file: FileSystemPath,
-}
-
-#[turbo_tasks::value_impl]
-impl ForbiddenTracedFileIssue {
-    #[turbo_tasks::function]
-    pub fn new(file: FileSystemPath) -> Vc<Self> {
-        Self { file }.cell()
-    }
-}
-
-#[async_trait]
-#[turbo_tasks::value_impl]
-impl Issue for ForbiddenTracedFileIssue {
-    fn severity(&self) -> IssueSeverity {
-        // Ideally this would be an error, but for now we keep it a warning to avoid breaking
-        // existing apps
-        IssueSeverity::Warning
-    }
-
-    fn stage(&self) -> IssueStage {
-        IssueStage::Misc
-    }
-
-    async fn file_path(&self) -> Result<FileSystemPath> {
-        Ok(self.file.clone())
-    }
-
-    async fn title(&self) -> Result<StyledString> {
-        Ok(StyledString::Text(rcstr!(
-            "Encountered unexpected file in NFT list"
-        )))
-    }
-
-    async fn description(&self) -> Result<Option<StyledString>> {
-        let stack = vec![
-            StyledString::Text(rcstr!(
-                "A file was traced that indicates that the whole project was traced \
-                 unintentionally. Somewhere in the import trace below, there are:"
-            )),
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!("- filesystem operations (like ")),
-                StyledString::Code(rcstr!("path.join")),
-                StyledString::Text(rcstr!(", ")),
-                StyledString::Code(rcstr!("path.resolve")),
-                StyledString::Text(rcstr!(" or ")),
-                StyledString::Code(rcstr!("fs.readFile")),
-                StyledString::Text(rcstr!("), or")),
-            ]),
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!("- very dynamic requires (like ")),
-                StyledString::Code(rcstr!("require('./' + foo)")),
-                StyledString::Text(rcstr!(").")),
-            ]),
-            StyledString::Text(rcstr!("To resolve this, you can")),
-            StyledString::Text(rcstr!("- remove them if possible, or")),
-            StyledString::Text(rcstr!("- only use them in development, or")),
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!(
-                    "- make sure they are statically scoped to some subfolder: "
-                )),
-                StyledString::Code(rcstr!("path.join(process.cwd(), 'data', bar)")),
-                StyledString::Text(rcstr!(", or")),
-            ]),
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!("- add ignore comments: ")),
-                StyledString::Code(rcstr!(
-                    "path.join(/*turbopackIgnore: true*/ process.cwd(), bar)"
-                )),
-            ]),
-        ];
-        Ok(Some(StyledString::Stack(stack)))
-    }
 }
 
 struct OutputAssetFilteredVisit {

--- a/test/production/build-tracing-message/index.test.ts
+++ b/test/production/build-tracing-message/index.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import stripAnsi from 'strip-ansi'
 
 // Only Turbopack prints these warnings
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
@@ -20,11 +21,18 @@ import { nextTestSetup } from 'e2e-utils'
         )
         .trim()
 
-      expect(output).toMatchInlineSnapshot(`
+      expect(stripAnsi(output)).toMatchInlineSnapshot(`
        "Turbopack build encountered 1 warnings:
-       ./next.config.js
+       ./app/join-cwd.js:4:10
        Encountered unexpected file in NFT list
-       A file was traced that indicates that the whole project was traced unintentionally. Somewhere in the import trace below, there are:
+         2 |
+         3 | export default function (f) {
+       > 4 |   return path.join(process.cwd(), f)
+           |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         5 | }
+         6 |
+
+       This import traced the next.config.js file which indicates that the whole project was traced unintentionally. Somewhere in the import trace below, there are:
        - filesystem operations (like path.join, path.resolve or fs.readFile), or
        - very dynamic requires (like require('./' + foo)).
        To resolve this, you can
@@ -35,7 +43,6 @@ import { nextTestSetup } from 'e2e-utils'
 
        Import trace:
          Server Component:
-           ./next.config.js
            ./app/join-cwd.js
            ./app/page.js"
       `)

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -10,6 +10,7 @@ use turbo_tasks::{
 
 use crate::{
     chunk::{ChunkingType, TracedMode},
+    issue::IssueSource,
     module::{Module, Modules},
     output::{
         ExpandOutputAssetsInput, ExpandedOutputAssets, OutputAsset, OutputAssets,
@@ -38,6 +39,10 @@ pub trait ModuleReference: ValueToString {
 
     fn binding_usage(&self) -> BindingUsage {
         BindingUsage::default()
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        None
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -148,6 +148,10 @@ impl ModuleReference for ImportAssetReference {
             hoisted: false,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -92,6 +92,10 @@ impl ModuleReference for UrlAssetReference {
             hoisted: false,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -80,6 +80,10 @@ impl ModuleReference for AmdDefineAssetReference {
             hoisted: false,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 #[derive(

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -77,6 +77,10 @@ impl ModuleReference for CjsAssetReference {
             hoisted: false,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 #[turbo_tasks::value]
@@ -138,6 +142,10 @@ impl ModuleReference for CjsRequireAssetReference {
             },
             |c| c.as_chunking_type(false, false),
         )
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
     }
 }
 
@@ -275,6 +283,10 @@ impl ModuleReference for CjsRequireResolveAssetReference {
             },
             |c| c.as_chunking_type(false, false),
         )
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -587,6 +587,10 @@ impl ModuleReference for EsmAssetReference {
             },
         }
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 impl EsmAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -112,6 +112,10 @@ impl ModuleReference for EsmAsyncAssetReference {
             export: self.export_usage.clone(),
         }
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 impl IntoCodeGenReference for EsmAsyncAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -107,6 +107,10 @@ impl ModuleReference for UrlAssetReference {
             hoisted: false,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 impl IntoCodeGenReference for UrlAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -83,6 +83,10 @@ impl ModuleReference for FileSourceReference {
             mode: TracedMode::Entry,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 #[turbo_tasks::value]
@@ -212,5 +216,9 @@ impl ModuleReference for DirAssetReference {
         Some(ChunkingType::Traced {
             mode: TracedMode::Entry,
         })
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -301,6 +301,10 @@ impl ModuleReference for RequireContextAssetReference {
             hoisted: false,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        self.issue_source
+    }
 }
 
 impl IntoCodeGenReference for RequireContextAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -262,6 +262,10 @@ impl ModuleReference for WorkerAssetReference {
             hoisted: false,
         })
     }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
 }
 
 impl WorkerAssetReference {


### PR DESCRIPTION
Finally, we can show a codeframe
<img width="1204" height="774" alt="Bildschirmfoto 2026-05-28 um 21 16 35" src="https://github.com/user-attachments/assets/a70c1fce-8a86-472a-9904-28f181d32385" />

