### PR TITLE
skip render dev overlay ux under private flag

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -160,6 +160,8 @@ export function getDefineEnv({
         ? 'development'
         : 'production',
     'process.env.__NEXT_DEV_SERVER': dev ? '1' : '',
+    'process.env.__NEXT_DISABLE_DEV_OVERLAY_UX':
+      process.env.NEXT_PRIVATE_DISABLE_DEV_OVERLAY_UX === '1',
     'process.env.NEXT_RUNTIME': isEdgeServer
       ? 'edge'
       : isNodeServer

--- a/packages/next/src/next-devtools/dev-overlay-ux.ts
+++ b/packages/next/src/next-devtools/dev-overlay-ux.ts
@@ -1,0 +1,5 @@
+import './dev-overlay/global.css'
+import './dev-overlay/components/toast/style.css'
+
+export { FontStyles } from './dev-overlay/font/font-styles'
+export { DevOverlay } from './dev-overlay/dev-overlay'

--- a/packages/next/src/next-devtools/dev-overlay.browser.tsx
+++ b/packages/next/src/next-devtools/dev-overlay.browser.tsx
@@ -37,10 +37,8 @@ import {
 } from 'react'
 import { createRoot } from 'react-dom/client'
 import type { CacheIndicatorState } from './dev-overlay/cache-indicator'
-import { FontStyles } from './dev-overlay/font/font-styles'
 import type { HydrationErrorState } from './shared/hydration-error'
 import type { DebugInfo } from './shared/types'
-import { DevOverlay } from './dev-overlay/dev-overlay'
 import type { DevIndicatorServerState } from '../server/dev/dev-indicator-server-state'
 import type { VersionInfo } from '../server/dev/parse-version-info'
 import {
@@ -84,6 +82,12 @@ export interface Dispatcher {
 type Dispatch = ReturnType<typeof useErrorOverlayReducer>[1]
 let maybeDispatch: Dispatch | null = null
 const queue: Array<(dispatch: Dispatch) => void> = []
+
+function loadDevOverlayUX() {
+  const { DevOverlay, FontStyles } =
+    require('./dev-overlay-ux') as typeof import('./dev-overlay-ux')
+  return { DevOverlay, FontStyles }
+}
 
 // Global state store for accessing current overlay state from outside React context
 type OverlayStateWithRouter = OverlayState & { routerType: 'pages' | 'app' }
@@ -302,6 +306,12 @@ function DevOverlayRoot({
     }
   }, [])
 
+  if (process.env.__NEXT_DISABLE_DEV_OVERLAY_UX) {
+    return null
+  }
+
+  const { DevOverlay, FontStyles } = loadDevOverlayUX()
+
   return (
     <>
       {/* Fonts can only be loaded outside the Shadow DOM. */}
@@ -351,22 +361,25 @@ export function renderAppDevOverlay(
   }
 
   if (!isAppMounted) {
-    // React 19 will not throw away `<script>` elements in a container it owns.
-    // This ensures the actual user-space React does not unmount the Dev Overlay.
-    const script = document.createElement('script')
-    script.style.display = 'block'
-    // Although the style applied to the shadow host is isolated,
-    // the element that attached the shadow host (i.e. "script")
-    // is still affected by the parent's style (e.g. "body"). This may
-    // occur style conflicts like "display: flex", with other children
-    // elements therefore give the shadow host an absolute position.
-    script.style.position = 'absolute'
-    script.setAttribute('data-nextjs-dev-overlay', 'true')
-
+    const shouldRenderOverlay = !process.env.__NEXT_DISABLE_DEV_OVERLAY_UX
     const container = document.createElement('nextjs-portal')
 
-    script.appendChild(container)
-    document.body.appendChild(script)
+    if (shouldRenderOverlay) {
+      // React 19 will not throw away `<script>` elements in a container it owns.
+      // This ensures the actual user-space React does not unmount the Dev Overlay.
+      const script = document.createElement('script')
+      script.style.display = 'block'
+      // Although the style applied to the shadow host is isolated,
+      // the element that attached the shadow host (i.e. "script")
+      // is still affected by the parent's style (e.g. "body"). This may
+      // occur style conflicts like "display: flex", with other children
+      // elements therefore give the shadow host an absolute position.
+      script.style.position = 'absolute'
+      script.setAttribute('data-nextjs-dev-overlay', 'true')
+
+      script.appendChild(container)
+      document.body.appendChild(script)
+    }
 
     const root = createRoot(container, {
       identifierPrefix: 'ndt-',
@@ -412,6 +425,7 @@ export function renderPagesDevOverlay(
   }
 
   if (!isPagesMounted) {
+    const shouldRenderOverlay = !process.env.__NEXT_DISABLE_DEV_OVERLAY_UX
     const container = document.createElement('nextjs-portal')
     // Although the style applied to the shadow host is isolated,
     // the element that attached the shadow host (i.e. "script")
@@ -423,21 +437,23 @@ export function renderPagesDevOverlay(
     // Pages Router runs with React 18 or 19 so we can't use the same trick as with
     // App Router. We just reconnect the container if React wipes it e.g. when
     // we recover from a shell error via createRoot()
-    new MutationObserver((records) => {
-      for (const record of records) {
-        if (record.type === 'childList') {
-          for (const node of record.removedNodes) {
-            if (node === container) {
-              // Reconnect the container to the body
-              document.body.appendChild(container)
+    if (shouldRenderOverlay) {
+      new MutationObserver((records) => {
+        for (const record of records) {
+          if (record.type === 'childList') {
+            for (const node of record.removedNodes) {
+              if (node === container) {
+                // Reconnect the container to the body
+                document.body.appendChild(container)
+              }
             }
           }
         }
-      }
-    }).observe(document.body, {
-      childList: true,
-    })
-    document.body.appendChild(container)
+      }).observe(document.body, {
+        childList: true,
+      })
+      document.body.appendChild(container)
+    }
 
     const root = createRoot(container, { identifierPrefix: 'ndt-' })
 

--- a/packages/next/src/next-devtools/entrypoint.ts
+++ b/packages/next/src/next-devtools/entrypoint.ts
@@ -1,3 +1,1 @@
-import './dev-overlay/global.css'
-import './dev-overlay/components/toast/style.css'
 export * from './dev-overlay.browser'

--- a/test/development/skip-dev-overlay/index.test.ts
+++ b/test/development/skip-dev-overlay/index.test.ts
@@ -1,0 +1,149 @@
+import { nextTestSetup } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+describe('skip dev overlay', () => {
+  const { next } = nextTestSetup({
+    env: { NEXT_PRIVATE_DISABLE_DEV_OVERLAY_UX: '1' },
+    nextConfig: {
+      logging: {
+        browserToTerminal: true,
+      },
+    },
+    files: {
+      'app/layout.js': `
+        export default function RootLayout({ children }) {
+          return (
+            <html>
+              <body>{children}</body>
+            </html>
+          )
+        }
+      `,
+      'app/runtime-error/page.js': `
+        import RuntimeError from './runtime-error'
+
+        export default function Page() {
+          return <RuntimeError />
+        }
+      `,
+      'app/runtime-error/runtime-error.js': `
+        'use client'
+
+        import { useEffect, useState } from 'react'
+
+        export default function RuntimeError() {
+          const [shouldThrow, setShouldThrow] = useState(false)
+
+          useEffect(() => {
+            setShouldThrow(true)
+          }, [])
+
+          if (shouldThrow) {
+            throw new Error('runtime-skip-dev-overlay')
+          }
+
+          return <p>runtime pending</p>
+        }
+      `,
+      'app/build-error/page.js': `
+        import Message from './message'
+
+        export default function Page() {
+          return <Message />
+        }
+      `,
+      'app/build-error/message.js': `
+        'use client'
+
+        export default function Message() {
+          return <p id="build-status">build ok</p>
+        }
+      `,
+    },
+  })
+
+  it('does not render the overlay for a runtime error but still reports recovery', async () => {
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser('/runtime-error')
+
+    await check(
+      () => next.cliOutput.slice(outputIndex),
+      /\[browser\][\s\S]*runtime-skip-dev-overlay/
+    )
+
+    expect(
+      await browser.eval(`Boolean(document.querySelector('nextjs-portal'))`)
+    ).toBe(false)
+
+    await next.patchFile(
+      'app/runtime-error/runtime-error.js',
+      `
+        'use client'
+
+        export default function RuntimeError() {
+          return <p id="runtime-status">runtime recovered</p>
+        }
+      `
+    )
+
+    expect(await browser.waitForElementByCss('#runtime-status').text()).toBe(
+      'runtime recovered'
+    )
+
+    await check(
+      () => next.cliOutput.slice(outputIndex),
+      /Fast Refresh had to perform a full reload due to a runtime error/
+    )
+
+    expect(
+      await browser.eval(`Boolean(document.querySelector('nextjs-portal'))`)
+    ).toBe(false)
+  })
+
+  it('does not render the overlay for an HMR build error and recovers', async () => {
+    const browser = await next.browser('/build-error')
+    expect(await browser.elementByCss('#build-status').text()).toBe('build ok')
+
+    const outputIndex = next.cliOutput.length
+    await next.patchFile(
+      'app/build-error/message.js',
+      `
+        'use client'
+
+        import missing from 'next-missing-dev-overlay-module'
+
+        export default function Message() {
+          return <p>{missing}</p>
+        }
+      `
+    )
+
+    await check(
+      () => next.cliOutput.slice(outputIndex),
+      /\[browser\][\s\S]*next-missing-dev-overlay-module/
+    )
+
+    expect(
+      await browser.eval(`Boolean(document.querySelector('nextjs-portal'))`)
+    ).toBe(false)
+
+    await next.patchFile(
+      'app/build-error/message.js',
+      `
+        'use client'
+
+        export default function Message() {
+          return <p id="build-status">build recovered</p>
+        }
+      `
+    )
+
+    expect(await browser.waitForElementByCss('#build-status').text()).toBe(
+      'build recovered'
+    )
+
+    expect(
+      await browser.eval(`Boolean(document.querySelector('nextjs-portal'))`)
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Introduce a private env `__NEXT_DISABLE_DEV_OVERLAY_UX ` to skip loading devtool UX when it's specified