### PR TITLE
[turbopack] standardize chunk entry names for webpack and postcss loaders

### DIFF
--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -9,13 +9,12 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexMap, OperationVc, PrettyPrintError, ResolvedVc, TryJoinIterExt,
-    ValueToString, Vc, duration_span, fxindexmap, parallel::available_parallelism,
+    Completion, FxIndexMap, OperationVc, PrettyPrintError, ResolvedVc, TryJoinIterExt, Vc,
+    duration_span, fxindexmap, parallel::available_parallelism,
     resolve_strongly_consistent_and_take_and_apply_effects, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, to_sys_path};
-use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher};
 use turbopack_core::{
     asset::AssetContent,
     changed::content_changed,
@@ -151,14 +150,15 @@ async fn emit_evaluate_pool_assets_operation(
         main_entry_ident,
     } = &*entries.await?;
 
-    let module_ident = main_entry_ident.to_string().await?;
-    let module_ident_hash = {
-        let mut hasher = Xxh3Hash64Hasher::new();
-        module_ident.deterministic_hash(&mut hasher);
-        hasher.finish()
-    };
-    let file_name = format!("{module_ident_hash:016x}.js");
-    let entrypoint = chunking_context.output_root().await?.join(&file_name)?;
+    let entrypoint = chunking_context
+        .chunk_path(
+            None,
+            **main_entry_ident,
+            Some(rcstr!("pool_entry")),
+            rcstr!(".js"),
+        )
+        .owned()
+        .await?;
 
     let bootstrap = chunking_context.root_entry_chunk_group_asset(
         entrypoint.clone(),
@@ -168,6 +168,7 @@ async fn emit_evaluate_pool_assets_operation(
         OutputAssets::empty(),
     );
 
+    // TODO
     let output_root = chunking_context.output_root().owned().await?;
     emit_package_json(output_root.clone())?
         .as_side_effect()

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -168,7 +168,6 @@ async fn emit_evaluate_pool_assets_operation(
         OutputAssets::empty(),
     );
 
-    // TODO
     let output_root = chunking_context.output_root().owned().await?;
     emit_package_json(output_root.clone())?
         .as_side_effect()

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Completions, ResolvedVc, TryFlatJoinIterExt, Vc, fxindexmap, trace::TraceRawVcs,
+    turbofmt,
 };
 use turbo_tasks_fs::{
     File, FileContent, FileSystemEntryType, FileSystemPath, json::parse_json_with_source_context,
@@ -342,8 +343,7 @@ pub(crate) async fn config_loader_source(
     project_path: FileSystemPath,
     postcss_config_path: FileSystemPath,
 ) -> Result<Vc<Box<dyn Source>>> {
-    let postcss_config_path_value = postcss_config_path.clone();
-    let postcss_config_path_filename = postcss_config_path_value.file_name();
+    let postcss_config_path_filename = postcss_config_path.file_name();
 
     if postcss_config_path_filename == "package.json" {
         return Ok(Vc::upcast(JsonSource::new(
@@ -353,9 +353,7 @@ pub(crate) async fn config_loader_source(
         )));
     }
 
-    if postcss_config_path_value.path.ends_with(".json")
-        || postcss_config_path_filename == ".postcssrc"
-    {
+    if postcss_config_path.path.ends_with(".json") || postcss_config_path_filename == ".postcssrc" {
         return Ok(Vc::upcast(JsonSource::new(
             postcss_config_path,
             Vc::cell(None),
@@ -364,11 +362,11 @@ pub(crate) async fn config_loader_source(
     }
 
     // We can only load js files with `import()`.
-    if !postcss_config_path_value.path.ends_with(".js") {
+    if !postcss_config_path.path.ends_with(".js") {
         return Ok(Vc::upcast(FileSource::new(postcss_config_path)));
     }
 
-    let Some(config_path) = project_path.get_relative_path_to(&postcss_config_path_value) else {
+    let Some(config_path) = project_path.get_relative_path_to(&postcss_config_path) else {
         bail!("Unable to get relative path to postcss config");
     };
 
@@ -405,7 +403,7 @@ async fn postcss_executor(
 ) -> Result<Vc<ProcessResult>> {
     let config_asset = asset_context
         .process(
-            config_loader_source(project_path, postcss_config_path),
+            config_loader_source(project_path, postcss_config_path.clone()),
             ReferenceType::Entry(EntryReferenceSubType::Undefined),
         )
         .module()
@@ -413,10 +411,11 @@ async fn postcss_executor(
         .await?;
 
     Ok(asset_context.process(
-        Vc::upcast(FileSource::new(
+        Vc::upcast(FileSource::new_with_query(
             embed_file_path(rcstr!("transforms/postcss.ts"))
                 .owned()
                 .await?,
+            turbofmt!("?config={postcss_config_path}").await?,
         )),
         ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
             rcstr!("CONFIG") => config_asset

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -29,6 +29,7 @@ use turbopack_core::{
     file_source::FileSource,
     ident::AssetIdent,
     issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
+    module::Module,
     module_graph::{
         ModuleGraph, SingleModuleGraph,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
@@ -762,8 +763,16 @@ impl EvaluateContext for WebpackLoaderContext {
                     .await?;
 
                 // Generate a full Node.js bundle using the real runtime
-                let output_root = self.chunking_context.output_root().owned().await?;
-                let entry_path = output_root.join("importModule.js")?;
+                let entry_path = self
+                    .chunking_context
+                    .chunk_path(
+                        None,
+                        module.ident(),
+                        Some(rcstr!("importModule")),
+                        rcstr!(".js"),
+                    )
+                    .owned()
+                    .await?;
 
                 let bootstrap = self.chunking_context.root_entry_chunk_group_asset(
                     entry_path.clone(),
@@ -780,6 +789,7 @@ impl EvaluateContext for WebpackLoaderContext {
                     true,
                 )
                 .await?;
+                let output_root = self.chunking_context.output_root().owned().await?;
 
                 let mut chunks = Vec::new();
                 for asset in all_assets {


### PR DESCRIPTION
### What?

Use the `chunk_path` api for computing entrypoint filepath names for our node worker pool files.  For postcss loaders ensure that the config filepath is part of the module ident of the transformer.

### Why?

I was investigating a bug in reported in next 16.2.6 (https://vercel.slack.com/archives/C09GRCW5MQR/p1780088728756579) and noticed that the chunk entry path construction logic was unusual.  It happens to be that https://github.com/vercel/next.js/pull/91338 fixed the reported bug (just not released yet).  This migrates all entry construction to the standard form

