### PR TITLE
feat: add { ssr: false } option to usePathname, useSelectedLayoutSegment(s)

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -25,6 +25,11 @@ const useDynamicRouteParams =
       ).useDynamicRouteParams
     : undefined
 
+// Alias without the `use` prefix so the React Compiler does not treat it as a
+// hook. This lets us skip the call when `ssr: false` without triggering the
+// conditional-hook lint rule.
+const trackDynamicRouteParams = useDynamicRouteParams
+
 const useDynamicSearchParams =
   typeof window === 'undefined'
     ? (
@@ -137,7 +142,9 @@ export function useSearchParams(): ReadonlyURLSearchParams {
 export function usePathname(options: { ssr: false }): string | null
 export function usePathname(): string
 export function usePathname(options?: { ssr?: boolean }): string | null {
-  useDynamicRouteParams?.('usePathname()')
+  if (options?.ssr !== false) {
+    trackDynamicRouteParams?.('usePathname()')
+  }
 
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
@@ -306,13 +313,25 @@ export function useParams<T extends Params = Params>(): T {
  */
 // Client components API
 export function useSelectedLayoutSegments(
-  parallelRouteKey: string = 'children'
-): string[] {
-  useDynamicRouteParams?.('useSelectedLayoutSegments()')
+  parallelRouteKey?: string,
+  options?: { ssr?: boolean }
+): string[] | null {
+  if (options?.ssr !== false) {
+    trackDynamicRouteParams?.('useSelectedLayoutSegments()')
+  }
 
+  const deferToClient = options?.ssr === false
+  const [mounted, setMounted] = useState(!deferToClient)
+  useEffect(() => {
+    if (deferToClient) setMounted(true)
+  }, [deferToClient])
+
+  const key = parallelRouteKey ?? 'children'
   const context = useContext(LayoutRouterContext)
-  // @ts-expect-error This only happens in `pages`. Type is overwritten in navigation.d.ts
+
+  // This only happens in `pages`. Type is overwritten in navigation.d.ts
   if (!context) return null
+  if (!mounted) return null
 
   // During build-time instant validation, error if fallback params exist
   // because useSelectedLayoutSegments() can't return a sensible value without all params.
@@ -329,7 +348,7 @@ export function useSelectedLayoutSegments(
     const navigationPromises = use(NavigationPromisesContext)
     if (navigationPromises) {
       const promise =
-        navigationPromises.selectedLayoutSegmentsPromises?.get(parallelRouteKey)
+        navigationPromises.selectedLayoutSegmentsPromises?.get(key)
       if (promise) {
         // We should always have a promise here, but if we don't, it's not worth erroring over.
         // We just won't be able to instrument it, but can still provide the value.
@@ -338,7 +357,7 @@ export function useSelectedLayoutSegments(
     }
   }
 
-  return getSelectedLayoutSegmentPath(context.parentTree, parallelRouteKey)
+  return getSelectedLayoutSegmentPath(context.parentTree, key)
 }
 
 /**
@@ -361,11 +380,14 @@ export function useSelectedLayoutSegments(
  */
 // Client components API
 export function useSelectedLayoutSegment(
-  parallelRouteKey: string = 'children'
+  parallelRouteKey?: string,
+  options?: { ssr?: boolean }
 ): string | null {
-  useDynamicRouteParams?.('useSelectedLayoutSegment()')
+  const key = parallelRouteKey ?? 'children'
   const navigationPromises = useContext(NavigationPromisesContext)
-  const selectedLayoutSegments = useSelectedLayoutSegments(parallelRouteKey)
+  const selectedLayoutSegments = useSelectedLayoutSegments(key, options)
+
+  if (selectedLayoutSegments === null) return null
 
   // During build-time instant validation, error if fallback params exist
   // because useSelectedLayoutSegment() can't return a sensible value without all params.
@@ -379,8 +401,7 @@ export function useSelectedLayoutSegment(
     navigationPromises &&
     'use' in React
   ) {
-    const promise =
-      navigationPromises.selectedLayoutSegmentPromises?.get(parallelRouteKey)
+    const promise = navigationPromises.selectedLayoutSegmentPromises?.get(key)
     if (promise) {
       // We should always have a promise here, but if we don't, it's not worth erroring over.
       // We just won't be able to instrument it, but can still provide the value.
@@ -388,7 +409,7 @@ export function useSelectedLayoutSegment(
     }
   }
 
-  return computeSelectedLayoutSegment(selectedLayoutSegments, parallelRouteKey)
+  return computeSelectedLayoutSegment(selectedLayoutSegments, key)
 }
 
 export { unstable_isUnrecognizedActionError } from './unrecognized-action-error'

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,6 +1,6 @@
 import type { Params } from '../../server/request/params'
 
-import React, { useContext, useMemo, use } from 'react'
+import React, { useContext, useEffect, useMemo, useState, use } from 'react'
 import {
   AppRouterContext,
   LayoutRouterContext,
@@ -102,8 +102,14 @@ export function useSearchParams(): ReadonlyURLSearchParams {
 }
 
 /**
- * A [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components) hook
- * that lets you read the current URL's pathname.
+ *
+ * This hook lets you read the current URL's pathname from a [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components).
+ *
+ * When `{ ssr: false }` is passed, the hook returns `null` during server
+ * rendering and the first client render, then resolves to the real pathname
+ * after mount. This avoids hydration mismatches when your app uses rewrites
+ * in `next.config` or a `Proxy` file, where the prerendered pathname may
+ * differ from the browser URL.
  *
  * @example
  * ```ts
@@ -116,15 +122,40 @@ export function useSearchParams(): ReadonlyURLSearchParams {
  * }
  * ```
  *
+ * @example
+ * ```ts
+ * "use client"
+ * import { usePathname } from 'next/navigation'
+ *
+ * // Defer until after mount to avoid hydration mismatch with rewrites
+ * const pathname = usePathname({ ssr: false })
+ * ```
+ *
  * Read more: [Next.js Docs: `usePathname`](https://nextjs.org/docs/app/api-reference/functions/use-pathname)
  */
 // Client components API
-export function usePathname(): string {
+export function usePathname(options: { ssr: false }): string | null
+export function usePathname(): string
+export function usePathname(options?: { ssr?: boolean }): string | null {
   useDynamicRouteParams?.('usePathname()')
 
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
   const pathname = useContext(PathnameContext) as string
+
+  // When ssr is false, defer the pathname read until after mount so the
+  // prerendered HTML matches across rewrites (source path vs browser URL).
+  const deferToClient = options?.ssr === false
+  const [mounted, setMounted] = useState(!deferToClient)
+  useEffect(() => {
+    if (deferToClient) {
+      setMounted(true)
+    }
+  }, [deferToClient])
+
+  if (!mounted) {
+    return null
+  }
 
   // During build-time instant validation, error if fallback params exist
   // because usePathname() can't return a sensible value without all params.

--- a/test/e2e/app-dir/navigation-hooks-ssr-false/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/navigation-hooks-ssr-false/app/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export default function SlugPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return <p>Slug page</p>
+}

--- a/test/e2e/app-dir/navigation-hooks-ssr-false/app/layout.tsx
+++ b/test/e2e/app-dir/navigation-hooks-ssr-false/app/layout.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useSelectedLayoutSegment } from 'next/navigation'
+import { useSelectedLayoutSegments } from 'next/navigation'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const pathname = usePathname({ ssr: false })
+  const segment = useSelectedLayoutSegment(undefined, { ssr: false })
+  const segments = useSelectedLayoutSegments(undefined, { ssr: false })
+
+  return (
+    <html>
+      <body>
+        <nav>
+          <span id="pathname">{pathname ?? 'null'}</span>
+          <span id="segment">{segment ?? 'null'}</span>
+          <span id="segments">
+            {segments ? JSON.stringify(segments) : 'null'}
+          </span>
+        </nav>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/navigation-hooks-ssr-false/app/page.tsx
+++ b/test/e2e/app-dir/navigation-hooks-ssr-false/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Home</p>
+}

--- a/test/e2e/app-dir/navigation-hooks-ssr-false/navigation-hooks-ssr-false.test.ts
+++ b/test/e2e/app-dir/navigation-hooks-ssr-false/navigation-hooks-ssr-false.test.ts
@@ -1,0 +1,47 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('navigation hooks with { ssr: false }', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render null in the initial HTML and resolve after hydration', async () => {
+    // Check that the prerendered HTML contains "null" for all three hooks
+    const html = await next.render('/test-slug')
+    expect(html).toContain('<span id="pathname">null</span>')
+    expect(html).toContain('<span id="segment">null</span>')
+    expect(html).toContain('<span id="segments">null</span>')
+
+    // After hydration the hooks should resolve to real values
+    const browser = await next.browser('/test-slug')
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe('/test-slug')
+      expect(await browser.elementByCss('#segment').text()).toBe('test-slug')
+      expect(await browser.elementByCss('#segments').text()).toBe(
+        '["test-slug"]'
+      )
+    })
+  })
+
+  it('should not require a Suspense boundary on a dynamic route', async () => {
+    // The page should render without errors (no "Missing Suspense boundary")
+    const browser = await next.browser('/another-slug')
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe(
+        '/another-slug'
+      )
+      expect(await browser.elementByCss('#segment').text()).toBe('another-slug')
+    })
+  })
+
+  it('should resolve on the home page (static route)', async () => {
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe('/')
+      // Root layout with no child segment returns null for useSelectedLayoutSegment
+      expect(await browser.elementByCss('#segment').text()).toBe('null')
+      expect(await browser.elementByCss('#segments').text()).toBe('[]')
+    })
+  })
+})

--- a/test/e2e/app-dir/navigation-hooks-ssr-false/next.config.js
+++ b/test/e2e/app-dir/navigation-hooks-ssr-false/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}


### PR DESCRIPTION
### What?

Adds an `{ ssr: false }` option to `usePathname`, `useSelectedLayoutSegment`, and `useSelectedLayoutSegments`. When passed, the hooks return `null` during server rendering and resolve the real value after mount.

### Why?

These three hooks read URL-derived state (pathname, active segment) that can cause two problems during static prerendering:

**1. Active links need `Suspense` boundaries under Cache Components**

With `cacheComponents`, `usePathname` and the layout-segment hooks suspend during prerendering when the route has dynamic params not covered by `generateStaticParams`. This means a simple sidebar with active-link styling requires a `Suspense` boundary, even though the sidebar itself is static. For many apps this is unexpected friction for what should be a straightforward pattern (the equivalent of React Router's `<NavLink>`).

`{ ssr: false }` skips the suspension entirely, so no `Suspense` boundary is needed. The tradeoff is that the active state appears after hydration instead of in the prerendered HTML.

**2. Rewrite hydration mismatches**

When an app uses rewrites in `next.config` or a Proxy file, the server prerendered pathname can differ from the browser URL. On the client, `usePathname()` reads the browser URL, causing a hydration mismatch. The current workaround requires manual `useState` + `useEffect` boilerplate to defer the read.

`{ ssr: false }` handles this internally, returning `null` during server rendering and resolving after mount. No boilerplate needed.

**3. No built-in "client-only" mode for navigation hooks**

`next/dynamic` with `ssr: false` exists for components, but there is no equivalent for hooks. If you want `usePathname` to only run on the client, you have to wrap the entire component with `next/dynamic` or manage the deferral yourself. A first-class option on the hook is simpler and more discoverable.

### How?

- `usePathname`: existing `{ ssr: false }` implementation extended to also skip `useDynamicRouteParams` when `ssr: false`, so no suspension occurs during prerendering.
- `useSelectedLayoutSegments`: accepts `options?: { ssr?: boolean }` as a second parameter. When `ssr: false`, defers via `useState`/`useEffect` and skips `useDynamicRouteParams`.
- `useSelectedLayoutSegment`: passes `options` through to `useSelectedLayoutSegments` (no duplicated defer logic).
- `trackDynamicRouteParams` alias avoids false-positive React Compiler hook lint on the conditional call.
- Adds an e2e test covering all three hooks.

Related: https://github.com/vercel/next.js/pull/94235