### PR TITLE
Avoid bundling HMR refresh reducer in production

### DIFF
--- a/packages/next/src/client/components/router-reducer/router-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer.ts
@@ -15,7 +15,6 @@ import { navigateReducer } from './reducers/navigate-reducer'
 import { serverPatchReducer } from './reducers/server-patch-reducer'
 import { restoreReducer } from './reducers/restore-reducer'
 import { refreshReducer } from './reducers/refresh-reducer'
-import { hmrRefreshReducer } from './reducers/hmr-refresh-reducer'
 import { serverActionReducer } from './reducers/server-action-reducer'
 
 /**
@@ -39,7 +38,15 @@ function clientReducer(
       return refreshReducer(state, action)
     }
     case ACTION_HMR_REFRESH: {
-      return hmrRefreshReducer(state)
+      if (process.env.NODE_ENV === 'development') {
+        const { hmrRefreshReducer } =
+          require('./reducers/hmr-refresh-reducer') as typeof import('./reducers/hmr-refresh-reducer')
+        return hmrRefreshReducer(state)
+      } else {
+        throw new Error(
+          'hmrRefresh can only be used in development mode. Please use refresh instead.'
+        )
+      }
     }
     case ACTION_SERVER_ACTION: {
       return serverActionReducer(state, action)

--- a/test/production/app-dir/browser-chunks/browser-chunks.test.ts
+++ b/test/production/app-dir/browser-chunks/browser-chunks.test.ts
@@ -64,6 +64,21 @@ describe('browser-chunks', () => {
     }
   })
 
+  it('must not bundle the HMR refresh reducer into browser chunks', () => {
+    const hmrReducerSources = sources.filter((source) => {
+      return source.includes('hmr-refresh-reducer')
+    })
+
+    if (hmrReducerSources.length > 0) {
+      const message = `Found the following HMR reducer modules:\n  ${hmrReducerSources.join('\n  ')}`
+
+      throw new Error(
+        'Did not expect the HMR refresh reducer in production browser chunks.\n' +
+          message
+      )
+    }
+  })
+
   it('must not include heavy dependencies into browser chunks', () => {
     const heavyDependencies = sources.filter((source) => {
       return source.includes('next/dist/compiled/safe-stable-stringify')


### PR DESCRIPTION
### What?

Prevent `hmrRefreshReducer` from being included in production App Router browser chunks and add regression coverage for the production bundle.

### Why?

`hmrRefreshReducer` is only used by development HMR, but its eager import from the client reducer caused it to be shipped in optimized production bundles.

### How?

Load the HMR reducer behind the compile-time development branch in `ACTION_HMR_REFRESH`, allowing production bundlers to eliminate its module edge. Extend the production `browser-chunks` test to reject `hmr-refresh-reducer` sources.

### Verification

- `pnpm --filter=next build`
- `pnpm next build test/e2e/app-dir/hello-world` and verified its production client chunks contain no `hmrRefreshReducer` or `hmr-refresh-reducer`
- Red check: restored the eager import and confirmed `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-turbo test/production/app-dir/browser-chunks/browser-chunks.test.ts` fails on the new assertion
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-turbo test/production/app-dir/browser-chunks/browser-chunks.test.ts`
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-webpack test/production/app-dir/browser-chunks/browser-chunks.test.ts`

<!-- NEXT_JS_LLM_PR -->