### PR TITLE
fix: #20924

### DIFF
--- a/packages/next/src/client/head-manager.ts
+++ b/packages/next/src/client/head-manager.ts
@@ -142,7 +142,7 @@ export default function initHeadManager(): {
               : ''
       }
       if (title !== document.title) document.title = title
-      ;['meta', 'base', 'link', 'style', 'script'].forEach((type) => {
+      ;['meta', 'base', 'link', 'style', 'script', 'noscript'].forEach((type) => {
         updateElements(type, tags[type] || [])
       })
     },

--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -46,6 +46,8 @@ function onlyReactElement(
   return list.concat(child)
 }
 
+const VALID_HEAD_TAGS = ['title', 'meta', 'base', 'link', 'style', 'script', 'noscript']
+
 const METATYPES = ['name', 'httpEquiv', 'charSet', 'itemProp']
 
 /*
@@ -128,6 +130,14 @@ function reduceComponents(
     .map((c: React.ReactElement<any>, i: number) => {
       const key = c.key || i
       if (process.env.NODE_ENV === 'development') {
+        if (
+          typeof c.type === 'string' &&
+          !VALID_HEAD_TAGS.includes(c.type)
+        ) {
+          warnOnce(
+            `<${c.type}> is not allowed in next/head. The only valid head elements are: ${VALID_HEAD_TAGS.join(', ')}. \nSee more info here: https://nextjs.org/docs/messages/no-document-head-tags`
+          )
+        }
         // omit JSON-LD structured data snippets from the warning
         if (c.type === 'script' && c.props['type'] !== 'application/ld+json') {
           const srcMessage = c.props['src']


### PR DESCRIPTION
Fixes #20924

## Summary

When users place invalid/unsupported HTML tags (like `<div>`, `<p>`, `<img>`) inside `next/head`, the previous behavior would silently drop them, leading to a confusing "next-head-count is missing" error. This PR adds a clear development-mode warning that tells users exactly which tag is invalid and lists the valid head elements.

## Changes

- **packages/next/src/shared/lib/head.tsx**: Added a `VALID_HEAD_TAGS` list and a dev-mode warning when an invalid tag type is used inside `next/head`
- **packages/next/src/client/head-manager.ts**: Added `noscript` to the list of managed head element types for consistency

## What was tested

- Verified the logic correctly identifies invalid tags (div, p, img, span, h1) and allows valid ones (title, meta, base, link, style, script, noscript)
- Existing unit test (next-head-rendering.test.ts) is unaffected