### PR TITLE
fix: match bare basePath root for catch-all middleware matchers

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.test.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.test.ts
@@ -86,5 +86,51 @@ describe('get-page-static-infos', () => {
         regex.test('/index.segments/$c$children/__PAGE__.segment.rsc')
       ).toBe(true)
     })
+
+    it('matches the bare basePath root for a catch-all matcher', () => {
+      // Regression test for https://github.com/vercel/next.js/issues/73786
+      const matcher = '/((?!api|_next/static|_next/image|favicon.ico).*)'
+      const regex = new RegExp(
+        getMiddlewareMatchers(matcher, {
+          i18n: undefined,
+          basePath: '/docs',
+        })[0].regexp
+      )
+
+      // The bare basePath root must match (previously it did not).
+      expect(regex.test('/docs')).toBe(true)
+      expect(regex.test('/docs/')).toBe(true)
+      expect(regex.test('/docs/foo')).toBe(true)
+      // Negative lookahead and word boundaries must still hold.
+      expect(regex.test('/docs/api/x')).toBe(false)
+      expect(regex.test('/docsfoo')).toBe(false)
+      expect(regex.test('/foo')).toBe(false)
+    })
+
+    it('does not match the bare basePath root for a specific matcher', () => {
+      const regex = new RegExp(
+        getMiddlewareMatchers('/dashboard', {
+          i18n: undefined,
+          basePath: '/docs',
+        })[0].regexp
+      )
+
+      expect(regex.test('/docs/dashboard')).toBe(true)
+      // A non-root matcher should not be widened to match the basePath root.
+      expect(regex.test('/docs')).toBe(false)
+      expect(regex.test('/docs/')).toBe(false)
+    })
+
+    it('does not match the bare basePath root for a param matcher', () => {
+      const regex = new RegExp(
+        getMiddlewareMatchers('/:id', {
+          i18n: undefined,
+          basePath: '/docs',
+        })[0].regexp
+      )
+
+      expect(regex.test('/docs/apple')).toBe(true)
+      expect(regex.test('/docs')).toBe(false)
+    })
   })
 })

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -492,6 +492,19 @@ export function getMiddlewareMatchers(
     }`
     source = `${OPTIONAL_MIDDLEWARE_NEXT_DATA_PREFIX}${source}${sourceSuffix}`
 
+    // Whether this matcher (before prepending `basePath`) matches the site
+    // root `/`. A catch-all like `/((?!api).*)` matches `/` because its single
+    // optional capture group can be empty. We need to know this before adding
+    // `basePath` so we can keep the bare `basePath` root matching too (see
+    // below).
+    const matchesRoot =
+      !!nextConfig.basePath &&
+      !isRoot &&
+      (() => {
+        const { regexStr } = tryToParsePath(source)
+        return regexStr ? new RegExp(regexStr).test('/') : false
+      })()
+
     if (nextConfig.basePath) {
       source = `${nextConfig.basePath}${source}`
     }
@@ -507,11 +520,23 @@ export function getMiddlewareMatchers(
       process.exit(1)
     }
 
+    // We know that parsed.regexStr is not undefined because we already
+    // checked that the source is valid.
+    let regexp = tryToParsePath(result.data).regexStr!
+
+    // When `basePath` is set, prepending it turns a matcher that previously
+    // matched `/` into one anchored at `${basePath}/...`, so the bare
+    // `basePath` root (e.g. `/docs`) no longer matches even though `/` did
+    // without a `basePath`. Restore that by also accepting the bare
+    // `basePath` root. See https://github.com/vercel/next.js/issues/73786.
+    if (matchesRoot) {
+      const basePathRoot = `${escapeStringRegexp(nextConfig.basePath!)}[\\/#\\?]?$`
+      regexp = `^(?:${basePathRoot}|${regexp.replace(/^\^/, '')})`
+    }
+
     return {
       ...rest,
-      // We know that parsed.regexStr is not undefined because we already
-      // checked that the source is valid.
-      regexp: tryToParsePath(result.data).regexStr!,
+      regexp,
       originalSource: originalSource || source,
     }
   })


### PR DESCRIPTION
## What

When `basePath` is set, middleware did not run on the bare basePath root. With

```js
// middleware config
export const config = {
  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
}
```

and `basePath: '/docs'` in `next.config`, a request to `/docs` skipped
middleware, while `/docs/` and `/docs/foo` ran it. Without a basePath the same
matcher runs on `/`. Fixes #73786.

## Why

`getMiddlewareMatchers` in `packages/next/src/build/analysis/get-page-static-info.ts`
builds each matcher's source and then prepends `basePath`. A catch-all like
`/((?!api).*)` matches `/` because its one capture group can be empty, so the
compiled regex is `^(?:/(...))(...)?[/#?]?$` and `/` matches.

Once `basePath` is prepended the regex becomes `^/docs(?:/(...))...`, which
requires a slash right after `/docs`. The bare `/docs` then fails to match even
though `/` matched before. The matcher is baked into the middleware manifest, so
this affects both the dev server and production (including Vercel), not just one
runtime.

## How

Before prepending `basePath`, check whether the matcher regex (without basePath)
matches `/`. If it does, after building the final regex also accept the bare
basePath root by OR-ing in an anchored alternative:

```
^(?:/docs[\/#\?]?$|<original-body>)
```

The check is gated on `basePath` being set and the matcher not being the literal
`/` root (which already has its own handling). Specific matchers like
`/dashboard` and param matchers like `/:id` do not match `/`, so they are left
unchanged and do not start matching the basePath root.

## Tests

Extended `get-page-static-info.test.ts` with three cases:

- catch-all matcher with `basePath: '/docs'`: `/docs`, `/docs/`, `/docs/foo`
  match; `/docs/api/x`, `/docsfoo`, `/foo` do not.
- static `/dashboard`: `/docs/dashboard` matches; `/docs` and `/docs/` do not.
- param `/:id`: `/docs/apple` matches; `/docs` does not.

All nine tests in the file pass (six existing plus the three new ones):

```
pnpm jest packages/next/src/build/analysis/get-page-static-info.test.ts
Tests: 9 passed, 9 total
```

prettier and eslint were run on both changed files.

## Signed commits

The commit is signed (SSH) and shows as verified, so it meets the protected
branch requirement.

<!-- NEXT_JS_LLM_PR -->

