### PR TITLE
Trace viewer: store span IDs in a Vec instead of a HashMap

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -67,9 +67,53 @@ enum InternalRowType {
     },
 }
 
+/// Dense map from external span id to `SpanIndex`.
+///
+/// The turbopack tracing layer assigns span ids sequentially starting at 1, so
+/// the key space is effectively contiguous (measured density ≈ 1.0 on real
+/// traces). Indexing a `Vec` beats hashing an `FxHashMap` on the ingest hot path
+/// and uses less memory; `Option<SpanIndex>` is a single `usize` thanks to the
+/// `NonZeroUsize` niche. Ids that have not been seen yet read back as `None`,
+/// matching the old `HashMap::get` semantics relied on for out-of-order parents.
+#[derive(Default)]
+struct DenseIdMap {
+    vec: Vec<Option<SpanIndex>>,
+    count: usize,
+}
+
+impl DenseIdMap {
+    fn with_capacity(cap: usize) -> Self {
+        Self {
+            vec: Vec::with_capacity(cap),
+            count: 0,
+        }
+    }
+
+    #[inline]
+    fn get(&self, id: u64) -> Option<SpanIndex> {
+        self.vec.get(id as usize).copied().flatten()
+    }
+
+    #[inline]
+    fn insert(&mut self, id: u64, index: SpanIndex) {
+        let i = id as usize;
+        if i >= self.vec.len() {
+            self.vec.resize(i + 1, None);
+        }
+        if self.vec[i].is_none() {
+            self.count += 1;
+        }
+        self.vec[i] = Some(index);
+    }
+
+    fn len(&self) -> usize {
+        self.count
+    }
+}
+
 pub struct TurbopackFormat {
     store: Arc<StoreContainer>,
-    id_mapping: FxHashMap<u64, SpanIndex>,
+    id_mapping: DenseIdMap,
     dropped_ids: FxHashSet<u64>,
     remaining_ids_to_drop: usize,
     queued_rows: FxHashMap<u64, Vec<InternalRow>>,
@@ -88,7 +132,7 @@ impl TurbopackFormat {
             .unwrap_or_default();
         Self {
             store,
-            id_mapping: FxHashMap::with_capacity_and_hasher(131_072, Default::default()),
+            id_mapping: DenseIdMap::with_capacity(131_072),
             dropped_ids: FxHashSet::with_capacity_and_hasher(drop_ids, Default::default()),
             remaining_ids_to_drop: drop_ids,
             queued_rows: FxHashMap::with_capacity_and_hasher(1_024, Default::default()),
@@ -366,8 +410,8 @@ impl TurbopackFormat {
             {
                 return;
             }
-            if let Some(id) = self.id_mapping.get(&id) {
-                Some(*id)
+            if let Some(index) = self.id_mapping.get(id) {
+                Some(index)
             } else {
                 // Parent hasn't been seen yet; queue this row to be processed
                 // when the parent arrives. The row is already lifetime-free


### PR DESCRIPTION
The tracing layer allocates span IDs sequentially, so when we index a trace file we expect nearly every ID to be encountered. This was backed up with analyzing some actual traces: I measured seen ID density to be somewhere between 0.997 and 0.999 (where 1.0 == every ID was encountered). This allows us to just store the span id -> index mapping in a `Vec<Option<T>>`, with linear lookup and a 3-4x reduction in memory.

The dense map itself is just a convenience data structure. Most of the methods are inlined for speed.

On medium-to-large traces I'm seeing an 8% reduction in file processing time.