### PR TITLE
docs: document Cache Components behavior for navigation hooks

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
@@ -5,8 +5,6 @@ description: API Reference for the usePathname hook.
 
 `usePathname` is a **Client Component** hook that lets you read the current URL's **pathname**.
 
-> **Good to know**: When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled `usePathname` may require a `Suspense` boundary around it if your route has a dynamic param. If you use `generateStaticParams` the `Suspense` boundary is optional
-
 ```tsx filename="app/example-client-component.tsx" switcher
 'use client'
 
@@ -66,6 +64,17 @@ const pathname = usePathname()
 | `/dashboard`        | `'/dashboard'`        |
 | `/dashboard?v=2`    | `'/dashboard'`        |
 | `/blog/hello-world` | `'/blog/hello-world'` |
+
+## Behavior
+
+### Cache Components
+
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the pathname can only be resolved on the server when every dynamic param in the route is known at build time. This affects whether `usePathname` needs a [`Suspense`](https://react.dev/reference/react/Suspense) boundary:
+
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the pathname is known during prerendering, so `usePathname` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `usePathname` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+
+This applies even when the component that calls `usePathname` is itself static. For example, a sidebar with active links rendered in a layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component that calls `usePathname` (or a parent) in a `Suspense` boundary with a fallback. See [Linking and Navigating](/docs/app/getting-started/linking-and-navigating#dynamic-segments-without-generatestaticparams) for guidance on dynamic segments and prerendering.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
@@ -34,7 +34,7 @@ For example, a Client Component with `usePathname` will be rendered into HTML on
 > **Good to know**:
 >
 > - Reading the current URL from a [Server Component](/docs/app/getting-started/server-and-client-components) is not supported. This design is intentional to support layout state being preserved across page navigations.
-> - If your page is being statically prerendered and your app has [rewrites](/docs/app/api-reference/config/next-config-js/rewrites) in `next.config` or a [Proxy](/docs/app/api-reference/file-conventions/proxy) file, reading the pathname with `usePathname()` can result in hydration mismatch errors—because the initial value comes from the server and may not match the actual browser pathname after routing. See our [example](#avoid-hydration-mismatch-with-rewrites) for a way to mitigate this issue.
+> - If your page is being statically prerendered and your app has [rewrites](/docs/app/api-reference/config/next-config-js/rewrites) in `next.config` or a [Proxy](/docs/app/api-reference/file-conventions/proxy) file, reading the pathname with `usePathname()` can result in hydration mismatch errors, because the initial value comes from the server and may not match the actual browser pathname after routing. See our [example](#avoid-hydration-mismatch-with-rewrites) for a way to mitigate this issue.
 
 <details>
 
@@ -49,10 +49,14 @@ To enhance compatibility between routing systems, if your project contains both 
 ## Parameters
 
 ```tsx
-const pathname = usePathname()
+const pathname = usePathname(options?)
 ```
 
-`usePathname` does not take any parameters.
+`usePathname` optionally accepts an `options` object:
+
+| Option | Type      | Description                                                                                                                                                                                                                          |
+| ------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ssr`  | `boolean` | When `false`, returns `null` during server rendering and the initial client render, then resolves the pathname after mount. Also removes the `Suspense` requirement under [Cache Components](#cache-components). Defaults to `true`. |
 
 ## Returns
 
@@ -65,6 +69,8 @@ const pathname = usePathname()
 | `/dashboard?v=2`    | `'/dashboard'`        |
 | `/blog/hello-world` | `'/blog/hello-world'` |
 
+When called with `{ ssr: false }`, `usePathname` returns `null` during server rendering and the initial client render, then returns the pathname string after the component mounts.
+
 ## Behavior
 
 ### Cache Components
@@ -75,6 +81,8 @@ When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComp
 - **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `usePathname` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
 
 This applies even when the component that calls `usePathname` is itself static. For example, a sidebar with active links rendered in a layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component that calls `usePathname` (or a parent) in a `Suspense` boundary with a fallback. See [Linking and Navigating](/docs/app/getting-started/linking-and-navigating#dynamic-segments-without-generatestaticparams) for guidance on dynamic segments and prerendering.
+
+> **Good to know**: If your app uses [rewrites](/docs/app/api-reference/config/next-config-js/rewrites) or a [Proxy](/docs/app/api-reference/file-conventions/proxy), pass `{ ssr: false }` to avoid hydration mismatches and remove the `Suspense` requirement. See the [rewrite example](#avoid-hydration-mismatch-with-rewrites) and the [Preventing flash before hydration](/docs/app/guides/preventing-flash-before-hydration) guide for eliminating any visible flicker.
 
 ## Examples
 
@@ -114,7 +122,47 @@ function ExampleClientComponent() {
 
 When a page is prerendered, the HTML is generated for the source pathname. If the page is then reached through a rewrite using `next.config` or `Proxy`, the browser URL may differ, and `usePathname()` will read the rewritten pathname on the client.
 
-To avoid hydration mismatches, design the UI so that only a small, isolated part depends on the client pathname. Render a stable fallback on the server and update that part after mount.
+There are two ways to defer the pathname read until after mount. Both avoid the hydration mismatch. Passing `{ ssr: false }` also removes the [`Suspense`](#cache-components) requirement under Cache Components, since the hook no longer runs during prerendering. The `useEffect` approach still requires a `Suspense` boundary.
+
+**Option 1: `{ ssr: false }`**
+
+Pass `{ ssr: false }` to return `null` during server rendering and resolve the pathname after mount:
+
+```tsx filename="app/example-client-component.tsx" switcher
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+export default function PathnameBadge() {
+  const pathname = usePathname({ ssr: false })
+
+  return (
+    <p>
+      Current pathname: <span>{pathname ?? ''}</span>
+    </p>
+  )
+}
+```
+
+```jsx filename="app/example-client-component.js" switcher
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+export default function PathnameBadge() {
+  const pathname = usePathname({ ssr: false })
+
+  return (
+    <p>
+      Current pathname: <span>{pathname ?? ''}</span>
+    </p>
+  )
+}
+```
+
+**Option 2: `useEffect`**
+
+If you need the return type to always be `string`, you can manage the deferred read manually with `useState` and `useEffect`:
 
 ```tsx filename="app/example-client-component.tsx" switcher
 'use client'
@@ -160,6 +208,7 @@ export default function PathnameBadge() {
 }
 ```
 
-| Version   | Changes                   |
-| --------- | ------------------------- |
-| `v13.0.0` | `usePathname` introduced. |
+| Version   | Changes                        |
+| --------- | ------------------------------ |
+| `v16.3.0` | `{ ssr: false }` option added. |
+| `v13.0.0` | `usePathname` introduced.      |

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
@@ -40,14 +40,15 @@ export default function ExampleClientComponent() {
 ## Parameters
 
 ```tsx
-const segment = useSelectedLayoutSegment(parallelRoutesKey?: string)
+const segment = useSelectedLayoutSegment(parallelRoutesKey?: string, options?: { ssr?: boolean })
 ```
 
-`useSelectedLayoutSegment` _optionally_ accepts a [`parallelRoutesKey`](/docs/app/api-reference/file-conventions/parallel-routes#with-useselectedlayoutsegments), which allows you to read the active route segment within that slot.
+- `parallelRoutesKey` (optional): a [`parallelRoutesKey`](/docs/app/api-reference/file-conventions/parallel-routes#with-useselectedlayoutsegments) that lets you read the active route segment within that slot.
+- `options.ssr` (optional): when `false`, returns `null` during server rendering and the initial client render, then resolves after mount. Also removes the `Suspense` requirement under [Cache Components](#cache-components). Defaults to `true`.
 
 ## Returns
 
-`useSelectedLayoutSegment` returns a string of the active segment or `null` if one doesn't exist.
+`useSelectedLayoutSegment` returns a string of the active segment or `null` if one doesn't exist. When called with `{ ssr: false }`, it returns `null` until the component mounts.
 
 For example, given the Layouts and URLs below, the returned segment would be:
 
@@ -78,6 +79,8 @@ When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComp
 This applies even when the segment you care about is static. For example, a tab bar in a layout suspends on any child page that has an unknown dynamic param, because the hook cannot return a value until all params below it are known.
 
 > **Good to know**: This hook returns [Route Groups](/docs/app/api-reference/file-conventions/route-groups) such as `(marketing)` as segments. If a route group sits directly below the layout, the returned value is the group name, not the visible path segment. Account for this when matching against link paths.
+
+> **Good to know**: If your app uses [rewrites](/docs/app/api-reference/config/next-config-js/rewrites) or a [Proxy](/docs/app/api-reference/file-conventions/proxy), pass `{ ssr: false }` to avoid hydration mismatches and remove the `Suspense` requirement. See the [`usePathname` rewrite example](/docs/app/api-reference/functions/use-pathname#avoid-hydration-mismatch-with-rewrites) and the [Preventing flash before hydration](/docs/app/guides/preventing-flash-before-hydration) guide.
 
 ## Examples
 
@@ -189,4 +192,5 @@ export default async function Layout({ children }) {
 
 | Version   | Changes                                |
 | --------- | -------------------------------------- |
+| `v16.3.0` | `{ ssr: false }` option added.         |
 | `v13.0.0` | `useSelectedLayoutSegment` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
@@ -66,6 +66,19 @@ For catch-all routes (`[...slug]`), the returned segment contains all matched pa
 | -------------------- | ------------- | ---------------- |
 | `app/blog/layout.js` | `/blog/a/b/c` | `'a/b/c'`        |
 
+## Behavior
+
+### Cache Components
+
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the selected segment can only be resolved on the server when every dynamic param in the route is known at build time:
+
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the segment is known during prerendering, so `useSelectedLayoutSegment` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `useSelectedLayoutSegment` suspends during prerendering, so the closest [`Suspense`](https://react.dev/reference/react/Suspense) boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+
+This applies even when the segment you care about is static. For example, a tab bar in a layout suspends on any child page that has an unknown dynamic param, because the hook cannot return a value until all params below it are known.
+
+> **Good to know**: This hook returns [Route Groups](/docs/app/api-reference/file-conventions/route-groups) such as `(marketing)` as segments. If a route group sits directly below the layout, the returned value is the group name, not the visible path segment. Account for this when matching against link paths.
+
 ## Examples
 
 ### Creating an active link component

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
@@ -52,14 +52,15 @@ export default function ExampleClientComponent() {
 ## Parameters
 
 ```tsx
-const segments = useSelectedLayoutSegments(parallelRoutesKey?: string)
+const segments = useSelectedLayoutSegments(parallelRoutesKey?: string, options?: { ssr?: boolean })
 ```
 
-`useSelectedLayoutSegments` _optionally_ accepts a [`parallelRoutesKey`](/docs/app/api-reference/file-conventions/parallel-routes#with-useselectedlayoutsegments), which allows you to read the active route segment within that slot.
+- `parallelRoutesKey` (optional): a [`parallelRoutesKey`](/docs/app/api-reference/file-conventions/parallel-routes#with-useselectedlayoutsegments) that lets you read the active route segment within that slot.
+- `options.ssr` (optional): when `false`, returns `null` during server rendering and the initial client render, then resolves after mount. Also removes the `Suspense` requirement under [Cache Components](#cache-components). Defaults to `true`.
 
 ## Returns
 
-`useSelectedLayoutSegments` returns an array of strings containing the active segments one level down from the layout the hook was called from. Or an empty array if none exist.
+`useSelectedLayoutSegments` returns an array of strings containing the active segments one level down from the layout the hook was called from, or an empty array if none exist. When called with `{ ssr: false }`, it returns `null` until the component mounts.
 
 For example, given the Layouts and URLs below, the returned segments would be:
 
@@ -87,8 +88,11 @@ When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComp
 - **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the segments are known during prerendering, so `useSelectedLayoutSegments` resolves on the server and no `Suspense` boundary is required.
 - **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `useSelectedLayoutSegments` suspends during prerendering, so the closest [`Suspense`](https://react.dev/reference/react/Suspense) boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
 
+> **Good to know**: If your app uses [rewrites](/docs/app/api-reference/config/next-config-js/rewrites) or a [Proxy](/docs/app/api-reference/file-conventions/proxy), pass `{ ssr: false }` to avoid hydration mismatches and remove the `Suspense` requirement. See the [`usePathname` rewrite example](/docs/app/api-reference/functions/use-pathname#avoid-hydration-mismatch-with-rewrites) and the [Preventing flash before hydration](/docs/app/guides/preventing-flash-before-hydration) guide.
+
 ## Version History
 
 | Version   | Changes                                 |
 | --------- | --------------------------------------- |
+| `v16.3.0` | `{ ssr: false }` option added.          |
 | `v13.0.0` | `useSelectedLayoutSegments` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
@@ -78,6 +78,15 @@ For catch-all routes (`[...slug]`), all matched path segments are returned as a 
 | `app/layout.js`      | `/blog/a/b/c` | `['blog', 'a/b/c']` |
 | `app/blog/layout.js` | `/blog/a/b/c` | `['a/b/c']`         |
 
+## Behavior
+
+### Cache Components
+
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the active segments can only be resolved on the server when every dynamic param in the route is known at build time:
+
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the segments are known during prerendering, so `useSelectedLayoutSegments` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `useSelectedLayoutSegments` suspends during prerendering, so the closest [`Suspense`](https://react.dev/reference/react/Suspense) boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+
 ## Version History
 
 | Version   | Changes                                 |


### PR DESCRIPTION
### What?

Adds a Cache Components behavior section to the `usePathname`, `useSelectedLayoutSegment`, and `useSelectedLayoutSegments` API reference pages.

### Why?

When `cacheComponents` is enabled, these hooks suspend during prerendering on routes that have dynamic params not covered by `generateStaticParams`. This was previously only hinted at with a one-line note on `usePathname` and undocumented on the layout segment hooks, even though they share the same behavior.

### How?

- `usePathname`: replaced the terse one-line note with a `## Behavior` → `### Cache Components` section explaining when it resolves on the server vs. suspends, and links to the existing Linking and Navigating guide for the worked example.
- `useSelectedLayoutSegment`: added the same `### Cache Components` section, plus a `Good to know` noting it returns Route Groups as segments.
- `useSelectedLayoutSegments`: added the `### Cache Components` section.