### PR TITLE
docs: document Cache Components behavior for navigation hooks

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
@@ -5,8 +5,6 @@ description: API Reference for the usePathname hook.
 
 `usePathname` is a **Client Component** hook that lets you read the current URL's **pathname**.
 
-> **Good to know**: When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled `usePathname` may require a `Suspense` boundary around it if your route has a dynamic param. If you use `generateStaticParams` the `Suspense` boundary is optional
-
 ```tsx filename="app/example-client-component.tsx" switcher
 'use client'
 
@@ -66,6 +64,17 @@ const pathname = usePathname()
 | `/dashboard`        | `'/dashboard'`        |
 | `/dashboard?v=2`    | `'/dashboard'`        |
 | `/blog/hello-world` | `'/blog/hello-world'` |
+
+## Behavior
+
+### Cache Components
+
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the pathname can only be resolved on the server when every dynamic param in the route is known at build time. This affects whether `usePathname` needs a [`Suspense`](https://react.dev/reference/react/Suspense) boundary:
+
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the pathname is known during prerendering, so `usePathname` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `usePathname` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+
+This applies even when the component that calls `usePathname` is itself static. For example, a sidebar with active links rendered in a layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component that calls `usePathname` (or a parent) in a `Suspense` boundary with a fallback.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
@@ -69,10 +69,10 @@ const pathname = usePathname()
 
 ### Cache Components
 
-When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the pathname can only be resolved on the server when every dynamic param in the route is known at build time. This affects whether `usePathname` needs a [`Suspense`](https://react.dev/reference/react/Suspense) boundary:
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, `usePathname` may require a [`Suspense`](https://react.dev/reference/react/Suspense) boundary. This depends on whether the pathname can be resolved during prerendering.
 
-- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the pathname is known during prerendering, so `usePathname` resolves on the server and no `Suspense` boundary is required.
-- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `usePathname` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: every route segment, including dynamic params, is known at build time. The pathname can be resolved during prerendering, so `usePathname` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that is not known until request time. The pathname cannot be resolved during prerendering, so `usePathname` suspends. Wrap the component (or a parent) in a `Suspense` boundary so its fallback can be rendered during prerendering; otherwise, the build fails.
 
 This applies even when the component that calls `usePathname` is itself static. For example, a sidebar with active links rendered in a layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component that calls `usePathname` (or a parent) in a `Suspense` boundary with a fallback.
 

--- a/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
@@ -34,7 +34,7 @@ For example, a Client Component with `usePathname` will be rendered into HTML on
 > **Good to know**:
 >
 > - Reading the current URL from a [Server Component](/docs/app/getting-started/server-and-client-components) is not supported. This design is intentional to support layout state being preserved across page navigations.
-> - If your page is being statically prerendered and your app has [rewrites](/docs/app/api-reference/config/next-config-js/rewrites) in `next.config` or a [Proxy](/docs/app/api-reference/file-conventions/proxy) file, reading the pathname with `usePathname()` can result in hydration mismatch errors—because the initial value comes from the server and may not match the actual browser pathname after routing. See our [example](#avoid-hydration-mismatch-with-rewrites) for a way to mitigate this issue.
+> - If your page is being statically prerendered and your app has [rewrites](/docs/app/api-reference/config/next-config-js/rewrites) in `next.config` or a [Proxy](/docs/app/api-reference/file-conventions/proxy) file, reading the pathname with `usePathname()` can result in hydration mismatch errors, because the initial value comes from the server and may not match the actual browser pathname after routing. See our [example](#avoid-hydration-mismatch-with-rewrites) for a way to mitigate this issue.
 
 <details>
 
@@ -114,7 +114,7 @@ function ExampleClientComponent() {
 
 When a page is prerendered, the HTML is generated for the source pathname. If the page is then reached through a rewrite using `next.config` or `Proxy`, the browser URL may differ, and `usePathname()` will read the rewritten pathname on the client.
 
-To avoid hydration mismatches, design the UI so that only a small, isolated part depends on the client pathname. Render a stable fallback on the server and update that part after mount.
+To avoid hydration mismatches, design the UI so that only a small, isolated part depends on the client pathname. Render a stable fallback on the server and update that part after mount. The deferred read shows a brief moment of the fallback before the real pathname appears; see [Preventing flash before hydration](/docs/app/guides/preventing-flash-before-hydration) for techniques that eliminate the visible flicker.
 
 ```tsx filename="app/example-client-component.tsx" switcher
 'use client'

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
@@ -70,12 +70,12 @@ For catch-all routes (`[...slug]`), the returned segment contains all matched pa
 
 ### Cache Components
 
-When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the active segment can only be resolved on the server when every dynamic param in the route is known at build time. This affects whether `useSelectedLayoutSegment` needs a [`Suspense`](https://react.dev/reference/react/Suspense) boundary:
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, `useSelectedLayoutSegment` may require a [`Suspense`](https://react.dev/reference/react/Suspense) boundary. This depends on whether the active segment can be resolved during prerendering.
 
-- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the segment is known during prerendering, so `useSelectedLayoutSegment` resolves on the server and no `Suspense` boundary is required.
-- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `useSelectedLayoutSegment` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: every route segment, including dynamic params, is known at build time. The active segment can be resolved during prerendering, so `useSelectedLayoutSegment` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that is not known until request time. The active segment cannot be resolved during prerendering, so `useSelectedLayoutSegment` suspends. Wrap the component (or a parent) in a `Suspense` boundary so its fallback can be rendered during prerendering; otherwise, the build fails.
 
-This applies even when the component that calls `useSelectedLayoutSegment` is itself static. A tab bar rendered in a parent layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component (or a parent) in a `Suspense` boundary with a fallback.
+This applies even when the component that calls `useSelectedLayoutSegment` is itself static. For example, a tab bar rendered in a parent layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component that calls `useSelectedLayoutSegment` (or a parent) in a `Suspense` boundary with a fallback.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
@@ -66,6 +66,17 @@ For catch-all routes (`[...slug]`), the returned segment contains all matched pa
 | -------------------- | ------------- | ---------------- |
 | `app/blog/layout.js` | `/blog/a/b/c` | `'a/b/c'`        |
 
+## Behavior
+
+### Cache Components
+
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the active segment can only be resolved on the server when every dynamic param in the route is known at build time. This affects whether `useSelectedLayoutSegment` needs a [`Suspense`](https://react.dev/reference/react/Suspense) boundary:
+
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the segment is known during prerendering, so `useSelectedLayoutSegment` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `useSelectedLayoutSegment` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+
+This applies even when the component that calls `useSelectedLayoutSegment` is itself static. A tab bar rendered in a parent layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component (or a parent) in a `Suspense` boundary with a fallback.
+
 ## Examples
 
 ### Creating an active link component

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
@@ -82,12 +82,12 @@ For catch-all routes (`[...slug]`), all matched path segments are returned as a 
 
 ### Cache Components
 
-When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the active segments can only be resolved on the server when every dynamic param in the route is known at build time. This affects whether `useSelectedLayoutSegments` needs a [`Suspense`](https://react.dev/reference/react/Suspense) boundary:
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, `useSelectedLayoutSegments` may require a [`Suspense`](https://react.dev/reference/react/Suspense) boundary. This depends on whether the active segments can be resolved during prerendering.
 
-- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the segments are known during prerendering, so `useSelectedLayoutSegments` resolves on the server and no `Suspense` boundary is required.
-- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `useSelectedLayoutSegments` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: every route segment, including dynamic params, is known at build time. The active segments can be resolved during prerendering, so `useSelectedLayoutSegments` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that is not known until request time. The active segments cannot be resolved during prerendering, so `useSelectedLayoutSegments` suspends. Wrap the component (or a parent) in a `Suspense` boundary so its fallback can be rendered during prerendering; otherwise, the build fails.
 
-This applies even when the component that calls `useSelectedLayoutSegments` is itself static. A breadcrumb component rendered in a parent layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component (or a parent) in a `Suspense` boundary with a fallback.
+This applies even when the component that calls `useSelectedLayoutSegments` is itself static. For example, a breadcrumb component rendered in a parent layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component that calls `useSelectedLayoutSegments` (or a parent) in a `Suspense` boundary with a fallback.
 
 ## Version History
 

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
@@ -78,6 +78,17 @@ For catch-all routes (`[...slug]`), all matched path segments are returned as a 
 | `app/layout.js`      | `/blog/a/b/c` | `['blog', 'a/b/c']` |
 | `app/blog/layout.js` | `/blog/a/b/c` | `['a/b/c']`         |
 
+## Behavior
+
+### Cache Components
+
+When [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, the active segments can only be resolved on the server when every dynamic param in the route is known at build time. This affects whether `useSelectedLayoutSegments` needs a [`Suspense`](https://react.dev/reference/react/Suspense) boundary:
+
+- **Static routes and routes with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)**: the segments are known during prerendering, so `useSelectedLayoutSegments` resolves on the server and no `Suspense` boundary is required.
+- **Routes with dynamic params not covered by `generateStaticParams`**: the param is a [fallback param](/docs/app/api-reference/functions/generate-static-params#all-paths-at-build-time) that isn't known until request time. `useSelectedLayoutSegments` suspends during prerendering, so the closest `Suspense` boundary renders its fallback. Wrap the component (or a parent) in `Suspense`, otherwise the build fails.
+
+This applies even when the component that calls `useSelectedLayoutSegments` is itself static. A breadcrumb component rendered in a parent layout suspends on any page below it that has an unknown dynamic param. To keep the rest of the layout prerendered, wrap the component (or a parent) in a `Suspense` boundary with a fallback.
+
 ## Version History
 
 | Version   | Changes                                 |


### PR DESCRIPTION
### What?

Adds a `## Behavior` → `### Cache Components` section to the API reference pages for `usePathname`, `useSelectedLayoutSegment`, and `useSelectedLayoutSegments`.

### Why?

When `cacheComponents` is enabled, these hooks suspend during prerendering on routes that have dynamic params not covered by `generateStaticParams`. This was previously only hinted at with a one-line note on `usePathname` and undocumented on the layout segment hooks, even though they share the same behavior.

### How?

- `usePathname`: replaced the terse one-line note with a `## Behavior` → `### Cache Components` section explaining when it resolves on the server vs. suspends. Also added a link to the [Preventing flash before hydration](/docs/app/guides/preventing-flash-before-hydration) guide in the existing rewrite-mismatch example, and cleaned up a stray em dash.
- `useSelectedLayoutSegment`: added the same `### Cache Components` section.
- `useSelectedLayoutSegments`: added the same `### Cache Components` section.

The rewrite/Proxy hydration-mismatch gotcha is intentionally not duplicated to the layout segment pages — those hooks derive their value from the routing tree, not the URL pathname, so rewrites don't produce the same mismatch.

Documents existing behavior only — no API surface changes.