### PR TITLE
[App Shells] staged shell rendering during build

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5426,6 +5426,16 @@ async function accumulateStreamChunks(
   signal: AbortSignal | null
 ): Promise<AccumulatedStreamChunks> {
   const accumulator = createStageChunksAccumulator()
+  await accumulateStreamChunksInto(accumulator, stream, stageController, signal)
+  return accumulator
+}
+
+async function accumulateStreamChunksInto(
+  accumulator: AccumulatedStreamChunks,
+  stream: AnyStream,
+  stageController: StagedRenderingController,
+  signal: AbortSignal | null
+): Promise<void> {
   if (stream instanceof ReadableStream) {
     const reader = stream.getReader()
 
@@ -5483,7 +5493,6 @@ async function accumulateStreamChunks(
       }
     }
   }
-  return accumulator
 }
 
 function accumulateChunk(
@@ -7514,7 +7523,7 @@ async function prerenderToStream(
     cacheComponents,
   } = renderOpts
 
-  const { cachedNavigations } = renderOpts.experimental
+  const { cachedNavigations, appShells } = renderOpts.experimental
 
   const renderFlightStream = process.env.__NEXT_USE_NODE_STREAMS
     ? renderToNodeFlightStream
@@ -7707,6 +7716,7 @@ async function prerenderToStream(
         // but we don't actually care about sync IO in this phase so we use a throw away controller
         // that isn't connected to anything
         controller: new AbortController(),
+        stagedRendering: null, // We don't need staging in the initial render
         // During the initial prerender we need to track all cache reads to ensure
         // we render long enough to fill every cache it is possible to visit during
         // the final prerender.
@@ -7740,6 +7750,7 @@ async function prerenderToStream(
         implicitTags,
         renderSignal: initialServerRenderController.signal,
         controller: initialServerPrerenderController,
+        stagedRendering: null, // We don't need staging in the initial render
         // During the initial prerender we need to track all cache reads to ensure
         // we render long enough to fill every cache it is possible to visit during
         // the final prerender.
@@ -7969,6 +7980,13 @@ async function prerenderToStream(
 
       const varyParamsAccumulator = createResponseVaryParamsAccumulator()
 
+      const finalStageController = new StagedRenderingController({
+        abortSignal: finalServerRenderController.signal,
+        abandonController: null,
+        shouldTrackSyncIO: true,
+        finalStage: RenderStage.Static,
+      })
+
       const finalServerPayloadPrerenderStore: PrerenderStore = {
         type: 'prerender',
         phase: 'render',
@@ -7982,6 +8000,9 @@ async function prerenderToStream(
         // but we don't actually care about sync IO in this phase so we use a throw away controller
         // that isn't connected to anything
         controller: new AbortController(),
+        // NOTE: we're not using the stage controller for sync IO tracking,
+        // so this doesn't break the "throwaway abort controller" trick above.
+        stagedRendering: finalStageController,
         // All caches we could read must already be filled so no tracking is necessary
         cacheSignal: null,
         dynamicTracking: null,
@@ -7994,12 +8015,19 @@ async function prerenderToStream(
         varyParamsAccumulator,
       }
 
+      const shellByteLengthDeferred = appShells
+        ? createPromiseWithResolvers<number | null>()
+        : null
+
       const finalServerPayload = await workUnitAsyncStorage.run(
         finalServerPayloadPrerenderStore,
         getRSCPayload,
         tree,
         ctx,
-        { is404: res.statusCode === 404 }
+        {
+          is404: res.statusCode === 404,
+          shellByteLengthPromise: shellByteLengthDeferred?.promise,
+        }
       )
 
       let staleTimeIterable: StaleTimeIterable | undefined
@@ -8011,7 +8039,7 @@ async function prerenderToStream(
       const serverDynamicTracking = createDynamicTrackingState(
         isDebugDynamicAccesses
       )
-      let serverIsDynamic = false
+      let resultIsPartial = false
 
       const finalServerPrerenderStore: PrerenderStore = (prerenderStore = {
         type: 'prerender',
@@ -8021,6 +8049,7 @@ async function prerenderToStream(
         implicitTags,
         renderSignal: finalServerRenderController.signal,
         controller: finalServerReactController,
+        stagedRendering: finalStageController,
         // All caches we could read must already be filled so no tracking is necessary
         cacheSignal: null,
         dynamicTracking: serverDynamicTracking,
@@ -8043,7 +8072,9 @@ async function prerenderToStream(
 
       const streamState = createStreamPendingState()
       const collectedChunks = createPrerenderChunksAccumulator()
+      const collectedChunksByStage = createStageChunksAccumulator()
       let debugEndTime: number | undefined = undefined
+      let didLinkDataUnblockNewContent = false
 
       await runInSequentialTasks(
         async () => {
@@ -8060,7 +8091,9 @@ async function prerenderToStream(
             )
           }
 
-          const stream = workUnitAsyncStorage.run(
+          finalStageController.advanceStage(RenderStage.ShellStatic)
+
+          let stream = workUnitAsyncStorage.run(
             finalServerPrerenderStore,
             ComponentMod.renderToReadableStream,
             finalServerPayload,
@@ -8085,6 +8118,18 @@ async function prerenderToStream(
             { once: true }
           )
 
+          if (appShells) {
+            let teedStream: typeof stream
+            ;[stream, teedStream] = stream.tee()
+
+            void accumulateStreamChunksInto(
+              collectedChunksByStage,
+              teedStream,
+              finalStageController,
+              finalServerRenderController.signal
+            ).catch(() => {})
+          }
+
           // Note: this await will only resolve after the last task (unless sync IO aborts the render earlier)
           // We await it here so that if the stream errors, it's not an unhandled rejection.
           await collectPrerenderChunksWeb(
@@ -8094,11 +8139,14 @@ async function prerenderToStream(
             finalServerReactController.signal
           )
         },
+        () => {
+          finalStageController.advanceStage(RenderStage.Static)
+        },
         async () => {
           if (finalServerReactController.signal.aborted) {
             // If the server controller is already aborted we must have called something
             // that required aborting the prerender synchronously such as with new Date()
-            serverIsDynamic = true
+            resultIsPartial = true
 
             // FIXME(NAR-810): If we're already aborted due to Sync IO, there should be no need to
             // finish the accumulators. However, it seems like in `--debug-prerender`
@@ -8112,6 +8160,15 @@ async function prerenderToStream(
             return
           }
 
+          // If new chunks were emitted in the static stage
+          // (after unblocking link data, i.e. static params)
+          // then the prerender uses link data.
+          // NOTE: we must capture this *before* resolving staleTime/varyParams,
+          // which always emit new static chunks.
+          didLinkDataUnblockNewContent =
+            collectedChunksByStage.staticChunks.length >
+            collectedChunksByStage.shellStaticChunks.length
+
           // Now that the prerendering is complete, we know the final stale
           // time and vary params. Close the stale time iterable and resolve
           // the vary params thenable so Flight can serialize their values
@@ -8122,14 +8179,25 @@ async function prerenderToStream(
           if (staleTimeIterable !== undefined) {
             staleTimeIterable.close()
           }
+          if (shellByteLengthDeferred) {
+            shellByteLengthDeferred.resolve(
+              didLinkDataUnblockNewContent
+                ? collectedChunksByStage.shellStaticChunks.reduce(
+                    (acc, chunk) => acc + chunk.byteLength,
+                    0
+                  )
+                : null
+            )
+          }
+
           // We're using a render, not a prerender, so React schedules rendering work in fast immediates,
-          // and we need to wait a fast immediate for the stale time/vary params chunks to flush.
+          // and we need to wait a fast immediate for the above accumulators to flush.
           await waitAtLeastOneReactRenderTask()
 
           if (streamState.isPending) {
             // If prerenderIsPending then we have blocked for longer than a Task and we assume
             // there is something unfinished.
-            serverIsDynamic = true
+            resultIsPartial = true
           }
 
           workUnitAsyncStorage.run(
@@ -8149,7 +8217,7 @@ async function prerenderToStream(
 
       const reactServerResult = (reactServerPrerenderResult =
         new ReactServerPrerenderResult(collectedChunks.prerenderChunks))
-      reactServerPrerenderResultIsDynamic = serverIsDynamic
+      reactServerPrerenderResultIsDynamic = resultIsPartial
       reactServerPrerenderStore = finalServerPrerenderStore
 
       if (shouldGenerateStaticFlightData(workStore)) {
@@ -8157,7 +8225,7 @@ async function prerenderToStream(
           cachedNavigations
             ? prependIsPartialByteToChunks(
                 reactServerResult.asChunks(),
-                serverIsDynamic
+                resultIsPartial
               )
             : reactServerResult.asChunks()
         )
@@ -8175,6 +8243,24 @@ async function prerenderToStream(
           ctx.pagePath,
           metadata
         )
+        if (appShells) {
+          // If link data (static params) unblocked new content, then the shell has to be partial.
+          // If not, then the shell prerender and the static prerender are the same except for staleTime/varyParams.
+          const shellIsPartial = didLinkDataUnblockNewContent
+            ? true
+            : resultIsPartial
+
+          metadata.segmentData ??= new Map()
+          metadata.segmentData.set(
+            '/_shell',
+            Buffer.concat(
+              prependIsPartialByteToChunks(
+                collectedChunksByStage.shellStaticChunks,
+                shellIsPartial
+              )
+            )
+          )
+        }
       }
 
       const clientDynamicTracking = createDynamicTrackingState(
@@ -8305,7 +8391,7 @@ async function prerenderToStream(
       })
 
       let htmlStream: AnyStream = prelude
-      if (serverIsDynamic) {
+      if (resultIsPartial) {
         if (postponed != null) {
           metadata.postponed = await getDynamicHTMLPostponedState(
             postponed,
@@ -8870,6 +8956,7 @@ async function prerenderToStream(
         implicitTags,
         renderSignal: errorServerRenderController.signal,
         controller: errorServerReactController,
+        stagedRendering: null,
         cacheSignal: null,
         dynamicTracking: errorServerDynamicTracking,
         revalidate:

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -182,6 +182,8 @@ export interface PrerenderStoreModernServer
   extends PrerenderStoreModernCommon,
     StaticPrerenderStoreCommon {
   readonly type: 'prerender'
+
+  readonly stagedRendering: StagedRenderingController | null
 }
 
 export interface PrerenderStoreModernRuntime
@@ -568,8 +570,8 @@ export function getStagedRenderingController(
   switch (workUnitStore.type) {
     case 'request':
     case 'prerender-runtime':
-      return workUnitStore.stagedRendering ?? null
     case 'prerender':
+      return workUnitStore.stagedRendering ?? null
     case 'prerender-client':
     case 'validation-client':
     case 'prerender-ppr':

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -397,17 +397,51 @@ function createStaticPrerenderParams(
   prerenderStore: StaticPrerenderStore,
   varyParamsAccumulator: VaryParamsAccumulator | null
 ): Promise<Params> {
-  const underlyingParamsWithVarying =
-    varyParamsAccumulator !== null
-      ? createVaryingParams(
-          varyParamsAccumulator,
-          underlyingParams,
-          optionalCatchAllParamName
-        )
-      : underlyingParams
-
   switch (prerenderStore.type) {
-    case 'prerender':
+    case 'prerender': {
+      const fallbackParams = prerenderStore.fallbackRouteParams
+      if (fallbackParams) {
+        for (const key in underlyingParams) {
+          if (fallbackParams.has(key)) {
+            // This params object has one or more fallback params, so we need
+            // to consider the awaiting of this params object "dynamic". Since
+            // we are in cacheComponents mode we encode this as a promise that never
+            // resolves.
+            return makeHangingParams(
+              underlyingParams,
+              workStore,
+              prerenderStore
+            )
+          }
+        }
+      }
+
+      // Even if all params are static, we need to exclude them from the shell
+      // by delaying them to the static stage. This includes root params.
+      const { stagedRendering } = prerenderStore
+      if (
+        process.env.__NEXT_APP_SHELLS &&
+        stagedRendering &&
+        !isEmptyParams(underlyingParams)
+      ) {
+        const underlyingParamsWithVarying =
+          varyParamsAccumulator !== null
+            ? createVaryingParams(
+                varyParamsAccumulator,
+                underlyingParams,
+                optionalCatchAllParamName
+              )
+            : underlyingParams
+
+        return stagedRendering.delayUntilStage(
+          // static prerenders don't distinguish early/late, this is just for consistency.
+          RENDER_STAGES_BY_DATA_KIND.staticLinkData.late,
+          'params',
+          underlyingParamsWithVarying
+        )
+      }
+      break
+    }
     case 'prerender-client': {
       const fallbackParams = prerenderStore.fallbackRouteParams
       if (fallbackParams) {
@@ -418,7 +452,7 @@ function createStaticPrerenderParams(
             // we are in cacheComponents mode we encode this as a promise that never
             // resolves.
             return makeHangingParams(
-              underlyingParamsWithVarying,
+              underlyingParams,
               workStore,
               prerenderStore
             )
@@ -433,7 +467,7 @@ function createStaticPrerenderParams(
         for (const key in underlyingParams) {
           if (fallbackParams.has(key)) {
             return makeErroringParams(
-              underlyingParamsWithVarying,
+              underlyingParams,
               fallbackParams,
               workStore,
               prerenderStore
@@ -449,6 +483,14 @@ function createStaticPrerenderParams(
       prerenderStore satisfies never
   }
 
+  const underlyingParamsWithVarying =
+    varyParamsAccumulator !== null
+      ? createVaryingParams(
+          varyParamsAccumulator,
+          underlyingParams,
+          optionalCatchAllParamName
+        )
+      : underlyingParams
   return makeUntrackedParams(underlyingParamsWithVarying)
 }
 

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -83,7 +83,35 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
       workUnitStore.readRootParamNames.add(paramName)
       return Promise.resolve(workUnitStore.rootParams[paramName])
     }
-    case 'prerender':
+    case 'prerender': {
+      const { stagedRendering, fallbackRouteParams } = workUnitStore
+      if (stagedRendering && process.env.__NEXT_APP_SHELLS) {
+        // If the root param is a fallback param, we don't have a value to return
+        if (fallbackRouteParams && fallbackRouteParams.has(paramName)) {
+          return makeHangingPromise<ParamValue>(
+            workUnitStore.renderSignal,
+            workStore.route,
+            apiName
+          )
+        }
+        // Otherwise, it's link data, so we delay it to exclude it from the shell
+        // and only resolve in the param-ful static stage
+        return createRootParamPromiseForShellRender(
+          stagedRendering,
+          getStaticLinkDataStage(stagedRendering),
+          apiName,
+          paramName,
+          workUnitStore.rootParams[paramName]
+        )
+      }
+
+      return createPrerenderRootParamPromise(
+        paramName,
+        workStore,
+        workUnitStore,
+        apiName
+      )
+    }
     case 'prerender-ppr':
     case 'prerender-legacy': {
       return createPrerenderRootParamPromise(

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -509,6 +509,7 @@ export class AppRouteRouteModule extends RouteModule<
               implicitTags,
               renderSignal: prospectiveController.signal,
               controller: prospectiveController,
+              stagedRendering: null,
               cacheSignal,
               // During prospective render we don't use a controller
               // because we need to let all caches fill.
@@ -606,6 +607,7 @@ export class AppRouteRouteModule extends RouteModule<
             implicitTags,
             renderSignal: finalController.signal,
             controller: finalController,
+            stagedRendering: null,
             cacheSignal: null,
             dynamicTracking,
             revalidate: defaultRevalidate,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2223,6 +2223,12 @@ export async function cache(
           rdcResult.readRootParamNames.size > 0
         ) {
           switch (workUnitStore.type) {
+            case 'prerender': {
+              await stagedRendering.waitForStage(
+                getStaticLinkDataStage(stagedRendering)
+              )
+              break
+            }
             case 'prerender-runtime': {
               // If we're rendering with shells, this is when params should resolve
               await stagedRendering.waitForStage(
@@ -2238,7 +2244,6 @@ export async function cache(
               )
               break
             }
-            case 'prerender':
             case 'cache':
             case 'private-cache':
             case 'prerender-legacy':


### PR DESCRIPTION
The final PR in the initial App Shell series. Here, we turn the build-time static prerender into a proper staged render, and recover a shell from it. The only difference between them is static link data, i.e. root params and static params. Those are delayed until the static stage analogously to the previous PRs.

We collect the chunks emitted in the shell stages and emit them as a special `/_shell` segment marked with an `isPartial` byte.