### PR TITLE
simplify `Transition` by removing dead members

### DIFF
--- a/crates/next-core/src/next_server_component/server_component_transition.rs
+++ b/crates/next-core/src/next_server_component/server_component_transition.rs
@@ -43,7 +43,6 @@ impl Transition for NextServerComponentTransition {
         // Capture the original source path before any transformation
         let source_path = source.ident().await?.path.clone();
 
-        let source = self.process_source(source);
         let module_asset_context = self.process_context(module_asset_context);
 
         Ok(

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -6,63 +6,16 @@ use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueDefault, Vc};
 use turbopack_core::{
-    compile_time_info::CompileTimeInfo, context::ProcessResult, module::Module,
-    reference_type::ReferenceType, source::Source,
+    context::ProcessResult, module::Module, reference_type::ReferenceType, source::Source,
 };
-use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
-use crate::{
-    ModuleAssetContext,
-    module_options::{ModuleOptionsContext, transition_rule::TransitionRule},
-};
+use crate::{ModuleAssetContext, module_options::transition_rule::TransitionRule};
 
 /// Some kind of operation that is executed during reference processing. e. g.
 /// you can transition to a different environment on a specific import
 /// (reference).
 #[turbo_tasks::value_trait]
 pub trait Transition {
-    /// Apply modifications/wrapping to the source asset
-    #[turbo_tasks::function]
-    fn process_source(self: Vc<Self>, asset: Vc<Box<dyn Source>>) -> Vc<Box<dyn Source>> {
-        asset
-    }
-
-    /// Apply modifications to the compile-time information
-    #[turbo_tasks::function]
-    fn process_compile_time_info(
-        self: Vc<Self>,
-        compile_time_info: Vc<CompileTimeInfo>,
-    ) -> Vc<CompileTimeInfo> {
-        compile_time_info
-    }
-
-    /// Apply modifications/wrapping to the module options context
-    #[turbo_tasks::function]
-    fn process_module_options_context(
-        self: Vc<Self>,
-        module_options_context: Vc<ModuleOptionsContext>,
-    ) -> Vc<ModuleOptionsContext> {
-        module_options_context
-    }
-
-    /// Apply modifications/wrapping to the resolve options context
-    #[turbo_tasks::function]
-    fn process_resolve_options_context(
-        self: Vc<Self>,
-        resolve_options_context: Vc<ResolveOptionsContext>,
-    ) -> Vc<ResolveOptionsContext> {
-        resolve_options_context
-    }
-
-    /// Apply modifications/wrapping to the transition options
-    #[turbo_tasks::function]
-    fn process_transition_options(
-        self: Vc<Self>,
-        transition_options: Vc<TransitionOptions>,
-    ) -> Vc<TransitionOptions> {
-        transition_options
-    }
-
     /// Apply modifications/wrapping to the final asset
     #[turbo_tasks::function]
     fn process_module(
@@ -80,20 +33,12 @@ pub trait Transition {
         module_asset_context: Vc<ModuleAssetContext>,
     ) -> Result<Vc<ModuleAssetContext>> {
         let module_asset_context = module_asset_context.await?;
-        let compile_time_info =
-            self.process_compile_time_info(*module_asset_context.compile_time_info);
-        let module_options_context =
-            self.process_module_options_context(*module_asset_context.module_options_context);
-        let resolve_options_context =
-            self.process_resolve_options_context(*module_asset_context.resolve_options_context);
-        let layer = module_asset_context.layer.clone();
-        let transition_options = self.process_transition_options(*module_asset_context.transitions);
         let module_asset_context = ModuleAssetContext::new(
-            transition_options,
-            compile_time_info,
-            module_options_context,
-            resolve_options_context,
-            layer,
+            *module_asset_context.transitions,
+            *module_asset_context.compile_time_info,
+            *module_asset_context.module_options_context,
+            *module_asset_context.resolve_options_context,
+            module_asset_context.layer.clone(),
         );
         Ok(module_asset_context)
     }
@@ -106,7 +51,6 @@ pub trait Transition {
         module_asset_context: Vc<ModuleAssetContext>,
         reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
-        let source = self.process_source(source);
         let module_asset_context = self.process_context(module_asset_context);
         let source = source.to_resolved().await?;
 


### PR DESCRIPTION
Remove a number of functions from `Transition` that are never overridden and had trivial implementations.

This reveals that the default `process_context` function is making a copy of the module context simply without the `transition` (makes sense) but also with the `replace_externals` property reset to `true`.  It isn't clear if that is intentional?

This is just a code health thing no real perf win expected (save a tiny bit of code size)