### PR TITLE
Run Server Functions in parallel

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -177,6 +177,9 @@ export function getDefineEnv({
     'process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS': Boolean(
       config.experimental.cachedNavigations
     ),
+    'process.env.__NEXT_EXPERIMENTAL_PARALLEL_SERVER_FUNCTIONS': Boolean(
+      config.experimental.parallelServerFunctions
+    ),
     'process.env.__NEXT_INSTANT_NAV_TOGGLE':
       !!config.experimental.instantNavigationDevToolsToggle,
     'process.env.__NEXT_USE_CACHE': isUseCacheEnabled,

--- a/packages/next/src/client/app-call-server.ts
+++ b/packages/next/src/client/app-call-server.ts
@@ -3,15 +3,38 @@ import { ACTION_SERVER_ACTION } from './components/router-reducer/router-reducer
 import { dispatchAppRouterAction } from './components/use-action-queue'
 
 export async function callServer(actionId: string, actionArgs: any[]) {
-  return new Promise((resolve, reject) => {
-    startTransition(() => {
-      dispatchAppRouterAction({
-        type: ACTION_SERVER_ACTION,
-        actionId,
-        actionArgs,
-        resolve,
-        reject,
+  if (process.env.__NEXT_EXPERIMENTAL_PARALLEL_SERVER_FUNCTIONS) {
+    // Lazy require: `callServer` is imported across the router graph, and
+    // `server-action-reducer` imports `callServer` back (static cycle). The
+    // require breaks the cycle and lets this branch DCE when the flag is off.
+    const { callServerParallel } =
+      require('./components/router-reducer/reducers/server-action-reducer') as typeof import('./components/router-reducer/reducers/server-action-reducer')
+    return callServerParallel(actionId, actionArgs)
+  } else {
+    return new Promise((resolve, reject) => {
+      startTransition(() => {
+        dispatchAppRouterAction({
+          type: ACTION_SERVER_ACTION,
+          actionId,
+          actionArgs,
+          resolve,
+          reject,
+          // Only provided from the parallel path flagged above.
+          // The legacy path will fetch inside the action queue.
+          fetchResult: null,
+          // Only provided from the parallel path flagged above.
+          // Legacy fetches and commits in the same reducer step,
+          // against one `state`, so the tree is identical at fetch
+          // and at commit: the result can't be stale.
+          //
+          // Whereas the parallel path fetches off-queue, so a
+          // navigation or refresh can commit and change the tree
+          // between the fetch and this commit. `expectedTree` records
+          // the tree at fetch time, so the commit can compare it with
+          // the current tree and detect whether the result is stale.
+          expectedTree: null,
+        })
       })
     })
-  })
+  }
 }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -30,7 +30,10 @@ import type {
   ReducerState,
   ServerActionAction,
 } from '../router-reducer-types'
-import { ScrollBehavior } from '../router-reducer-types'
+import { ACTION_SERVER_ACTION, ScrollBehavior } from '../router-reducer-types'
+import { dispatchAppRouterAction } from '../../use-action-queue'
+import { getCurrentAppRouterState } from '../../app-router-instance'
+import { startTransition } from 'react'
 import { assignLocation } from '../../../assign-location'
 import { createHrefFromUrl } from '../create-href-from-url'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
@@ -87,10 +90,8 @@ if (process.env.__NEXT_DEV_SERVER && process.env.__NEXT_REACT_DEBUG_CHANNEL) {
   ).createDebugChannel
 }
 
-// TODO: Refactor to be a discriminated union. Or just get rid of it;
-// fetchServerAction only has one caller, no reason this intermediate type has
-// to exist.
-type FetchServerActionResult = {
+// TODO: Refactor to be a discriminated union.
+export type FetchServerActionResult = {
   redirectLocation: URL | undefined
   redirectType: RedirectType | undefined
   revalidationKind: ActionRevalidationKind
@@ -104,9 +105,9 @@ type FetchServerActionResult = {
 async function fetchServerAction(
   state: ReadonlyReducerState,
   nextUrl: ReadonlyReducerState['nextUrl'],
-  action: ServerActionAction
+  actionId: string,
+  actionArgs: any[]
 ): Promise<FetchServerActionResult> {
-  const { actionId, actionArgs } = action
   const temporaryReferences = createTemporaryReferenceSet()
   const info = extractInfoFromServerReferenceId(actionId)
   const usedArgs = omitUnusedArgs(actionArgs, info)
@@ -164,7 +165,7 @@ async function fetchServerAction(
         if (offline !== null) {
           await waitForConnection(offline)
         }
-        return fetchServerAction(state, nextUrl, action)
+        return fetchServerAction(state, nextUrl, actionId, actionArgs)
       }
     }
     throw err
@@ -318,19 +319,10 @@ export function serverActionReducer(
   // If the route has been intercepted, the action should be as well.
   // Otherwise the server action might be intercepted with the wrong action id
   // (ie, one that corresponds with the intercepted route)
-  const nextUrl =
-    // We always send the last next-url, not the current when
-    // performing a dynamic request. This is because we update
-    // the next-url after a navigation, but we want the same
-    // interception route to be matched that used the last
-    // next-url.
-    (state.previousNextUrl || state.nextUrl) &&
-    hasInterceptionRouteInCurrentTree(state.tree)
-      ? state.previousNextUrl || state.nextUrl
-      : null
+  const nextUrl = getServerActionNextUrl(state)
 
-  return fetchServerAction(state, nextUrl, action).then(
-    async ({
+  const applyResult = async (result: FetchServerActionResult) => {
+    const {
       revalidationKind,
       actionResult,
       actionFlightData: flightData,
@@ -339,209 +331,273 @@ export function serverActionReducer(
       redirectType,
       isPrerender,
       couldBeIntercepted,
-    }) => {
-      if (revalidationKind !== ActionDidNotRevalidate) {
-        // There was either a revalidation or a refresh, or maybe both.
+    } = result
+    if (revalidationKind !== ActionDidNotRevalidate) {
+      // There was either a revalidation or a refresh, or maybe both.
 
-        // Evict the BFCache, which may contain dynamic data.
-        invalidateBfCache()
+      // Evict the BFCache, which may contain dynamic data.
+      invalidateBfCache()
 
-        // Store whether this action triggered any revalidation
-        // The action queue will use this information to potentially
-        // trigger a refresh action if the action was discarded
-        // (ie, due to a navigation, before the action completed)
-        action.didRevalidate = true
+      // Store whether this action triggered any revalidation
+      // The action queue will use this information to potentially
+      // trigger a refresh action if the action was discarded
+      // (ie, due to a navigation, before the action completed)
+      action.didRevalidate = true
 
-        // If there was a revalidation, evict the prefetch cache.
-        // TODO: Evict only segments with matching tags and/or paths.
-        // TODO: We should only invalidate the route cache if cookies were
-        // mutated, since route trees may vary based on cookies. For now we
-        // invalidate both caches until we have a way to detect cookie
-        // mutations on the client.
-        if (revalidationKind === ActionDidRevalidateStaticAndDynamic) {
-          invalidateEntirePrefetchCache(nextUrl, state.tree)
-        }
-
-        // Start a cooldown before re-prefetching to allow CDN cache
-        // propagation.
-        startRevalidationCooldown()
+      // If there was a revalidation, evict the prefetch cache.
+      // TODO: Evict only segments with matching tags and/or paths.
+      // TODO: We should only invalidate the route cache if cookies were
+      // mutated, since route trees may vary based on cookies. For now we
+      // invalidate both caches until we have a way to detect cookie
+      // mutations on the client.
+      if (revalidationKind === ActionDidRevalidateStaticAndDynamic) {
+        invalidateEntirePrefetchCache(nextUrl, state.tree)
       }
 
-      const navigateType = redirectType || 'push'
+      // Start a cooldown before re-prefetching to allow CDN cache
+      // propagation.
+      startRevalidationCooldown()
+    }
 
-      if (redirectLocation !== undefined) {
-        // If the action triggered a redirect, the action promise will be rejected with
-        // a redirect so that it's handled by RedirectBoundary as we won't have a valid
-        // action result to resolve the promise with. This will effectively reset the state of
-        // the component that called the action as the error boundary will remount the tree.
-        // The status code doesn't matter here as the action handler will have already sent
-        // a response with the correct status code.
+    const navigateType = redirectType || 'push'
 
-        if (isExternalURL(redirectLocation)) {
-          // External redirect. Triggers an MPA navigation.
-          const redirectHref = redirectLocation.href
-          const redirectError = createRedirectErrorForAction(
-            redirectHref,
-            navigateType
-          )
-          reject(redirectError)
+    if (redirectLocation !== undefined) {
+      // If the action triggered a redirect, the action promise will be rejected with
+      // a redirect so that it's handled by RedirectBoundary as we won't have a valid
+      // action result to resolve the promise with. This will effectively reset the state of
+      // the component that called the action as the error boundary will remount the tree.
+      // The status code doesn't matter here as the action handler will have already sent
+      // a response with the correct status code.
+
+      if (isExternalURL(redirectLocation)) {
+        // External redirect. Triggers an MPA navigation.
+        const redirectHref = redirectLocation.href
+        const redirectError = createRedirectErrorForAction(
+          redirectHref,
+          navigateType
+        )
+        reject(redirectError)
+
+        // The legacy path triggers the MPA here. The parallel path could hit a
+        // case where the external redirect is superseded by a navigation or refresh,
+        // and the redirect should be dropped. Will refresh the current route instead.
+        if (!process.env.__NEXT_EXPERIMENTAL_PARALLEL_SERVER_FUNCTIONS) {
           return completeHardNavigation(state, redirectLocation, navigateType)
-        } else {
-          // Internal redirect. Triggers an SPA navigation.
-          const redirectWithBasepath = createHrefFromUrl(
-            redirectLocation,
-            false
-          )
-          const redirectHref = hasBasePath(redirectWithBasepath)
-            ? removeBasePath(redirectWithBasepath)
-            : redirectWithBasepath
-          const redirectError = createRedirectErrorForAction(
-            redirectHref,
-            navigateType
-          )
-          reject(redirectError)
         }
       } else {
-        // If there's no redirect, resolve the action with the result.
-        resolve(actionResult)
+        // Internal redirect. Triggers an SPA navigation.
+        const redirectWithBasepath = createHrefFromUrl(redirectLocation, false)
+        const redirectHref = hasBasePath(redirectWithBasepath)
+          ? removeBasePath(redirectWithBasepath)
+          : redirectWithBasepath
+        const redirectError = createRedirectErrorForAction(
+          redirectHref,
+          navigateType
+        )
+        reject(redirectError)
       }
+    } else {
+      // If there's no redirect, resolve the action with the result.
+      resolve(actionResult)
+    }
 
-      // Check if we can bail out without updating any state.
-      if (
-        // Did the action trigger a redirect?
-        redirectLocation === undefined &&
-        // Did the action revalidate any data?
-        revalidationKind === ActionDidNotRevalidate &&
-        // Did the server render new data?
-        flightData === undefined
-      ) {
-        // The action did not trigger any revalidations or redirects. No
-        // navigation is required.
+    if (process.env.__NEXT_EXPERIMENTAL_PARALLEL_SERVER_FUNCTIONS) {
+      // If the tree changed after this action's off-queue fetch, another commit
+      // (a navigation, a refresh, or another Server Function) landed first, so
+      // this result is a patch against a tree that no longer exists. Drop it the
+      // way the legacy queue drops a superseded action. If the action also
+      // revalidated, dropping its render leaves that data change unreflected, so
+      // re-navigate the current route with RefreshAll to refetch and sync it.
+      //
+      // "Revalidated" is any change the server flags as needing a re-render
+      // (revalidationKind !== ActionDidNotRevalidate): revalidatePath, updateTag,
+      // or a cookie mutation (cookies can change what the route renders). A plain
+      // redirect is not a revalidation, so a stale redirect is just dropped, with
+      // no refetch.
+      //
+      // Concurrent revalidating commits each refetch here: the first commit
+      // applies cleanly, the other N-1 are stale and refetch. Coalescing them
+      // into a single refetch is a known follow-up.
+      //
+      // This is the "action ran, but the tree moved under it" case. The
+      // complementary case, where a navigation discards this action while it is
+      // still pending in the queue, is handled separately by the queue (it sets
+      // `needsRefresh` from `action.didRevalidate`). The two never double-fire:
+      // a discarded action's reducer result is thrown away, so only one refresh
+      // runs.
+      const treeChangedSinceFetch =
+        action.expectedTree !== null && action.expectedTree !== state.tree
+      if (treeChangedSinceFetch) {
+        if (revalidationKind !== ActionDidNotRevalidate) {
+          const refreshUrl = new URL(state.canonicalUrl, location.origin)
+          return navigate(
+            state,
+            refreshUrl,
+            refreshUrl,
+            state.renderedSearch,
+            state.cache,
+            state.tree,
+            nextUrl,
+            FreshnessPolicy.RefreshAll,
+            ScrollBehavior.Default,
+            'push'
+          )
+        }
         return state
       }
 
-      if (flightData === undefined && redirectLocation !== undefined) {
-        // The server redirected, but did not send any Flight data. This implies
-        // an external redirect.
-        // TODO: We should refactor the action response type to be more explicit
-        // about the various response types.
+      // Tree matches expected, handle external redirects here.
+      if (redirectLocation !== undefined && isExternalURL(redirectLocation)) {
         return completeHardNavigation(state, redirectLocation, navigateType)
       }
+    }
 
-      if (typeof flightData === 'string') {
-        // If the flight data is just a string, something earlier in the
-        // response handling triggered an external redirect.
-        return completeHardNavigation(
-          state,
-          new URL(flightData, location.origin),
-          navigateType
-        )
-      }
+    // Check if we can bail out without updating any state.
+    if (hasNothingToCommit(result)) {
+      // The action did not trigger any revalidations or redirects. No
+      // navigation is required.
+      return state
+    }
 
-      // The action triggered a navigation — either a redirect, a revalidation,
-      // or both.
+    if (flightData === undefined && redirectLocation !== undefined) {
+      // The server redirected, but did not send any Flight data. This implies
+      // an external redirect.
+      // TODO: We should refactor the action response type to be more explicit
+      // about the various response types.
+      return completeHardNavigation(state, redirectLocation, navigateType)
+    }
 
-      // If there was no redirect, then the target URL is the same as the
-      // current URL.
-      const currentUrl = new URL(state.canonicalUrl, location.origin)
-      const currentRenderedSearch = state.renderedSearch
-      const redirectUrl =
-        redirectLocation !== undefined ? redirectLocation : currentUrl
-      const currentFlightRouterState = state.tree
-      const scrollBehavior = ScrollBehavior.Default
+    if (typeof flightData === 'string') {
+      // If the flight data is just a string, something earlier in the
+      // response handling triggered an external redirect.
+      return completeHardNavigation(
+        state,
+        new URL(flightData, location.origin),
+        navigateType
+      )
+    }
 
-      // If the action triggered a revalidation of the cache, we should also
-      // refresh all the dynamic data.
-      const freshnessPolicy =
-        revalidationKind === ActionDidNotRevalidate
-          ? FreshnessPolicy.Default
-          : FreshnessPolicy.RefreshAll
+    // The action triggered a navigation — either a redirect, a revalidation,
+    // or both.
 
-      // The server may have sent back new data. If so, we will perform a
-      // "seeded" navigation that uses the data from the response.
-      // TODO: Currently the server always renders from the root in
-      // response to a Server Action. In the case of a normal redirect
-      // with no revalidation, it should skip over the shared layouts.
-      if (flightData !== undefined && flightDataRenderedSearch !== undefined) {
-        // The server sent back new route data as part of the response. We
-        // will use this to render the new page. If this happens to be only a
-        // subset of the data needed to render the new page, we'll initiate a
-        // new fetch, like we would for a normal navigation.
-        const redirectCanonicalUrl = createHrefFromUrl(redirectUrl)
-        const now = Date.now()
-        // TODO: Store the dynamic stale time on the top-level state so it's
-        // known during restores and refreshes.
-        const redirectSeed = convertServerPatchToFullTree(
+    // If there was no redirect, then the target URL is the same as the
+    // current URL.
+    const currentUrl = new URL(state.canonicalUrl, location.origin)
+    const currentRenderedSearch = state.renderedSearch
+    const redirectUrl =
+      redirectLocation !== undefined ? redirectLocation : currentUrl
+    const currentFlightRouterState = state.tree
+    const scrollBehavior = ScrollBehavior.Default
+
+    // If the action triggered a revalidation of the cache, we should also
+    // refresh all the dynamic data.
+    const freshnessPolicy =
+      revalidationKind === ActionDidNotRevalidate
+        ? FreshnessPolicy.Default
+        : FreshnessPolicy.RefreshAll
+
+    // The server may have sent back new data. If so, we will perform a
+    // "seeded" navigation that uses the data from the response.
+    // TODO: Currently the server always renders from the root in
+    // response to a Server Action. In the case of a normal redirect
+    // with no revalidation, it should skip over the shared layouts.
+    if (flightData !== undefined && flightDataRenderedSearch !== undefined) {
+      // The server sent back new route data as part of the response. We
+      // will use this to render the new page. If this happens to be only a
+      // subset of the data needed to render the new page, we'll initiate a
+      // new fetch, like we would for a normal navigation.
+      const redirectCanonicalUrl = createHrefFromUrl(redirectUrl)
+      const now = Date.now()
+      // TODO: Store the dynamic stale time on the top-level state so it's
+      // known during restores and refreshes.
+      const redirectSeed = convertServerPatchToFullTree(
+        now,
+        currentFlightRouterState,
+        flightData,
+        flightDataRenderedSearch,
+        UnknownDynamicStaleTime
+      )
+
+      // Learn the route pattern so we can predict it for future navigations.
+      const metadataVaryPath = redirectSeed.metadataVaryPath
+      if (metadataVaryPath !== null) {
+        discoverKnownRoute(
           now,
-          currentFlightRouterState,
-          flightData,
-          flightDataRenderedSearch,
-          UnknownDynamicStaleTime
-        )
-
-        // Learn the route pattern so we can predict it for future navigations.
-        const metadataVaryPath = redirectSeed.metadataVaryPath
-        if (metadataVaryPath !== null) {
-          discoverKnownRoute(
-            now,
-            redirectUrl.pathname,
-            redirectUrl.search as NormalizedSearch,
-            nextUrl,
-            null, // No pending entry
-            redirectSeed.routeTree,
-            metadataVaryPath,
-            couldBeIntercepted,
-            redirectCanonicalUrl,
-            isPrerender,
-            false // hasDynamicRewrite
-          )
-        }
-
-        return navigateToKnownRoute(
-          now,
-          state,
-          redirectUrl,
-          redirectCanonicalUrl,
-          redirectSeed,
-          currentUrl,
-          currentRenderedSearch,
-          state.cache,
-          currentFlightRouterState,
-          freshnessPolicy,
+          redirectUrl.pathname,
+          redirectUrl.search as NormalizedSearch,
           nextUrl,
-          scrollBehavior,
-          navigateType,
-          null,
-          // Server action redirects don't use route prediction - we already
-          // have the route tree from the server response. If a mismatch occurs
-          // during dynamic data fetch, the retry handler will traverse the
-          // known route tree to mark the entry as having a dynamic rewrite.
-          null
+          null, // No pending entry
+          redirectSeed.routeTree,
+          metadataVaryPath,
+          couldBeIntercepted,
+          redirectCanonicalUrl,
+          isPrerender,
+          false // hasDynamicRewrite
         )
       }
 
-      // The server did not send back new data. We'll perform a regular, non-
-      // seeded navigation — effectively the same as <Link> or router.push().
-      return navigate(
+      return navigateToKnownRoute(
+        now,
         state,
         redirectUrl,
+        redirectCanonicalUrl,
+        redirectSeed,
         currentUrl,
         currentRenderedSearch,
         state.cache,
         currentFlightRouterState,
-        nextUrl,
         freshnessPolicy,
+        nextUrl,
         scrollBehavior,
-        navigateType
+        navigateType,
+        null,
+        // Server action redirects don't use route prediction - we already
+        // have the route tree from the server response. If a mismatch occurs
+        // during dynamic data fetch, the retry handler will traverse the
+        // known route tree to mark the entry as having a dynamic rewrite.
+        null
       )
-    },
-    (e: any) => {
-      // When the server action is rejected we don't update the state and instead call the reject handler of the promise.
-      reject(e)
-
-      return state
     }
-  )
+
+    // The server did not send back new data. We'll perform a regular, non-
+    // seeded navigation — effectively the same as <Link> or router.push().
+    return navigate(
+      state,
+      redirectUrl,
+      currentUrl,
+      currentRenderedSearch,
+      state.cache,
+      currentFlightRouterState,
+      nextUrl,
+      freshnessPolicy,
+      scrollBehavior,
+      navigateType
+    )
+  }
+
+  // Parallel path (experimental.parallelServerFunctions): `callServerParallel`
+  // already fetched this call without dispatching it into the queue and passed
+  // the result in as `fetchResult`. Skip the fetch and commit that result here,
+  // in queue order. DCE'd when the flag is off, so the legacy path below is
+  // untouched. (Results with nothing to commit never reach this reducer; they
+  // were resolved without ever being dispatched to the queue.)
+  if (process.env.__NEXT_EXPERIMENTAL_PARALLEL_SERVER_FUNCTIONS) {
+    if (action.fetchResult !== null) {
+      return applyResult(action.fetchResult)
+    }
+  }
+
+  return fetchServerAction(
+    state,
+    nextUrl,
+    action.actionId,
+    action.actionArgs
+  ).then(applyResult, (e: any) => {
+    // When the server action is rejected we don't update the state and instead call the reject handler of the promise.
+    reject(e)
+
+    return state
+  })
 }
 
 function createRedirectErrorForAction(
@@ -556,4 +612,117 @@ function createRedirectErrorForAction(
   // have all the necessary RSC data to render the new page within a single roundtrip.
   ;(redirectError as any).handled = true
   return redirectError
+}
+
+/**
+ * Computes the `nextUrl` to send with a Server Function request. We only pass
+ * along the `nextUrl` param (used for interception routes) if the current route
+ * was intercepted. If the route has been intercepted, the action should be as
+ * well. Otherwise the server action might be intercepted with the wrong action
+ * id (ie, one that corresponds with the intercepted route).
+ */
+function getServerActionNextUrl(
+  state: ReadonlyReducerState
+): ReadonlyReducerState['nextUrl'] {
+  return (
+    // We always send the last next-url, not the current when
+    // performing a dynamic request. This is because we update
+    // the next-url after a navigation, but we want the same
+    // interception route to be matched that used the last
+    // next-url.
+    (state.previousNextUrl || state.nextUrl) &&
+      hasInterceptionRouteInCurrentTree(state.tree)
+      ? state.previousNextUrl || state.nextUrl
+      : null
+  )
+}
+
+/**
+ * Returns whether a Server Function result has nothing for the router to
+ * commit: it did not redirect, revalidate, or return new flight data, so the
+ * caller's value can resolve immediately, without dispatching into the action
+ * queue. This reflects the client result, not server intent: a server-side
+ * mutation that triggers none of these is indistinguishable from a read here.
+ *
+ * Single source of truth shared by `callServerParallel` (to resolve a value
+ * without a commit) and `serverActionReducer` (to bail out without updating
+ * state).
+ */
+function hasNothingToCommit(result: FetchServerActionResult): boolean {
+  return (
+    // no redirect,
+    result.redirectLocation === undefined &&
+    // no revalidation,
+    result.revalidationKind === ActionDidNotRevalidate &&
+    // and no new server-rendered data.
+    result.actionFlightData === undefined
+  )
+}
+
+/**
+ * Parallel `callServer` path (experimental.parallelServerFunctions).
+ *
+ * The legacy path dispatches the call into the action queue and fetches it from
+ * there, so calls run serially, and each waits for the previous round-trip. This
+ * path issues the fetch without dispatching into the queue, so concurrent Server
+ * Function calls overlap on the network, then routes the result based on whether
+ * it must change router state.
+ *
+ * Ordering: the commit is dispatched when the fetch resolves, not when the call
+ * is made, so commits run in completion order, not call order. The action queue
+ * still serializes them (one at a time, never interleaved with each other or
+ * with navigations), but concurrent calls have no guaranteed order relative to
+ * one another. Code that needs ordered, sequential semantics should use
+ * `useActionState`, which chains its dispatches at the hook level.
+ */
+export async function callServerParallel(actionId: string, actionArgs: any[]) {
+  const state = getCurrentAppRouterState()
+  if (state === null) {
+    // Unreachable in practice: a Server Function can only be called from a
+    // hydrated tree. Mirror `dispatchAppRouterAction`'s guard so the failure
+    // mode matches the legacy path exactly.
+    throw new Error(
+      'Internal Next.js error: Router action dispatched before initialization.'
+    )
+  }
+
+  // The generation this fetch is issued against. The commit compares it to the
+  // live tree to detect a navigation that landed while the fetch was in flight,
+  // which would make this result's flight data a patch against a stale tree.
+  const expectedTree = state.tree
+
+  // 1. Fetch without dispatching into the action queue. This is the whole point
+  // of the parallel path: the request goes out now, not when the queue gets
+  // around to it, so multiple in-flight Server Function calls overlap instead of
+  // running one at a time.
+  const nextUrl = getServerActionNextUrl(state)
+  const result = await fetchServerAction(state, nextUrl, actionId, actionArgs)
+
+  // 2. The result changes nothing in the router (no redirect, no revalidation,
+  // no new flight data), so there is nothing to serialize. Return the value
+  // directly and never enter the queue.
+  if (hasNothingToCommit(result)) {
+    return result.actionResult
+  }
+
+  // 3. Commit through the queue. Dispatch to the same queue the legacy path
+  // uses, but carry the result we already fetched: the reducer sees it and
+  // handles it directly instead of fetching again, so the queue replays only
+  // the state mutation, not the network round-trip.
+  return new Promise((resolve, reject) => {
+    startTransition(() => {
+      dispatchAppRouterAction({
+        type: ACTION_SERVER_ACTION,
+        // Required by the action shape but unused on this path: the reducer
+        // commits `fetchResult` directly and never re-fetches, so it does not
+        // read `actionId`/`actionArgs` here (only the legacy path does).
+        actionId,
+        actionArgs,
+        resolve,
+        reject,
+        fetchResult: result,
+        expectedTree,
+      })
+    })
+  })
 }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -2,6 +2,7 @@ import type { CacheNode, ScrollRef } from '../../../shared/lib/app-router-types'
 import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 import type { NavigationSeed } from '../segment-cache/navigation'
 import type { FetchServerResponseResult } from './fetch-server-response'
+import type { FetchServerActionResult } from './reducers/server-action-reducer'
 
 export const ACTION_REFRESH = 'refresh'
 export const ACTION_NAVIGATE = 'navigate'
@@ -53,6 +54,30 @@ export interface ServerActionAction {
   resolve: (value: any) => void
   reject: (reason?: any) => void
   didRevalidate?: boolean
+  /**
+   * NOTE: This is passed when `experimental.parallelServerFunctions` is enabled.
+   *
+   * The result of a Server Function call that the parallel `callServer` path
+   * already fetched without dispatching into the action queue. Normally the
+   * reducer performs the fetch itself, inside the queue. When this is set, the
+   * round-trip has already happened. So the reducer skips its own fetch and
+   * commits this result directly, in queue order. `null` on the legacy path,
+   * where the reducer still performs the fetch.
+   */
+  fetchResult: FetchServerActionResult | null
+  /**
+   * NOTE: This is passed when `experimental.parallelServerFunctions` is enabled.
+   *
+   * The router tree at the time the parallel path issued its off-queue fetch.
+   * The server computes `fetchResult`'s flight data as a patch against this
+   * tree. Because the fetch runs off-queue, another commit (a navigation, a
+   * refresh, or another Server Function) can change the tree before this action
+   * commits, so the reducer compares `expectedTree` to the live tree and drops
+   * the now-stale patch instead of applying it. `null` on the legacy path, which
+   * fetches in-queue against the same `state` it commits against, so it is never
+   * stale.
+   */
+  expectedTree: FlightRouterState | null
 }
 
 /**

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -221,6 +221,7 @@ export const experimentalSchema = {
   caseSensitiveRoutes: z.boolean().optional(),
   clientParamParsingOrigins: z.array(z.string()).optional(),
   cachedNavigations: z.boolean().optional(),
+  parallelServerFunctions: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -467,6 +467,17 @@ export interface ExperimentalConfig {
    */
   clientParamParsingOrigins?: string[]
   cachedNavigations?: boolean
+  /**
+   * When enabled, Server Functions and Cache Functions (i.e. `'use cache'` variants)
+   * invoked from the client run in parallel instead of being sequenced through
+   * the client action queue.
+   *
+   * Sequential Server Action behavior remains available
+   * via [`useActionState`](https://react.dev/reference/react/useActionState).
+   *
+   * **WARNING:** This is a breaking change and should be enabled with caution.
+   */
+  parallelServerFunctions?: boolean
   dynamicOnHover?: boolean
   useOffline?: boolean
   optimisticRouting?: boolean
@@ -1977,6 +1988,7 @@ export const defaultConfig = Object.freeze({
     caseSensitiveRoutes: false,
     clientParamParsingOrigins: undefined,
     cachedNavigations: false,
+    parallelServerFunctions: false,
     dynamicOnHover: false,
     useOffline: false,
     varyParams: true,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2201,6 +2201,25 @@ function enforceExperimentalFeatures(
     config.experimental.cachedNavigations = true
   }
 
+  // TODO: Remove this once parallelServerFunctions is the default.
+  if (
+    process.env.__NEXT_EXPERIMENTAL_PARALLEL_SERVER_FUNCTIONS === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.parallelServerFunctions === undefined ||
+      (isDefaultConfig && !config.experimental.parallelServerFunctions))
+  ) {
+    config.experimental.parallelServerFunctions = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'parallelServerFunctions',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_PARALLEL_SERVER_FUNCTIONS`'
+      )
+    }
+  }
+
   // TODO: Remove this once appNewScrollHandler is the default.
   if (
     process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER === 'true' &&

--- a/test/e2e/app-dir/server-functions-parallel/app/actions.ts
+++ b/test/e2e/app-dir/server-functions-parallel/app/actions.ts
@@ -1,0 +1,115 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { cookies } from 'next/headers'
+import { writeReconcile } from './reconcile-store'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Long enough that parallel calls clearly overlap, short enough that 3 serial
+// calls still finish inside the retry window.
+const WORK_MS = 400
+
+export type Span = {
+  label: string
+  start: number
+  end: number
+  // What a writing action stored; used by the reconcile test.
+  value?: number
+}
+
+// A read-only server action.
+export async function slowRead(label: string): Promise<Span> {
+  const start = Date.now()
+  await sleep(WORK_MS)
+  return { label, start, end: Date.now() }
+}
+
+// A fast read, to show a quick call can return without waiting for slow ones.
+export async function fastRead(label: string): Promise<Span> {
+  const start = Date.now()
+  await sleep(50)
+  return { label, start, end: Date.now() }
+}
+
+// A mutating action: writes its own cookie and returns its span. Each call uses
+// a different cookie name, so the test can confirm every call applied (no lost
+// update). Cookies travel with the browser, so this also works on deploy.
+// Non-httpOnly so the test can read it from document.cookie.
+export async function mutate(label: string): Promise<Span> {
+  const start = Date.now()
+  await sleep(WORK_MS)
+  ;(await cookies()).set(`psf-mut-${label}`, '1', {
+    httpOnly: false,
+    path: '/',
+  })
+  return { label, start, end: Date.now() }
+}
+
+// Used to prove failures are isolated per call.
+export async function maybeFail(
+  label: string,
+  shouldFail: boolean
+): Promise<Span> {
+  const start = Date.now()
+  await sleep(WORK_MS)
+  if (shouldFail) {
+    throw new Error(`psf-fail-${label}`)
+  }
+  return { label, start, end: Date.now() }
+}
+
+// An action that redirects, to exercise redirect handling on the parallel path.
+export async function redirectFromAction(target: string): Promise<void> {
+  await sleep(50)
+  redirect(target)
+}
+
+// Slow and revalidating, for the navigation-race test. Revalidating makes it
+// commit (not just resolve a value) and makes the server send page data. That
+// data is the stale input a broken commit would wrongly apply to the new route.
+export async function slowRevalidate(): Promise<void> {
+  await sleep(1000)
+  revalidatePath('/origin')
+}
+
+// A slow redirect, for the redirect race. Slow enough that a navigation lands
+// first, so the redirect arrives stale.
+export async function slowRedirect(target: string): Promise<void> {
+  await sleep(1500)
+  redirect(target)
+}
+
+// For the reconcile test. Each action writes its number to the shared cookie and
+// revalidates, so it commits (instead of resolving off-queue). The delays differ
+// by 100ms, so the one writing 3 finishes last and the final value is 3 however
+// the commits race. A dynamic component reads it, so the refresh must bring the
+// UI to 3.
+export async function resetReconcile(): Promise<void> {
+  await writeReconcile(0)
+}
+
+export async function reconcileOne(): Promise<Span> {
+  const start = Date.now()
+  await sleep(300)
+  await writeReconcile(1)
+  revalidatePath('/reconcile')
+  return { label: 'one', start, end: Date.now(), value: 1 }
+}
+
+export async function reconcileTwo(): Promise<Span> {
+  const start = Date.now()
+  await sleep(400)
+  await writeReconcile(2)
+  revalidatePath('/reconcile')
+  return { label: 'two', start, end: Date.now(), value: 2 }
+}
+
+export async function reconcileThree(): Promise<Span> {
+  const start = Date.now()
+  await sleep(500)
+  await writeReconcile(3)
+  revalidatePath('/reconcile')
+  return { label: 'three', start, end: Date.now(), value: 3 }
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/cache.ts
+++ b/test/e2e/app-dir/server-functions-parallel/app/cache.ts
@@ -1,0 +1,16 @@
+'use cache'
+
+import { cacheLife } from 'next/cache'
+import type { Span } from './actions'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// A `'use cache'` function called from the client. The label is part of the
+// cache key, so a unique label per call (tests pass a nonce) forces a real run
+// instead of a cache hit.
+export async function slowCache(label: string): Promise<Span> {
+  cacheLife('seconds')
+  const start = Date.now()
+  await sleep(400)
+  return { label, start, end: Date.now() }
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/destination/page.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/destination/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main>
+      <h1 data-testid="content">Destination</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/layout.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/mutations/fanout.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/mutations/fanout.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import { mutate } from '../actions'
+import { slowCache } from '../cache'
+
+let seq = 0
+const nonce = () => `${Date.now()}-${seq++}`
+
+export function MutationFanout() {
+  const [out, setOut] = useState<Record<string, string>>({})
+  const set = (key: string, value: unknown) =>
+    setOut((o) => ({ ...o, [key]: JSON.stringify(value) }))
+
+  const fireMutations = async () => {
+    set('mutations', await Promise.all([mutate('a'), mutate('b'), mutate('c')]))
+  }
+
+  // A cache read fired alongside a mutation must not wait behind it.
+  const fireCacheVsMutation = async () => {
+    const n = nonce()
+    set(
+      'cache-vs-mutation',
+      await Promise.all([slowCache(`cm-cache-${n}`), mutate('cm')])
+    )
+  }
+
+  return (
+    <>
+      <button data-testid="fire-mutations" onClick={fireMutations}>
+        mutations
+      </button>
+      <button
+        data-testid="fire-cache-vs-mutation"
+        onClick={fireCacheVsMutation}
+      >
+        cache-vs-mutation
+      </button>
+      <pre data-testid="out-mutations">{out.mutations ?? ''}</pre>
+      <pre data-testid="out-cache-vs-mutation">
+        {out['cache-vs-mutation'] ?? ''}
+      </pre>
+    </>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/mutations/page.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/mutations/page.tsx
@@ -1,0 +1,9 @@
+import { MutationFanout } from './fanout'
+
+export default function Page() {
+  return (
+    <main>
+      <MutationFanout />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/opt-out/client.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/opt-out/client.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useActionState, useState } from 'react'
+import { slowRead, type Span } from '../actions'
+
+let seq = 0
+const nonce = () => `${Date.now()}-${seq++}`
+
+export function OptOut() {
+  // useActionState runs its dispatches one after another (React chains them at
+  // the hook level). This is the opt-out for sequential behavior, flag or not.
+  const [uasLog, dispatch] = useActionState<Span[], string>(
+    async (prev, label) => [...prev, await slowRead(label)],
+    []
+  )
+
+  const [awaitLog, setAwaitLog] = useState('')
+
+  const fireUAS = () => {
+    const n = nonce()
+    dispatch(`u1-${n}`)
+    dispatch(`u2-${n}`)
+    dispatch(`u3-${n}`)
+  }
+
+  const fireAwait = async () => {
+    const n = nonce()
+    const a = await slowRead(`a1-${n}`)
+    const b = await slowRead(`a2-${n}`)
+    const c = await slowRead(`a3-${n}`)
+    setAwaitLog(JSON.stringify([a, b, c]))
+  }
+
+  return (
+    <main>
+      <button data-testid="fire-uas" onClick={fireUAS}>
+        useActionState
+      </button>
+      <button data-testid="fire-await" onClick={fireAwait}>
+        await
+      </button>
+      <pre data-testid="out-uas">{JSON.stringify(uasLog)}</pre>
+      <pre data-testid="out-await">{awaitLog}</pre>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/opt-out/page.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/opt-out/page.tsx
@@ -1,0 +1,5 @@
+import { OptOut } from './client'
+
+export default function Page() {
+  return <OptOut />
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/origin/page.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/origin/page.tsx
@@ -1,0 +1,10 @@
+import { RaceTrigger } from './trigger'
+
+export default function Page() {
+  return (
+    <main>
+      <h1 data-testid="content">Origin</h1>
+      <RaceTrigger />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/origin/trigger.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/origin/trigger.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { slowRevalidate, slowRedirect } from '../actions'
+
+export function RaceTrigger() {
+  const router = useRouter()
+
+  const onRevalidateRace = () => {
+    // Start the slow action without awaiting, then navigate away. Its fetch is
+    // still in flight, so the navigation lands first and the action ends up
+    // trying to commit on /destination. Flag on `window` (survives the SPA nav)
+    // when it resolves, so the test can prove the stale path actually ran, not
+    // just that nothing changed. No `.catch`: this action should resolve, so a
+    // rejection should fail the test.
+    slowRevalidate().then(() => {
+      ;(window as any).__raceActionSettled = true
+    })
+    router.push('/destination')
+  }
+
+  const onRedirectRace = () => {
+    // Same race, but the action redirects. /destination lands first, so the late
+    // redirect is stale and gets dropped: we stay on /destination instead of
+    // going to /mutations. A redirect rejects its caller, so we catch it and flag
+    // on `window` (survives the SPA nav) that it ran, proving the drop path
+    // executed.
+    slowRedirect('/mutations').catch(() => {
+      ;(window as any).__redirectRaceSettled = true
+    })
+    router.push('/destination')
+  }
+
+  const onExternalRedirectRace = () => {
+    // Same as onRedirectRace, but to another site, which would normally force a
+    // full-page jump away from the app. /destination lands first, so the late
+    // external redirect is stale and dropped instead of jumping away: we stay on
+    // /destination. We catch the redirect rejection and flag on `window`
+    // (survives the SPA nav) that it ran, proving the drop path executed.
+    slowRedirect(
+      'https://next-data-api-endpoint.vercel.app/api/random?page'
+    ).catch(() => {
+      ;(window as any).__externalRedirectRaceSettled = true
+    })
+    router.push('/destination')
+  }
+
+  return (
+    <>
+      <button data-testid="fire-race" onClick={onRevalidateRace}>
+        go
+      </button>
+      <button data-testid="fire-redirect-race" onClick={onRedirectRace}>
+        redirect-race
+      </button>
+      <button
+        data-testid="fire-external-redirect-race"
+        onClick={onExternalRedirectRace}
+      >
+        external-redirect-race
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/reads/fanout.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/reads/fanout.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState } from 'react'
+import { slowRead, fastRead, maybeFail, redirectFromAction } from '../actions'
+import { slowCache } from '../cache'
+
+// Unique label per click, so cache calls always miss and runs never collide.
+let seq = 0
+const nonce = () => `${Date.now()}-${seq++}`
+
+export function Fanout() {
+  const [out, setOut] = useState<Record<string, string>>({})
+  const set = (key: string, value: unknown) =>
+    setOut((o) => ({ ...o, [key]: JSON.stringify(value) }))
+
+  const fireCache = async () => {
+    const n = nonce()
+    set(
+      'cache',
+      await Promise.all([
+        slowCache(`c1-${n}`),
+        slowCache(`c2-${n}`),
+        slowCache(`c3-${n}`),
+      ])
+    )
+  }
+
+  const fireRead = async () => {
+    const n = nonce()
+    set(
+      'read',
+      await Promise.all([
+        slowRead(`r1-${n}`),
+        slowRead(`r2-${n}`),
+        slowRead(`r3-${n}`),
+      ])
+    )
+  }
+
+  const fireMixed = async () => {
+    const n = nonce()
+    set(
+      'mixed',
+      await Promise.all([
+        slowRead(`m1-${n}`),
+        slowCache(`m2-${n}`),
+        slowRead(`m3-${n}`),
+      ])
+    )
+  }
+
+  // Start slow then fast without awaiting; record which finishes first. If calls
+  // were serial we'd see 'slow' first; in parallel the quick one wins: 'fast'.
+  const fireOrder = async () => {
+    const n = nonce()
+    const order: string[] = []
+    const slow = slowRead(`slow-${n}`).then(() => order.push('slow'))
+    const fast = fastRead(`fast-${n}`).then(() => order.push('fast'))
+    await Promise.all([slow, fast])
+    set('order', order)
+  }
+
+  const fireError = async () => {
+    const n = nonce()
+    const results = await Promise.allSettled([
+      maybeFail(`ok1-${n}`, false),
+      maybeFail(`bad-${n}`, true),
+      maybeFail(`ok2-${n}`, false),
+    ])
+    set(
+      'error',
+      results.map((r) => r.status)
+    )
+  }
+
+  const fireLarge = async () => {
+    const n = nonce()
+    set(
+      'large',
+      await Promise.all(
+        Array.from({ length: 10 }, (_, i) => slowRead(`L${i}-${n}`))
+      )
+    )
+  }
+
+  const fireBound = async () => {
+    const n = nonce()
+    const b1 = slowRead.bind(null, `b1-${n}`)
+    const b2 = slowRead.bind(null, `b2-${n}`)
+    const b3 = slowRead.bind(null, `b3-${n}`)
+    set('bound', await Promise.all([b1(), b2(), b3()]))
+  }
+
+  const fireRedirect = () => {
+    // The action redirects: the router does the navigation, and the call itself
+    // rejects with a handled redirect error, so we swallow it.
+    redirectFromAction('/mutations').catch(() => {})
+  }
+
+  return (
+    <main>
+      <button data-testid="fire-cache" onClick={fireCache}>
+        cache
+      </button>
+      <button data-testid="fire-read" onClick={fireRead}>
+        read
+      </button>
+      <button data-testid="fire-mixed" onClick={fireMixed}>
+        mixed
+      </button>
+      <button data-testid="fire-order" onClick={fireOrder}>
+        order
+      </button>
+      <button data-testid="fire-error" onClick={fireError}>
+        error
+      </button>
+      <button data-testid="fire-large" onClick={fireLarge}>
+        large
+      </button>
+      <button data-testid="fire-bound" onClick={fireBound}>
+        bound
+      </button>
+      <button data-testid="fire-redirect" onClick={fireRedirect}>
+        redirect
+      </button>
+      <pre data-testid="out-cache">{out.cache ?? ''}</pre>
+      <pre data-testid="out-read">{out.read ?? ''}</pre>
+      <pre data-testid="out-mixed">{out.mixed ?? ''}</pre>
+      <pre data-testid="out-order">{out.order ?? ''}</pre>
+      <pre data-testid="out-error">{out.error ?? ''}</pre>
+      <pre data-testid="out-large">{out.large ?? ''}</pre>
+      <pre data-testid="out-bound">{out.bound ?? ''}</pre>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/reads/page.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/reads/page.tsx
@@ -1,0 +1,5 @@
+import { Fanout } from './fanout'
+
+export default function Page() {
+  return <Fanout />
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/reconcile-store.ts
+++ b/test/e2e/app-dir/server-functions-parallel/app/reconcile-store.ts
@@ -1,0 +1,17 @@
+// Shared value for the reconcile test: an action writes it, the page reads it.
+// We use a cookie, not a module variable, because the action and the render can
+// run in different places (different module copies on webpack, or separate
+// lambdas on deploy) and wouldn't see each other's writes. A cookie travels with
+// the browser, so the read always sees the latest write.
+import { cookies } from 'next/headers'
+
+const COOKIE = 'psf-reconcile'
+
+export async function writeReconcile(value: number): Promise<void> {
+  ;(await cookies()).set(COOKIE, String(value))
+}
+
+export async function readReconcile(): Promise<number> {
+  const n = Number((await cookies()).get(COOKIE)?.value)
+  return Number.isFinite(n) ? n : 0
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/reconcile/page.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/reconcile/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { readReconcile } from '../reconcile-store'
+import { ReconcileTrigger } from './trigger'
+
+async function Reconciled() {
+  // connection() forces a fresh dynamic render, so each refresh re-reads the
+  // cookie instead of showing a cached value.
+  await connection()
+  const value = await readReconcile()
+  return <p data-testid="reconciled">{value}</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p data-testid="reconciled">pending</p>}>
+        <Reconciled />
+      </Suspense>
+      <ReconcileTrigger />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/app/reconcile/trigger.tsx
+++ b/test/e2e/app-dir/server-functions-parallel/app/reconcile/trigger.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  resetReconcile,
+  reconcileOne,
+  reconcileTwo,
+  reconcileThree,
+} from '../actions'
+
+export function ReconcileTrigger() {
+  const [out, setOut] = useState('')
+
+  // Reset, then fire three writing actions at once. They overlap, and the one
+  // writing 3 finishes last, so the final value settles on 3.
+  const onFire = async () => {
+    await resetReconcile()
+    const results = await Promise.all([
+      reconcileOne(),
+      reconcileTwo(),
+      reconcileThree(),
+    ])
+    setOut(JSON.stringify(results))
+  }
+
+  return (
+    <>
+      <button data-testid="fire-reconcile" onClick={onFire}>
+        reconcile
+      </button>
+      <pre data-testid="out-reconcile">{out}</pre>
+    </>
+  )
+}

--- a/test/e2e/app-dir/server-functions-parallel/next.config.js
+++ b/test/e2e/app-dir/server-functions-parallel/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  cacheComponents: true,
+  experimental: {
+    parallelServerFunctions: true,
+  },
+}

--- a/test/e2e/app-dir/server-functions-parallel/server-functions-parallel.test.ts
+++ b/test/e2e/app-dir/server-functions-parallel/server-functions-parallel.test.ts
@@ -1,0 +1,296 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+type Span = {
+  label: string
+  start: number
+  end: number
+  value?: number
+}
+
+// Two server-measured intervals that overlap ran concurrently.
+function anyOverlap(spans: Span[]): boolean {
+  for (let i = 0; i < spans.length; i++) {
+    for (let j = i + 1; j < spans.length; j++) {
+      if (spans[i].start < spans[j].end && spans[j].start < spans[i].end) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+describe('parallel Server Functions', () => {
+  const { next } = nextTestSetup({ files: __dirname })
+
+  async function readJson(browser: any, testid: string): Promise<any> {
+    return JSON.parse(
+      await browser.elementByCss(`[data-testid=${testid}]`).text()
+    )
+  }
+
+  it('should run Cache Functions in parallel', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-cache]').click()
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-cache')
+      expect(spans).toHaveLength(3)
+      expect(anyOverlap(spans)).toBe(true)
+    })
+  })
+
+  it('should run read Server Actions in parallel, each returning its own value', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-read]').click()
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-read')
+      expect(spans).toHaveLength(3)
+      expect(anyOverlap(spans)).toBe(true)
+      expect(spans.map((s) => s.label.split('-')[0]).sort()).toEqual([
+        'r1',
+        'r2',
+        'r3',
+      ])
+    })
+  })
+
+  it('should run mixed Cache Function and Server Action calls in parallel', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-mixed]').click()
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-mixed')
+      expect(spans).toHaveLength(3)
+      expect(anyOverlap(spans)).toBe(true)
+    })
+  })
+
+  it('should run mutating Server Actions in parallel, each writing its own state', async () => {
+    const browser = await next.browser('/mutations')
+    await browser.elementByCss('[data-testid=fire-mutations]').click()
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-mutations')
+      expect(spans).toHaveLength(3)
+      expect(anyOverlap(spans)).toBe(true)
+      expect(spans.map((s) => s.label).sort()).toEqual(['a', 'b', 'c'])
+    })
+    // Every call kept its own write (no lost update). Cookies live in the
+    // browser, so this holds on deploy too.
+    await retry(async () => {
+      const cookie: string = await browser.eval('document.cookie')
+      expect(cookie).toContain('psf-mut-a=')
+      expect(cookie).toContain('psf-mut-b=')
+      expect(cookie).toContain('psf-mut-c=')
+    })
+  })
+
+  it('should resolve a fast call before a slow one fired together', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-order]').click()
+    await retry(async () => {
+      const order: string[] = await readJson(browser, 'out-order')
+      expect(order).toHaveLength(2)
+      expect(order[0]).toBe('fast')
+    })
+  })
+
+  it('should not make a Cache Function wait behind a mutation', async () => {
+    const browser = await next.browser('/mutations')
+    await browser.elementByCss('[data-testid=fire-cache-vs-mutation]').click()
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-cache-vs-mutation')
+      expect(spans).toHaveLength(2)
+      expect(anyOverlap(spans)).toBe(true)
+    })
+  })
+
+  // Redirecting from a Server Action is already covered by the actions suite;
+  // this just re-checks it through the parallel commit path.
+  // TODO: remove once parallel is the default.
+  it('should navigate when a Server Action redirects', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-redirect]').click()
+    await retry(async () => {
+      expect(await browser.url()).toContain('/mutations')
+    })
+  })
+
+  it('should keep useActionState dispatches serial', async () => {
+    const browser = await next.browser('/opt-out')
+    await browser.elementByCss('[data-testid=fire-uas]').click()
+    await retry(async () => {
+      expect(await readJson(browser, 'out-uas')).toHaveLength(3)
+    })
+    expect(anyOverlap(await readJson(browser, 'out-uas'))).toBe(false)
+  })
+
+  it('should run awaited calls sequentially', async () => {
+    const browser = await next.browser('/opt-out')
+    await browser.elementByCss('[data-testid=fire-await]').click()
+    await retry(async () => {
+      expect(await readJson(browser, 'out-await')).toHaveLength(3)
+    })
+    expect(anyOverlap(await readJson(browser, 'out-await'))).toBe(false)
+  })
+
+  it('should not block other calls when one fails', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-error]').click()
+    await retry(async () => {
+      const statuses: string[] = await readJson(browser, 'out-error')
+      expect(statuses).toEqual(['fulfilled', 'rejected', 'fulfilled'])
+    })
+  })
+
+  it('should run a large fan-out in parallel', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-large]').click()
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-large')
+      expect(spans).toHaveLength(10)
+      expect(anyOverlap(spans)).toBe(true)
+    })
+  })
+
+  it('should run bound-arg Server Actions in parallel', async () => {
+    const browser = await next.browser('/reads')
+    await browser.elementByCss('[data-testid=fire-bound]').click()
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-bound')
+      expect(spans).toHaveLength(3)
+      expect(anyOverlap(spans)).toBe(true)
+    })
+  })
+
+  it('should not commit a Server Action after navigation superseded mid-flight', async () => {
+    const browser = await next.browser('/origin')
+    expect(await browser.elementByCss('[data-testid=content]').text()).toBe(
+      'Origin'
+    )
+
+    // Start the slow action, then go to "/destination" before it finishes. The
+    // navigation lands first.
+    await browser.elementByCss('[data-testid=fire-race]').click()
+
+    await retry(async () => {
+      expect(await browser.url()).toContain('/destination')
+      expect(await browser.elementByCss('[data-testid=content]').text()).toBe(
+        'Destination'
+      )
+    })
+
+    // When the action finishes ~1s later, its result was built for the old
+    // "/origin" page. Applied to "/destination" it would flip the text back to
+    // "Origin", so it's ignored and "/destination" is refetched instead. We poll
+    // for that bad flip directly (retry() would stop at the first good read and
+    // miss a later flip). 4s easily covers the action's 1s delay.
+    const deadline = Date.now() + 4000
+    while (Date.now() < deadline) {
+      expect(await browser.elementByCss('[data-testid=content]').text()).toBe(
+        'Destination'
+      )
+      await waitFor(50)
+    }
+
+    // Make sure the action actually finished, so the check above means something:
+    // a hung action would also leave the text unchanged and pass for the wrong
+    // reason. The flag lives on `window`, which survives the SPA nav.
+    await retry(async () => {
+      expect(await browser.eval('Boolean(window.__raceActionSettled)')).toBe(
+        true
+      )
+    })
+  })
+
+  it('should drop a raced Server Action redirect that the mid-flight navigation superseded', async () => {
+    const browser = await next.browser('/origin')
+
+    // Start the slow redirect, then go to "/destination" first. The redirect
+    // resolves ~1.5s later, too late: the page already moved on.
+    await browser.elementByCss('[data-testid=fire-redirect-race]').click()
+
+    // The fast navigation lands first.
+    await retry(async () => {
+      expect(await browser.url()).toContain('/destination')
+    })
+
+    // Being stale, the redirect is dropped: we stay on "/destination" and never
+    // go to "/mutations".
+    const deadline = Date.now() + 4000
+    while (Date.now() < deadline) {
+      expect(await browser.url()).toContain('/destination')
+      await waitFor(50)
+    }
+
+    // Make sure the redirect actually ran (so this isn't passing just because
+    // nothing happened). A redirect rejects its caller; the trigger records that
+    // on `window`, which survives the SPA nav.
+    await retry(async () => {
+      expect(await browser.eval('Boolean(window.__redirectRaceSettled)')).toBe(
+        true
+      )
+    })
+  })
+
+  it('should drop a raced Server Action external redirect that the mid-flight navigation superseded', async () => {
+    const browser = await next.browser('/origin')
+
+    // Same race, but the redirect points to another site, which would normally
+    // force a full-page jump away from the app. The navigation to "/destination"
+    // lands first; the redirect resolves ~1.5s later, already stale.
+    await browser
+      .elementByCss('[data-testid=fire-external-redirect-race]')
+      .click()
+
+    // The fast navigation lands first.
+    await retry(async () => {
+      expect(await browser.url()).toContain('/destination')
+    })
+
+    // Being stale, it's dropped: we stay on "/destination" and never jump to the
+    // other site. Poll for that bad outcome directly (retry() would stop at the
+    // first good read). 4s covers the ~1.5s delay.
+    const deadline = Date.now() + 4000
+    while (Date.now() < deadline) {
+      const url = await browser.url()
+      expect(url).toContain('/destination')
+      expect(url).not.toContain('next-data-api-endpoint.vercel.app')
+      await waitFor(50)
+    }
+
+    // Make sure the redirect actually ran (so this isn't passing just because
+    // nothing happened). A redirect rejects its caller; the trigger records that
+    // on `window`, which survives the SPA nav.
+    await retry(async () => {
+      expect(
+        await browser.eval('Boolean(window.__externalRedirectRaceSettled)')
+      ).toBe(true)
+    })
+  })
+
+  it('should reconcile the UI to the final value after concurrent committing Server Actions', async () => {
+    const browser = await next.browser('/reconcile')
+    await browser.elementByCss('[data-testid=fire-reconcile]').click()
+
+    // The three writing actions overlap on the network and each returns its own
+    // value. Their delays differ, so the one writing 3 finishes last and the
+    // final shared value is 3.
+    await retry(async () => {
+      const spans: Span[] = await readJson(browser, 'out-reconcile')
+      expect(spans).toHaveLength(3)
+      expect(anyOverlap(spans)).toBe(true)
+      expect(spans.map((s) => s.value).sort((a, b) => a! - b!)).toEqual([
+        1, 2, 3,
+      ])
+    })
+
+    // A dynamic component reads that shared value. Once the commits settle, the
+    // UI must catch up to the last write, 3 (the first commit applies its data,
+    // the later two are stale and refetch). If reconcile is broken, it gets stuck
+    // on an earlier value. Wide window for the refresh.
+    await retry(async () => {
+      expect(
+        await browser.elementByCss('[data-testid=reconciled]').text()
+      ).toBe('3')
+    }, 10000)
+  })
+})


### PR DESCRIPTION
This PR enabled parallel invocation of Server Functions from the client under the `experimental.parallelServerFunctions` flag. This includes Cache Functions (`'use cache'`) as well.

To put certain Functions in sequence, use [useActionState](https://react.dev/reference/react/useActionState).

Current behavior (failed CI): https://github.com/vercel/next.js/actions/runs/26725536820/job/78760169966?pr=94277#step:41:547