### PR TITLE
Improve Turbopack error for external next package symlinks

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1185,6 +1185,7 @@ pub async fn get_next_package(context_directory: FileSystemPath) -> Result<FileS
 struct MissingNextFolderIssue {
     path: FileSystemPath,
     root: FileSystemPath,
+    external_next_symlink: Option<RcStr>,
 }
 
 #[async_trait]
@@ -1221,7 +1222,7 @@ impl Issue for MissingNextFolderIssue {
             _ => rcstr!("{unknown}"),
         };
 
-        Ok(Some(StyledString::Stack(vec![
+        let mut lines = vec![
             StyledString::Line(vec![
                 StyledString::Text(rcstr!("Resolved from: ")),
                 StyledString::Strong(context_path),
@@ -1232,6 +1233,26 @@ impl Issue for MissingNextFolderIssue {
             ]),
             StyledString::Line(vec![StyledString::Text(rcstr!(""))]),
             StyledString::Line(vec![StyledString::Text(rcstr!("Possible causes:"))]),
+        ];
+
+        if let Some(target) = &self.external_next_symlink {
+            lines.push(StyledString::Line(vec![
+                StyledString::Text(rcstr!(
+                    "  - node_modules/next resolves outside the Turbopack root: "
+                )),
+                StyledString::Strong(target.clone()),
+            ]));
+            lines.push(StyledString::Line(vec![
+                StyledString::Text(rcstr!("    Configure ")),
+                StyledString::Code(rcstr!("turbopack.root")),
+                StyledString::Text(rcstr!(
+                    " to include both the project and that external store, or disable pnpm's \
+                     global virtual store for this project."
+                )),
+            ]));
+        }
+
+        lines.extend([
             StyledString::Line(vec![StyledString::Text(rcstr!(
                 "  - node_modules is being reorganized by a concurrent install (e.g. pnpm adding \
                  a package with a `next` peer dependency). This is transient and should clear \
@@ -1261,7 +1282,9 @@ impl Issue for MissingNextFolderIssue {
                 "Note: To ensure a hermetic build and a portable cache, files outside of the \
                  workspace root are not compiled."
             ))]),
-        ])))
+        ]);
+
+        Ok(Some(StyledString::Stack(lines)))
     }
 
     fn documentation_link(&self) -> RcStr {
@@ -1285,14 +1308,52 @@ pub async fn try_get_next_package(
     if let Some(source) = result.await?.first_source() {
         Ok(Vc::cell(Some(source.ident().await?.path.parent())))
     } else {
+        let external_next_symlink =
+            external_next_symlink_target(context_directory.clone(), root.clone()).await?;
         MissingNextFolderIssue {
             path: context_directory,
             root,
+            external_next_symlink,
         }
         .resolved_cell()
         .emit();
         Ok(Vc::cell(None))
     }
+}
+
+async fn external_next_symlink_target(
+    context_directory: FileSystemPath,
+    root: FileSystemPath,
+) -> Result<Option<RcStr>> {
+    let Some(root_sys_path) = to_sys_path(root.clone()).await? else {
+        return Ok(None);
+    };
+    let root_sys_path = std::fs::canonicalize(&root_sys_path).unwrap_or(root_sys_path);
+
+    let mut lookup_path = context_directory;
+    let mut lookup_path_value = lookup_path.clone();
+    while lookup_path_value.is_inside_ref(&root) {
+        let candidate = lookup_path.join("node_modules/next")?;
+        if let Some(candidate_sys_path) = to_sys_path(candidate).await?
+            && let Ok(metadata) = std::fs::symlink_metadata(&candidate_sys_path)
+            && metadata.file_type().is_symlink()
+            && let Ok(target) = std::fs::canonicalize(&candidate_sys_path)
+            && !target.starts_with(&root_sys_path)
+        {
+            return Ok(Some(
+                target.to_str().unwrap_or("{unknown external path}").into(),
+            ));
+        }
+
+        lookup_path = lookup_path.parent();
+        let new_lookup_path_value = lookup_path.clone();
+        if new_lookup_path_value == lookup_path_value {
+            break;
+        }
+        lookup_path_value = new_lookup_path_value;
+    }
+
+    Ok(None)
 }
 
 pub async fn insert_alias_option<const N: usize>(

--- a/test/development/app-dir/concurrent-install/concurrent-install.test.ts
+++ b/test/development/app-dir/concurrent-install/concurrent-install.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import fs from 'fs/promises'
+import os from 'os'
 import path from 'path'
 
 /**
@@ -47,6 +48,71 @@ describeMaybe('concurrent-install', () => {
     await fs.rename(stash, original)
   }
 
+  async function moveNextToExternalSymlink(): Promise<{
+    original: string
+    externalRoot: string
+    externalNext: string
+    originalLinkTarget?: string
+  }> {
+    const original = await getNextPath()
+    const externalRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'next-external-symlink-')
+    )
+    const externalNext = path.join(externalRoot, 'next')
+    const originalStat = await fs.lstat(original)
+
+    if (originalStat.isSymbolicLink()) {
+      const originalLinkTarget = await fs.readlink(original)
+      const originalRealPath = await fs.realpath(original)
+      await fs.cp(originalRealPath, externalNext, { recursive: true })
+      await fs.rm(original, { recursive: true, force: true })
+      await fs.symlink(
+        externalNext,
+        original,
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+      return {
+        original,
+        externalRoot,
+        externalNext,
+        originalLinkTarget,
+      }
+    }
+
+    await fs.rename(original, externalNext)
+    await fs.symlink(
+      externalNext,
+      original,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    return { original, externalRoot, externalNext }
+  }
+
+  async function restoreNextFromExternalSymlink({
+    original,
+    externalRoot,
+    externalNext,
+    originalLinkTarget,
+  }: {
+    original: string
+    externalRoot: string
+    externalNext: string
+    originalLinkTarget?: string
+  }): Promise<void> {
+    await fs.rm(original, { recursive: true, force: true })
+    if (originalLinkTarget) {
+      await fs.symlink(
+        originalLinkTarget,
+        original,
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+    } else {
+      await fs.rename(externalNext, original)
+    }
+    await fs.rm(externalRoot, { recursive: true, force: true })
+  }
+
   itTurbopack(
     'does not crash when node_modules/next is moved mid-session',
     async () => {
@@ -86,6 +152,64 @@ describeMaybe('concurrent-install', () => {
         'FATAL: An unexpected Turbopack error occurred'
       )
       expect(getOutput()).not.toContain('TurbopackInternalError')
+    }
+  )
+
+  itTurbopack(
+    'explains when node_modules/next points outside the turbopack root',
+    async () => {
+      const getOutput = next.getCliOutputFromHere()
+      const externalInfo = await moveNextToExternalSymlink()
+      try {
+        await next.patchFile(
+          'app/page.tsx',
+          `export default function Page() {
+  return <p>hello world (external-next)</p>
+}
+`
+        )
+
+        await next.fetch('/late-route').catch(() => {
+          // The request itself may fail (500) while next points outside the
+          // Turbopack root. We only care that the issue is specific.
+        })
+
+        await retry(
+          async () => {
+            expect(getOutput()).toContain(
+              'node_modules/next resolves outside the Turbopack root'
+            )
+          },
+          10000,
+          500
+        )
+
+        expect(getOutput()).toContain('turbopack.root')
+        expect(getOutput()).not.toContain(
+          'FATAL: An unexpected Turbopack error occurred'
+        )
+        expect(getOutput()).not.toContain('TurbopackInternalError')
+      } finally {
+        await restoreNextFromExternalSymlink(externalInfo)
+      }
+
+      await next.patchFile(
+        'app/page.tsx',
+        `export default function Page() {
+  return <p>hello world (external-next-restored)</p>
+}
+`
+      )
+
+      await retry(
+        async () => {
+          const res = await next.fetch('/')
+          expect(res.status).toBe(200)
+          expect(await res.text()).toContain('external-next-restored')
+        },
+        15000,
+        500
+      )
     }
   )
 


### PR DESCRIPTION
### What?

Improve the recoverable Turbopack issue shown when `next/package.json` cannot be resolved and `node_modules/next` is a symlink to a package outside the configured Turbopack root.

### Why?

With package-manager layouts such as pnpm's global virtual store, the generic "Could not find the Next.js package" message does not explain that the symlink target is outside the root that Turbopack is allowed to compile. This adds a more specific cause and points users at `turbopack.root` or disabling pnpm's global virtual store for the project.

Refs #93556

### How?

- Detect a `node_modules/next` symlink during the missing-package issue path.
- If its canonical target is outside the canonical Turbopack root, include that target in the issue description.
- Add a development Turbopack regression test that simulates the external symlink without moving the package-manager store entry needed by `next dev` itself.

### Tests

- `cargo check -p next-core`
- `pnpm swc-build-native`
- `pnpm test-dev-turbo test/development/app-dir/concurrent-install/concurrent-install.test.ts`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->
