### PR TITLE
[turbopack] Use `ast_path.kinds()` instead of mapping over `ast_path` in the analyzer

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -52,11 +52,8 @@ pub fn as_parent_path_skip(
     ast_path: &AstNodePath<AstParentNodeRef<'_>>,
     skip: usize,
 ) -> Vec<AstParentKind> {
-    ast_path
-        .iter()
-        .take(ast_path.len() - skip)
-        .map(|n| n.kind())
-        .collect()
+    let kinds = ast_path.kinds();
+    kinds[..kinds.len() - skip].to_vec()
 }
 
 pub(super) struct Analyzer<'a> {
@@ -466,7 +463,7 @@ mod analyzer_state {
 }
 
 pub fn as_parent_path(ast_path: &AstNodePath<AstParentNodeRef<'_>>) -> Vec<AstParentKind> {
-    ast_path.iter().map(|n| n.kind()).collect()
+    ast_path.kinds().to_vec()
 }
 
 /// Extracts export names from usage patterns on a dynamic import.
@@ -601,11 +598,11 @@ pub fn as_parent_path_with(
     ast_path: &AstNodePath<AstParentNodeRef<'_>>,
     additional: AstParentKind,
 ) -> Vec<AstParentKind> {
-    ast_path
-        .iter()
-        .map(|n| n.kind())
-        .chain([additional])
-        .collect()
+    let kinds = ast_path.kinds();
+    let mut path = Vec::with_capacity(kinds.len() + 1);
+    path.extend_from_slice(kinds);
+    path.push(additional);
+    path
 }
 
 enum CallOrNewExpr<'ast> {


### PR DESCRIPTION
@lukesandberg and I were looking at the call stack for the analyzer this morning and we talked about how we appeared to be spending a lot of time calculating the kind of each node's parent, see:

<img width="939" height="291" alt="Screenshot 2026-05-29 at 12 24 41 AM" src="https://github.com/user-attachments/assets/1f9d2c02-0a49-4e33-8107-626791e85ba1" />

Interestingly, SWC also appears to be calculating this information based on the call stack. And it appears that SWC's [`AstNodePath`'s `kinds()` method](https://rustdoc.swc.rs/swc_common/pass/struct.AstNodePath.html#method.kinds) is a pre-computed version of what we were computing. This PR switches us to using that method to see if there any potential performance benefits.

I think I need a little bit of help benchmarking this more but running:

```
cargo bench --manifest-path /Users/sampoder/dev/next.js/Cargo.toml  -p turbopack-ecmascript --bench analyzer  -- --baseline orig 'create_graph/(peg|react-dom-production|md5)'
```

First on the branch without this switch, and then on this branch suggests improvements:

```
analyzer/create_graph/md5
                        time:   [109.87 µs 110.24 µs 110.59 µs]
                        change: [-3.3365% -2.7341% -2.1580%] (p = 0.00 < 0.05)
                        Performance has improved.
analyzer/create_graph/peg
                        time:   [1.3740 ms 1.3813 ms 1.3887 ms]
                        change: [-8.4332% -7.7685% -7.1580%] (p = 0.00 < 0.05)
                        Performance has improved.
analyzer/create_graph/react-dom-production
                        time:   [2.9095 ms 2.9319 ms 2.9553 ms]
                        change: [-17.616% -16.642% -15.677%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
analyzer/create_graph/md5-reduced
                        time:   [26.658 µs 26.725 µs 26.794 µs]
                        change: [-5.7610% -5.2585% -4.7925%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
analyzer/create_graph/md5_2
                        time:   [109.99 µs 110.30 µs 110.64 µs]
                        change: [-9.0036% -8.5102% -8.0469%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```
