### PR TITLE
fix(ts-plugin): allow promise-like server action returns

### DIFF
--- a/packages/next/src/server/typescript/rules/server-boundary.test.ts
+++ b/packages/next/src/server/typescript/rules/server-boundary.test.ts
@@ -1,0 +1,100 @@
+import ts from 'typescript/lib/tsserverlibrary'
+
+import { NEXT_TS_ERRORS } from '../constant'
+import { init } from '../utils'
+import serverBoundary from './server-boundary'
+
+function getDiagnostics(sourceText: string) {
+  const fileName = 'C:/project/app/actions.ts'
+  const compilerOptions = {
+    lib: ['lib.es2022.d.ts', 'lib.dom.d.ts'],
+    module: ts.ModuleKind.CommonJS,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+  }
+  const host = ts.createCompilerHost(compilerOptions)
+  const readFile = host.readFile.bind(host)
+  const fileExists = host.fileExists.bind(host)
+
+  host.readFile = (file) => (file === fileName ? sourceText : readFile(file))
+  host.fileExists = (file) => file === fileName || fileExists(file)
+
+  const program = ts.createProgram([fileName], compilerOptions, host)
+  const source = program.getSourceFile(fileName)
+  if (!source) {
+    throw new Error('Failed to create test source file')
+  }
+
+  init({
+    ts,
+    info: {
+      languageService: {
+        getProgram: () => program,
+      },
+      project: {
+        getCurrentDirectory: () => 'C:/project',
+        projectService: {
+          logger: {
+            info: jest.fn(),
+          },
+        },
+      },
+    } as any,
+  })
+
+  const diagnostics: ts.Diagnostic[] = []
+
+  ts.forEachChild(source, (node) => {
+    if (
+      ts.isVariableStatement(node) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      diagnostics.push(
+        ...serverBoundary.getSemanticDiagnosticsForExportVariableStatement(
+          source,
+          node
+        )
+      )
+    } else if (
+      ts.isFunctionDeclaration(node) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      diagnostics.push(
+        ...serverBoundary.getSemanticDiagnosticsForFunctionExport(source, node)
+      )
+    }
+  })
+
+  return diagnostics
+}
+
+describe('server-boundary rule', () => {
+  it('allows PromiseLike and promise intersection return types', () => {
+    const diagnostics = getDiagnostics(`
+      "use server"
+
+      function something(): () => Promise<any> & { __errorType?: Error } {
+        return {} as any
+      }
+
+      export const actionL = something()
+      export const promiseLike = (): PromiseLike<number> => Promise.resolve(1)
+      export function promise(): Promise<number> {
+        return Promise.resolve(1)
+      }
+    `)
+
+    expect(diagnostics).toEqual([])
+  })
+
+  it('reports exported functions that do not return promise-like values', () => {
+    const diagnostics = getDiagnostics(`
+      "use server"
+
+      export const plain = (): number => 1
+    `)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0].code).toBe(NEXT_TS_ERRORS.INVALID_SERVER_ENTRY_RETURN)
+  })
+})

--- a/packages/next/src/server/typescript/rules/server-boundary.ts
+++ b/packages/next/src/server/typescript/rules/server-boundary.ts
@@ -4,19 +4,21 @@ import { NEXT_TS_ERRORS } from '../constant'
 import { getTs, getTypeChecker } from '../utils'
 import type tsModule from 'typescript/lib/tsserverlibrary'
 
-// Check if the type is `Promise<T>`.
-function isPromiseType(type: tsModule.Type, typeChecker: tsModule.TypeChecker) {
+// Check if the type is promise-like.
+function isPromiseLikeType(
+  type: tsModule.Type,
+  typeChecker: tsModule.TypeChecker
+): boolean {
+  if (type.isIntersection()) {
+    return type.types.some((t) => isPromiseLikeType(t, typeChecker))
+  }
+
   const typeReferenceType = type as tsModule.TypeReference
   if (!typeReferenceType.target) return false
 
-  // target should be Promise or Promise<...>
-  if (
-    !/^Promise(<.+>)?$/.test(typeChecker.typeToString(typeReferenceType.target))
-  ) {
-    return false
-  }
-
-  return true
+  return /^Promise(?:Like)?(<.+>)?$/.test(
+    typeChecker.typeToString(typeReferenceType.target)
+  )
 }
 
 function isFunctionReturningPromise(
@@ -36,13 +38,13 @@ function isFunctionReturningPromise(
       const returnType = signature.getReturnType()
       if (returnType.isUnion()) {
         for (const t of returnType.types) {
-          if (!isPromiseType(t, typeChecker)) {
+          if (!isPromiseLikeType(t, typeChecker)) {
             isPromise = false
             break
           }
         }
       } else {
-        isPromise = isPromiseType(returnType, typeChecker)
+        isPromise = isPromiseLikeType(returnType, typeChecker)
       }
     }
   } else {


### PR DESCRIPTION
Fixes #74722.

## Summary

- Treat `PromiseLike<T>` return types as valid for `"use server"` exports.
- Accept intersection return types that include a promise-like constituent, such as `Promise<T> & { __errorType?: Error }`.
- Add focused unit coverage for `PromiseLike`, promise intersections, and non-promise returns.

## Why

The TypeScript plugin only recognized return types whose type reference target printed as `Promise<T>`. That rejected valid promise-like server action return types, including the shape reported in the issue.

## Validation

- `packages/next/src/server/typescript/rules/server-boundary.test.ts` with an isolated Jest runner: 2 tests passed.
- TypeScript compile checks for the touched rule/test against TypeScript 5.1.6 and 6.0.2.
- `npx -y prettier@3.6.2 --check packages/next/src/server/typescript/rules/server-boundary.ts packages/next/src/server/typescript/rules/server-boundary.test.ts`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->
