### PR TITLE
fix: #38863 - POST request succeeds for pages with next dev

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2276,6 +2276,13 @@ export default abstract class Server<
       res.statusCode = parseInt(pathname.slice(1), 10)
     }
 
+    // When automatic static optimization is disabled (custom _app.getInitialProps),
+    // pages are dynamically rendered in production too, so POST should be allowed.
+    const hasCustomAppGetInitialProps =
+      components.App?.getInitialProps &&
+      components.App.getInitialProps !==
+        (components.App as any).origGetInitialProps
+
     if (
       // Server actions can use non-GET/HEAD methods.
       !isPossibleServerAction &&
@@ -2286,7 +2293,15 @@ export default abstract class Server<
       pathname !== '/_error' &&
       req.method !== 'HEAD' &&
       req.method !== 'GET' &&
-      (typeof components.Component === 'string' || isSSG)
+      (typeof components.Component === 'string' ||
+        isSSG ||
+        // In dev mode, pages without getServerSideProps or getInitialProps are
+        // rendered dynamically but should still reject non-GET/HEAD methods,
+        // matching production behavior where they would be static strings.
+        (!isAppPath &&
+          !hasServerProps &&
+          !hasCustomAppGetInitialProps &&
+          !(components.Component as any)?.getInitialProps))
     ) {
       res.statusCode = 405
       res.setHeader('Allow', ['GET', 'HEAD'])


### PR DESCRIPTION
## Summary

Fixes #38863

In dev mode, pages are always rendered dynamically (the Component is never a pre-rendered string), so the existing check for rejecting non-GET/HEAD methods only triggered for SSG pages. This meant regular pages without `getServerSideProps` or `getInitialProps` would incorrectly accept POST requests in dev, while correctly returning 405 in production.

## Changes

Extended the method validation check in `base-server.ts` to also reject non-GET/HEAD requests for pages router pages that don't have:
- `getServerSideProps`
- `getInitialProps` on the page component
- A custom `_app.getInitialProps` (which disables automatic static optimization)

This makes dev mode behavior match production behavior for static pages.

## Testing

- Existing test in `test/e2e/prerender.test.ts` already validates 405 for POST to static pages
- Pages with `getServerSideProps` (like `fully-dynamic`) continue to accept POST (200)
- App router pages are unaffected