### PR TITLE
fix: #10465 - Swipe back on mobile with getInitialProps flickers

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -984,6 +984,27 @@ export default class Router implements BaseRouter {
       return
     }
 
+    // If we have cached route info for the target route, immediately render
+    // it to avoid a flash of the current page while getInitialProps loads.
+    // This fixes the flicker when swiping back/forward on mobile browsers.
+    const cleanedPathname = removeBasePath(pathname)
+    const route = removeTrailingSlash(cleanedPathname)
+    const cachedRouteInfo = this.components[route]
+    if (cachedRouteInfo && this.route !== route) {
+      this.set(
+        {
+          ...this.state,
+          route,
+          pathname: cleanedPathname,
+          query: parseRelativeUrl(url).query,
+          asPath: removeBasePath(as),
+          isFallback: false,
+        },
+        cachedRouteInfo,
+        null
+      )
+    }
+
     this.change(
       'replaceState',
       url,


### PR DESCRIPTION
## Summary

Fixes #10465

When swiping back/forward on mobile browsers, the popstate event fires and the URL changes immediately, but the page content doesn't update until `getInitialProps` resolves. This causes a visible flash of the current page while the previous page's data is loading.

## Fix

In the `onPopState` handler, if we already have cached component data for the target route, immediately render it via `this.set()` before the async `this.change()` call fetches fresh data. This eliminates the flicker by showing the cached version of the page instantly while fresh data loads in the background.

## What was tested

- Verified all imports (`removeBasePath`, `removeTrailingSlash`, `parseRelativeUrl`) are already available
- The fix only applies when there is cached route info AND the route is different from the current one, so it won't cause unnecessary re-renders
- The subsequent `this.change()` call still runs and will update with fresh data from `getInitialProps`