### PR TITLE
Persist debug channel via `IndexedDB` without blocking hydration

### DIFF
--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -1,6 +1,22 @@
 import { NEXT_REQUEST_ID_HEADER } from '../components/app-router-headers'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
+declare global {
+  interface Window {
+    /**
+     * Test-only flag, set once this document's debug channel entry is durably
+     * committed. Persistence is deferred to an idle callback and its write is
+     * async, so exposing this flag is a deliberate compromise: it lets e2e
+     * tests await persistence deterministically — rather than relying on
+     * timing/idle hacks — while coupling only to "an entry was persisted" and
+     * not to how or where it is stored. It resets naturally on each navigation
+     * since every document gets a fresh window. Only set when
+     * `process.env.__NEXT_TEST_MODE` is enabled.
+     */
+    __NEXT_DEBUG_CHANNEL_PERSISTED?: boolean
+  }
+}
+
 export interface DebugChannelReadableWriterPair {
   readonly readable: ReadableStream<Uint8Array>
   readonly writer: WritableStreamDefaultWriter<Uint8Array>
@@ -8,42 +24,155 @@ export interface DebugChannelReadableWriterPair {
 
 const pairs = new Map<string, DebugChannelReadableWriterPair>()
 
-const DEBUG_CHANNEL_STORAGE_KEY_PREFIX = '__next_debug_channel:'
+const DB_NAME = '__next_debug_channel'
+const STORE_NAME = 'channels'
+const CREATED_AT_INDEX = 'createdAt'
+const MAX_ENTRIES = 10
 
-// Buffer for the initial document's debug channel data. Written to
-// sessionStorage once complete so it can be restored when the browser serves
-// the page from HTTP cache (back-forward navigation, tab duplication, etc.).
-let initialDocumentDebugChunks: Uint8Array[] = []
+interface DebugChannelEntry {
+  readonly requestId: string
+  readonly createdAt: number
+  readonly chunks: Uint8Array[]
+}
 
-function persistDebugChannelToSessionStorage(requestId: string): void {
-  const key = DEBUG_CHANNEL_STORAGE_KEY_PREFIX + requestId
-  const value = JSON.stringify(
-    initialDocumentDebugChunks.map((chunk) => {
-      let binary = ''
-      for (let i = 0; i < chunk.byteLength; i++) {
-        binary += String.fromCharCode(chunk[i])
-      }
-      return btoa(binary)
-    })
-  )
+function openDebugChannelDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1)
+    req.onupgradeneeded = () => {
+      const store = req.result.createObjectStore(STORE_NAME, {
+        keyPath: 'requestId',
+      })
+      store.createIndex(CREATED_AT_INDEX, 'createdAt')
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => reject(req.error)
+  })
+}
+
+/**
+ * Resolves on the next idle period via `requestIdleCallback`, falling back to a
+ * `setTimeout` where `requestIdleCallback` is unavailable.
+ *
+ * In test mode we pass a `timeout` so the callback reliably fires under
+ * Playwright, where a timeout-less `requestIdleCallback` may otherwise never
+ * run. Production stays timeout-less so persistence never forces a blocking
+ * write during a busy period — it fires at genuine idle or is skipped.
+ */
+function whenIdle(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(
+        () => resolve(),
+        process.env.__NEXT_TEST_MODE ? { timeout: 100 } : undefined
+      )
+    } else {
+      setTimeout(resolve, 0)
+    }
+  })
+}
+
+async function persistDebugChannelToIndexedDB(
+  requestId: string,
+  chunks: Uint8Array[]
+): Promise<void> {
+  let db: IDBDatabase
+  try {
+    db = await openDebugChannelDB()
+  } catch {
+    return
+  }
 
   try {
-    sessionStorage.setItem(key, value)
-  } catch {
-    // Likely a quota error. Drop entries from previous documents in this tab
-    // (we only need to restore the current one's entry on cache restore) and
-    // retry once. If it still fails, skip silently — the location.reload()
-    // fallback in createDebugChannel handles this case.
-    for (let i = sessionStorage.length - 1; i >= 0; i--) {
-      const k = sessionStorage.key(i)
-      if (k?.startsWith(DEBUG_CHANNEL_STORAGE_KEY_PREFIX) && k !== key) {
-        sessionStorage.removeItem(k)
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite')
+      const store = tx.objectStore(STORE_NAME)
+
+      store.put({
+        requestId,
+        createdAt: Date.now(),
+        chunks,
+      } satisfies DebugChannelEntry)
+
+      // Prune oldest entries beyond the cap to bound storage growth across tabs
+      // and/or page loads. The createdAt index gives ordered traversal without
+      // scanning, and the cursor deletes commit atomically with the put above.
+      const countReq = store.count()
+      countReq.onsuccess = () => {
+        let entriesToDelete = countReq.result - MAX_ENTRIES
+        if (entriesToDelete <= 0) {
+          return
+        }
+        const cursorReq = store.index(CREATED_AT_INDEX).openCursor()
+        cursorReq.onsuccess = () => {
+          const cursor = cursorReq.result
+          if (!cursor || entriesToDelete === 0) {
+            return
+          }
+          cursor.delete()
+          entriesToDelete--
+          cursor.continue()
+        }
       }
-    }
-    try {
-      sessionStorage.setItem(key, value)
-    } catch {}
+
+      tx.oncomplete = () => {
+        if (process.env.__NEXT_TEST_MODE) {
+          self.__NEXT_DEBUG_CHANNEL_PERSISTED = true
+        }
+        resolve()
+      }
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error)
+    })
+  } catch {
+    // Best-effort: if persistence fails (quota, transaction abort, etc.), an
+    // HTTP cache restore will fall back to location.reload() since no entry
+    // will be found.
+  } finally {
+    db.close()
   }
+}
+function restoreDebugChannelFromIndexedDB(
+  requestId: string
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let entry: DebugChannelEntry | undefined
+
+      try {
+        const db = await openDebugChannelDB()
+        try {
+          entry = await new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readonly')
+            const store = tx.objectStore(STORE_NAME)
+            const getReq: IDBRequest<DebugChannelEntry | undefined> =
+              store.get(requestId)
+            getReq.onsuccess = () => resolve(getReq.result)
+            getReq.onerror = () => reject(getReq.error)
+          })
+        } finally {
+          db.close()
+        }
+      } catch {
+        // Treat any IDB failure as "no entry" and fall through to reload.
+      }
+
+      if (!entry) {
+        // Debug channel can't be restored — missing debug chunks would block
+        // hydration. Force a fresh page load from the server. Leave the stream
+        // parked (no enqueue, no close) so the Flight client stays put until
+        // the reload tears the document down, instead of synchronously erroring
+        // with "Connection closed.".
+        location.reload()
+        return
+      }
+
+      for (const chunk of entry.chunks) {
+        controller.enqueue(chunk)
+      }
+      controller.close()
+    },
+  })
 }
 
 const enum ExecTimeCacheDecision {
@@ -183,54 +312,22 @@ function getNavigationEntry(): NavigationEntry | undefined {
   }
 }
 
-function restoreDebugChannelFromSessionStorage(
-  requestId: string
-): ReadableStream<Uint8Array> | undefined {
-  try {
-    const serializedData = sessionStorage.getItem(
-      DEBUG_CHANNEL_STORAGE_KEY_PREFIX + requestId
-    )
-
-    if (!serializedData) {
-      return undefined
-    }
-
-    const chunks = (JSON.parse(serializedData) as string[]).map((base64) => {
-      const binary = atob(base64)
-      const bytes = new Uint8Array(binary.length)
-      for (let i = 0; i < binary.length; i++) {
-        bytes[i] = binary.charCodeAt(i)
-      }
-      return bytes
-    })
-
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        for (const chunk of chunks) {
-          controller.enqueue(chunk)
-        }
-        controller.close()
-      },
-    })
-  } catch {
-    return undefined
-  }
-}
-
 export function getOrCreateDebugChannelReadableWriterPair(
   requestId: string
 ): DebugChannelReadableWriterPair {
   let pair = pairs.get(requestId)
 
   if (!pair) {
-    // Only buffer chunks for the initial document's debug channel, not for
-    // client-side navigation requests.
-    const shouldBuffer = requestId === self.__next_r
+    // Buffer chunks only for the initial document's debug channel, not for
+    // client-side navigation requests. Persisted to IndexedDB once complete so
+    // it can be restored when the browser serves the page from HTTP cache
+    // (back-forward navigation, tab duplication, etc.).
+    const chunks: Uint8Array[] | null = requestId === self.__next_r ? [] : null
 
     const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
-        if (shouldBuffer) {
-          initialDocumentDebugChunks.push(chunk.slice())
+        if (chunks) {
+          chunks.push(chunk.slice())
         }
         controller.enqueue(chunk)
       },
@@ -240,12 +337,29 @@ export function getOrCreateDebugChannelReadableWriterPair(
     pairs.set(requestId, pair)
 
     pair.writer.closed
-      .then(() => {
-        if (shouldBuffer) {
-          persistDebugChannelToSessionStorage(requestId)
+      .then(async () => {
+        if (!chunks) {
+          return
+        }
+        // The initial document's debug stream closes while hydration is still
+        // running, so persisting here would steal main-thread time from it.
+        // Wait for genuine idle (no timeout): persistence is best-effort, so if
+        // the page never idles before navigation we skip it and a later restore
+        // falls back to a reload, rather than forcing a blocking write.
+        await whenIdle()
+        await persistDebugChannelToIndexedDB(requestId, chunks)
+      })
+      .catch(() => {
+        // writer.closed rejected (e.g., stream aborted) — nothing to persist.
+      })
+      .finally(() => {
+        pairs.delete(requestId)
+        // Release the buffered chunk bytes once the channel is done, whether or
+        // not we were able to persist them.
+        if (chunks) {
+          chunks.length = 0
         }
       })
-      .finally(() => pairs.delete(requestId))
   }
 
   return pair
@@ -277,7 +391,7 @@ export function createDebugChannel(
     }
   }
 
-  // Only attempt to restore the sessionStorage debug channel entry for the
+  // Only attempt to restore the IndexedDB debug channel entry for the
   // initial document load (no request headers). Client-side navigations pass
   // request headers and should always use the WebSocket-backed debug channel.
   if (!requestHeaders) {
@@ -307,7 +421,7 @@ export function createDebugChannel(
 function restoreDebugChannelOrReload(
   requestId: string
 ): ReadableStream<Uint8Array> {
-  const readable = restoreDebugChannelFromSessionStorage(requestId)
+  const readable = restoreDebugChannelFromIndexedDB(requestId)
 
   if (readable) {
     return readable

--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -53,19 +53,11 @@ function openDebugChannelDB(): Promise<IDBDatabase> {
 /**
  * Resolves on the next idle period via `requestIdleCallback`, falling back to a
  * `setTimeout` where `requestIdleCallback` is unavailable.
- *
- * In test mode we pass a `timeout` so the callback reliably fires under
- * Playwright, where a timeout-less `requestIdleCallback` may otherwise never
- * run. Production stays timeout-less so persistence never forces a blocking
- * write during a busy period — it fires at genuine idle or is skipped.
  */
 function whenIdle(): Promise<void> {
   return new Promise((resolve) => {
     if (typeof requestIdleCallback === 'function') {
-      requestIdleCallback(
-        () => resolve(),
-        process.env.__NEXT_TEST_MODE ? { timeout: 100 } : undefined
-      )
+      requestIdleCallback(() => resolve())
     } else {
       setTimeout(resolve, 0)
     }

--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -1,22 +1,6 @@
 import { NEXT_REQUEST_ID_HEADER } from '../components/app-router-headers'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
-declare global {
-  interface Window {
-    /**
-     * Test-only flag, set once this document's debug channel entry is durably
-     * committed. Persistence is deferred to an idle callback and its write is
-     * async, so exposing this flag is a deliberate compromise: it lets e2e
-     * tests await persistence deterministically — rather than relying on
-     * timing/idle hacks — while coupling only to "an entry was persisted" and
-     * not to how or where it is stored. It resets naturally on each navigation
-     * since every document gets a fresh window. Only set when
-     * `process.env.__NEXT_TEST_MODE` is enabled.
-     */
-    __NEXT_DEBUG_CHANNEL_PERSISTED?: boolean
-  }
-}
-
 export interface DebugChannelReadableWriterPair {
   readonly readable: ReadableStream<Uint8Array>
   readonly writer: WritableStreamDefaultWriter<Uint8Array>
@@ -37,16 +21,16 @@ interface DebugChannelEntry {
 
 function openDebugChannelDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, 1)
-    req.onupgradeneeded = () => {
-      const store = req.result.createObjectStore(STORE_NAME, {
+    const openRequest = indexedDB.open(DB_NAME, 1)
+    openRequest.onupgradeneeded = () => {
+      const store = openRequest.result.createObjectStore(STORE_NAME, {
         keyPath: 'requestId',
       })
       store.createIndex(CREATED_AT_INDEX, 'createdAt')
     }
-    req.onsuccess = () => resolve(req.result)
-    req.onerror = () => reject(req.error)
-    req.onblocked = () => reject(req.error)
+    openRequest.onsuccess = () => resolve(openRequest.result)
+    openRequest.onerror = () => reject(openRequest.error)
+    openRequest.onblocked = () => reject(openRequest.error)
   })
 }
 
@@ -78,8 +62,8 @@ async function persistDebugChannelToIndexedDB(
 
   try {
     await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite')
-      const store = tx.objectStore(STORE_NAME)
+      const transaction = db.transaction(STORE_NAME, 'readwrite')
+      const store = transaction.objectStore(STORE_NAME)
 
       store.put({
         requestId,
@@ -108,14 +92,24 @@ async function persistDebugChannelToIndexedDB(
         }
       }
 
-      tx.oncomplete = () => {
+      transaction.oncomplete = () => {
         if (process.env.__NEXT_TEST_MODE) {
-          self.__NEXT_DEBUG_CHANNEL_PERSISTED = true
+          // Test-only flag, set once this document's debug channel entry is
+          // durably committed. Persistence is deferred to an idle callback and
+          // the IndexedDB write is async, so this flag lets e2e tests await
+          // persistence deterministically — coupling only to "an entry was
+          // persisted" and not to how or where it is stored. It resets
+          // naturally on each navigation since every document gets a fresh
+          // window. The local cast keeps the augmentation out of the shipped
+          // declaration files.
+          ;(
+            self as { __NEXT_DEBUG_CHANNEL_PERSISTED?: boolean }
+          ).__NEXT_DEBUG_CHANNEL_PERSISTED = true
         }
         resolve()
       }
-      tx.onerror = () => reject(tx.error)
-      tx.onabort = () => reject(tx.error)
+      transaction.onerror = () => reject(transaction.error)
+      transaction.onabort = () => reject(transaction.error)
     })
   } catch (error) {
     // Best-effort: if persistence fails (quota, transaction abort, etc.), an

--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -71,7 +71,8 @@ async function persistDebugChannelToIndexedDB(
   let db: IDBDatabase
   try {
     db = await openDebugChannelDB()
-  } catch {
+  } catch (error) {
+    console.debug('Failed to open debug channel IndexedDB for write', error)
     return
   }
 
@@ -116,10 +117,11 @@ async function persistDebugChannelToIndexedDB(
       tx.onerror = () => reject(tx.error)
       tx.onabort = () => reject(tx.error)
     })
-  } catch {
+  } catch (error) {
     // Best-effort: if persistence fails (quota, transaction abort, etc.), an
     // HTTP cache restore will fall back to location.reload() since no entry
     // will be found.
+    console.debug('Failed to write debug channel entry to IndexedDB', error)
   } finally {
     db.close()
   }
@@ -145,8 +147,12 @@ function restoreDebugChannelFromIndexedDB(
         } finally {
           db.close()
         }
-      } catch {
+      } catch (error) {
         // Treat any IDB failure as "no entry" and fall through to reload.
+        console.debug(
+          'Failed to read debug channel entry from IndexedDB',
+          error
+        )
       }
 
       if (!entry) {
@@ -341,8 +347,9 @@ export function getOrCreateDebugChannelReadableWriterPair(
         await whenIdle()
         await persistDebugChannelToIndexedDB(requestId, chunks)
       })
-      .catch(() => {
+      .catch((error) => {
         // writer.closed rejected (e.g., stream aborted) — nothing to persist.
+        console.debug('Debug channel writer closed with error', error)
       })
       .finally(() => {
         pairs.delete(requestId)

--- a/test/e2e/app-dir/bfcache-regression/app/large-debug-data/client.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/large-debug-data/client.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useState } from 'react'
+
+export function ClientComponent() {
+  const [count, setCount] = useState(0)
+
+  return <button onClick={() => setCount(count + 1)}>Count: {count}</button>
+}

--- a/test/e2e/app-dir/bfcache-regression/app/large-debug-data/page.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/large-debug-data/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+import { ClientComponent } from './client'
+
+// This page is only for manual performance profiling of the debug channel
+// persistence (it streams a large amount of debug data). It is not used by any
+// end-to-end test.
+async function Home() {
+  for (let i = 0; i < 50; i++) {
+    await new Promise((resolve) =>
+      setTimeout(() => resolve('a'.repeat(1_000_000)))
+    )
+  }
+
+  return (
+    <div>
+      <h2>Large Debug Data</h2>
+      <ClientComponent />
+    </div>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Home />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/bfcache-regression/app/layout.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/layout.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { ReactNode } from 'react'
 export default function Root({ children }: { children: ReactNode }) {
   return (
@@ -5,6 +6,9 @@ export default function Root({ children }: { children: ReactNode }) {
       <body>
         <p>
           <a href="/target-page">MPA Link</a>
+        </p>
+        <p>
+          <Link href="/large-debug-data">Large Debug Data</Link>
         </p>
         <main>{children}</main>
       </body>

--- a/test/e2e/app-dir/bfcache-regression/app/purge/[slug]/page.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/purge/[slug]/page.tsx
@@ -1,0 +1,27 @@
+const numberOfPages = 11
+
+export function generateStaticParams() {
+  return Array.from({ length: numberOfPages }, (_, i) => ({
+    slug: String(i + 1),
+  }))
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const n = Number(slug)
+
+  return (
+    <div>
+      <h2 id={`purge-${n}`}>Purge {n}</h2>
+      {n < numberOfPages ? (
+        <a id="next" href={`/purge/${n + 1}`}>
+          Next
+        </a>
+      ) : null}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
+++ b/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
@@ -151,4 +151,105 @@ describe('bfcache-regression', () => {
       await assertNoConsoleErrors(browser)
     })
   }
+
+  if (isNextDev && global.browserName !== 'safari') {
+    // Persistence only exists in dev. Excludes Safari: the WebKit build
+    // Playwright drives here re-fetches the document from the server on
+    // back-navigation instead of restoring it from the HTTP cache like Chrome
+    // and Firefox, so each back-navigation gets a fresh request ID that was
+    // never persisted, the request-id-keyed restore always misses, and every
+    // page reloads — the pruned-vs-cached distinction this test relies on never
+    // appears. Real Safari serves back-navigations from cache without a server
+    // request, so this is a limitation of the test's WebKit rather than of the
+    // feature.
+    it('should reload to recover when a debug channel entry was pruned by newer page loads', async () => {
+      // The debug channel for the initial document is buffered and persisted to
+      // IndexedDB so it can be restored when the browser serves the page from
+      // the HTTP cache (back-forward navigation). Persistence is bounded to a
+      // maximum number of entries, pruning the oldest on each write. This
+      // verifies that an entry pushed out by newer page loads is no longer
+      // restorable, so going back to it recovers via a full reload instead.
+
+      // One past the persistence cap (MAX_ENTRIES = 10): loading the whole
+      // chain writes 11 entries, pruning exactly the first page's entry and
+      // leaving /purge/2..11 cached.
+      const PAGES = 11
+
+      // Snapshot the server output so we can count requests made during this
+      // test. Recovery is observed through server requests rather than client
+      // load events: a still-cached page is restored client-side from the HTTP
+      // cache with no server request, while the pruned page misses and recovers
+      // with a full reload, which is a fresh server request. Load-event counts
+      // would be browser-dependent here, since some browsers fire the reload
+      // before the back-navigation's own load event and some after.
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/purge/1')
+
+      // Wait until the just-loaded page's debug channel has been durably
+      // committed to IndexedDB before navigating away. Persistence is deferred
+      // to an idle callback and its IndexedDB write is async; navigating before
+      // it commits would abort the transaction and drop the entry. The page
+      // sets a flag once the commit completes (test mode only), which resets
+      // naturally on each navigation since every document gets a fresh window.
+      const waitForPersisted = () =>
+        retry(async () => {
+          expect(
+            await browser.eval(
+              () => (self as any).__NEXT_DEBUG_CHANNEL_PERSISTED
+            )
+          ).toBe(true)
+        })
+
+      // Hard-navigate through the chain. Each load persists its own entry, so
+      // after more than MAX_ENTRIES loads the earliest pages are pruned.
+      for (let n = 1; n <= PAGES; n++) {
+        await retry(async () => {
+          expect(await browser.elementById(`purge-${n}`).text()).toBe(
+            `Purge ${n}`
+          )
+        })
+        await waitForPersisted()
+        if (n < PAGES) {
+          await browser.elementById('next').click()
+        }
+      }
+
+      // Back-navigate the whole way to the first page. Each step restores the
+      // page's HTML from the HTTP cache and re-runs the debug channel restore.
+      for (let n = PAGES; n > 1; n--) {
+        await browser.back()
+        await retry(async () => {
+          expect(await browser.elementById(`purge-${n - 1}`).text()).toBe(
+            `Purge ${n - 1}`
+          )
+        })
+      }
+
+      // Each page is requested once on the forward pass. On the way back the
+      // cached pages are restored from the HTTP cache without hitting the
+      // server, so they stay at one request, while /purge/1 was pruned and its
+      // restore misses, recovering with a reload that is a second server
+      // request.
+      await retry(async () => {
+        const getCounts: Record<string, number> = {}
+        const output = next.cliOutput.slice(outputIndex)
+        for (const [, path] of output.matchAll(/GET (\/purge\/\d+) /g)) {
+          getCounts[path] = (getCounts[path] ?? 0) + 1
+        }
+        expect(getCounts).toEqual({
+          '/purge/1': 2,
+          '/purge/2': 1,
+          '/purge/3': 1,
+          '/purge/4': 1,
+          '/purge/5': 1,
+          '/purge/6': 1,
+          '/purge/7': 1,
+          '/purge/8': 1,
+          '/purge/9': 1,
+          '/purge/10': 1,
+          '/purge/11': 1,
+        })
+      })
+    })
+  }
 })

--- a/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
+++ b/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
@@ -155,15 +155,6 @@ describe('bfcache-regression', () => {
   if (
     // Persistence only exists in dev.
     isNextDev &&
-    // Excludes Safari: the WebKit build Playwright uses re-fetches the document
-    // from the server on back-navigation instead of restoring it from the HTTP
-    // cache like Chrome and Firefox, so each back-navigation gets a fresh
-    // request ID that was never persisted, the request-id-keyed restore always
-    // misses, and every page reloads — the pruned-vs-cached distinction this
-    // test relies on never appears. Real Safari serves back-navigations from
-    // cache without a server request, so this is a limitation of the test's
-    // WebKit rather than of the feature.
-    global.browserName !== 'safari' &&
     // TODO: Re-enable for node streams once the React debug channel integration
     // is fixed there. With `__NEXT_USE_NODE_STREAMS` the debug channel readable
     // doesn't close as expected, so the client never persists the buffered
@@ -233,11 +224,29 @@ describe('bfcache-regression', () => {
         })
       }
 
-      // Each page is requested once on the forward pass. On the way back the
-      // cached pages are restored from the HTTP cache without hitting the
-      // server, so they stay at one request, while /purge/1 was pruned and its
-      // restore misses, recovering with a reload that is a second server
-      // request.
+      // Per-page server request counts after the forward + back traversal.
+      // /purge/1 reaches 2 requests in every browser but via different paths:
+      //
+      // Chrome and Firefox restore each back-navigation from the HTTP cache
+      // (the HMR WebSocket disqualifies bfcache, so the browser falls back to
+      // HTTP cache restore with no server request). /purge/2..10 stay at one
+      // request because their IDB entries are still around and the restore
+      // replays them silently. /purge/1's IDB entry was pruned by the time we
+      // get back to it (MAX_ENTRIES=10), so its restore misses and recovers
+      // via a single location.reload() — that's the second server request.
+      //
+      // Playwright's WebKit is encoded as a separate expectation because it
+      // doesn't match real Safari behavior. Real Safari keeps recent pages in
+      // bfcache and falls back to HTTP cache restore for evicted ones, so it
+      // would behave like Chrome/Firefox here. Playwright's WebKit instead
+      // re-fetches every back-navigation target from the server, which adds
+      // one extra server request per back-step (including /purge/1 — the same
+      // re-fetch behavior already accounts for its second request, so the
+      // pruned IDB entry never triggers a reload there). The fresh re-fetch
+      // is correctly classified as a non-cache-restore by debug-channel.ts
+      // (the deferred-pageshow branch routes it to the live WebSocket-backed
+      // channel), so no spurious reload follows.
+      const isSafari = global.browserName === 'safari'
       await retry(async () => {
         const getCounts: Record<string, number> = {}
         const output = next.cliOutput.slice(outputIndex)
@@ -246,15 +255,17 @@ describe('bfcache-regression', () => {
         }
         expect(getCounts).toEqual({
           '/purge/1': 2,
-          '/purge/2': 1,
-          '/purge/3': 1,
-          '/purge/4': 1,
-          '/purge/5': 1,
-          '/purge/6': 1,
-          '/purge/7': 1,
-          '/purge/8': 1,
-          '/purge/9': 1,
-          '/purge/10': 1,
+          // Chrome/Firefox: 1 forward only (HTTP cache restore on back).
+          // Safari (Playwright/WebKit): 1 forward + 1 back re-fetch = 2.
+          '/purge/2': isSafari ? 2 : 1,
+          '/purge/3': isSafari ? 2 : 1,
+          '/purge/4': isSafari ? 2 : 1,
+          '/purge/5': isSafari ? 2 : 1,
+          '/purge/6': isSafari ? 2 : 1,
+          '/purge/7': isSafari ? 2 : 1,
+          '/purge/8': isSafari ? 2 : 1,
+          '/purge/9': isSafari ? 2 : 1,
+          '/purge/10': isSafari ? 2 : 1,
           '/purge/11': 1,
         })
       })

--- a/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
+++ b/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
@@ -152,16 +152,24 @@ describe('bfcache-regression', () => {
     })
   }
 
-  if (isNextDev && global.browserName !== 'safari') {
-    // Persistence only exists in dev. Excludes Safari: the WebKit build
-    // Playwright drives here re-fetches the document from the server on
-    // back-navigation instead of restoring it from the HTTP cache like Chrome
-    // and Firefox, so each back-navigation gets a fresh request ID that was
-    // never persisted, the request-id-keyed restore always misses, and every
-    // page reloads — the pruned-vs-cached distinction this test relies on never
-    // appears. Real Safari serves back-navigations from cache without a server
-    // request, so this is a limitation of the test's WebKit rather than of the
-    // feature.
+  if (
+    // Persistence only exists in dev.
+    isNextDev &&
+    // Excludes Safari: the WebKit build Playwright uses re-fetches the document
+    // from the server on back-navigation instead of restoring it from the HTTP
+    // cache like Chrome and Firefox, so each back-navigation gets a fresh
+    // request ID that was never persisted, the request-id-keyed restore always
+    // misses, and every page reloads — the pruned-vs-cached distinction this
+    // test relies on never appears. Real Safari serves back-navigations from
+    // cache without a server request, so this is a limitation of the test's
+    // WebKit rather than of the feature.
+    global.browserName !== 'safari' &&
+    // TODO: Re-enable for node streams once the React debug channel integration
+    // is fixed there. With `__NEXT_USE_NODE_STREAMS` the debug channel readable
+    // doesn't close as expected, so the client never persists the buffered
+    // entry and this test's wait-for-persisted step times out.
+    !process.env.__NEXT_USE_NODE_STREAMS
+  ) {
     it('should reload to recover when a debug channel entry was pruned by newer page loads', async () => {
       // The debug channel for the initial document is buffered and persisted to
       // IndexedDB so it can be restored when the browser serves the page from


### PR DESCRIPTION
In development the debug channel that streams React's Server Component debug information to the browser is buffered for the initial document and persisted, so that it can be replayed when the browser later serves the page from its HTTP cache — for example on back/forward navigation or tab duplication — instead of forcing a full reload. This changes where that buffer is persisted, moving it from `sessionStorage` to `IndexedDB`.

The largest win comes from no longer having to serialize the data. `sessionStorage` can only hold strings, so the binary debug chunks had to be encoded into a string before being written and parsed back out again on restore, which becomes expensive once the payload grows to several megabytes. `IndexedDB` stores the chunks directly as the `Uint8Array`s they already are, so there is no encode and parse round trip on either side. Its asynchronous API helps a little on top of that, since the write itself no longer has to happen synchronously.

The other improvement is that persistence no longer competes with hydration. The initial document's debug stream closes while hydration is still running, and the previous synchronous `sessionStorage` write happened at exactly that moment, taking main thread time away from hydration. The write is now deferred with `requestIdleCallback`, so it only runs once the main thread is genuinely idle, which is after hydration has drained, and it is skipped entirely if the page navigates away before that happens, in which case a later restore simply falls back to a reload. This is visible in the profiles below: with `sessionStorage` there is still hydration work running after the persistence task, whereas with the idle-scheduled `IndexedDB` write the persistence only runs once hydration is done.

In a profile of a test page that deliberately transfers a large amount of debug information, the persistence work on the main thread dropped from more than 700 ms to roughly 25 to 45 ms. A real application with far less debug data will see a smaller difference, so the test page amplifies the effect, but the direction is the same.

The number of persisted entries stays bounded to 10, with the oldest pruned on each write, and an end-to-end test covers the case where an entry is pushed out by newer page loads so that navigating back to it recovers through a page reload.

**Before with `sessionStorage`**:

<img width="973" height="627" alt="sessionStorage" src="https://github.com/user-attachments/assets/b8ff8464-9ccf-4363-b1fe-78db0fd3e1eb" />

**After with idle-scheduled `IndexedDB`:**

<img width="973" height="627" alt="indexedDB" src="https://github.com/user-attachments/assets/94a557a3-c82d-4771-bd81-3b4dfd906f25" />
