### PR TITLE
fix(eslint-plugin): respect pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -10,6 +10,8 @@ import {
   getUrlFromAppDirectory,
 } from '../utils/url'
 
+const DEFAULT_PAGE_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
+
 const pagesDirWarning = execOnce((pagesDirs) => {
   console.warn(
     `Pages directory cannot be found at ${pagesDirs.join(' or ')}. ` +
@@ -34,6 +36,31 @@ const memoize = <T = any>(fn: (...args: any[]) => T) => {
 
 const cachedGetUrlFromPagesDirectories = memoize(getUrlFromPagesDirectories)
 const cachedGetUrlFromAppDirectory = memoize(getUrlFromAppDirectory)
+
+/**
+ * Attempt to read pageExtensions from next.config.js in the given root directories.
+ * Returns null if the config cannot be loaded or does not specify pageExtensions.
+ */
+function readPageExtensionsFromConfig(rootDirs: string[]): string[] | null {
+  for (const rootDir of rootDirs) {
+    for (const configFile of ['next.config.js', 'next.config.cjs']) {
+      const configPath = path.join(rootDir, configFile)
+      try {
+        if (fs.existsSync(configPath)) {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const config = require(configPath)
+          const resolved = config?.default ?? config
+          if (Array.isArray(resolved?.pageExtensions)) {
+            return resolved.pageExtensions
+          }
+        }
+      } catch {
+        // Ignore: config may use ESM, have syntax errors, or side effects
+      }
+    }
+  }
+  return null
+}
 
 const url = 'https://nextjs.org/docs/messages/no-html-link-for-pages'
 
@@ -62,6 +89,17 @@ export default defineRule({
           },
         ],
       },
+      {
+        type: 'object',
+        properties: {
+          pageExtensions: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
     ],
   },
 
@@ -69,8 +107,9 @@ export default defineRule({
    * Creates an ESLint rule listener.
    */
   create(context) {
-    const ruleOptions: (string | string[])[] = context.options
-    const [customPagesDirectory] = ruleOptions
+    const ruleOptions: (string | string[] | { pageExtensions?: string[] })[] =
+      context.options
+    const [customPagesDirectory, secondOption] = ruleOptions
 
     const rootDirs = getRootDirs(context)
 
@@ -107,8 +146,22 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    // Resolve pageExtensions: rule option > next.config.js > default
+    const pageExtensions: string[] =
+      (secondOption as { pageExtensions?: string[] })?.pageExtensions ??
+      readPageExtensionsFromConfig(rootDirs) ??
+      DEFAULT_PAGE_EXTENSIONS
+
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,62 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+const DEFAULT_PAGE_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
+
+function buildExtensionRegex(pageExtensions: string[]) {
+  const escaped = pageExtensions.map((ext) =>
+    ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  )
+  return new RegExp(`\\.(${escaped.join('|')})$`)
+}
+
+function buildIndexRegex(pageExtensions: string[]) {
+  const escaped = pageExtensions.map((ext) =>
+    ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  )
+  return new RegExp(`^index\\.(${escaped.join('|')})$`)
+}
+
+function buildPageRegex(pageExtensions: string[]) {
+  const escaped = pageExtensions.map((ext) =>
+    ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  )
+  return new RegExp(`^page\\.(${escaped.join('|')})$`)
+}
+
+function buildLayoutRegex(pageExtensions: string[]) {
+  const escaped = pageExtensions.map((ext) =>
+    ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  )
+  return new RegExp(`^layout\\.(${escaped.join('|')})$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extensionRegex = buildExtensionRegex(pageExtensions)
+  const indexRegex = buildIndexRegex(pageExtensions)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extensionRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -36,24 +70,31 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extensionRegex = buildExtensionRegex(pageExtensions)
+  const pageRegex = buildPageRegex(pageExtensions)
+  const layoutRegex = buildLayoutRegex(pageExtensions)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extensionRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -132,17 +173,20 @@ export function normalizeAppPath(route: string) {
 }
 
 /**
- * Gets the possible URLs from a directory.
+ * Gets the possible URLs from a pages directory, respecting custom pageExtensions.
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +200,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.


### PR DESCRIPTION
Fixes #53473

## What

The `no-html-link-for-pages` ESLint rule hardcoded `.js/.jsx/.ts/.tsx` as the only recognized page extensions (there was even a TODO comment flagging this). When a project configures custom `pageExtensions` in `next.config.js`, the rule would not recognize those files as pages and either miss violations or produce false positives.

## How

**`packages/eslint-plugin-next/src/utils/url.ts`**
- `parseUrlForPages` and `parseUrlForAppDir` now accept a `pageExtensions: string[]` parameter (defaults to `['js','jsx','ts','tsx']`)
- Extension regexes are built dynamically from the provided extensions instead of being hardcoded
- `getUrlFromPagesDirectories` and `getUrlFromAppDirectory` forward `pageExtensions` through

**`packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts`**
- Adds `readPageExtensionsFromConfig` which tries to `require()` `next.config.js` / `next.config.cjs` from each root dir and extract `pageExtensions` (safe try/catch for ESM/errors)
- Adds an optional second rule option `{ pageExtensions: string[] }` for projects that cannot expose CJS config
- Resolution order: **rule option > next.config.js > default**

## Testing

Existing tests should pass unchanged (defaults are preserved). A project with `pageExtensions: ['page.tsx', 'page.jsx']` in `next.config.js` will now have those extensions respected by the rule.