### PR TITLE
enable eviction on canary

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -53,6 +53,7 @@ import { HardDeprecatedConfigError } from '../shared/lib/errors/hard-deprecated-
 import { NextInstanceErrorState } from './mcp/tools/next-instance-error-state'
 import { Bundler } from '../lib/bundler'
 import type { MemoryEvictionMode } from '../build/swc/types'
+import { isStableBuild } from '../shared/lib/errors/canary-only-config-error'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
@@ -436,7 +437,9 @@ function assignDefaultsAndValidate(
     const rawEnv = process.env.TURBO_ENGINE_EVICT_AFTER_SNAPSHOT
     turbopackMemoryEvictionMode =
       rawEnv == null
-        ? 'off'
+        ? isStableBuild()
+          ? 'off'
+          : 'full'
         : rawEnv === '1' || rawEnv === 'true'
           ? 'full'
           : 'off'


### PR DESCRIPTION
Enable turbopack memory eviction by default on canary

Can be disabled by setting the option to `off` directly.  

Our intent is to simply enable by default (See #94452) but that is separate so it is easier to revert