### PR TITLE
Keep Instant DevTools locked when opening error overlay

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
@@ -512,7 +512,12 @@ export function NextLogo({
                         return
                       }
                       dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
-                      setPanel(null)
+                      // Keep the instant navigation panel mounted so its capture
+                      // survives and it stays behind the error overlay backdrop.
+                      // Other panels still close when the overlay opens.
+                      if (panel !== 'instant-navs') {
+                        setPanel(null)
+                      }
                     }}
                   >
                     {state.disableDevIndicator && (

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
@@ -5,10 +5,12 @@ import { css } from '../../../../utils/css'
 interface DevToolsHeaderProps {
   title: React.ReactNode
   children?: React.ReactNode
+  onClose?: () => void
 }
 export function DevToolsHeader({
   title,
   children,
+  onClose,
   ref,
 }: DevToolsHeaderProps & { ref?: React.Ref<HTMLDivElement> }) {
   const { setPanel } = usePanelRouterContext()
@@ -41,6 +43,10 @@ export function DevToolsHeader({
         id="_next-devtools-panel-close"
         className="dev-tools-info-close-button"
         onClick={() => {
+          if (onClose) {
+            onClose()
+            return
+          }
           setPanel('panel-selector')
         }}
         aria-label="Close devtools panel"

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -195,6 +195,8 @@ function InstantNavTransitionLayer({
   )
 }
 
+// Ends the capture: deleting the cookie triggers the CookieStore handler in
+// navigation-testing-lock.ts, which releases the lock and soft-refreshes to real data.
 function clearInstantNavCaptureCookie(): void {
   setInstantNavTransientStatus('idle')
   if (typeof cookieStore !== 'undefined') {
@@ -210,16 +212,18 @@ export function InstantNavsPanel() {
   // state, including the from-route URL for SPA captures.
   const cookieData = useInstantNavCookieState()
 
-  // Cleanup on unmount: clear cookie and close the panel.
+  // Reset UI state only, not the cookie: unmount also fires on Fast Refresh
+  // remounts, where ending an active capture would be wrong.
   useEffect(() => {
     return () => {
-      clearInstantNavCaptureCookie()
+      setInstantNavTransientStatus('idle')
       dispatch({ type: ACTION_INSTANT_NAVS_RESET })
     }
   }, [dispatch])
 
-  // Panel routes stay mounted briefly for exit animations. Reset as soon as
-  // close is requested so reopening during that animation starts fresh.
+  // Leaving the instant panel (menu/logo, X, ESC) ends the capture. The error
+  // overlay is the exception: it keeps `panel` as 'instant-navs' and only moves
+  // the panel behind it, so this effect never fires and the capture survives.
   useEffect(() => {
     if (panel !== 'instant-navs') {
       clearInstantNavCaptureCookie()

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -13,7 +13,7 @@ import {
   MENU_DURATION_MS,
 } from '../components/errors/dev-tools-indicator/utils'
 import { useDevOverlayContext } from '../../dev-overlay.browser'
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useEffect, useRef } from 'react'
 import { useRenderErrorContext } from '../dev-overlay'
 import {
   ACTION_DEV_INDICATOR_SET,
@@ -179,9 +179,37 @@ const useToggleDevtoolsVisibility = () => {
 
 export const PanelRouter = () => {
   const { state } = useDevOverlayContext()
-  const { triggerRef } = usePanelRouterContext()
+  const { triggerRef, setPanel } = usePanelRouterContext()
   const toggleDevtools = useToggleDevtoolsVisibility()
   const isAppRouter = state.routerType === 'app'
+
+  // True while the error overlay is open, cleared on a deferred tick so the single
+  // ESC that closes the overlay does not also release the capture (the instant
+  // panel's ESC handler runs later in that same keystroke). A later ESC releases.
+  const errorOverlayOpenRef = useRef(false)
+  useEffect(() => {
+    if (state.isErrorOverlayOpen) {
+      errorOverlayOpenRef.current = true
+      return
+    }
+    const timeout = setTimeout(() => {
+      errorOverlayOpenRef.current = false
+    })
+    return () => clearTimeout(timeout)
+  }, [state.isErrorOverlayOpen])
+
+  // Returns to the menu, which ends the capture via the panel-switch effect.
+  // Exceptions: clicking outside is ignored (keeps the frozen page interactive);
+  // an ESC that just closed the error overlay is ignored (errorOverlayOpenRef).
+  const closeInstantPanel = (reason?: 'escape' | 'outside') => {
+    if (reason === 'outside') {
+      return
+    }
+    if (reason === 'escape' && errorOverlayOpenRef.current) {
+      return
+    }
+    setPanel('panel-selector')
+  }
 
   useShortcuts(
     state.hideShortcut ? { [state.hideShortcut]: toggleDevtools } : {},
@@ -274,11 +302,18 @@ export const PanelRouter = () => {
             sharePanelSizeGlobally={false}
             sharePanelPositionGlobally={false}
             draggable
+            keepBehindErrorOverlay
+            onClose={closeInstantPanel}
             sizeConfig={{
               kind: 'auto',
               width: 460 / state.scale,
             }}
-            header={<DevToolsHeader title="Navigation Inspector" />}
+            header={
+              <DevToolsHeader
+                title="Navigation Inspector"
+                onClose={() => closeInstantPanel()}
+              />
+            }
           >
             <InstantNavsPanel />
           </DynamicPanel>

--- a/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.tsx
@@ -92,6 +92,8 @@ export function DynamicPanel({
   sharePanelSizeGlobally = true,
   sharePanelPositionGlobally = true,
   containerProps,
+  onClose,
+  keepBehindErrorOverlay = false,
 }: {
   header: React.ReactNode
   children: React.ReactNode
@@ -119,6 +121,8 @@ export function DynamicPanel({
         width: number
       }
   closeOnClickOutside?: boolean
+  onClose?: (reason: 'escape' | 'outside') => void
+  keepBehindErrorOverlay?: boolean
 }) {
   const { setPanel } = usePanelRouterContext()
   const { name, mounted } = usePanelContext()
@@ -142,6 +146,10 @@ export function DynamicPanel({
     triggerRef,
     mounted,
     (reason) => {
+      if (onClose) {
+        onClose(reason)
+        return
+      }
       switch (reason) {
         case 'escape': {
           setPanel('panel-selector')
@@ -188,6 +196,9 @@ export function DynamicPanel({
 
   const isResizable = sizeConfig.kind === 'resizable'
 
+  const isKeptBehindErrorOverlay =
+    keepBehindErrorOverlay && state.isErrorOverlayOpen
+
   const resolvedDimensions = useResolvedDimensions(
     isResizable ? sizeConfig.minWidth : undefined,
     isResizable ? sizeConfig.minHeight : undefined,
@@ -228,8 +239,13 @@ export function DynamicPanel({
         tabIndex={-1}
         ref={resizeContainerRef}
         className="dynamic-panel-container"
+        inert={isKeptBehindErrorOverlay || undefined}
         style={
           {
+            // While the error overlay is open, drop below it (2147483646) so the
+            // overlay's blur+dim backdrop covers this panel. Otherwise inherit the
+            // z-index from .dynamic-panel-container in dynamic-panel.css.
+            zIndex: isKeptBehindErrorOverlay ? 2147483645 : undefined,
             '--panel-top': positionStyle.top,
             '--panel-bottom': positionStyle.bottom,
             '--panel-left': positionStyle.left,

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/error-trigger.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/error-trigger.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+export function ErrorTrigger() {
+  return (
+    <button
+      type="button"
+      data-testid="trigger-error"
+      onClick={() => {
+        // Throw asynchronously so the error is reported to the dev overlay's
+        // issue list (the badge toast) WITHOUT auto-opening the overlay. A
+        // render-time throw would be caught by AppDevOverlayErrorBoundary, which
+        // calls openErrorOverlay() and auto-opens the overlay, preempting the
+        // toast-click path these tests exercise.
+        setTimeout(() => {
+          throw new Error('Instant nav devtools test error')
+        })
+      }}
+    >
+      Trigger error
+    </button>
+  )
+}

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/page.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/page.tsx
@@ -1,11 +1,13 @@
 import Link from 'next/link'
 import { HydrationMarker } from './hydration-marker'
+import { ErrorTrigger } from './error-trigger'
 
 export default function Page() {
   return (
     <div>
       <HydrationMarker />
       <h1 data-testid="home-title">Instant Navigation Mode Demo</h1>
+      <ErrorTrigger />
       <p>
         This fixture tests the <strong>Instant Navigation Mode</strong> toggle
         in Next.js Dev Tools. When enabled, navigations show only the cached or

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -1,8 +1,7 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { retry, toggleDevToolsIndicatorPopover } from 'next-test-utils'
 
-// FIXME: Skipped due to flakiness. Reenable when fixed
-describe.skip('instant-nav-panel', () => {
+describe('instant-nav-panel', () => {
   const { isNextDev, isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
@@ -309,7 +308,8 @@ describe.skip('instant-nav-panel', () => {
     return browser
   }
 
-  describe('idle state', () => {
+  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
+  describe.skip('idle state', () => {
     it('should open panel in the idle state', async () => {
       const browser = await next.browser('/')
       await clearInstantModeCookie(browser)
@@ -355,7 +355,8 @@ describe.skip('instant-nav-panel', () => {
     })
   })
 
-  describe('awaiting navigation state', () => {
+  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
+  describe.skip('awaiting navigation state', () => {
     it('should reset the panel and app when pressing the close button from awaiting navigation', async () => {
       const browser = await next.browser('/')
       await clearInstantModeCookie(browser)
@@ -376,7 +377,8 @@ describe.skip('instant-nav-panel', () => {
     })
   })
 
-  describe('MPA captures', () => {
+  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
+  describe.skip('MPA captures', () => {
     it('should show page load state after clicking Start and refreshing', async () => {
       const browser = await next.browser(targetPage)
       await clearInstantModeCookie(browser)
@@ -492,7 +494,8 @@ describe.skip('instant-nav-panel', () => {
     })
   })
 
-  describe('SPA captures', () => {
+  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
+  describe.skip('SPA captures', () => {
     it('should show client nav state after clicking Start and navigating', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 
@@ -590,7 +593,8 @@ describe.skip('instant-nav-panel', () => {
     })
   })
 
-  describe('transitions between capture types', () => {
+  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
+  describe.skip('transitions between capture types', () => {
     it('should keep the panel in MPA state after capture -> reload and then update to SPA state after client navigation', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 
@@ -627,8 +631,8 @@ describe.skip('instant-nav-panel', () => {
     })
   })
 
-  describe('keeps capture across navigation', () => {
-    it('keeps the capture when opening the menu via the logo', async () => {
+  describe('capture lifecycle', () => {
+    it('ends the capture when opening the menu via the logo', async () => {
       const browser = await next.browser('/')
       await clearInstantModeCookie(browser)
       await browser.waitForElementByCss('[data-testid="home-title"]')
@@ -638,18 +642,13 @@ describe.skip('instant-nav-panel', () => {
       await clickStartCapturing(browser)
       await expectPendingPanel(browser)
 
-      // Click the logo: this opens the menu and hides the instant panel.
+      // Click the logo: opening the menu switches away from the instant panel,
+      // which ends the capture.
       await toggleDevToolsIndicatorPopover(browser)
       await waitForPanelRouterTransition()
 
-      // The capture cookie must survive the panel switch.
-      await waitForInstantModeCookie(browser)
-
-      // Reopen from the menu and confirm we are still capturing.
-      await reopenInstantNavPanelFromMenu(browser)
-      await expectPendingPanel(browser)
-
-      await clearInstantModeCookie(browser)
+      // Leaving the panel for the menu releases the capture cookie.
+      await waitForInstantModeCookieAbsent(browser)
     })
 
     it('ends the capture when pressing Escape (no error overlay open)', async () => {

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -1,7 +1,14 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { retry, toggleDevToolsIndicatorPopover } from 'next-test-utils'
 
-describe('instant-nav-panel', () => {
+/*
+  FIXME: This entire module is flaky on CI. When making changes, remove the
+  .skip and run locally, but add it back before pushing.
+
+  We can re-enable the module on CI when the root cause of the flakiness is
+  determined (#94196).
+*/
+describe.skip('instant-nav-panel', () => {
   const { isNextDev, isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
@@ -308,8 +315,7 @@ describe('instant-nav-panel', () => {
     return browser
   }
 
-  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
-  describe.skip('idle state', () => {
+  describe('idle state', () => {
     it('should open panel in the idle state', async () => {
       const browser = await next.browser('/')
       await clearInstantModeCookie(browser)
@@ -355,8 +361,7 @@ describe('instant-nav-panel', () => {
     })
   })
 
-  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
-  describe.skip('awaiting navigation state', () => {
+  describe('awaiting navigation state', () => {
     it('should reset the panel and app when pressing the close button from awaiting navigation', async () => {
       const browser = await next.browser('/')
       await clearInstantModeCookie(browser)
@@ -377,8 +382,7 @@ describe('instant-nav-panel', () => {
     })
   })
 
-  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
-  describe.skip('MPA captures', () => {
+  describe('MPA captures', () => {
     it('should show page load state after clicking Start and refreshing', async () => {
       const browser = await next.browser(targetPage)
       await clearInstantModeCookie(browser)
@@ -494,8 +498,7 @@ describe('instant-nav-panel', () => {
     })
   })
 
-  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
-  describe.skip('SPA captures', () => {
+  describe('SPA captures', () => {
     it('should show client nav state after clicking Start and navigating', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 
@@ -593,8 +596,7 @@ describe('instant-nav-panel', () => {
     })
   })
 
-  // FIXME: Skipped due to flakiness. Reenable when fixed (#94196).
-  describe.skip('transitions between capture types', () => {
+  describe('transitions between capture types', () => {
     it('should keep the panel in MPA state after capture -> reload and then update to SPA state after client navigation', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -114,6 +114,52 @@ describe.skip('instant-nav-panel', () => {
     })
   }
 
+  async function triggerAppError(browser: Playwright) {
+    await browser.eval(() => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="trigger-error"]')!
+        .click()
+    })
+  }
+
+  async function waitForErrorToast(browser: Playwright) {
+    await retry(async () => {
+      const hasToast = await browser.eval(() => {
+        const portal = document.querySelector('nextjs-portal')
+        const root = portal?.shadowRoot ?? document
+        return Boolean(root.querySelector('[data-issues-open]'))
+      })
+      expect(hasToast).toBe(true)
+    })
+  }
+
+  async function clickErrorToast(browser: Playwright) {
+    await browser.elementByCss('[data-issues-open]').click()
+  }
+
+  async function isErrorOverlayOpen(browser: Playwright): Promise<boolean> {
+    // The overlay can linger in the DOM (hidden via React Activity) after
+    // closing, so key on data-rendered="true" rather than mere presence.
+    return browser.eval(() => {
+      const portal = document.querySelector('nextjs-portal')
+      const root = portal?.shadowRoot ?? document
+      return Boolean(
+        root.querySelector('[data-nextjs-dialog-overlay][data-rendered="true"]')
+      )
+    })
+  }
+
+  async function readInstantPanelZIndex(
+    browser: Playwright
+  ): Promise<number | null> {
+    return browser.eval(() => {
+      const portal = document.querySelector('nextjs-portal')
+      const root = portal?.shadowRoot
+      const el = root?.querySelector('.dynamic-panel-container')
+      return el ? Number(getComputedStyle(el).zIndex) : null
+    })
+  }
+
   async function clickInstantNavMenuItemIfMounted(browser: Playwright) {
     return browser.eval(() => {
       const portal = document.querySelector('nextjs-portal')
@@ -578,6 +624,148 @@ describe.skip('instant-nav-panel', () => {
 
       await expectMpaPanel(browser)
       await expectTargetPageMpaShell(browser)
+    })
+  })
+
+  describe('keeps capture across navigation', () => {
+    it('keeps the capture when opening the menu via the logo', async () => {
+      const browser = await next.browser('/')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      // Click the logo: this opens the menu and hides the instant panel.
+      await toggleDevToolsIndicatorPopover(browser)
+      await waitForPanelRouterTransition()
+
+      // The capture cookie must survive the panel switch.
+      await waitForInstantModeCookie(browser)
+
+      // Reopen from the menu and confirm we are still capturing.
+      await reopenInstantNavPanelFromMenu(browser)
+      await expectPendingPanel(browser)
+
+      await clearInstantModeCookie(browser)
+    })
+
+    it('ends the capture when pressing Escape (no error overlay open)', async () => {
+      const browser = await next.browser('/')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      await browser.keydown('Escape')
+      await browser.keyup('Escape')
+
+      await waitForPanelRouterTransition()
+      await waitForInstantModeCookieAbsent(browser)
+    })
+
+    it('ends the capture when pressing the X close button', async () => {
+      const browser = await next.browser('/')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      await closePanelViaHeader(browser)
+
+      await waitForPanelRouterTransition()
+      await waitForInstantModeCookieAbsent(browser)
+    })
+
+    it('keeps the capture and panel mounted when opening the error overlay', async () => {
+      const browser = await next.browser('/')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      await triggerAppError(browser)
+      await waitForErrorToast(browser)
+      await clickErrorToast(browser)
+      await retry(async () => {
+        expect(await isErrorOverlayOpen(browser)).toBe(true)
+      })
+
+      // Capture survives and the panel stays mounted behind the overlay.
+      await waitForInstantModeCookie(browser)
+      expect(await isInstantNavPanelMounted(browser)).toBe(true)
+
+      await clearInstantModeCookie(browser)
+    })
+
+    it('keeps the instant panel behind the error overlay', async () => {
+      const browser = await next.browser('/')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await triggerAppError(browser)
+      await waitForErrorToast(browser)
+      await clickErrorToast(browser)
+      await retry(async () => {
+        expect(await isErrorOverlayOpen(browser)).toBe(true)
+      })
+
+      await retry(async () => {
+        const z = await readInstantPanelZIndex(browser)
+        expect(z).not.toBeNull()
+        expect(z).toBeLessThan(2147483646)
+      })
+
+      await clearInstantModeCookie(browser)
+    })
+
+    it('closes the error overlay first on Escape and keeps the capture', async () => {
+      const browser = await next.browser('/')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await triggerAppError(browser)
+      await waitForErrorToast(browser)
+      await clickErrorToast(browser)
+      await retry(async () => {
+        expect(await isErrorOverlayOpen(browser)).toBe(true)
+      })
+
+      // First Escape: the overlay closes, the capture survives.
+      await browser.keydown('Escape')
+      await browser.keyup('Escape')
+      await retry(async () => {
+        expect(await isErrorOverlayOpen(browser)).toBe(false)
+      })
+      await waitForInstantModeCookie(browser)
+      expect(await isInstantNavPanelMounted(browser)).toBe(true)
+
+      // Wait for the deferred errorOverlayOpenRef clear so the next ESC releases.
+      await waitForPanelRouterTransition()
+
+      // Second Escape: now the panel close releases the capture.
+      await browser.keydown('Escape')
+      await browser.keyup('Escape')
+      await waitForInstantModeCookieAbsent(browser)
+
+      await clearInstantModeCookie(browser)
     })
   })
 })


### PR DESCRIPTION
### Why?

The Instant DevTools closes when opening the error overlay and continues hydration. This is annoying when I wanted to check the error, but didn't mean to stop the capture.

Before:

[github.com/user-attachments/assets/f1de72a9-5a2b-4e4e-bd7e-e7f36c975ea7](https://github.com/user-attachments/assets/f1de72a9-5a2b-4e4e-bd7e-e7f36c975ea7)

After:

https://github.com/user-attachments/assets/f060e11e-9d60-43f6-a1fd-ca735fad1aa1