### PR TITLE
fix: build hangs if sync IO aborts before root chunk is flushed

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -165,6 +165,7 @@ import {
   trackThrownErrorInNavigation,
   createInstantValidationState,
   type NavigationValidationResult,
+  throwIfSyncIOUsed,
 } from './dynamic-rendering'
 import { logBuildDebugHint } from './blocking-route-messages'
 import {
@@ -7813,6 +7814,14 @@ async function prerenderToStream(
           finalServerReactController.abort()
         }
       )
+
+      // If a sync IO error occurred, there's no point continuing.
+      // NOTE: this early exit is load-bearing. The way we simulate a halt
+      // in a render (ignoring all chunks emitted after an abort)
+      // can lead to a blocked root chunk (if it didn't flush before the abort).
+      // This means that deserializing the RSC payload can hang in unexpected places --
+      // normally, we can at least get the outer object with hanging promises inside.
+      throwIfSyncIOUsed(workStore, serverDynamicTracking)
 
       const reactServerResult = (reactServerPrerenderResult =
         new ReactServerPrerenderResult(collectedChunks.prerenderChunks))

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1969,6 +1969,17 @@ async function finalRuntimeServerPrerender(
         // something that required aborting the prerender synchronously such
         // as with new Date()
         serverIsDynamic = true
+
+        // FIXME(NAR-810): If we're already aborted due to Sync IO, there should be no need to
+        // finish the accumulators. However, it seems like in `--debug-prerender`
+        // the stream will stay open if we don't close the iterable here.
+        if (
+          process.env.NODE_ENV === 'development' &&
+          staleTimeIterable !== undefined
+        ) {
+          staleTimeIterable.close()
+        }
+
         return
       }
 
@@ -7788,6 +7799,16 @@ async function prerenderToStream(
             // If the server controller is already aborted we must have called something
             // that required aborting the prerender synchronously such as with new Date()
             serverIsDynamic = true
+
+            // FIXME(NAR-810): If we're already aborted due to Sync IO, there should be no need to
+            // finish the accumulators. However, it seems like in `--debug-prerender`
+            // the stream will stay open if we don't close the iterable here.
+            if (
+              process.env.NODE_ENV === 'development' &&
+              staleTimeIterable !== undefined
+            ) {
+              staleTimeIterable.close()
+            }
             return
           }
 

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -1244,13 +1244,10 @@ export function logDisallowedDynamicError(
   logBuildDebugHint(workStore.route)
 }
 
-export function throwIfDisallowedDynamic(
+export function throwIfSyncIOUsed(
   workStore: WorkStore,
-  prelude: PreludeState,
-  dynamicValidation: DynamicValidationState,
-  serverDynamic: DynamicTrackingState,
-  allowEmptyStaticShell: boolean
-): void {
+  serverDynamic: DynamicTrackingState
+) {
   if (serverDynamic.syncDynamicErrorWithStack) {
     logDisallowedDynamicError(
       workStore,
@@ -1258,6 +1255,16 @@ export function throwIfDisallowedDynamic(
     )
     throw new StaticGenBailoutError()
   }
+}
+
+export function throwIfDisallowedDynamic(
+  workStore: WorkStore,
+  prelude: PreludeState,
+  dynamicValidation: DynamicValidationState,
+  serverDynamic: DynamicTrackingState,
+  allowEmptyStaticShell: boolean
+): void {
+  throwIfSyncIOUsed(workStore, serverDynamic)
 
   // The dynamic metadata error is a mistake-detection signal. It fires when the
   // rest of the shell is otherwise fully static apart from metadata, suggesting

--- a/test/production/app-dir/sync-io-blocks-root/app/async-root-sync-page/layout.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/async-root-sync-page/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default async function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/sync-io-blocks-root/app/async-root-sync-page/page.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/async-root-sync-page/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <SyncIO />
+    </Suspense>
+  )
+}
+
+function SyncIO() {
+  const now = Date.now()
+  return <code>{now}</code>
+}

--- a/test/production/app-dir/sync-io-blocks-root/app/sync-root-async-page/layout.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/sync-root-async-page/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+
+// Note: it's important that the root layout is sync.
+// If it's async, then it gets outlined and the root chunk
+// manages to flush before the sync IO is triggered.
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/sync-io-blocks-root/app/sync-root-async-page/page.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/sync-root-async-page/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+
+export default async function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <SyncIO />
+    </Suspense>
+  )
+}
+
+async function SyncIO() {
+  const now = Date.now()
+  return <code>{now}</code>
+}

--- a/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page-no-suspense/layout.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page-no-suspense/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+
+// Note: it's important that the root layout is sync.
+// If it's async, then it gets outlined and the root chunk
+// manages to flush before the sync IO is triggered.
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page-no-suspense/page.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page-no-suspense/page.tsx
@@ -1,0 +1,4 @@
+export default function Page() {
+  const now = Date.now()
+  return <code>{now}</code>
+}

--- a/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page/layout.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+
+// Note: it's important that the root layout is sync.
+// If it's async, then it gets outlined and the root chunk
+// manages to flush before the sync IO is triggered.
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page/page.tsx
+++ b/test/production/app-dir/sync-io-blocks-root/app/sync-root-sync-page/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <SyncIO />
+    </Suspense>
+  )
+}
+
+function SyncIO() {
+  const now = Date.now()
+  return <code>{now}</code>
+}

--- a/test/production/app-dir/sync-io-blocks-root/next.config.js
+++ b/test/production/app-dir/sync-io-blocks-root/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  staticPageGenerationTimeout: 30,
+  experimental: {
+    staticGenerationRetryCount: 1,
+    staticGenerationMaxConcurrency: 1,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
+++ b/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
@@ -1,0 +1,56 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('sync IO that blocks the root', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  // This test suite repros a regression introduced in https://github.com/vercel/next.js/pull/94044.
+  // We switched from prerender to render + cutting of chunks that are emitted after abort.
+  // This works for the abort we trigger to finish prerendering, because we ensure that
+  // everything that was going to flush some output already did so before we abort.
+  // However, when Sync IO causes an abrupt abort in the middle of rendering, we also have
+  // to stop collecting output immediately (because e.g. async iterables are errored immediately,
+  // without `scheduleWork`), which means that partially finished chunks may get omitted from the output.
+  // Essentially, when Sync IO happens, we might lose more content that we would've if we did a halt.
+  // With the pages in this test suite, the root chunk (row 0) ends up being blocked.
+  // Before the fix introduced in this PR, this bad RSC payload would then flow into `collec-segment-data.ts`
+  // which attempts to deserialize it and hangs in an unexpected way (because with a halt, the
+  // root chunk was always there).
+
+  describe.each([
+    {
+      description: 'production',
+      isDebugPrerender: false,
+    },
+    {
+      description: 'with --debug-prerender',
+      isDebugPrerender: true,
+    },
+  ])(
+    'does not hang the build and reports sync IO errors - $description',
+    ({ isDebugPrerender }) => {
+      it.each([
+        '/async-root-sync-page',
+        '/sync-root-async-page',
+        '/sync-root-sync-page',
+        '/sync-root-sync-page-no-suspense',
+      ])('%s', async (route) => {
+        const args = [`--debug-build-paths=app/${route}/*`]
+        if (isDebugPrerender) {
+          args.push('--debug-prerender')
+        }
+        const result = await next.build({ args })
+
+        expect(result.cliOutput).toContain(
+          `Error: Route "${route}": Next.js encountered the unstable value \`Date.now()\` while prerendering.`
+        )
+        expect(result.cliOutput).not.toMatch(
+          /Failed to build .*? because it took more than \d+ seconds\. Retrying again shortly\./
+        )
+        expect(result.exitCode).toBe(1)
+      })
+    }
+  )
+})

--- a/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
+++ b/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
@@ -15,7 +15,7 @@ describe('sync IO that blocks the root', () => {
   // without `scheduleWork`), which means that partially finished chunks may get omitted from the output.
   // Essentially, when Sync IO happens, we might lose more content that we would've if we did a halt.
   // With the pages in this test suite, the root chunk (row 0) ends up being blocked.
-  // Before the fix introduced in this PR, this bad RSC payload would then flow into `collec-segment-data.ts`
+  // Before the fix introduced in this PR, this bad RSC payload would then flow into `collect-segment-data.ts`
   // which attempts to deserialize it and hangs in an unexpected way (because with a halt, the
   // root chunk was always there).
 


### PR DESCRIPTION

Mitigates a regression introduced in https://github.com/vercel/next.js/pull/94044. We switched from prerender to render + cutting of chunks that are emitted after abort. This works well for the abort we trigger to finish prerendering, because we ensure that everything that was going to flush some output already did so before we abort.
However, when Sync IO causes an abrupt abort in the middle of rendering, we also have to stop collecting output immediately (because e.g. async iterables are errored ~immediately, without `scheduleWork`), which means that partially-finished chunks may get omitted from the output. Essentially, when Sync IO happens, we might lose more content that we would've if we did a halt.

In the the pages in the test suite added here, the root chunk (row 0) ends up being blocked. Before the fix introduced in this PR, this bad RSC payload would then flow into `collect-segment-data.ts` which attempts to deserialize it and hangs in an unexpected way (because with a halt, the root chunk was always there). 

I've also had to add a weird workaround to the streaming prerender codepaths -- it seems like in --debug-prerender, the stale time iterable keeps the stream open even after an abort, and we need to close it manually (which seems like a react bug). See NAR-810