### PR TITLE
[turbopack] Handle negative numbers as constants in the analyzer

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
@@ -11,7 +11,10 @@ use turbo_rcstr::{RcStr, rcstr};
 
 use crate::{
     SpecifiedModuleType,
-    analyzer::{ConstantValue, ImportMap, JsValue, ObjectPart, WellKnownObjectKind, is_unresolved},
+    analyzer::{
+        ConstantNumber, ConstantValue, ImportMap, JsValue, ObjectPart, WellKnownObjectKind,
+        is_unresolved,
+    },
     references::constant_value::parse_single_expr_lit,
     utils::unparen,
 };
@@ -152,6 +155,12 @@ impl EvalContext {
                 arg: box Expr::Lit(_),
                 ..
             }) => JsValue::Constant(ConstantValue::Undefined),
+
+            Expr::Unary(UnaryExpr {
+                op: op!(unary, "-"),
+                arg: box Expr::Lit(Lit::Num(n)),
+                ..
+            }) => JsValue::Constant(ConstantValue::Num(ConstantNumber((-n.value).into()))),
 
             Expr::Unary(UnaryExpr {
                 op: op!("!"), arg, ..

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
@@ -448,11 +448,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -680876936.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -694,11 +698,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -389564586.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -1190,11 +1198,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1044525330.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -1436,11 +1448,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -176418897.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -1932,11 +1948,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1473231341.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -2178,11 +2198,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -45705983.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -2674,11 +2698,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1958414417.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -2920,11 +2948,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -42063.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -3166,11 +3198,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1990404162.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -3662,11 +3698,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -40341101.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -3908,11 +3948,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1502002290.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-explained.snapshot
@@ -1,70 +1,44 @@
 a#3 = (
   | 1732584193
-  | md5ff(a, b, c, d, x[i], 7, ???*0*)
-  | md5ff(a, b, c, d, x[(i + 4)], 7, ???*1*)
+  | md5ff(a, b, c, d, x[i], 7, -680876936)
+  | md5ff(a, b, c, d, x[(i + 4)], 7, -176418897)
   | md5ff(a, b, c, d, x[(i + 8)], 7, 1770035416)
   | md5ff(a, b, c, d, x[(i + 12)], 7, 1804603682)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
 
 a#5 = arguments[1]
 
 a#6 = arguments[0]
 
 b#3 = (
-  | ???*0*
-  | md5ff(b, c, d, a, x[(i + 3)], 22, ???*1*)
-  | md5ff(b, c, d, a, x[(i + 7)], 22, ???*2*)
-  | md5ff(b, c, d, a, x[(i + 11)], 22, ???*3*)
+  | -271733879
+  | md5ff(b, c, d, a, x[(i + 3)], 22, -1044525330)
+  | md5ff(b, c, d, a, x[(i + 7)], 22, -45705983)
+  | md5ff(b, c, d, a, x[(i + 11)], 22, -1990404162)
   | md5ff(b, c, d, a, x[(i + 15)], 22, 1236535329)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
 
 b#5 = arguments[2]
 
 b#6 = arguments[1]
 
 c#3 = (
-  | ???*0*
+  | -1732584194
   | md5ff(c, d, a, b, x[(i + 2)], 17, 606105819)
-  | md5ff(c, d, a, b, x[(i + 6)], 17, ???*1*)
-  | md5ff(c, d, a, b, x[(i + 10)], 17, ???*2*)
-  | md5ff(c, d, a, b, x[(i + 14)], 17, ???*3*)
+  | md5ff(c, d, a, b, x[(i + 6)], 17, -1473231341)
+  | md5ff(c, d, a, b, x[(i + 10)], 17, -42063)
+  | md5ff(c, d, a, b, x[(i + 14)], 17, -1502002290)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
 
 c#6 = arguments[2]
 
 d#3 = (
   | 271733878
-  | md5ff(d, a, b, c, x[(i + 1)], 12, ???*0*)
+  | md5ff(d, a, b, c, x[(i + 1)], 12, -389564586)
   | md5ff(d, a, b, c, x[(i + 5)], 12, 1200080426)
-  | md5ff(d, a, b, c, x[(i + 9)], 12, ???*1*)
-  | md5ff(d, a, b, c, x[(i + 13)], 12, ???*2*)
+  | md5ff(d, a, b, c, x[(i + 9)], 12, -1958414417)
+  | md5ff(d, a, b, c, x[(i + 13)], 12, -40341101)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
 
 d#6 = arguments[3]
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -70,11 +70,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -680876936.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -148,11 +152,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -176418897.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -342,11 +350,15 @@
         Alternatives {
             total_nodes: 54,
             values: [
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -271733879.0,
+                            ),
+                        ),
+                    ),
+                ),
                 Call(
                     13,
                     Variable(
@@ -418,11 +430,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1044525330.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -496,11 +512,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -45705983.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -574,11 +594,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1990404162.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -686,11 +710,15 @@
         Alternatives {
             total_nodes: 54,
             values: [
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1732584194.0,
+                            ),
+                        ),
+                    ),
+                ),
                 Call(
                     13,
                     Variable(
@@ -844,11 +872,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1473231341.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -922,11 +954,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -42063.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1000,11 +1036,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1502002290.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
             ],
@@ -1103,11 +1143,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -389564586.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1263,11 +1307,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1958414417.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1341,11 +1389,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -40341101.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
             ],

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-effects.snapshot
@@ -2,7 +2,7 @@
 
 0 -> 3 free var = FreeVar(md5)
 
-0 -> 8 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, ???*7*)
+0 -> 8 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, -680876936)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -17,10 +17,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 10 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
+0 -> 10 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, -389564586)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -35,8 +33,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 12 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, 606105819)
 - *0* unsupported expression
@@ -54,7 +50,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 14 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
+0 -> 14 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, -1044525330)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -69,10 +65,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 16 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, ???*7*)
+0 -> 16 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, -176418897)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -87,8 +81,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 18 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, 1200080426)
 - *0* unsupported expression
@@ -106,7 +98,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 20 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
+0 -> 20 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, -1473231341)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -121,10 +113,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 22 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
+0 -> 22 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, -45705983)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -139,8 +129,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 24 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, 1770035416)
 - *0* unsupported expression
@@ -158,7 +146,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 26 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
+0 -> 26 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, -1958414417)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -173,10 +161,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 28 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
+0 -> 28 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, -42063)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -191,10 +177,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 30 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
+0 -> 30 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, -1990404162)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -209,8 +193,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 32 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, 1804603682)
 - *0* unsupported expression
@@ -228,7 +210,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 34 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
+0 -> 34 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, -40341101)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -243,10 +225,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 36 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
+0 -> 36 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, -1502002290)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -261,8 +241,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 38 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, 1236535329)
 - *0* unsupported expression

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/graph-explained.snapshot
@@ -10,44 +10,24 @@ a#18 = arguments[0]
 
 a#7 = (
   | 1732584193
-  | md5ff(a, b, c, d, x[i], 7, ???*0*)
-  | md5ff(a, b, c, d, x[(i + 4)], 7, ???*1*)
+  | md5ff(a, b, c, d, x[i], 7, -680876936)
+  | md5ff(a, b, c, d, x[(i + 4)], 7, -176418897)
   | md5ff(a, b, c, d, x[(i + 8)], 7, 1770035416)
   | md5ff(a, b, c, d, x[(i + 12)], 7, 1804603682)
-  | md5gg(a, b, c, d, x[(i + 1)], 5, ???*2*)
-  | md5gg(a, b, c, d, x[(i + 5)], 5, ???*3*)
+  | md5gg(a, b, c, d, x[(i + 1)], 5, -165796510)
+  | md5gg(a, b, c, d, x[(i + 5)], 5, -701558691)
   | md5gg(a, b, c, d, x[(i + 9)], 5, 568446438)
-  | md5gg(a, b, c, d, x[(i + 13)], 5, ???*4*)
-  | md5hh(a, b, c, d, x[(i + 5)], 4, ???*5*)
-  | md5hh(a, b, c, d, x[(i + 1)], 4, ???*6*)
+  | md5gg(a, b, c, d, x[(i + 13)], 5, -1444681467)
+  | md5hh(a, b, c, d, x[(i + 5)], 4, -378558)
+  | md5hh(a, b, c, d, x[(i + 1)], 4, -1530992060)
   | md5hh(a, b, c, d, x[(i + 13)], 4, 681279174)
-  | md5hh(a, b, c, d, x[(i + 9)], 4, ???*7*)
-  | md5ii(a, b, c, d, x[i], 6, ???*8*)
+  | md5hh(a, b, c, d, x[(i + 9)], 4, -640364487)
+  | md5ii(a, b, c, d, x[i], 6, -198630844)
   | md5ii(a, b, c, d, x[(i + 12)], 6, 1700485571)
   | md5ii(a, b, c, d, x[(i + 8)], 6, 1873313359)
-  | md5ii(a, b, c, d, x[(i + 4)], 6, ???*9*)
+  | md5ii(a, b, c, d, x[(i + 4)], 6, -145523070)
   | safeAdd(a, olda)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
 
 b#14 = arguments[2]
 
@@ -60,51 +40,25 @@ b#17 = arguments[1]
 b#18 = arguments[1]
 
 b#7 = (
-  | ???*0*
-  | md5ff(b, c, d, a, x[(i + 3)], 22, ???*1*)
-  | md5ff(b, c, d, a, x[(i + 7)], 22, ???*2*)
-  | md5ff(b, c, d, a, x[(i + 11)], 22, ???*3*)
+  | -271733879
+  | md5ff(b, c, d, a, x[(i + 3)], 22, -1044525330)
+  | md5ff(b, c, d, a, x[(i + 7)], 22, -45705983)
+  | md5ff(b, c, d, a, x[(i + 11)], 22, -1990404162)
   | md5ff(b, c, d, a, x[(i + 15)], 22, 1236535329)
-  | md5gg(b, c, d, a, x[i], 20, ???*4*)
-  | md5gg(b, c, d, a, x[(i + 4)], 20, ???*5*)
+  | md5gg(b, c, d, a, x[i], 20, -373897302)
+  | md5gg(b, c, d, a, x[(i + 4)], 20, -405537848)
   | md5gg(b, c, d, a, x[(i + 8)], 20, 1163531501)
-  | md5gg(b, c, d, a, x[(i + 12)], 20, ???*6*)
-  | md5hh(b, c, d, a, x[(i + 14)], 23, ???*7*)
-  | md5hh(b, c, d, a, x[(i + 10)], 23, ???*8*)
+  | md5gg(b, c, d, a, x[(i + 12)], 20, -1926607734)
+  | md5hh(b, c, d, a, x[(i + 14)], 23, -35309556)
+  | md5hh(b, c, d, a, x[(i + 10)], 23, -1094730640)
   | md5hh(b, c, d, a, x[(i + 6)], 23, 76029189)
-  | md5hh(b, c, d, a, x[(i + 2)], 23, ???*9*)
-  | md5ii(b, c, d, a, x[(i + 5)], 21, ???*10*)
-  | md5ii(b, c, d, a, x[(i + 1)], 21, ???*11*)
+  | md5hh(b, c, d, a, x[(i + 2)], 23, -995338651)
+  | md5ii(b, c, d, a, x[(i + 5)], 21, -57434055)
+  | md5ii(b, c, d, a, x[(i + 1)], 21, -2054922799)
   | md5ii(b, c, d, a, x[(i + 13)], 21, 1309151649)
-  | md5ii(b, c, d, a, x[(i + 9)], 21, ???*12*)
+  | md5ii(b, c, d, a, x[(i + 9)], 21, -343485551)
   | safeAdd(b, oldb)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* unsupported expression
-  ⚠️  This value might have side effects
 
 bitRotateLeft (const after eval) = (...) => ???*0*
 - *0* unsupported expression
@@ -123,47 +77,25 @@ c#17 = arguments[2]
 c#18 = arguments[2]
 
 c#7 = (
-  | ???*0*
+  | -1732584194
   | md5ff(c, d, a, b, x[(i + 2)], 17, 606105819)
-  | md5ff(c, d, a, b, x[(i + 6)], 17, ???*1*)
-  | md5ff(c, d, a, b, x[(i + 10)], 17, ???*2*)
-  | md5ff(c, d, a, b, x[(i + 14)], 17, ???*3*)
+  | md5ff(c, d, a, b, x[(i + 6)], 17, -1473231341)
+  | md5ff(c, d, a, b, x[(i + 10)], 17, -42063)
+  | md5ff(c, d, a, b, x[(i + 14)], 17, -1502002290)
   | md5gg(c, d, a, b, x[(i + 11)], 14, 643717713)
-  | md5gg(c, d, a, b, x[(i + 15)], 14, ???*4*)
-  | md5gg(c, d, a, b, x[(i + 3)], 14, ???*5*)
+  | md5gg(c, d, a, b, x[(i + 15)], 14, -660478335)
+  | md5gg(c, d, a, b, x[(i + 3)], 14, -187363961)
   | md5gg(c, d, a, b, x[(i + 7)], 14, 1735328473)
   | md5hh(c, d, a, b, x[(i + 11)], 16, 1839030562)
-  | md5hh(c, d, a, b, x[(i + 7)], 16, ???*6*)
-  | md5hh(c, d, a, b, x[(i + 3)], 16, ???*7*)
+  | md5hh(c, d, a, b, x[(i + 7)], 16, -155497632)
+  | md5hh(c, d, a, b, x[(i + 3)], 16, -722521979)
   | md5hh(c, d, a, b, x[(i + 15)], 16, 530742520)
-  | md5ii(c, d, a, b, x[(i + 14)], 15, ???*8*)
-  | md5ii(c, d, a, b, x[(i + 10)], 15, ???*9*)
-  | md5ii(c, d, a, b, x[(i + 6)], 15, ???*10*)
+  | md5ii(c, d, a, b, x[(i + 14)], 15, -1416354905)
+  | md5ii(c, d, a, b, x[(i + 10)], 15, -1051523)
+  | md5ii(c, d, a, b, x[(i + 6)], 15, -1560198380)
   | md5ii(c, d, a, b, x[(i + 2)], 15, 718787259)
   | safeAdd(c, oldc)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
 
 cnt = arguments[1]
 
@@ -177,48 +109,24 @@ d#18 = arguments[3]
 
 d#7 = (
   | 271733878
-  | md5ff(d, a, b, c, x[(i + 1)], 12, ???*0*)
+  | md5ff(d, a, b, c, x[(i + 1)], 12, -389564586)
   | md5ff(d, a, b, c, x[(i + 5)], 12, 1200080426)
-  | md5ff(d, a, b, c, x[(i + 9)], 12, ???*1*)
-  | md5ff(d, a, b, c, x[(i + 13)], 12, ???*2*)
-  | md5gg(d, a, b, c, x[(i + 6)], 9, ???*3*)
+  | md5ff(d, a, b, c, x[(i + 9)], 12, -1958414417)
+  | md5ff(d, a, b, c, x[(i + 13)], 12, -40341101)
+  | md5gg(d, a, b, c, x[(i + 6)], 9, -1069501632)
   | md5gg(d, a, b, c, x[(i + 10)], 9, 38016083)
-  | md5gg(d, a, b, c, x[(i + 14)], 9, ???*4*)
-  | md5gg(d, a, b, c, x[(i + 2)], 9, ???*5*)
-  | md5hh(d, a, b, c, x[(i + 8)], 11, ???*6*)
+  | md5gg(d, a, b, c, x[(i + 14)], 9, -1019803690)
+  | md5gg(d, a, b, c, x[(i + 2)], 9, -51403784)
+  | md5hh(d, a, b, c, x[(i + 8)], 11, -2022574463)
   | md5hh(d, a, b, c, x[(i + 4)], 11, 1272893353)
-  | md5hh(d, a, b, c, x[i], 11, ???*7*)
-  | md5hh(d, a, b, c, x[(i + 12)], 11, ???*8*)
+  | md5hh(d, a, b, c, x[i], 11, -358537222)
+  | md5hh(d, a, b, c, x[(i + 12)], 11, -421815835)
   | md5ii(d, a, b, c, x[(i + 7)], 10, 1126891415)
-  | md5ii(d, a, b, c, x[(i + 3)], 10, ???*9*)
-  | md5ii(d, a, b, c, x[(i + 15)], 10, ???*10*)
-  | md5ii(d, a, b, c, x[(i + 11)], 10, ???*11*)
+  | md5ii(d, a, b, c, x[(i + 3)], 10, -1894986606)
+  | md5ii(d, a, b, c, x[(i + 15)], 10, -30611744)
+  | md5ii(d, a, b, c, x[(i + 11)], 10, -1120210379)
   | safeAdd(d, oldd)
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
-  ⚠️  This value might have side effects
 
 hex = (
   | ???*0*

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-effects.snapshot
@@ -172,7 +172,7 @@
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 36 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, ???*7*)
+0 -> 36 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, -680876936)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -187,10 +187,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 38 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
+0 -> 38 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, -389564586)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -205,8 +203,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 40 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, 606105819)
 - *0* unsupported expression
@@ -224,7 +220,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 42 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
+0 -> 42 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, -1044525330)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -239,10 +235,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 44 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, ???*7*)
+0 -> 44 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, -176418897)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -257,8 +251,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 46 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, 1200080426)
 - *0* unsupported expression
@@ -276,7 +268,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 48 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
+0 -> 48 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, -1473231341)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -291,10 +283,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 50 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
+0 -> 50 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, -45705983)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -309,8 +299,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 52 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, 1770035416)
 - *0* unsupported expression
@@ -328,7 +316,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 54 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
+0 -> 54 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, -1958414417)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -343,10 +331,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 56 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
+0 -> 56 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, -42063)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -361,10 +347,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 58 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
+0 -> 58 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, -1990404162)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -379,8 +363,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 60 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 7, 1804603682)
 - *0* unsupported expression
@@ -398,7 +380,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 62 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
+0 -> 62 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, -40341101)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -413,10 +395,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 64 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
+0 -> 64 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, -1502002290)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -431,8 +411,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 66 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, 1236535329)
 - *0* unsupported expression
@@ -450,7 +428,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 68 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, ???*7*)
+0 -> 68 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, -165796510)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -465,10 +443,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 70 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, ???*7*)
+0 -> 70 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, -1069501632)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -483,8 +459,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 72 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 14, 643717713)
 - *0* unsupported expression
@@ -502,7 +476,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 74 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, ???*7*)
+0 -> 74 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, -373897302)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -517,10 +491,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 76 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, ???*7*)
+0 -> 76 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, -701558691)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -535,8 +507,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 78 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, 38016083)
 - *0* unsupported expression
@@ -554,7 +524,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 80 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 14, ???*7*)
+0 -> 80 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 14, -660478335)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -569,10 +539,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 82 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, ???*7*)
+0 -> 82 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, -405537848)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -587,8 +555,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 84 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, 568446438)
 - *0* unsupported expression
@@ -606,7 +572,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 86 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, ???*7*)
+0 -> 86 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, -1019803690)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -621,10 +587,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 88 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 14, ???*7*)
+0 -> 88 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 14, -187363961)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -639,8 +603,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 90 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, 1163531501)
 - *0* unsupported expression
@@ -658,7 +620,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 92 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, ???*7*)
+0 -> 92 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, -1444681467)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -673,10 +635,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 94 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, ???*7*)
+0 -> 94 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, -51403784)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -691,8 +651,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 96 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 14, 1735328473)
 - *0* unsupported expression
@@ -710,7 +668,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 98 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, ???*7*)
+0 -> 98 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, -1926607734)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -725,10 +683,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 100 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, ???*7*)
+0 -> 100 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, -378558)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -743,10 +699,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 102 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, ???*7*)
+0 -> 102 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, -2022574463)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -761,8 +715,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 104 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 16, 1839030562)
 - *0* unsupported expression
@@ -780,7 +732,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 106 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, ???*7*)
+0 -> 106 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, -35309556)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -795,10 +747,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 108 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, ???*7*)
+0 -> 108 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, -1530992060)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -813,8 +763,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 110 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, 1272893353)
 - *0* unsupported expression
@@ -832,7 +780,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 112 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 16, ???*7*)
+0 -> 112 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 16, -155497632)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -847,10 +795,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 114 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, ???*7*)
+0 -> 114 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, -1094730640)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -865,8 +811,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 116 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, 681279174)
 - *0* unsupported expression
@@ -884,7 +828,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 118 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, ???*7*)
+0 -> 118 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, -358537222)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -899,10 +843,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 120 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 16, ???*7*)
+0 -> 120 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 16, -722521979)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -917,8 +859,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 122 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, 76029189)
 - *0* unsupported expression
@@ -936,7 +876,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 124 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, ???*7*)
+0 -> 124 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, -640364487)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -951,10 +891,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 126 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, ???*7*)
+0 -> 126 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, -421815835)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -969,8 +907,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 128 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 16, 530742520)
 - *0* unsupported expression
@@ -988,7 +924,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 130 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, ???*7*)
+0 -> 130 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, -995338651)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1003,10 +939,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 132 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 6, ???*7*)
+0 -> 132 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 6, -198630844)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1021,8 +955,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 134 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, 1126891415)
 - *0* unsupported expression
@@ -1040,7 +972,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 136 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, ???*7*)
+0 -> 136 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, -1416354905)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1055,10 +987,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 138 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, ???*7*)
+0 -> 138 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, -57434055)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1073,8 +1003,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 140 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 6, 1700485571)
 - *0* unsupported expression
@@ -1092,7 +1020,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 142 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, ???*7*)
+0 -> 142 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, -1894986606)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1107,10 +1035,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 144 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, ???*7*)
+0 -> 144 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, -1051523)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1125,10 +1051,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 146 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, ???*7*)
+0 -> 146 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, -2054922799)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1143,8 +1067,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 148 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 6, 1873313359)
 - *0* unsupported expression
@@ -1162,7 +1084,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 150 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, ???*7*)
+0 -> 150 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, -30611744)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1177,10 +1099,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 152 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, ???*7*)
+0 -> 152 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, -1560198380)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1195,8 +1115,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 154 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, 1309151649)
 - *0* unsupported expression
@@ -1214,7 +1132,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 156 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 6, ???*7*)
+0 -> 156 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 6, -145523070)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1229,10 +1147,8 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
-0 -> 158 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, ???*7*)
+0 -> 158 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, -1120210379)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1247,8 +1163,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 160 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, 718787259)
 - *0* unsupported expression
@@ -1266,7 +1180,7 @@
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 162 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, ???*7*)
+0 -> 162 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, -343485551)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1281,8 +1195,6 @@
   ⚠️  unknown object
 - *6* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *7* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 163 call = (...) => ???*0*(???*1*, ???*2*)
 - *0* unsupported expression

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
@@ -6347,11 +6347,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -680876936.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -6685,11 +6689,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -389564586.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -7365,11 +7373,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1044525330.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -7703,11 +7715,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -176418897.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -8383,11 +8399,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1473231341.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -8721,11 +8741,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -45705983.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -9401,11 +9425,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1958414417.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -9739,11 +9767,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -42063.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -10077,11 +10109,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1990404162.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -10757,11 +10793,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -40341101.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -11095,11 +11135,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1502002290.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -11775,11 +11819,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -165796510.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -12113,11 +12161,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1069501632.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -12793,11 +12845,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -373897302.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -13131,11 +13187,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -701558691.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -13811,11 +13871,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -660478335.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -14149,11 +14213,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -405537848.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -14829,11 +14897,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1019803690.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -15167,11 +15239,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -187363961.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -15847,11 +15923,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1444681467.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -16185,11 +16265,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -51403784.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -16865,11 +16949,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1926607734.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -17203,11 +17291,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -378558.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -17541,11 +17633,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -2022574463.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -18221,11 +18317,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -35309556.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -18559,11 +18659,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1530992060.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -19239,11 +19343,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -155497632.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -19577,11 +19685,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1094730640.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -20257,11 +20369,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -358537222.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -20595,11 +20711,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -722521979.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -21275,11 +21395,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -640364487.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -21613,11 +21737,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -421815835.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -22293,11 +22421,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -995338651.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -22631,11 +22763,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -198630844.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -23311,11 +23447,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1416354905.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -23649,11 +23789,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -57434055.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -24329,11 +24473,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1894986606.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -24667,11 +24815,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1051523.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -25005,11 +25157,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -2054922799.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -25685,11 +25841,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -30611744.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -26023,11 +26183,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1560198380.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -26703,11 +26867,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -145523070.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -27041,11 +27209,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1120210379.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [
@@ -27721,11 +27893,15 @@
                 ),
             ),
             Value(
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -343485551.0,
+                            ),
+                        ),
+                    ),
+                ),
             ),
         ],
         ast_path: [

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-explained.snapshot
@@ -30,45 +30,25 @@ a#10 = arguments[0]
 
 a#4 = (
   | 1732584193
-  | FF(a, b, c, d, m[(i + 0)], 7, ???*0*)
-  | FF(a, b, c, d, m[(i + 4)], 7, ???*1*)
+  | FF(a, b, c, d, m[(i + 0)], 7, -680876936)
+  | FF(a, b, c, d, m[(i + 4)], 7, -176418897)
   | FF(a, b, c, d, m[(i + 8)], 7, 1770035416)
   | FF(a, b, c, d, m[(i + 12)], 7, 1804603682)
-  | GG(a, b, c, d, m[(i + 1)], 5, ???*2*)
-  | GG(a, b, c, d, m[(i + 5)], 5, ???*3*)
+  | GG(a, b, c, d, m[(i + 1)], 5, -165796510)
+  | GG(a, b, c, d, m[(i + 5)], 5, -701558691)
   | GG(a, b, c, d, m[(i + 9)], 5, 568446438)
-  | GG(a, b, c, d, m[(i + 13)], 5, ???*4*)
-  | HH(a, b, c, d, m[(i + 5)], 4, ???*5*)
-  | HH(a, b, c, d, m[(i + 1)], 4, ???*6*)
+  | GG(a, b, c, d, m[(i + 13)], 5, -1444681467)
+  | HH(a, b, c, d, m[(i + 5)], 4, -378558)
+  | HH(a, b, c, d, m[(i + 1)], 4, -1530992060)
   | HH(a, b, c, d, m[(i + 13)], 4, 681279174)
-  | HH(a, b, c, d, m[(i + 9)], 4, ???*7*)
-  | II(a, b, c, d, m[(i + 0)], 6, ???*8*)
+  | HH(a, b, c, d, m[(i + 9)], 4, -640364487)
+  | II(a, b, c, d, m[(i + 0)], 6, -198630844)
   | II(a, b, c, d, m[(i + 12)], 6, 1700485571)
   | II(a, b, c, d, m[(i + 8)], 6, 1873313359)
-  | II(a, b, c, d, m[(i + 4)], 6, ???*9*)
-  | ???*10*
+  | II(a, b, c, d, m[(i + 4)], 6, -145523070)
+  | ???*0*
 )
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
   ⚠️  This value might have side effects
 
 a#7 = arguments[0]
@@ -82,49 +62,26 @@ aa = (a | undefined)
 b#10 = arguments[1]
 
 b#4 = (
-  | ???*0*
-  | FF(b, c, d, a, m[(i + 3)], 22, ???*1*)
-  | FF(b, c, d, a, m[(i + 7)], 22, ???*2*)
-  | FF(b, c, d, a, m[(i + 11)], 22, ???*3*)
+  | -271733879
+  | FF(b, c, d, a, m[(i + 3)], 22, -1044525330)
+  | FF(b, c, d, a, m[(i + 7)], 22, -45705983)
+  | FF(b, c, d, a, m[(i + 11)], 22, -1990404162)
   | FF(b, c, d, a, m[(i + 15)], 22, 1236535329)
-  | GG(b, c, d, a, m[(i + 0)], 20, ???*4*)
-  | GG(b, c, d, a, m[(i + 4)], 20, ???*5*)
+  | GG(b, c, d, a, m[(i + 0)], 20, -373897302)
+  | GG(b, c, d, a, m[(i + 4)], 20, -405537848)
   | GG(b, c, d, a, m[(i + 8)], 20, 1163531501)
-  | GG(b, c, d, a, m[(i + 12)], 20, ???*6*)
-  | HH(b, c, d, a, m[(i + 14)], 23, ???*7*)
-  | HH(b, c, d, a, m[(i + 10)], 23, ???*8*)
+  | GG(b, c, d, a, m[(i + 12)], 20, -1926607734)
+  | HH(b, c, d, a, m[(i + 14)], 23, -35309556)
+  | HH(b, c, d, a, m[(i + 10)], 23, -1094730640)
   | HH(b, c, d, a, m[(i + 6)], 23, 76029189)
-  | HH(b, c, d, a, m[(i + 2)], 23, ???*9*)
-  | II(b, c, d, a, m[(i + 5)], 21, ???*10*)
-  | II(b, c, d, a, m[(i + 1)], 21, ???*11*)
+  | HH(b, c, d, a, m[(i + 2)], 23, -995338651)
+  | II(b, c, d, a, m[(i + 5)], 21, -57434055)
+  | II(b, c, d, a, m[(i + 1)], 21, -2054922799)
   | II(b, c, d, a, m[(i + 13)], 21, 1309151649)
-  | II(b, c, d, a, m[(i + 9)], 21, ???*12*)
+  | II(b, c, d, a, m[(i + 9)], 21, -343485551)
+  | ???*0*
 )
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* unsupported expression
   ⚠️  This value might have side effects
 
 b#7 = arguments[1]
@@ -140,45 +97,26 @@ bin = FreeVar(require)("charenc")["bin"]
 c#10 = arguments[2]
 
 c#4 = (
-  | ???*0*
+  | -1732584194
   | FF(c, d, a, b, m[(i + 2)], 17, 606105819)
-  | FF(c, d, a, b, m[(i + 6)], 17, ???*1*)
-  | FF(c, d, a, b, m[(i + 10)], 17, ???*2*)
-  | FF(c, d, a, b, m[(i + 14)], 17, ???*3*)
+  | FF(c, d, a, b, m[(i + 6)], 17, -1473231341)
+  | FF(c, d, a, b, m[(i + 10)], 17, -42063)
+  | FF(c, d, a, b, m[(i + 14)], 17, -1502002290)
   | GG(c, d, a, b, m[(i + 11)], 14, 643717713)
-  | GG(c, d, a, b, m[(i + 15)], 14, ???*4*)
-  | GG(c, d, a, b, m[(i + 3)], 14, ???*5*)
+  | GG(c, d, a, b, m[(i + 15)], 14, -660478335)
+  | GG(c, d, a, b, m[(i + 3)], 14, -187363961)
   | GG(c, d, a, b, m[(i + 7)], 14, 1735328473)
   | HH(c, d, a, b, m[(i + 11)], 16, 1839030562)
-  | HH(c, d, a, b, m[(i + 7)], 16, ???*6*)
-  | HH(c, d, a, b, m[(i + 3)], 16, ???*7*)
+  | HH(c, d, a, b, m[(i + 7)], 16, -155497632)
+  | HH(c, d, a, b, m[(i + 3)], 16, -722521979)
   | HH(c, d, a, b, m[(i + 15)], 16, 530742520)
-  | II(c, d, a, b, m[(i + 14)], 15, ???*8*)
-  | II(c, d, a, b, m[(i + 10)], 15, ???*9*)
-  | II(c, d, a, b, m[(i + 6)], 15, ???*10*)
+  | II(c, d, a, b, m[(i + 14)], 15, -1416354905)
+  | II(c, d, a, b, m[(i + 10)], 15, -1051523)
+  | II(c, d, a, b, m[(i + 6)], 15, -1560198380)
   | II(c, d, a, b, m[(i + 2)], 15, 718787259)
+  | ???*0*
 )
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
   ⚠️  This value might have side effects
 
 c#7 = arguments[2]
@@ -195,49 +133,25 @@ d#10 = arguments[3]
 
 d#4 = (
   | 271733878
-  | FF(d, a, b, c, m[(i + 1)], 12, ???*0*)
+  | FF(d, a, b, c, m[(i + 1)], 12, -389564586)
   | FF(d, a, b, c, m[(i + 5)], 12, 1200080426)
-  | FF(d, a, b, c, m[(i + 9)], 12, ???*1*)
-  | FF(d, a, b, c, m[(i + 13)], 12, ???*2*)
-  | GG(d, a, b, c, m[(i + 6)], 9, ???*3*)
+  | FF(d, a, b, c, m[(i + 9)], 12, -1958414417)
+  | FF(d, a, b, c, m[(i + 13)], 12, -40341101)
+  | GG(d, a, b, c, m[(i + 6)], 9, -1069501632)
   | GG(d, a, b, c, m[(i + 10)], 9, 38016083)
-  | GG(d, a, b, c, m[(i + 14)], 9, ???*4*)
-  | GG(d, a, b, c, m[(i + 2)], 9, ???*5*)
-  | HH(d, a, b, c, m[(i + 8)], 11, ???*6*)
+  | GG(d, a, b, c, m[(i + 14)], 9, -1019803690)
+  | GG(d, a, b, c, m[(i + 2)], 9, -51403784)
+  | HH(d, a, b, c, m[(i + 8)], 11, -2022574463)
   | HH(d, a, b, c, m[(i + 4)], 11, 1272893353)
-  | HH(d, a, b, c, m[(i + 0)], 11, ???*7*)
-  | HH(d, a, b, c, m[(i + 12)], 11, ???*8*)
+  | HH(d, a, b, c, m[(i + 0)], 11, -358537222)
+  | HH(d, a, b, c, m[(i + 12)], 11, -421815835)
   | II(d, a, b, c, m[(i + 7)], 10, 1126891415)
-  | II(d, a, b, c, m[(i + 3)], 10, ???*9*)
-  | II(d, a, b, c, m[(i + 15)], 10, ???*10*)
-  | II(d, a, b, c, m[(i + 11)], 10, ???*11*)
-  | ???*12*
+  | II(d, a, b, c, m[(i + 3)], 10, -1894986606)
+  | II(d, a, b, c, m[(i + 15)], 10, -30611744)
+  | II(d, a, b, c, m[(i + 11)], 10, -1120210379)
+  | ???*0*
 )
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* unsupported expression
   ⚠️  This value might have side effects
 
 d#7 = arguments[3]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -437,11 +437,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -680876936.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -515,11 +519,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -176418897.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -757,11 +765,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -165796510.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -835,11 +847,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -701558691.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -995,11 +1011,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1444681467.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1073,11 +1093,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -378558.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1151,11 +1175,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1530992060.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1311,11 +1339,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -640364487.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1389,11 +1421,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -198630844.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1631,11 +1667,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -145523070.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Unknown {
@@ -1696,13 +1736,17 @@
     (
         "b#4",
         Alternatives {
-            total_nodes: 210,
+            total_nodes: 211,
             values: [
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -271733879.0,
+                            ),
+                        ),
+                    ),
+                ),
                 Call(
                     13,
                     Variable(
@@ -1774,11 +1818,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1044525330.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1852,11 +1900,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -45705983.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -1930,11 +1982,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1990404162.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2090,11 +2146,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -373897302.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2168,11 +2228,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -405537848.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2328,11 +2392,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1926607734.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2406,11 +2474,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -35309556.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2484,11 +2556,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1094730640.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2644,11 +2720,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -995338651.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2722,11 +2802,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -57434055.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2800,11 +2884,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -2054922799.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -2960,13 +3048,22 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -343485551.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
+                Unknown {
+                    original_value: None,
+                    reason: "unsupported expression",
+                    has_side_effects: true,
+                },
             ],
             logical_property: None,
         },
@@ -3048,13 +3145,17 @@
     (
         "c#4",
         Alternatives {
-            total_nodes: 210,
+            total_nodes: 211,
             values: [
-                Unknown {
-                    original_value: None,
-                    reason: "unsupported expression",
-                    has_side_effects: true,
-                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                -1732584194.0,
+                            ),
+                        ),
+                    ),
+                ),
                 Call(
                     13,
                     Variable(
@@ -3208,11 +3309,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1473231341.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -3286,11 +3391,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -42063.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -3364,11 +3473,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1502002290.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -3524,11 +3637,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -660478335.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -3602,11 +3719,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -187363961.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -3844,11 +3965,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -155497632.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -3922,11 +4047,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -722521979.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4082,11 +4211,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1416354905.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4160,11 +4293,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1051523.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4238,11 +4375,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1560198380.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4327,6 +4468,11 @@
                         ),
                     ],
                 ),
+                Unknown {
+                    original_value: None,
+                    reason: "unsupported expression",
+                    has_side_effects: true,
+                },
             ],
             logical_property: None,
         },
@@ -4480,11 +4626,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -389564586.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4640,11 +4790,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1958414417.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4718,11 +4872,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -40341101.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4796,11 +4954,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1069501632.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -4956,11 +5118,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1019803690.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -5034,11 +5200,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -51403784.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -5112,11 +5282,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -2022574463.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -5272,11 +5446,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -358537222.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -5350,11 +5528,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -421815835.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -5510,11 +5692,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1894986606.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -5588,11 +5774,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -30611744.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Call(
@@ -5666,11 +5856,15 @@
                                 ),
                             ),
                         ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        -1120210379.0,
+                                    ),
+                                ),
+                            ),
+                        ),
                     ],
                 ),
                 Unknown {

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-effects.snapshot
@@ -326,7 +326,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 0)],
     7,
-    ???*14*
+    -680876936
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -360,8 +360,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 52 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -370,7 +368,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 1)],
     12,
-    ???*14*
+    -389564586
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -404,8 +402,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 54 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -456,7 +452,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 3)],
     22,
-    ???*14*
+    -1044525330
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -490,8 +486,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 58 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -500,7 +494,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 4)],
     7,
-    ???*14*
+    -176418897
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -534,8 +528,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 60 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -586,7 +578,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 6)],
     17,
-    ???*14*
+    -1473231341
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -620,8 +612,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 64 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -630,7 +620,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 7)],
     22,
-    ???*14*
+    -45705983
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -664,8 +654,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 66 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -716,7 +704,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 9)],
     12,
-    ???*14*
+    -1958414417
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -750,8 +738,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 70 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -760,7 +746,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 10)],
     17,
-    ???*14*
+    -42063
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -794,8 +780,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 72 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -804,7 +788,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 11)],
     22,
-    ???*14*
+    -1990404162
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -838,8 +822,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 74 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -890,7 +872,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 13)],
     12,
-    ???*14*
+    -40341101
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -924,8 +906,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 78 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -934,7 +914,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 14)],
     17,
-    ???*14*
+    -1502002290
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -968,8 +948,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 80 call = (...) => crypt["endian"]([a, b, c, d])["_ff"](
     ???*0*,
@@ -1020,7 +998,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 1)],
     5,
-    ???*14*
+    -165796510
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1054,8 +1032,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 84 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1064,7 +1040,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 6)],
     9,
-    ???*14*
+    -1069501632
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1098,8 +1074,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 86 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1150,7 +1124,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 0)],
     20,
-    ???*14*
+    -373897302
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1184,8 +1158,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 90 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1194,7 +1166,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 5)],
     5,
-    ???*14*
+    -701558691
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1228,8 +1200,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 92 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1280,7 +1250,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 15)],
     14,
-    ???*14*
+    -660478335
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1314,8 +1284,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 96 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1324,7 +1292,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 4)],
     20,
-    ???*14*
+    -405537848
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1358,8 +1326,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 98 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1410,7 +1376,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 14)],
     9,
-    ???*14*
+    -1019803690
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1444,8 +1410,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 102 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1454,7 +1418,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 3)],
     14,
-    ???*14*
+    -187363961
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1488,8 +1452,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 104 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1540,7 +1502,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 13)],
     5,
-    ???*14*
+    -1444681467
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1574,8 +1536,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 108 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1584,7 +1544,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 2)],
     9,
-    ???*14*
+    -51403784
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1618,8 +1578,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 110 call = (...) => crypt["endian"]([a, b, c, d])["_gg"](
     ???*0*,
@@ -1670,7 +1628,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 12)],
     20,
-    ???*14*
+    -1926607734
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1704,8 +1662,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 114 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -1714,7 +1670,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 5)],
     4,
-    ???*14*
+    -378558
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1748,8 +1704,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 116 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -1758,7 +1712,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 8)],
     11,
-    ???*14*
+    -2022574463
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1792,8 +1746,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 118 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -1844,7 +1796,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 14)],
     23,
-    ???*14*
+    -35309556
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1878,8 +1830,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 122 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -1888,7 +1838,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 1)],
     4,
-    ???*14*
+    -1530992060
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -1922,8 +1872,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 124 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -1974,7 +1922,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 7)],
     16,
-    ???*14*
+    -155497632
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2008,8 +1956,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 128 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -2018,7 +1964,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 10)],
     23,
-    ???*14*
+    -1094730640
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2052,8 +1998,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 130 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -2104,7 +2048,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 0)],
     11,
-    ???*14*
+    -358537222
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2138,8 +2082,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 134 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -2148,7 +2090,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 3)],
     16,
-    ???*14*
+    -722521979
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2182,8 +2124,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 136 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -2234,7 +2174,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 9)],
     4,
-    ???*14*
+    -640364487
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2268,8 +2208,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 140 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -2278,7 +2216,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 12)],
     11,
-    ???*14*
+    -421815835
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2312,8 +2250,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 142 call = (...) => crypt["endian"]([a, b, c, d])["_hh"](
     ???*0*,
@@ -2364,7 +2300,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 2)],
     23,
-    ???*14*
+    -995338651
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2398,8 +2334,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 146 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2408,7 +2342,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 0)],
     6,
-    ???*14*
+    -198630844
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2442,8 +2376,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 148 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2494,7 +2426,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 14)],
     15,
-    ???*14*
+    -1416354905
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2528,8 +2460,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 152 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2538,7 +2468,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 5)],
     21,
-    ???*14*
+    -57434055
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2572,8 +2502,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 154 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2624,7 +2552,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 3)],
     10,
-    ???*14*
+    -1894986606
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2658,8 +2586,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 158 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2668,7 +2594,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 10)],
     15,
-    ???*14*
+    -1051523
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2702,8 +2628,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 160 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2712,7 +2636,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 1)],
     21,
-    ???*14*
+    -2054922799
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2746,8 +2670,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 162 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2798,7 +2720,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 15)],
     10,
-    ???*14*
+    -30611744
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2832,8 +2754,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 166 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2842,7 +2762,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 6)],
     15,
-    ???*14*
+    -1560198380
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2876,8 +2796,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 168 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2928,7 +2846,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 4)],
     6,
-    ???*14*
+    -145523070
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -2962,8 +2880,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 172 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -2972,7 +2888,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 11)],
     10,
-    ???*14*
+    -1120210379
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -3006,8 +2922,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 174 call = (...) => crypt["endian"]([a, b, c, d])["_ii"](
     ???*0*,
@@ -3058,7 +2972,7 @@
     ???*3*,
     module<crypt, {}>["bytesToWords"]((???*4* | ???*5* | ???*7*))[((0 | ???*11* | ???*12*) + 9)],
     21,
-    ???*14*
+    -343485551
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
@@ -3092,8 +3006,6 @@
   ⚠️  nested operation
 - *13* i
   ⚠️  circular variable reference
-- *14* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 178 member call = module<crypt, {}>["endian"]([???*0*, ???*1*, ???*2*, ???*3*])
 - *0* max number of linking steps reached

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-explained.snapshot
@@ -255,12 +255,10 @@ describeExpectation = (...) => DESCRIBE_EXPECTATION_FNS[expectation["type"]](exp
 describeExpected = (...) => (
   | descriptions[0]
   | `${descriptions[0]} or ${descriptions[1]}`
-  | `${descriptions["slice"](0, ???*0*)["join"](", ")}, or ${descriptions[???*1*]}`
+  | `${descriptions["slice"](0, -1)["join"](", ")}, or ${descriptions[???*0*]}`
   | undefined
 )
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
   ⚠️  This value might have side effects
 
 describeFound = (...) => (found ? `"${literalEscape(found)}"` : "end of input")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-effects.snapshot
@@ -41,14 +41,12 @@
 0 -> 23 call = (...) => (
   | descriptions[0]
   | `${descriptions[0]} or ${descriptions[1]}`
-  | `${descriptions["slice"](0, ???*0*)["join"](", ")}, or ${descriptions[???*1*]}`
+  | `${descriptions["slice"](0, -1)["join"](", ")}, or ${descriptions[???*0*]}`
   | undefined
-)(???*2*)
+)(???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* arguments[0]
+- *1* arguments[0]
   ⚠️  function calls are not analyzed yet
 
 0 -> 24 call = (...) => (found ? `"${literalEscape(found)}"` : "end of input")(???*0*)
@@ -443,7 +441,7 @@
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 134 member call = new ???*0*(???*1*)["slice"](0, ???*3*)
+0 -> 134 member call = new ???*0*(???*1*)["slice"](0, -1)
 - *0* FreeVar(Array)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -451,13 +449,10 @@
   ⚠️  unknown object
 - *2* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *3* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 135 member call = ???*0*["join"](", ")
-- *0* ???*1*(0, ???*6*)
+- *0* ???*1*(0, -1)
   ⚠️  unknown callee
-  ⚠️  This value might have side effects
 - *1* ???*2*["slice"]
   ⚠️  unknown object
 - *2* new ???*3*(???*4*)
@@ -469,8 +464,6 @@
   ⚠️  unknown object
 - *5* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *6* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 138 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
@@ -299,12 +299,10 @@ describeExpectation = (...) => DESCRIBE_EXPECTATION_FNS[expectation["type"]](exp
 describeExpected = (...) => (
   | descriptions[0]
   | `${descriptions[0]} or ${descriptions[1]}`
-  | `${descriptions["slice"](0, ???*0*)["join"](", ")}, or ${descriptions[???*1*]}`
+  | `${descriptions["slice"](0, -1)["join"](", ")}, or ${descriptions[???*0*]}`
   | undefined
 )
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
   ⚠️  This value might have side effects
 
 describeFound = (...) => (found ? `"${literalEscape(found)}"` : "end of input")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
@@ -399,9 +399,7 @@ Bj (const after eval) = (???*0* | *anonymous function 86340*)
 - *0* Bj
   ⚠️  pattern without value
 
-Bk = (???*0* | B())
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+Bk = (-1 | B())
 
 C = (
   | 0
@@ -763,12 +761,10 @@ Kj = (!(1) | g | h)
 
 Kk (const after eval) = (...) => ((null === a) ? ai : a)
 
-L (const after eval) = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))
+L (const after eval) = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 La = (???*0* | ((b && b[1]) || ""))
@@ -1153,10 +1149,8 @@ Td (const after eval) = rd(Sd)
 
 Te = (!(1) | !(0))
 
-Tf = (???*0* | ???*1*)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* updated with update expression
+Tf = (-1 | ???*0*)
+- *0* updated with update expression
   ⚠️  This value might have side effects
 
 Tg (const after eval) = (...) => undefined
@@ -3030,9 +3024,7 @@ b#587 = (
 - *0* b
   ⚠️  pattern without value
 
-b#589 = (arguments[1] | ch(???*0*, 1))
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+b#589 = (arguments[1] | ch(-1, 1))
 
 b#590 = arguments[1]
 
@@ -3704,13 +3696,9 @@ c#576 = ???*0*
 - *0* c
   ⚠️  pattern without value
 
-c#578 = (arguments[2] | ch(???*0*, c))
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+c#578 = (arguments[2] | ch(-1, c))
 
-c#580 = (arguments[2] | ch(???*0*, c))
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+c#580 = (arguments[2] | ch(-1, c))
 
 c#584 = b["stack"]
 
@@ -3793,14 +3781,10 @@ c#673 = (
   | a["ownerDocument"]
   | d["anchorNode"]
   | null
-  | (((???*1* === h) || (???*2* === k)) ? null : {"start": h, "end": k})
+  | (((-1 === h) || (-1 === k)) ? null : {"start": h, "end": k})
   | (c || {"start": 0, "end": 0})
 )
 - *0* assignment expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
   ⚠️  This value might have side effects
 
 c#68 = b["checked"]
@@ -4763,9 +4747,7 @@ e#77 = (0 | undefined | ???*0* | b["hasOwnProperty"](`$${a[c]["value"]}`))
 
 e#785 = (b["return"] | undefined)
 
-e#807 = (K | undefined | xc(a) | a["current"]["alternate"] | a["suspendedLanes"] | ???*0* | g)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+e#807 = (K | undefined | xc(a) | a["current"]["alternate"] | a["suspendedLanes"] | -1 | g)
 
 e#819 = (c[d] | undefined | e["value"])
 
@@ -5312,9 +5294,7 @@ gc (const after eval) = ca["unstable_UserBlockingPriority"]
 
 gd (const after eval) = (...) => undefined
 
-ge (const after eval) = (...) => ((???*0* !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+ge (const after eval) = (...) => ((-1 !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)
 
 gf (const after eval) = (0 | ???*0*)
 - *0* updated with update expression
@@ -5424,9 +5404,7 @@ h#639 = (e[l] | undefined | ((null != e) ? e[l] : undefined) | (h ? h["__html"] 
 
 h#647 = (f[g] | undefined | e)
 
-h#673 = (???*0* | undefined | (g + e) | g)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+h#673 = (-1 | undefined | (g + e) | g)
 
 h#708 = ???*0*
 - *0* h
@@ -5626,9 +5604,7 @@ k#639 = (d[l] | undefined | (k ? k["__html"] : undefined))
 
 k#647 = (h[f] | undefined | (k ? k["__html"] : undefined))
 
-k#673 = (???*0* | undefined | (g + d) | g)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+k#673 = (-1 | undefined | (g + d) | g)
 
 k#716 = (e["alternate"] | undefined)
 
@@ -5672,10 +5648,8 @@ k#883 = (0 | undefined | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-k#919 = (h["firstContext"] | undefined | ch(???*0*, ???*1*) | f["alternate"] | k["next"])
+k#919 = (h["firstContext"] | undefined | ch(-1, ???*0*) | f["alternate"] | k["next"])
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
   ⚠️  This value might have side effects
 
 k#953 = arguments[8]
@@ -6478,9 +6452,7 @@ va (const after eval) = FreeVar(Symbol)["for"]("react.element")
 
 vb (const after eval) = (...) => (("string" === typeof(b["is"])) | !(1) | !(0) | undefined)
 
-vc (const after eval) = (...) => ((b + 250) | (b + 5000) | ???*0* | undefined)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+vc (const after eval) = (...) => ((b + 250) | (b + 5000) | -1 | undefined)
 
 vd (const after eval) = rd(ud)
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
@@ -67,12 +67,10 @@
 - *7* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-16 -> 17 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+16 -> 17 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 16 -> 18 call = (...) => undefined((???*0* ? ???*4* : null), ???*7*, 1, ((???*8* ? ???*10* : ???*11*) | undefined))
@@ -98,21 +96,15 @@
   ⚠️  This value might have side effects
 - *10* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* (???*12* ? (???*16* | ???*17*) : ???*18*)
+- *11* (???*12* ? (-1 | ???*14*) : ???*15*)
   ⚠️  nested operation
-- *12* (???*13* !== (???*14* | ???*15*))
+- *12* (-1 !== (-1 | ???*13*))
   ⚠️  nested operation
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* module<scheduler, {}>["unstable_now"]()
+- *13* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* module<scheduler, {}>["unstable_now"]()
+- *14* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *18* assignment expression
+- *15* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 19 call = (...) => undefined(???*0*, 1)
@@ -147,12 +139,10 @@
 - *7* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-23 -> 24 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+23 -> 24 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 23 -> 25 call = (...) => undefined(
@@ -183,21 +173,15 @@
   ⚠️  This value might have side effects
 - *10* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* (???*12* ? (???*16* | ???*17*) : ???*18*)
+- *11* (???*12* ? (-1 | ???*14*) : ???*15*)
   ⚠️  nested operation
-- *12* (???*13* !== (???*14* | ???*15*))
+- *12* (-1 !== (-1 | ???*13*))
   ⚠️  nested operation
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* module<scheduler, {}>["unstable_now"]()
+- *13* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* module<scheduler, {}>["unstable_now"]()
+- *14* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *18* assignment expression
+- *15* assignment expression
   ⚠️  This value might have side effects
 
 21 -> 26 call = (...) => undefined(???*0*, 134217728)
@@ -306,12 +290,10 @@
 - *7* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-31 -> 32 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+31 -> 32 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 31 -> 33 call = (...) => undefined(
@@ -404,21 +386,15 @@
   ⚠️  This value might have side effects
 - *33* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *34* (???*35* ? (???*39* | ???*40*) : ???*41*)
+- *34* (???*35* ? (-1 | ???*37*) : ???*38*)
   ⚠️  nested operation
-- *35* (???*36* !== (???*37* | ???*38*))
+- *35* (-1 !== (-1 | ???*36*))
   ⚠️  nested operation
-- *36* unsupported expression
-  ⚠️  This value might have side effects
-- *37* unsupported expression
-  ⚠️  This value might have side effects
-- *38* module<scheduler, {}>["unstable_now"]()
+- *36* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* module<scheduler, {}>["unstable_now"]()
+- *37* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *41* assignment expression
+- *38* assignment expression
   ⚠️  This value might have side effects
 
 28 -> 34 call = (...) => undefined(
@@ -6872,12 +6848,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 1046 conditional = (???*0* === ???*1*)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* ???*2*["indexOf"]("-")
+0 -> 1046 conditional = (-1 === ???*0*)
+- *0* ???*1*["indexOf"]("-")
   ⚠️  unknown callee object
-- *2* arguments[0]
+- *1* arguments[0]
   ⚠️  function calls are not analyzed yet
 
 1046 -> 1047 typeof = typeof(???*0*)
@@ -8684,14 +8658,12 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *8* unsupported assign operation
   ⚠️  This value might have side effects
 
-0 -> 1308 conditional = (???*0* === (???*1* | undefined))
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* ???*2*[g]
+0 -> 1308 conditional = (-1 === (???*0* | undefined))
+- *0* ???*1*[g]
   ⚠️  unknown object
-- *2* ???*3*["expirationTimes"]
+- *1* ???*2*["expirationTimes"]
   ⚠️  unknown object
-- *3* arguments[0]
+- *2* arguments[0]
   ⚠️  function calls are not analyzed yet
 
 1308 -> 1309 conditional = ((0 === ???*0*) | (0 !== ???*1*))
@@ -8700,12 +8672,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-1309 -> 1311 call = (...) => ((b + 250) | (b + 5000) | ???*0* | undefined)((???*1* | undefined), ???*2*)
+1309 -> 1311 call = (...) => ((b + 250) | (b + 5000) | -1 | undefined)((???*0* | undefined), ???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* arguments[1]
+- *1* arguments[1]
   ⚠️  function calls are not analyzed yet
 
 0 -> 1314 conditional = (0 !== (???*0* | ???*1*))
@@ -12258,48 +12228,46 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 
 0 -> 1740 conditional = (false | true)
 
-1740 -> 1741 call = (...) => ((???*0* !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)((???*1* | null | ???*2* | ???*15*), ???*16*)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* arguments[0]
+1740 -> 1741 call = (...) => ((-1 !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)((???*0* | null | ???*1* | ???*14*), ???*15*)
+- *0* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *2* ???*3*((???*10* | 0 | ???*11*), ???*12*)
+- *1* ???*2*((???*9* | 0 | ???*10*), ???*11*)
   ⚠️  unknown callee
   ⚠️  This value might have side effects
-- *3* ???*4*["slice"]
+- *2* ???*3*["slice"]
   ⚠️  unknown object
-- *4* (???*5* ? (null["value"] | ???*6*) : (null["textContent"] | ???*8*))
+- *3* (???*4* ? (null["value"] | ???*5*) : (null["textContent"] | ???*7*))
   ⚠️  nested operation
-- *5* unsupported expression
+- *4* unsupported expression
   ⚠️  This value might have side effects
-- *6* ???*7*["value"]
+- *5* ???*6*["value"]
   ⚠️  unknown object
-- *7* (??? ? (??? | ???) : (??? | ??? | ???))
+- *6* (??? ? (??? | ???) : (??? | ??? | ???))
   ⚠️  nested operation
-- *8* ???*9*["textContent"]
+- *7* ???*8*["textContent"]
   ⚠️  unknown object
-- *9* (??? ? (??? | ???) : (??? | ??? | ???))
+- *8* (??? ? (??? | ???) : (??? | ??? | ???))
   ⚠️  nested operation
-- *10* a
+- *9* a
   ⚠️  pattern without value
-- *11* updated with update expression
+- *10* updated with update expression
   ⚠️  This value might have side effects
-- *12* (???*13* ? ???*14* : undefined)
+- *11* (???*12* ? ???*13* : undefined)
   ⚠️  nested operation
+- *12* unsupported expression
+  ⚠️  This value might have side effects
 - *13* unsupported expression
   ⚠️  This value might have side effects
-- *14* unsupported expression
+- *14* assignment expression
   ⚠️  This value might have side effects
-- *15* assignment expression
-  ⚠️  This value might have side effects
-- *16* arguments[1]
+- *15* arguments[1]
   ⚠️  function calls are not analyzed yet
 
 1740 -> 1742 conditional = (
   | ("compositionend" === (???*0* | null | ???*1* | ???*14*))
   | !((???*15* | ???*19*))
-  | (???*20* !== ???*21*)
-  | (229 !== ???*25*)
+  | (-1 !== ???*20*)
+  | (229 !== ???*24*)
   | true
   | false
   | undefined
@@ -12346,19 +12314,17 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *19* unsupported expression
   ⚠️  This value might have side effects
-- *20* unsupported expression
-  ⚠️  This value might have side effects
-- *21* ???*22*(???*23*)
+- *20* ???*21*(???*22*)
   ⚠️  unknown callee
-- *22* [9, 13, 27, 32]["indexOf"]
+- *21* [9, 13, 27, 32]["indexOf"]
   ⚠️  non-num constant property on array
-- *23* ???*24*["keyCode"]
+- *22* ???*23*["keyCode"]
   ⚠️  unknown object
-- *24* arguments[1]
+- *23* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *25* ???*26*["keyCode"]
+- *24* ???*25*["keyCode"]
   ⚠️  unknown object
-- *26* arguments[1]
+- *25* arguments[1]
   ⚠️  function calls are not analyzed yet
 
 1742 -> 1743 call = (...) => (md | ???*0*)()
@@ -16047,12 +16013,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 
 2330 -> 2332 conditional = (false | true)
 
-2332 -> 2333 call = (...) => ((???*0* !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)(???*1*, ???*2*)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* arguments[0]
+2332 -> 2333 call = (...) => ((-1 !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)(???*0*, ???*1*)
+- *0* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *2* arguments[2]
+- *1* arguments[2]
   ⚠️  function calls are not analyzed yet
 
 2253 -> 2336 conditional = (
@@ -20104,12 +20068,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 2978 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 2978 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 2979 call = (...) => (1 | ???*0* | ???*1* | a)((???*2* | ???*3*))
@@ -20129,18 +20091,18 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
     (???*0* ? ???*2* : ???*3*),
     (
       | 1
+      | ???*8*
+      | ???*9*
+      | ???*10*
       | ???*11*
-      | ???*12*
-      | ???*13*
-      | ???*14*
       | 0
-      | ???*16*
+      | ???*13*
       | 4
       | undefined
-      | ((???*17* | ???*19*) ? ???*20* : 4)
-      | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-      | ???*32*
-      | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*14* | ???*16*) ? ???*17* : 4)
+      | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+      | ???*29*
+      | (???*31* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     )
 )
 - *0* (0 !== ???*1*)
@@ -20149,18 +20111,128 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* assignment expression
   ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *8* unsupported expression
   ⚠️  This value might have side effects
+- *9* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *10* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *11* ???*12*["_reactInternals"]
+  ⚠️  unknown object
+- *12* a
+  ⚠️  circular variable reference
+- *13* C
+  ⚠️  circular variable reference
+- *14* (0 !== ???*15*)
+  ⚠️  nested operation
+- *15* C
+  ⚠️  circular variable reference
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* C
+  ⚠️  circular variable reference
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* (???*20* ? ???*21* : 1)
+  ⚠️  nested operation
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
+  ⚠️  nested operation
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *27* ???*28*["value"]
+  ⚠️  unknown object
+- *28* arguments[1]
+  ⚠️  function calls are not analyzed yet
+- *29* ???*30*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *31* (undefined === ???*32*)
+  ⚠️  nested operation
+- *32* a
+  ⚠️  circular variable reference
+
+0 -> 2983 call = (...) => (null | Zg(a, c))(
+    (???*0* | ???*1*),
+    {
+        "eventTime": (???*3* ? ???*5* : ???*6*),
+        "lane": (
+          | 1
+          | ???*11*
+          | ???*12*
+          | ???*13*
+          | ???*14*
+          | 0
+          | ???*16*
+          | 4
+          | undefined
+          | ((???*17* | ???*19*) ? ???*20* : 4)
+          | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
+          | ???*32*
+          | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+        ),
+        "tag": 0,
+        "payload": null,
+        "callback": null,
+        "next": null
+    },
+    (
+      | 1
+      | ???*36*
+      | ???*37*
+      | ???*38*
+      | ???*39*
+      | 0
+      | ???*41*
+      | 4
+      | undefined
+      | ((???*42* | ???*44*) ? ???*45* : 4)
+      | (???*46* ? 16 : (???*47* | undefined | null | ???*54* | ???*55*))
+      | ???*57*
+      | (???*59* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+    )
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *1* ???*2*["_reactInternals"]
+  ⚠️  unknown object
+- *2* a
+  ⚠️  circular variable reference
+- *3* (0 !== ???*4*)
+  ⚠️  nested operation
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* (???*7* ? (-1 | ???*9*) : ???*10*)
+  ⚠️  nested operation
+- *7* (-1 !== (-1 | ???*8*))
+  ⚠️  nested operation
+- *8* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
 - *9* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *10* assignment expression
@@ -20218,180 +20290,58 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  nested operation
 - *35* a
   ⚠️  circular variable reference
-
-0 -> 2983 call = (...) => (null | Zg(a, c))(
-    (???*0* | ???*1*),
-    {
-        "eventTime": (???*3* ? ???*5* : ???*6*),
-        "lane": (
-          | 1
-          | ???*14*
-          | ???*15*
-          | ???*16*
-          | ???*17*
-          | 0
-          | ???*19*
-          | 4
-          | undefined
-          | ((???*20* | ???*22*) ? ???*23* : 4)
-          | (???*24* ? 16 : (???*25* | undefined | null | ???*32* | ???*33*))
-          | ???*35*
-          | (???*37* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-        ),
-        "tag": 0,
-        "payload": null,
-        "callback": null,
-        "next": null
-    },
-    (
-      | 1
-      | ???*39*
-      | ???*40*
-      | ???*41*
-      | ???*42*
-      | 0
-      | ???*44*
-      | 4
-      | undefined
-      | ((???*45* | ???*47*) ? ???*48* : 4)
-      | (???*49* ? 16 : (???*50* | undefined | null | ???*57* | ???*58*))
-      | ???*60*
-      | (???*62* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-    )
-)
-- *0* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *1* ???*2*["_reactInternals"]
-  ⚠️  unknown object
-- *2* a
-  ⚠️  circular variable reference
-- *3* (0 !== ???*4*)
-  ⚠️  nested operation
-- *4* unsupported expression
+- *36* unsupported expression
   ⚠️  This value might have side effects
-- *5* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *6* (???*7* ? (???*11* | ???*12*) : ???*13*)
-  ⚠️  nested operation
-- *7* (???*8* !== (???*9* | ???*10*))
-  ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *13* assignment expression
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* Ck
+- *37* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *16* arguments[0]
+- *38* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *17* ???*18*["_reactInternals"]
+- *39* ???*40*["_reactInternals"]
   ⚠️  unknown object
-- *18* a
+- *40* a
   ⚠️  circular variable reference
-- *19* C
+- *41* C
   ⚠️  circular variable reference
-- *20* (0 !== ???*21*)
+- *42* (0 !== ???*43*)
   ⚠️  nested operation
-- *21* C
+- *43* C
   ⚠️  circular variable reference
-- *22* unsupported expression
+- *44* unsupported expression
   ⚠️  This value might have side effects
-- *23* C
+- *45* C
   ⚠️  circular variable reference
-- *24* unsupported expression
+- *46* unsupported expression
   ⚠️  This value might have side effects
-- *25* (???*26* ? ???*27* : 1)
+- *47* (???*48* ? ???*49* : 1)
   ⚠️  nested operation
-- *26* unsupported expression
+- *48* unsupported expression
   ⚠️  This value might have side effects
-- *27* (???*28* ? ???*29* : 4)
+- *49* (???*50* ? ???*51* : 4)
   ⚠️  nested operation
-- *28* unsupported expression
+- *50* unsupported expression
   ⚠️  This value might have side effects
-- *29* (???*30* ? 16 : 536870912)
+- *51* (???*52* ? 16 : 536870912)
   ⚠️  nested operation
-- *30* (0 !== ???*31*)
-  ⚠️  nested operation
-- *31* unsupported expression
-  ⚠️  This value might have side effects
-- *32* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *33* ???*34*["value"]
-  ⚠️  unknown object
-- *34* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *35* ???*36*["event"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *36* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *37* (undefined === ???*38*)
-  ⚠️  nested operation
-- *38* a
-  ⚠️  circular variable reference
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* Ck
-  ⚠️  sequence with side effects
-  ⚠️  This value might have side effects
-- *41* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *42* ???*43*["_reactInternals"]
-  ⚠️  unknown object
-- *43* a
-  ⚠️  circular variable reference
-- *44* C
-  ⚠️  circular variable reference
-- *45* (0 !== ???*46*)
-  ⚠️  nested operation
-- *46* C
-  ⚠️  circular variable reference
-- *47* unsupported expression
-  ⚠️  This value might have side effects
-- *48* C
-  ⚠️  circular variable reference
-- *49* unsupported expression
-  ⚠️  This value might have side effects
-- *50* (???*51* ? ???*52* : 1)
-  ⚠️  nested operation
-- *51* unsupported expression
-  ⚠️  This value might have side effects
-- *52* (???*53* ? ???*54* : 4)
+- *52* (0 !== ???*53*)
   ⚠️  nested operation
 - *53* unsupported expression
   ⚠️  This value might have side effects
-- *54* (???*55* ? 16 : 536870912)
-  ⚠️  nested operation
-- *55* (0 !== ???*56*)
-  ⚠️  nested operation
-- *56* unsupported expression
-  ⚠️  This value might have side effects
-- *57* arguments[0]
+- *54* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *58* ???*59*["value"]
+- *55* ???*56*["value"]
   ⚠️  unknown object
-- *59* arguments[1]
+- *56* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *60* ???*61*["event"]
+- *57* ???*58*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *61* FreeVar(window)
+- *58* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *62* (undefined === ???*63*)
+- *59* (undefined === ???*60*)
   ⚠️  nested operation
-- *63* a
+- *60* a
   ⚠️  circular variable reference
 
 0 -> 2984 call = (...) => undefined(
@@ -20495,21 +20445,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *38* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *39* (???*40* ? (???*44* | ???*45*) : ???*46*)
+- *39* (???*40* ? (-1 | ???*42*) : ???*43*)
   ⚠️  nested operation
-- *40* (???*41* !== (???*42* | ???*43*))
+- *40* (-1 !== (-1 | ???*41*))
   ⚠️  nested operation
-- *41* unsupported expression
-  ⚠️  This value might have side effects
-- *42* unsupported expression
-  ⚠️  This value might have side effects
-- *43* module<scheduler, {}>["unstable_now"]()
+- *41* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *44* unsupported expression
-  ⚠️  This value might have side effects
-- *45* module<scheduler, {}>["unstable_now"]()
+- *42* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *46* assignment expression
+- *43* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 2985 call = (...) => undefined(
@@ -20607,12 +20551,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *35* a
   ⚠️  circular variable reference
 
-0 -> 2987 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 2987 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 2988 call = (...) => (1 | ???*0* | ???*1* | a)((???*2* | ???*3*))
@@ -20632,18 +20574,18 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
     (???*0* ? ???*2* : ???*3*),
     (
       | 1
+      | ???*8*
+      | ???*9*
+      | ???*10*
       | ???*11*
-      | ???*12*
-      | ???*13*
-      | ???*14*
       | 0
-      | ???*16*
+      | ???*13*
       | 4
       | undefined
-      | ((???*17* | ???*19*) ? ???*20* : 4)
-      | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-      | ???*32*
-      | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*14* | ???*16*) ? ???*17* : 4)
+      | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+      | ???*29*
+      | (???*31* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     )
 )
 - *0* (0 !== ???*1*)
@@ -20652,18 +20594,128 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* assignment expression
   ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *8* unsupported expression
   ⚠️  This value might have side effects
+- *9* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *10* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *11* ???*12*["_reactInternals"]
+  ⚠️  unknown object
+- *12* a
+  ⚠️  circular variable reference
+- *13* C
+  ⚠️  circular variable reference
+- *14* (0 !== ???*15*)
+  ⚠️  nested operation
+- *15* C
+  ⚠️  circular variable reference
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* C
+  ⚠️  circular variable reference
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* (???*20* ? ???*21* : 1)
+  ⚠️  nested operation
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
+  ⚠️  nested operation
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *27* ???*28*["value"]
+  ⚠️  unknown object
+- *28* arguments[1]
+  ⚠️  function calls are not analyzed yet
+- *29* ???*30*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *31* (undefined === ???*32*)
+  ⚠️  nested operation
+- *32* a
+  ⚠️  circular variable reference
+
+0 -> 2993 call = (...) => (null | Zg(a, c))(
+    (???*0* | ???*1*),
+    {
+        "eventTime": (???*3* ? ???*5* : ???*6*),
+        "lane": (
+          | 1
+          | ???*11*
+          | ???*12*
+          | ???*13*
+          | ???*14*
+          | 0
+          | ???*16*
+          | 4
+          | undefined
+          | ((???*17* | ???*19*) ? ???*20* : 4)
+          | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
+          | ???*32*
+          | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+        ),
+        "tag": 0,
+        "payload": null,
+        "callback": null,
+        "next": null
+    },
+    (
+      | 1
+      | ???*36*
+      | ???*37*
+      | ???*38*
+      | ???*39*
+      | 0
+      | ???*41*
+      | 4
+      | undefined
+      | ((???*42* | ???*44*) ? ???*45* : 4)
+      | (???*46* ? 16 : (???*47* | undefined | null | ???*54* | ???*55*))
+      | ???*57*
+      | (???*59* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+    )
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *1* ???*2*["_reactInternals"]
+  ⚠️  unknown object
+- *2* a
+  ⚠️  circular variable reference
+- *3* (0 !== ???*4*)
+  ⚠️  nested operation
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* (???*7* ? (-1 | ???*9*) : ???*10*)
+  ⚠️  nested operation
+- *7* (-1 !== (-1 | ???*8*))
+  ⚠️  nested operation
+- *8* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
 - *9* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *10* assignment expression
@@ -20721,180 +20773,58 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  nested operation
 - *35* a
   ⚠️  circular variable reference
-
-0 -> 2993 call = (...) => (null | Zg(a, c))(
-    (???*0* | ???*1*),
-    {
-        "eventTime": (???*3* ? ???*5* : ???*6*),
-        "lane": (
-          | 1
-          | ???*14*
-          | ???*15*
-          | ???*16*
-          | ???*17*
-          | 0
-          | ???*19*
-          | 4
-          | undefined
-          | ((???*20* | ???*22*) ? ???*23* : 4)
-          | (???*24* ? 16 : (???*25* | undefined | null | ???*32* | ???*33*))
-          | ???*35*
-          | (???*37* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-        ),
-        "tag": 0,
-        "payload": null,
-        "callback": null,
-        "next": null
-    },
-    (
-      | 1
-      | ???*39*
-      | ???*40*
-      | ???*41*
-      | ???*42*
-      | 0
-      | ???*44*
-      | 4
-      | undefined
-      | ((???*45* | ???*47*) ? ???*48* : 4)
-      | (???*49* ? 16 : (???*50* | undefined | null | ???*57* | ???*58*))
-      | ???*60*
-      | (???*62* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-    )
-)
-- *0* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *1* ???*2*["_reactInternals"]
-  ⚠️  unknown object
-- *2* a
-  ⚠️  circular variable reference
-- *3* (0 !== ???*4*)
-  ⚠️  nested operation
-- *4* unsupported expression
+- *36* unsupported expression
   ⚠️  This value might have side effects
-- *5* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *6* (???*7* ? (???*11* | ???*12*) : ???*13*)
-  ⚠️  nested operation
-- *7* (???*8* !== (???*9* | ???*10*))
-  ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *13* assignment expression
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* Ck
+- *37* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *16* arguments[0]
+- *38* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *17* ???*18*["_reactInternals"]
+- *39* ???*40*["_reactInternals"]
   ⚠️  unknown object
-- *18* a
+- *40* a
   ⚠️  circular variable reference
-- *19* C
+- *41* C
   ⚠️  circular variable reference
-- *20* (0 !== ???*21*)
+- *42* (0 !== ???*43*)
   ⚠️  nested operation
-- *21* C
+- *43* C
   ⚠️  circular variable reference
-- *22* unsupported expression
+- *44* unsupported expression
   ⚠️  This value might have side effects
-- *23* C
+- *45* C
   ⚠️  circular variable reference
-- *24* unsupported expression
+- *46* unsupported expression
   ⚠️  This value might have side effects
-- *25* (???*26* ? ???*27* : 1)
+- *47* (???*48* ? ???*49* : 1)
   ⚠️  nested operation
-- *26* unsupported expression
+- *48* unsupported expression
   ⚠️  This value might have side effects
-- *27* (???*28* ? ???*29* : 4)
+- *49* (???*50* ? ???*51* : 4)
   ⚠️  nested operation
-- *28* unsupported expression
+- *50* unsupported expression
   ⚠️  This value might have side effects
-- *29* (???*30* ? 16 : 536870912)
+- *51* (???*52* ? 16 : 536870912)
   ⚠️  nested operation
-- *30* (0 !== ???*31*)
-  ⚠️  nested operation
-- *31* unsupported expression
-  ⚠️  This value might have side effects
-- *32* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *33* ???*34*["value"]
-  ⚠️  unknown object
-- *34* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *35* ???*36*["event"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *36* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *37* (undefined === ???*38*)
-  ⚠️  nested operation
-- *38* a
-  ⚠️  circular variable reference
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* Ck
-  ⚠️  sequence with side effects
-  ⚠️  This value might have side effects
-- *41* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *42* ???*43*["_reactInternals"]
-  ⚠️  unknown object
-- *43* a
-  ⚠️  circular variable reference
-- *44* C
-  ⚠️  circular variable reference
-- *45* (0 !== ???*46*)
-  ⚠️  nested operation
-- *46* C
-  ⚠️  circular variable reference
-- *47* unsupported expression
-  ⚠️  This value might have side effects
-- *48* C
-  ⚠️  circular variable reference
-- *49* unsupported expression
-  ⚠️  This value might have side effects
-- *50* (???*51* ? ???*52* : 1)
-  ⚠️  nested operation
-- *51* unsupported expression
-  ⚠️  This value might have side effects
-- *52* (???*53* ? ???*54* : 4)
+- *52* (0 !== ???*53*)
   ⚠️  nested operation
 - *53* unsupported expression
   ⚠️  This value might have side effects
-- *54* (???*55* ? 16 : 536870912)
-  ⚠️  nested operation
-- *55* (0 !== ???*56*)
-  ⚠️  nested operation
-- *56* unsupported expression
-  ⚠️  This value might have side effects
-- *57* arguments[0]
+- *54* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *58* ???*59*["value"]
+- *55* ???*56*["value"]
   ⚠️  unknown object
-- *59* arguments[1]
+- *56* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *60* ???*61*["event"]
+- *57* ???*58*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *61* FreeVar(window)
+- *58* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *62* (undefined === ???*63*)
+- *59* (undefined === ???*60*)
   ⚠️  nested operation
-- *63* a
+- *60* a
   ⚠️  circular variable reference
 
 0 -> 2994 call = (...) => undefined(
@@ -20998,21 +20928,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *38* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *39* (???*40* ? (???*44* | ???*45*) : ???*46*)
+- *39* (???*40* ? (-1 | ???*42*) : ???*43*)
   ⚠️  nested operation
-- *40* (???*41* !== (???*42* | ???*43*))
+- *40* (-1 !== (-1 | ???*41*))
   ⚠️  nested operation
-- *41* unsupported expression
-  ⚠️  This value might have side effects
-- *42* unsupported expression
-  ⚠️  This value might have side effects
-- *43* module<scheduler, {}>["unstable_now"]()
+- *41* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *44* unsupported expression
-  ⚠️  This value might have side effects
-- *45* module<scheduler, {}>["unstable_now"]()
+- *42* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *46* assignment expression
+- *43* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 2995 call = (...) => undefined(
@@ -21110,12 +21034,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *35* a
   ⚠️  circular variable reference
 
-0 -> 2997 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 2997 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 2998 call = (...) => (1 | ???*0* | ???*1* | a)((???*2* | ???*3*))
@@ -21135,18 +21057,18 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
     (???*0* ? ???*2* : ???*3*),
     (
       | 1
+      | ???*8*
+      | ???*9*
+      | ???*10*
       | ???*11*
-      | ???*12*
-      | ???*13*
-      | ???*14*
       | 0
-      | ???*16*
+      | ???*13*
       | 4
       | undefined
-      | ((???*17* | ???*19*) ? ???*20* : 4)
-      | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-      | ???*32*
-      | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*14* | ???*16*) ? ???*17* : 4)
+      | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+      | ???*29*
+      | (???*31* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     )
 )
 - *0* (0 !== ???*1*)
@@ -21155,18 +21077,128 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* assignment expression
   ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *8* unsupported expression
   ⚠️  This value might have side effects
+- *9* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *10* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *11* ???*12*["_reactInternals"]
+  ⚠️  unknown object
+- *12* a
+  ⚠️  circular variable reference
+- *13* C
+  ⚠️  circular variable reference
+- *14* (0 !== ???*15*)
+  ⚠️  nested operation
+- *15* C
+  ⚠️  circular variable reference
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* C
+  ⚠️  circular variable reference
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* (???*20* ? ???*21* : 1)
+  ⚠️  nested operation
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
+  ⚠️  nested operation
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *27* ???*28*["value"]
+  ⚠️  unknown object
+- *28* arguments[1]
+  ⚠️  function calls are not analyzed yet
+- *29* ???*30*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *31* (undefined === ???*32*)
+  ⚠️  nested operation
+- *32* a
+  ⚠️  circular variable reference
+
+0 -> 3002 call = (...) => (null | Zg(a, c))(
+    (???*0* | ???*1*),
+    {
+        "eventTime": (???*3* ? ???*5* : ???*6*),
+        "lane": (
+          | 1
+          | ???*11*
+          | ???*12*
+          | ???*13*
+          | ???*14*
+          | 0
+          | ???*16*
+          | 4
+          | undefined
+          | ((???*17* | ???*19*) ? ???*20* : 4)
+          | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
+          | ???*32*
+          | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+        ),
+        "tag": 0,
+        "payload": null,
+        "callback": null,
+        "next": null
+    },
+    (
+      | 1
+      | ???*36*
+      | ???*37*
+      | ???*38*
+      | ???*39*
+      | 0
+      | ???*41*
+      | 4
+      | undefined
+      | ((???*42* | ???*44*) ? ???*45* : 4)
+      | (???*46* ? 16 : (???*47* | undefined | null | ???*54* | ???*55*))
+      | ???*57*
+      | (???*59* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+    )
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *1* ???*2*["_reactInternals"]
+  ⚠️  unknown object
+- *2* a
+  ⚠️  circular variable reference
+- *3* (0 !== ???*4*)
+  ⚠️  nested operation
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* (???*7* ? (-1 | ???*9*) : ???*10*)
+  ⚠️  nested operation
+- *7* (-1 !== (-1 | ???*8*))
+  ⚠️  nested operation
+- *8* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
 - *9* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *10* assignment expression
@@ -21224,180 +21256,58 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  nested operation
 - *35* a
   ⚠️  circular variable reference
-
-0 -> 3002 call = (...) => (null | Zg(a, c))(
-    (???*0* | ???*1*),
-    {
-        "eventTime": (???*3* ? ???*5* : ???*6*),
-        "lane": (
-          | 1
-          | ???*14*
-          | ???*15*
-          | ???*16*
-          | ???*17*
-          | 0
-          | ???*19*
-          | 4
-          | undefined
-          | ((???*20* | ???*22*) ? ???*23* : 4)
-          | (???*24* ? 16 : (???*25* | undefined | null | ???*32* | ???*33*))
-          | ???*35*
-          | (???*37* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-        ),
-        "tag": 0,
-        "payload": null,
-        "callback": null,
-        "next": null
-    },
-    (
-      | 1
-      | ???*39*
-      | ???*40*
-      | ???*41*
-      | ???*42*
-      | 0
-      | ???*44*
-      | 4
-      | undefined
-      | ((???*45* | ???*47*) ? ???*48* : 4)
-      | (???*49* ? 16 : (???*50* | undefined | null | ???*57* | ???*58*))
-      | ???*60*
-      | (???*62* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-    )
-)
-- *0* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *1* ???*2*["_reactInternals"]
-  ⚠️  unknown object
-- *2* a
-  ⚠️  circular variable reference
-- *3* (0 !== ???*4*)
-  ⚠️  nested operation
-- *4* unsupported expression
+- *36* unsupported expression
   ⚠️  This value might have side effects
-- *5* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *6* (???*7* ? (???*11* | ???*12*) : ???*13*)
-  ⚠️  nested operation
-- *7* (???*8* !== (???*9* | ???*10*))
-  ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *13* assignment expression
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* Ck
+- *37* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *16* arguments[0]
+- *38* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *17* ???*18*["_reactInternals"]
+- *39* ???*40*["_reactInternals"]
   ⚠️  unknown object
-- *18* a
+- *40* a
   ⚠️  circular variable reference
-- *19* C
+- *41* C
   ⚠️  circular variable reference
-- *20* (0 !== ???*21*)
+- *42* (0 !== ???*43*)
   ⚠️  nested operation
-- *21* C
+- *43* C
   ⚠️  circular variable reference
-- *22* unsupported expression
+- *44* unsupported expression
   ⚠️  This value might have side effects
-- *23* C
+- *45* C
   ⚠️  circular variable reference
-- *24* unsupported expression
+- *46* unsupported expression
   ⚠️  This value might have side effects
-- *25* (???*26* ? ???*27* : 1)
+- *47* (???*48* ? ???*49* : 1)
   ⚠️  nested operation
-- *26* unsupported expression
+- *48* unsupported expression
   ⚠️  This value might have side effects
-- *27* (???*28* ? ???*29* : 4)
+- *49* (???*50* ? ???*51* : 4)
   ⚠️  nested operation
-- *28* unsupported expression
+- *50* unsupported expression
   ⚠️  This value might have side effects
-- *29* (???*30* ? 16 : 536870912)
+- *51* (???*52* ? 16 : 536870912)
   ⚠️  nested operation
-- *30* (0 !== ???*31*)
-  ⚠️  nested operation
-- *31* unsupported expression
-  ⚠️  This value might have side effects
-- *32* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *33* ???*34*["value"]
-  ⚠️  unknown object
-- *34* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *35* ???*36*["event"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *36* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *37* (undefined === ???*38*)
-  ⚠️  nested operation
-- *38* a
-  ⚠️  circular variable reference
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* Ck
-  ⚠️  sequence with side effects
-  ⚠️  This value might have side effects
-- *41* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *42* ???*43*["_reactInternals"]
-  ⚠️  unknown object
-- *43* a
-  ⚠️  circular variable reference
-- *44* C
-  ⚠️  circular variable reference
-- *45* (0 !== ???*46*)
-  ⚠️  nested operation
-- *46* C
-  ⚠️  circular variable reference
-- *47* unsupported expression
-  ⚠️  This value might have side effects
-- *48* C
-  ⚠️  circular variable reference
-- *49* unsupported expression
-  ⚠️  This value might have side effects
-- *50* (???*51* ? ???*52* : 1)
-  ⚠️  nested operation
-- *51* unsupported expression
-  ⚠️  This value might have side effects
-- *52* (???*53* ? ???*54* : 4)
+- *52* (0 !== ???*53*)
   ⚠️  nested operation
 - *53* unsupported expression
   ⚠️  This value might have side effects
-- *54* (???*55* ? 16 : 536870912)
-  ⚠️  nested operation
-- *55* (0 !== ???*56*)
-  ⚠️  nested operation
-- *56* unsupported expression
-  ⚠️  This value might have side effects
-- *57* arguments[0]
+- *54* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *58* ???*59*["value"]
+- *55* ???*56*["value"]
   ⚠️  unknown object
-- *59* arguments[1]
+- *56* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *60* ???*61*["event"]
+- *57* ???*58*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *61* FreeVar(window)
+- *58* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *62* (undefined === ???*63*)
+- *59* (undefined === ???*60*)
   ⚠️  nested operation
-- *63* a
+- *60* a
   ⚠️  circular variable reference
 
 0 -> 3003 call = (...) => undefined(
@@ -21501,21 +21411,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *38* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *39* (???*40* ? (???*44* | ???*45*) : ???*46*)
+- *39* (???*40* ? (-1 | ???*42*) : ???*43*)
   ⚠️  nested operation
-- *40* (???*41* !== (???*42* | ???*43*))
+- *40* (-1 !== (-1 | ???*41*))
   ⚠️  nested operation
-- *41* unsupported expression
-  ⚠️  This value might have side effects
-- *42* unsupported expression
-  ⚠️  This value might have side effects
-- *43* module<scheduler, {}>["unstable_now"]()
+- *41* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *44* unsupported expression
-  ⚠️  This value might have side effects
-- *45* module<scheduler, {}>["unstable_now"]()
+- *42* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *46* assignment expression
+- *43* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 3004 call = (...) => undefined(
@@ -28406,7 +28310,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* arguments[0]
   ⚠️  function calls are not analyzed yet
 
-0 -> 3860 call = (...) => undefined((???*0* ? ???*4* : null), ???*7*, 1, ???*8*)
+0 -> 3860 call = (...) => undefined((???*0* ? ???*4* : null), ???*7*, 1, -1)
 - *0* (3 === ???*1*)
   ⚠️  nested operation
 - *1* ???*2*["tag"]
@@ -28423,8 +28327,6 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  function calls are not analyzed yet
 - *7* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *8* unsupported expression
-  ⚠️  This value might have side effects
 
 0 -> 3861 call = (...) => P()
 
@@ -29603,12 +29505,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *56* a
   ⚠️  circular variable reference
 
-3977 -> 3980 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+3977 -> 3980 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 3977 -> 3981 call = (...) => undefined(
@@ -29777,21 +29677,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *58* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *59* (???*60* ? (???*64* | ???*65*) : ???*66*)
+- *59* (???*60* ? (-1 | ???*62*) : ???*63*)
   ⚠️  nested operation
-- *60* (???*61* !== (???*62* | ???*63*))
+- *60* (-1 !== (-1 | ???*61*))
   ⚠️  nested operation
-- *61* unsupported expression
-  ⚠️  This value might have side effects
-- *62* unsupported expression
-  ⚠️  This value might have side effects
-- *63* module<scheduler, {}>["unstable_now"]()
+- *61* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *64* unsupported expression
-  ⚠️  This value might have side effects
-- *65* module<scheduler, {}>["unstable_now"]()
+- *62* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *66* assignment expression
+- *63* assignment expression
   ⚠️  This value might have side effects
 
 3977 -> 3982 call = (...) => undefined(
@@ -30180,21 +30074,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *34* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *35* (???*36* ? (???*40* | ???*41*) : ???*42*)
+- *35* (???*36* ? (-1 | ???*38*) : ???*39*)
   ⚠️  nested operation
-- *36* (???*37* !== (???*38* | ???*39*))
+- *36* (-1 !== (-1 | ???*37*))
   ⚠️  nested operation
-- *37* unsupported expression
-  ⚠️  This value might have side effects
-- *38* unsupported expression
-  ⚠️  This value might have side effects
-- *39* module<scheduler, {}>["unstable_now"]()
+- *37* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *40* unsupported expression
-  ⚠️  This value might have side effects
-- *41* module<scheduler, {}>["unstable_now"]()
+- *38* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *42* assignment expression
+- *39* assignment expression
   ⚠️  This value might have side effects
 
 3985 -> 3991 conditional = ((0 === ???*0*) | (null === (???*2* | undefined)) | (0 === (???*4* | undefined["lanes"])) | ???*7*)
@@ -30348,17 +30236,17 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
     ),
     (
       | 1
-      | ???*44*
-      | ???*45*
-      | ???*46*
+      | ???*41*
+      | ???*42*
+      | ???*43*
       | 0
-      | ???*47*
+      | ???*44*
       | 4
       | undefined
-      | ((???*48* | ???*50*) ? ???*51* : 4)
-      | (???*52* ? 16 : (???*53* | undefined | null | ???*60* | ???*61*))
-      | ???*63*
-      | (???*65* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*45* | ???*47*) ? ???*48* : 4)
+      | (???*49* ? 16 : (???*50* | undefined | null | ???*57* | ???*58*))
+      | ???*60*
+      | (???*62* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     )
 )
 - *0* arguments[0]
@@ -30436,78 +30324,70 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *35* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *36* (???*37* ? (???*41* | ???*42*) : ???*43*)
+- *36* (???*37* ? (-1 | ???*39*) : ???*40*)
   ⚠️  nested operation
-- *37* (???*38* !== (???*39* | ???*40*))
+- *37* (-1 !== (-1 | ???*38*))
   ⚠️  nested operation
-- *38* unsupported expression
+- *38* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *39* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *40* assignment expression
   ⚠️  This value might have side effects
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *41* unsupported expression
   ⚠️  This value might have side effects
-- *42* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *43* assignment expression
-  ⚠️  This value might have side effects
-- *44* unsupported expression
-  ⚠️  This value might have side effects
-- *45* Ck
+- *42* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *46* arguments[0]
+- *43* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *47* C
+- *44* C
   ⚠️  circular variable reference
-- *48* (0 !== ???*49*)
+- *45* (0 !== ???*46*)
   ⚠️  nested operation
-- *49* C
+- *46* C
   ⚠️  circular variable reference
-- *50* unsupported expression
+- *47* unsupported expression
   ⚠️  This value might have side effects
-- *51* C
+- *48* C
   ⚠️  circular variable reference
-- *52* unsupported expression
+- *49* unsupported expression
   ⚠️  This value might have side effects
-- *53* (???*54* ? ???*55* : 1)
+- *50* (???*51* ? ???*52* : 1)
   ⚠️  nested operation
-- *54* unsupported expression
+- *51* unsupported expression
   ⚠️  This value might have side effects
-- *55* (???*56* ? ???*57* : 4)
+- *52* (???*53* ? ???*54* : 4)
+  ⚠️  nested operation
+- *53* unsupported expression
+  ⚠️  This value might have side effects
+- *54* (???*55* ? 16 : 536870912)
+  ⚠️  nested operation
+- *55* (0 !== ???*56*)
   ⚠️  nested operation
 - *56* unsupported expression
   ⚠️  This value might have side effects
-- *57* (???*58* ? 16 : 536870912)
-  ⚠️  nested operation
-- *58* (0 !== ???*59*)
-  ⚠️  nested operation
-- *59* unsupported expression
-  ⚠️  This value might have side effects
-- *60* arguments[0]
+- *57* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *61* ???*62*["value"]
+- *58* ???*59*["value"]
   ⚠️  unknown object
-- *62* arguments[1]
+- *59* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *63* ???*64*["event"]
+- *60* ???*61*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *64* FreeVar(window)
+- *61* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *65* (undefined === ???*66*)
+- *62* (undefined === ???*63*)
   ⚠️  nested operation
-- *66* a
+- *63* a
   ⚠️  circular variable reference
 
-3985 -> 4008 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+3985 -> 4008 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 3985 -> 4009 call = (...) => undefined(
@@ -30689,21 +30569,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *65* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *66* (???*67* ? (???*71* | ???*72*) : ???*73*)
+- *66* (???*67* ? (-1 | ???*69*) : ???*70*)
   ⚠️  nested operation
-- *67* (???*68* !== (???*69* | ???*70*))
+- *67* (-1 !== (-1 | ???*68*))
   ⚠️  nested operation
-- *68* unsupported expression
-  ⚠️  This value might have side effects
-- *69* unsupported expression
-  ⚠️  This value might have side effects
-- *70* module<scheduler, {}>["unstable_now"]()
+- *68* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *71* unsupported expression
-  ⚠️  This value might have side effects
-- *72* module<scheduler, {}>["unstable_now"]()
+- *69* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *73* assignment expression
+- *70* assignment expression
   ⚠️  This value might have side effects
 
 3985 -> 4010 call = (...) => undefined(
@@ -32105,19 +31979,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 4145 -> 4147 free var = FreeVar(Map)
 
 0 -> 4148 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(
-    ???*0*,
+    -1,
     (
-      | ???*1*
-      | {"eventTime": ???*2*, "lane": ???*3*, "tag": 0, "payload": null, "callback": null, "next": null}
+      | ???*0*
+      | {"eventTime": -1, "lane": ???*1*, "tag": 0, "payload": null, "callback": null, "next": null}
     )
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* arguments[2]
+- *0* arguments[2]
   ⚠️  function calls are not analyzed yet
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* c
+- *1* c
   ⚠️  circular variable reference
 
 0 -> 4153 call = (...) => undefined(???*0*, ???*1*)
@@ -32131,19 +32001,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 
 0 -> 4155 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(
-    ???*0*,
+    -1,
     (
-      | ???*1*
-      | {"eventTime": ???*2*, "lane": ???*3*, "tag": 0, "payload": null, "callback": null, "next": null}
+      | ???*0*
+      | {"eventTime": -1, "lane": ???*1*, "tag": 0, "payload": null, "callback": null, "next": null}
     )
 )
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* arguments[2]
+- *0* arguments[2]
   ⚠️  function calls are not analyzed yet
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* c
+- *1* c
   ⚠️  circular variable reference
 
 0 -> 4159 typeof = typeof(???*0*)
@@ -32619,14 +32485,12 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 
 4216 -> 4217 conditional = (???*0* === (
   | ???*1*
-  | {"eventTime": ???*2*, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
+  | {"eventTime": -1, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
 ))
 - *0* arguments[0]
   ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *2* unsupported expression
-  ⚠️  This value might have side effects
 
 4217 -> 4224 conditional = (null === ???*0*)
 - *0* ???*1*["alternate"]
@@ -32634,15 +32498,13 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* arguments[2]
   ⚠️  function calls are not analyzed yet
 
-4224 -> 4226 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(???*0*, 1)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+4224 -> 4226 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(-1, 1)
 
 4224 -> 4228 call = (...) => (null | Zg(a, c))(
     ???*0*,
     (
       | ???*1*
-      | {"eventTime": ???*2*, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
+      | {"eventTime": -1, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
     ),
     1
 )
@@ -32650,8 +32512,6 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *2* unsupported expression
-  ⚠️  This value might have side effects
 
 4216 -> 4230 unreachable = ???*0*
 - *0* unreachable
@@ -35862,14 +35722,12 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-4725 -> 4731 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
+4725 -> 4731 call = (...) => undefined(???*0*, ???*1*, ???*2*, -1)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *3* unsupported expression
   ⚠️  This value might have side effects
 
 4724 -> 4732 call = (...) => undefined()
@@ -40653,10 +40511,8 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *0* labeled statement
   ⚠️  This value might have side effects
 
-5577 -> 5593 conditional = (???*0* === ???*1*)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+5577 -> 5593 conditional = (-1 === ???*0*)
+- *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5599 conditional = (0 !== ???*0*)
@@ -42776,12 +42632,8 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 
 6222 -> 6223 call = module<scheduler, {}>["unstable_now"]()
 
-6222 -> 6224 conditional = (???*0* !== (???*1* | ???*2*))
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* module<scheduler, {}>["unstable_now"]()
+6222 -> 6224 conditional = (-1 !== (-1 | ???*0*))
+- *0* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 
 6224 -> 6225 call = module<scheduler, {}>["unstable_now"]()
@@ -43780,12 +43632,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6338 -> 6339 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+6338 -> 6339 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 6335 -> 6344 member call = (...) => null["bind"](null, ???*0*, ???*1*, null)
@@ -45646,12 +45496,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6772 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 6772 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 6773 call = (...) => undefined(???*0*, 1, ???*1*)
@@ -45784,12 +45632,10 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6791 -> 6795 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+6791 -> 6795 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 6791 -> 6796 call = (...) => undefined(???*0*, 1, ???*1*)
@@ -45817,29 +45663,21 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *6* (???*7* ? (???*11* | ???*12*) : ???*13*)
+- *6* (???*7* ? (-1 | ???*9*) : ???*10*)
   ⚠️  nested operation
-- *7* (???*8* !== (???*9* | ???*10*))
+- *7* (-1 !== (-1 | ???*8*))
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
+- *8* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* module<scheduler, {}>["unstable_now"]()
+- *9* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *13* assignment expression
+- *10* assignment expression
   ⚠️  This value might have side effects
 
-0 -> 6802 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 6802 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 6805 call = module<scheduler, {}>["unstable_now"]()
@@ -45872,33 +45710,25 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *4* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *5* (???*6* ? (???*10* | ???*11*) : ???*12*)
+- *5* (???*6* ? (-1 | ???*8*) : ???*9*)
   ⚠️  nested operation
-- *6* (???*7* !== (???*8* | ???*9*))
+- *6* (-1 !== (-1 | ???*7*))
   ⚠️  nested operation
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *7* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* module<scheduler, {}>["unstable_now"]()
+- *8* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *12* assignment expression
+- *9* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 6810 conditional = (0 === ???*0*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-0 -> 6811 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 6811 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 6812 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)((???*0* | (???*1* ? ???*5* : null)), (???*8* | 1 | 4194304 | ???*9*))
@@ -45954,21 +45784,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *12* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *13* (???*14* ? (???*18* | ???*19*) : ???*20*)
+- *13* (???*14* ? (-1 | ???*16*) : ???*17*)
   ⚠️  nested operation
-- *14* (???*15* !== (???*16* | ???*17*))
+- *14* (-1 !== (-1 | ???*15*))
   ⚠️  nested operation
-- *15* unsupported expression
-  ⚠️  This value might have side effects
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* module<scheduler, {}>["unstable_now"]()
+- *15* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *18* unsupported expression
-  ⚠️  This value might have side effects
-- *19* module<scheduler, {}>["unstable_now"]()
+- *16* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *20* assignment expression
+- *17* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 6814 call = (...) => undefined((???*0* | (???*1* ? ???*5* : null)), (???*8* ? ???*10* : ???*11*))
@@ -45994,21 +45818,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *10* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* (???*12* ? (???*16* | ???*17*) : ???*18*)
+- *11* (???*12* ? (-1 | ???*14*) : ???*15*)
   ⚠️  nested operation
-- *12* (???*13* !== (???*14* | ???*15*))
+- *12* (-1 !== (-1 | ???*13*))
   ⚠️  nested operation
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* module<scheduler, {}>["unstable_now"]()
+- *13* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* module<scheduler, {}>["unstable_now"]()
+- *14* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *18* assignment expression
+- *15* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 6817 call = (...) => undefined(???*0*, (0 | ???*1*))
@@ -47007,10 +46825,8 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7042 -> 7043 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(???*0*, ???*1*)
+7042 -> 7043 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(-1, ???*0*)
 - *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
   ⚠️  This value might have side effects
 
 7042 -> 7046 conditional = (null !== ???*0*)
@@ -48318,9 +48134,7 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 
 0 -> 7292 call = (...) => b(0)
 
-0 -> 7294 call = (...) => b(???*0*)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+0 -> 7294 call = (...) => b(-1)
 
 0 -> 7303 call = (...) => b(0)
 
@@ -48574,42 +48388,42 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
     (???*0* | ???*1* | ???*3*),
     (???*5* | (???*6* ? ???*8* : ???*9*)),
     true,
-    (???*17* | ???*18*),
+    (???*14* | ???*15*),
     (
-      | ???*19*
+      | ???*16*
       | 1
-      | ???*20*
-      | ???*21*
-      | ???*22*
-      | new (...) => undefined(???*24*, (???*25* | ???*26* | 1 | ???*38* | 0), true, ???*39*, ???*40*)["current"]
+      | ???*17*
+      | ???*18*
+      | ???*19*
+      | new (...) => undefined(???*21*, (???*22* | ???*23* | 1 | ???*32* | 0), true, ???*33*, ???*34*)["current"]
       | 0
-      | ???*41*
+      | ???*35*
       | 4
       | undefined
-      | ((???*42* | ???*44*) ? ???*45* : 4)
-      | (???*46* ? 16 : (???*47* | undefined | null | ???*54* | ???*55*))
-      | ???*57*
-      | (???*59* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*36* | ???*38*) ? ???*39* : 4)
+      | (???*40* ? 16 : (???*41* | undefined | null | ???*48* | ???*49*))
+      | ???*51*
+      | (???*53* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     ),
     (
-      | ???*61*
+      | ???*55*
       | {
-            "eventTime": (???*62* | (???*63* ? ???*65* : ???*66*)),
+            "eventTime": (???*56* | (???*57* ? ???*59* : ???*60*)),
             "lane": (
-              | ???*74*
+              | ???*65*
               | 1
-              | ???*75*
-              | ???*76*
-              | ???*77*
-              | new (...) => undefined(???*79*, (???*80* | ???*81* | 1 | ???*91* | 0), true, ???*92*, ???*93*)["current"]
+              | ???*66*
+              | ???*67*
+              | ???*68*
+              | new (...) => undefined(???*70*, (???*71* | ???*72* | 1 | ???*80* | 0), true, ???*81*, ???*82*)["current"]
               | 0
-              | ???*94*
+              | ???*83*
               | 4
               | undefined
-              | ((???*95* | ???*97*) ? ???*98* : 4)
-              | (???*99* ? 16 : (???*100* | undefined | null | ???*107* | ???*108*))
-              | ???*110*
-              | (???*112* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+              | ((???*84* | ???*86*) ? ???*87* : 4)
+              | (???*88* ? 16 : (???*89* | undefined | null | ???*96* | ???*97*))
+              | ???*99*
+              | (???*101* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
             ),
             "tag": 0,
             "payload": null,
@@ -48617,9 +48431,9 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
             "next": null
         }
     ),
-    ???*114*,
-    ???*115*,
-    ???*116*
+    ???*103*,
+    ???*104*,
+    ???*105*
 )
 - *0* arguments[2]
   ⚠️  function calls are not analyzed yet
@@ -48640,237 +48454,213 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *8* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *9* (???*10* ? (???*14* | ???*15*) : ???*16*)
+- *9* (???*10* ? (-1 | ???*12*) : ???*13*)
   ⚠️  nested operation
-- *10* (???*11* !== (???*12* | ???*13*))
+- *10* (-1 !== (-1 | ???*11*))
   ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* module<scheduler, {}>["unstable_now"]()
+- *11* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* module<scheduler, {}>["unstable_now"]()
+- *12* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *16* assignment expression
+- *13* assignment expression
   ⚠️  This value might have side effects
-- *17* arguments[0]
+- *14* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *18* node limit reached
+- *15* node limit reached
   ⚠️  This value might have side effects
-- *19* arguments[4]
+- *16* arguments[4]
   ⚠️  function calls are not analyzed yet
-- *20* unsupported expression
+- *17* unsupported expression
   ⚠️  This value might have side effects
-- *21* Ck
+- *18* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *22* ???*23*["current"]
+- *19* ???*20*["current"]
   ⚠️  unknown object
-- *23* arguments[0]
+- *20* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *24* a
+- *21* a
   ⚠️  circular variable reference
-- *25* arguments[3]
+- *22* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *26* (???*27* ? ???*29* : ???*30*)
+- *23* (???*24* ? ???*26* : ???*27*)
   ⚠️  nested operation
-- *27* (0 !== ???*28*)
+- *24* (0 !== ???*25*)
   ⚠️  nested operation
-- *28* unsupported expression
+- *25* unsupported expression
   ⚠️  This value might have side effects
-- *29* module<scheduler, {}>["unstable_now"]()
+- *26* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *30* (???*31* ? (???*35* | ???*36*) : ???*37*)
+- *27* (???*28* ? (-1 | ???*30*) : ???*31*)
   ⚠️  nested operation
-- *31* (???*32* !== (???*33* | ???*34*))
+- *28* (-1 !== (-1 | ???*29*))
   ⚠️  nested operation
-- *32* unsupported expression
-  ⚠️  This value might have side effects
-- *33* unsupported expression
-  ⚠️  This value might have side effects
-- *34* ...[...]()
+- *29* ...[...]()
   ⚠️  nested operation
-- *35* unsupported expression
-  ⚠️  This value might have side effects
-- *36* module<scheduler, {}>["unstable_now"]()
+- *30* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *37* assignment expression
+- *31* assignment expression
   ⚠️  This value might have side effects
-- *38* unsupported assign operation
+- *32* unsupported assign operation
   ⚠️  This value might have side effects
-- *39* arguments[7]
+- *33* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *40* arguments[8]
+- *34* arguments[8]
   ⚠️  function calls are not analyzed yet
-- *41* C
+- *35* C
   ⚠️  circular variable reference
-- *42* (0 !== ???*43*)
+- *36* (0 !== ???*37*)
   ⚠️  nested operation
-- *43* C
+- *37* C
   ⚠️  circular variable reference
+- *38* unsupported expression
+  ⚠️  This value might have side effects
+- *39* C
+  ⚠️  circular variable reference
+- *40* unsupported expression
+  ⚠️  This value might have side effects
+- *41* (???*42* ? ???*43* : 1)
+  ⚠️  nested operation
+- *42* unsupported expression
+  ⚠️  This value might have side effects
+- *43* (???*44* ? ???*45* : 4)
+  ⚠️  nested operation
 - *44* unsupported expression
   ⚠️  This value might have side effects
-- *45* C
-  ⚠️  circular variable reference
-- *46* unsupported expression
-  ⚠️  This value might have side effects
-- *47* (???*48* ? ???*49* : 1)
+- *45* (???*46* ? 16 : 536870912)
   ⚠️  nested operation
-- *48* unsupported expression
-  ⚠️  This value might have side effects
-- *49* (???*50* ? ???*51* : 4)
+- *46* (0 !== ???*47*)
   ⚠️  nested operation
-- *50* unsupported expression
+- *47* unsupported expression
   ⚠️  This value might have side effects
-- *51* (???*52* ? 16 : 536870912)
-  ⚠️  nested operation
-- *52* (0 !== ???*53*)
-  ⚠️  nested operation
-- *53* unsupported expression
-  ⚠️  This value might have side effects
-- *54* arguments[0]
+- *48* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *55* ???*56*["value"]
+- *49* ???*50*["value"]
   ⚠️  unknown object
-- *56* arguments[1]
+- *50* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *57* ???*58*["event"]
+- *51* ???*52*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *58* FreeVar(window)
+- *52* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *59* (undefined === ???*60*)
+- *53* (undefined === ???*54*)
   ⚠️  nested operation
-- *60* a
+- *54* a
   ⚠️  circular variable reference
-- *61* arguments[5]
+- *55* arguments[5]
   ⚠️  function calls are not analyzed yet
-- *62* arguments[3]
+- *56* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *63* (0 !== ???*64*)
+- *57* (0 !== ???*58*)
   ⚠️  nested operation
-- *64* unsupported expression
+- *58* unsupported expression
   ⚠️  This value might have side effects
-- *65* module<scheduler, {}>["unstable_now"]()
+- *59* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *66* (???*67* ? (???*71* | ???*72*) : ???*73*)
+- *60* (???*61* ? (-1 | ???*63*) : ???*64*)
   ⚠️  nested operation
-- *67* (???*68* !== (???*69* | ???*70*))
+- *61* (-1 !== (-1 | ???*62*))
   ⚠️  nested operation
-- *68* unsupported expression
+- *62* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *63* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *64* assignment expression
   ⚠️  This value might have side effects
-- *69* unsupported expression
-  ⚠️  This value might have side effects
-- *70* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *71* unsupported expression
-  ⚠️  This value might have side effects
-- *72* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *73* assignment expression
-  ⚠️  This value might have side effects
-- *74* arguments[4]
+- *65* arguments[4]
   ⚠️  function calls are not analyzed yet
-- *75* unsupported expression
+- *66* unsupported expression
   ⚠️  This value might have side effects
-- *76* Ck
+- *67* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *77* ???*78*["current"]
+- *68* ???*69*["current"]
   ⚠️  unknown object
-- *78* arguments[0]
+- *69* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *79* a
+- *70* a
   ⚠️  circular variable reference
-- *80* arguments[3]
+- *71* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *81* (???*82* ? ???*84* : ???*85*)
+- *72* (???*73* ? ???*75* : ???*76*)
   ⚠️  nested operation
-- *82* (0 !== ???*83*)
+- *73* (0 !== ???*74*)
   ⚠️  nested operation
-- *83* unsupported expression
+- *74* unsupported expression
   ⚠️  This value might have side effects
-- *84* module<scheduler, {}>["unstable_now"]()
+- *75* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *85* (???*86* ? (???*88* | ???*89*) : ???*90*)
+- *76* (???*77* ? (-1 | ???*78*) : ???*79*)
   ⚠️  nested operation
-- *86* (???*87* !== (... | ...))
+- *77* (-1 !== (... | ...))
   ⚠️  nested operation
-- *87* unsupported expression
+- *78* ...()
+  ⚠️  nested operation
+- *79* assignment expression
   ⚠️  This value might have side effects
+- *80* unsupported assign operation
+  ⚠️  This value might have side effects
+- *81* arguments[7]
+  ⚠️  function calls are not analyzed yet
+- *82* arguments[8]
+  ⚠️  function calls are not analyzed yet
+- *83* C
+  ⚠️  circular variable reference
+- *84* (0 !== ???*85*)
+  ⚠️  nested operation
+- *85* C
+  ⚠️  circular variable reference
+- *86* unsupported expression
+  ⚠️  This value might have side effects
+- *87* C
+  ⚠️  circular variable reference
 - *88* unsupported expression
   ⚠️  This value might have side effects
-- *89* ...()
+- *89* (???*90* ? ???*91* : 1)
   ⚠️  nested operation
-- *90* assignment expression
+- *90* unsupported expression
   ⚠️  This value might have side effects
-- *91* unsupported assign operation
+- *91* (???*92* ? ???*93* : 4)
+  ⚠️  nested operation
+- *92* unsupported expression
   ⚠️  This value might have side effects
-- *92* arguments[7]
+- *93* (???*94* ? 16 : 536870912)
+  ⚠️  nested operation
+- *94* (0 !== ???*95*)
+  ⚠️  nested operation
+- *95* unsupported expression
+  ⚠️  This value might have side effects
+- *96* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *93* arguments[8]
-  ⚠️  function calls are not analyzed yet
-- *94* C
-  ⚠️  circular variable reference
-- *95* (0 !== ???*96*)
-  ⚠️  nested operation
-- *96* C
-  ⚠️  circular variable reference
-- *97* unsupported expression
-  ⚠️  This value might have side effects
-- *98* C
-  ⚠️  circular variable reference
-- *99* unsupported expression
-  ⚠️  This value might have side effects
-- *100* (???*101* ? ???*102* : 1)
-  ⚠️  nested operation
-- *101* unsupported expression
-  ⚠️  This value might have side effects
-- *102* (???*103* ? ???*104* : 4)
-  ⚠️  nested operation
-- *103* unsupported expression
-  ⚠️  This value might have side effects
-- *104* (???*105* ? 16 : 536870912)
-  ⚠️  nested operation
-- *105* (0 !== ???*106*)
-  ⚠️  nested operation
-- *106* unsupported expression
-  ⚠️  This value might have side effects
-- *107* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *108* ???*109*["value"]
+- *97* ???*98*["value"]
   ⚠️  unknown object
-- *109* arguments[1]
+- *98* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *110* ???*111*["event"]
+- *99* ???*100*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *111* FreeVar(window)
+- *100* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *112* (undefined === ???*113*)
+- *101* (undefined === ???*102*)
   ⚠️  nested operation
-- *113* a
+- *102* a
   ⚠️  circular variable reference
-- *114* arguments[6]
+- *103* arguments[6]
   ⚠️  function calls are not analyzed yet
-- *115* arguments[7]
+- *104* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *116* arguments[8]
+- *105* arguments[8]
   ⚠️  function calls are not analyzed yet
 
 0 -> 7356 call = (...) => (Vf | bg(a, c, b) | b)(null)
 
-0 -> 7358 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 7358 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 7359 call = (...) => (1 | ???*0* | ???*1* | a)((???*2* | ???*3* | ???*5*))
@@ -48894,20 +48684,20 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
 0 -> 7360 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(
     (???*0* | (???*1* ? ???*3* : ???*4*)),
     (
-      | ???*12*
+      | ???*9*
       | 1
-      | ???*13*
-      | ???*14*
-      | ???*15*
-      | new (...) => undefined(???*17*, (???*18* | ???*19* | 1 | ???*31* | 0), true, ???*32*, ???*33*)["current"]
+      | ???*10*
+      | ???*11*
+      | ???*12*
+      | new (...) => undefined(???*14*, (???*15* | ???*16* | 1 | ???*25* | 0), true, ???*26*, ???*27*)["current"]
       | 0
-      | ???*34*
+      | ???*28*
       | 4
       | undefined
-      | ((???*35* | ???*37*) ? ???*38* : 4)
-      | (???*39* ? 16 : (???*40* | undefined | null | ???*47* | ???*48*))
-      | ???*50*
-      | (???*52* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*29* | ???*31*) ? ???*32* : 4)
+      | (???*33* ? 16 : (???*34* | undefined | null | ???*41* | ???*42*))
+      | ???*44*
+      | (???*46* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     )
 )
 - *0* arguments[3]
@@ -48918,108 +48708,96 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *3* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *4* (???*5* ? (???*9* | ???*10*) : ???*11*)
+- *4* (???*5* ? (-1 | ???*7*) : ???*8*)
   ⚠️  nested operation
-- *5* (???*6* !== (???*7* | ???*8*))
+- *5* (-1 !== (-1 | ???*6*))
   ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
+- *7* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* assignment expression
+- *8* assignment expression
   ⚠️  This value might have side effects
-- *12* arguments[4]
+- *9* arguments[4]
   ⚠️  function calls are not analyzed yet
-- *13* unsupported expression
+- *10* unsupported expression
   ⚠️  This value might have side effects
-- *14* Ck
+- *11* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *15* ???*16*["current"]
+- *12* ???*13*["current"]
   ⚠️  unknown object
-- *16* arguments[0]
+- *13* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *17* a
+- *14* a
   ⚠️  circular variable reference
-- *18* arguments[3]
+- *15* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *19* (???*20* ? ???*22* : ???*23*)
+- *16* (???*17* ? ???*19* : ???*20*)
   ⚠️  nested operation
-- *20* (0 !== ???*21*)
+- *17* (0 !== ???*18*)
   ⚠️  nested operation
-- *21* unsupported expression
+- *18* unsupported expression
   ⚠️  This value might have side effects
-- *22* module<scheduler, {}>["unstable_now"]()
+- *19* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *23* (???*24* ? (???*28* | ???*29*) : ???*30*)
+- *20* (???*21* ? (-1 | ???*23*) : ???*24*)
   ⚠️  nested operation
-- *24* (???*25* !== (???*26* | ???*27*))
+- *21* (-1 !== (-1 | ???*22*))
   ⚠️  nested operation
-- *25* unsupported expression
-  ⚠️  This value might have side effects
-- *26* unsupported expression
-  ⚠️  This value might have side effects
-- *27* ...[...]()
+- *22* ...[...]()
   ⚠️  nested operation
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* module<scheduler, {}>["unstable_now"]()
+- *23* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *30* assignment expression
+- *24* assignment expression
   ⚠️  This value might have side effects
-- *31* unsupported assign operation
+- *25* unsupported assign operation
   ⚠️  This value might have side effects
-- *32* arguments[7]
+- *26* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *33* arguments[8]
+- *27* arguments[8]
   ⚠️  function calls are not analyzed yet
-- *34* C
+- *28* C
   ⚠️  circular variable reference
-- *35* (0 !== ???*36*)
+- *29* (0 !== ???*30*)
   ⚠️  nested operation
-- *36* C
+- *30* C
   ⚠️  circular variable reference
+- *31* unsupported expression
+  ⚠️  This value might have side effects
+- *32* C
+  ⚠️  circular variable reference
+- *33* unsupported expression
+  ⚠️  This value might have side effects
+- *34* (???*35* ? ???*36* : 1)
+  ⚠️  nested operation
+- *35* unsupported expression
+  ⚠️  This value might have side effects
+- *36* (???*37* ? ???*38* : 4)
+  ⚠️  nested operation
 - *37* unsupported expression
   ⚠️  This value might have side effects
-- *38* C
-  ⚠️  circular variable reference
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* (???*41* ? ???*42* : 1)
+- *38* (???*39* ? 16 : 536870912)
   ⚠️  nested operation
-- *41* unsupported expression
-  ⚠️  This value might have side effects
-- *42* (???*43* ? ???*44* : 4)
+- *39* (0 !== ???*40*)
   ⚠️  nested operation
-- *43* unsupported expression
+- *40* unsupported expression
   ⚠️  This value might have side effects
-- *44* (???*45* ? 16 : 536870912)
-  ⚠️  nested operation
-- *45* (0 !== ???*46*)
-  ⚠️  nested operation
-- *46* unsupported expression
-  ⚠️  This value might have side effects
-- *47* arguments[0]
+- *41* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *48* ???*49*["value"]
+- *42* ???*43*["value"]
   ⚠️  unknown object
-- *49* arguments[1]
+- *43* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *50* ???*51*["event"]
+- *44* ???*45*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *51* FreeVar(window)
+- *45* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *52* (undefined === ???*53*)
+- *46* (undefined === ???*47*)
   ⚠️  nested operation
-- *53* a
+- *47* a
   ⚠️  circular variable reference
 
 0 -> 7362 conditional = ((undefined !== ???*0*) | (null !== ???*1*))
@@ -49035,20 +48813,20 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
       | {
             "eventTime": (???*6* | (???*7* ? ???*9* : ???*10*)),
             "lane": (
-              | ???*18*
+              | ???*15*
               | 1
-              | ???*19*
-              | ???*20*
-              | ???*21*
-              | new (...) => undefined(???*23*, (???*24* | ???*25* | 1 | ???*35* | 0), true, ???*36*, ???*37*)["current"]
+              | ???*16*
+              | ???*17*
+              | ???*18*
+              | new (...) => undefined(???*20*, (???*21* | ???*22* | 1 | ???*30* | 0), true, ???*31*, ???*32*)["current"]
               | 0
-              | ???*38*
+              | ???*33*
               | 4
               | undefined
-              | ((???*39* | ???*41*) ? ???*42* : 4)
-              | (???*43* ? 16 : (???*44* | undefined | null | ???*51* | ???*52*))
-              | ???*54*
-              | (???*56* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+              | ((???*34* | ???*36*) ? ???*37* : 4)
+              | (???*38* ? 16 : (???*39* | undefined | null | ???*46* | ???*47*))
+              | ???*49*
+              | (???*51* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
             ),
             "tag": 0,
             "payload": null,
@@ -49057,20 +48835,20 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
         }
     ),
     (
-      | ???*58*
+      | ???*53*
       | 1
-      | ???*59*
-      | ???*60*
-      | ???*61*
-      | new (...) => undefined(???*63*, (???*64* | ???*65* | 1 | ???*77* | 0), true, ???*78*, ???*79*)["current"]
+      | ???*54*
+      | ???*55*
+      | ???*56*
+      | new (...) => undefined(???*58*, (???*59* | ???*60* | 1 | ???*69* | 0), true, ???*70*, ???*71*)["current"]
       | 0
-      | ???*80*
+      | ???*72*
       | 4
       | undefined
-      | ((???*81* | ???*83*) ? ???*84* : 4)
-      | (???*85* ? 16 : (???*86* | undefined | null | ???*93* | ???*94*))
-      | ???*96*
-      | (???*98* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*73* | ???*75*) ? ???*76* : 4)
+      | (???*77* ? 16 : (???*78* | undefined | null | ???*85* | ???*86*))
+      | ???*88*
+      | (???*90* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     )
 )
 - *0* arguments[2]
@@ -49094,191 +48872,175 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *9* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* (???*11* ? (???*15* | ???*16*) : ???*17*)
+- *10* (???*11* ? (-1 | ???*13*) : ???*14*)
   ⚠️  nested operation
-- *11* (???*12* !== (???*13* | ???*14*))
+- *11* (-1 !== (-1 | ???*12*))
   ⚠️  nested operation
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* module<scheduler, {}>["unstable_now"]()
+- *12* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *15* unsupported expression
-  ⚠️  This value might have side effects
-- *16* module<scheduler, {}>["unstable_now"]()
+- *13* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *17* assignment expression
+- *14* assignment expression
   ⚠️  This value might have side effects
-- *18* arguments[4]
+- *15* arguments[4]
   ⚠️  function calls are not analyzed yet
-- *19* unsupported expression
+- *16* unsupported expression
   ⚠️  This value might have side effects
-- *20* Ck
+- *17* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *21* ???*22*["current"]
+- *18* ???*19*["current"]
   ⚠️  unknown object
-- *22* arguments[0]
+- *19* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *23* a
+- *20* a
   ⚠️  circular variable reference
-- *24* arguments[3]
+- *21* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *25* (???*26* ? ???*28* : ???*29*)
+- *22* (???*23* ? ???*25* : ???*26*)
   ⚠️  nested operation
-- *26* (0 !== ???*27*)
+- *23* (0 !== ???*24*)
   ⚠️  nested operation
-- *27* unsupported expression
+- *24* unsupported expression
   ⚠️  This value might have side effects
-- *28* module<scheduler, {}>["unstable_now"]()
+- *25* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *29* (???*30* ? (???*32* | ???*33*) : ???*34*)
+- *26* (???*27* ? (-1 | ???*28*) : ???*29*)
   ⚠️  nested operation
-- *30* (???*31* !== (... | ...))
+- *27* (-1 !== (... | ...))
   ⚠️  nested operation
-- *31* unsupported expression
-  ⚠️  This value might have side effects
-- *32* unsupported expression
-  ⚠️  This value might have side effects
-- *33* ...()
+- *28* ...()
   ⚠️  nested operation
-- *34* assignment expression
+- *29* assignment expression
   ⚠️  This value might have side effects
-- *35* unsupported assign operation
+- *30* unsupported assign operation
   ⚠️  This value might have side effects
-- *36* arguments[7]
+- *31* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *37* arguments[8]
+- *32* arguments[8]
   ⚠️  function calls are not analyzed yet
-- *38* C
+- *33* C
   ⚠️  circular variable reference
-- *39* (0 !== ???*40*)
+- *34* (0 !== ???*35*)
   ⚠️  nested operation
-- *40* C
+- *35* C
   ⚠️  circular variable reference
-- *41* unsupported expression
+- *36* unsupported expression
   ⚠️  This value might have side effects
-- *42* C
+- *37* C
   ⚠️  circular variable reference
-- *43* unsupported expression
+- *38* unsupported expression
   ⚠️  This value might have side effects
-- *44* (???*45* ? ???*46* : 1)
+- *39* (???*40* ? ???*41* : 1)
+  ⚠️  nested operation
+- *40* unsupported expression
+  ⚠️  This value might have side effects
+- *41* (???*42* ? ???*43* : 4)
+  ⚠️  nested operation
+- *42* unsupported expression
+  ⚠️  This value might have side effects
+- *43* (???*44* ? 16 : 536870912)
+  ⚠️  nested operation
+- *44* (0 !== ???*45*)
   ⚠️  nested operation
 - *45* unsupported expression
   ⚠️  This value might have side effects
-- *46* (???*47* ? ???*48* : 4)
-  ⚠️  nested operation
-- *47* unsupported expression
-  ⚠️  This value might have side effects
-- *48* (???*49* ? 16 : 536870912)
-  ⚠️  nested operation
-- *49* (0 !== ???*50*)
-  ⚠️  nested operation
-- *50* unsupported expression
-  ⚠️  This value might have side effects
-- *51* arguments[0]
+- *46* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *52* ???*53*["value"]
+- *47* ???*48*["value"]
   ⚠️  unknown object
-- *53* arguments[1]
+- *48* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *54* ???*55*["event"]
+- *49* ???*50*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *55* FreeVar(window)
+- *50* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *56* (undefined === ???*57*)
+- *51* (undefined === ???*52*)
   ⚠️  nested operation
-- *57* a
+- *52* a
   ⚠️  circular variable reference
-- *58* arguments[4]
+- *53* arguments[4]
   ⚠️  function calls are not analyzed yet
-- *59* unsupported expression
+- *54* unsupported expression
   ⚠️  This value might have side effects
-- *60* Ck
+- *55* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *61* ???*62*["current"]
+- *56* ???*57*["current"]
   ⚠️  unknown object
-- *62* arguments[0]
+- *57* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *63* a
+- *58* a
   ⚠️  circular variable reference
-- *64* arguments[3]
+- *59* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *65* (???*66* ? ???*68* : ???*69*)
+- *60* (???*61* ? ???*63* : ???*64*)
   ⚠️  nested operation
-- *66* (0 !== ???*67*)
+- *61* (0 !== ???*62*)
   ⚠️  nested operation
-- *67* unsupported expression
+- *62* unsupported expression
   ⚠️  This value might have side effects
-- *68* module<scheduler, {}>["unstable_now"]()
+- *63* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *69* (???*70* ? (???*74* | ???*75*) : ???*76*)
+- *64* (???*65* ? (-1 | ???*67*) : ???*68*)
   ⚠️  nested operation
-- *70* (???*71* !== (???*72* | ???*73*))
+- *65* (-1 !== (-1 | ???*66*))
   ⚠️  nested operation
-- *71* unsupported expression
-  ⚠️  This value might have side effects
-- *72* unsupported expression
-  ⚠️  This value might have side effects
-- *73* ...[...]()
+- *66* ...[...]()
   ⚠️  nested operation
-- *74* unsupported expression
-  ⚠️  This value might have side effects
-- *75* module<scheduler, {}>["unstable_now"]()
+- *67* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *76* assignment expression
+- *68* assignment expression
   ⚠️  This value might have side effects
-- *77* unsupported assign operation
+- *69* unsupported assign operation
   ⚠️  This value might have side effects
-- *78* arguments[7]
+- *70* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *79* arguments[8]
+- *71* arguments[8]
   ⚠️  function calls are not analyzed yet
-- *80* C
+- *72* C
   ⚠️  circular variable reference
-- *81* (0 !== ???*82*)
+- *73* (0 !== ???*74*)
   ⚠️  nested operation
-- *82* C
+- *74* C
   ⚠️  circular variable reference
-- *83* unsupported expression
+- *75* unsupported expression
   ⚠️  This value might have side effects
-- *84* C
+- *76* C
   ⚠️  circular variable reference
-- *85* unsupported expression
+- *77* unsupported expression
   ⚠️  This value might have side effects
-- *86* (???*87* ? ???*88* : 1)
+- *78* (???*79* ? ???*80* : 1)
   ⚠️  nested operation
-- *87* unsupported expression
+- *79* unsupported expression
   ⚠️  This value might have side effects
-- *88* (???*89* ? ???*90* : 4)
+- *80* (???*81* ? ???*82* : 4)
   ⚠️  nested operation
-- *89* unsupported expression
+- *81* unsupported expression
   ⚠️  This value might have side effects
-- *90* (???*91* ? 16 : 536870912)
+- *82* (???*83* ? 16 : 536870912)
   ⚠️  nested operation
-- *91* (0 !== ???*92*)
+- *83* (0 !== ???*84*)
   ⚠️  nested operation
-- *92* unsupported expression
+- *84* unsupported expression
   ⚠️  This value might have side effects
-- *93* arguments[0]
+- *85* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *94* ???*95*["value"]
+- *86* ???*87*["value"]
   ⚠️  unknown object
-- *95* arguments[1]
+- *87* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *96* ???*97*["event"]
+- *88* ???*89*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *97* FreeVar(window)
+- *89* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *98* (undefined === ???*99*)
+- *90* (undefined === ???*91*)
   ⚠️  nested operation
-- *99* a
+- *91* a
   ⚠️  circular variable reference
 
 0 -> 7366 call = (...) => undefined(
@@ -49289,17 +49051,17 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
       | ???*3*
       | ???*4*
       | ???*5*
-      | new (...) => undefined(???*7*, (???*8* | ???*9* | 1 | ???*21* | 0), true, ???*22*, ???*23*)["current"]
+      | new (...) => undefined(???*7*, (???*8* | ???*9* | 1 | ???*18* | 0), true, ???*19*, ???*20*)["current"]
       | 0
-      | ???*24*
+      | ???*21*
       | 4
       | undefined
-      | ((???*25* | ???*27*) ? ???*28* : 4)
-      | (???*29* ? 16 : (???*30* | undefined | null | ???*37* | ???*38*))
-      | ???*40*
-      | (???*42* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*22* | ???*24*) ? ???*25* : 4)
+      | (???*26* ? 16 : (???*27* | undefined | null | ???*34* | ???*35*))
+      | ???*37*
+      | (???*39* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     ),
-    (???*44* | (???*45* ? ???*47* : ???*48*))
+    (???*41* | (???*42* ? ???*44* : ???*45*))
 )
 - *0* arguments[0]
   ⚠️  function calls are not analyzed yet
@@ -49328,93 +49090,81 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *12* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *13* (???*14* ? (???*18* | ???*19*) : ???*20*)
+- *13* (???*14* ? (-1 | ???*16*) : ???*17*)
   ⚠️  nested operation
-- *14* (???*15* !== (???*16* | ???*17*))
+- *14* (-1 !== (-1 | ???*15*))
   ⚠️  nested operation
-- *15* unsupported expression
-  ⚠️  This value might have side effects
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* ...[...]()
+- *15* ...[...]()
   ⚠️  nested operation
-- *18* unsupported expression
-  ⚠️  This value might have side effects
-- *19* module<scheduler, {}>["unstable_now"]()
+- *16* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *20* assignment expression
+- *17* assignment expression
   ⚠️  This value might have side effects
-- *21* unsupported assign operation
+- *18* unsupported assign operation
   ⚠️  This value might have side effects
-- *22* arguments[7]
+- *19* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *23* arguments[8]
+- *20* arguments[8]
   ⚠️  function calls are not analyzed yet
-- *24* C
+- *21* C
   ⚠️  circular variable reference
-- *25* (0 !== ???*26*)
+- *22* (0 !== ???*23*)
   ⚠️  nested operation
-- *26* C
+- *23* C
   ⚠️  circular variable reference
-- *27* unsupported expression
+- *24* unsupported expression
   ⚠️  This value might have side effects
-- *28* C
+- *25* C
   ⚠️  circular variable reference
-- *29* unsupported expression
+- *26* unsupported expression
   ⚠️  This value might have side effects
-- *30* (???*31* ? ???*32* : 1)
+- *27* (???*28* ? ???*29* : 1)
   ⚠️  nested operation
-- *31* unsupported expression
+- *28* unsupported expression
   ⚠️  This value might have side effects
-- *32* (???*33* ? ???*34* : 4)
+- *29* (???*30* ? ???*31* : 4)
+  ⚠️  nested operation
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* (???*32* ? 16 : 536870912)
+  ⚠️  nested operation
+- *32* (0 !== ???*33*)
   ⚠️  nested operation
 - *33* unsupported expression
   ⚠️  This value might have side effects
-- *34* (???*35* ? 16 : 536870912)
-  ⚠️  nested operation
-- *35* (0 !== ???*36*)
-  ⚠️  nested operation
-- *36* unsupported expression
-  ⚠️  This value might have side effects
-- *37* arguments[0]
+- *34* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *38* ???*39*["value"]
+- *35* ???*36*["value"]
   ⚠️  unknown object
-- *39* arguments[1]
+- *36* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *40* ???*41*["event"]
+- *37* ???*38*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *41* FreeVar(window)
+- *38* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *42* (undefined === ???*43*)
+- *39* (undefined === ???*40*)
   ⚠️  nested operation
-- *43* a
+- *40* a
   ⚠️  circular variable reference
-- *44* arguments[3]
+- *41* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *45* (0 !== ???*46*)
+- *42* (0 !== ???*43*)
   ⚠️  nested operation
-- *46* unsupported expression
+- *43* unsupported expression
   ⚠️  This value might have side effects
+- *44* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *45* (???*46* ? (-1 | ???*48*) : ???*49*)
+  ⚠️  nested operation
+- *46* (-1 !== (-1 | ???*47*))
+  ⚠️  nested operation
 - *47* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *48* (???*49* ? (???*53* | ???*54*) : ???*55*)
+- *48* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *49* (???*50* !== (???*51* | ???*52*))
-  ⚠️  nested operation
-- *50* unsupported expression
-  ⚠️  This value might have side effects
-- *51* unsupported expression
-  ⚠️  This value might have side effects
-- *52* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *53* unsupported expression
-  ⚠️  This value might have side effects
-- *54* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *55* assignment expression
+- *49* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 7367 call = (...) => undefined((???*0* | ???*1*), (???*2* | (???*3* ? ???*5* : ???*6*)))
@@ -49430,33 +49180,25 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *6* (???*7* ? (???*11* | ???*12*) : ???*13*)
+- *6* (???*7* ? (-1 | ???*9*) : ???*10*)
   ⚠️  nested operation
-- *7* (???*8* !== (???*9* | ???*10*))
+- *7* (-1 !== (-1 | ???*8*))
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
+- *8* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* module<scheduler, {}>["unstable_now"]()
+- *9* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *13* assignment expression
+- *10* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 7368 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 7370 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
+0 -> 7370 call = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))()
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 7371 call = (...) => (1 | ???*0* | ???*1* | a)((???*2* | undefined | ???*4*))
@@ -49514,19 +49256,19 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
     (???*0* ? ???*2* : ???*3*),
     (
       | 1
-      | ???*11*
-      | ???*12*
-      | ???*13*
+      | ???*8*
+      | ???*9*
+      | ???*10*
       | undefined
-      | ???*15*
+      | ???*12*
       | 0
-      | ???*16*
+      | ???*13*
       | 4
-      | ((???*17* | ???*19*) ? ???*20* : 4)
-      | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-      | ???*32*
-      | ???*33*
-      | (???*35* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*14* | ???*16*) ? ???*17* : 4)
+      | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+      | ???*29*
+      | ???*30*
+      | (???*32* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     )
 )
 - *0* (0 !== ???*1*)
@@ -49535,33 +49277,161 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
+  ⚠️  nested operation
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* assignment expression
+  ⚠️  This value might have side effects
+- *8* unsupported expression
+  ⚠️  This value might have side effects
+- *9* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *10* ???*11*["current"]
+  ⚠️  unknown object
+- *11* arguments[1]
+  ⚠️  function calls are not analyzed yet
+- *12* unknown mutation
+  ⚠️  This value might have side effects
+- *13* C
+  ⚠️  circular variable reference
+- *14* (0 !== ???*15*)
+  ⚠️  nested operation
+- *15* C
+  ⚠️  circular variable reference
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* C
+  ⚠️  circular variable reference
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* (???*20* ? ???*21* : 1)
+  ⚠️  nested operation
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
+  ⚠️  nested operation
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *27* ???*28*["value"]
+  ⚠️  unknown object
+- *28* arguments[1]
+  ⚠️  function calls are not analyzed yet
+- *29* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *30* ???*31*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *32* (undefined === ???*33*)
+  ⚠️  nested operation
+- *33* a
+  ⚠️  circular variable reference
+
+0 -> 7379 conditional = (undefined === (???*0* | ???*1*))
+- *0* arguments[3]
+  ⚠️  function calls are not analyzed yet
+- *1* (???*2* ? null : ???*4*)
+  ⚠️  nested operation
+- *2* (undefined === ???*3*)
+  ⚠️  nested operation
+- *3* d
+  ⚠️  circular variable reference
+- *4* d
+  ⚠️  circular variable reference
+
+0 -> 7381 call = (...) => (null | Zg(a, c))(
+    (???*0* | undefined | ???*2*),
+    (
+      | ???*3*
+      | {
+            "eventTime": (???*4* ? ???*6* : ???*7*),
+            "lane": (
+              | 1
+              | ???*12*
+              | ???*13*
+              | ???*14*
+              | 0
+              | ???*16*
+              | 4
+              | undefined
+              | ((???*17* | ???*19*) ? ???*20* : 4)
+              | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
+              | ???*32*
+              | ???*33*
+              | (???*35* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+            ),
+            "tag": 0,
+            "payload": null,
+            "callback": null,
+            "next": null
+        }
+    ),
+    (
+      | 1
+      | ???*37*
+      | ???*38*
+      | ???*39*
+      | undefined
+      | ???*41*
+      | 0
+      | ???*42*
+      | 4
+      | ((???*43* | ???*45*) ? ???*46* : 4)
+      | (???*47* ? 16 : (???*48* | undefined | null | ???*55* | ???*56*))
+      | ???*58*
+      | ???*59*
+      | (???*61* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+    )
+)
+- *0* ???*1*["current"]
+  ⚠️  unknown object
+- *1* arguments[1]
+  ⚠️  function calls are not analyzed yet
+- *2* unknown mutation
+  ⚠️  This value might have side effects
+- *3* arguments[1]
+  ⚠️  function calls are not analyzed yet
+- *4* (0 !== ???*5*)
   ⚠️  nested operation
 - *5* unsupported expression
   ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
+- *7* (???*8* ? (-1 | ???*10*) : ???*11*)
+  ⚠️  nested operation
+- *8* (-1 !== (-1 | ???*9*))
+  ⚠️  nested operation
 - *9* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *10* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *11* assignment expression
   ⚠️  This value might have side effects
-- *11* unsupported expression
+- *12* unsupported expression
   ⚠️  This value might have side effects
-- *12* Ck
+- *13* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *13* ???*14*["current"]
+- *14* ???*15*["current"]
   ⚠️  unknown object
-- *14* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *15* unknown mutation
-  ⚠️  This value might have side effects
+- *15* b
+  ⚠️  circular variable reference
 - *16* C
   ⚠️  circular variable reference
 - *17* (0 !== ???*18*)
@@ -49606,200 +49476,60 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  nested operation
 - *36* a
   ⚠️  circular variable reference
-
-0 -> 7379 conditional = (undefined === (???*0* | ???*1*))
-- *0* arguments[3]
-  ⚠️  function calls are not analyzed yet
-- *1* (???*2* ? null : ???*4*)
-  ⚠️  nested operation
-- *2* (undefined === ???*3*)
-  ⚠️  nested operation
-- *3* d
-  ⚠️  circular variable reference
-- *4* d
-  ⚠️  circular variable reference
-
-0 -> 7381 call = (...) => (null | Zg(a, c))(
-    (???*0* | undefined | ???*2*),
-    (
-      | ???*3*
-      | {
-            "eventTime": (???*4* ? ???*6* : ???*7*),
-            "lane": (
-              | 1
-              | ???*15*
-              | ???*16*
-              | ???*17*
-              | 0
-              | ???*19*
-              | 4
-              | undefined
-              | ((???*20* | ???*22*) ? ???*23* : 4)
-              | (???*24* ? 16 : (???*25* | undefined | null | ???*32* | ???*33*))
-              | ???*35*
-              | ???*36*
-              | (???*38* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-            ),
-            "tag": 0,
-            "payload": null,
-            "callback": null,
-            "next": null
-        }
-    ),
-    (
-      | 1
-      | ???*40*
-      | ???*41*
-      | ???*42*
-      | undefined
-      | ???*44*
-      | 0
-      | ???*45*
-      | 4
-      | ((???*46* | ???*48*) ? ???*49* : 4)
-      | (???*50* ? 16 : (???*51* | undefined | null | ???*58* | ???*59*))
-      | ???*61*
-      | ???*62*
-      | (???*64* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
-    )
-)
-- *0* ???*1*["current"]
-  ⚠️  unknown object
-- *1* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *2* unknown mutation
+- *37* unsupported expression
   ⚠️  This value might have side effects
-- *3* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *4* (0 !== ???*5*)
-  ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *7* (???*8* ? (???*12* | ???*13*) : ???*14*)
-  ⚠️  nested operation
-- *8* (???*9* !== (???*10* | ???*11*))
-  ⚠️  nested operation
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *14* assignment expression
-  ⚠️  This value might have side effects
-- *15* unsupported expression
-  ⚠️  This value might have side effects
-- *16* Ck
+- *38* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *17* ???*18*["current"]
+- *39* ???*40*["current"]
   ⚠️  unknown object
-- *18* b
-  ⚠️  circular variable reference
-- *19* C
-  ⚠️  circular variable reference
-- *20* (0 !== ???*21*)
-  ⚠️  nested operation
-- *21* C
-  ⚠️  circular variable reference
-- *22* unsupported expression
-  ⚠️  This value might have side effects
-- *23* C
-  ⚠️  circular variable reference
-- *24* unsupported expression
-  ⚠️  This value might have side effects
-- *25* (???*26* ? ???*27* : 1)
-  ⚠️  nested operation
-- *26* unsupported expression
-  ⚠️  This value might have side effects
-- *27* (???*28* ? ???*29* : 4)
-  ⚠️  nested operation
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* (???*30* ? 16 : 536870912)
-  ⚠️  nested operation
-- *30* (0 !== ???*31*)
-  ⚠️  nested operation
-- *31* unsupported expression
-  ⚠️  This value might have side effects
-- *32* arguments[0]
+- *40* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *33* ???*34*["value"]
-  ⚠️  unknown object
-- *34* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *35* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *36* ???*37*["event"]
-  ⚠️  unknown object
+- *41* unknown mutation
   ⚠️  This value might have side effects
-- *37* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *38* (undefined === ???*39*)
+- *42* C
+  ⚠️  circular variable reference
+- *43* (0 !== ???*44*)
   ⚠️  nested operation
-- *39* a
+- *44* C
   ⚠️  circular variable reference
-- *40* unsupported expression
+- *45* unsupported expression
   ⚠️  This value might have side effects
-- *41* Ck
-  ⚠️  sequence with side effects
-  ⚠️  This value might have side effects
-- *42* ???*43*["current"]
-  ⚠️  unknown object
-- *43* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *44* unknown mutation
-  ⚠️  This value might have side effects
-- *45* C
+- *46* C
   ⚠️  circular variable reference
-- *46* (0 !== ???*47*)
+- *47* unsupported expression
+  ⚠️  This value might have side effects
+- *48* (???*49* ? ???*50* : 1)
   ⚠️  nested operation
-- *47* C
-  ⚠️  circular variable reference
-- *48* unsupported expression
+- *49* unsupported expression
   ⚠️  This value might have side effects
-- *49* C
-  ⚠️  circular variable reference
-- *50* unsupported expression
-  ⚠️  This value might have side effects
-- *51* (???*52* ? ???*53* : 1)
+- *50* (???*51* ? ???*52* : 4)
   ⚠️  nested operation
-- *52* unsupported expression
+- *51* unsupported expression
   ⚠️  This value might have side effects
-- *53* (???*54* ? ???*55* : 4)
+- *52* (???*53* ? 16 : 536870912)
+  ⚠️  nested operation
+- *53* (0 !== ???*54*)
   ⚠️  nested operation
 - *54* unsupported expression
   ⚠️  This value might have side effects
-- *55* (???*56* ? 16 : 536870912)
-  ⚠️  nested operation
-- *56* (0 !== ???*57*)
-  ⚠️  nested operation
-- *57* unsupported expression
-  ⚠️  This value might have side effects
+- *55* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *56* ???*57*["value"]
+  ⚠️  unknown object
+- *57* arguments[1]
+  ⚠️  function calls are not analyzed yet
 - *58* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *59* ???*60*["value"]
-  ⚠️  unknown object
-- *60* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *61* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *62* ???*63*["event"]
+- *59* ???*60*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *63* FreeVar(window)
+- *60* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *64* (undefined === ???*65*)
+- *61* (undefined === ???*62*)
   ⚠️  nested operation
-- *65* a
+- *62* a
   ⚠️  circular variable reference
 
 0 -> 7382 call = (...) => undefined(
@@ -49892,21 +49622,15 @@ ${(???*50* | ???*51* | undefined | ???*55* | undefined[1] | "")}${(???*59* | ???
   ⚠️  This value might have side effects
 - *32* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *33* (???*34* ? (???*38* | ???*39*) : ???*40*)
+- *33* (???*34* ? (-1 | ???*36*) : ???*37*)
   ⚠️  nested operation
-- *34* (???*35* !== (???*36* | ???*37*))
+- *34* (-1 !== (-1 | ???*35*))
   ⚠️  nested operation
-- *35* unsupported expression
-  ⚠️  This value might have side effects
-- *36* unsupported expression
-  ⚠️  This value might have side effects
-- *37* module<scheduler, {}>["unstable_now"]()
+- *35* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *38* unsupported expression
-  ⚠️  This value might have side effects
-- *39* module<scheduler, {}>["unstable_now"]()
+- *36* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *40* assignment expression
+- *37* assignment expression
   ⚠️  This value might have side effects
 
 0 -> 7383 call = (...) => undefined(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
@@ -427,9 +427,7 @@ Bj = (???*0* | (...) => undefined)
 - *0* Bj
   ⚠️  pattern without value
 
-Bk = (???*0* | module<scheduler, {}>["unstable_now"]())
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+Bk = (-1 | module<scheduler, {}>["unstable_now"]())
 
 C = (
   | 0
@@ -1056,12 +1054,10 @@ Kj = ???*0*
 
 Kk = (...) => ((null === a) ? ai : a)
 
-L = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))
+L = (...) => ((0 !== ???*0*) ? B() : ((-1 !== Bk) ? Bk : ???*1*))
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* assignment expression
+- *1* assignment expression
   ⚠️  This value might have side effects
 
 La = (???*0* | ???*1* | undefined | ???*6* | undefined[1] | "")
@@ -1983,10 +1979,8 @@ Td = (...) => ???*0*
 
 Te = (false | true)
 
-Tf = (???*0* | ???*1*)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* updated with update expression
+Tf = (-1 | ???*0*)
+- *0* updated with update expression
   ⚠️  This value might have side effects
 
 Tg = (...) => undefined
@@ -8613,12 +8607,10 @@ b#587 = (???*0* | (13 === ???*1*) | ???*3* | (???*5* ? ???*7* : true))
 
 b#589 = (
   | ???*0*
-  | {"eventTime": ???*1*, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
+  | {"eventTime": -1, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *1* unsupported expression
-  ⚠️  This value might have side effects
 
 b#590 = ???*0*
 - *0* arguments[1]
@@ -9150,21 +9142,15 @@ b#915 = (???*0* | (???*1* ? ???*3* : ???*4*))
   ⚠️  This value might have side effects
 - *3* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *4* (???*5* ? (???*9* | ???*10*) : ???*11*)
+- *4* (???*5* ? (-1 | ???*7*) : ???*8*)
   ⚠️  nested operation
-- *5* (???*6* !== (???*7* | ???*8*))
+- *5* (-1 !== (-1 | ???*6*))
   ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
+- *7* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* assignment expression
+- *8* assignment expression
   ⚠️  This value might have side effects
 
 b#916 = (???*0* | 1 | 4194304 | ???*1*)
@@ -9313,18 +9299,18 @@ b#961 = (
         "eventTime": (???*1* ? ???*3* : ???*4*),
         "lane": (
           | 1
-          | ???*12*
-          | ???*13*
-          | ???*14*
+          | ???*9*
+          | ???*10*
+          | ???*11*
           | 0
-          | ???*16*
+          | ???*13*
           | 4
           | undefined
-          | ((???*17* | ???*19*) ? ???*20* : 4)
-          | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-          | ???*32*
-          | ???*33*
-          | (???*35* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+          | ((???*14* | ???*16*) ? ???*17* : 4)
+          | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+          | ???*29*
+          | ???*30*
+          | (???*32* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
         ),
         "tag": 0,
         "payload": null,
@@ -9340,74 +9326,68 @@ b#961 = (
   ⚠️  This value might have side effects
 - *3* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *4* (???*5* ? (???*9* | ???*10*) : ???*11*)
+- *4* (???*5* ? (-1 | ???*7*) : ???*8*)
   ⚠️  nested operation
-- *5* (???*6* !== (???*7* | ???*8*))
+- *5* (-1 !== (-1 | ???*6*))
   ⚠️  nested operation
-- *6* unsupported expression
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *8* assignment expression
   ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *9* unsupported expression
   ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *11* assignment expression
-  ⚠️  This value might have side effects
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* Ck
+- *10* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *14* ???*15*["current"]
+- *11* ???*12*["current"]
   ⚠️  unknown object
-- *15* b
+- *12* b
   ⚠️  circular variable reference
-- *16* C
+- *13* C
   ⚠️  circular variable reference
-- *17* (0 !== ???*18*)
+- *14* (0 !== ???*15*)
   ⚠️  nested operation
-- *18* C
+- *15* C
   ⚠️  circular variable reference
-- *19* unsupported expression
+- *16* unsupported expression
   ⚠️  This value might have side effects
-- *20* C
+- *17* C
   ⚠️  circular variable reference
-- *21* unsupported expression
+- *18* unsupported expression
   ⚠️  This value might have side effects
-- *22* (???*23* ? ???*24* : 1)
+- *19* (???*20* ? ???*21* : 1)
   ⚠️  nested operation
-- *23* unsupported expression
+- *20* unsupported expression
   ⚠️  This value might have side effects
-- *24* (???*25* ? ???*26* : 4)
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
   ⚠️  nested operation
 - *25* unsupported expression
   ⚠️  This value might have side effects
-- *26* (???*27* ? 16 : 536870912)
-  ⚠️  nested operation
-- *27* (0 !== ???*28*)
-  ⚠️  nested operation
-- *28* unsupported expression
-  ⚠️  This value might have side effects
+- *26* arguments[0]
+  ⚠️  function calls are not analyzed yet
+- *27* ???*28*["value"]
+  ⚠️  unknown object
+- *28* arguments[1]
+  ⚠️  function calls are not analyzed yet
 - *29* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *30* ???*31*["value"]
-  ⚠️  unknown object
-- *31* arguments[1]
-  ⚠️  function calls are not analyzed yet
-- *32* arguments[0]
-  ⚠️  function calls are not analyzed yet
-- *33* ???*34*["event"]
+- *30* ???*31*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *34* FreeVar(window)
+- *31* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *35* (undefined === ???*36*)
+- *32* (undefined === ???*33*)
   ⚠️  nested operation
-- *36* a
+- *33* a
   ⚠️  circular variable reference
 
 b#963 = ???*0*
@@ -10530,21 +10510,15 @@ c#419 = (???*0* ? ???*2* : ???*3*)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 c#420 = ???*0*
@@ -11459,24 +11433,20 @@ c#576 = ???*0*
 
 c#578 = (
   | ???*0*
-  | {"eventTime": ???*1*, "lane": ???*2*, "tag": 0, "payload": null, "callback": null, "next": null}
+  | {"eventTime": -1, "lane": ???*1*, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[2]
   ⚠️  function calls are not analyzed yet
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* c
+- *1* c
   ⚠️  circular variable reference
 
 c#580 = (
   | ???*0*
-  | {"eventTime": ???*1*, "lane": ???*2*, "tag": 0, "payload": null, "callback": null, "next": null}
+  | {"eventTime": -1, "lane": ???*1*, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[2]
   ⚠️  function calls are not analyzed yet
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* c
+- *1* c
   ⚠️  circular variable reference
 
 c#584 = ???*0*
@@ -12059,21 +12029,15 @@ c#916 = (???*0* ? ???*2* : ???*3*)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 c#917 = (0 | ???*0*)
@@ -12270,21 +12234,15 @@ c#992 = ((???*0* ? ???*2* : ???*3*) | undefined)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 c#994 = ((???*0* ? ???*2* : ???*3*) | undefined)
@@ -12294,21 +12252,15 @@ c#994 = ((???*0* ? ???*2* : ???*3*) | undefined)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 c#997 = ((???*0* ? ???*4* : null) | undefined)
@@ -12943,21 +12895,15 @@ d#417 = (???*0* ? ???*2* : ???*3*)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 d#418 = (???*0* ? ???*2* : ???*3*)
@@ -12967,21 +12913,15 @@ d#418 = (???*0* ? ???*2* : ???*3*)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 d#419 = (
@@ -14680,21 +14620,15 @@ d#960 = (???*0* | (???*1* ? ???*3* : ???*4*))
   ⚠️  This value might have side effects
 - *3* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *4* (???*5* ? (???*9* | ???*10*) : ???*11*)
+- *4* (???*5* ? (-1 | ???*7*) : ???*8*)
   ⚠️  nested operation
-- *5* (???*6* !== (???*7* | ???*8*))
+- *5* (-1 !== (-1 | ???*6*))
   ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* module<scheduler, {}>["unstable_now"]()
+- *7* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* assignment expression
+- *8* assignment expression
   ⚠️  This value might have side effects
 
 d#961 = (???*0* | (???*1* ? null : ???*3*))
@@ -14722,21 +14656,15 @@ d#997 = ((???*0* ? ???*2* : ???*3*) | undefined)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 da = new ???*0*()
@@ -15635,18 +15563,18 @@ e#419 = {
     "eventTime": (???*0* ? ???*2* : ???*3*),
     "lane": (
       | 1
+      | ???*8*
+      | ???*9*
+      | ???*10*
       | ???*11*
-      | ???*12*
-      | ???*13*
-      | ???*14*
       | 0
-      | ???*16*
+      | ???*13*
       | 4
       | undefined
-      | ((???*17* | ???*19*) ? ???*20* : 4)
-      | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-      | ???*32*
-      | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*14* | ???*16*) ? ???*17* : 4)
+      | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+      | ???*29*
+      | (???*31* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     ),
     "tag": 0,
     "payload": null,
@@ -15659,74 +15587,68 @@ e#419 = {
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* assignment expression
   ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *8* unsupported expression
   ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *10* assignment expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* Ck
+- *9* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *13* arguments[0]
+- *10* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *14* ???*15*["_reactInternals"]
+- *11* ???*12*["_reactInternals"]
   ⚠️  unknown object
-- *15* a
+- *12* a
   ⚠️  circular variable reference
-- *16* C
+- *13* C
   ⚠️  circular variable reference
-- *17* (0 !== ???*18*)
+- *14* (0 !== ???*15*)
   ⚠️  nested operation
-- *18* C
+- *15* C
   ⚠️  circular variable reference
-- *19* unsupported expression
+- *16* unsupported expression
   ⚠️  This value might have side effects
-- *20* C
+- *17* C
   ⚠️  circular variable reference
-- *21* unsupported expression
+- *18* unsupported expression
   ⚠️  This value might have side effects
-- *22* (???*23* ? ???*24* : 1)
+- *19* (???*20* ? ???*21* : 1)
   ⚠️  nested operation
-- *23* unsupported expression
+- *20* unsupported expression
   ⚠️  This value might have side effects
-- *24* (???*25* ? ???*26* : 4)
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
   ⚠️  nested operation
 - *25* unsupported expression
   ⚠️  This value might have side effects
-- *26* (???*27* ? 16 : 536870912)
-  ⚠️  nested operation
-- *27* (0 !== ???*28*)
-  ⚠️  nested operation
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* arguments[0]
+- *26* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *30* ???*31*["value"]
+- *27* ???*28*["value"]
   ⚠️  unknown object
-- *31* arguments[1]
+- *28* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *32* ???*33*["event"]
+- *29* ???*30*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *33* FreeVar(window)
+- *30* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *34* (undefined === ???*35*)
+- *31* (undefined === ???*32*)
   ⚠️  nested operation
-- *35* a
+- *32* a
   ⚠️  circular variable reference
 
 e#420 = ???*0*
@@ -16041,21 +15963,15 @@ e#537 = ((???*0* ? ???*2* : ???*3*) | undefined)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 e#539 = (
@@ -16152,21 +16068,15 @@ e#539 = (
   ⚠️  This value might have side effects
 - *33* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *34* (???*35* ? (???*39* | ???*40*) : ???*41*)
+- *34* (???*35* ? (-1 | ???*37*) : ???*38*)
   ⚠️  nested operation
-- *35* (???*36* !== (???*37* | ???*38*))
+- *35* (-1 !== (-1 | ???*36*))
   ⚠️  nested operation
-- *36* unsupported expression
-  ⚠️  This value might have side effects
-- *37* unsupported expression
-  ⚠️  This value might have side effects
-- *38* module<scheduler, {}>["unstable_now"]()
+- *36* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* module<scheduler, {}>["unstable_now"]()
+- *37* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *41* assignment expression
+- *38* assignment expression
   ⚠️  This value might have side effects
 
 e#559 = (
@@ -16778,15 +16688,15 @@ e#960 = (
   | ???*1*
   | ???*2*
   | ???*3*
-  | new (...) => undefined(???*5*, (???*6* | ???*7* | 1 | ???*19* | 0), true, ???*20*, ???*21*)["current"]
+  | new (...) => undefined(???*5*, (???*6* | ???*7* | 1 | ???*16* | 0), true, ???*17*, ???*18*)["current"]
   | 0
-  | ???*22*
+  | ???*19*
   | 4
   | undefined
-  | ((???*23* | ???*25*) ? ???*26* : 4)
-  | (???*27* ? 16 : (???*28* | undefined | null | ???*35* | ???*36*))
-  | ???*38*
-  | (???*40* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+  | ((???*20* | ???*22*) ? ???*23* : 4)
+  | (???*24* ? 16 : (???*25* | undefined | null | ???*32* | ???*33*))
+  | ???*35*
+  | (???*37* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
 )
 - *0* arguments[4]
   ⚠️  function calls are not analyzed yet
@@ -16811,69 +16721,63 @@ e#960 = (
   ⚠️  This value might have side effects
 - *10* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *11* (???*12* ? (???*16* | ???*17*) : ???*18*)
+- *11* (???*12* ? (-1 | ???*14*) : ???*15*)
   ⚠️  nested operation
-- *12* (???*13* !== (???*14* | ???*15*))
+- *12* (-1 !== (-1 | ???*13*))
   ⚠️  nested operation
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* module<scheduler, {}>["unstable_now"]()
+- *13* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* module<scheduler, {}>["unstable_now"]()
+- *14* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *18* assignment expression
+- *15* assignment expression
   ⚠️  This value might have side effects
-- *19* unsupported assign operation
+- *16* unsupported assign operation
   ⚠️  This value might have side effects
-- *20* arguments[7]
+- *17* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *21* arguments[8]
+- *18* arguments[8]
   ⚠️  function calls are not analyzed yet
-- *22* C
+- *19* C
   ⚠️  circular variable reference
-- *23* (0 !== ???*24*)
+- *20* (0 !== ???*21*)
   ⚠️  nested operation
-- *24* C
+- *21* C
   ⚠️  circular variable reference
-- *25* unsupported expression
+- *22* unsupported expression
   ⚠️  This value might have side effects
-- *26* C
+- *23* C
   ⚠️  circular variable reference
-- *27* unsupported expression
+- *24* unsupported expression
   ⚠️  This value might have side effects
-- *28* (???*29* ? ???*30* : 1)
+- *25* (???*26* ? ???*27* : 1)
   ⚠️  nested operation
-- *29* unsupported expression
+- *26* unsupported expression
   ⚠️  This value might have side effects
-- *30* (???*31* ? ???*32* : 4)
+- *27* (???*28* ? ???*29* : 4)
+  ⚠️  nested operation
+- *28* unsupported expression
+  ⚠️  This value might have side effects
+- *29* (???*30* ? 16 : 536870912)
+  ⚠️  nested operation
+- *30* (0 !== ???*31*)
   ⚠️  nested operation
 - *31* unsupported expression
   ⚠️  This value might have side effects
-- *32* (???*33* ? 16 : 536870912)
-  ⚠️  nested operation
-- *33* (0 !== ???*34*)
-  ⚠️  nested operation
-- *34* unsupported expression
-  ⚠️  This value might have side effects
-- *35* arguments[0]
+- *32* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *36* ???*37*["value"]
+- *33* ???*34*["value"]
   ⚠️  unknown object
-- *37* arguments[1]
+- *34* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *38* ???*39*["event"]
+- *35* ???*36*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *39* FreeVar(window)
+- *36* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *40* (undefined === ???*41*)
+- *37* (undefined === ???*38*)
   ⚠️  nested operation
-- *41* a
+- *38* a
   ⚠️  circular variable reference
 
 e#961 = (???*0* | undefined | ???*2*)
@@ -17403,18 +17307,18 @@ f#417 = {
     "eventTime": (???*0* ? ???*2* : ???*3*),
     "lane": (
       | 1
+      | ???*8*
+      | ???*9*
+      | ???*10*
       | ???*11*
-      | ???*12*
-      | ???*13*
-      | ???*14*
       | 0
-      | ???*16*
+      | ???*13*
       | 4
       | undefined
-      | ((???*17* | ???*19*) ? ???*20* : 4)
-      | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-      | ???*32*
-      | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*14* | ???*16*) ? ???*17* : 4)
+      | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+      | ???*29*
+      | (???*31* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     ),
     "tag": 0,
     "payload": null,
@@ -17427,92 +17331,86 @@ f#417 = {
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* assignment expression
   ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *8* unsupported expression
   ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *10* assignment expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* Ck
+- *9* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *13* arguments[0]
+- *10* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *14* ???*15*["_reactInternals"]
+- *11* ???*12*["_reactInternals"]
   ⚠️  unknown object
-- *15* a
+- *12* a
   ⚠️  circular variable reference
-- *16* C
+- *13* C
   ⚠️  circular variable reference
-- *17* (0 !== ???*18*)
+- *14* (0 !== ???*15*)
   ⚠️  nested operation
-- *18* C
+- *15* C
   ⚠️  circular variable reference
-- *19* unsupported expression
+- *16* unsupported expression
   ⚠️  This value might have side effects
-- *20* C
+- *17* C
   ⚠️  circular variable reference
-- *21* unsupported expression
+- *18* unsupported expression
   ⚠️  This value might have side effects
-- *22* (???*23* ? ???*24* : 1)
+- *19* (???*20* ? ???*21* : 1)
   ⚠️  nested operation
-- *23* unsupported expression
+- *20* unsupported expression
   ⚠️  This value might have side effects
-- *24* (???*25* ? ???*26* : 4)
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
   ⚠️  nested operation
 - *25* unsupported expression
   ⚠️  This value might have side effects
-- *26* (???*27* ? 16 : 536870912)
-  ⚠️  nested operation
-- *27* (0 !== ???*28*)
-  ⚠️  nested operation
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* arguments[0]
+- *26* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *30* ???*31*["value"]
+- *27* ???*28*["value"]
   ⚠️  unknown object
-- *31* arguments[1]
+- *28* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *32* ???*33*["event"]
+- *29* ???*30*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *33* FreeVar(window)
+- *30* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *34* (undefined === ???*35*)
+- *31* (undefined === ???*32*)
   ⚠️  nested operation
-- *35* a
+- *32* a
   ⚠️  circular variable reference
 
 f#418 = {
     "eventTime": (???*0* ? ???*2* : ???*3*),
     "lane": (
       | 1
+      | ???*8*
+      | ???*9*
+      | ???*10*
       | ???*11*
-      | ???*12*
-      | ???*13*
-      | ???*14*
       | 0
-      | ???*16*
+      | ???*13*
       | 4
       | undefined
-      | ((???*17* | ???*19*) ? ???*20* : 4)
-      | (???*21* ? 16 : (???*22* | undefined | null | ???*29* | ???*30*))
-      | ???*32*
-      | (???*34* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+      | ((???*14* | ???*16*) ? ???*17* : 4)
+      | (???*18* ? 16 : (???*19* | undefined | null | ???*26* | ???*27*))
+      | ???*29*
+      | (???*31* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
     ),
     "tag": 0,
     "payload": null,
@@ -17525,74 +17423,68 @@ f#418 = {
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
+- *5* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *6* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *7* assignment expression
   ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *8* unsupported expression
   ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *10* assignment expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* Ck
+- *9* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *13* arguments[0]
+- *10* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *14* ???*15*["_reactInternals"]
+- *11* ???*12*["_reactInternals"]
   ⚠️  unknown object
-- *15* a
+- *12* a
   ⚠️  circular variable reference
-- *16* C
+- *13* C
   ⚠️  circular variable reference
-- *17* (0 !== ???*18*)
+- *14* (0 !== ???*15*)
   ⚠️  nested operation
-- *18* C
+- *15* C
   ⚠️  circular variable reference
-- *19* unsupported expression
+- *16* unsupported expression
   ⚠️  This value might have side effects
-- *20* C
+- *17* C
   ⚠️  circular variable reference
-- *21* unsupported expression
+- *18* unsupported expression
   ⚠️  This value might have side effects
-- *22* (???*23* ? ???*24* : 1)
+- *19* (???*20* ? ???*21* : 1)
   ⚠️  nested operation
-- *23* unsupported expression
+- *20* unsupported expression
   ⚠️  This value might have side effects
-- *24* (???*25* ? ???*26* : 4)
+- *21* (???*22* ? ???*23* : 4)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* (???*24* ? 16 : 536870912)
+  ⚠️  nested operation
+- *24* (0 !== ???*25*)
   ⚠️  nested operation
 - *25* unsupported expression
   ⚠️  This value might have side effects
-- *26* (???*27* ? 16 : 536870912)
-  ⚠️  nested operation
-- *27* (0 !== ???*28*)
-  ⚠️  nested operation
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* arguments[0]
+- *26* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *30* ???*31*["value"]
+- *27* ???*28*["value"]
   ⚠️  unknown object
-- *31* arguments[1]
+- *28* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *32* ???*33*["event"]
+- *29* ???*30*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *33* FreeVar(window)
+- *30* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *34* (undefined === ???*35*)
+- *31* (undefined === ???*32*)
   ⚠️  nested operation
-- *35* a
+- *32* a
   ⚠️  circular variable reference
 
 f#420 = ???*0*
@@ -18210,20 +18102,20 @@ f#960 = (
   | {
         "eventTime": (???*1* | (???*2* ? ???*4* : ???*5*)),
         "lane": (
-          | ???*13*
+          | ???*10*
           | 1
-          | ???*14*
-          | ???*15*
-          | ???*16*
-          | new (...) => undefined(???*18*, (???*19* | ???*20* | 1 | ???*32* | 0), true, ???*33*, ???*34*)["current"]
+          | ???*11*
+          | ???*12*
+          | ???*13*
+          | new (...) => undefined(???*15*, (???*16* | ???*17* | 1 | ???*26* | 0), true, ???*27*, ???*28*)["current"]
           | 0
-          | ???*35*
+          | ???*29*
           | 4
           | undefined
-          | ((???*36* | ???*38*) ? ???*39* : 4)
-          | (???*40* ? 16 : (???*41* | undefined | null | ???*48* | ???*49*))
-          | ???*51*
-          | (???*53* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
+          | ((???*30* | ???*32*) ? ???*33* : 4)
+          | (???*34* ? 16 : (???*35* | undefined | null | ???*42* | ???*43*))
+          | ???*45*
+          | (???*47* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
         ),
         "tag": 0,
         "payload": null,
@@ -18241,108 +18133,96 @@ f#960 = (
   ⚠️  This value might have side effects
 - *4* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *5* (???*6* ? (???*10* | ???*11*) : ???*12*)
+- *5* (???*6* ? (-1 | ???*8*) : ???*9*)
   ⚠️  nested operation
-- *6* (???*7* !== (???*8* | ???*9*))
+- *6* (-1 !== (-1 | ???*7*))
   ⚠️  nested operation
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *7* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* module<scheduler, {}>["unstable_now"]()
+- *8* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *12* assignment expression
+- *9* assignment expression
   ⚠️  This value might have side effects
-- *13* arguments[4]
+- *10* arguments[4]
   ⚠️  function calls are not analyzed yet
-- *14* unsupported expression
+- *11* unsupported expression
   ⚠️  This value might have side effects
-- *15* Ck
+- *12* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *16* ???*17*["current"]
+- *13* ???*14*["current"]
   ⚠️  unknown object
-- *17* arguments[0]
+- *14* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *18* a
+- *15* a
   ⚠️  circular variable reference
-- *19* arguments[3]
+- *16* arguments[3]
   ⚠️  function calls are not analyzed yet
-- *20* (???*21* ? ???*23* : ???*24*)
+- *17* (???*18* ? ???*20* : ???*21*)
   ⚠️  nested operation
-- *21* (0 !== ???*22*)
+- *18* (0 !== ???*19*)
   ⚠️  nested operation
-- *22* unsupported expression
+- *19* unsupported expression
   ⚠️  This value might have side effects
-- *23* module<scheduler, {}>["unstable_now"]()
+- *20* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *24* (???*25* ? (???*29* | ???*30*) : ???*31*)
+- *21* (???*22* ? (-1 | ???*24*) : ???*25*)
   ⚠️  nested operation
-- *25* (???*26* !== (???*27* | ???*28*))
+- *22* (-1 !== (-1 | ???*23*))
   ⚠️  nested operation
-- *26* unsupported expression
-  ⚠️  This value might have side effects
-- *27* unsupported expression
-  ⚠️  This value might have side effects
-- *28* ...()
+- *23* ...()
   ⚠️  nested operation
-- *29* unsupported expression
-  ⚠️  This value might have side effects
-- *30* ...[...]()
+- *24* ...[...]()
   ⚠️  nested operation
-- *31* assignment expression
+- *25* assignment expression
   ⚠️  This value might have side effects
-- *32* unsupported assign operation
+- *26* unsupported assign operation
   ⚠️  This value might have side effects
-- *33* arguments[7]
+- *27* arguments[7]
   ⚠️  function calls are not analyzed yet
-- *34* arguments[8]
+- *28* arguments[8]
   ⚠️  function calls are not analyzed yet
-- *35* C
+- *29* C
   ⚠️  circular variable reference
-- *36* (0 !== ???*37*)
+- *30* (0 !== ???*31*)
   ⚠️  nested operation
-- *37* C
+- *31* C
   ⚠️  circular variable reference
+- *32* unsupported expression
+  ⚠️  This value might have side effects
+- *33* C
+  ⚠️  circular variable reference
+- *34* unsupported expression
+  ⚠️  This value might have side effects
+- *35* (???*36* ? ???*37* : 1)
+  ⚠️  nested operation
+- *36* unsupported expression
+  ⚠️  This value might have side effects
+- *37* (???*38* ? ???*39* : 4)
+  ⚠️  nested operation
 - *38* unsupported expression
   ⚠️  This value might have side effects
-- *39* C
-  ⚠️  circular variable reference
-- *40* unsupported expression
-  ⚠️  This value might have side effects
-- *41* (???*42* ? ???*43* : 1)
+- *39* (???*40* ? 16 : 536870912)
   ⚠️  nested operation
-- *42* unsupported expression
-  ⚠️  This value might have side effects
-- *43* (???*44* ? ???*45* : 4)
+- *40* (0 !== ???*41*)
   ⚠️  nested operation
-- *44* unsupported expression
+- *41* unsupported expression
   ⚠️  This value might have side effects
-- *45* (???*46* ? 16 : 536870912)
-  ⚠️  nested operation
-- *46* (0 !== ???*47*)
-  ⚠️  nested operation
-- *47* unsupported expression
-  ⚠️  This value might have side effects
-- *48* arguments[0]
+- *42* arguments[0]
   ⚠️  function calls are not analyzed yet
-- *49* ???*50*["value"]
+- *43* ???*44*["value"]
   ⚠️  unknown object
-- *50* arguments[1]
+- *44* arguments[1]
   ⚠️  function calls are not analyzed yet
-- *51* ???*52*["event"]
+- *45* ???*46*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *52* FreeVar(window)
+- *46* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *53* (undefined === ???*54*)
+- *47* (undefined === ???*48*)
   ⚠️  nested operation
-- *54* a
+- *48* a
   ⚠️  circular variable reference
 
 f#961 = (???*0* ? ???*2* : ???*3*)
@@ -18352,21 +18232,15 @@ f#961 = (???*0* ? ???*2* : ???*3*)
   ⚠️  This value might have side effects
 - *2* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *3* (???*4* ? (???*8* | ???*9*) : ???*10*)
+- *3* (???*4* ? (-1 | ???*6*) : ???*7*)
   ⚠️  nested operation
-- *4* (???*5* !== (???*6* | ???*7*))
+- *4* (-1 !== (-1 | ???*5*))
   ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* module<scheduler, {}>["unstable_now"]()
+- *5* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *6* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* assignment expression
+- *7* assignment expression
   ⚠️  This value might have side effects
 
 f#979 = (???*0* | (...) => undefined | undefined)
@@ -19021,9 +18895,7 @@ gc = module<scheduler, {}>["unstable_UserBlockingPriority"]
 
 gd = (...) => undefined
 
-ge = (...) => ((???*0* !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+ge = (...) => ((-1 !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)
 
 gf = (0 | ???*0*)
 - *0* updated with update expression
@@ -21430,9 +21302,7 @@ va = ???*0*
 
 vb = (...) => (("string" === typeof(b["is"])) | !(1) | !(0) | undefined)
 
-vc = (...) => ((b + 250) | (b + 5000) | ???*0* | undefined)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
+vc = (...) => ((b + 250) | (b + 5000) | -1 | undefined)
 
 vd = (...) => ???*0*
 - *0* unsupported expression


### PR DESCRIPTION
Previously, these were unknown / unsupported expressions:
```
Unknown {
    original_value: None,
    reason: "unsupported expression",
    has_side_effects: true,
},
```

This prevented us from folding `-1 === -1` into true, for example. Most of this PR's changes are updates to the snapshot. It exists in this stack because the code it touches was moved in the stack.