### PR TITLE
Revert "Keep the dev React debug channel on Node streams end to end"

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3593,7 +3593,7 @@ async function renderToStream(
       ) {
         if (process.env.__NEXT_USE_NODE_STREAMS) {
           // MARK: nodeStreams dev CacheComponents RSC
-          let debugChannelClientStream: ReplayableNodeStream | undefined
+          let debugChannel: DebugChannelPair | undefined
 
           // eslint-disable-next-line @typescript-eslint/no-shadow
           const getPayload = async (requestStore: RequestStore) => {
@@ -3652,11 +3652,11 @@ async function renderToStream(
 
             let validationDebugChannelClient: AnyStream | undefined = undefined
             if (returnedDebugChannel) {
-              debugChannelClientStream = new ReplayableNodeStream(
+              const [t1, t2] = teeStream(
                 returnedDebugChannel.clientSide.readable
               )
-              validationDebugChannelClient =
-                debugChannelClientStream.createReplayStream()
+              returnedDebugChannel.clientSide.readable = t1
+              validationDebugChannelClient = t2
             }
 
             consoleAsyncStorage.run(
@@ -3676,14 +3676,14 @@ async function renderToStream(
 
             reactServerResult = new ReactServerResult(serverStream)
             requestStore = finalRequestStore
+            debugChannel = returnedDebugChannel
           } else {
             logValidationSkipped(ctx)
 
             // We're either bypassing caches or we can't restart the render.
             // Do a dynamic render, but with (basic) environment labels.
 
-            const debugChannel =
-              setReactDebugChannel && createNodeDebugChannel()
+            debugChannel = setReactDebugChannel && createNodeDebugChannel()
 
             const serverStream = await stagedRenderWithoutCachesInDevNode(
               ctx,
@@ -3696,19 +3696,17 @@ async function renderToStream(
               }
             )
             reactServerResult = new ReactServerResult(serverStream)
-
-            if (debugChannel) {
-              debugChannelClientStream = new ReplayableNodeStream(
-                debugChannel.clientSide.readable
-              )
-            }
           }
 
-          if (debugChannelClientStream && setReactDebugChannel) {
-            reactDebugStream = debugChannelClientStream.createReplayStream()
+          if (debugChannel && setReactDebugChannel) {
+            const [readableSsr, readableBrowser] = teeStream(
+              debugChannel.clientSide.readable
+            )
+
+            reactDebugStream = readableSsr
 
             setReactDebugChannel(
-              { readable: debugChannelClientStream.createReplayStream() },
+              { readable: readableBrowser },
               htmlRequestId,
               requestId
             )

--- a/packages/next/src/server/app-render/debug-channel-server.node.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.node.ts
@@ -3,27 +3,17 @@
  * Loaded by debug-channel-server.ts when __NEXT_USE_NODE_STREAMS is enabled.
  */
 
-import { PassThrough, Writable, type Readable } from 'node:stream'
-import type { DebugChannelServer } from './debug-channel-server.web'
+import { PassThrough, Writable } from 'node:stream'
+import type { DebugChannelPair } from './debug-channel-server.web'
 
 export { createWebDebugChannel } from './debug-channel-server.web'
-
-/**
- * Node variant: identical to `DebugChannelPair` except the client-side readable
- * is narrowed to a Node `Readable`, so node call sites can consume it (e.g.
- * `new ReplayableNodeStream(...)`) without casting `AnyStream` down.
- */
-export type NodeDebugChannelPair = {
-  serverSide: DebugChannelServer
-  clientSide: { readable: Readable }
-}
 
 /**
  * Creates a debug channel using Node.js streams.
  * Use with renderToNodeFlightStream (React's renderToPipeableStream),
  * which expects debugChannel to be a Node.js stream with a .write() method.
  */
-export function createNodeDebugChannel(): NodeDebugChannelPair {
+export function createNodeDebugChannel(): DebugChannelPair {
   // The readable side is a PassThrough that the client reads from. The
   // server-side write target is a separate, write-only Writable that forwards
   // into it rather than the PassThrough itself: React's renderToPipeableStream
@@ -33,11 +23,12 @@ export function createNodeDebugChannel(): NodeDebugChannelPair {
   // The forwarding must use `passthrough.write()` / `passthrough.end()`, not
   // `passthrough.push()` / `passthrough.push(null)`. A PassThrough is a Duplex;
   // pushing `null` ends only its readable half and leaves the writable half
-  // open (`writableEnded` stays false). If the readable is consumed via
-  // `Readable.toWeb()`, that web stream never closes while the PassThrough's
-  // writable half is still open — so the debug channel would never close on the
-  // client. Ending it via `passthrough.end()` closes both halves and the close
-  // propagates.
+  // open (`writableEnded` stays false). The readable is later consumed via
+  // `Readable.toWeb()` (in `connectReactDebugChannel`, and inside `teeStream`),
+  // and `Readable.toWeb()` never closes the resulting web stream while the
+  // PassThrough's writable half is still open — so the debug channel never
+  // closes on the client. Ending it via `passthrough.end()` closes both halves
+  // and the close propagates.
   const passthrough = new PassThrough()
 
   const writable = new Writable({

--- a/packages/next/src/server/app-render/debug-channel-server.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.ts
@@ -8,13 +8,11 @@ export type {
   DebugChannelPair,
   DebugChannelServer,
 } from './debug-channel-server.web'
-export type { NodeDebugChannelPair } from './debug-channel-server.node'
 import type { DebugChannelPair } from './debug-channel-server.web'
-import type { NodeDebugChannelPair } from './debug-channel-server.node'
 
 type DebugChannelMod = {
   createWebDebugChannel: typeof import('./debug-channel-server.web').createWebDebugChannel
-  createNodeDebugChannel: typeof import('./debug-channel-server.node').createNodeDebugChannel
+  createNodeDebugChannel: typeof import('./debug-channel-server.web').createNodeDebugChannel
 }
 
 let _m: DebugChannelMod
@@ -34,7 +32,7 @@ export function createWebDebugChannel(): DebugChannelPair | undefined {
   return _m.createWebDebugChannel()
 }
 
-export function createNodeDebugChannel(): NodeDebugChannelPair | undefined {
+export function createNodeDebugChannel(): DebugChannelPair | undefined {
   if (process.env.NODE_ENV === 'production') {
     return undefined
   }

--- a/packages/next/src/server/app-render/debug-channel-server.web.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.web.ts
@@ -53,6 +53,6 @@ export function createWebDebugChannel(): DebugChannelPair {
  * Use with renderToNodeFlightStream (React's renderToPipeableStream),
  * which expects debugChannel to be a Node.js stream with a .write() method.
  */
-export function createNodeDebugChannel(): never {
+export function createNodeDebugChannel(): DebugChannelPair {
   throw new Error('not implemented')
 }

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -36,10 +36,7 @@ import {
   htmlEscapeJsonString,
 } from '../../shared/lib/htmlescape'
 import { createInlinedDataReadableStream } from './use-flight-response'
-import {
-  ReplayableNodeStream,
-  type AnyStream as AnyStreamType,
-} from './app-render-prerender-utils'
+import type { AnyStream as AnyStreamType } from './app-render-prerender-utils'
 import { DetachedPromise } from '../../lib/detached-promise'
 import { getTracer } from '../lib/trace/tracer'
 import { AppRenderSpan } from '../lib/trace/constants'
@@ -121,14 +118,10 @@ function webToReadable(
 
 // ---------------------------------------------------------------------------
 // Buffered transform – Node.js Transform that coalesces chunks written in the
-// same microtask into a single Uint8Array before pushing downstream, flushing
-// synchronously once the buffer reaches `maxBufferByteLength` (default: never,
-// i.e. microtask-only).
+// same microtask into a single Uint8Array before pushing downstream.
 // ---------------------------------------------------------------------------
 
-export function createNodeBufferedTransformStream(
-  maxBufferByteLength: number = Infinity
-): Transform {
+function createBufferedTransformStream(): Transform {
   let bufferedChunks: Array<Uint8Array> = []
   let bufferByteLength = 0
   let flushScheduled = false
@@ -153,9 +146,7 @@ export function createNodeBufferedTransformStream(
       bufferedChunks.push(chunk)
       bufferByteLength += chunk.byteLength
 
-      if (bufferByteLength >= maxBufferByteLength) {
-        flushBuffered(this)
-      } else if (!flushScheduled) {
+      if (!flushScheduled) {
         flushScheduled = true
         queueMicrotask(() => {
           flushScheduled = false
@@ -734,7 +725,7 @@ export async function continueFizzStream(
   // 1. Buffer – coalesces chunks written in the same microtask into one Uint8Array
   // 2. Flight data injection – interleaves RSC data chunks with the HTML stream
   // 3. Head insertion – inserts server-generated HTML before </head>
-  const buffered = createNodeBufferedTransformStream()
+  const buffered = createBufferedTransformStream()
   webToReadable(renderStream).pipe(buffered)
 
   let source: Readable = buffered
@@ -845,7 +836,7 @@ export async function continueDynamicHTMLResumeNode(
 ): Promise<AnyStream> {
   await waitAtLeastOneReactRenderTask()
 
-  const buffered = createNodeBufferedTransformStream()
+  const buffered = createBufferedTransformStream()
   webToReadable(renderStream).pipe(buffered)
 
   let source: Readable = buffered
@@ -1107,12 +1098,7 @@ export function getServerPrerender(ComponentMod: {
 export const getClientPrerender: typeof import('react-dom/static').prerender =
   prerender
 
-// Node counterpart of the web `teeStream`. Like the web version it assumes the
-// stream type matching its build — here a Node `Readable` — and fans out
-// through `ReplayableNodeStream`. Need three or more consumers from one source?
-// Use `ReplayableNodeStream` directly (N `createReplayStream()` calls) to avoid
-// nesting tees.
 export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
-  const replayable = new ReplayableNodeStream(stream as Readable)
-  return [replayable.createReplayStream(), replayable.createReplayStream()]
+  const [s1, s2] = nodeReadableToWebReadableStream(stream).tee()
+  return [webToReadable(s1), webToReadable(s2)]
 }

--- a/packages/next/src/server/dev/debug-channel.ts
+++ b/packages/next/src/server/dev/debug-channel.ts
@@ -6,9 +6,14 @@ import {
 } from './hot-reloader-types'
 import type { AnyStream } from '../app-render/stream-ops'
 
-// Chunks are sent to the browser in batches to reduce overhead, flushing
-// synchronously once this many bytes have accumulated.
-const MAX_DEBUG_CHANNEL_BATCH_BYTES = 128 * 1024
+function toWebReadableStream(stream: AnyStream): ReadableStream<Uint8Array> {
+  if (stream instanceof ReadableStream) {
+    return stream
+  }
+  const { Readable: ReadableClass } =
+    require('node:stream') as typeof import('node:stream')
+  return ReadableClass.toWeb(stream as Readable) as ReadableStream<Uint8Array>
+}
 
 export interface ReactDebugChannelForBrowser {
   readonly readable: AnyStream
@@ -19,23 +24,19 @@ const reactDebugChannelsByHtmlRequestId = new Map<
   ReactDebugChannelForBrowser
 >()
 
-/**
- * Reads the React debug channel and forwards its chunks to the browser through
- * the websocket. Branches on the stream type so that Node streams stay
- * node-native — batched with a Node `Transform` and consumed via events.
- */
 export function connectReactDebugChannel(
   requestId: string,
   debugChannel: ReactDebugChannelForBrowser,
   sendToClient: (message: HmrMessageSentToBrowser) => void
 ) {
-  let finished = false
+  const reader = toWebReadableStream(debugChannel.readable)
+    .pipeThrough(
+      // We're sending the chunks in batches to reduce overhead in the browser.
+      createBufferedTransformStream({ maxBufferByteLength: 128 * 1024 })
+    )
+    .getReader()
 
   const stop = () => {
-    if (finished) {
-      return
-    }
-    finished = true
     sendToClient({
       type: HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK,
       requestId,
@@ -44,58 +45,25 @@ export function connectReactDebugChannel(
   }
 
   const onError = (err: unknown) => {
-    if (!finished) {
-      console.error(
-        new Error('React debug channel stream error', { cause: err })
-      )
-    }
+    console.error(new Error('React debug channel stream error', { cause: err }))
     stop()
   }
 
-  const sendChunk = (chunk: Uint8Array) => {
-    sendToClient({
-      type: HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK,
-      requestId,
-      chunk,
-    })
-  }
+  const progress = (entry: ReadableStreamReadResult<Uint8Array>) => {
+    if (entry.done) {
+      stop()
+    } else {
+      sendToClient({
+        type: HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK,
+        requestId,
+        chunk: entry.value,
+      })
 
-  const { readable } = debugChannel
-
-  if (readable instanceof ReadableStream) {
-    const reader = readable
-      .pipeThrough(
-        createBufferedTransformStream({
-          maxBufferByteLength: MAX_DEBUG_CHANNEL_BATCH_BYTES,
-        })
-      )
-      .getReader()
-
-    const progress = (entry: ReadableStreamReadResult<Uint8Array>) => {
-      if (entry.done) {
-        stop()
-      } else {
-        sendChunk(entry.value)
-        reader.read().then(progress, onError)
-      }
+      reader.read().then(progress, onError)
     }
-
-    reader.read().then(progress, onError)
-  } else {
-    const { createNodeBufferedTransformStream } =
-      require('../app-render/stream-ops.node') as typeof import('../app-render/stream-ops.node')
-
-    const source = readable as Readable
-    // `pipe` does not forward source errors to the destination, so handle them
-    // on the source directly.
-    source.on('error', onError)
-    const batched = source.pipe(
-      createNodeBufferedTransformStream(MAX_DEBUG_CHANNEL_BATCH_BYTES)
-    )
-    batched.on('data', sendChunk)
-    batched.on('end', stop)
-    batched.on('error', onError)
   }
+
+  reader.read().then(progress, onError)
 }
 
 export function connectReactDebugChannelForHtmlRequest(


### PR DESCRIPTION
Reverts https://github.com/vercel/next.js/pull/94433

Somewhere the bundling is taking a wrong and using installed React.

Fixes 
> Error: Package subpath './static' is not defined by "exports" in /private/var/folders/pw/l2r2l0mn4gq7jg3bprfv_w740000gn/T/next-install-e07ea988ac58480be8a8e79aa3bb7b70c4ace6c9a4a7536e2b3a5dd8572364a6/node_modules/.pnpm/next@file+..+..+..+..+..+..+..+Users+sebbie+repos+next.js+packages+next+packed.tgz_reac_4e32bbad19d0960a68a7ab2bff9d122c/node_modules/react-dom/package.json

-- https://github.com/vercel/next.js/actions/runs/26943313529/job/79510490402