### PR TITLE
Fix root inference for ambiguous lockfiles

### DIFF
--- a/packages/next/src/lib/find-root.test.ts
+++ b/packages/next/src/lib/find-root.test.ts
@@ -1,0 +1,227 @@
+import { mkdtemp, mkdir, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { findRootDirAndLockFiles } from './find-root'
+
+async function createTempDir() {
+  return mkdtemp(join(tmpdir(), 'next-find-root-'))
+}
+
+async function writeJson(path: string, value: unknown) {
+  await writeFile(path, JSON.stringify(value))
+}
+
+describe('findRootDirAndLockFiles', () => {
+  it('uses cwd when no lockfile is found', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'app')
+    await mkdir(appDir, { recursive: true })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [],
+      rootDir: appDir,
+    })
+  })
+
+  it('uses the only detected lockfile as root', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'app')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [join(rootDir, 'package-lock.json')],
+      rootDir,
+    })
+  })
+
+  it('uses the closest lockfile when a parent lockfile is not a workspace root', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'app')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [
+        join(appDir, 'package-lock.json'),
+        join(rootDir, 'package-lock.json'),
+      ],
+      rootDir: appDir,
+    })
+  })
+
+  it('uses a parent package.json workspaces root when it contains the app', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'apps', 'web')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package.json'), {
+      private: true,
+      workspaces: ['apps/*'],
+    })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [
+        join(appDir, 'package-lock.json'),
+        join(rootDir, 'package-lock.json'),
+      ],
+      rootDir,
+    })
+  })
+
+  it('uses a parent package.json workspaces root when it contains an ancestor package', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'packages', 'site', 'apps', 'web')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package.json'), {
+      private: true,
+      workspaces: ['packages/*'],
+    })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [
+        join(appDir, 'package-lock.json'),
+        join(rootDir, 'package-lock.json'),
+      ],
+      rootDir,
+    })
+  })
+
+  it('supports package.json workspaces.packages objects and exclusions', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'apps', 'web')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package.json'), {
+      private: true,
+      workspaces: {
+        packages: ['apps/*', '!apps/docs'],
+      },
+    })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [
+        join(appDir, 'package-lock.json'),
+        join(rootDir, 'package-lock.json'),
+      ],
+      rootDir,
+    })
+  })
+
+  it('normalizes package.json workspace patterns before matching', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'apps', 'web')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package.json'), {
+      private: true,
+      workspaces: ['./apps/*/'],
+    })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [
+        join(appDir, 'package-lock.json'),
+        join(rootDir, 'package-lock.json'),
+      ],
+      rootDir,
+    })
+  })
+
+  it('does not use a parent package.json workspaces root when the app is excluded', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'apps', 'docs')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package.json'), {
+      private: true,
+      workspaces: {
+        packages: ['./apps/*/', '!./apps/docs/'],
+      },
+    })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [
+        join(appDir, 'package-lock.json'),
+        join(rootDir, 'package-lock.json'),
+      ],
+      rootDir: appDir,
+    })
+  })
+
+  it('applies package.json workspace exclusions regardless of order', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'apps', 'docs')
+    await mkdir(appDir, { recursive: true })
+    await writeJson(join(rootDir, 'package.json'), {
+      private: true,
+      workspaces: {
+        packages: ['!apps/docs', 'apps/*'],
+      },
+    })
+    await writeJson(join(rootDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [
+        join(appDir, 'package-lock.json'),
+        join(rootDir, 'package-lock.json'),
+      ],
+      rootDir: appDir,
+    })
+  })
+
+  it('prioritizes pnpm-workspace.yaml over lockfiles', async () => {
+    const rootDir = await createTempDir()
+    const appDir = join(rootDir, 'app')
+    await mkdir(appDir, { recursive: true })
+    await writeFile(
+      join(rootDir, 'pnpm-workspace.yaml'),
+      'packages:\n  - app\n'
+    )
+    await writeJson(join(appDir, 'package-lock.json'), {
+      lockfileVersion: 3,
+    })
+
+    expect(findRootDirAndLockFiles(appDir)).toEqual({
+      lockFiles: [join(rootDir, 'pnpm-workspace.yaml')],
+      rootDir,
+    })
+  })
+})

--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -1,6 +1,109 @@
-import { dirname } from 'path'
+import { dirname, join, posix, relative } from 'path'
+import { existsSync, readFileSync } from 'fs'
 import findUp from 'next/dist/compiled/find-up'
+import picomatch from 'next/dist/compiled/picomatch'
 import * as Log from '../build/output/log'
+import { normalizePath } from './normalize-path'
+
+function normalizeWorkspacePattern(pattern: string) {
+  const isExcluded = pattern.startsWith('!')
+  let normalizedPattern = normalizePath(isExcluded ? pattern.slice(1) : pattern)
+
+  while (normalizedPattern.startsWith('./')) {
+    normalizedPattern = normalizedPattern.slice(2)
+  }
+  while (normalizedPattern.endsWith('/')) {
+    normalizedPattern = normalizedPattern.slice(0, -1)
+  }
+
+  return `${isExcluded ? '!' : ''}${normalizedPattern}`
+}
+
+function getWorkspacePatternStrings(workspaces: unknown): string[] {
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter((item): item is string => typeof item === 'string')
+  }
+
+  if (
+    workspaces &&
+    typeof workspaces === 'object' &&
+    Array.isArray((workspaces as { packages?: unknown }).packages)
+  ) {
+    return (workspaces as { packages: unknown[] }).packages.filter(
+      (item): item is string => typeof item === 'string'
+    )
+  }
+
+  return []
+}
+
+function getWorkspacePatterns(workspaceRoot: string): string[] {
+  const packageJsonPath = join(workspaceRoot, 'package.json')
+
+  if (!existsSync(packageJsonPath)) {
+    return []
+  }
+
+  let workspaces: unknown
+  try {
+    workspaces = JSON.parse(readFileSync(packageJsonPath, 'utf8')).workspaces
+  } catch {
+    return []
+  }
+
+  return getWorkspacePatternStrings(workspaces)
+    .map(normalizeWorkspacePattern)
+    .filter((item) => item !== '' && item !== '!')
+}
+
+function isAppInWorkspace(workspaceRoot: string, appDir: string) {
+  const relativeAppDir = normalizePath(relative(workspaceRoot, appDir))
+
+  if (
+    !relativeAppDir ||
+    relativeAppDir === '.' ||
+    relativeAppDir.startsWith('../') ||
+    relativeAppDir === '..'
+  ) {
+    return false
+  }
+
+  const candidateDirs: string[] = []
+  let candidateDir = relativeAppDir
+  while (candidateDir && candidateDir !== '.') {
+    candidateDirs.push(candidateDir)
+    const parentDir = posix.dirname(candidateDir)
+    if (parentDir === candidateDir || parentDir === '.') {
+      break
+    }
+    candidateDir = parentDir
+  }
+
+  const workspacePatterns = getWorkspacePatterns(workspaceRoot).map(
+    (pattern) => {
+      const isExcluded = pattern.startsWith('!')
+      return {
+        isExcluded,
+        match: picomatch(isExcluded ? pattern.slice(1) : pattern),
+      }
+    }
+  )
+  const matchesWorkspacePattern = (candidate: string) => {
+    let hasInclude = false
+    for (const { isExcluded, match } of workspacePatterns) {
+      if (!match(candidate)) {
+        continue
+      }
+      if (isExcluded) {
+        return false
+      }
+      hasInclude = true
+    }
+    return hasInclude
+  }
+
+  return candidateDirs.some((candidate) => matchesWorkspacePattern(candidate))
+}
 
 function findWorkRoot(cwd: string) {
   // Find-up evaluates the list of files at each level.
@@ -58,23 +161,38 @@ export function findRootDirAndLockFiles(cwd: string): {
     lockFiles.push(newLockFile)
   }
 
+  let rootDir = dirname(lockFiles[0])
+
+  if (lockFiles.length > 1) {
+    for (let i = lockFiles.length - 1; i >= 1; i--) {
+      const candidateRootDir = dirname(lockFiles[i])
+      if (isAppInWorkspace(candidateRootDir, dirname(lockFiles[0]))) {
+        rootDir = candidateRootDir
+        break
+      }
+    }
+  }
+
   return {
     lockFiles,
-    rootDir: dirname(lockFiles[lockFiles.length - 1]),
+    rootDir,
   }
 }
 
-export function warnDuplicatedLockFiles(lockFiles: string[]) {
+export function warnDuplicatedLockFiles(lockFiles: string[], rootDir?: string) {
   if (lockFiles.length > 1) {
+    const selectedLockFile =
+      lockFiles.find((lockFile) => dirname(lockFile) === rootDir) ??
+      lockFiles[lockFiles.length - 1]
     const additionalLockFiles = lockFiles
-      .slice(0, -1)
+      .filter((lockFile) => lockFile !== selectedLockFile)
       .map((str) => `\n   * ${str}`)
       .join('')
 
     if (process.env.TURBOPACK) {
       Log.warnOnce(
         `Warning: Next.js inferred your workspace root, but it may not be correct.\n` +
-          ` We detected multiple lockfiles and selected the directory of ${lockFiles[lockFiles.length - 1]} as the root directory.\n` +
+          ` We detected multiple lockfiles and selected the directory of ${selectedLockFile} as the root directory.\n` +
           ` To silence this warning, set \`turbopack.root\` in your Next.js config, or consider ` +
           `removing one of the lockfiles if it's not needed.\n` +
           `   See https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory for more information.\n` +
@@ -83,7 +201,7 @@ export function warnDuplicatedLockFiles(lockFiles: string[]) {
     } else {
       Log.warnOnce(
         `Warning: Next.js inferred your workspace root, but it may not be correct.\n` +
-          ` We detected multiple lockfiles and selected the directory of ${lockFiles[lockFiles.length - 1]} as the root directory.\n` +
+          ` We detected multiple lockfiles and selected the directory of ${selectedLockFile} as the root directory.\n` +
           ` To silence this warning, set \`outputFileTracingRoot\` in your Next.js config, or consider ` +
           `removing one of the lockfiles if it's not needed.\n` +
           `   See https://nextjs.org/docs/app/api-reference/config/next-config-js/output#caveats for more information.\n` +

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1142,7 +1142,7 @@ function assignDefaultsAndValidate(
     const { rootDir: foundRootDir, lockFiles } = findRootDirAndLockFiles(dir)
     rootDir = foundRootDir
     if (!silent) {
-      warnDuplicatedLockFiles(lockFiles)
+      warnDuplicatedLockFiles(lockFiles, rootDir)
     }
   }
 

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -25,8 +25,13 @@ describe('multiple-lockfiles', () => {
 
   it('should have multiple lockfiles warnings', async () => {
     await retry(async () => {
+      const selectedLockFile = join(next.testDir, 'pnpm-lock.yaml')
+
       expect(next.cliOutput).toMatch(
         /We detected multiple lockfiles and selected the directory of .+ as the root directory\./
+      )
+      expect(next.cliOutput).toContain(
+        `We detected multiple lockfiles and selected the directory of ${selectedLockFile} as the root directory.`
       )
 
       if (isTurbopack) {


### PR DESCRIPTION
### What?

- Changes multiple-lockfile root inference to default to the closest lockfile unless an ancestor `package.json#workspaces` entry explicitly contains the app or one of its ancestor package directories.
- Keeps `pnpm-workspace.yaml` priority and explicit `outputFileTracingRoot` / `turbopack.root` behavior.
- Updates the multiple-lockfiles warning to report the actually selected lockfile and not list it as an additional lockfile.

### Why?

- In ambiguous projects with an unrelated parent lockfile, the previous unconditional outermost-lockfile root could expand Turbopack and output tracing scope to a large parent directory.
- Turbopack uses the configured root to resolve and watch files, so an overbroad inferred root can create unnecessary filesystem work and memory pressure.

### How?

- Parse `package.json` workspace arrays and `workspaces.packages` objects from ancestor lockfile directories.
- Match normalized workspace globs against the app directory and its ancestor package directories.
- Preserve explicit config and real workspace behavior; otherwise keep the inferred root at the nearest lockfile.

Fixes #94432

### Testing

- `pnpm --filter next... build`
- `pnpm testonly packages/next/src/lib/find-root.test.ts --runInBand`
- `pnpm testonly test/unit/isolated/config.test.ts --runInBand`
- `pnpm lint-eslint packages/next/src/lib/find-root.ts packages/next/src/lib/find-root.test.ts packages/next/src/server/config.ts test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts`
- `pnpm prettier --check packages/next/src/lib/find-root.ts packages/next/src/lib/find-root.test.ts packages/next/src/server/config.ts test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts`
- `git diff --check`
- `pnpm test-dev-turbo test/e2e/app-dir/multiple-lockfiles`
- `pnpm test-dev test/e2e/app-dir/multiple-lockfiles`
- `pnpm test-dev-turbo test/e2e/app-dir/pnpm-workspace-root -t "should not have multiple lockfiles warning"`

<!-- NEXT_JS_LLM_PR -->