### PR TITLE
Turbopack: remove EcmascriptParsable::parse_original

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -393,7 +393,7 @@ async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionA
         return Ok(Vc::cell(None));
     };
 
-    let ecmascript_asset =
+    let original_asset =
         if let Some(module) = ResolvedVc::try_downcast_type::<EcmascriptModulePartAsset>(module) {
             let module = module.await?;
             if matches!(module.part, ModulePart::Evaluation | ModulePart::Facade) {
@@ -404,7 +404,7 @@ async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionA
             ecmascript_asset
         };
 
-    let original_parsed = ecmascript_asset.failsafe_parse().to_resolved().await?;
+    let original_parsed = original_asset.failsafe_parse().to_resolved().await?;
 
     let ParseResult::Ok {
         program: original,
@@ -421,9 +421,9 @@ async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionA
         return Ok(Vc::cell(None));
     };
 
-    let fragment = ecmascript_asset.failsafe_parse().to_resolved().await?;
-
-    if fragment != original_parsed {
+    // If this is a module-fragment, filter the exports
+    if original_asset != ecmascript_asset {
+        let fragment = ecmascript_asset.failsafe_parse().to_resolved().await?;
         let ParseResult::Ok {
             program: fragment, ..
         } = &*fragment.await?

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -393,16 +393,18 @@ async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionA
         return Ok(Vc::cell(None));
     };
 
-    if let Some(module) = ResolvedVc::try_downcast_type::<EcmascriptModulePartAsset>(module)
-        && matches!(
-            module.await?.part,
-            ModulePart::Evaluation | ModulePart::Facade
-        )
-    {
-        return Ok(Vc::cell(None));
-    }
+    let ecmascript_asset =
+        if let Some(module) = ResolvedVc::try_downcast_type::<EcmascriptModulePartAsset>(module) {
+            let module = module.await?;
+            if matches!(module.part, ModulePart::Evaluation | ModulePart::Facade) {
+                return Ok(Vc::cell(None));
+            }
+            ResolvedVc::upcast(module.full_module)
+        } else {
+            ecmascript_asset
+        };
 
-    let original_parsed = *ecmascript_asset.parse_original().to_resolved().await?;
+    let original_parsed = ecmascript_asset.failsafe_parse().to_resolved().await?;
 
     let ParseResult::Ok {
         program: original,
@@ -419,7 +421,7 @@ async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionA
         return Ok(Vc::cell(None));
     };
 
-    let fragment = *ecmascript_asset.failsafe_parse().to_resolved().await?;
+    let fragment = ecmascript_asset.failsafe_parse().to_resolved().await?;
 
     if fragment != original_parsed {
         let ParseResult::Ok {

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -720,8 +720,8 @@ impl Request {
     /// Turns the request into a pattern, similar to [Request::request()] but
     /// more complete.
     #[turbo_tasks::function]
-    pub async fn request_pattern(self: Vc<Self>) -> Result<Vc<Pattern>> {
-        Ok(Pattern::new(match &*self.await? {
+    pub async fn request_pattern(&self) -> Result<Vc<Pattern>> {
+        Ok(Pattern::new(match self {
             Request::Raw { path, .. } => path.clone(),
             Request::Relative { path, .. } => path.clone(),
             Request::Module { module, path, .. } => {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -433,13 +433,7 @@ pub struct EcmascriptModuleAsset {
 #[turbo_tasks::value_trait]
 pub trait EcmascriptParsable {
     #[turbo_tasks::function]
-    fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>>;
-
-    #[turbo_tasks::function]
-    fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>>;
-
-    #[turbo_tasks::function]
-    fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>>;
+    fn failsafe_parse(self: Vc<Self>) -> Vc<ParseResult>;
 }
 
 #[turbo_tasks::value_trait]
@@ -599,16 +593,6 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
         } else {
             Ok(real_result)
         }
-    }
-
-    #[turbo_tasks::function]
-    fn parse_original(self: Vc<Self>) -> Vc<ParseResult> {
-        self.failsafe_parse()
-    }
-
-    #[turbo_tasks::function]
-    fn ty(&self) -> Vc<EcmascriptModuleAssetType> {
-        self.ty.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
@@ -12,8 +12,8 @@ use turbopack_core::{
 
 use crate::{
     AnalyzeEcmascriptModuleResult, EcmascriptAnalyzable, EcmascriptAnalyzableExt,
-    EcmascriptModuleAsset, EcmascriptModuleAssetType, EcmascriptModuleContent,
-    EcmascriptModuleContentOptions, EcmascriptParsable,
+    EcmascriptModuleAsset, EcmascriptModuleContent, EcmascriptModuleContentOptions,
+    EcmascriptParsable,
     chunk::{
         EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports,
         ecmascript_chunk_item,
@@ -46,15 +46,6 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
         let split_data = split_module(*self.full_module);
         assert_ne!(self.part, ModulePart::Facade);
         Ok(part_of_module(split_data, self.part.clone()))
-    }
-    #[turbo_tasks::function]
-    fn parse_original(&self) -> Vc<ParseResult> {
-        self.full_module.parse_original()
-    }
-
-    #[turbo_tasks::function]
-    fn ty(&self) -> Vc<EcmascriptModuleAssetType> {
-        self.full_module.ty()
     }
 }
 


### PR DESCRIPTION
`EcmascriptParsable::parse_original` is used to access the original module when using 'split modules', the only place that needed this was already checking for split modules for other reasons so we can simply remove this function from the trait and access the split module 'original' directly.

Also remove EcmascriptParseable::ty which was dead