### PR TITLE
Fix Turbopack invalid source map columns

### DIFF
--- a/test/e2e/app-dir/turbopack-invalid-source-map/app/layout.tsx
+++ b/test/e2e/app-dir/turbopack-invalid-source-map/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/turbopack-invalid-source-map/app/page.tsx
+++ b/test/e2e/app-dir/turbopack-invalid-source-map/app/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import SimplePeer from 'simple-peer/simplepeer.min.js'
+
+export default function Page() {
+  return <p>SimplePeer: {typeof SimplePeer}</p>
+}

--- a/test/e2e/app-dir/turbopack-invalid-source-map/turbopack-invalid-source-map.test.ts
+++ b/test/e2e/app-dir/turbopack-invalid-source-map/turbopack-invalid-source-map.test.ts
@@ -1,0 +1,171 @@
+import { nextTestSetup } from 'e2e-utils'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+describe('turbopack invalid source map', () => {
+  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      'simple-peer': '9.11.1',
+    },
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('does not emit huge VLQ column deltas for minified vendor sources', async () => {
+    if (!isNextDev || !isTurbopack) {
+      return
+    }
+
+    const html = await (await next.fetch('/')).text()
+    expect(html).toMatch(/SimplePeer:.*function/s)
+
+    const chunksDir = path.join(next.testDir, '.next/dev/static/chunks')
+    const mapFiles = (await listFiles(chunksDir)).filter((file) =>
+      file.endsWith('.js.map')
+    )
+    const failures: string[] = []
+
+    for (const file of mapFiles) {
+      const map = JSON.parse(await fs.readFile(file, 'utf8'))
+      for (const section of sourceMapSections(map)) {
+        if (
+          !section.sources?.some((source) =>
+            source.includes('simplepeer.min.js')
+          )
+        ) {
+          continue
+        }
+
+        failures.push(...findInvalidSourceMapSegments(file, section))
+      }
+    }
+
+    expect(failures).toEqual([])
+  })
+})
+
+async function listFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const fullPath = path.join(dir, entry.name)
+      return entry.isDirectory() ? listFiles(fullPath) : [fullPath]
+    })
+  )
+  return files.flat()
+}
+
+function sourceMapSections(map: any): any[] {
+  if (Array.isArray(map.sections)) {
+    return map.sections.flatMap((section: any) =>
+      sourceMapSections(section.map)
+    )
+  }
+  return [map]
+}
+
+function findInvalidSourceMapSegments(file: string, map: any): string[] {
+  const failures: string[] = []
+  const lineLengthsBySource = new Map<number, number[]>()
+  const state = {
+    sourceIndex: 0,
+    sourceLine: 0,
+    sourceColumn: 0,
+    nameIndex: 0,
+  }
+
+  for (const [generatedLine, line] of (map.mappings || '')
+    .split(';')
+    .entries()) {
+    let generatedColumn = 0
+    for (const segment of line.split(',')) {
+      if (!segment) {
+        continue
+      }
+
+      const values = decodeVlqSegment(segment)
+      if (values.some((value) => Math.abs(value) > 1_000_000)) {
+        failures.push(`${file}:${generatedLine}:${generatedColumn} ${segment}`)
+      }
+
+      generatedColumn += values[0]
+      if (values.length <= 1) {
+        continue
+      }
+
+      state.sourceIndex += values[1]
+      state.sourceLine += values[2]
+      state.sourceColumn += values[3]
+      if (values.length > 4) {
+        state.nameIndex += values[4]
+      }
+
+      const lineLengths = getSourceLineLengths(
+        map,
+        state.sourceIndex,
+        lineLengthsBySource
+      )
+      if (
+        state.sourceLine < 0 ||
+        state.sourceLine >= lineLengths.length ||
+        state.sourceColumn < 0 ||
+        state.sourceColumn > lineLengths[state.sourceLine]
+      ) {
+        failures.push(
+          `${file}:${generatedLine}:${generatedColumn} ${segment} -> ${JSON.stringify(
+            state
+          )}`
+        )
+      }
+    }
+  }
+
+  return failures
+}
+
+function getSourceLineLengths(
+  map: any,
+  sourceIndex: number,
+  cache: Map<number, number[]>
+) {
+  if (!cache.has(sourceIndex)) {
+    cache.set(
+      sourceIndex,
+      (map.sourcesContent?.[sourceIndex] ?? '')
+        .split('\n')
+        .map((line: string) => line.length)
+    )
+  }
+  return cache.get(sourceIndex)!
+}
+
+const VLQ_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+function decodeVlqSegment(segment: string) {
+  const values: number[] = []
+  let current = 0
+  let shift = 0
+
+  for (const char of segment) {
+    const encoded = VLQ_CHARS.indexOf(char)
+    const digit = encoded & 31
+    const continuation = encoded >> 5
+    current += digit * 2 ** shift
+    shift += 5
+
+    if (continuation === 0) {
+      const negative = current & 1
+      current = Math.floor(current / 2)
+      values.push(negative ? -current : current)
+      current = 0
+      shift = 0
+    }
+  }
+
+  return values
+}

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -194,7 +194,7 @@ pub fn generate_js_source_map<'a>(
     let fast_path_single_original_source_map =
         original_source_maps.len() == 1 && original_source_maps_complete;
 
-    let mut new_mappings = build_source_map(
+    let new_mappings = build_source_map(
         files_map,
         &mappings,
         None,
@@ -211,6 +211,7 @@ pub fn generate_js_source_map<'a>(
     );
 
     if original_source_maps.is_empty() {
+        let mut new_mappings = drop_invalid_source_map_tokens(new_mappings);
         // We don't convert sourcemap::SourceMap into raw_sourcemap::SourceMap because we don't
         // need to adjust mappings
 
@@ -231,6 +232,7 @@ pub fn generate_js_source_map<'a>(
         Ok(Rope::from(result))
     } else {
         let mut map = new_mappings.adjust_mappings_from_multiple(original_source_maps);
+        map = drop_invalid_source_map_tokens(map);
 
         add_default_ignore_list(&mut map);
 
@@ -238,6 +240,66 @@ pub fn generate_js_source_map<'a>(
         map.to_writer(&mut result)?;
         Ok(Rope::from(result))
     }
+}
+
+fn drop_invalid_source_map_tokens(map: swc_sourcemap::SourceMap) -> swc_sourcemap::SourceMap {
+    let source_line_lengths = (0..map.get_source_count())
+        .map(|source_id| {
+            map.get_source_contents(source_id).map(|content| {
+                content
+                    .split('\n')
+                    .map(|line| line.encode_utf16().count() as u32)
+                    .collect::<Vec<_>>()
+            })
+        })
+        .collect::<Vec<_>>();
+    if source_line_lengths.iter().all(Option::is_none) {
+        return map;
+    }
+
+    let mut removed_invalid_token = false;
+    let tokens = map
+        .tokens()
+        .filter_map(|token| {
+            if token.has_source()
+                && let Some(Some(line_lengths)) =
+                    source_line_lengths.get(token.get_src_id() as usize)
+            {
+                let source_line = token.get_src_line() as usize;
+                if source_line >= line_lengths.len()
+                    || token.get_src_col() > line_lengths[source_line]
+                {
+                    removed_invalid_token = true;
+                    return None;
+                }
+            }
+
+            Some(token.get_raw_token())
+        })
+        .collect::<Vec<_>>();
+
+    if !removed_invalid_token {
+        return map;
+    }
+
+    let file = map.get_file().cloned();
+    let names = map.names().cloned().collect();
+    let sources = map.sources().cloned().collect::<Vec<_>>();
+    let source_contents = (0..sources.len())
+        .map(|source_id| map.get_source_contents(source_id as u32).cloned())
+        .collect::<Vec<_>>();
+    let source_root = map.get_source_root().cloned();
+    let debug_id = map.get_debug_id();
+    let ignore_list = map.ignore_list().copied().collect::<Vec<_>>();
+
+    let mut map =
+        swc_sourcemap::SourceMap::new(file, tokens, names, sources, Some(source_contents));
+    map.set_source_root(source_root);
+    map.set_debug_id(debug_id);
+    for source_id in ignore_list {
+        map.add_to_ignore_list(source_id);
+    }
+    map
 }
 
 /// A config to generate a source map which includes the source content of every
@@ -793,7 +855,7 @@ mod tests {
         ecma::parser::{Parser, Syntax, TsSyntax, lexer::Lexer},
     };
 
-    use super::VarDeclWithTsDeclareCollector;
+    use super::{VarDeclWithTsDeclareCollector, drop_invalid_source_map_tokens};
 
     fn parse_and_collect(code: &str) -> Vec<String> {
         GLOBALS.set(&Default::default(), || {
@@ -866,5 +928,38 @@ mod tests {
         // `declare namespace Foo {}` should also be collected
         let ids = parse_and_collect("declare namespace Foo {}");
         assert_eq!(ids, vec!["Foo"]);
+    }
+
+    #[test]
+    fn test_drop_invalid_source_map_tokens() {
+        let mut builder = swc_sourcemap::SourceMapBuilder::new(None);
+        let source_id = builder.add_source("vendor.min.js".into());
+        builder.set_source_contents(source_id, Some("abc\ndef".into()));
+        builder.add_raw(0, 0, 0, 0, Some(source_id), None, false);
+        builder.add_raw(0, 1, 1, u32::MAX - 4, Some(source_id), None, false);
+        builder.add_raw(0, 2, 1, 2, Some(source_id), None, false);
+
+        let map = drop_invalid_source_map_tokens(builder.into_sourcemap());
+        let tokens = map.tokens().collect::<Vec<_>>();
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].get_src_col(), 0);
+        assert_eq!(tokens[1].get_src_col(), 2);
+
+        let mut output = vec![];
+        map.to_writer(&mut output).expect("map should serialize");
+        let map = serde_json::from_slice::<serde_json::Value>(&output).expect("map should be json");
+        let mappings = map["mappings"].as_str().expect("map should have mappings");
+        for segment in mappings
+            .split(';')
+            .flat_map(|line| line.split(','))
+            .filter(|segment| !segment.is_empty())
+        {
+            let nums =
+                swc_sourcemap::vlq::parse_vlq_segment(segment).expect("segment should decode");
+            assert!(
+                nums.iter().all(|value| value.abs() < 1_000_000),
+                "segment {segment} contains huge VLQ deltas {nums:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
<!-- NEXT_JS_LLM_PR -->

### What?

Drop Turbopack source map tokens whose original source positions point outside the embedded source contents before serializing the map.

This preserves the existing source map metadata while rebuilding the token list so VLQ deltas are recomputed from valid neighboring tokens. It also adds dev Turbopack e2e coverage for importing `simple-peer/simplepeer.min.js` and validating the emitted source map segments.

### Why?

Firefox rejects the affected source maps with an invalid `mappings` error when already-minified vendor sources produce impossible original source columns.

Fixes #93462

### How?

Use embedded `sourcesContent` line lengths to identify impossible original source line or column positions, drop those invalid tokens, and reconstruct the SWC source map while preserving sources, names, source contents, source root, debug id, and ignore list.

Closes NEXT-

### Tests

- `corepack pnpm --filter @next/swc build-native`
- `HEADLESS=true corepack pnpm test-dev-turbo test/e2e/app-dir/turbopack-invalid-source-map/turbopack-invalid-source-map.test.ts`
- `cargo test -p turbopack-ecmascript test_drop_invalid_source_map_tokens -- --nocapture`
- `cargo fmt --package turbopack-ecmascript -- --check`
- `git diff --check HEAD`
