### PR TITLE
fix(eslint-plugin-next): detect pages directory by segment

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-page-custom-font.ts
+++ b/packages/eslint-plugin-next/src/rules/no-page-custom-font.ts
@@ -1,6 +1,5 @@
 import { defineRule } from '../utils/define-rule'
 import NodeAttributes from '../utils/node-attributes'
-import { sep, posix } from 'path'
 import type { AST } from 'eslint'
 
 const url = 'https://nextjs.org/docs/messages/no-page-custom-font'
@@ -21,17 +20,17 @@ export default defineRule({
   },
   create(context) {
     const { sourceCode } = context
-    const paths = context.filename.split('pages')
-    const page = paths[paths.length - 1]
+    const normalizedFilename = context.filename.replace(/\\/g, '/')
+    const pathSegments = normalizedFilename.split('/')
+    const pagesDirIndex = pathSegments.lastIndexOf('pages')
 
     // outside of a file within `pages`, bail
-    if (!page) {
+    if (pagesDirIndex === -1 || pagesDirIndex === pathSegments.length - 1) {
       return {}
     }
 
-    const is_Document =
-      page.startsWith(`${sep}_document`) ||
-      page.startsWith(`${posix.sep}_document`)
+    const page = `/${pathSegments.slice(pagesDirIndex + 1).join('/')}`
+    const is_Document = page.startsWith('/_document')
 
     let documentImportName
     let localDefaultExportId

--- a/test/unit/eslint-plugin-next/no-page-custom-font.test.ts
+++ b/test/unit/eslint-plugin-next/no-page-custom-font.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint'
+import { Linter, RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-page-custom-font']
@@ -115,6 +115,37 @@ const tests = {
     }`,
       filename,
     },
+    {
+      code: `
+      export default function RootLayout({ children }) {
+        return (
+          <html lang="en">
+            <head>
+              <link
+                href="https://fonts.googleapis.com/css2?family=Inter"
+                rel="stylesheet"
+              />
+            </head>
+            <body>{children}</body>
+          </html>
+        )
+      }
+      `,
+      filename: 'packages/web/src/app/layout.tsx',
+    },
+    {
+      code: `
+      export default function Component() {
+        return (
+          <link
+            href="https://fonts.googleapis.com/css2?family=Inter"
+            rel="stylesheet"
+          />
+        )
+      }
+      `,
+      filename: 'webpages/index.tsx',
+    },
   ],
 
   invalid: [
@@ -136,6 +167,32 @@ const tests = {
       }
       `,
       filename: 'pages/index.tsx',
+      errors: [
+        {
+          message:
+            'Custom fonts not added in `pages/_document.js` will only load for a single page. This is discouraged. See: https://nextjs.org/docs/messages/no-page-custom-font',
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
+    {
+      code: `
+      import Head from 'next/head'
+      export default function IndexPage() {
+        return (
+          <div>
+            <Head>
+              <link
+                href="https://fonts.googleapis.com/css2?family=Inter"
+                rel="stylesheet"
+              />
+            </Head>
+            <p>Hello world!</p>
+          </div>
+        )
+      }
+      `,
+      filename: 'packages/web/src/pages/index.tsx',
       errors: [
         {
           message:
@@ -203,4 +260,47 @@ describe('no-page-custom-font', () => {
       },
     },
   }).run('eslint', NextESLintRule, tests)
+
+  it('detects pages files when cwd is the pages directory', () => {
+    const linter = new Linter({
+      cwd: '/repo/pages',
+      configType: 'eslintrc',
+    })
+    linter.defineRule('no-page-custom-font', NextESLintRule)
+
+    const messages = linter.verify(
+      `
+      import Head from 'next/head'
+      export default function IndexPage() {
+        return (
+          <Head>
+            <link
+              href="https://fonts.googleapis.com/css2?family=Inter"
+              rel="stylesheet"
+            />
+          </Head>
+        )
+      }
+      `,
+      {
+        parserOptions: {
+          ecmaVersion: 2018,
+          sourceType: 'module',
+          ecmaFeatures: {
+            modules: true,
+            jsx: true,
+          },
+        },
+        rules: {
+          'no-page-custom-font': 2,
+        },
+      },
+      { filename: '/repo/pages/index.tsx' }
+    )
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].message).toBe(
+      'Custom fonts not added in `pages/_document.js` will only load for a single page. This is discouraged. See: https://nextjs.org/docs/messages/no-page-custom-font'
+    )
+  })
 })


### PR DESCRIPTION
### What?

Fixes a false positive in `@next/next/no-page-custom-font` by making the rule detect the `pages` directory by path segment instead of matching the substring `pages` anywhere in `context.filename`.

### Why?

The rule is intended to bail out for files outside the Pages Router `pages` directory, but `context.filename.split('pages')` still returns the full filename for App Router paths like `packages/web/src/app/layout.tsx`.

As a result, App Router layouts with a Google Fonts stylesheet `<link>` could receive a Pages Router-specific warning that points users to `pages/_document.js`.

Fixes #80963

### How?

- Normalize path separators to `/`.
- Split the normalized filename into path segments and look for a real `pages` segment.
- Apply the rule only when the file path contains a real `pages` segment.
- Preserve the existing `_document` handling by deriving the page path from the segment after `pages`.
- Add regression coverage for App Router layouts, substring false positives such as `webpages/index.tsx`, Pages Router files in monorepo paths, and ESLint runs where `cwd` is the `pages` directory.

## For Contributors

### Fixing a bug

- [x] Related issue linked using `Fixes #80963`.
- [x] Tests added for the regression and the preserved Pages Router behavior.
- [x] No new error message or error link is introduced.


## Verification

- `pnpm prettier --check packages/eslint-plugin-next/src/rules/no-page-custom-font.ts test/unit/eslint-plugin-next/no-page-custom-font.test.ts`
- `pnpm --filter @next/eslint-plugin-next build`
- `pnpm testonly test/unit/eslint-plugin-next/no-page-custom-font.test.ts`

Note: `pnpm testonly` printed the existing `.build-commit marker` stale-build warning, but the targeted test suite passed.

## Notes

- AI assistance was used for English translation and wording of this PR description.

