### PR TITLE
chore(turbopack): bump lightningcss to alpha.71

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4119,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.70"
+version = "1.0.0-alpha.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efb6a77b2389e62735b0b8157be9cc10a159eb4d1c3b864e99db9f297ada1b0"
+checksum = "cb6314c2f0590ac93c86099b98bb7ba8abcf759bfd89604ffca906472bb54937"
 dependencies = [
  "ahash 0.8.12",
  "bitflags 2.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,7 +277,7 @@ indexmap = "2.13.0"
 indoc = "2.0.0"
 inventory = "0.3.21"
 itertools = "0.10.5"
-lightningcss = { version = "1.0.0-alpha.70", features = [
+lightningcss = { version = "1.0.0-alpha.71", features = [
   "serde",
   "visitor",
   "into_owned",


### PR DESCRIPTION
changelog: https://github.com/parcel-bundler/lightningcss/releases/tag/v1.32.0