### PR TITLE
test: debug logs for "can not run export while server is running"

### DIFF
--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -212,12 +212,12 @@ export class PatchedFileRef {
   }
 }
 
-let nextInstance: NextInstance | undefined = undefined
+let currentNextInstance: NextInstance | undefined = undefined
 
 if (typeof afterAll === 'function') {
   afterAll(async () => {
-    if (nextInstance) {
-      await nextInstance.destroy()
+    if (currentNextInstance) {
+      await currentNextInstance.destroy()
       throw new Error(
         `next instance not destroyed before exiting, make sure to call .destroy() after the tests after finished`
       )
@@ -245,17 +245,18 @@ const setupTracing = () => {
 async function createNext(
   opts: NextInstanceOpts & { skipStart?: boolean; patchFileDelay?: number }
 ): Promise<NextInstance> {
-  try {
-    if (nextInstance) {
-      throw new Error(`createNext called without destroying previous instance`)
-    }
+  if (currentNextInstance) {
+    throw new Error(`createNext called without destroying previous instance`)
+  }
 
+  try {
     setupTracing()
     return await trace('createNext').traceAsyncFn(async (rootSpan) => {
       const useTurbo = isNextTestWasm
         ? false
         : (opts?.turbo ?? shouldUseTurbopack())
 
+      let nextInstance: NextInstance | undefined = undefined
       if (testMode === 'dev') {
         // next dev
         rootSpan.traceChild('init next dev instance').traceFn(() => {
@@ -279,32 +280,33 @@ async function createNext(
           })
         })
       }
-
       nextInstance = nextInstance!
 
       nextInstance.on('destroy', () => {
-        nextInstance = undefined
+        currentNextInstance = undefined
       })
 
-      await nextInstance.setup(rootSpan)
+      try {
+        await nextInstance.setup(rootSpan)
 
-      if (!opts.skipStart) {
-        await rootSpan
-          .traceChild('start next instance')
-          .traceAsyncFn(async () => {
-            await nextInstance!.start()
-          })
+        if (!opts.skipStart) {
+          await rootSpan
+            .traceChild('start next instance')
+            .traceAsyncFn(async () => {
+              await nextInstance!.start()
+            })
+        }
+      } catch (err) {
+        try {
+          await nextInstance.destroy()
+        } catch (_) {}
       }
 
-      return nextInstance!
+      currentNextInstance = nextInstance
+      return nextInstance
     })
   } catch (err) {
     require('console').error('Failed to create next instance', err)
-    try {
-      await nextInstance?.destroy()
-    } catch (_) {}
-
-    nextInstance = undefined
     // Throw instead of process exit to ensure that Jest reports the tests as failed.
     throw err
   } finally {

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -6,6 +6,7 @@ import { Span } from 'next/dist/trace'
 import stripAnsi from 'strip-ansi'
 import { quote as shellQuote } from 'shell-quote'
 import { shouldUseTurbopack } from 'next-test-utils'
+import { ChildProcess } from 'child_process'
 
 export class NextStartInstance extends NextInstance {
   private _buildId: string
@@ -64,7 +65,9 @@ export class NextStartInstance extends NextInstance {
     options: { skipBuild?: boolean; env?: Record<string, string> } = {}
   ) {
     if (this.childProcess) {
-      throw new Error('next already started')
+      throw new Error(
+        `next already started.\nexisting process: ${childProcessDebug(this.childProcess)}`
+      )
     }
 
     this._cliOutput = ''
@@ -253,7 +256,7 @@ export class NextStartInstance extends NextInstance {
   ) {
     if (this.childProcess) {
       throw new Error(
-        `can not run export while server is running, use next.stop() first`
+        `can not run export while server is running, use next.stop() first\nexisting process: ${childProcessDebug(this.childProcess)}`
       )
     }
 
@@ -333,4 +336,16 @@ export class NextStartInstance extends NextInstance {
       })
     }
   }
+}
+
+function childProcessDebug(childProcess: ChildProcess): string {
+  const { inspect } = require('util') as typeof import('util')
+  return inspect({
+    pid: childProcess.pid,
+    spawnfile: childProcess.spawnfile,
+    spawnopts: childProcess.spawnargs,
+    exitCode: childProcess.exitCode,
+    signalCode: childProcess.signalCode,
+    killed: childProcess.killed,
+  })
 }


### PR DESCRIPTION
we're seeing strange errors from `next.build()` even in tests that use `skipStart`
> **app-dir - server-action-period-hash-custom-key › should have a different manifest if the encryption key from process env is changed**
> ```
> can not run export while server is running, use next.stop() first
> ```
> https://github.com/vercel/next.js/actions/runs/26654624514/job/78561883102#step:41:859

This is an attempt to see what the childProcess is when we hit this weird state