### PR TITLE
enable eviction by default

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackMemoryEviction.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackMemoryEviction.mdx
@@ -6,12 +6,12 @@ description: Learn how to control Turbopack's memory eviction strategy for the p
 
 ## Usage
 
-`turbopackMemoryEviction` controls how aggressively Turbopack reclaims memory while the persistent (FileSystem) cache is enabled. After Turbopack writes a snapshot of its cache to disk, it can evict the in-memory copies of that data and reload them from disk on demand, lowering peak memory usage at the cost of some extra disk reads.
+`turbopackMemoryEviction` controls how whether Turbopack reclaims memory while the persistent (FileSystem) cache is enabled. After Turbopack writes a snapshot of its cache to disk, it can 'evict' the in-memory copies of that data and reload them from disk on demand.
 
 Currently there are two options
 
-- `false` (default): never evict. Cached data stays in memory for the lifetime of the process.
-- `'full'`: after every snapshot, evict all evictable tasks from memory. They are reloaded from disk on demand.
+- `false`: never evict. Cached data stays in memory for the lifetime of the process.
+- `'full'` (default): after every snapshot, evict all possible data from memory. They are reloaded from disk on demand.
 
 > **Good to know:** This option only has an effect in `next dev` sessions when the [FileSystem Cache](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled, since eviction relies on data already being persisted to disk. It is experimental and under active development.
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -691,7 +691,7 @@ export interface ExperimentalConfig {
    * - `false`: disable eviction.
    * - `'full'`: after every snapshot, drop as much memory as possible.
    *
-   * Defaults to `false`
+   * Defaults to `'full'`
    */
   turbopackMemoryEviction?: false | 'full'
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -53,7 +53,6 @@ import { HardDeprecatedConfigError } from '../shared/lib/errors/hard-deprecated-
 import { NextInstanceErrorState } from './mcp/tools/next-instance-error-state'
 import { Bundler } from '../lib/bundler'
 import type { MemoryEvictionMode } from '../build/swc/types'
-import { isStableBuild } from '../shared/lib/errors/canary-only-config-error'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
@@ -436,13 +435,7 @@ function assignDefaultsAndValidate(
     // Not set by the user: fall back to the env var if present, otherwise 'off'.
     const rawEnv = process.env.TURBO_ENGINE_EVICT_AFTER_SNAPSHOT
     turbopackMemoryEvictionMode =
-      rawEnv == null
-        ? isStableBuild()
-          ? 'off'
-          : 'full'
-        : rawEnv === '1' || rawEnv === 'true'
-          ? 'full'
-          : 'off'
+      rawEnv == null || rawEnv === '1' || rawEnv === 'true' ? 'full' : 'off'
   }
   ;(result as NextConfigComplete).experimental.turbopackMemoryEvictionMode =
     turbopackMemoryEvictionMode as MemoryEvictionMode


### PR DESCRIPTION
Enable memory eviction by default

If this causes trouble setting `experimental.turbopackMemoryEviction=false` can disable this feature.