### PR TITLE
Turbopack: fix pages index normalization for --debug-build-paths

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -246,45 +246,47 @@ impl DebugBuildPathsRouteKeys {
             .into())
     }
 
+    fn pages_route_key_from_debug_path(path: &RcStr) -> Result<RcStr> {
+        // Strip extension: "/foo.tsx" -> "/foo"
+        // Catch-all routes like "/foo/[...slug]" contain dots in the segment name;
+        // only treat the suffix as an extension when it is a plain alphanumeric token.
+        let file_name = path.rsplit('/').next().unwrap_or(path);
+        let result = if let Some(dot_idx) = file_name.rfind('.') {
+            let ext = &file_name[dot_idx + 1..];
+            if !ext.is_empty() && ext.chars().all(|c| c.is_ascii_alphanumeric()) {
+                let trimmed_len = path.len() - (file_name.len() - dot_idx);
+                path[..trimmed_len].into()
+            } else {
+                path.clone()
+            }
+        } else {
+            path.clone()
+        };
+
+        // Strip index suffix: "/foo/index.tsx" -> "/foo"
+        Ok(if let Some(stripped) = result.strip_suffix("/index") {
+            if stripped.is_empty() {
+                "/".into()
+            } else {
+                stripped.into()
+            }
+        } else {
+            result
+        })
+    }
+
     fn from_debug_build_paths(paths: &DebugBuildPaths) -> Result<Self> {
         Ok(Self {
             app: paths
                 .app
                 .iter()
                 .map(|path| Self::app_route_key_from_debug_path(path))
-                .collect::<Result<FxHashSet<_>>>()?,
+                .collect::<Result<_>>()?,
             pages: paths
                 .pages
                 .iter()
-                .map(|path| {
-                    // Pages router: "/foo.tsx" -> "/foo"
-                    // Also: "/foo/index.tsx" -> "/foo" (strip "/index" suffix).
-                    // Catch-all routes like "/foo/[...slug]" contain dots in the segment name;
-                    // only treat the suffix as an extension when it is a plain alphanumeric token.
-                    let file_name = path.rsplit('/').next().unwrap_or(path);
-                    let mut result: RcStr = if let Some(dot_idx) = file_name.rfind('.') {
-                        let ext = &file_name[dot_idx + 1..];
-                        if !ext.is_empty() && ext.chars().all(|c| c.is_ascii_alphanumeric()) {
-                            let trimmed_len = path.len() - (file_name.len() - dot_idx);
-                            path[..trimmed_len].into()
-                        } else {
-                            path.clone()
-                        }
-                    } else {
-                        path.clone()
-                    };
-
-                    if let Some(stripped) = result.strip_suffix("/index") {
-                        result = if stripped.is_empty() {
-                            "/".into()
-                        } else {
-                            stripped.into()
-                        };
-                    }
-
-                    result
-                })
-                .collect(),
+                .map(Self::pages_route_key_from_debug_path)
+                .collect::<Result<_>>()?,
         })
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -258,17 +258,31 @@ impl DebugBuildPathsRouteKeys {
                 .iter()
                 .map(|path| {
                     // Pages router: "/foo.tsx" -> "/foo"
+                    // Also: "/foo/index.tsx" -> "/foo" (strip "/index" suffix).
                     // Catch-all routes like "/foo/[...slug]" contain dots in the segment name;
                     // only treat the suffix as an extension when it is a plain alphanumeric token.
                     let file_name = path.rsplit('/').next().unwrap_or(path);
-                    if let Some(dot_idx) = file_name.rfind('.') {
+                    let mut result: RcStr = if let Some(dot_idx) = file_name.rfind('.') {
                         let ext = &file_name[dot_idx + 1..];
                         if !ext.is_empty() && ext.chars().all(|c| c.is_ascii_alphanumeric()) {
                             let trimmed_len = path.len() - (file_name.len() - dot_idx);
-                            return path[..trimmed_len].into();
+                            path[..trimmed_len].into()
+                        } else {
+                            path.clone()
                         }
+                    } else {
+                        path.clone()
+                    };
+
+                    if let Some(stripped) = result.strip_suffix("/index") {
+                        result = if stripped.is_empty() {
+                            "/".into()
+                        } else {
+                            stripped.into()
+                        };
                     }
-                    path.clone()
+
+                    result
                 })
                 .collect(),
         })

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -46,6 +46,20 @@ describe('debug-build-paths', () => {
         `)
       })
 
+      it('should normalize pages index routes with debug-prerender', async () => {
+        const buildResult = await next.build({
+          args: ['--debug-prerender', '--debug-build-paths', 'pages/**'],
+        })
+        expect(buildResult.exitCode).toBe(0)
+        expect(buildResult.cliOutput).toBeDefined()
+
+        expect(buildResult.cliOutput).toContain('Route (pages)')
+        expect(buildResult.cliOutput).toContain('○ /product-tour')
+        expect(buildResult.cliOutput).not.toContain(
+          'Cannot find module for page'
+        )
+      })
+
       it('should build multiple pages routes', async () => {
         const buildResult = await next.build({
           args: ['--debug-build-paths', 'pages/foo.tsx,pages/bar.tsx'],

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -46,7 +46,7 @@ describe('debug-build-paths', () => {
         `)
       })
 
-      it('should normalize pages index routes with debug-prerender', async () => {
+      it('should include pages index routes with debug-prerender', async () => {
         const buildResult = await next.build({
           args: ['--debug-prerender', '--debug-build-paths', 'pages/**'],
         })
@@ -54,7 +54,7 @@ describe('debug-build-paths', () => {
         expect(buildResult.cliOutput).toBeDefined()
 
         expect(buildResult.cliOutput).toContain('Route (pages)')
-        expect(buildResult.cliOutput).toContain('○ /product-tour')
+        expect(buildResult.cliOutput).toContain('○ /with-index')
         expect(buildResult.cliOutput).not.toContain(
           'Cannot find module for page'
         )

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -46,20 +46,6 @@ describe('debug-build-paths', () => {
         `)
       })
 
-      it('should include pages index routes with debug-prerender', async () => {
-        const buildResult = await next.build({
-          args: ['--debug-prerender', '--debug-build-paths', 'pages/**'],
-        })
-        expect(buildResult.exitCode).toBe(0)
-        expect(buildResult.cliOutput).toBeDefined()
-
-        expect(buildResult.cliOutput).toContain('Route (pages)')
-        expect(buildResult.cliOutput).toContain('○ /with-index')
-        expect(buildResult.cliOutput).not.toContain(
-          'Cannot find module for page'
-        )
-      })
-
       it('should build multiple pages routes', async () => {
         const buildResult = await next.build({
           args: ['--debug-build-paths', 'pages/foo.tsx,pages/bar.tsx'],
@@ -97,7 +83,7 @@ describe('debug-build-paths', () => {
     describe('glob pattern matching', () => {
       it('should match app and pages routes with glob patterns', async () => {
         const buildResult = await next.build({
-          args: ['--debug-build-paths', 'pages/*.tsx,app/page.tsx'],
+          args: ['--debug-build-paths', 'pages/**/*.tsx,app/page.tsx'],
         })
         expect(buildResult.exitCode).toBe(0)
         expect(buildResult.cliOutput).toBeDefined()
@@ -108,7 +94,8 @@ describe('debug-build-paths', () => {
          └ ○ /_not-found
          Route (pages)
          ┌ ○ /bar
-         └ ○ /foo"
+         ├ ○ /foo
+         └ ○ /with-index"
         `)
       })
 

--- a/test/production/debug-build-path/fixtures/default/pages/product-tour/index.tsx
+++ b/test/production/debug-build-path/fixtures/default/pages/product-tour/index.tsx
@@ -1,0 +1,3 @@
+export default function ProductTourPage() {
+  return <main>Product tour</main>
+}

--- a/test/production/debug-build-path/fixtures/default/pages/product-tour/index.tsx
+++ b/test/production/debug-build-path/fixtures/default/pages/product-tour/index.tsx
@@ -1,3 +1,0 @@
-export default function ProductTourPage() {
-  return <main>Product tour</main>
-}

--- a/test/production/debug-build-path/fixtures/default/pages/with-index/index.tsx
+++ b/test/production/debug-build-path/fixtures/default/pages/with-index/index.tsx
@@ -1,0 +1,3 @@
+export default function WithIndexPage() {
+  return <main>With index page</main>
+}


### PR DESCRIPTION
Recreation of https://github.com/vercel/next.js/pull/90314

---

## Summary
- Fix `--debug-build-paths` pages normalization in Turbopack so `pages/<name>/index.tsx` maps to `/<name>` (matching JS `getPageFromPath()` behavior).
- Handle index page edge case: `/index.tsx -> /`.
- Keep regression coverage in `test/production/debug-build-path/debug-build-paths.test.ts` with a generic fixture `pages/with-index/index.tsx`.

## Current Behavior Reference
- CI run (before this fix) that failed as expected for this bug:
  - https://github.com/vercel/next.js/actions/runs/22266469801/job/64413677099?pr=90314#step:35:216

## Root Cause
Rust-side debug-build-path normalization removed file extensions but did not remove `/index`, producing route keys like `/with-index/index` while pages route keys are `/with-index`. That mismatch filtered out the page and caused `PageNotFoundError` during page-data collection.