### PR TITLE
Turbopack: support turbopackIgnore on more traced calls

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3541,7 +3541,10 @@ async fn value_visitor_inner(
         JsValue::WellKnownFunction(
             WellKnownFunctionKind::PathJoin
             | WellKnownFunctionKind::PathResolve(_)
-            | WellKnownFunctionKind::FsReadMethod(_),
+            | WellKnownFunctionKind::FsReadMethod(_)
+            | WellKnownFunctionKind::FsReadDir
+            | WellKnownFunctionKind::ChildProcessSpawnMethod(_)
+            | WellKnownFunctionKind::ChildProcessFork,
         ) => {
             if ignore {
                 return Ok((


### PR DESCRIPTION
This already worked:
```js
fs.readFileSync(/*turbopackIgnore: true*/ x)
```
but this didn't:
```js
fs.readdirSync(/*turbopackIgnore: true*/ x)
```