### PR TITLE
fix: release retained fetch dedupe clones at cache-scope completion

### DIFF
--- a/packages/next/src/server/lib/clone-response.test.ts
+++ b/packages/next/src/server/lib/clone-response.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ */
+import { cloneResponse, cancelUnconsumedBodyOnAbort } from './clone-response'
+
+// Drain microtasks/macrotasks so a Web Streams `cancel()` settles. This waits on
+// stream-internal tasks, not application state — there is no condition to poll,
+// so a fixed drain (rather than a `retry()`-style wait) is the right tool here.
+async function flush() {
+  for (let i = 0; i < 6; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+function streamedResponse(text: string) {
+  const bytes = new TextEncoder().encode(text)
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes)
+        controller.close()
+      },
+    }),
+    { status: 200, statusText: 'OK', headers: { 'x-test': '1' } }
+  )
+}
+
+// A cancelled stream yields `{ done: true }` with no data on the first read.
+async function firstReadDone(body: ReadableStream | null) {
+  if (!body) return true
+  const reader = body.getReader()
+  const { done } = await reader.read()
+  reader.releaseLock()
+  return done
+}
+
+describe('cloneResponse', () => {
+  it('returns the same response twice when there is no body', () => {
+    const original = new Response(null, { status: 204 })
+    const [cloned1, cloned2] = cloneResponse(original)
+    expect(cloned1).toBe(original)
+    expect(cloned2).toBe(original)
+  })
+
+  it('produces two independently readable clones', async () => {
+    const [cloned1, cloned2] = cloneResponse(new Response('hello'))
+    expect(await cloned1.text()).toBe('hello')
+    expect(await cloned2.text()).toBe('hello')
+  })
+
+  it('preserves status, statusText and headers on both clones', () => {
+    const [cloned1, cloned2] = cloneResponse(
+      new Response('x', {
+        status: 201,
+        statusText: 'Created',
+        headers: { 'x-test': 'yes' },
+      })
+    )
+    for (const clone of [cloned1, cloned2]) {
+      expect(clone.status).toBe(201)
+      expect(clone.statusText).toBe('Created')
+      expect(clone.headers.get('x-test')).toBe('yes')
+    }
+  })
+})
+
+describe('cancelUnconsumedBodyOnAbort', () => {
+  // Regression test for https://github.com/vercel/next.js/issues/92287: a
+  // retained, un-read clone must be released when the render aborts, instead of
+  // being held off-heap until the FinalizationRegistry happens to run.
+  it('cancels a retained, un-read body when the signal aborts', async () => {
+    const controller = new AbortController()
+    const [, retained] = cloneResponse(streamedResponse('leak'))
+    cancelUnconsumedBodyOnAbort(controller.signal, retained.body)
+
+    controller.abort()
+    await flush()
+
+    expect(await firstReadDone(retained.body)).toBe(true)
+  })
+
+  // Models the real leak ordering: the cache side drains the sibling clone
+  // (which fills the retained clone's tee buffer), then the render aborts.
+  it('releases a retained body whose sibling was already drained', async () => {
+    const controller = new AbortController()
+    const [consumed, retained] = cloneResponse(streamedResponse('leak-body'))
+    cancelUnconsumedBodyOnAbort(controller.signal, retained.body)
+
+    expect(await consumed.text()).toBe('leak-body')
+    expect(retained.body!.locked).toBe(false)
+
+    controller.abort()
+    await flush()
+
+    expect(await firstReadDone(retained.body)).toBe(true)
+  })
+
+  it('does nothing without a signal', async () => {
+    const [, retained] = cloneResponse(streamedResponse('keep'))
+    cancelUnconsumedBodyOnAbort(null, retained.body)
+    cancelUnconsumedBodyOnAbort(undefined, retained.body)
+    await flush()
+    expect(await retained.text()).toBe('keep')
+  })
+
+  it('does nothing for a null body', () => {
+    const controller = new AbortController()
+    expect(() =>
+      cancelUnconsumedBodyOnAbort(controller.signal, null)
+    ).not.toThrow()
+    controller.abort()
+  })
+
+  it('does not interrupt a body that is being read (locked)', async () => {
+    const controller = new AbortController()
+    const [, retained] = cloneResponse(streamedResponse('reading'))
+    const reader = retained.body!.getReader()
+    cancelUnconsumedBodyOnAbort(controller.signal, retained.body)
+
+    controller.abort()
+    await flush()
+
+    // Locked -> not cancelled; the in-flight read still yields the data.
+    const { value } = await reader.read()
+    expect(new TextDecoder().decode(value)).toBe('reading')
+    reader.releaseLock()
+  })
+
+  it('cancels on a later microtask when the signal is already aborted', async () => {
+    const [, retained] = cloneResponse(streamedResponse('gone'))
+    cancelUnconsumedBodyOnAbort(AbortSignal.abort(), retained.body)
+    await flush()
+    expect(await firstReadDone(retained.body)).toBe(true)
+  })
+
+  it('attaches a single abort listener per signal across many registrations', async () => {
+    const controller = new AbortController()
+    let abortListeners = 0
+    const original = controller.signal.addEventListener.bind(controller.signal)
+    controller.signal.addEventListener = ((type: string, ...rest: any[]) => {
+      if (type === 'abort') abortListeners++
+      return (original as (...args: any[]) => void)(type, ...rest)
+    }) as typeof controller.signal.addEventListener
+
+    const bodies: Array<ReadableStream | null> = []
+    for (let i = 0; i < 10; i++) {
+      const [, retained] = cloneResponse(streamedResponse('x'))
+      bodies.push(retained.body)
+      cancelUnconsumedBodyOnAbort(controller.signal, retained.body)
+    }
+    expect(abortListeners).toBe(1)
+
+    controller.abort()
+    await flush()
+    for (const body of bodies) {
+      expect(await firstReadDone(body)).toBe(true)
+    }
+  })
+
+  it('leaves the consumer clone fully readable after the retained clone is cancelled', async () => {
+    const controller = new AbortController()
+    // Register only the retained (second) clone, exactly as the dedupe cache
+    // does — the first clone is handed to the caller and must stay intact.
+    const [consumer, retained] = cloneResponse(
+      streamedResponse('consumer-keeps-this')
+    )
+    cancelUnconsumedBodyOnAbort(controller.signal, retained.body)
+
+    controller.abort()
+    await flush()
+
+    expect(await firstReadDone(retained.body)).toBe(true)
+    expect(await consumer.text()).toBe('consumer-keeps-this')
+  })
+})

--- a/packages/next/src/server/lib/clone-response.ts
+++ b/packages/next/src/server/lib/clone-response.ts
@@ -80,3 +80,83 @@ export function cloneResponse(original: Response): [Response, Response] {
 
   return [cloned1, cloned2]
 }
+
+type AbortCancellations = Array<() => void>
+const cancellationsBySignal = new WeakMap<AbortSignal, AbortCancellations>()
+
+/**
+ * Registers `cancel` to run when `signal` aborts. A single native `abort`
+ * listener is attached per signal and fans out to the registered callbacks (the
+ * same approach as `makeHangingPromise`), so a render that performs many cached
+ * fetches doesn't add one listener per fetch and trigger a
+ * `MaxListenersExceededWarning`.
+ */
+function runOnAbort(signal: AbortSignal, cancel: () => void): void {
+  const existing = cancellationsBySignal.get(signal)
+  if (existing) {
+    existing.push(cancel)
+    return
+  }
+
+  const cancellations: AbortCancellations = [cancel]
+  cancellationsBySignal.set(signal, cancellations)
+  signal.addEventListener(
+    'abort',
+    () => {
+      // Detach first so the callbacks (and the WeakRefs they hold) are released.
+      cancellationsBySignal.delete(signal)
+      for (let i = 0; i < cancellations.length; i++) {
+        // A throw from one cancellation must not starve the others.
+        try {
+          cancellations[i]()
+        } catch {}
+      }
+    },
+    { once: true }
+  )
+}
+
+/**
+ * Deterministically cancels a *retained, un-consumed* response body when
+ * `signal` aborts, releasing the off-heap bytes buffered in its `tee()` branch
+ * instead of waiting for the `FinalizationRegistry` to run on the next GC.
+ *
+ * Pass only a body you retain un-read — e.g. the second `cloneResponse` clone
+ * stored in the fetch dedupe cache. Do NOT pass a body that is returned to a
+ * consumer: cancelling one the consumer is about to read would race that read.
+ * (A body that is already being read is `locked`, and is left untouched.)
+ *
+ * This matters because the buffered bytes are off-heap (`arrayBuffers` /
+ * `external`), so they don't create the JS-heap pressure that schedules GC and
+ * can otherwise grow until OOM under sustained, high-cardinality load.
+ *
+ * @see https://github.com/vercel/next.js/issues/92287
+ */
+export function cancelUnconsumedBodyOnAbort(
+  signal: AbortSignal | null | undefined,
+  body: ReadableStream | null | undefined
+): void {
+  if (!signal || !body) {
+    return
+  }
+
+  // Hold only a WeakRef so this never itself keeps the tee branch (and its
+  // buffered bytes) alive: if the body is still reachable when the signal
+  // aborts — the leak scenario, where a dedupe/cache map retains it — we cancel
+  // it; otherwise the WeakRef derefs to undefined and the `FinalizationRegistry`
+  // above reclaims it.
+  const bodyRef = new WeakRef(body)
+  const cancel = () => {
+    const stream = bodyRef.deref()
+    if (stream && !stream.locked) {
+      stream.cancel('Retained response is no longer needed').then(noop, noop)
+    }
+  }
+
+  if (signal.aborted) {
+    // Defer so the caller's synchronous setup runs before we cancel.
+    queueMicrotask(cancel)
+  } else {
+    runOnAbort(signal, cancel)
+  }
+}

--- a/packages/next/src/server/lib/dedupe-fetch.test.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.test.ts
@@ -14,19 +14,24 @@ jest.mock('react', () => ({
       return cache.get(key)!
     }) as T
   },
+  // React aborts the cache scope's signal on completion; the dedupe fetcher
+  // reads it to release the retained clone. Configurable per test.
+  cacheSignal: jest.fn(() => null),
 }))
 
-// Mock the clone-response module
+// Mock the clone-response module. `cancelUnconsumedBodyOnAbort` is a jest.fn so
+// tests can assert the cache scope signal is threaded through to it.
 jest.mock('./clone-response', () => ({
-  cloneResponse: (response: Response) => {
-    // Create two independent clones of the response
-    const clone1 = response.clone()
-    const clone2 = response.clone()
-    return [clone1, clone2]
-  },
+  cloneResponse: jest.fn((response: Response) => [
+    response.clone(),
+    response.clone(),
+  ]),
+  cancelUnconsumedBodyOnAbort: jest.fn(),
 }))
 
+import * as React from 'react'
 import { createDedupeFetch } from './dedupe-fetch'
+import { cloneResponse, cancelUnconsumedBodyOnAbort } from './clone-response'
 
 describe('dedupe-fetch', () => {
   let originalFetch: jest.MockedFunction<typeof fetch>
@@ -39,6 +44,9 @@ describe('dedupe-fetch', () => {
 
     // Clear all mocks between tests
     jest.clearAllMocks()
+    // clearAllMocks() clears call history but not a mockReturnValue set by a
+    // prior test, so restore the default (no cache scope) to avoid leakage.
+    ;(React.cacheSignal as jest.Mock).mockReturnValue(null)
   })
 
   describe('deduplication behavior', () => {
@@ -694,6 +702,85 @@ describe('dedupe-fetch', () => {
 
       // Should only call original fetch once
       expect(originalFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Regression coverage for https://github.com/vercel/next.js/issues/92287:
+  // the retained dedupe clone must be registered for cancellation against the
+  // cache scope's signal (React's `cacheSignal()`), which React aborts when the
+  // scope settles, so the clone is released then instead of lingering off-heap
+  // until GC. This fires for fetches inside `"use cache"` as well as
+  // render-level fetches.
+  describe('cache scope signal threading', () => {
+    const mockCancel = cancelUnconsumedBodyOnAbort as jest.Mock
+    const mockCacheSignal = React.cacheSignal as jest.Mock
+    const mockClone = cloneResponse as jest.Mock
+
+    // `cloneResponse` returns `[cloned1, cloned2]`: cloned1 is returned to the
+    // caller, cloned2 is retained in the dedupe cache. Cancelling cloned1 would
+    // race the caller's read (corrupting the served body), so it is critical
+    // that cloned2.body — never cloned1.body — is the one registered. These
+    // helpers pin that by reference (`toBe`), which a deep-equality matcher on
+    // two opaque streams could not distinguish.
+    const lastCancelCall = () => mockCancel.mock.calls.at(-1)!
+    const lastClonePair = () => mockClone.mock.results.at(-1)!.value
+
+    it('registers cloned2.body — not the consumer cloned1.body — on a cache miss', async () => {
+      originalFetch.mockResolvedValue(new Response('x', { status: 200 }))
+      const controller = new AbortController()
+      mockCacheSignal.mockReturnValue(controller.signal)
+
+      await dedupeFetch('https://example.com/api')
+
+      const [signalArg, bodyArg] = lastCancelCall()
+      const [consumer, retained] = lastClonePair()
+      expect(signalArg).toBe(controller.signal)
+      expect(bodyArg).toBe(retained.body)
+      expect(bodyArg).not.toBe(consumer.body)
+    })
+
+    it('registers cloned2.body on the cache-hit path too', async () => {
+      originalFetch.mockResolvedValue(new Response('x', { status: 200 }))
+      const controller = new AbortController()
+      mockCacheSignal.mockReturnValue(controller.signal)
+
+      // First call populates the dedupe cache, second hits it; both retain a
+      // fresh clone that must be registered for cancellation.
+      await dedupeFetch('https://example.com/api')
+      await dedupeFetch('https://example.com/api')
+
+      expect(mockCancel).toHaveBeenCalledTimes(2)
+      const [signalArg, bodyArg] = lastCancelCall()
+      const [consumer, retained] = lastClonePair()
+      expect(signalArg).toBe(controller.signal)
+      expect(bodyArg).toBe(retained.body)
+      expect(bodyArg).not.toBe(consumer.body)
+    })
+
+    it('passes a null signal when there is no cache scope', async () => {
+      originalFetch.mockResolvedValue(new Response('x', { status: 200 }))
+      mockCacheSignal.mockReturnValue(null)
+
+      await dedupeFetch('https://example.com/api')
+
+      const [signalArg, bodyArg] = lastCancelCall()
+      expect(signalArg).toBeNull()
+      expect(bodyArg).toBe(lastClonePair()[1].body)
+    })
+
+    it('is a no-op (null signal) when React.cacheSignal is unavailable', async () => {
+      // Older React builds that do not export `cacheSignal`: the `typeof …
+      // === 'function'` guard yields a null signal and the FinalizationRegistry
+      // backstop (not asserted here) is left to reclaim the clone.
+      const original = (React as { cacheSignal?: unknown }).cacheSignal
+      delete (React as { cacheSignal?: unknown }).cacheSignal
+      try {
+        originalFetch.mockResolvedValue(new Response('x', { status: 200 }))
+        await dedupeFetch('https://example.com/api')
+        expect(lastCancelCall()[0]).toBeNull()
+      } finally {
+        ;(React as { cacheSignal?: unknown }).cacheSignal = original
+      }
     })
   })
 })

--- a/packages/next/src/server/lib/dedupe-fetch.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.ts
@@ -2,7 +2,7 @@
  * Based on https://github.com/facebook/react/blob/d4e78c42a94be027b4dc7ed2659a5fddfbf9bd4e/packages/react/src/ReactFetch.js
  */
 import * as React from 'react'
-import { cloneResponse } from './clone-response'
+import { cloneResponse, cancelUnconsumedBodyOnAbort } from './clone-response'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 const simpleCacheKey = '["GET",[],null,"follow",null,null,null,null]' // generateCacheKey(new Request('https://blank'));
@@ -91,6 +91,24 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
       url = request.url
     }
 
+    // React aborts the current cache scope's signal when that scope settles —
+    // on success ("All cacheSignals are now aborted to allow clean up of any
+    // unused resources"), error, or explicit abort — which is exactly when the
+    // clone we retain below (entry[2]) is no longer needed. Releasing it then,
+    // rather than waiting for GC, keeps the off-heap `tee()` bytes from piling
+    // up under sustained load. This fires for fetches issued inside `"use
+    // cache"` (which run in their own cache scope, not a render) as well as
+    // render-level fetches. `cacheSignal()` is `null` outside an RSC cache
+    // scope, where the `FinalizationRegistry` in `cloneResponse` is the
+    // backstop. See https://github.com/vercel/next.js/issues/92287
+    //
+    // The React types model `cacheSignal()`'s result as an opaque `CacheSignal`,
+    // but at runtime it is the cache scope's `AbortSignal`.
+    const cacheSignal =
+      typeof React.cacheSignal === 'function'
+        ? (React.cacheSignal() as AbortSignal | null)
+        : null
+
     const cacheEntries = getCacheEntries(url)
     for (let i = 0, j = cacheEntries.length; i < j; i += 1) {
       const [key, promise] = cacheEntries[i]
@@ -105,6 +123,9 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
           // https://github.com/vercel/next.js/pull/73274
           const [cloned1, cloned2] = cloneResponse(response)
           cacheEntries[i][2] = cloned2
+          // cloned2 is retained here un-read for a later duplicate; release it
+          // when the cache scope settles instead of waiting for GC.
+          cancelUnconsumedBodyOnAbort(cacheSignal, cloned2.body)
           return cloned1
         })
       }
@@ -123,6 +144,9 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
       // https://github.com/vercel/next.js/pull/73274
       const [cloned1, cloned2] = cloneResponse(response)
       entry[2] = cloned2
+      // cloned2 is retained here un-read for a later duplicate; release it
+      // when the cache scope settles instead of waiting for GC.
+      cancelUnconsumedBodyOnAbort(cacheSignal, cloned2.body)
       return cloned1
     })
   }


### PR DESCRIPTION
Fixes #92287

## What

Under Cache Components, especially in `output: "standalone"` deployments, cached server-side `fetch()` calls can grow `arrayBuffers` / `external` until the process OOMs (#92287). This releases those off-heap bytes **deterministically when the cache scope completes**, instead of waiting for GC to run soon enough.

## Root cause

To both cache a response and hand it to the caller, `cloneResponse()` `tee()`s the body. The React fetch-dedupe cache retains the **second** branch (`entry[2]`) per URL so a later duplicate fetch in the same scope can be served. Draining the first branch force-fills the retained branch with the whole body (`tee()` buffering), so the retained clone holds the entire response **off-heap**.

That clone lives in a `React.cache` map keyed by the cache fill's `RequestInstance`, and on the normal-completion path only becomes unreachable once React drops the instance **and** GC runs. But the bytes are off-heap, so they create little JS-heap pressure and a major GC isn't scheduled promptly; under sustained, high-cardinality load, new cache-fill scopes create retained clones faster than completed scopes become unreachable and collected, and the retained clones pile up until OOM.

This is reachability/scope-lifetime, **not** collectable garbage:

- A forced full `global.gc()` at peak reclaims **< 10%** of `arrayBuffers` (the rest is genuinely reachable).
- Memory **fully recovers at idle** once the load stops and the fills' `RequestInstance`s become unreachable.

The existing `FinalizationRegistry` in `cloneResponse` is a backstop, but it can only run on the GC that lags here.

## Fix

Register the retained clone's body for cancellation on **`React.cacheSignal()`** — the signal React aborts when the cache scope settles (success, error, or explicit abort): *"All cacheSignals are now aborted to allow clean up of any unused resources."* When it fires we `cancel()` the un-read `tee()` branch, releasing the off-heap bytes immediately rather than waiting for GC.

- **`clone-response.ts`** — `cancelUnconsumedBodyOnAbort(signal, body)`: cancels a retained, un-read body when `signal` aborts. A `locked`/in-flight body is left untouched, and a single `abort` listener is shared per signal (fanning out to each retained clone) so a fill that performs many cached fetches doesn't add one listener per fetch and trigger a `MaxListenersExceededWarning`. The `FinalizationRegistry` stays as the backstop.
- **`dedupe-fetch.ts`** — registers the retained clone (`entry[2]`) against `React.cacheSignal()` at both clone sites.

Why this is safe:

- Cancellation runs when the cache scope's signal aborts — at **scope completion**, or on the next microtask if the scope already settled before the fetch resolved — always after any in-scope duplicate fetch has re-cloned the spare, so it cannot race a live consumer.
- It touches only the **retained spare** (`cloned2`), never the clone returned to the caller (`cloned1`).
- `React.cacheSignal` is accessed defensively (`typeof … === 'function'`). Outside a React cache/render scope, or on older React builds without `cacheSignal`, this is a no-op and behavior is unchanged — the `FinalizationRegistry` remains the backstop.

This covers fetches issued **inside `"use cache"`** (whose work-unit store carries no render abort signal — the gap that made earlier render-signal-based attempts a no-op for the reported repro) as well as render-level fetches, uniformly.

## Verification

Environment: the official minimal repro (`output: "standalone"`, `cacheComponents: true`, a `"use cache"` data fetcher hit from a route handler over an internal `fetch()` streaming 512 KB bodies) — Next `16.3.0-canary.33`, Node `24.12.0`, React `19.1.0`.

Load A/B on the **same build with the cancel toggled on/off** (no build-pipeline confound), 96-concurrency API load, 150 s:

| | peak `arrayBuffers` | 30 s-tail average | end of load | requests | failed |
|---|---:|---:|---:|---:|---:|
| off | 876 MB (still rising) | 807 MB | 876 MB | 18,378 | 0 |
| on | 272 MB | 222 MB | 214 MB | 18,546 | 0 |

`arrayBuffers` trajectory (~10 s apart) — the trend, not a single noisy peak:

```
off: 208 568 659 626 643 635 642 637 637 711 740 738 750 837 819   (climbs toward OOM)
on:  205 192 188 214 189 226 191 238 246 254 222 228 237 207 214   (flat — bounded working set)
```

(The table's peak is the max across all 2 s samples; the trajectory lists points ~10 s apart, so the 876 MB peak falls between the shown 837/819 samples.)

≈ **−72%** on the noise-robust 30 s-tail average; the unpatched arm **accumulates** (would OOM given time), the patched arm stays **bounded** at the in-flight working set. Instrumentation confirmed each completed fill's retained spare was cancelled at scope completion (**18,334 cancels, 0 errors**). The small gap to 18,546 requests is fills still in flight when the load was stopped, not failures — **0 responses failed** in either arm, so the deterministic cancel never truncates a served body.

- **Mechanism (forced-GC probe):** a major `global.gc()` at peak frees < 10%, so the retention is genuine reachability and a deterministic cancel — not GC tuning — is what's required.
- **Unit tests:** `clone-response.test.ts` + `dedupe-fetch.test.ts` (42 pass) — cover the helper and the cache-scope-signal threading on the cache-miss path, cache-hit path, and the no-scope (`null`) case.
- **Types:** `tsc --noEmit` on `packages/next` is clean.

Related: #88577, #89040, #90897.

<!-- NEXT_JS_LLM_PR -->
