### PR TITLE
Deprecate undocumented custom server methods

### DIFF
--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -74,6 +74,45 @@ export type UpgradeHandler = (
 
 const SYMBOL_LOAD_CONFIG = Symbol('next.load_config')
 
+type DeprecatedCustomServerMethod =
+  | 'setAssetPrefix'
+  | 'logError'
+  | 'logErrorWithOriginalStack'
+  | 'revalidate'
+  | 'render'
+  | 'renderToHTML'
+  | 'renderError'
+  | 'renderErrorToHTML'
+  | 'render404'
+
+const DEPRECATED_CUSTOM_SERVER_METHOD_GUIDANCE: Record<
+  DeprecatedCustomServerMethod,
+  string
+> = {
+  setAssetPrefix: 'Please configure `assetPrefix` in `next.config.js` instead.',
+  logError: 'Please use application logging instead.',
+  logErrorWithOriginalStack: 'Please use application logging instead.',
+  revalidate: 'Please use documented application revalidation APIs instead.',
+  render:
+    'Please use `app.getRequestHandler()` with an adjusted parsed URL instead.',
+  renderToHTML:
+    'Please use `app.getRequestHandler()` with an adjusted parsed URL instead.',
+  renderError:
+    'Please use `app.getRequestHandler()` with an adjusted parsed URL instead.',
+  renderErrorToHTML:
+    'Please use `app.getRequestHandler()` with an adjusted parsed URL instead.',
+  render404:
+    'Please use `app.getRequestHandler()` with an adjusted parsed URL instead.',
+}
+
+function warnDeprecatedCustomServerMethod(
+  method: DeprecatedCustomServerMethod
+) {
+  log.warnOnce(
+    `The \`app.${method}()\` method is deprecated in custom servers. ${DEPRECATED_CUSTOM_SERVER_METHOD_GUIDANCE[method]}`
+  )
+}
+
 interface NextWrapperServer {
   // NOTE: the methods/properties here are the public API for custom servers.
   // Consider backwards compatibilty when changing something here!
@@ -84,6 +123,7 @@ interface NextWrapperServer {
 
   getRequestHandler(): RequestHandler
   prepare(serverFields?: ServerFields): Promise<void>
+  /** @deprecated Configure `assetPrefix` in `next.config.js` instead. */
   setAssetPrefix(assetPrefix: string): void
   close(): Promise<void>
 
@@ -92,30 +132,48 @@ interface NextWrapperServer {
 
   // legacy methods that we left exposed in the past
 
+  /** @deprecated Use application logging instead. */
   logError(...args: Parameters<NextNodeServer['logError']>): void
 
+  /** @deprecated Use documented application revalidation APIs instead. */
   revalidate(
     ...args: Parameters<NextNodeServer['revalidate']>
   ): ReturnType<NextNodeServer['revalidate']>
 
+  /** @deprecated Use application logging instead. */
   logErrorWithOriginalStack(err: unknown, type: string): void
 
+  /**
+   * @deprecated Use `app.getRequestHandler()` with an adjusted parsed URL instead.
+   */
   render(
     ...args: Parameters<NextNodeServer['render']>
   ): ReturnType<NextNodeServer['render']>
 
+  /**
+   * @deprecated Use `app.getRequestHandler()` with an adjusted parsed URL instead.
+   */
   renderToHTML(
     ...args: Parameters<NextNodeServer['renderToHTML']>
   ): ReturnType<NextNodeServer['renderToHTML']>
 
+  /**
+   * @deprecated Use `app.getRequestHandler()` with an adjusted parsed URL instead.
+   */
   renderError(
     ...args: Parameters<NextNodeServer['renderError']>
   ): ReturnType<NextNodeServer['renderError']>
 
+  /**
+   * @deprecated Use `app.getRequestHandler()` with an adjusted parsed URL instead.
+   */
   renderErrorToHTML(
     ...args: Parameters<NextNodeServer['renderErrorToHTML']>
   ): ReturnType<NextNodeServer['renderErrorToHTML']>
 
+  /**
+   * @deprecated Use `app.getRequestHandler()` with an adjusted parsed URL instead.
+   */
   render404(
     ...args: Parameters<NextNodeServer['render404']>
   ): ReturnType<NextNodeServer['render404']>
@@ -463,6 +521,7 @@ class NextCustomServer implements NextWrapperServer {
   }
 
   async render(...args: Parameters<NextWrapperServer['render']>) {
+    warnDeprecatedCustomServerMethod('render')
     let [req, res, pathname, query, parsedUrl] = args
     this.setupWebSocketHandler(this.options.httpServer, req as IncomingMessage)
 
@@ -483,6 +542,7 @@ class NextCustomServer implements NextWrapperServer {
   }
 
   setAssetPrefix(assetPrefix: string): void {
+    warnDeprecatedCustomServerMethod('setAssetPrefix')
     this.server.setAssetPrefix(assetPrefix)
 
     // update the router-server nextConfig instance as
@@ -507,32 +567,39 @@ class NextCustomServer implements NextWrapperServer {
   }
 
   logError(...args: Parameters<NextWrapperServer['logError']>) {
+    warnDeprecatedCustomServerMethod('logError')
     this.server.logError(...args)
   }
 
   logErrorWithOriginalStack(err: unknown, type: string) {
+    warnDeprecatedCustomServerMethod('logErrorWithOriginalStack')
     return this.server.logErrorWithOriginalStack(err, type)
   }
 
   async revalidate(...args: Parameters<NextWrapperServer['revalidate']>) {
+    warnDeprecatedCustomServerMethod('revalidate')
     return this.server.revalidate(...args)
   }
 
   async renderToHTML(...args: Parameters<NextWrapperServer['renderToHTML']>) {
+    warnDeprecatedCustomServerMethod('renderToHTML')
     return this.server.renderToHTML(...args)
   }
 
   async renderError(...args: Parameters<NextWrapperServer['renderError']>) {
+    warnDeprecatedCustomServerMethod('renderError')
     return this.server.renderError(...args)
   }
 
   async renderErrorToHTML(
     ...args: Parameters<NextWrapperServer['renderErrorToHTML']>
   ) {
+    warnDeprecatedCustomServerMethod('renderErrorToHTML')
     return this.server.renderErrorToHTML(...args)
   }
 
   async render404(...args: Parameters<NextWrapperServer['render404']>) {
+    warnDeprecatedCustomServerMethod('render404')
     return this.server.render404(...args)
   }
 

--- a/test/e2e/custom-app-render/custom-app-render.test.ts
+++ b/test/e2e/custom-app-render/custom-app-render.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('custom-app-render', () => {
   const { next, skipped } = nextTestSetup({
@@ -18,5 +19,14 @@ describe('custom-app-render', () => {
   it.each(['/', '/render'])('should render %s', async (page) => {
     const $ = await next.render$(page)
     expect($('#page').data('page')).toBe(page)
+  })
+
+  it('should warn when using the deprecated render method', async () => {
+    await next.render('/render')
+    await retry(async () => {
+      expect(next.cliOutput).toContain(
+        'The `app.render()` method is deprecated in custom servers.'
+      )
+    })
   })
 })

--- a/test/e2e/custom-server/custom-server.test.ts
+++ b/test/e2e/custom-server/custom-server.test.ts
@@ -6,6 +6,8 @@ import https from 'https'
 
 const sharedDeps = { 'get-port': '5.1.1' }
 const sharedNodeEnv = isNextDev ? 'development' : 'production'
+const deprecatedWarning = (method: string) =>
+  `The \`app.${method}()\` method is deprecated in custom servers.`
 
 describe.each([
   { title: 'HTTP', useHttps: 'false' },
@@ -52,6 +54,9 @@ describe.each([
         { agent }
       )
       expect(dynamicUsage).toMatch(/127\.0\.0\.1/)
+      await retry(async () => {
+        expect(next.cliOutput).toContain(deprecatedWarning('setAssetPrefix'))
+      })
     })
 
     it('should handle null assetPrefix accordingly', async () => {
@@ -76,11 +81,31 @@ describe.each([
         expect(normalUsage).not.toMatch(/127\.0\.0\.1/)
         expect(dynamicUsage).toMatch(/127\.0\.0\.1/)
       }
+
+      await retry(async () => {
+        expect(
+          next.cliOutput.split(deprecatedWarning('setAssetPrefix')).length - 1
+        ).toBe(1)
+      })
     })
 
     it('should render nested index', async () => {
       const html = await next.render('/dashboard', undefined, { agent })
       expect(html).toMatch(/made it to dashboard/)
+      await retry(async () => {
+        expect(next.cliOutput).toContain(deprecatedWarning('render'))
+      })
+    })
+
+    it('should warn once for repeated render calls', async () => {
+      await next.render('/dashboard', undefined, { agent })
+      await next.render('/dashboard', undefined, { agent })
+
+      await retry(async () => {
+        expect(
+          next.cliOutput.split(deprecatedWarning('render')).length - 1
+        ).toBe(1)
+      })
     })
 
     it('should handle custom urls with requests handler', async () => {
@@ -309,6 +334,9 @@ describe.each([
       const text = $('p').text()
       expect(text).toContain('made it to dynamic dashboard')
       expect(text).toContain('query param: 1')
+      await retry(async () => {
+        expect(next.cliOutput).toContain(deprecatedWarning('renderToHTML'))
+      })
     })
 
     it('NextCustomServer.render404', async () => {
@@ -316,6 +344,9 @@ describe.each([
         agent,
       })
       expect(html).toContain('made it to 404')
+      await retry(async () => {
+        expect(next.cliOutput).toContain(deprecatedWarning('render404'))
+      })
     })
 
     it('NextCustomServer.renderError', async () => {
@@ -329,6 +360,9 @@ describe.each([
       } else {
         expect(html).toContain('made it to 500')
       }
+      await retry(async () => {
+        expect(next.cliOutput).toContain(deprecatedWarning('renderError'))
+      })
     })
 
     it('NextCustomServer.renderErrorToHTML', async () => {
@@ -342,6 +376,23 @@ describe.each([
       } else {
         expect(html).toContain('made it to 500')
       }
+      await retry(async () => {
+        expect(next.cliOutput).toContain(deprecatedWarning('renderErrorToHTML'))
+      })
+    })
+
+    it.each([
+      ['logError', '/legacy-methods/log-error'],
+      [
+        'logErrorWithOriginalStack',
+        '/legacy-methods/log-error-with-original-stack',
+      ],
+      ['revalidate', '/legacy-methods/revalidate'],
+    ])('warns for NextCustomServer.%s', async (method, path) => {
+      await next.fetch(path, { agent })
+      await retry(async () => {
+        expect(next.cliOutput).toContain(deprecatedWarning(method))
+      })
     })
   })
 })

--- a/test/e2e/custom-server/server.js
+++ b/test/e2e/custom-server/server.js
@@ -58,12 +58,14 @@ async function main() {
       return res.end('ok')
     }
 
-    if (/setAssetPrefix/.test(req.url)) {
-      app.setAssetPrefix(`http://127.0.0.1:${port}`)
-    } else if (/setEmptyAssetPrefix/.test(req.url)) {
-      app.setAssetPrefix('')
-    } else {
-      app.setAssetPrefix('')
+    if (/\/asset(?:\?|$)/.test(req.url)) {
+      if (/setAssetPrefix/.test(req.url)) {
+        app.setAssetPrefix(`http://127.0.0.1:${port}`)
+      } else if (/setEmptyAssetPrefix/.test(req.url)) {
+        app.setAssetPrefix('')
+      } else {
+        app.setAssetPrefix('')
+      }
     }
 
     if (/test-index-hmr/.test(req.url)) {
@@ -90,6 +92,31 @@ async function main() {
       return handleNextRequests(req, res, parse('/dashboard', true))
     }
 
+    if (/legacy-methods\/log-error-with-original-stack/.test(req.url)) {
+      try {
+        await app.logErrorWithOriginalStack(
+          new Error('custom server logErrorWithOriginalStack test'),
+          'warning'
+        )
+      } catch {}
+      res.end('ok')
+      return
+    }
+
+    if (/legacy-methods\/log-error/.test(req.url)) {
+      app.logError(new Error('custom server logError test'))
+      res.end('ok')
+      return
+    }
+
+    if (/legacy-methods\/revalidate/.test(req.url)) {
+      try {
+        await app.revalidate({ urlPath: '/', headers: {}, opts: {} })
+      } catch {}
+      res.end('ok')
+      return
+    }
+
     if (/legacy-methods\/render-to-html/.test(req.url)) {
       try {
         const html = await app.renderToHTML(req, res, '/dynamic-dashboard', {
@@ -111,18 +138,6 @@ async function main() {
       return
     }
 
-    if (/legacy-methods\/render-error/.test(req.url)) {
-      try {
-        res.statusCode = 500
-        await app.renderError(new Error('kaboom'), req, res, '/dashboard', {
-          q: '1',
-        })
-      } catch (err) {
-        res.end(err.message)
-      }
-      return
-    }
-
     if (/legacy-methods\/render-error-to-html/.test(req.url)) {
       try {
         res.statusCode = 500
@@ -134,6 +149,18 @@ async function main() {
           { q: '1' }
         )
         res.end(html)
+      } catch (err) {
+        res.end(err.message)
+      }
+      return
+    }
+
+    if (/legacy-methods\/render-error/.test(req.url)) {
+      try {
+        res.statusCode = 500
+        await app.renderError(new Error('kaboom'), req, res, '/dashboard', {
+          q: '1',
+        })
       } catch (err) {
         res.end(err.message)
       }

--- a/test/e2e/filesystempublicroutes/server.js
+++ b/test/e2e/filesystempublicroutes/server.js
@@ -13,14 +13,6 @@ async function main() {
   const port = await getPort()
 
   const server = new http.Server((req, res) => {
-    if (/setAssetPrefix/.test(req.url)) {
-      app.setAssetPrefix(`http://127.0.0.1:${port}`)
-    } else if (/setEmptyAssetPrefix/.test(req.url)) {
-      app.setAssetPrefix('')
-    } else {
-      app.setAssetPrefix('')
-    }
-
     handleNextRequests(req, res)
   })
 

--- a/test/production/custom-server/server.js
+++ b/test/production/custom-server/server.js
@@ -28,23 +28,20 @@ async function main() {
           // Be sure to pass `true` as the second argument to `url.parse`.
           // This tells it to parse the query portion of the URL.
           const parsedUrl = parse(req.url, true)
-          let { pathname, query } = parsedUrl
+          let { pathname } = parsedUrl
 
           if (conf?.basePath) {
             pathname = pathname.replace(conf.basePath, '') || '/'
           }
 
-          if (pathname === '/a') {
-            await app.render(req, res, '/a', query)
-          } else if (pathname === '/b') {
-            await app.render(req, res, '/page-b', query)
-          } else if (pathname === '/error') {
-            await app.render(req, res, '/page-error')
-          } else {
-            parsedUrl.pathname = pathname
-            // TODO: Accept WHATWG URLs in Next.js request handlers
-            await handle(req, res, parsedUrl)
-          }
+          parsedUrl.pathname =
+            pathname === '/b'
+              ? '/page-b'
+              : pathname === '/error'
+                ? '/page-error'
+                : pathname
+          // TODO: Accept WHATWG URLs in Next.js request handlers
+          await handle(req, res, parsedUrl)
         } catch (err) {
           console.error('Error occurred handling', req.url, err)
           res.statusCode = 500


### PR DESCRIPTION
### What?

Deprecate undocumented custom-server methods exposed by `next()` while preserving their runtime behavior.

- Add TypeScript deprecation annotations and one-time runtime warnings for `setAssetPrefix()`, logging helpers, `revalidate()`, and legacy `render*` helpers.
- Extend custom-server tests to cover warnings and warning deduplication.
- Move unrelated test fixtures away from deprecated custom-server calls.

### Why?

These methods are not part of the documented custom-server API, but existing applications may still rely on them. Warning-only deprecation gives users migration guidance without introducing a breaking runtime change.

### How?

Warnings are emitted only through `NextCustomServer`, so framework-owned `NextServer` usage remains quiet. The warning text points `render*` callers toward `app.getRequestHandler()`, `setAssetPrefix()` callers toward configuration, and logging and revalidation callers toward supported application APIs.

The tests retain compatibility assertions for existing behavior, add deliberate invocations for previously uncovered methods, verify once-per-process warning deduplication, and remove incidental warning sources in unrelated fixtures.

<!-- NEXT_JS_LLM_PR -->