### PR TITLE
refactor: make stage advancing logic more generic

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1284,5 +1284,6 @@
   "1283": "Cache Components error recovery expected an original Flight prerender result",
   "1284": "Cache Components error recovery expected an original prerender store",
   "1285": "Cache Components error recovery expected an original resume data cache",
-  "1286": "Route \"%s\": Could not validate that a segment in your UI has instant navigation."
+  "1286": "Route \"%s\": Could not validate that a segment in your UI has instant navigation.",
+  "1287": "A render that hasn't started yet cannot be abandoned"
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -252,7 +252,11 @@ import {
 import type { Params } from '../request/params'
 import { ImageConfigContext } from '../../shared/lib/image-config-context.shared-runtime'
 import { imageConfigDefault } from '../../shared/lib/image-config'
-import { RenderStage, StagedRenderingController } from './staged-rendering'
+import {
+  getNextStage,
+  RenderStage,
+  StagedRenderingController,
+} from './staged-rendering'
 import {
   anySegmentHasRuntimePrefetchEnabled,
   isPageAllowedToBlock,
@@ -5321,7 +5325,8 @@ async function countStaticStageBytes(
   let byteLength = 0
   const reader = stream.getReader()
 
-  stageController.onStage(RenderStage.EarlyRuntime, () => {
+  const endStage = getNextStage(RenderStage.Static)
+  stageController.onStage(endStage, () => {
     reader.cancel()
   })
 
@@ -5348,7 +5353,8 @@ async function countStaticStageBytesNode(
   let byteLength = 0
   let cancelled = false
 
-  stageController.onStage(RenderStage.EarlyRuntime, () => {
+  const endStage = getNextStage(RenderStage.Static)
+  stageController.onStage(endStage, () => {
     cancelled = true
     stream.destroy()
   })

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -3,19 +3,39 @@ import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolv
 
 export enum RenderStage {
   Before = 1,
+  //
   EarlyStatic = 2,
   Static = 3,
+  //
   EarlyRuntime = 4,
   Runtime = 5,
+  //
   Dynamic = 6,
   Abandoned = 7,
 }
 
-export type AdvanceableRenderStage =
-  | RenderStage.Static
-  | RenderStage.EarlyRuntime
-  | RenderStage.Runtime
-  | RenderStage.Dynamic
+export type AdvanceableRenderStage = Exclude<
+  RenderStage,
+  RenderStage.Before | RenderStage.Abandoned
+>
+
+export const RENDER_STAGE_ADVANCE_ORDER: AdvanceableRenderStage[] = [
+  RenderStage.EarlyStatic,
+  RenderStage.Static,
+  //
+  RenderStage.EarlyRuntime,
+  RenderStage.Runtime,
+  //
+  RenderStage.Dynamic,
+]
+
+export function getNextStage(
+  stage: Exclude<AdvanceableRenderStage, RenderStage.Dynamic>
+) {
+  return RENDER_STAGE_ADVANCE_ORDER[
+    RENDER_STAGE_ADVANCE_ORDER.indexOf(stage) + 1
+  ]
+}
 
 export class StagedRenderingController {
   private abortSignal: AbortSignal | null
@@ -25,18 +45,16 @@ export class StagedRenderingController {
   currentStage: RenderStage = RenderStage.Before
 
   syncInterruptReason: Error | null = null
-  staticStageEndTime: number = Infinity
-  runtimeStageEndTime: number = Infinity
 
-  private staticStageListeners: Array<() => void> = []
-  private earlyRuntimeStageListeners: Array<() => void> = []
-  private runtimeStageListeners: Array<() => void> = []
-  private dynamicStageListeners: Array<() => void> = []
-
-  private staticStagePromise = createPromiseWithResolvers<void>()
-  private earlyRuntimeStagePromise = createPromiseWithResolvers<void>()
-  private runtimeStagePromise = createPromiseWithResolvers<void>()
-  private dynamicStagePromise = createPromiseWithResolvers<void>()
+  triggers: Record<AdvanceableRenderStage, StageTrigger> = {
+    [RenderStage.EarlyStatic]: createStageTrigger(),
+    [RenderStage.Static]: createStageTrigger(),
+    //
+    [RenderStage.EarlyRuntime]: createStageTrigger(),
+    [RenderStage.Runtime]: createStageTrigger(),
+    //
+    [RenderStage.Dynamic]: createStageTrigger(),
+  }
 
   constructor({
     abortSignal,
@@ -56,18 +74,11 @@ export class StagedRenderingController {
         'abort',
         () => {
           // Reject all stage promises that haven't already been resolved.
-          // If a promise was already resolved via advanceStage, the reject
-          // is a no-op. The ignoreReject handler suppresses unhandled
-          // rejection warnings for promises that no one is awaiting.
+          // `cancelStageTrigger` is a noop if the trigger already resolved.
           const { reason } = abortSignal
-          this.staticStagePromise.promise.catch(ignoreReject)
-          this.staticStagePromise.reject(reason)
-          this.earlyRuntimeStagePromise.promise.catch(ignoreReject)
-          this.earlyRuntimeStagePromise.reject(reason)
-          this.runtimeStagePromise.promise.catch(ignoreReject)
-          this.runtimeStagePromise.reject(reason)
-          this.dynamicStagePromise.promise.catch(ignoreReject)
-          this.dynamicStagePromise.reject(reason)
+          for (const trigger of Object.values(this.triggers)) {
+            cancelStageTrigger(trigger, reason)
+          }
         },
         { once: true }
       )
@@ -85,20 +96,7 @@ export class StagedRenderingController {
   }
 
   onStage(stage: AdvanceableRenderStage, callback: () => void) {
-    if (this.currentStage >= stage) {
-      callback()
-    } else if (stage === RenderStage.Static) {
-      this.staticStageListeners.push(callback)
-    } else if (stage === RenderStage.EarlyRuntime) {
-      this.earlyRuntimeStageListeners.push(callback)
-    } else if (stage === RenderStage.Runtime) {
-      this.runtimeStageListeners.push(callback)
-    } else if (stage === RenderStage.Dynamic) {
-      this.dynamicStageListeners.push(callback)
-    } else {
-      // This should never happen
-      throw new InvariantError(`Invalid render stage: ${stage}`)
-    }
+    addSyncTriggerListener(this.triggers[stage], callback)
   }
 
   shouldTrackSyncInterrupt(): boolean {
@@ -125,6 +123,7 @@ export class StagedRenderingController {
       case RenderStage.Abandoned:
         return false
       default:
+        this.currentStage satisfies never
         return false
     }
   }
@@ -170,12 +169,18 @@ export class StagedRenderingController {
         return
       }
       case RenderStage.Runtime: {
-        // canSyncInterrupt returns false for Runtime, so we should
+        // `shouldTrackSyncInterrupt` returns false for Runtime, so we should
         // never get here. Defensive no-op.
-        return
+        break
       }
-      case RenderStage.Dynamic:
-      default:
+      case RenderStage.Dynamic: {
+        // `shouldTrackSyncInterrupt` returns false for Dynamic, so we should
+        // never get here. Defensive no-op.
+        break
+      }
+      default: {
+        this.currentStage satisfies never
+      }
     }
   }
 
@@ -184,11 +189,17 @@ export class StagedRenderingController {
   }
 
   getStaticStageEndTime() {
-    return this.staticStageEndTime
+    // The Static stage ends when the stage after it began.
+    return (
+      this.triggers[getNextStage(RenderStage.Static)].triggeredAt ?? Infinity
+    )
   }
 
   getRuntimeStageEndTime() {
-    return this.runtimeStageEndTime
+    // The Runtime stage ended when the stage after it began.
+    return (
+      this.triggers[getNextStage(RenderStage.Runtime)].triggeredAt ?? Infinity
+    )
   }
 
   private abandonRender() {
@@ -201,130 +212,83 @@ export class StagedRenderingController {
     // In either case, we'll be doing another render after this one,
     // so we only want to unblock the next stage, not Dynamic, because
     // unblocking the dynamic stage would likely lead to wasted (uncached) IO.
+
     const { currentStage } = this
     switch (currentStage) {
-      case RenderStage.EarlyStatic: {
-        this.resolveStaticStage()
+      case RenderStage.Before: {
+        throw new InvariantError(
+          "A render that hasn't started yet cannot be abandoned"
+        )
       }
-      // intentional fallthrough
-      case RenderStage.Static: {
-        this.resolveEarlyRuntimeStage()
-      }
-      // intentional fallthrough
-      case RenderStage.EarlyRuntime: {
-        this.resolveRuntimeStage()
-      }
-      // intentional fallthrough
+      case RenderStage.EarlyStatic:
+      case RenderStage.Static:
+      case RenderStage.EarlyRuntime:
       case RenderStage.Runtime: {
+        // Resolve all stages after the current one, up to runtime (excluding dynamic)
+        const nextStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(currentStage) + 1
+        const dynamicStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(
+          RenderStage.Dynamic
+        )
+        for (let i = nextStageIx; i < dynamicStageIx; i++) {
+          this.resolveStage(RENDER_STAGE_ADVANCE_ORDER[i])
+        }
+
         this.currentStage = RenderStage.Abandoned
-        return
+        break
       }
       case RenderStage.Dynamic:
-      case RenderStage.Before:
-      case RenderStage.Abandoned:
+      case RenderStage.Abandoned: {
         break
+      }
       default: {
         currentStage satisfies never
       }
     }
   }
 
-  advanceStage(
-    stage:
-      | RenderStage.EarlyStatic
-      | RenderStage.Static
-      | RenderStage.EarlyRuntime
-      | RenderStage.Runtime
-      | RenderStage.Dynamic
-  ) {
+  advanceStage(targetStage: AdvanceableRenderStage) {
     // If we're already at the target stage or beyond, do nothing.
     // (this can happen e.g. if sync IO advanced us to the dynamic stage)
-    if (stage <= this.currentStage) {
+    if (targetStage <= this.currentStage) {
       return
     }
 
-    let currentStage = this.currentStage
-    this.currentStage = stage
+    const { currentStage } = this
+    this.currentStage = targetStage
 
-    if (currentStage < RenderStage.Static && stage >= RenderStage.Static) {
-      this.resolveStaticStage()
-    }
-    if (
-      currentStage < RenderStage.EarlyRuntime &&
-      stage >= RenderStage.EarlyRuntime
-    ) {
-      this.resolveEarlyRuntimeStage()
-    }
-    if (currentStage < RenderStage.Runtime && stage >= RenderStage.Runtime) {
-      this.staticStageEndTime = performance.now() + performance.timeOrigin
-      this.resolveRuntimeStage()
-    }
-    if (currentStage < RenderStage.Dynamic && stage >= RenderStage.Dynamic) {
-      this.runtimeStageEndTime = performance.now() + performance.timeOrigin
-      this.resolveDynamicStage()
-      return
+    switch (currentStage) {
+      case RenderStage.Before:
+      case RenderStage.EarlyStatic:
+      case RenderStage.Static:
+      case RenderStage.EarlyRuntime:
+      case RenderStage.Runtime: {
+        // Resolve all stages between the current stage and the target.
+        const nextStageIx =
+          currentStage === RenderStage.Before
+            ? 0
+            : RENDER_STAGE_ADVANCE_ORDER.indexOf(currentStage) + 1
+        const targetStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(targetStage)
+        for (let i = nextStageIx; i <= targetStageIx; i++) {
+          this.resolveStage(RENDER_STAGE_ADVANCE_ORDER[i])
+        }
+        break
+      }
+      case RenderStage.Dynamic:
+      case RenderStage.Abandoned: {
+        break
+      }
+      default: {
+        currentStage satisfies never
+      }
     }
   }
 
-  /** Fire the `onStage` listeners for the static stage and unblock any promises waiting for it. */
-  private resolveStaticStage() {
-    const staticListeners = this.staticStageListeners
-    for (let i = 0; i < staticListeners.length; i++) {
-      staticListeners[i]()
-    }
-    staticListeners.length = 0
-    this.staticStagePromise.resolve()
-  }
-
-  /** Fire the `onStage` listeners for the early runtime stage and unblock any promises waiting for it. */
-  private resolveEarlyRuntimeStage() {
-    const earlyRuntimeListeners = this.earlyRuntimeStageListeners
-    for (let i = 0; i < earlyRuntimeListeners.length; i++) {
-      earlyRuntimeListeners[i]()
-    }
-    earlyRuntimeListeners.length = 0
-    this.earlyRuntimeStagePromise.resolve()
-  }
-
-  /** Fire the `onStage` listeners for the runtime stage and unblock any promises waiting for it. */
-  private resolveRuntimeStage() {
-    const runtimeListeners = this.runtimeStageListeners
-    for (let i = 0; i < runtimeListeners.length; i++) {
-      runtimeListeners[i]()
-    }
-    runtimeListeners.length = 0
-    this.runtimeStagePromise.resolve()
-  }
-
-  /** Fire the `onStage` listeners for the dynamic stage and unblock any promises waiting for it. */
-  private resolveDynamicStage() {
-    const dynamicListeners = this.dynamicStageListeners
-    for (let i = 0; i < dynamicListeners.length; i++) {
-      dynamicListeners[i]()
-    }
-    dynamicListeners.length = 0
-    this.dynamicStagePromise.resolve()
+  private resolveStage(stage: AdvanceableRenderStage) {
+    fireStageTrigger(this.triggers[stage])
   }
 
   private getStagePromise(stage: AdvanceableRenderStage): Promise<void> {
-    switch (stage) {
-      case RenderStage.Static: {
-        return this.staticStagePromise.promise
-      }
-      case RenderStage.EarlyRuntime: {
-        return this.earlyRuntimeStagePromise.promise
-      }
-      case RenderStage.Runtime: {
-        return this.runtimeStagePromise.promise
-      }
-      case RenderStage.Dynamic: {
-        return this.dynamicStagePromise.promise
-      }
-      default: {
-        stage satisfies never
-        throw new InvariantError(`Invalid render stage: ${stage}`)
-      }
-    }
+    return this.triggers[stage].promise
   }
 
   waitForStage(stage: AdvanceableRenderStage) {
@@ -377,4 +341,65 @@ function makeDevtoolsIOPromiseFromIOTrigger<T>(
     promise.displayName = displayName
   }
   return promise
+}
+
+type StageTrigger = {
+  state: 'pending' | 'triggered' | 'cancelled'
+  triggeredAt: number | null
+  promise: Promise<void>
+  _listeners: Array<() => void>
+  _resolvePromise: () => void
+  _rejectPromise: (reason: unknown) => void
+}
+
+function addSyncTriggerListener(trigger: StageTrigger, listener: () => void) {
+  if (trigger.state === 'pending') {
+    trigger._listeners.push(listener)
+  } else {
+    listener()
+  }
+}
+
+function createStageTrigger(): StageTrigger {
+  const { promise, resolve, reject } = createPromiseWithResolvers<void>()
+  return {
+    state: 'pending',
+    triggeredAt: null,
+    promise,
+    _listeners: [],
+    _resolvePromise: resolve,
+    _rejectPromise: reject,
+  }
+}
+
+function fireStageTrigger(trigger: StageTrigger) {
+  if (trigger.state !== 'pending') {
+    return
+  }
+  trigger.state = 'triggered'
+  trigger.triggeredAt = performance.now() + performance.timeOrigin
+  try {
+    const { _listeners: listeners } = trigger
+    for (let i = 0; i < listeners.length; i++) {
+      listeners[i]()
+    }
+    listeners.length = 0
+  } finally {
+    trigger._resolvePromise()
+  }
+}
+
+function cancelStageTrigger(trigger: StageTrigger, reason: unknown) {
+  if (trigger.state !== 'pending') {
+    return
+  }
+  trigger.state = 'cancelled'
+  // we didn't trigger, so don't save `triggeredAt`.
+
+  // We're not gonna fire the listeners, we may as well free them.
+  trigger._listeners.length = 0
+
+  // Suppress unhandled rejection warnings for promises that no one is awaiting.
+  trigger.promise.catch(ignoreReject)
+  trigger._rejectPromise(reason)
 }


### PR DESCRIPTION
In #93801, we'll be adding 4 new stages. `StagedRenderingController` already contains a lot of duplication around advancing stages, and i want to avoid adding to that, so this PR does some cleanup.

Previously, for a stage, we had
- `resolve<name>Stage` - triggers listener callbacks and resolves the promise for the stage
  - `<name>StageListeners` - added via `onStage`, triggered when advancing to the stage but before resolving the promise
  - `<name>StagePromise` - resolved when we enter the stage (or rejected on abort/abandon)
- sometimes, `<name>EndTime`

these behaviors are all now packaged up into `StageTrigger`, which can be "fired" (when advancing to a stage) or "cancelled" (when aborting/abandoning) and tracks the time.

In addition, we now have `RENDER_STAGE_ADVANCE_ORDER`, an array that defines the order in which advanceable stages (i.e. excluding Before/Abandoned) should happen. We can loop through this to advance stages without relying on a huge switch statement with fallthroughs. Re-working the logic into this shape will be handy in the future, when we want each route param to have its own stage, and the set of stages is no longer statically known.
