### PR TITLE
fix: remove dead code and duplicate words in comments

### DIFF
--- a/packages/next/src/client/components/bfcache-state-manager.ts
+++ b/packages/next/src/client/components/bfcache-state-manager.ts
@@ -25,7 +25,7 @@ export type RouterBFCacheEntry = {
  *
  * The purpose of this cache is to we can preserve the React and DOM state of
  * some number of inactive trees, by rendering them in an <Activity> boundary.
- * That means it would not make sense for the the lifetime of the cache to be
+ * That means it would not make sense for the lifetime of the cache to be
  * any longer than the lifetime of the React tree; e.g. if the hook were
  * unmounted, then the React tree would be, too. So, we use React state to
  * manage it.

--- a/packages/next/src/client/components/segment-cache/vary-path.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.ts
@@ -214,7 +214,7 @@ export function finalizeMetadataVaryPath(
   // parallel pages.
   //
   // However, this means the metadata request key is insufficient for
-  // caching the the metadata in the client cache, because on the client we
+  // caching the metadata in the client cache, because on the client we
   // use the request key to distinguish the metadata entry from all other
   // page's metadata entries.
   //
@@ -288,7 +288,7 @@ export function getSegmentVaryPathForRequest(
       fetchStrategy === FetchStrategy.PPRRuntime
 
     if (!doesVaryOnSearchParams) {
-      // The response from the the server will not vary on search params. Clone
+      // The response from the server will not vary on search params. Clone
       // the end of the original vary path to replace the search params
       // with Fallback.
       //

--- a/packages/next/src/server/mcp/tools/get-project-metadata.ts
+++ b/packages/next/src/server/mcp/tools/get-project-metadata.ts
@@ -10,7 +10,7 @@ export function registerGetProjectMetadataTool(
     'get_project_metadata',
     {
       description:
-        'Returns the the metadata of this Next.js project, including project path, dev server URL, etc.',
+        'Returns the metadata of this Next.js project, including project path, dev server URL, etc.',
       inputSchema: {},
     },
     async (_request) => {

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -209,7 +209,6 @@ export class Telemetry {
       })
 
     ;(prom as any)._events = Array.isArray(_events) ? _events : [_events]
-    ;(prom as any)._controller = (prom as any)._controller
     // Track this `Promise` so we can flush pending events
     this.queue.add(prom)
 

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -455,7 +455,7 @@ describe.skip('ppr-full', () => {
         })
 
         /**
-         * This test is really here to just to force the the suite to have the expected route
+         * This test is really here to just force the suite to have the expected route
          * as part of the build. If this failed we'd get a build error and all the tests would fail
          */
         it('will allow dynamic fallback shells even when static is enforced', async () => {

--- a/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+++ b/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
@@ -130,7 +130,7 @@ describe.skip('segment cache (refresh)', () => {
     // If this is still 0, then the nav bar was not successfully refreshed
     expect(await navbarDynamicRenderCounter.textContent()).toBe('1')
 
-    // Confirm that navigating the the docs page does not require any
+    // Confirm that navigating the docs page does not require any
     // additional requests.
     await act(async () => {
       const link = await browser.elementByCss('a[href="/docs"]')

--- a/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
@@ -45,7 +45,7 @@ describe('segment cache (search params)', () => {
         await revealC.click()
       },
       // This should not issue a new request for the page segment, because
-      // search params are not included in the the PPR shell. So we can reuse
+      // search params are not included in the PPR shell. So we can reuse
       // the shell we fetched for `searchParam=a`.
       { includes: 'target-page-with-search-param', block: 'reject' }
     )


### PR DESCRIPTION
## Summary

### Bug fix: dead self-assignment in telemetry storage
- `packages/next/src/telemetry/storage.ts:212` — `_controller = _controller` was a no-op self-assignment
- The property is properly initialized in the `fetch()` method (line 329)
- Removed the dead line

### Typo fixes: duplicate "the the" across 6 files
- `test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts:133`
- `test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts:48`
- `test/e2e/app-dir/ppr-full/ppr-full.test.ts:458` (also removed extra "to")
- `packages/next/src/client/components/bfcache-state-manager.ts:28`
- `packages/next/src/client/components/segment-cache/vary-path.ts:217,291`
- `packages/next/src/server/mcp/tools/get-project-metadata.ts:13`

<!-- NEXT_JS_LLM_PR -->