### PR TITLE
Fix debug channel not closing on the client with Node streams

### DIFF
--- a/packages/next/src/server/app-render/debug-channel-server.node.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.node.ts
@@ -14,24 +14,34 @@ export { createWebDebugChannel } from './debug-channel-server.web'
  * which expects debugChannel to be a Node.js stream with a .write() method.
  */
 export function createNodeDebugChannel(): DebugChannelPair {
-  const readable = new PassThrough()
+  // The readable side is a PassThrough that the client reads from. The
+  // server-side write target is a separate, write-only Writable that forwards
+  // into it rather than the PassThrough itself: React's renderToPipeableStream
+  // detects `.read()` on the debug channel and would enter bidirectional mode,
+  // reading its own output back as commands.
+  //
+  // The forwarding must use `passthrough.write()` / `passthrough.end()`, not
+  // `passthrough.push()` / `passthrough.push(null)`. A PassThrough is a Duplex;
+  // pushing `null` ends only its readable half and leaves the writable half
+  // open (`writableEnded` stays false). The readable is later consumed via
+  // `Readable.toWeb()` (in `connectReactDebugChannel`, and inside `teeStream`),
+  // and `Readable.toWeb()` never closes the resulting web stream while the
+  // PassThrough's writable half is still open — so the debug channel never
+  // closes on the client. Ending it via `passthrough.end()` closes both halves
+  // and the close propagates.
+  const passthrough = new PassThrough()
 
-  // Use a plain Writable instead of exposing the PassThrough directly.
-  // React's renderToPipeableStream detects .read() on the debugChannel and
-  // enters bidirectional mode, reading its own output back as commands.
   const writable = new Writable({
-    write(chunk, _encoding, callback) {
-      readable.push(chunk)
-      callback()
+    write(chunk, encoding, callback) {
+      passthrough.write(chunk, encoding, callback)
     },
     final(callback) {
-      readable.push(null)
-      callback()
+      passthrough.end(callback)
     },
   })
 
   return {
     serverSide: writable,
-    clientSide: { readable },
+    clientSide: { readable: passthrough },
   }
 }

--- a/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
+++ b/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
@@ -152,15 +152,8 @@ describe('bfcache-regression', () => {
     })
   }
 
-  if (
+  if (isNextDev) {
     // Persistence only exists in dev.
-    isNextDev &&
-    // TODO: Re-enable for node streams once the React debug channel integration
-    // is fixed there. With `__NEXT_USE_NODE_STREAMS` the debug channel readable
-    // doesn't close as expected, so the client never persists the buffered
-    // entry and this test's wait-for-persisted step times out.
-    !process.env.__NEXT_USE_NODE_STREAMS
-  ) {
     it('should reload to recover when a debug channel entry was pruned by newer page loads', async () => {
       // The debug channel for the initial document is buffered and persisted to
       // IndexedDB so it can be restored when the browser serves the page from


### PR DESCRIPTION
The debug channel's Node streams implementation never closed on the client. This leaked memory, because the resources held for each debug channel — the buffered chunks and its entry in the client-side registry, and the pending reader and stream pipeline on the server — are only released once the channel closes. It also meant the buffered debug entry was never persisted to `IndexedDB`, so the bfcache restore test timed out waiting for it.

The server-side write target forwarded React's writes into the readable side with `passthrough.push()` and signalled completion with `passthrough.push(null)`. Because a `PassThrough` is a `Duplex`, pushing `null` ends only its readable half and leaves the writable half open, so `writableEnded` stays `false`. The readable is later consumed through `Readable.toWeb()`, both in `connectReactDebugChannel` and inside `teeStream`, and `Readable.toWeb()` never closes the resulting web stream while the writable half is still open. The close therefore never reached the client, nothing was cleaned up, and the test's wait-for-persisted step never resolved.

Forwarding through `passthrough.write()` and `passthrough.end()` instead ends both halves, so the close propagates through the conversion and the channel closes on the client as expected.

This also re-enables the previously skipped node streams case of the bfcache regression test, which now passes alongside the web streams case.