### PR TITLE
docs: correct custom server optimization guidance

### DIFF
--- a/docs/01-app/02-guides/custom-server.mdx
+++ b/docs/01-app/02-guides/custom-server.mdx
@@ -10,7 +10,7 @@ Next.js includes its own server with `next start` by default. If you have an exi
 
 > **Good to know**:
 >
-> - Before deciding to use a custom server, keep in mind that it should only be used when the integrated router of Next.js can't meet your app requirements. A custom server will remove important performance optimizations, like **[Automatic Static Optimization](/docs/pages/building-your-application/rendering/automatic-static-optimization).**
+> - Before deciding to use a custom server, keep in mind that it should only be used when the integrated router of Next.js can't meet your app requirements.
 > - When using standalone output mode, it does not trace custom server files. This mode outputs a separate minimal `server.js` file, instead. These cannot be used together.
 
 Take a look at the [following example](https://github.com/vercel/next.js/tree/canary/examples/custom-server) of a custom server:


### PR DESCRIPTION
## Summary

- remove the inaccurate claim that a custom server disables Automatic Static Optimization
- retain the guidance to use a custom server only when the integrated router cannot meet an app's requirements

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --check docs/01-app/02-guides/custom-server.mdx`
- commit hook: `prettier --write` and `eslint --fix` for the changed MDX file