### PR TITLE
feat(image-optimization): add experimental flag `imgOptOperationCache`

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -260,6 +260,7 @@ export const experimentalSchema = {
   fullySpecified: z.boolean().optional(),
   gzipSize: z.boolean().optional(),
   imgOptConcurrency: z.number().int().optional().nullable(),
+  imgOptOperationCache: z.boolean().optional().nullable(),
   imgOptTimeoutInSeconds: z.number().int().optional(),
   imgOptMaxInputPixels: z.number().int().optional(),
   imgOptSequentialRead: z.boolean().optional().nullable(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -534,6 +534,7 @@ export interface ExperimentalConfig {
   allowedRevalidateHeaderKeys?: string[]
   fetchCacheKeyPrefix?: string
   imgOptConcurrency?: number | null
+  imgOptOperationCache?: boolean | null
   imgOptTimeoutInSeconds?: number
   imgOptMaxInputPixels?: number
   imgOptSequentialRead?: boolean | null
@@ -1995,6 +1996,7 @@ export const defaultConfig = Object.freeze({
     ),
     memoryBasedWorkersCount: false,
     imgOptConcurrency: null,
+    imgOptOperationCache: null,
     imgOptTimeoutInSeconds: 7,
     imgOptMaxInputPixels: 268_402_689, // https://sharp.pixelplumbing.com/api-constructor#:~:text=%5Boptions.limitInputPixels%5D
     imgOptSequentialRead: null,
@@ -2149,6 +2151,7 @@ export interface NextConfigRuntime {
     | 'hideLogsAfterAbort'
     | 'removeUncaughtErrorAndRejectionListeners'
     | 'imgOptConcurrency'
+    | 'imgOptOperationCache'
     | 'imgOptMaxInputPixels'
     | 'imgOptSequentialRead'
     | 'imgOptSkipMetadata'
@@ -2218,6 +2221,7 @@ export function getNextConfigRuntime(
     removeUncaughtErrorAndRejectionListeners:
       ex.removeUncaughtErrorAndRejectionListeners,
     imgOptConcurrency: ex.imgOptConcurrency,
+    imgOptOperationCache: ex.imgOptOperationCache,
     imgOptMaxInputPixels: ex.imgOptMaxInputPixels,
     imgOptSequentialRead: ex.imgOptSequentialRead,
     imgOptSkipMetadata: ex.imgOptSkipMetadata,

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -84,13 +84,19 @@ async function initCacheEntries(
   return entries.sort((a, b) => a.expireAt - b.expireAt)
 }
 
-export function getSharp(concurrency: number | null | undefined) {
+export function getSharp(
+  concurrency: number | null | undefined,
+  operationCache: boolean | null | undefined
+) {
   if (_sharp) {
     return _sharp
   }
   try {
     _sharp = require('sharp') as typeof import('sharp')
-    if (_sharp && _sharp.concurrency() > 1) {
+    if (typeof operationCache === 'boolean') {
+      _sharp.cache(operationCache)
+    }
+    if (_sharp.concurrency() > 1) {
       // Reducing concurrency should reduce the memory usage too.
       // We more aggressively reduce in dev but also reduce in prod.
       // https://sharp.pixelplumbing.com/api-utility#concurrency
@@ -223,7 +229,8 @@ async function deleteFromCacheDir(cacheDir: string, cacheKey: string) {
 export async function detectContentType(
   buffer: Buffer,
   skipMetadata: boolean | null | undefined,
-  concurrency?: number | null | undefined
+  concurrency?: number | null | undefined,
+  operationCache?: boolean | null | undefined
 ): Promise<string | null> {
   if (buffer.byteLength === 0) {
     return null
@@ -308,7 +315,7 @@ export async function detectContentType(
   format = detector(buffer)
 
   if (!format && !skipMetadata) {
-    const sharp = getSharp(concurrency)
+    const sharp = getSharp(concurrency, operationCache)
     const meta = await sharp(buffer)
       .metadata()
       .catch((_) => null)
@@ -806,6 +813,7 @@ export async function optimizeImage({
   width,
   height,
   concurrency,
+  operationCache,
   limitInputPixels,
   sequentialRead,
   timeoutInSeconds,
@@ -816,11 +824,12 @@ export async function optimizeImage({
   width: number
   height?: number
   concurrency?: number | null
+  operationCache?: boolean | null | undefined
   limitInputPixels?: number
   sequentialRead?: boolean | null
   timeoutInSeconds?: number
 }): Promise<Buffer> {
-  const sharp = getSharp(concurrency)
+  const sharp = getSharp(concurrency, operationCache)
   const transformer = sharp(buffer, {
     limitInputPixels,
     sequentialRead: sequentialRead ?? undefined,
@@ -1054,6 +1063,7 @@ export async function imageOptimizer(
     experimental: Pick<
       NextConfigComplete['experimental'],
       | 'imgOptConcurrency'
+      | 'imgOptOperationCache'
       | 'imgOptMaxInputPixels'
       | 'imgOptSequentialRead'
       | 'imgOptSkipMetadata'
@@ -1087,7 +1097,8 @@ export async function imageOptimizer(
   const upstreamType = await detectContentType(
     upstreamBuffer,
     nextConfig.experimental.imgOptSkipMetadata,
-    nextConfig.experimental.imgOptConcurrency
+    nextConfig.experimental.imgOptConcurrency,
+    nextConfig.experimental.imgOptOperationCache
   )
 
   if (
@@ -1177,6 +1188,7 @@ export async function imageOptimizer(
       quality,
       width,
       concurrency: nextConfig.experimental.imgOptConcurrency,
+      operationCache: nextConfig.experimental.imgOptOperationCache,
       limitInputPixels: nextConfig.experimental.imgOptMaxInputPixels,
       sequentialRead: nextConfig.experimental.imgOptSequentialRead,
       timeoutInSeconds: nextConfig.experimental.imgOptTimeoutInSeconds,


### PR DESCRIPTION
This PR adds a new experimental option to enable/disable operation cache in sharp.

https://sharp.pixelplumbing.com/api-utility/#cache