### PR TITLE
Fix Navigation Inspector Continue Rendering with loading.tsx

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -127,6 +127,8 @@ export type NavigationRequestAccumulation = {
   scrollRef: ScrollRef | null
 }
 
+export type NavigationLock = Promise<void> | null
+
 const noop = () => {}
 
 export function createInitialCacheNodeForHydration(
@@ -1383,7 +1385,8 @@ export function spawnDynamicRequests(
   // The original navigation's push/replace intent. Threaded through to the
   // server-patch retry logic so it can inherit the intent if the original
   // transition hasn't committed yet.
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  navigationLock: NavigationLock
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
   if (dynamicRequestTree === null) {
@@ -1401,7 +1404,6 @@ export function spawnDynamicRequests(
   // block the navigation, and collect the promises. The next function,
   // `finishNavigationTask`, can await the promises in any order without
   // accidentally introducing a network waterfall.
-  const lockAtRequestStart = getCurrentNavigationLock()
   const primaryRequestPromise = fetchMissingDynamicData(
     task,
     dynamicRequestTree,
@@ -1409,7 +1411,7 @@ export function spawnDynamicRequests(
     nextUrl,
     freshnessPolicy,
     routeCacheEntry,
-    lockAtRequestStart
+    navigationLock
   )
 
   const separateRefreshUrls = accumulation.separateRefreshUrls
@@ -1462,7 +1464,7 @@ export function spawnDynamicRequests(
             nextUrl,
             freshnessPolicy,
             routeCacheEntry,
-            lockAtRequestStart
+            navigationLock
           )
         )
       }
@@ -1701,7 +1703,7 @@ async function fetchMissingDynamicData(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  lockAtRequestStart: Promise<void> | null
+  navigationLock: NavigationLock
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
   url: URL
@@ -1738,7 +1740,7 @@ async function fetchMissingDynamicData(
     // writing the dynamic data. This allows tests to assert on the prefetched
     // UI state.
     if (process.env.__NEXT_EXPOSE_TESTING_API) {
-      await waitForNavigationLock(lockAtRequestStart)
+      await waitForNavigationLock(navigationLock)
     }
 
     if (routeCacheEntry !== null && result.staticStageData !== null) {
@@ -2152,13 +2154,13 @@ function createDeferredRsc<
 }
 
 /**
- * Helper for the Instant Navigation Testing API. Waits for the navigation lock
- * to be released before returning. The network request has already completed by
- * the time this is called, so this only delays writing the dynamic data.
+ * Helper for the Instant Navigation Testing API. Snapshots the lock that is
+ * active when a navigation starts, so the navigation can wait for the same lock
+ * even if another lock is acquired before its dynamic response is applied.
  *
  * Not exposed in production builds by default.
  */
-function getCurrentNavigationLock(): Promise<void> | null {
+export function getCurrentNavigationLock(): NavigationLock {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     const { getCurrentNavigationLock: getCurrentLock } =
       require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
@@ -2167,9 +2169,7 @@ function getCurrentNavigationLock(): Promise<void> | null {
   return null
 }
 
-async function waitForNavigationLock(
-  lock: Promise<void> | null = getCurrentNavigationLock()
-): Promise<void> {
+async function waitForNavigationLock(lock: NavigationLock): Promise<void> {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     const { waitForNavigationLockIfActive } =
       require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1703,6 +1703,8 @@ async function fetchMissingDynamicData(
   url: URL
   seed: NavigationSeed | null
 }> {
+  const lockAtRequestStart = getCurrentNavigationLock()
+
   try {
     const result = await fetchServerResponse(url, {
       flightRouterState: dynamicRequestTree,
@@ -1734,7 +1736,7 @@ async function fetchMissingDynamicData(
     // writing the dynamic data. This allows tests to assert on the prefetched
     // UI state.
     if (process.env.__NEXT_EXPOSE_TESTING_API) {
-      await waitForNavigationLock()
+      await waitForNavigationLock(lockAtRequestStart)
     }
 
     if (routeCacheEntry !== null && result.staticStageData !== null) {
@@ -2154,10 +2156,21 @@ function createDeferredRsc<
  *
  * Not exposed in production builds by default.
  */
-async function waitForNavigationLock(): Promise<void> {
+function getCurrentNavigationLock(): Promise<void> | null {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    const { getCurrentNavigationLock: getCurrentLock } =
+      require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
+    return getCurrentLock()
+  }
+  return null
+}
+
+async function waitForNavigationLock(
+  lock: Promise<void> | null = getCurrentNavigationLock()
+): Promise<void> {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     const { waitForNavigationLockIfActive } =
       require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
-    await waitForNavigationLockIfActive()
+    await waitForNavigationLockIfActive(lock)
   }
 }

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1401,13 +1401,15 @@ export function spawnDynamicRequests(
   // block the navigation, and collect the promises. The next function,
   // `finishNavigationTask`, can await the promises in any order without
   // accidentally introducing a network waterfall.
+  const lockAtRequestStart = getCurrentNavigationLock()
   const primaryRequestPromise = fetchMissingDynamicData(
     task,
     dynamicRequestTree,
     primaryUrl,
     nextUrl,
     freshnessPolicy,
-    routeCacheEntry
+    routeCacheEntry,
+    lockAtRequestStart
   )
 
   const separateRefreshUrls = accumulation.separateRefreshUrls
@@ -1459,7 +1461,8 @@ export function spawnDynamicRequests(
             // hard refresh.
             nextUrl,
             freshnessPolicy,
-            routeCacheEntry
+            routeCacheEntry,
+            lockAtRequestStart
           )
         )
       }
@@ -1697,14 +1700,13 @@ async function fetchMissingDynamicData(
   url: URL,
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
-  routeCacheEntry: FulfilledRouteCacheEntry | null
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  lockAtRequestStart: Promise<void> | null
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
   url: URL
   seed: NavigationSeed | null
 }> {
-  const lockAtRequestStart = getCurrentNavigationLock()
-
   try {
     const result = await fetchServerResponse(url, {
       flightRouterState: dynamicRequestTree,

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -10,7 +10,7 @@ import {
 } from '../../segment-cache/navigation'
 import { invalidateSegmentCacheEntries } from '../../segment-cache/cache'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
-import { FreshnessPolicy } from '../ppr-navigations'
+import { FreshnessPolicy, getCurrentNavigationLock } from '../ppr-navigations'
 import {
   invalidateBfCache,
   UnknownDynamicStaleTime,
@@ -61,6 +61,7 @@ export function refreshDynamicData(
   const currentRenderedSearch = state.renderedSearch
   const currentFlightRouterState = state.tree
   const scrollBehavior = ScrollBehavior.NoScroll
+  const navigationLock = getCurrentNavigationLock()
 
   // Create a NavigationSeed from the current FlightRouterState.
   // TODO: Eventually we will store this type directly on the state object
@@ -92,6 +93,7 @@ export function refreshDynamicData(
     nextUrlForRefresh,
     scrollBehavior,
     navigateType,
+    navigationLock,
     null,
     // Refresh navigations don't use route prediction, so there's no route
     // cache entry to mark as having a dynamic rewrite on mismatch. If a

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -6,6 +6,7 @@ import type {
 import { extractPathFromFlightRouterState } from '../compute-changed-path'
 import {
   FreshnessPolicy,
+  getCurrentNavigationLock,
   spawnDynamicRequests,
   startPPRNavigation,
   type NavigationRequestAccumulation,
@@ -43,6 +44,7 @@ export function restoreReducer(
   const restoredUrl = action.url
   const restoredNextUrl =
     extractPathFromFlightRouterState(treeToRestore) ?? restoredUrl.pathname
+  const navigationLock = getCurrentNavigationLock()
 
   const now = Date.now()
   // TODO: Store the dynamic stale time on the top-level state so it's known
@@ -89,7 +91,8 @@ export function restoreReducer(
     // to find and mark the entry.
     null,
     // History traversal always uses 'replace'.
-    'replace'
+    'replace',
+    navigationLock
   )
   return completeTraverseNavigation(
     state,

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -67,7 +67,7 @@ import {
   type ActionRevalidationKind,
 } from '../../../../shared/lib/action-revalidation-kind'
 import { isExternalURL } from '../../app-router-utils'
-import { FreshnessPolicy } from '../ppr-navigations'
+import { FreshnessPolicy, getCurrentNavigationLock } from '../ppr-navigations'
 import { processFetch } from '../fetch-server-response'
 import {
   invalidateBfCache,
@@ -496,6 +496,7 @@ export function serverActionReducer(
             false // hasDynamicRewrite
           )
         }
+        const navigationLock = getCurrentNavigationLock()
 
         return navigateToKnownRoute(
           now,
@@ -511,6 +512,7 @@ export function serverActionReducer(
           nextUrl,
           scrollBehavior,
           navigateType,
+          navigationLock,
           null,
           // Server action redirects don't use route prediction - we already
           // have the route tree from the server response. If a mismatch occurs

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -11,7 +11,7 @@ import {
   navigateToKnownRoute,
 } from '../../segment-cache/navigation'
 import { refreshReducer } from './refresh-reducer'
-import { FreshnessPolicy } from '../ppr-navigations'
+import { FreshnessPolicy, getCurrentNavigationLock } from '../ppr-navigations'
 
 export function serverPatchReducer(
   state: ReadonlyReducerState,
@@ -43,6 +43,7 @@ export function serverPatchReducer(
   const retryCanonicalUrl = createHrefFromUrl(retryUrl)
   const retryNextUrl = action.nextUrl
   const scrollBehavior = ScrollBehavior.Default
+  const navigationLock = getCurrentNavigationLock()
   const now = Date.now()
   return navigateToKnownRoute(
     now,
@@ -58,6 +59,7 @@ export function serverPatchReducer(
     retryNextUrl,
     scrollBehavior,
     navigateType,
+    navigationLock,
     null,
     // Server patch (retry) navigations don't use route prediction. This is
     // typically a retry after a previous mismatch, so the route was already

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -20,29 +20,20 @@ import { refreshOnInstantNavigationUnlock } from '../use-action-queue'
 
 type InstantNavCookieState = 'empty' | 'pending' | 'mpa' | 'spa'
 
-type ParsedInstantNavCookie = {
-  state: InstantNavCookieState
-  id: string | null
-}
-
-function parseCookie(raw: string): ParsedInstantNavCookie {
+function parseCookieValue(raw: string): InstantNavCookieState {
   if (raw === '') {
-    return { state: 'empty', id: null }
+    return 'empty'
   }
   try {
     const parsed = JSON.parse(raw)
     if (Array.isArray(parsed)) {
-      const id = typeof parsed[1] === 'string' ? parsed[1] : null
-      if (parsed[0] === 0) {
-        return { state: 'pending', id }
-      }
       if (parsed.length >= 3) {
         const rawState = parsed[2]
-        return { state: rawState === null ? 'mpa' : 'spa', id }
+        return rawState === null ? 'mpa' : 'spa'
       }
     }
   } catch {}
-  return { state: 'pending', id: null }
+  return 'pending'
 }
 
 function writeCookieValue(value: InstantCookie): void {
@@ -80,7 +71,6 @@ function writeCookieValue(value: InstantCookie): void {
 type NavigationLockState = {
   promise: Promise<void>
   resolve: () => void
-  pendingId: string | null
   // The pre-lock `window.fetch`, captured at `acquireLock` time and
   // restored at `releaseLock`. Internal Next.js code reads this via
   // `getPreLockFetch` to bypass the override we install on `window.fetch`
@@ -94,7 +84,7 @@ export function getPreLockFetch(): typeof fetch | null {
   return lockState !== null ? lockState.fetch : null
 }
 
-function acquireLock(pendingId: string | null = null): void {
+function acquireLock(): void {
   if (lockState !== null) {
     return
   }
@@ -102,7 +92,7 @@ function acquireLock(pendingId: string | null = null): void {
   const promise = new Promise<void>((r) => {
     resolve = r
   })
-  lockState = { promise, resolve: resolve!, pendingId, fetch: window.fetch }
+  lockState = { promise, resolve: resolve!, fetch: window.fetch }
 
   // Install the fetch blocker. We only intercept `window.fetch` for the
   // duration of the lock so that — outside of a testing scope — user-
@@ -196,17 +186,18 @@ export function startListeningForInstantNavigationCookie(): void {
     cookieStore.addEventListener('change', (event: CookieChangeEvent) => {
       for (const cookie of event.changed) {
         if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
-          const { state, id } = parseCookie(cookie.value ?? '')
+          const state = parseCookieValue(cookie.value ?? '')
 
           if (state === 'pending') {
             // External actor starting a new lock scope.
             if (lockState !== null) {
-              if (lockState.pendingId === id && id !== null) {
-                return
-              }
-              releaseLock()
+              // This can be the delayed CookieStore event for the pending
+              // cookie that was already observed synchronously from
+              // document.cookie. Keep the existing lock identity so work that
+              // captured it keeps waiting on the same promise.
+              return
             }
-            acquireLock(id)
+            acquireLock()
           }
           // Captured value (our own transition) or empty. Ignore.
           return
@@ -263,14 +254,13 @@ export function isNavigationLocked(): boolean {
     const target = NEXT_INSTANT_TEST_COOKIE + '='
     for (const segment of allCookies.split(';')) {
       const trimmed = segment.trim()
-      if (trimmed.startsWith(target)) {
-        const { state, id } = parseCookie(trimmed.slice(target.length))
-        if (state !== 'pending') {
-          continue
-        }
+      if (
+        trimmed.startsWith(target) &&
+        parseCookieValue(trimmed.slice(target.length)) === 'pending'
+      ) {
         // The cookie was set by an external actor but the change event was not
         // yet dispatched. Acquire the lock synchronously.
-        acquireLock(id)
+        acquireLock()
         return true
       }
     }

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -20,18 +20,29 @@ import { refreshOnInstantNavigationUnlock } from '../use-action-queue'
 
 type InstantNavCookieState = 'empty' | 'pending' | 'mpa' | 'spa'
 
-function parseCookieValue(raw: string): InstantNavCookieState {
+type ParsedInstantNavCookie = {
+  state: InstantNavCookieState
+  id: string | null
+}
+
+function parseCookie(raw: string): ParsedInstantNavCookie {
   if (raw === '') {
-    return 'empty'
+    return { state: 'empty', id: null }
   }
   try {
     const parsed = JSON.parse(raw)
-    if (Array.isArray(parsed) && parsed.length >= 3) {
-      const rawState = parsed[2]
-      return rawState === null ? 'mpa' : 'spa'
+    if (Array.isArray(parsed)) {
+      const id = typeof parsed[1] === 'string' ? parsed[1] : null
+      if (parsed[0] === 0) {
+        return { state: 'pending', id }
+      }
+      if (parsed.length >= 3) {
+        const rawState = parsed[2]
+        return { state: rawState === null ? 'mpa' : 'spa', id }
+      }
     }
   } catch {}
-  return 'pending'
+  return { state: 'pending', id: null }
 }
 
 function writeCookieValue(value: InstantCookie): void {
@@ -69,6 +80,7 @@ function writeCookieValue(value: InstantCookie): void {
 type NavigationLockState = {
   promise: Promise<void>
   resolve: () => void
+  pendingId: string | null
   // The pre-lock `window.fetch`, captured at `acquireLock` time and
   // restored at `releaseLock`. Internal Next.js code reads this via
   // `getPreLockFetch` to bypass the override we install on `window.fetch`
@@ -82,7 +94,7 @@ export function getPreLockFetch(): typeof fetch | null {
   return lockState !== null ? lockState.fetch : null
 }
 
-function acquireLock(): void {
+function acquireLock(pendingId: string | null = null): void {
   if (lockState !== null) {
     return
   }
@@ -90,7 +102,7 @@ function acquireLock(): void {
   const promise = new Promise<void>((r) => {
     resolve = r
   })
-  lockState = { promise, resolve: resolve!, fetch: window.fetch }
+  lockState = { promise, resolve: resolve!, pendingId, fetch: window.fetch }
 
   // Install the fetch blocker. We only intercept `window.fetch` for the
   // duration of the lock so that — outside of a testing scope — user-
@@ -184,14 +196,17 @@ export function startListeningForInstantNavigationCookie(): void {
     cookieStore.addEventListener('change', (event: CookieChangeEvent) => {
       for (const cookie of event.changed) {
         if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
-          const state = parseCookieValue(cookie.value ?? '')
+          const { state, id } = parseCookie(cookie.value ?? '')
 
           if (state === 'pending') {
             // External actor starting a new lock scope.
             if (lockState !== null) {
+              if (lockState.pendingId === id && id !== null) {
+                return
+              }
               releaseLock()
             }
-            acquireLock()
+            acquireLock(id)
           }
           // Captured value (our own transition) or empty. Ignore.
           return
@@ -248,13 +263,14 @@ export function isNavigationLocked(): boolean {
     const target = NEXT_INSTANT_TEST_COOKIE + '='
     for (const segment of allCookies.split(';')) {
       const trimmed = segment.trim()
-      if (
-        trimmed.startsWith(target) &&
-        parseCookieValue(trimmed.slice(target.length)) === 'pending'
-      ) {
+      if (trimmed.startsWith(target)) {
+        const { state, id } = parseCookie(trimmed.slice(target.length))
+        if (state !== 'pending') {
+          continue
+        }
         // The cookie was set by an external actor but the change event was not
         // yet dispatched. Acquire the lock synchronously.
-        acquireLock()
+        acquireLock(id)
         return true
       }
     }

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -262,14 +262,23 @@ export function isNavigationLocked(): boolean {
   return false
 }
 
+export function getCurrentNavigationLock(): Promise<void> | null {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    return lockState !== null ? lockState.promise : null
+  }
+  return null
+}
+
 /**
  * Waits for the navigation lock to be released, if it's currently held.
  * No-op if the lock is not acquired.
  */
-export async function waitForNavigationLockIfActive(): Promise<void> {
+export async function waitForNavigationLockIfActive(
+  lock: Promise<void> | null = getCurrentNavigationLock()
+): Promise<void> {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (lockState !== null) {
-      await lockState.promise
+    if (lock !== null) {
+      await lock
     }
   }
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -12,6 +12,8 @@ import {
   startPPRNavigation,
   spawnDynamicRequests,
   FreshnessPolicy,
+  getCurrentNavigationLock,
+  type NavigationLock,
   type NavigationRequestAccumulation,
 } from '../router-reducer/ppr-navigations'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
@@ -60,6 +62,8 @@ export function navigate(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): AppRouterState | Promise<AppRouterState> {
+  let navigationLock: NavigationLock = null
+
   // Instant Navigation Testing API: when the lock is active, ensure a
   // prefetch task has been initiated before proceeding with the navigation.
   // This guarantees that segment data requests are at least pending, even
@@ -70,6 +74,7 @@ export function navigate(
     const { isNavigationLocked } =
       require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
     if (isNavigationLocked()) {
+      navigationLock = getCurrentNavigationLock()
       return ensurePrefetchThenNavigate(
         state,
         url,
@@ -80,7 +85,8 @@ export function navigate(
         nextUrl,
         freshnessPolicy,
         scrollBehavior,
-        navigateType
+        navigateType,
+        navigationLock
       )
     }
   }
@@ -95,7 +101,8 @@ export function navigate(
     nextUrl,
     freshnessPolicy,
     scrollBehavior,
-    navigateType
+    navigateType,
+    navigationLock
   )
 }
 
@@ -109,7 +116,8 @@ function navigateImpl(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  navigationLock: NavigationLock
 ): AppRouterState | Promise<AppRouterState> {
   const now = Date.now()
   const href = url.href
@@ -130,7 +138,8 @@ function navigateImpl(
       freshnessPolicy,
       scrollBehavior,
       navigateType,
-      route
+      route,
+      navigationLock
     )
   }
 
@@ -166,7 +175,8 @@ function navigateImpl(
           freshnessPolicy,
           scrollBehavior,
           navigateType,
-          optimisticRoute
+          optimisticRoute,
+          navigationLock
         )
       }
     }
@@ -188,7 +198,8 @@ function navigateImpl(
     currentFlightRouterState,
     freshnessPolicy,
     scrollBehavior,
-    navigateType
+    navigateType,
+    navigationLock
   ).catch(() => {
     // If the navigation fails, return the current state
     return state
@@ -209,6 +220,7 @@ export function navigateToKnownRoute(
   nextUrl: string | null,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
+  navigationLock: NavigationLock,
   debugInfo: Array<unknown> | null,
   // The route cache entry used for this navigation, if it came from route
   // prediction. Passed through so it can be marked as having a dynamic rewrite
@@ -272,7 +284,8 @@ export function navigateToKnownRoute(
         freshnessPolicy,
         accumulation,
         routeCacheEntry,
-        navigateType
+        navigateType,
+        navigationLock
       )
     }
     return completeSoftNavigation(
@@ -305,7 +318,8 @@ function navigateUsingPrefetchedRouteTree(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  route: FulfilledRouteCacheEntry
+  route: FulfilledRouteCacheEntry,
+  navigationLock: NavigationLock
 ): AppRouterState {
   const routeTree = route.tree
   const canonicalUrl = route.canonicalUrl + url.hash
@@ -332,6 +346,7 @@ function navigateUsingPrefetchedRouteTree(
     nextUrl,
     scrollBehavior,
     navigateType,
+    navigationLock,
     null,
     route
   )
@@ -360,7 +375,8 @@ async function navigateToUnknownRoute(
   currentFlightRouterState: FlightRouterState,
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  navigationLock: NavigationLock
 ): Promise<AppRouterState> {
   // Runs when a navigation happens but there's no cached prefetch we can use.
   // Don't bother to wait for a prefetch response; go straight to a full
@@ -520,6 +536,7 @@ async function navigateToUnknownRoute(
     nextUrl,
     scrollBehavior,
     navigateType,
+    navigationLock,
     debugInfo,
     // Unknown route navigations don't use route prediction - the route tree
     // came directly from the server. If a mismatch occurs during dynamic data
@@ -947,7 +964,8 @@ async function ensurePrefetchThenNavigate(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  navigationLock: NavigationLock
 ): Promise<AppRouterState> {
   const link = getLinkForCurrentNavigation()
   const fetchStrategy = link !== null ? link.fetchStrategy : FetchStrategy.PPR
@@ -977,7 +995,8 @@ async function ensurePrefetchThenNavigate(
     nextUrl,
     freshnessPolicy,
     scrollBehavior,
-    navigateType
+    navigateType,
+    navigationLock
   )
 
   // Only transition to captured-SPA once the navigation is known to be an SPA.

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/await-connection/loading.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/await-connection/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading await connection page...</div>
+}

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/await-connection/page.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/await-connection/page.tsx
@@ -1,0 +1,12 @@
+import { connection } from 'next/server'
+
+export default async function TargetPage() {
+  await connection()
+
+  return (
+    <div>
+      <h1>Target Page</h1>
+      <div data-testid="dynamic-content">Dynamic content loaded</div>
+    </div>
+  )
+}

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/page.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/page.tsx
@@ -31,49 +31,41 @@ export default function Page() {
         </li>
       </ol>
       <nav style={{ marginTop: '1.5rem' }}>
-        <Link
-          href="/target-page/my-post?search=foo"
-          id="link-to-target"
-          style={{
-            display: 'inline-block',
-            padding: '0.5rem 1rem',
-            background: '#0070f3',
-            color: '#fff',
-            borderRadius: 6,
-            textDecoration: 'none',
-          }}
-        >
-          Go to target page &rarr;
-        </Link>
-        <Link
-          href="/mpa-target"
-          id="link-to-mpa-target"
-          style={{
-            display: 'inline-block',
-            marginLeft: '0.75rem',
-            padding: '0.5rem 1rem',
-            background: '#111',
-            color: '#fff',
-            borderRadius: 6,
-            textDecoration: 'none',
-          }}
-        >
-          Go to MPA target &rarr;
-        </Link>
-        {/* <Link
-          href="/blocking-page?foo=bar"
-          id="link-to-target"
-          style={{
-            display: 'inline-block',
-            padding: '0.5rem 1rem',
-            background: '#0070f3',
-            color: '#fff',
-            borderRadius: 6,
-            textDecoration: 'none',
-          }}
-        >
-          Go to blocking page
-        </Link> */}
+        <div>
+          <Link
+            href="/target-page/my-post?search=foo"
+            id="link-to-target"
+            style={{
+              display: 'inline-block',
+              padding: '0.5rem 1rem',
+              background: '#0070f3',
+              color: '#fff',
+              borderRadius: 6,
+              textDecoration: 'none',
+            }}
+          >
+            Go to target page &rarr;
+          </Link>
+          <Link
+            href="/mpa-target"
+            id="link-to-mpa-target"
+            style={{
+              display: 'inline-block',
+              marginLeft: '0.75rem',
+              padding: '0.5rem 1rem',
+              background: '#111',
+              color: '#fff',
+              borderRadius: 6,
+              textDecoration: 'none',
+            }}
+          >
+            Go to MPA target &rarr;
+          </Link>
+        </div>
+
+        <div>
+          <Link href="/await-connection">Page with await connection</Link>
+        </div>
       </nav>
     </div>
   )

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -2,12 +2,10 @@ import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { retry, toggleDevToolsIndicatorPopover } from 'next-test-utils'
 
 // FIXME: Skipped due to flakiness. Reenable when fixed
-describe.skip('instant-nav-panel', () => {
+describe('instant-nav-panel', () => {
   const { isNextDev, isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
-
-  const targetPage = '/target-page/my-post?search=foo'
 
   async function waitForPanelRouterTransition() {
     // Run all the necessary CSS transitions
@@ -249,12 +247,26 @@ describe.skip('instant-nav-panel', () => {
       .waitFor({ state: 'visible', timeout: 30000 })
   }
 
+  async function expectAwaitConnectionPageLoading(browser: Playwright) {
+    await retry(
+      async () => {
+        const text = await browser.elementByCss('body').text()
+        expect(text).toContain('Loading await connection page...')
+      },
+      30_000,
+      500
+    )
+    expect(
+      await browser.locator('[data-testid="dynamic-content"]').count()
+    ).toBe(0)
+  }
+
   async function openHomeWithTargetPageWarmup() {
     const [browser] = await Promise.all([
       next.browser('/'),
       isNextDev && !isTurbopack
         ? // warmup target page compilation before clicking Start, to avoid extra flakiness.
-          next.render(targetPage).catch(() => {})
+          next.render('/target-page/my-post?search=foo').catch(() => {})
         : null,
     ])
     await clearInstantModeCookie(browser)
@@ -332,7 +344,7 @@ describe.skip('instant-nav-panel', () => {
 
   describe('MPA captures', () => {
     it('should show page load state after clicking Start and refreshing', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await next.browser('/target-page/my-post?search=foo')
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)
@@ -369,7 +381,7 @@ describe.skip('instant-nav-panel', () => {
     })
 
     it('should reset the panel and app when pressing the close button from captured MPA state', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await next.browser('/target-page/my-post?search=foo')
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)
@@ -389,7 +401,7 @@ describe.skip('instant-nav-panel', () => {
     })
 
     it('should keep params and searchParams RSC content suspended for a captured MPA page load', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await next.browser('/target-page/my-post?search=foo')
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)
@@ -428,7 +440,7 @@ describe.skip('instant-nav-panel', () => {
     })
 
     it('should re-arm capture and return to awaiting navigation after Continue Rendering from MPA state', async () => {
-      const browser = await next.browser(targetPage)
+      const browser = await next.browser('/target-page/my-post?search=foo')
       await clearInstantModeCookie(browser)
 
       await openInstantNavPanel(browser)
@@ -467,7 +479,7 @@ describe.skip('instant-nav-panel', () => {
       })
 
       // Navigate to target page via SPA (use eval to bypass overlay pointer interception)
-      await clickLink(browser, targetPage)
+      await clickLink(browser, '/target-page/my-post?search=foo')
 
       // Panel should transition to client navigation capture state
       await expectSpaPanel(browser)
@@ -485,7 +497,7 @@ describe.skip('instant-nav-panel', () => {
       await clickStartCapturing(browser)
 
       // Navigate to target page via SPA (use eval to bypass overlay pointer interception)
-      await clickLink(browser, targetPage)
+      await clickLink(browser, '/target-page/my-post?search=foo')
 
       // Dynamic data should be suspended under the lock.
       // Use a longer timeout because dev mode needs to compile the target page.
@@ -505,7 +517,7 @@ describe.skip('instant-nav-panel', () => {
 
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
-      await clickLink(browser, targetPage)
+      await clickLink(browser, '/target-page/my-post?search=foo')
       await expectSpaPanel(browser)
       await expectTargetPageSpaShell(browser)
 
@@ -523,7 +535,7 @@ describe.skip('instant-nav-panel', () => {
 
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
-      await clickLink(browser, targetPage)
+      await clickLink(browser, '/target-page/my-post?search=foo')
       await expectSpaPanel(browser)
 
       await expectTargetPageSpaShell(browser)
@@ -534,8 +546,23 @@ describe.skip('instant-nav-panel', () => {
 
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
-      await clickLink(browser, targetPage)
+      await clickLink(browser, '/target-page/my-post?search=foo')
       await expectSpaPanel(browser)
+
+      await clickContinueRendering(browser)
+      await expectPendingPanel(browser)
+      await expectTargetPageRendered(browser)
+      await waitForInstantModeCookie(browser)
+    })
+
+    it('should continue rendering a captured await connection navigation with loading.tsx', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(browser, '/await-connection')
+      await expectSpaPanel(browser)
+      await expectAwaitConnectionPageLoading(browser)
 
       await clickContinueRendering(browser)
       await expectPendingPanel(browser)
@@ -556,7 +583,7 @@ describe.skip('instant-nav-panel', () => {
       await waitForInstantNavPanelOpen(browser)
       await expectMpaPanel(browser)
 
-      await clickLink(browser, targetPage)
+      await clickLink(browser, '/target-page/my-post?search=foo')
       await expectSpaPanel(browser)
       await expectTargetPageSpaShell(browser)
     })
@@ -566,7 +593,7 @@ describe.skip('instant-nav-panel', () => {
 
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
-      await clickLink(browser, targetPage)
+      await clickLink(browser, '/target-page/my-post?search=foo')
       await expectSpaPanel(browser)
 
       await browser.refresh()

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { retry, toggleDevToolsIndicatorPopover } from 'next-test-utils'
 
 // FIXME: Skipped due to flakiness. Reenable when fixed
-describe('instant-nav-panel', () => {
+describe.skip('instant-nav-panel', () => {
   const { isNextDev, isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })


### PR DESCRIPTION
## Summary

- Add regression coverage for Navigation Inspector `Continue Rendering` with a route-level `loading.tsx`
- Fix Instant Navigation lock timing by snapshotting the active lock when a dynamic request starts
- Prevent inspector re-arm from trapping in-flight dynamic responses behind the next capture lock

## Why

The Navigation Inspector recently changed `Continue Rendering` to re-arm capture after releasing the current lock. That surfaced a race in the lower-level Instant Navigation lock handling.

The flow was:

1. `Continue Rendering` deletes the `next-instant-navigation-testing` cookie.
2. Deleting the cookie releases the current navigation lock and triggers a soft refresh.
3. The inspector quickly writes a new pending cookie to re-arm capture.
4. A route-level `loading.tsx` navigation may still have dynamic data applying from the unlock-triggered refresh.
5. Before this change, `fetchMissingDynamicData` waited on whichever lock was active when the response was applied.

That meant the refresh response could accidentally see the newly re-armed lock and suspend forever.

This surfaced with `loading.tsx` more reliably than inline Suspense because the route-level loading boundary commits the segment loading shell, then final content depends on the unlock refresh path. Inline Suspense generally keeps the deferred dynamic work associated with the original captured navigation, so it waits on the original lock and resumes when that lock is released.

## Fix

Dynamic requests now capture the current navigation lock when the request starts, then wait only on that specific lock when applying the response.

This preserves the intended behavior:

- Requests started during a capture still wait for that capture to release.
- Requests started after unlock are not blocked by a later re-arm.
- The inspector can continue re-arming capture without racing in-flight refresh responses.

Conceptually, a dynamic request should wait on the lock that existed when that request started, not whatever lock happens to exist later when its response is applied.