### PR TITLE
Turbopack: Remove a cell from DataUri patterns and requests

### DIFF
--- a/turbopack/crates/turbopack-core/src/data_uri_source.rs
+++ b/turbopack/crates/turbopack-core/src/data_uri_source.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 
@@ -16,7 +16,7 @@ use crate::{
 pub struct DataUriSource {
     media_type: RcStr,
     encoding: RcStr,
-    data: ResolvedVc<RcStr>,
+    data: RcStr,
     lookup_path: FileSystemPath,
 }
 
@@ -26,7 +26,7 @@ impl DataUriSource {
     pub fn new(
         media_type: RcStr,
         encoding: RcStr,
-        data: ResolvedVc<RcStr>,
+        data: RcStr,
         lookup_path: FileSystemPath,
     ) -> Vc<Self> {
         Self::cell(DataUriSource {
@@ -41,19 +41,17 @@ impl DataUriSource {
 #[turbo_tasks::value_impl]
 impl Source for DataUriSource {
     #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<RcStr>> {
+    fn description(&self) -> Vc<RcStr> {
         let media_type = &self.media_type;
         let encoding = &self.encoding;
-        let data = self.data.await?;
+        let data = &self.data;
         // Build the data URI prefix for identification; data URIs can be very
         // long so we cap the total display at 50 characters.
         let sep = if encoding.is_empty() { "" } else { ";" };
         let full_with_data = format!("data:{media_type}{sep}{encoding},{data}");
         let prefix: String = full_with_data.chars().take(50).collect();
         let ellipsis = if full_with_data.len() > 50 { "..." } else { "" };
-        Ok(Vc::cell(
-            format!("data URI content ({prefix}{ellipsis})").into(),
-        ))
+        Vc::cell(format!("data URI content ({prefix}{ellipsis})").into())
     }
 
     #[turbo_tasks::function]
@@ -62,7 +60,7 @@ impl Source for DataUriSource {
         let filename = format!(
             "data:{}",
             &encode_hex(hash_xxh3_hash64((
-                &*self.data.await?,
+                &self.data,
                 &self.media_type,
                 &self.encoding
             )))[0..6]
@@ -76,8 +74,8 @@ impl Source for DataUriSource {
 #[turbo_tasks::value_impl]
 impl Asset for DataUriSource {
     #[turbo_tasks::function]
-    async fn content(&self) -> Result<Vc<AssetContent>> {
-        let data = self.data.await?;
+    fn content(&self) -> Result<Vc<AssetContent>> {
+        let data = &self.data;
         let rope = if self.encoding == "base64" {
             let decoded = data_encoding::BASE64.decode(data.as_bytes())?;
             // TODO this should read self.media_type and potentially use a different encoding

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2105,9 +2105,7 @@ async fn resolve_internal_inline(
                 data,
             } => {
                 // Behave like Request::Uri
-                let uri: RcStr = stringify_data_uri(media_type, encoding, *data)
-                    .await?
-                    .into();
+                let uri = stringify_data_uri(media_type, encoding, data);
                 if options_value.parse_data_uris {
                     ResolveResult::primary_with_key(
                         RequestKey::new(uri.clone()),
@@ -2115,7 +2113,7 @@ async fn resolve_internal_inline(
                             DataUriSource::new(
                                 media_type.clone(),
                                 encoding.clone(),
-                                **data,
+                                data.clone(),
                                 lookup_path.clone(),
                             )
                             .to_resolved()

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use anyhow::{Ok, Result};
 use regex::Regex;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc, turbofmt};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 
 use super::pattern::Pattern;
 
@@ -51,7 +51,7 @@ pub enum Request {
     DataUri {
         media_type: RcStr,
         encoding: RcStr,
-        data: ResolvedVc<RcStr>,
+        data: RcStr,
     },
     Unknown {
         path: Pattern,
@@ -220,7 +220,7 @@ impl Request {
                 return Request::DataUri {
                     media_type,
                     encoding,
-                    data: ResolvedVc::cell(data),
+                    data,
                 };
             }
 
@@ -578,7 +578,7 @@ impl Request {
                     .iter()
                     .copied()
                     .map(|req| req.with_fragment(fragment.clone()))
-                    .map(|v| async move { v.to_resolved().await })
+                    .map(|v| v.to_resolved())
                     .try_join()
                     .await?;
                 Request::Alternatives { requests }.cell()
@@ -658,7 +658,7 @@ impl Request {
                 encoding,
                 data,
             } => {
-                let data = ResolvedVc::cell(turbofmt!("{}{suffix}", *data).await?);
+                let data = RcStr::from(format!("{data}{suffix}"));
                 Self::DataUri {
                     media_type: media_type.clone(),
                     encoding: encoding.clone(),
@@ -690,7 +690,7 @@ impl Request {
             Request::Alternatives { requests } => {
                 let requests = requests
                     .iter()
-                    .map(|req| async { req.append_path(suffix.clone()).to_resolved().await })
+                    .map(|req| req.append_path(suffix.clone()).to_resolved())
                     .try_join()
                     .await?;
                 Request::Alternatives { requests }.cell()
@@ -738,11 +738,7 @@ impl Request {
                 media_type,
                 encoding,
                 data,
-            } => Pattern::Constant(
-                stringify_data_uri(media_type, encoding, *data)
-                    .await?
-                    .into(),
-            ),
+            } => Pattern::Constant(stringify_data_uri(media_type, encoding, data)),
             Request::Uri {
                 protocol,
                 remainder,
@@ -816,11 +812,7 @@ impl ValueToString for Request {
                 media_type,
                 encoding,
                 data,
-            } => format!(
-                "data uri \"{media_type}\" \"{encoding}\" \"{}\"",
-                data.await?
-            )
-            .into(),
+            } => format!("data uri \"{media_type}\" \"{encoding}\" \"{data}\"",).into(),
             Request::Uri {
                 protocol,
                 remainder,
@@ -840,15 +832,10 @@ impl ValueToString for Request {
     }
 }
 
-pub async fn stringify_data_uri(
-    media_type: &RcStr,
-    encoding: &RcStr,
-    data: ResolvedVc<RcStr>,
-) -> Result<String> {
-    Ok(format!(
-        "data:{media_type}{}{encoding},{}",
+pub fn stringify_data_uri(media_type: &RcStr, encoding: &RcStr, data: &RcStr) -> RcStr {
+    RcStr::from(format!(
+        "data:{media_type}{}{encoding},{data}",
         if encoding.is_empty() { "" } else { ";" },
-        data.await?
     ))
 }
 


### PR DESCRIPTION
This `cell` seemed arbitrary since data-uri values are always available synchronously.  Just removed it to clarify some APIs