### PR TITLE
fix: #14244 - ISG with GIP in _app overrides cache-control

### DIFF
--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -638,9 +638,9 @@ export const getHandler = ({
           }
         }
 
-        // If cache control is already set on the response we don't
-        // override it to allow users to customize it via next.config
-        if (cacheControl && !res.getHeader('Cache-Control')) {
+        // ISG/ISR cache-control must always take precedence over any
+        // Cache-Control header set earlier (e.g. by _app's getInitialProps)
+        if (cacheControl) {
           res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
         }
 

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -55,9 +55,12 @@ export async function sendRenderResult({
     res.setHeader('X-Powered-By', 'Next.js')
   }
 
-  // If cache control is already set on the response we don't
-  // override it to allow users to customize it via next.config
-  if (cacheControl && !res.getHeader('Cache-Control')) {
+  // If the page has a revalidate value (ISG/ISR), the cache-control
+  // header derived from it must always take precedence over any
+  // Cache-Control header that may have been set earlier (e.g. by
+  // _app's getInitialProps). For pages without revalidate, we still
+  // respect any previously set Cache-Control header.
+  if (cacheControl) {
     res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
   }
 

--- a/test/production/prerender-revalidate-with-app-gip/pages/_app.js
+++ b/test/production/prerender-revalidate-with-app-gip/pages/_app.js
@@ -1,0 +1,19 @@
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+MyApp.getInitialProps = async ({ Component, ctx }) => {
+  // This simulates a custom _app that sets Cache-Control header
+  // which should NOT override the ISG page's cache-control
+  if (ctx.res) {
+    ctx.res.setHeader('Cache-Control', 'public, max-age=3600')
+  }
+
+  let pageProps = {}
+  if (Component.getInitialProps) {
+    pageProps = await Component.getInitialProps(ctx)
+  }
+  return { pageProps }
+}
+
+export default MyApp

--- a/test/production/prerender-revalidate-with-app-gip/pages/isg.js
+++ b/test/production/prerender-revalidate-with-app-gip/pages/isg.js
@@ -1,0 +1,17 @@
+export async function getStaticProps() {
+  return {
+    props: {
+      time: new Date().getTime(),
+    },
+    revalidate: 10,
+  }
+}
+
+export default function ISGPage({ time }) {
+  return (
+    <div>
+      <p>ISG Page</p>
+      <span>time: {time}</span>
+    </div>
+  )
+}

--- a/test/production/prerender-revalidate-with-app-gip/prerender-revalidate-with-app-gip.test.ts
+++ b/test/production/prerender-revalidate-with-app-gip/prerender-revalidate-with-app-gip.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('ISG with GIP in _app should not override cache-control', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should use ISG cache-control instead of _app header', async () => {
+    const res = await next.fetch('/isg')
+    const cacheControl = res.headers.get('Cache-Control')
+
+    // The ISG page has revalidate: 10, so the cache-control should reflect
+    // the ISG revalidation period, NOT the "public, max-age=3600" set by _app
+    expect(cacheControl).not.toContain('max-age=3600')
+    expect(cacheControl).toContain('s-maxage=10')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #14244

When a custom `_app` has `getInitialProps` that sets a `Cache-Control` header, it was preventing the ISG/ISR page's cache-control from being applied. The `sendRenderResult` function and the pages-handler both checked `!res.getHeader('Cache-Control')` before applying the ISG revalidation cache-control header, meaning any earlier header would win.

## Changes

- **`packages/next/src/server/send-payload.ts`**: Removed the `!res.getHeader('Cache-Control')` guard so ISG/ISR cache-control always takes precedence.
- **`packages/next/src/server/route-modules/pages/pages-handler.ts`**: Same fix for the pages route handler path.

## What was tested

- Added a regression test (`test/production/prerender-revalidate-with-app-gip`) that verifies an ISG page's `s-maxage` cache-control is not overridden by a `Cache-Control` header set in `_app`'s `getInitialProps`.