### PR TITLE
[cd] Stop fetching all tags when searching for ancestor tag

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -84,7 +84,6 @@ jobs:
 
       - name: Get commit of the latest tag
         run: |
-          # Prefer increasing shallow clone depth over deepening since deepening is expensive.
           latest_tag="$(git describe --tags --abbrev=0)"
           echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 "$latest_tag")" >> $GITHUB_ENV
 

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -71,7 +71,8 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       - name: Clone Next.js repository
-        run: git clone https://github.com/vercel/next.js.git --depth=25 --single-branch --branch ${GITHUB_REF_NAME:-canary} .
+        # We expect to find the latest tag on this branch in the last 1000 commits.
+        run: git clone https://github.com/vercel/next.js.git --depth=1000 --single-branch --branch ${GITHUB_REF_NAME:-canary} .
 
       - name: Check token
         run: gh auth status
@@ -83,7 +84,7 @@ jobs:
 
       - name: Get commit of the latest tag
         run: |
-          git fetch --tags --force --deepen=1000 origin
+          # Prefer increasing shallow clone depth over deepening since deepening is expensive.
           latest_tag="$(git describe --tags --abbrev=0)"
           echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 "$latest_tag")" >> $GITHUB_ENV
 


### PR DESCRIPTION
A normal checkout during release is a shallow clone with the last 25 commits. 25 commits can be too shallow to find the closest ancestor tag.

We used to deepen to 1k to increase chances of finding a tag. However, we were also fetching **all** tags.
This is wasteful in a default config that auto-follows tags i.e. by default, Git already includes the tags in the commits it fetches. So if there was a tag in the clone depth, it was included. Deepening a clone is also expensive. That's why you should only use shallow clones in CI and never locally where you commonly need to deepen.

Now we always clone with a depth of 1000 immediately.

## test plan

cherry-picked to branch that won't do any mutative actions: https://github.com/vercel/next.js/actions/runs/26754284162/job/78849950644

Clone with 1000 depth is around 20-25s. Deepen + `--tags` is ~120s (https://github.com/vercel/next.js/actions/runs/26697902192/job/78685430123#step:7:1)
