### PR TITLE
Turbopack: Add an experimental option for eviction

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -81,8 +81,8 @@ use crate::{
         analyze::{WriteAnalyzeResult, write_analyze_data_with_issues_operation},
         endpoint::ExternalEndpoint,
         turbopack_ctx::{
-            NapiNextTurbopackCallbacks, NapiNextTurbopackCallbacksJsObject, NextTurboTasks,
-            NextTurbopackContext, create_turbo_tasks,
+            MemoryEvictionMode, NapiNextTurbopackCallbacks, NapiNextTurbopackCallbacksJsObject,
+            NextTurboTasks, NextTurbopackContext, create_turbo_tasks,
         },
         utils::{
             DetachedVc, NapiIssue, NapiUsedFeature, RootTask, TurbopackResult, get_issues,
@@ -282,6 +282,8 @@ pub struct NapiTurboEngineOptions {
     pub is_short_session: Option<bool>,
     /// Whether to skip database compaction during shutdown.
     pub skip_compaction: Option<bool>,
+    /// Turbopack memory eviction mode for the persistent cache.
+    pub turbopack_memory_eviction: MemoryEvictionMode,
 }
 
 impl From<NapiWatchOptions> for WatchOptions {
@@ -561,6 +563,7 @@ pub fn project_new(
             let is_ci = turbo_engine_options.is_ci.unwrap_or(false);
             let is_short_session = turbo_engine_options.is_short_session.unwrap_or(false);
             let skip_compaction = turbo_engine_options.skip_compaction.unwrap_or(false);
+            let turbopack_memory_eviction = turbo_engine_options.turbopack_memory_eviction;
             let turbo_tasks = create_turbo_tasks(
                 PathBuf::from(&options.dist_dir),
                 &options.next_version,
@@ -570,6 +573,7 @@ pub fn project_new(
                 is_ci,
                 is_short_session,
                 skip_compaction,
+                turbopack_memory_eviction,
             )?;
             let turbopack_ctx = NextTurbopackContext::new(turbo_tasks.clone(), napi_callbacks);
 

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -222,6 +222,28 @@ pub fn git_version_info(describe: &str) -> GitVersionInfo<'_> {
     }
 }
 
+/// Turbopack's memory eviction strategy for the persistent cache, mirroring the
+/// `experimental.turbopackMemoryEviction` config option.
+#[napi(string_enum = "lowercase")]
+#[derive(Debug, PartialEq, Eq)]
+pub enum MemoryEvictionMode {
+    /// Never evict.
+    Off,
+    /// After every snapshot, evict all evictable tasks from memory, reloading
+    /// them from disk on demand.
+    Full,
+}
+
+impl MemoryEvictionMode {
+    /// Whether this mode evicts evictable tasks after each snapshot.
+    fn evicts_after_snapshot(self) -> bool {
+        match self {
+            Self::Off => false,
+            Self::Full => true,
+        }
+    }
+}
+
 pub fn create_turbo_tasks(
     output_path: PathBuf,
     next_version: &str,
@@ -231,7 +253,9 @@ pub fn create_turbo_tasks(
     is_ci: bool,
     is_short_session: bool,
     skip_compaction: bool,
+    turbopack_memory_eviction: MemoryEvictionMode,
 ) -> Result<NextTurboTasks> {
+    let evict_after_snapshot = turbopack_memory_eviction.evicts_after_snapshot();
     Ok(if persistent_caching {
         let describe = cache_describe(next_version);
         let version_info = git_version_info(&describe);
@@ -253,8 +277,7 @@ pub fn create_turbo_tasks(
                 }),
                 dependency_tracking,
                 num_workers: Some(tokio::runtime::Handle::current().metrics().num_workers()),
-                evict_after_snapshot: std::env::var("TURBO_ENGINE_EVICT_AFTER_SNAPSHOT")
-                    .is_ok_and(|v| v == "1" || v == "true"),
+                evict_after_snapshot,
                 ..Default::default()
             },
             backing_storage,

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackMemoryEviction.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackMemoryEviction.mdx
@@ -1,0 +1,47 @@
+---
+title: Turbopack Memory Eviction
+nav_title: turbopackMemoryEviction
+description: Learn how to control Turbopack's memory eviction strategy for the persistent cache.
+---
+
+## Usage
+
+`turbopackMemoryEviction` controls how aggressively Turbopack reclaims memory while the persistent (FileSystem) cache is enabled. After Turbopack writes a snapshot of its cache to disk, it can evict the in-memory copies of that data and reload them from disk on demand, lowering peak memory usage at the cost of some extra disk reads.
+
+Currently there are two options
+
+- `false` (default): never evict. Cached data stays in memory for the lifetime of the process.
+- `'full'`: after every snapshot, evict all evictable tasks from memory. They are reloaded from disk on demand.
+
+> **Good to know:** This option only has an effect in `next dev` sessions when the [FileSystem Cache](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled, since eviction relies on data already being persisted to disk. It is experimental and under active development.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    // Evict in-memory cache data after each snapshot to reduce memory usage
+    turbopackMemoryEviction: 'full',
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    // Evict in-memory cache data after each snapshot to reduce memory usage
+    turbopackMemoryEviction: 'full',
+  },
+}
+
+module.exports = nextConfig
+```
+
+## Version Changes
+
+| Version   | Changes                                             |
+| --------- | --------------------------------------------------- |
+| `v16.3.0` | `turbopackMemoryEviction` released as experimental. |

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -319,6 +319,8 @@ export interface NapiTurboEngineOptions {
   isShortSession?: boolean
   /** Whether to skip database compaction during shutdown. */
   skipCompaction?: boolean
+  /** Turbopack memory eviction mode for the persistent cache. */
+  turbopackMemoryEviction: MemoryEvictionMode
 }
 export declare function projectNew(
   options: NapiProjectOptions,
@@ -532,6 +534,19 @@ export interface NapiNextTurbopackCallbacksJsObject {
 export interface TurbopackInternalErrorOpts {
   message: string
   anonymizedLocation?: string
+}
+/**
+ * Turbopack's memory eviction strategy for the persistent cache, mirroring the
+ * `experimental.turbopackMemoryEviction` config option.
+ */
+export const enum MemoryEvictionMode {
+  /** Never evict. */
+  Off = 'off',
+  /**
+   * After every snapshot, evict all evictable tasks from memory, reloading
+   * them from disk on demand.
+   */
+  Full = 'full',
 }
 export declare function rootTaskDispose(rootTask: {
   __napiType: 'RootTask'

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1255,7 +1255,7 @@ function bindingToApi(
     return new ProjectImpl(
       await binding.projectNew(
         await rustifyProjectOptions(options),
-        turboEngineOptions || {},
+        turboEngineOptions,
         {
           throwTurbopackInternalError: (
             require('../../shared/lib/turbopack/internal-error') as typeof import('../../shared/lib/turbopack/internal-error')
@@ -1390,7 +1390,7 @@ async function loadWasm(importPath = '') {
     turbo: {
       createProject(
         _options: ProjectOptions,
-        _turboEngineOptions?: TurboEngineOptions | undefined,
+        _turboEngineOptions: TurboEngineOptions,
         _callbacks?: import('./types').TurbopackProjectCallbacks | undefined
       ): Promise<Project> {
         throw new Error(

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -12,11 +12,14 @@ import type {
   TraceServerHandle,
   TraceQueryOptions,
   TraceQueryResult,
+  MemoryEvictionMode,
 } from './generated-native'
 
 export type { TraceServerHandle, TraceQueryOptions, TraceQueryResult }
 
 export type { NapiTurboEngineOptions as TurboEngineOptions }
+
+export type { MemoryEvictionMode }
 
 export type Lockfile = { __napiType: 'Lockfile' }
 
@@ -29,7 +32,7 @@ export interface Binding {
   turbo: {
     createProject(
       options: ProjectOptions,
-      turboEngineOptions?: NapiTurboEngineOptions,
+      turboEngineOptions: NapiTurboEngineOptions,
       callbacks?: TurbopackProjectCallbacks
     ): Promise<Project>
     startTurbopackTraceServerHandle(

--- a/packages/next/src/build/turbopack-analyze/index.ts
+++ b/packages/next/src/build/turbopack-analyze/index.ts
@@ -93,7 +93,7 @@ export async function turbopackAnalyze(
       nextVersion: process.env.__NEXT_VERSION as string,
     },
     {
-      memoryLimit: config.experimental?.turbopackMemoryLimit,
+      turbopackMemoryEviction: config.experimental.turbopackMemoryEvictionMode,
       dependencyTracking: persistentCaching,
       isCi: isCI,
       isShortSession: true,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -118,7 +118,7 @@ export async function turbopackBuild(telemetry: Telemetry): Promise<{
   }
 
   const sharedTurboOptions = {
-    memoryLimit: config.experimental?.turbopackMemoryLimit,
+    turbopackMemoryEviction: config.experimental.turbopackMemoryEvictionMode,
     dependencyTracking: persistentCaching || hasDeferredEntries,
     isCi: isCI,
     isShortSession: true,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -365,6 +365,9 @@ export const experimentalSchema = {
   webpackBuildWorker: z.boolean().optional(),
   webpackMemoryOptimizations: z.boolean().optional(),
   turbopackMemoryLimit: z.number().optional(),
+  turbopackMemoryEviction: z
+    .union([z.literal(false), z.literal('full')])
+    .optional(),
   turbopackPluginRuntimeStrategy: z
     .enum(['workerThreads', 'childProcesses', 'forceWorkerThreads'])
     .optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -14,6 +14,7 @@ import type { SupportedTestRunners } from '../cli/next-test'
 import type { ExperimentalPPRConfig } from './lib/experimental/ppr'
 import { INFINITE_CACHE } from '../lib/constants'
 import type { FallbackRouteParam } from '../build/static-paths/types'
+import type { MemoryEvictionMode } from '../build/swc/types'
 
 /**
  * Resolved form of the prefetchInlining config after normalization in
@@ -38,6 +39,8 @@ export type NextConfigComplete = Required<Omit<NextConfig, 'configFile'>> & {
     useCacheTimeout: number
     // Normalized by config.ts `finalizeConfig`: defaulted to `'warning'`
     instantInsights: { validationLevel: ValidationLevel }
+    // Normalized by finalized config with a default and the expected type
+    turbopackMemoryEvictionMode: MemoryEvictionMode
   }
   // The root directory of the distDir. In development mode, this is the parent directory of `distDir`
   // since development builds use `{distDir}/dev`. This is used to ensure that the bundler doesn't
@@ -680,9 +683,17 @@ export interface ExperimentalConfig {
   gestureTransition?: boolean
 
   /**
-   * A target memory limit for turbo, in bytes.
+   * Controls Turbopack's memory eviction strategy for development sessions
+   *
+   * Only effective in dev sessions where
+   * `experimental.turbopackFileSystemCacheForDev` is enabled (which it is by default).
+   *
+   * - `false`: disable eviction.
+   * - `'full'`: after every snapshot, drop as much memory as possible.
+   *
+   * Defaults to `false`
    */
-  turbopackMemoryLimit?: number
+  turbopackMemoryEviction?: false | 'full'
 
   /**
    * Selects the backend used by Turbopack for Node.js evaluation, e.g. webpack

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -52,6 +52,7 @@ import type { NextAdapter } from '../build/adapter/build-complete'
 import { HardDeprecatedConfigError } from '../shared/lib/errors/hard-deprecated-config-error'
 import { NextInstanceErrorState } from './mcp/tools/next-instance-error-state'
 import { Bundler } from '../lib/bundler'
+import type { MemoryEvictionMode } from '../build/swc/types'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
@@ -421,6 +422,27 @@ function assignDefaultsAndValidate(
   if (!result.experimental.trustHostHeader && ciEnvironment.hasNextSupport) {
     result.experimental.trustHostHeader = true
   }
+
+  // Normalize the user-facing `turbopackMemoryEviction` (`false | 'full' |
+  // undefined`) into the `turbopackMemoryEvictionMode` enum expected by napi
+  // (`'off' | 'full'`).
+  let turbopackMemoryEvictionMode: 'off' | 'full'
+  if (result.experimental.turbopackMemoryEviction === false) {
+    turbopackMemoryEvictionMode = 'off'
+  } else if (result.experimental.turbopackMemoryEviction === 'full') {
+    turbopackMemoryEvictionMode = 'full'
+  } else {
+    // Not set by the user: fall back to the env var if present, otherwise 'off'.
+    const rawEnv = process.env.TURBO_ENGINE_EVICT_AFTER_SNAPSHOT
+    turbopackMemoryEvictionMode =
+      rawEnv == null
+        ? 'off'
+        : rawEnv === '1' || rawEnv === 'true'
+          ? 'full'
+          : 'off'
+  }
+  ;(result as NextConfigComplete).experimental.turbopackMemoryEvictionMode =
+    turbopackMemoryEvictionMode as MemoryEvictionMode
 
   // Normalize experimental.browserDebugInfoInTerminal to logging.browserToTerminal
   if (

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -417,7 +417,8 @@ export async function createHotReloaderTurbopack(
       serverHmr: serverFastRefresh,
     },
     {
-      memoryLimit: opts.nextConfig.experimental?.turbopackMemoryLimit,
+      turbopackMemoryEviction:
+        opts.nextConfig.experimental.turbopackMemoryEvictionMode,
       isShortSession: false,
     }
   )

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -202,7 +202,7 @@ async function main() {
     isPersistentCachingEnabled: false,
     nextVersion: '0.0.0',
   }, {
-    turbopackMemoryEviction: 'off' as MemoryEvictionMode,
+    turbopackMemoryEviction: 'off',
   });
 
   const entrypointsSubscription = project.entrypointsSubscribe();

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -3,6 +3,7 @@ import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
 import { createDefineEnv, loadBindings, HmrTarget } from 'next/dist/build/swc'
 import type {
   Issue,
+  MemoryEvictionMode,
   Project,
   RawEntrypoints,
   StyledString,
@@ -200,6 +201,8 @@ async function main() {
     currentNodeJsVersion: '18.0.0',
     isPersistentCachingEnabled: false,
     nextVersion: '0.0.0',
+  }, {
+    turbopackMemoryEviction: 'off' as MemoryEvictionMode,
   });
 
   const entrypointsSubscription = project.entrypointsSubscribe();
@@ -313,46 +316,51 @@ describe('next.rs api', () => {
       ? path.resolve(__dirname, '../../..')
       : next.testDir
     const distDir = '.next'
-    project = await bindings.turbo.createProject({
-      env: {},
-      nextConfig: nextConfig,
-      rootPath,
-      projectPath: path.relative(rootPath, next.testDir) || '.',
-      distDir,
-      watch: {
-        enable: true,
-      },
-      dev: true,
-      defineEnv: createDefineEnv({
-        projectPath: next.testDir,
-        isTurbopack: true,
-        clientRouterFilters: undefined,
-        config: nextConfig,
-        dev: true,
-        distDir: path.join(rootPath, distDir),
-        fetchCacheKeyPrefix: undefined,
-        hasRewrites: false,
-        middlewareMatchers: undefined,
-        rewrites: {
-          beforeFiles: [],
-          afterFiles: [],
-          fallback: [],
+    project = await bindings.turbo.createProject(
+      {
+        env: {},
+        nextConfig: nextConfig,
+        rootPath,
+        projectPath: path.relative(rootPath, next.testDir) || '.',
+        distDir,
+        watch: {
+          enable: true,
         },
-      }),
-      buildId: 'development',
-      encryptionKey: '12345',
-      previewProps: {
-        previewModeId: 'development',
-        previewModeEncryptionKey: '12345',
-        previewModeSigningKey: '12345',
+        dev: true,
+        defineEnv: createDefineEnv({
+          projectPath: next.testDir,
+          isTurbopack: true,
+          clientRouterFilters: undefined,
+          config: nextConfig,
+          dev: true,
+          distDir: path.join(rootPath, distDir),
+          fetchCacheKeyPrefix: undefined,
+          hasRewrites: false,
+          middlewareMatchers: undefined,
+          rewrites: {
+            beforeFiles: [],
+            afterFiles: [],
+            fallback: [],
+          },
+        }),
+        buildId: 'development',
+        encryptionKey: '12345',
+        previewProps: {
+          previewModeId: 'development',
+          previewModeEncryptionKey: '12345',
+          previewModeSigningKey: '12345',
+        },
+        browserslistQuery: 'last 2 versions',
+        noMangling: false,
+        writeRoutesHashesManifest: false,
+        currentNodeJsVersion: '18.0.0',
+        isPersistentCachingEnabled: false,
+        nextVersion: '0.0.0',
       },
-      browserslistQuery: 'last 2 versions',
-      noMangling: false,
-      writeRoutesHashesManifest: false,
-      currentNodeJsVersion: '18.0.0',
-      isPersistentCachingEnabled: false,
-      nextVersion: '0.0.0',
-    })
+      {
+        turbopackMemoryEviction: 'off' as MemoryEvictionMode,
+      }
+    )
     projectUpdateSubscription = filterMapAsyncIterator(
       project.updateInfoSubscribe(1000),
       (update) => (update.updateType === 'end' ? update.value : undefined)

--- a/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
+++ b/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
@@ -8,7 +8,7 @@ import { retry, waitFor } from 'next-test-utils'
     'ENABLE_CACHING=1',
     'TURBO_ENGINE_IGNORE_DIRTY=1',
     'TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000',
-    'TURBO_ENGINE_EVICT_AFTER_SNAPSHOT=1',
+    'ENABLE_EVICTION=1',
   ].join(' ')
 
   const { skipped, next } = nextTestSetup({

--- a/test/e2e/filesystem-cache/next.config.js
+++ b/test/e2e/filesystem-cache/next.config.js
@@ -21,7 +21,7 @@ const nextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: enableCaching,
     turbopackFileSystemCacheForDev: enableCaching,
-    turbopackMemoryEviction: enableEviction ? 'full' : 'off',
+    turbopackMemoryEviction: enableEviction ? false : 'off',
   },
   env: {
     NEXT_PUBLIC_CONFIG_ENV: 'hello world',

--- a/test/e2e/filesystem-cache/next.config.js
+++ b/test/e2e/filesystem-cache/next.config.js
@@ -1,4 +1,5 @@
 const enableCaching = !!process.env.ENABLE_CACHING
+const enableEviction = !!process.env.ENABLE_EVICTION
 
 /**
  * @type {import('next').NextConfig}
@@ -20,6 +21,7 @@ const nextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: enableCaching,
     turbopackFileSystemCacheForDev: enableCaching,
+    turbopackMemoryEviction: enableEviction ? 'full' : 'off',
   },
   env: {
     NEXT_PUBLIC_CONFIG_ENV: 'hello world',


### PR DESCRIPTION
`experimental.turbopackMemoryEviction = "full" | false`

controls the new feature, currently it is disabled.
