### PR TITLE
Fix: POST request succeeds for standard pages in next dev (issue #38863)

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2286,7 +2286,7 @@ export default abstract class Server<
       pathname !== '/_error' &&
       req.method !== 'HEAD' &&
       req.method !== 'GET' &&
-      (typeof components.Component === 'string' || isSSG)
+      (this.dev || typeof components.Component === 'string' || isSSG)
     ) {
       res.statusCode = 405
       res.setHeader('Allow', ['GET', 'HEAD'])


### PR DESCRIPTION
## Description
This PR resolves a known bug (issue #38863) where non-GET/HEAD HTTP requests (such as POST) to standard page routes succeed with a `200` status in development (`next dev`), whereas they correctly fail with a `405 Method Not Allowed` in production (`next start`).

### Root Cause
In `packages/next/src/server/base-server.ts`, the `renderToResponseImpl` method validates that only `GET` and `HEAD` methods are accepted for page routes, but limits this verification to statically-generated or pre-rendered pages via the check:
```typescript
(typeof components.Component === 'string' || isSSG)
```
During development, pages are rendered dynamically on-demand, so `isSSG` is `false` and the component type is not `'string'`, bypassing the 405 check entirely.

### Solution
This PR updates the verification check to also activate during development (`this.dev` is `true`), ensuring that development and production servers behave consistently for standard page routes:
```typescript
(this.dev || typeof components.Component === 'string' || isSSG)
```
This cleanly blocks non-GET/HEAD requests in development for regular pages while correctly maintaining all existing exceptions (such as Server Actions which run via POST requests).