### PR TITLE
DiskFileSystem: store Effect full_path as Arc<Path>

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -938,7 +938,7 @@ impl FileSystem for DiskFileSystem {
 
         #[derive(TraceRawVcs, NonLocalValue, Clone)]
         struct WriteEffect {
-            full_path: Arc<PathBuf>,
+            full_path: Arc<Path>,
             inner: Arc<DiskFileSystemInner>,
             content: ReadRef<PersistedFileContent>,
             content_hash: u128,
@@ -1088,7 +1088,7 @@ impl FileSystem for DiskFileSystem {
 
         let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content));
         emit_effect(WriteEffect {
-            full_path: Arc::new(full_path),
+            full_path: Arc::from(full_path),
             inner,
             content,
             content_hash,
@@ -1115,7 +1115,7 @@ impl FileSystem for DiskFileSystem {
 
         #[derive(TraceRawVcs, NonLocalValue, Clone)]
         struct WriteLinkEffect {
-            full_path: Arc<PathBuf>,
+            full_path: Arc<Path>,
             inner: Arc<DiskFileSystemInner>,
             content: ReadRef<LinkContent>,
             content_hash: u128,
@@ -1371,7 +1371,7 @@ impl FileSystem for DiskFileSystem {
 
         let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content));
         emit_effect(WriteLinkEffect {
-            full_path: Arc::new(full_path),
+            full_path: Arc::from(full_path),
             inner,
             content,
             content_hash,


### PR DESCRIPTION
### What?

In the `DiskFileSystem` `write` and `write_link` implementations (`turbopack/crates/turbo-tasks-fs/src/lib.rs`), change the `full_path` field on the `WriteEffect` and `WriteLinkEffect` structs from `Arc<PathBuf>` to `Arc<Path>`.

### Why?

`Arc<PathBuf>` stores two heap allocations and an extra indirection: the `Arc` allocation holds a `PathBuf` (`Vec<u8>`-like), which in turn points to the actual path bytes. `Arc<Path>` is a thin/wide-pointer to a single allocation containing the path bytes inline next to the `Arc` header, which is both smaller (no separate `PathBuf` capacity field) and removes one level of pointer chasing on every access.

These effects are cloned per write side-effect and live until the effect is applied, so the saved allocation/indirection is a small but free win.

### How?

- Change the `full_path` field type on `WriteEffect` and `WriteLinkEffect` from `Arc<PathBuf>` to `Arc<Path>`.
- Update the two construction sites from `Arc::new(full_path)` to `Arc::from(full_path)`, which uses the standard library's `From<PathBuf> for Arc<Path>` impl to move the path bytes directly into a single `Arc<Path>` allocation.

No call sites needed updating: all existing uses (`validate_path_length(&self.full_path)`, `self.inner.invalidate_from_write(&self.full_path)`, `self.full_path.as_os_str()`) already only need `&Path`, which is reached via `Deref` from both `Arc<PathBuf>` and `Arc<Path>`.

Verified locally with `cargo check -p turbo-tasks-fs` and `cargo clippy -p turbo-tasks-fs --all-targets`.

<!-- NEXT_JS_LLM_PR -->
