### PR TITLE
[15.5.x] Fix CI

### DIFF
--- a/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
+++ b/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
@@ -19,7 +19,7 @@ describe('Middleware fetches with any HTTP method', () => {
         'middleware.js': `
           import { NextResponse } from 'next/server';
 
-          const HTTP_ECHO_URL = 'https://http-echo-kou029w.vercel.app/';
+          const HTTP_ECHO_URL = 'https://next-data-api-endpoint.vercel.app/api/echo-headers';
 
           export default async (req) => {
             const kind = req.nextUrl.searchParams.get('kind')

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -148,7 +148,6 @@ describe('Middleware can set the matcher in its config', () => {
          "middleware": {
            "/": {
              "assets": [],
-             "entrypoint": "<entrypoint>",
              "env": {
                "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY": "<redacted>",
                "__NEXT_BUILD_ID": "<redacted>",

--- a/test/integration/create-next-app/templates/app.test.ts
+++ b/test/integration/create-next-app/templates/app.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import {
+  pinTailwindForNode18,
   projectShouldHaveNoGitChanges,
   shouldBeTemplateProject,
   tryNextDev,
@@ -146,6 +147,7 @@ describe('create-next-app --app (App Router)', () => {
         mode: 'ts',
         srcDir: true,
       })
+      await pinTailwindForNode18(join(cwd, projectName))
       await tryNextDev({
         cwd,
         projectName,
@@ -223,6 +225,7 @@ describe('create-next-app --app (App Router)', () => {
         mode: 'ts',
         srcDir: true,
       })
+      await pinTailwindForNode18(join(cwd, projectName))
       await tryNextDev({
         cwd,
         projectName,

--- a/test/integration/create-next-app/templates/matrix.test.ts
+++ b/test/integration/create-next-app/templates/matrix.test.ts
@@ -1,4 +1,5 @@
-import { run, tryNextDev, useTempDir } from '../utils'
+import { join } from 'node:path'
+import { pinTailwindForNode18, run, tryNextDev, useTempDir } from '../utils'
 
 describe.each(['app', 'pages'] as const)(
   'CNA options matrix - %s',
@@ -71,6 +72,10 @@ describe.each(['app', 'pages'] as const)(
           }
         )
         expect(exitCode).toBe(0)
+
+        if (flags.includes('--tailwind')) {
+          await pinTailwindForNode18(join(cwd, projectName))
+        }
 
         await tryNextDev({
           cwd,

--- a/test/integration/create-next-app/templates/pages.test.ts
+++ b/test/integration/create-next-app/templates/pages.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import {
+  pinTailwindForNode18,
   projectShouldHaveNoGitChanges,
   run,
   shouldBeTemplateProject,
@@ -154,6 +155,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
         mode: 'ts',
         srcDir: true,
       })
+      await pinTailwindForNode18(join(cwd, projectName))
       await tryNextDev({
         cwd,
         projectName,
@@ -233,6 +235,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
         mode: 'ts',
         srcDir: true,
       })
+      await pinTailwindForNode18(join(cwd, projectName))
       await tryNextDev({
         cwd,
         projectName,

--- a/test/integration/create-next-app/utils.ts
+++ b/test/integration/create-next-app/utils.ts
@@ -1,6 +1,24 @@
 import execa from 'execa'
+import fsp from 'fs/promises'
 import { join } from 'path'
 import { fetchViaHTTP, findPort, killApp, launchApp } from 'next-test-utils'
+
+// Tailwind v4.2.0 bumped `@tailwindcss/oxide`'s engines to `node: '>= 20'`,
+// which makes npm silently drop the platform binding on this branch's
+// Node 18.18.2 test jobs. Pin to the 4.1.x line so the binding installs.
+export async function pinTailwindForNode18(projectDir: string) {
+  const pkgJsonPath = join(projectDir, 'package.json')
+  const pkgJson = JSON.parse(await fsp.readFile(pkgJsonPath, 'utf8'))
+
+  pkgJson.devDependencies['tailwindcss'] = '~4.1.18'
+  pkgJson.devDependencies['@tailwindcss/postcss'] = '~4.1.18'
+
+  await fsp.writeFile(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
+  await execa('npm', ['install', '--no-fund', '--no-audit'], {
+    cwd: projectDir,
+    stdio: 'inherit',
+  })
+}
 
 export const CNA_PATH = require.resolve('create-next-app/dist/index.js')
 export const EXAMPLE_REPO = 'https://github.com/vercel/next.js/tree/canary'

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -106,13 +106,22 @@ describe('Next Lint', () => {
       expect(output).toContain('Cancel')
     })
 
-    for (const { packageManger, lockFile } of [
-      { packageManger: 'yarn', lockFile: 'yarn.lock' },
-      { packageManger: 'pnpm', lockFile: 'pnpm-lock.yaml' },
-      { packageManger: 'npm', lockFile: 'package-lock.json' },
+    for (const { packageManger, lockFile, version } of [
+      { packageManger: 'yarn', lockFile: 'yarn.lock', version: '1.22.19' },
+      { packageManger: 'pnpm', lockFile: 'pnpm-lock.yaml', version: '9.6.0' },
+      { packageManger: 'npm', lockFile: 'package-lock.json', version: '9.8.1' },
     ]) {
       test(`installs eslint and eslint-config-next as devDependencies if missing with ${packageManger}`, async () => {
         const { stdout, pkgJson } = await nextLintTemp(async (folder) => {
+          const pkgJson = JSON.parse(
+            await fs.readFile(join(folder, 'package.json'), 'utf8')
+          )
+          pkgJson.packageManager = `${packageManger}@${version}`
+          await fs.writeFile(
+            join(folder, 'package.json'),
+            JSON.stringify(pkgJson, null, 2) + os.EOL
+          )
+
           await fs.writeFile(join(folder, lockFile), '')
         })
 
@@ -128,6 +137,15 @@ describe('Next Lint', () => {
         // App Router
         const { stdout: appStdout, pkgJson: appPkgJson } = await nextLintTemp(
           async (folder) => {
+            const pkgJson = JSON.parse(
+              await fs.readFile(join(folder, 'package.json'), 'utf8')
+            )
+            pkgJson.packageManager = `${packageManger}@${version}`
+            await fs.writeFile(
+              join(folder, 'package.json'),
+              JSON.stringify(pkgJson, null, 2) + os.EOL
+            )
+
             await fs.writeFile(join(folder, lockFile), '')
           },
           true

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -35,6 +35,36 @@ describe('Next Lint', () => {
       const folder = join(os.tmpdir(), Math.random().toString(36).substring(2))
       await fs.mkdirp(folder)
       await fs.copy(join(dirNoConfig, isApp ? 'app' : ''), folder)
+      // Pin eslint-config-next to the locally-built tarball (same approach
+      // create-next-app tests use for `next`). Force `eslint-visitor-keys`
+      // to ^4 via both `overrides` (npm/pnpm) and `resolutions` (yarn)
+      // because `@typescript-eslint/visitor-keys@8.60.0` (pulled transitively
+      // by eslint-config-next's broad `^5 || ^6 || ^7 || ^8` range) bumped
+      // its inner `eslint-visitor-keys` dep to ^5, which requires Node 20+
+      // and breaks the Node 18.18.2 jobs. That's its only breaking change
+      // so we can safely work around it by forcing eslint-visitor-keys to ^4.
+      const pkgPaths = new Map(JSON.parse(process.env.NEXT_TEST_PKG_PATHS))
+      await fs.writeFile(
+        join(folder, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'no-config',
+            version: '0.0.0',
+            private: true,
+            devDependencies: {
+              'eslint-config-next': pkgPaths.get('eslint-config-next'),
+            },
+            overrides: {
+              'eslint-visitor-keys': '^4',
+            },
+            resolutions: {
+              'eslint-visitor-keys': '^4',
+            },
+          },
+          null,
+          2
+        )
+      )
       await setupCallback?.(folder)
 
       try {


### PR DESCRIPTION
Backports:
1. #86157

The other fixes are due to tests using unpinned versions. The latest versions (e.g. Tailwind or `eslint-config-next`) are no longer compatible with Node.js 18 (used in Next.js 15 CI).