### PR TITLE
docs: fix link reference for child Layout in documentation

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
@@ -55,7 +55,7 @@ export default function RootLayout({ children }) {
 
 #### `children` (required)
 
-Layout components should accept and use a `children` prop. During rendering, `children` will be populated with the route segments the layout is wrapping. These will primarily be the component of a child [Layout](/docs/app/api-reference/file-conventions/page) (if it exists) or [Page](/docs/app/api-reference/file-conventions/page), but could also be other special files like [Loading](/docs/app/api-reference/file-conventions/loading) or [Error](/docs/app/getting-started/error-handling) when applicable.
+Layout components should accept and use a `children` prop. During rendering, `children` will be populated with the route segments the layout is wrapping. These will primarily be the component of a child [Layout](/docs/app/api-reference/file-conventions/layout) (if it exists) or [Page](/docs/app/api-reference/file-conventions/page), but could also be other special files like [Loading](/docs/app/api-reference/file-conventions/loading) or [Error](/docs/app/getting-started/error-handling) when applicable.
 
 #### `params` (optional)
 


### PR DESCRIPTION
Fix the link for `Layout`. Current doc links it to `page` component. 