### PR TITLE
[App Shells] staged shell rendering in cached navs

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -287,6 +287,7 @@ import type {
 import { ResponseCookies } from '../web/spec-extension/cookies'
 import { isInstantValidationError } from './instant-validation/instant-validation-error'
 import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
+import { RENDER_STAGES_BY_DATA_KIND } from '../dynamic-rendering-utils'
 
 export type GetDynamicParamFromSegment = (
   // The LoaderTree to extract the dynamic param from
@@ -914,6 +915,7 @@ async function generateStagedDynamicFlightRenderResultWeb(
   const { renderToReadableStream, routeModule } = componentMod
   const { loaderTree } = routeModule.userland
   const { onInstrumentationRequestError, experimental } = renderOpts
+  const { appShells } = experimental
 
   function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
@@ -964,10 +966,10 @@ async function generateStagedDynamicFlightRenderResultWeb(
   // Deferred promise for the static stage byte length. Flight serializes the
   // resolved value into the stream so the client knows where the static
   // prefix ends.
-  let resolveStaticStageByteLength: (count: number) => void
-  const staticStageByteLengthPromise = new Promise<number>((resolve) => {
-    resolveStaticStageByteLength = resolve
-  })
+  const shellByteLengthDeferred = appShells
+    ? createPromiseWithResolvers<number | null>()
+    : null
+  const staticStageByteLengthDeferred = createPromiseWithResolvers<number>()
 
   // Check if this route has opted into runtime prefetching via
   // unstable_instant. If so, we piggyback on the dynamic render to fill caches
@@ -1015,7 +1017,12 @@ async function generateStagedDynamicFlightRenderResultWeb(
     requestStore,
     generateDynamicRSCPayload,
     ctx,
-    { staleTimeIterable, staticStageByteLengthPromise, runtimePrefetchStream }
+    {
+      staleTimeIterable,
+      staticStageByteLengthPromise: staticStageByteLengthDeferred.promise,
+      shellByteLengthPromise: shellByteLengthDeferred?.promise,
+      runtimePrefetchStream,
+    }
   )
 
   const { clientModules } = getClientReferenceManifest()
@@ -1035,8 +1042,11 @@ async function generateStagedDynamicFlightRenderResultWeb(
 
       const [dynamicStream, staticStream] = stream.tee()
 
-      countStaticStageBytes(staticStream, stageController).then(
-        resolveStaticStageByteLength
+      void countShellAndStaticStageBytes(staticStream, stageController).then(
+        (byteLengths) => {
+          staticStageByteLengthDeferred.resolve(byteLengths[RenderStage.Static])
+          shellByteLengthDeferred?.resolve(byteLengths[RenderStage.ShellStatic])
+        }
       )
 
       return dynamicStream
@@ -1077,6 +1087,7 @@ async function generateStagedDynamicFlightRenderResultNode(
   const { routeModule } = componentMod
   const { loaderTree } = routeModule.userland
   const { onInstrumentationRequestError, experimental } = renderOpts
+  const { appShells } = experimental
 
   function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
@@ -1124,13 +1135,10 @@ async function generateStagedDynamicFlightRenderResultNode(
     selectStaleTime
   )
 
-  // Deferred promise for the static stage byte length. Flight serializes the
-  // resolved value into the stream so the client knows where the static
-  // prefix ends.
-  let resolveStaticStageByteLength: (count: number) => void
-  const staticStageByteLengthPromise = new Promise<number>((resolve) => {
-    resolveStaticStageByteLength = resolve
-  })
+  const shellByteLengthDeferred = appShells
+    ? createPromiseWithResolvers<number | null>()
+    : null
+  const staticStageByteLengthDeferred = createPromiseWithResolvers<number>()
 
   // Check if this route has opted into runtime prefetching via
   // unstable_instant. If so, we piggyback on the dynamic render to fill caches
@@ -1178,7 +1186,12 @@ async function generateStagedDynamicFlightRenderResultNode(
     requestStore,
     generateDynamicRSCPayload,
     ctx,
-    { staleTimeIterable, staticStageByteLengthPromise, runtimePrefetchStream }
+    {
+      staleTimeIterable,
+      staticStageByteLengthPromise: staticStageByteLengthDeferred.promise,
+      shellByteLengthPromise: shellByteLengthDeferred?.promise,
+      runtimePrefetchStream,
+    }
   )
 
   const { clientModules } = getClientReferenceManifest()
@@ -1201,8 +1214,11 @@ async function generateStagedDynamicFlightRenderResultNode(
       const dynamicStream = replayable.createReplayStream()
       const staticStream = replayable.createReplayStream()
 
-      countStaticStageBytesNode(staticStream, stageController).then(
-        resolveStaticStageByteLength
+      void countShellAndStaticStageBytes(staticStream, stageController).then(
+        (byteLengths) => {
+          staticStageByteLengthDeferred.resolve(byteLengths[RenderStage.Static])
+          shellByteLengthDeferred?.resolve(byteLengths[RenderStage.ShellStatic])
+        }
       )
 
       return dynamicStream
@@ -2197,6 +2213,7 @@ async function getRSCPayload(
     is404: boolean
     staleTimeIterable?: AsyncIterable<number>
     staticStageByteLengthPromise?: Promise<number>
+    shellByteLengthPromise?: Promise<number | null>
     runtimePrefetchStream?: ReadableStream<Uint8Array>
   }
 ): Promise<InitialRSCPayload & { P: ReactNode }> {
@@ -2204,6 +2221,7 @@ async function getRSCPayload(
     is404,
     staleTimeIterable,
     staticStageByteLengthPromise,
+    shellByteLengthPromise,
     runtimePrefetchStream,
   } = options
   const injectedCSS = new Set<string>()
@@ -2350,6 +2368,7 @@ async function getRSCPayload(
     S: workStore.isStaticGeneration || ctx.renderOpts.cacheComponents,
     h: getMetadataVaryParamsThenable(),
     s: staleTimeIterable,
+    a: shellByteLengthPromise,
     l: staticStageByteLengthPromise,
     p: runtimePrefetchStream,
     // Include the per-page dynamic stale time from unstable_dynamicStaleTime, but
@@ -2360,7 +2379,7 @@ async function getRSCPayload(
     d: !workStore.isStaticGeneration
       ? ((await getDynamicStaleTime(tree)) ?? undefined)
       : undefined,
-  })
+  } satisfies InitialRSCPayload & { P: ReactNode })
 }
 
 /**
@@ -3433,7 +3452,7 @@ async function renderToStream(
     cacheComponents,
   } = renderOpts
 
-  const { cachedNavigations } = renderOpts.experimental
+  const { cachedNavigations, appShells } = renderOpts.experimental
 
   const { ServerInsertedHTMLProvider, renderServerInsertedHTML } =
     createServerInsertedHTML()
@@ -3851,12 +3870,11 @@ async function renderToStream(
             selectStaleTime
           )
 
-          let resolveStaticStageByteLength: (count: number) => void
-          const staticStageByteLengthPromise = new Promise<number>(
-            (resolve) => {
-              resolveStaticStageByteLength = resolve
-            }
-          )
+          const shellByteLengthDeferred = appShells
+            ? createPromiseWithResolvers<number | null>()
+            : null
+          const staticStageByteLengthDeferred =
+            createPromiseWithResolvers<number>()
 
           // If the route has runtime prefetching enabled, spawn a runtime
           // prerender after the resume render fills caches. The result is
@@ -3899,7 +3917,9 @@ async function renderToStream(
             {
               is404: res.statusCode === 404,
               staleTimeIterable,
-              staticStageByteLengthPromise,
+              shellByteLengthPromise: shellByteLengthDeferred?.promise,
+              staticStageByteLengthPromise:
+                staticStageByteLengthDeferred.promise,
               runtimePrefetchStream,
             }
           )
@@ -3925,9 +3945,17 @@ async function renderToStream(
               const dynamicStream = replayable.createReplayStream()
               const staticStream = replayable.createReplayStream()
 
-              countStaticStageBytesNode(staticStream, stageController).then(
-                resolveStaticStageByteLength!
-              )
+              void countShellAndStaticStageBytes(
+                staticStream,
+                stageController
+              ).then((byteLengths) => {
+                staticStageByteLengthDeferred.resolve(
+                  byteLengths[RenderStage.Static]
+                )
+                shellByteLengthDeferred?.resolve(
+                  byteLengths[RenderStage.ShellStatic]
+                )
+              })
 
               return dynamicStream
             },
@@ -3987,12 +4015,11 @@ async function renderToStream(
             selectStaleTime
           )
 
-          let resolveStaticStageByteLength: (count: number) => void
-          const staticStageByteLengthPromise = new Promise<number>(
-            (resolve) => {
-              resolveStaticStageByteLength = resolve
-            }
-          )
+          const shellByteLengthDeferred = appShells
+            ? createPromiseWithResolvers<number | null>()
+            : null
+          const staticStageByteLengthDeferred =
+            createPromiseWithResolvers<number>()
 
           // If the route has runtime prefetching enabled, spawn a runtime
           // prerender after the resume render fills caches. The result is
@@ -4035,7 +4062,9 @@ async function renderToStream(
             {
               is404: res.statusCode === 404,
               staleTimeIterable,
-              staticStageByteLengthPromise,
+              shellByteLengthPromise: shellByteLengthDeferred?.promise,
+              staticStageByteLengthPromise:
+                staticStageByteLengthDeferred.promise,
               runtimePrefetchStream,
             }
           )
@@ -4058,9 +4087,17 @@ async function renderToStream(
 
               const [dynamicStream, staticStream] = stream.tee()
 
-              countStaticStageBytes(staticStream, stageController).then(
-                resolveStaticStageByteLength!
-              )
+              void countShellAndStaticStageBytes(
+                staticStream,
+                stageController
+              ).then((byteLengths) => {
+                staticStageByteLengthDeferred.resolve(
+                  byteLengths[RenderStage.Static]
+                )
+                shellByteLengthDeferred?.resolve(
+                  byteLengths[RenderStage.ShellStatic]
+                )
+              })
 
               return dynamicStream
             },
@@ -5484,65 +5521,35 @@ function accumulateChunk(
   }
 }
 
-async function countStaticStageBytes(
-  stream: ReadableStream<Uint8Array>,
+async function countShellAndStaticStageBytes(
+  stream: AnyStream,
   stageController: StagedRenderingController
-): Promise<number> {
-  let byteLength = 0
-  const reader = stream.getReader()
+): Promise<
+  Pick<StageByteLengths, RenderStage.ShellStatic | RenderStage.Static>
+> {
+  const byteLengths = createStageByteLengths()
 
+  // Abort the signal whenever we advance to the stage after static.
+  const abortController = new AbortController()
   const endStage = getNextStage(RenderStage.Static)
-  stageController.onStage(endStage, () => {
-    reader.cancel()
-  })
+  stageController.onStage(endStage, abortController.abort.bind(abortController))
 
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) {
-      break
-    }
-    if (stageController.currentStage <= RenderStage.Static) {
-      byteLength += value.byteLength
-    } else {
-      reader.cancel()
-      break
-    }
+  if (stream instanceof ReadableStream) {
+    await countStageBytesUntilAbortWeb(
+      byteLengths,
+      stream,
+      stageController,
+      abortController.signal
+    )
+  } else {
+    await countStageBytesUntilAbortNode(
+      byteLengths,
+      stream,
+      stageController,
+      abortController.signal
+    )
   }
-
-  return byteLength
-}
-
-async function countStaticStageBytesNode(
-  stream: Readable,
-  stageController: StagedRenderingController
-): Promise<number> {
-  let byteLength = 0
-  let cancelled = false
-
-  const endStage = getNextStage(RenderStage.Static)
-  stageController.onStage(endStage, () => {
-    cancelled = true
-    stream.destroy()
-  })
-
-  try {
-    for await (const value of stream) {
-      if (cancelled) break
-      if (stageController.currentStage <= RenderStage.Static) {
-        byteLength += (value as Uint8Array).byteLength
-      } else {
-        cancelled = true
-        stream.destroy()
-        break
-      }
-    }
-  } catch (err) {
-    if (!cancelled) {
-      throw err
-    }
-  }
-
-  return byteLength
+  return byteLengths
 }
 
 type StageByteLengths = Record<AdvanceableRenderStage, number>
@@ -5579,6 +5586,38 @@ async function countStageBytesUntilAbortWeb(
   }
 }
 
+async function countStageBytesUntilAbortNode(
+  byteLengths: StageByteLengths,
+  stream: Readable,
+  stageController: StagedRenderingController,
+  abortSignal: AbortSignal
+): Promise<void> {
+  let cancelled = false
+  abortSignal.addEventListener(
+    'abort',
+    () => {
+      cancelled = true
+      stream.destroy()
+    },
+    { once: true }
+  )
+
+  try {
+    for await (const value of stream) {
+      if (cancelled) break
+      increaseChunkByteLengths(
+        byteLengths,
+        stageController.currentStage,
+        (value as Uint8Array).byteLength
+      )
+    }
+  } catch (err) {
+    if (!cancelled) {
+      throw err
+    }
+  }
+}
+
 function increaseChunkByteLengths(
   byteLengths: StageByteLengths,
   currentStage: RenderStage,
@@ -5605,56 +5644,62 @@ function createAsyncApiPromises(
   mutableCookies: RequestStore['mutableCookies'],
   headers: RequestStore['headers']
 ): NonNullable<RequestStore['asyncApiPromises']> {
+  // NOTE: Must be kept in sync with cookies.ts, headers.ts, params.ts, search-params.ts
+  const cookiesStages = RENDER_STAGES_BY_DATA_KIND.sessionData
+  const headersStages = RENDER_STAGES_BY_DATA_KIND.sessionData
+  const paramsStages = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
+  const searchParamsStages = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
+
   return {
     // Runtime APIs (for prefetch segments)
     cookies: stagedRendering.delayUntilStage(
-      RenderStage.Runtime,
+      cookiesStages.late,
       'cookies',
       cookies
     ),
     earlyCookies: stagedRendering.delayUntilStage(
-      RenderStage.EarlyRuntime,
+      cookiesStages.early,
       'cookies',
       cookies
     ),
     mutableCookies: stagedRendering.delayUntilStage(
-      RenderStage.Runtime,
+      cookiesStages.late,
       'cookies',
       mutableCookies as RequestStore['cookies']
     ),
     earlyMutableCookies: stagedRendering.delayUntilStage(
-      RenderStage.EarlyRuntime,
+      cookiesStages.early,
       'cookies',
       mutableCookies as RequestStore['cookies']
     ),
     headers: stagedRendering.delayUntilStage(
-      RenderStage.Runtime,
+      headersStages.late,
       'headers',
       headers
     ),
     earlyHeaders: stagedRendering.delayUntilStage(
-      RenderStage.EarlyRuntime,
+      headersStages.early,
       'headers',
       headers
     ),
     // These are not used directly, but we chain other `params`/`searchParams` promises off of them.
     sharedParamsParent: stagedRendering.delayUntilStage(
-      RenderStage.Runtime,
+      paramsStages.late,
       undefined,
       '<internal params>'
     ),
     earlySharedParamsParent: stagedRendering.delayUntilStage(
-      RenderStage.EarlyRuntime,
+      paramsStages.early,
       undefined,
       '<internal params>'
     ),
     sharedSearchParamsParent: stagedRendering.delayUntilStage(
-      RenderStage.Runtime,
+      searchParamsStages.late,
       undefined,
       '<internal searchParams>'
     ),
     earlySharedSearchParamsParent: stagedRendering.delayUntilStage(
-      RenderStage.EarlyRuntime,
+      searchParamsStages.early,
       undefined,
       '<internal searchParams>'
     ),

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -84,6 +84,21 @@ export function makeHangingPromise<T>(
 
 function ignoreReject() {}
 
+/**
+ * Creates a promise that will be triggered when another promise resolves.
+ * It will not emit unhandled rejections, which is important if the trigger
+ * is a promise that might itself get rejected (e.g. when a prerender/render
+ * are aborted due to sync IO)
+ */
+export function makePromiseFromTrigger<T>(
+  trigger: Promise<any>,
+  value: T
+): Promise<T> {
+  const promise = trigger.then(() => value)
+  promise.catch(ignoreReject)
+  return promise
+}
+
 export function makeDevtoolsIOAwarePromise<T>(
   underlying: T,
   requestStore: RequestStore,

--- a/packages/next/src/server/node-environment-extensions/unhandled-rejection.external.tsx
+++ b/packages/next/src/server/node-environment-extensions/unhandled-rejection.external.tsx
@@ -605,9 +605,10 @@ function filteringUnhandledRejectionHandler(
       case 'prerender':
       case 'prerender-client':
       case 'validation-client':
-      case 'prerender-runtime': {
+      case 'prerender-runtime':
+      case 'request': {
         const signal = workUnitStore.renderSignal
-        if (signal.aborted) {
+        if (signal && signal.aborted) {
           // This unhandledRejection is from async work spawned in a now
           // aborted prerender. We don't need to report this.
           return
@@ -616,7 +617,6 @@ function filteringUnhandledRejectionHandler(
       }
       case 'prerender-ppr':
       case 'prerender-legacy':
-      case 'request':
       case 'cache':
       case 'private-cache':
       case 'unstable-cache':

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -233,7 +233,7 @@ function makeUntrackedHeadersWithDevWarnings(
   const promise = makeDevtoolsIOAwarePromise(
     underlyingHeaders,
     requestStore,
-    RenderStage.Runtime // TODO(app-shells): headers should be dynamic instead.
+    RenderStage.Runtime
   )
 
   const proxiedPromise = instrumentHeadersPromiseWithDevWarnings(promise, route)

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -267,10 +267,9 @@ export function createServerParamsForServerSegment(
             workUnitStore,
             isRuntimePrefetchable
           )
-        } else if (
-          workUnitStore.asyncApiPromises &&
-          workUnitStore.validationSamples
-        ) {
+        }
+
+        if (workUnitStore.asyncApiPromises && workUnitStore.validationSamples) {
           return createServerParamsInInstantValidation(
             underlyingParams,
             workStore,
@@ -278,18 +277,48 @@ export function createServerParamsForServerSegment(
             workUnitStore.asyncApiPromises,
             isRuntimePrefetchable
           )
-        } else if (
-          workUnitStore.asyncApiPromises &&
-          hasFallbackRouteParams(underlyingParams, workUnitStore.fallbackParams)
-        ) {
-          return (
-            isRuntimePrefetchable
-              ? workUnitStore.asyncApiPromises.earlySharedParamsParent
-              : workUnitStore.asyncApiPromises.sharedParamsParent
-          ).then(() => underlyingParams)
-        } else {
-          return createRenderParamsInProd(underlyingParams)
         }
+
+        const { stagedRendering } = workUnitStore
+
+        if (workUnitStore.asyncApiPromises && stagedRendering) {
+          // We're rendering in stages for cachedNavigations.
+          const hasFallbackParams = hasFallbackRouteParams(
+            underlyingParams,
+            workUnitStore.fallbackParams
+          )
+
+          // If we're rendering with shells, even static params must be delayed to exclude them from the shell.
+          // NOTE: For a dynamic request, assume we're recovering a static shell.
+          // If a session shell is needed, we do it in a separate render
+          if (
+            process.env.__NEXT_APP_SHELLS &&
+            // Params are non-empty, and there's no fallback params, so all params are static
+            !isEmptyParams(underlyingParams) &&
+            !hasFallbackParams
+          ) {
+            const paramsStages = RENDER_STAGES_BY_DATA_KIND.staticLinkData
+            const stage = isRuntimePrefetchable
+              ? paramsStages.early
+              : paramsStages.late
+            return stagedRendering.delayUntilStage(
+              stage,
+              'params',
+              underlyingParams
+            )
+          }
+
+          // Otherwise, only delay if we have fallbacks params
+          if (hasFallbackParams) {
+            return (
+              isRuntimePrefetchable
+                ? workUnitStore.asyncApiPromises.earlySharedParamsParent
+                : workUnitStore.asyncApiPromises.sharedParamsParent
+            ).then(() => underlyingParams)
+          }
+        }
+
+        return createRenderParamsInProd(underlyingParams)
       default:
         workUnitStore satisfies never
     }

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -34,6 +34,7 @@ import {
 import {
   makeDevtoolsIOAwarePromise,
   makeHangingPromise,
+  makePromiseFromTrigger,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -310,11 +311,12 @@ export function createServerParamsForServerSegment(
 
           // Otherwise, only delay if we have fallbacks params
           if (hasFallbackParams) {
-            return (
+            return makePromiseFromTrigger(
               isRuntimePrefetchable
                 ? workUnitStore.asyncApiPromises.earlySharedParamsParent
-                : workUnitStore.asyncApiPromises.sharedParamsParent
-            ).then(() => underlyingParams)
+                : workUnitStore.asyncApiPromises.sharedParamsParent,
+              underlyingParams
+            )
           }
         }
 
@@ -523,11 +525,12 @@ function createServerParamsInInstantValidation(
     declaredParams,
     workStore.route
   )
-  return (
+  return makePromiseFromTrigger(
     isRuntimePrefetchable
       ? asyncApiPromises.earlySharedParamsParent
-      : asyncApiPromises.sharedParamsParent
-  ).then(() => proxiedUnderlying)
+      : asyncApiPromises.sharedParamsParent,
+    proxiedUnderlying
+  )
 }
 
 function createClientParamsInInstantValidation(

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -79,6 +79,7 @@ export function createServerPathnameForMetadata(
         }
       }
       case 'request':
+        // TODO(app-shells): this should be delayed if there's non-static params
         return createRenderPathname(underlyingPathname)
       default:
         workUnitStore satisfies never

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -15,6 +15,7 @@ import {
 } from '../app-render/work-unit-async-storage.external'
 import {
   getRuntimeLinkDataStage,
+  getStaticLinkDataStage,
   makeHangingPromise,
 } from '../dynamic-rendering-utils'
 import type { ParamValue } from './params'
@@ -115,6 +116,22 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
         } catch (err) {
           return Promise.reject(err)
         }
+        break
+      }
+
+      const { stagedRendering } = workUnitStore
+      if (stagedRendering && process.env.__NEXT_APP_SHELLS) {
+        return createRootParamPromiseForShellRender(
+          stagedRendering,
+          // Assuming we're rendering for cached navs, we only need
+          // to recover a static shell and a static stage, so we can
+          // resolve root params here. it means we can't get a session shell,
+          // but that's okay because we get that from a separate render anyway.
+          getStaticLinkDataStage(stagedRendering),
+          apiName,
+          paramName,
+          workUnitStore.rootParams[paramName]
+        )
       }
       break
     }

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -30,6 +30,7 @@ import { InvariantError } from '../../shared/lib/invariant-error'
 import {
   makeDevtoolsIOAwarePromise,
   makeHangingPromise,
+  makePromiseFromTrigger,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -298,11 +299,12 @@ function createRenderSearchParams(
         )
       }
 
-      return (
+      return makePromiseFromTrigger(
         isRuntimePrefetchable
           ? requestStore.asyncApiPromises.earlySharedSearchParamsParent
-          : requestStore.asyncApiPromises.sharedSearchParamsParent
-      ).then(() => underlyingSearchParams)
+          : requestStore.asyncApiPromises.sharedSearchParamsParent,
+        underlyingSearchParams
+      )
     } else {
       return makeUntrackedSearchParams(underlyingSearchParams)
     }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -43,6 +43,7 @@ import {
   makeHangingPromise,
   getSessionDataStage,
   getRuntimeLinkDataStage,
+  getStaticLinkDataStage,
 } from '../dynamic-rendering-utils'
 
 import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
@@ -1702,7 +1703,8 @@ export async function cache(
           // whether we're in the early or late stages.
           const stagedRendering = outerWorkUnitStore.stagedRendering
           const stage = stagedRendering
-            ? getSessionDataStage(stagedRendering)
+            ? // TODO(app-shells): exclude private caches with a short staletime
+              getSessionDataStage(stagedRendering)
             : RenderStage.Runtime
           await makeDevtoolsIOAwarePromise(undefined, outerWorkUnitStore, stage)
         }
@@ -2137,7 +2139,8 @@ export async function cache(
 
                 const stagedRendering = workUnitStore.stagedRendering
                 const stage = stagedRendering
-                  ? getSessionDataStage(stagedRendering)
+                  ? // TODO(app-shells): exclude caches with a short staletime
+                    getSessionDataStage(stagedRendering)
                   : RenderStage.Runtime
                 await makeDevtoolsIOAwarePromise(
                   undefined,
@@ -2227,7 +2230,14 @@ export async function cache(
               )
               break
             }
-            case 'request':
+            case 'request': {
+              // For a staged dynamic request, assume we're recovering a static shell --
+              // If a session shell is needed, we do it in a separate render
+              await stagedRendering.waitForStage(
+                getStaticLinkDataStage(stagedRendering)
+              )
+              break
+            }
             case 'prerender':
             case 'cache':
             case 'private-cache':
@@ -2676,9 +2686,11 @@ export async function cache(
                 // unnecessary restarts. We don't end the cache read here, so
                 // this will always appear as a cache miss in the static stage,
                 // and thus will cause a restart even if all caches are filled.
+
                 const stagedRendering = workUnitStore.stagedRendering
                 const stage = stagedRendering
-                  ? getSessionDataStage(stagedRendering)
+                  ? // TODO(app-shells): exclude caches with a short staletime
+                    getSessionDataStage(stagedRendering)
                   : RenderStage.Runtime
                 await makeDevtoolsIOAwarePromise(
                   undefined,

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -350,6 +350,11 @@ export type InitialRSCPayload = {
   s?: AsyncIterable<number>
   /** staticStageByteLength - Resolves when the static stage ends. */
   l?: Promise<number>
+  /**
+   * shellByteLength - Resolves when the shell stage ends.
+   * If it resolves to null, then the shell is the same as the main response.
+   * */
+  a?: Promise<number | null>
   /** runtimePrefetchStream — Embedded runtime prefetch Flight stream. */
   p?: ReadableStream<Uint8Array>
   /**

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -792,27 +792,6 @@ describe('instant validation', () => {
             9 |   return (
            10 |     <main>
            11 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
-         Error: Route "/suspense-in-root/runtime/invalid-sync-io": Next.js encountered the unstable value \`Date.now()\` while prerendering.
-
-         This value can change between renders, so it must be either prerendered or computed later.
-
-         Ways to fix this:
-           - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#generate-on-every-request
-           - [cache] Prerender and cache the value with \`"use cache"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#cache-the-timestamp
-           - [client] Render the value on the client with \`"use client"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#render-on-the-client
-           - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#for-telemetry-use-a-timing-api
-             at b (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:8:20)
-            6 | export default async function Page() {
-            7 |   await cookies()
-         >  8 |   const now = Date.now()
-              |                    ^
-            9 |   return (
-           10 |     <main>
-           11 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io".
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
            - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/runtime/invalid-sync-io" in your browser to investigate the error.
@@ -867,48 +846,6 @@ describe('instant validation', () => {
            - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
              https://nextjs.org/docs/messages/blocking-prerender-current-time#for-telemetry-use-a-timing-api
              at a (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:12:20)
-           10 | export default async function Page() {
-           11 |   await cookies()
-         > 12 |   const now = Date.now()
-              |                    ^
-           13 |   return (
-           14 |     <main>
-           15 |       <p>Runtime page with sync IO after cookies: {now}</p>
-         Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent": Next.js encountered the unstable value \`Date.now()\` while prerendering.
-
-         This value can change between renders, so it must be either prerendered or computed later.
-
-         Ways to fix this:
-           - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#generate-on-every-request
-           - [cache] Prerender and cache the value with \`"use cache"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#cache-the-timestamp
-           - [client] Render the value on the client with \`"use client"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#render-on-the-client
-           - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#for-telemetry-use-a-timing-api
-             at b (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:12:20)
-           10 | export default async function Page() {
-           11 |   await cookies()
-         > 12 |   const now = Date.now()
-              |                    ^
-           13 |   return (
-           14 |     <main>
-           15 |       <p>Runtime page with sync IO after cookies: {now}</p>
-         Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent": Next.js encountered the unstable value \`Date.now()\` while prerendering.
-
-         This value can change between renders, so it must be either prerendered or computed later.
-
-         Ways to fix this:
-           - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#generate-on-every-request
-           - [cache] Prerender and cache the value with \`"use cache"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#cache-the-timestamp
-           - [client] Render the value on the client with \`"use client"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#render-on-the-client
-           - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#for-telemetry-use-a-timing-api
-             at c (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:12:20)
            10 | export default async function Page() {
            11 |   await cookies()
          > 12 |   const now = Date.now()
@@ -1074,27 +1011,6 @@ describe('instant validation', () => {
            10 |   return {
            11 |     title: \`Sync IO in metadata: \${now}\`,
            12 |   }
-         Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata": Next.js encountered the unstable value \`Date.now()\` while prerendering.
-
-         This value can change between renders, so it must be either prerendered or computed later.
-
-         Ways to fix this:
-           - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#generate-on-every-request
-           - [cache] Prerender and cache the value with \`"use cache"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#cache-the-timestamp
-           - [client] Render the value on the client with \`"use client"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#render-on-the-client
-           - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#for-telemetry-use-a-timing-api
-             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:9:20)
-            7 | export async function generateMetadata() {
-            8 |   await cookies()
-         >  9 |   const now = Date.now()
-              |                    ^
-           10 |   return {
-           11 |     title: \`Sync IO in metadata: \${now}\`,
-           12 |   }
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata".
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
            - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" in your browser to investigate the error.
@@ -1154,48 +1070,6 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata": Next.js encountered the unstable value \`Date.now()\` while prerendering.
-
-         This value can change between renders, so it must be either prerendered or computed later.
-
-         Ways to fix this:
-           - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#generate-on-every-request
-           - [cache] Prerender and cache the value with \`"use cache"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#cache-the-timestamp
-           - [client] Render the value on the client with \`"use client"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#render-on-the-client
-           - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#for-telemetry-use-a-timing-api
-             at Module.d [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/layout.tsx:11:20)
-            9 | export async function generateMetadata() {
-           10 |   await cookies()
-         > 11 |   const now = Date.now()
-              |                    ^
-           12 |   return {
-           13 |     title: \`Layout metadata with sync IO: \${now}\`,
-           14 |   }
-         Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata": Next.js encountered the unstable value \`Date.now()\` while prerendering.
-
-         This value can change between renders, so it must be either prerendered or computed later.
-
-         Ways to fix this:
-           - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#generate-on-every-request
-           - [cache] Prerender and cache the value with \`"use cache"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#cache-the-timestamp
-           - [client] Render the value on the client with \`"use client"\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#render-on-the-client
-           - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
-             https://nextjs.org/docs/messages/blocking-prerender-current-time#for-telemetry-use-a-timing-api
-             at Module.d [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/layout.tsx:11:20)
-            9 | export async function generateMetadata() {
-           10 |   await cookies()
-         > 11 |   const now = Date.now()
-              |                    ^
-           12 |   return {
-           13 |     title: \`Layout metadata with sync IO: \${now}\`,
-           14 |   }
-         Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata": Next.js encountered the unstable value \`Date.now()\` while prerendering.
 
          This value can change between renders, so it must be either prerendered or computed later.
 


### PR DESCRIPTION
Continuing the app shell implementation work. This PR implements recovering *static* shells from staged dynamic requests, so that we can recover a shell from a navigation. This is done using a byte offset, analogous to existing recovery of the static stage.

in #93801 we already implemented the session shell codepath, in `spawnRuntimePrefetchWithFilledCaches`, so we're not concerned with session shells here. This means that for a navigation, we can resolve static params in the static stage -- we don't care about recovering a  session shell, so we don't have to delay link data until the runtime stage.

One notable difference from the previous PR is that we don't set the byte length to `null` if the whole response is the same as the shell stage. We don't really expect this to happen -- if a page is fully static, it shouldn't be doing a navigation request anyway, so this doesn't seem worth optimizing.

Highlight: changing the timing of when cookies/headers resolve affected some Sync IO tests -- params/searchParams were now unresolved at the abort point, and triggered a bunch of unhandled rejections. This led to the discovery that we our unhandled rejection filter is not applied to build validation, which is why we were seeing mysterious duplicated error logs in those tests. This is also fixed here since now it became more of a problem.