### PR TITLE
Revert "ci: run Linux Playwright jobs in prebuilt Microsoft container (#93794)"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -588,7 +588,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        # Playwright hangs on Node 24.16+, we can remove this exact node version
+        # pin once we update to playwright 1.60.0 or newer.
+        # https://github.com/microsoft/playwright/issues/40724
+        node: [22, '24.15.0']
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -610,7 +613,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        # Playwright hangs on Node 24.16+, we can remove this exact node version
+        # pin once we update to playwright 1.60.0 or newer.
+        node: [22, '24.15.0']
 
     uses: ./.github/workflows/build_reusable.yml
     with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -525,9 +525,6 @@ jobs:
     with:
       skipNativeBuild: 'yes'
       skipNativeInstall: 'yes'
-      # `afterBuild` invokes `rustup target add`, which is not preinstalled
-      # in the Playwright Docker image; run this job on the bare runner.
-      usePlaywrightContainer: 'no'
       afterBuild: |
         rustup target add wasm32-unknown-unknown
         node ./scripts/normalize-version-bump.js

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -101,29 +101,6 @@ on:
         required: false
         type: string
         default: 'yes'
-      playwrightDockerImage:
-        description: >
-          Docker image to use on Linux runners that need Playwright. Pinned to
-          the same version as the `playwright` dependency in `package.json`;
-          the image ships Chromium/Firefox/WebKit and all system deps
-          preinstalled, so the per-job install step is skipped on Linux.
-          Use the `-noble` (Ubuntu 24.04) variant so its glibc (>=2.39)
-          matches the `ubuntu-latest` host runners that build the
-          `next-swc.linux-x64-gnu.node` native binary; an older base (e.g.
-          `-jammy`) fails to dlopen the native binary at runtime with
-          `GLIBC_2.39 not found`.
-        required: false
-        type: string
-        default: 'mcr.microsoft.com/playwright:v1.58.2-noble'
-      usePlaywrightContainer:
-        description: >
-          When 'no', run the job directly on the Linux runner and install
-          Playwright at runtime instead of wrapping the job in
-          `playwrightDockerImage`. Use this for jobs that need tooling not
-          shipped in the container image (e.g. `rustup` for the wasm tests).
-        required: false
-        type: string
-        default: 'yes'
 env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.9.4
@@ -179,36 +156,6 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     runs-on: ${{ fromJson(inputs.runs_on_labels) }}
 
-    # Run inside Microsoft's prebuilt Playwright image on Linux when the job
-    # actually needs browsers, so the per-job "Install Playwright browsers"
-    # step (download + apt-based `--with-deps`) disappears entirely. When the
-    # expression evaluates to '', GitHub Actions runs the job directly on the
-    # runner (Windows jobs, build-only jobs, and any job that opts out via
-    # `needsPlaywright: 'no'` or `skipInstallBuild: 'yes'`).
-    container:
-      image: ${{ (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows')) && inputs.playwrightDockerImage || '' }}
-      # --ipc=host avoids Chromium running out of memory in /dev/shm.
-      # --init reaps zombie browser processes properly.
-      options: --ipc=host --init
-      env:
-        # The Next.js standalone server template binds to
-        # `process.env.HOSTNAME || '0.0.0.0'` (see
-        # `packages/next/src/build/utils.ts`). Docker auto-sets `HOSTNAME`
-        # to the container ID, which `bash -l` then preserves, so the
-        # standalone server ends up listening on the container hostname
-        # (e.g. `3363ea41c9fa`) instead of `0.0.0.0`. That breaks tests
-        # like `test/production/standalone-mode/**` that fetch
-        # `http://localhost:<port>` and now get `ECONNREFUSED`. Force the
-        # standalone default here so the bound address matches what tests
-        # expect.
-        HOSTNAME: 0.0.0.0
-        # Opt out of Next.js's Docker auto-detection so build artifacts use
-        # the persistent on-disk cache. Without this, `cache-dir.ts`
-        # short-circuits to ephemeral storage on every build and breaks
-        # tests asserting determinism between consecutive builds in the
-        # same workspace (e.g. `test/production/deterministic-build`).
-        NEXT_IGNORE_IS_DOCKER: '1'
-
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -234,32 +181,6 @@ jobs:
           else
             echo "fnm not found."
             echo "found=false" >> $GITHUB_OUTPUT
-          fi
-
-      # The Microsoft Playwright image is browser-focused and does not ship
-      # `jq`/`unzip` (required by the fnm install + `fnm env --json` parse
-      # below) or `build-essential` (required by `node-gyp` when test
-      # fixtures install native modules like `node-pty`). Install them
-      # unconditionally inside the container.
-      - name: Install container build dependencies (Linux container)
-        if: ${{ runner.os == 'Linux' && inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows') }}
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends jq unzip build-essential
-
-      # GitHub Actions sets `HOME=/github/home` for every step in a
-      # container job and overrides anything set via `container.env`.
-      # Playwright's GitHub Actions example runs the container as a
-      # non-root user, but this reusable workflow needs root so it can
-      # install jq/unzip/build-essential from the upstream image before
-      # bootstrapping. Firefox still requires $HOME to be owned by the
-      # current user, so re-own GitHub's mounted home directory in the
-      # Playwright container before tests run.
-      - name: Take ownership of /github/home (Linux container)
-        if: ${{ runner.os == 'Linux' && inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows') }}
-        run: |
-          if [ "$(id -u)" = "0" ] && [ -d /github/home ]; then
-            chown -R root:root /github/home
           fi
 
       - name: Install fnm
@@ -318,19 +239,9 @@ jobs:
         with:
           fetch-depth: 25
 
-      - name: Mark workspace as safe for Git (Linux container)
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          if [ "$(id -u)" = "0" ]; then
-            git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          fi
-
-      # Cache pnpm store on GitHub-hosted runners (self-hosted runners have
-      # their own persistent storage). Also fire inside the Playwright
-      # container since the container filesystem is always ephemeral, even
-      # when the host runner is persistent.
+      # Cache pnpm store on GitHub-hosted runners (self-hosted runners have their own persistent storage)
       - name: Get pnpm store directory
-        if: ${{ runner.environment == 'github-hosted' || (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows')) }}
+        if: ${{ runner.environment == 'github-hosted' }}
         id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
@@ -403,7 +314,7 @@ jobs:
         # risk caching an incomplete store
         # If keep conditions in sync breaks, we can split into restore and save
         # steps where saving runs based on the outcome of the install step
-        if: ${{ (runner.environment == 'github-hosted' || (inputs.needsPlaywright != 'no' && inputs.skipInstallBuild != 'yes' && inputs.usePlaywrightContainer != 'no' && !contains(inputs.runs_on_labels, 'windows'))) && (inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes') }}
+        if: ${{ runner.environment == 'github-hosted' && (inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes') }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         timeout-minutes: 5
         id: cache-pnpm-store
@@ -424,8 +335,28 @@ jobs:
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
       - name: Install Playwright browsers
-        if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' && (runner.os == 'Windows' || inputs.usePlaywrightContainer == 'no') }}
-        run: pnpm playwright install --with-deps ${{ inputs.browser }}
+        if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' }}
+        run: |
+          PW_VERSION=$(pnpm playwright --version 2>/dev/null || echo "unknown")
+          CACHE_DIR="$HOME/.cache"
+          VERSION_FILE="$CACHE_DIR/playwright-version"
+          STAMP="$CACHE_DIR/playwright-deps-$(echo "${{ inputs.browser }}" | tr ' ' '-')"
+
+          # Clear stamp files when Playwright version changes
+          if [ -f "$VERSION_FILE" ] && [ "$(cat "$VERSION_FILE")" != "$PW_VERSION" ]; then
+            echo "Playwright version changed ($(cat "$VERSION_FILE") -> $PW_VERSION), clearing stamps"
+            rm -f "$CACHE_DIR"/playwright-deps-*
+          fi
+
+          mkdir -p "$CACHE_DIR"
+          echo "$PW_VERSION" > "$VERSION_FILE"
+
+          if [ -f "$STAMP" ]; then
+            pnpm playwright install ${{ inputs.browser }}
+          else
+            pnpm playwright install --with-deps ${{ inputs.browser }}
+            touch "$STAMP"
+          fi
 
       - name: Download pre-built test timings
         if: ${{ inputs.testTimingsArtifact != '' }}

--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -203,8 +203,7 @@ function startServer(dir: string, port: number): Promise<void> {
 
     server.on('error', onError)
 
-    // Listen on localhost (both IPv4 and IPv6)
-    server.listen(port, () => {
+    server.listen(port, 'localhost', () => {
       const address = server.address()
       if (address == null) {
         reject(new Error('Unable to get server address'))

--- a/packages/next/src/server/cache-dir.ts
+++ b/packages/next/src/server/cache-dir.ts
@@ -2,16 +2,6 @@ import path from 'path'
 import isDockerFunction from 'next/dist/compiled/is-docker'
 
 export function getStorageDirectory(distDir: string): string | undefined {
-  // Allow CI environments (notably the Microsoft Playwright Docker image used
-  // by our own CI) to opt out of the Docker auto-detection. The detection
-  // assumes ephemeral storage and short-circuits to `undefined`, which forces
-  // preview/server-action keys to be regenerated on every build and breaks
-  // tests asserting determinism between consecutive builds in the same
-  // workspace.
-  if (process.env.NEXT_IGNORE_IS_DOCKER === '1') {
-    return path.join(distDir, 'cache')
-  }
-
   const isLikelyEphemeral = isDockerFunction()
 
   if (isLikelyEphemeral) {

--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -13,12 +13,9 @@ describe('nx-handling', () => {
       private: true,
       packageManager: 'npm@10.9.2',
       scripts: {
-        // Nx's isolated plugin worker can race in CI and crash before Next.js
-        // starts, so keep this fixture focused on Next.js integration.
-        build:
-          'rm -rf dist; NX_ISOLATE_PLUGINS=false nx run next-nx-test:build',
-        dev: 'NX_ISOLATE_PLUGINS=false nx run next-nx-test:dev',
-        start: 'NX_ISOLATE_PLUGINS=false nx run next-nx-test:serve:production',
+        build: 'rm -rf dist; nx run next-nx-test:build',
+        dev: 'nx run next-nx-test:dev',
+        start: 'nx run next-nx-test:serve:production',
       },
       dependencies: {
         react: '19.0.0',

--- a/test/e2e/app-dir/nx-handling/package.json
+++ b/test/e2e/app-dir/nx-handling/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "NX_ISOLATE_PLUGINS=false nx run next-nx-test:build",
-    "dev": "NX_ISOLATE_PLUGINS=false nx run next-nx-test:dev",
-    "start": "NX_ISOLATE_PLUGINS=false nx run next-nx-test:serve:production",
+    "build": "nx run next-nx-test:build",
+    "dev": "nx run next-nx-test:dev",
+    "start": "nx run next-nx-test:serve:production",
     "repro": "rm -rf dist && npm run build && npm run start"
   },
   "private": true,


### PR DESCRIPTION
We're going to go with custom images instead, though we don't have an implementation for this yet.

This does save a meaningful amount of minutes, but it also significantly increases complexity.

This is a clean revert, minus the fix that the PR included for listening on localhost in `packages/next/src/build/analyze/index.ts`, which is still good.

This also pins our exact version of Node 24 in some e2e tests because there is a bug with older versions of `playwright install` on newer versions of Node: https://github.com/microsoft/playwright/issues/40724