### PR TITLE
fix: #13653 - prevent scroll to hash on browser back navigation

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -158,7 +158,10 @@ class Container extends React.Component<{
   }
 
   componentDidUpdate() {
-    this.scrollToHash()
+    // Don't scrollToHash here unconditionally — the router already handles
+    // hash scrolling during navigations (push/replace). Doing it on every
+    // update causes unwanted scrolling when the user navigates back to a
+    // page with a hash via the browser back button (popstate).
   }
 
   scrollToHash() {


### PR DESCRIPTION
Fixes #13653

## Summary

When a user navigates back to a page with a URL hash (e.g. `/page#anchor`) using the browser back button, the `Container`'s `componentDidUpdate` was unconditionally calling `scrollToHash()`, causing unexpected scrolling to the anchor element.

## Problem

The `componentDidUpdate` lifecycle in the client-side `Container` component called `scrollToHash()` on every re-render, including when the user navigates back/forward via popstate. This overrides the browser's native scroll restoration behavior.

## Fix

Removed the `scrollToHash()` call from `componentDidUpdate`. This is safe because:

1. **Initial page load** is handled by `componentDidMount` which still calls `scrollToHash()`
2. **Forward navigations** (push/replace) are handled by the router's own `change()` method which already calls `scrollToHash()` when appropriate (respecting the `scroll` option)
3. **Back/forward (popstate) navigations** should rely on the browser's scroll restoration or the router's `forcedScroll` mechanism — not an unconditional scroll in `componentDidUpdate`

## Testing

Verified against existing e2e tests in `test/e2e/router-hash-navigation/` and `test/development/pages-dir/client-navigation/url-hash.test.ts`.