### PR TITLE
refactor: make early/late checks stricter

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1285,5 +1285,6 @@
   "1284": "Cache Components error recovery expected an original prerender store",
   "1285": "Cache Components error recovery expected an original resume data cache",
   "1286": "Route \"%s\": Could not validate that a segment in your UI has instant navigation.",
-  "1287": "A render that hasn't started yet cannot be abandoned"
+  "1287": "A render that hasn't started yet cannot be abandoned",
+  "1288": "Cannot determine late/early stage before starting the render"
 }

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -65,7 +65,10 @@ export function createMetadataComponents({
     parsedQuery,
     isRuntimePrefetchable
   )
-  const pathnameForMetadata = createServerPathnameForMetadata(pathname)
+  const pathnameForMetadata = createServerPathnameForMetadata(
+    pathname,
+    isRuntimePrefetchable
+  )
 
   async function Viewport() {
     // Gate metadata to the correct render stage. If the page is not

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -37,6 +37,27 @@ export function getNextStage(
   ]
 }
 
+export function isEarlyRenderStage(
+  stage: Exclude<RenderStage, RenderStage.Before>
+): boolean {
+  switch (stage) {
+    case RenderStage.EarlyStatic:
+    case RenderStage.EarlyRuntime: {
+      return true
+    }
+    case RenderStage.Static:
+    case RenderStage.Runtime:
+    case RenderStage.Dynamic:
+    case RenderStage.Abandoned: {
+      return false
+    }
+    default: {
+      stage satisfies never
+      throw new InvariantError(`Invalid render stage: ${stage}`)
+    }
+  }
+}
+
 export class StagedRenderingController {
   private abortSignal: AbortSignal | null
   private abandonController: AbortController | null

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -21,7 +21,7 @@ import type { WorkStore } from './work-async-storage.external'
 import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../client/components/app-router-headers'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import type { StagedRenderingController } from './staged-rendering'
-import { RenderStage } from './staged-rendering'
+import { isEarlyRenderStage, RenderStage } from './staged-rendering'
 import type { ValidationBoundaryTracking } from './instant-validation/boundary-tracking'
 import type { InstantValidationSampleTracking } from './instant-validation/instant-samples'
 
@@ -131,10 +131,13 @@ export type AsyncApiPromises = {
 export function isInEarlyRenderStage(requestStore: RequestStore): boolean {
   const stagedRendering = requestStore.stagedRendering
   if (stagedRendering) {
-    return (
-      stagedRendering.currentStage === RenderStage.EarlyStatic ||
-      stagedRendering.currentStage === RenderStage.EarlyRuntime
-    )
+    const { currentStage } = stagedRendering
+    if (currentStage === RenderStage.Before) {
+      throw new InvariantError(
+        'Cannot determine late/early stage before starting the render'
+      )
+    }
+    return isEarlyRenderStage(currentStage)
   }
   return false
 }

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -1,7 +1,9 @@
+import { InvariantError } from '../shared/lib/invariant-error'
 import {
   RenderStage,
   type AdvanceableRenderStage,
   type StagedRenderingController,
+  isEarlyRenderStage,
 } from './app-render/staged-rendering'
 import type {
   PrerenderStoreModernRuntime,
@@ -117,13 +119,15 @@ export function makeDevtoolsIOAwarePromise<T>(
 export function getRuntimeStage(
   stagedRendering: StagedRenderingController
 ): RenderStage.EarlyRuntime | RenderStage.Runtime {
-  if (
-    stagedRendering.currentStage === RenderStage.EarlyStatic ||
-    stagedRendering.currentStage === RenderStage.EarlyRuntime
-  ) {
-    return RenderStage.EarlyRuntime
+  const { currentStage } = stagedRendering
+  if (currentStage === RenderStage.Before) {
+    throw new InvariantError(
+      'Cannot determine late/early stage before starting the render'
+    )
   }
-  return RenderStage.Runtime
+  return isEarlyRenderStage(currentStage)
+    ? RenderStage.EarlyRuntime
+    : RenderStage.Runtime
 }
 
 /**

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -15,14 +15,13 @@ import {
   type PrerenderStoreModernServer,
   type PrerenderStorePPR,
 } from '../app-render/work-unit-async-storage.external'
-import {
-  delayUntilRuntimeStage,
-  makeHangingPromise,
-} from '../dynamic-rendering-utils'
+import { makeHangingPromise } from '../dynamic-rendering-utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
+import { RenderStage } from '../app-render/staged-rendering'
 
 export function createServerPathnameForMetadata(
-  underlyingPathname: string
+  underlyingPathname: string,
+  isRuntimePrefetchable: boolean
 ): Promise<string> {
   const workStore = workAsyncStorage.getStore()
   if (!workStore) {
@@ -55,11 +54,21 @@ export function createServerPathnameForMetadata(
         throw new InvariantError(
           'createServerPathnameForMetadata should not be called inside generateStaticParams.'
         )
-      case 'prerender-runtime':
-        return delayUntilRuntimeStage(
-          workUnitStore,
-          createRenderPathname(underlyingPathname)
-        )
+      case 'prerender-runtime': {
+        const { stagedRendering } = workUnitStore
+        if (stagedRendering) {
+          const stage = isRuntimePrefetchable
+            ? RenderStage.EarlyRuntime
+            : RenderStage.Runtime
+          return stagedRendering.delayUntilStage(
+            stage,
+            undefined,
+            underlyingPathname
+          )
+        } else {
+          return createRenderPathname(underlyingPathname)
+        }
+      }
       case 'request':
         return createRenderPathname(underlyingPathname)
       default:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

While working on #93801 , i added some stricter checks about early/late stages. In particular, if we're in the `Before`stage (generally, while running `createComponentTree`), we can't know if we're supposed to use early or late stages. Making this stricter revealed that `createServerPathnameForMetadata` was accidentally always using the late stage because it runs in `Before`. Instead, it should check `isRuntimePrefetchable` like we do for `params` and `searchParams`, so i'm refactoring it to do that here.