### PR TITLE
fix(turbopack): allow `#/` prefixed subpath import specifiers

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3309,11 +3309,6 @@ async fn resolve_package_internal_with_imports_field(
     let Pattern::Constant(specifier) = pattern else {
         bail!("PackageInternal requests can only be Constant strings");
     };
-    // Node.js spec rejects specifiers that are exactly "#", start with "#/", or end with "/".
-    // However, the "#/*" pattern (e.g. { "#/*": "./src/*" }) is widely used in TypeScript
-    // projects and is supported by webpack (enhanced-resolve). Turbopack follows webpack
-    // behavior here to avoid a webpack/Turbopack divergence for this common pattern.
-    // See: https://github.com/vercel/next.js/issues/94290
     if specifier == "#" || specifier.ends_with('/') {
         ResolvingIssue {
             severity: resolve_error_severity(resolve_options).await?,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3309,8 +3309,12 @@ async fn resolve_package_internal_with_imports_field(
     let Pattern::Constant(specifier) = pattern else {
         bail!("PackageInternal requests can only be Constant strings");
     };
-    // https://github.com/nodejs/node/blob/1b177932/lib/internal/modules/esm/resolve.js#L615-L619
-    if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with('/') {
+    // Node.js spec rejects specifiers that are exactly "#", start with "#/", or end with "/".
+    // However, the "#/*" pattern (e.g. { "#/*": "./src/*" }) is widely used in TypeScript
+    // projects and is supported by webpack (enhanced-resolve). Turbopack follows webpack
+    // behavior here to avoid a webpack/Turbopack divergence for this common pattern.
+    // See: https://github.com/vercel/next.js/issues/94290
+    if specifier == "#" || specifier.ends_with('/') {
         ResolvingIssue {
             severity: resolve_error_severity(resolve_options).await?,
             file_path: file_path.clone(),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/index.js
@@ -1,0 +1,5 @@
+import greeting from '#/greeting.js'
+
+it('should resolve #/* subpath imports', () => {
+  expect(greeting).toBe('hello')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "subpath-imports-slash",
+  "imports": {
+    "#/*": "./src/*"
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/src/greeting.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/src/greeting.js
@@ -1,0 +1,1 @@
+export default 'hello'


### PR DESCRIPTION
## What?

Fixes Turbopack failing to resolve imports using the common `"#/*": "./src/*"` pattern in `package.json` `imports` field.

## Why?

The resolver had an early-rejection check that incorrectly blocked all specifiers starting with `#/`:

```rust
if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with(/) {
    // emit error, return unresolvable
}
```

Node.js and webpack (enhanced-resolve) both support the widely-used TypeScript pattern:

```json
"imports": {
  "#/*": "./src/*"
}
```

When a user writes `import x from '#/greeting'`, the specifier `#/greeting` starts with `#/`, so Turbopack was erroneously rejecting it before attempting the `imports` field lookup. Only bare `#` and directory-trailing `/` specifiers should be rejected early — `#/something` is perfectly valid and should reach the `imports` field resolver.

Since Turbopack is a drop-in webpack replacement in Next.js, it should support the same resolution patterns. The `AliasMap` already handles wildcard pattern matching correctly once the early rejection is bypassed — removing the `starts_with("#/")` guard is sufficient.

## How?

- Remove `specifier.starts_with("#/")` from the early rejection condition in `resolve_package_internal_with_imports_field`
- Add a test fixture (`subpath-imports-slash`) that validates `#/*` wildcard imports resolve correctly

## Testing

New test case in `turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash`:

```json
{ "imports": { "#/*": "./src/*" } }
```

```js
import greeting from '#/greeting.js'
it('should resolve #/* subpath imports', () => {
  expect(greeting).toBe('hello')
})
```

Closes #94290