### PR TITLE
docs: correct wording and casing in turbopack tracing guide

### DIFF
--- a/contributing/turbopack/tracing.md
+++ b/contributing/turbopack/tracing.md
@@ -18,7 +18,7 @@ Alternatively, any directives syntax supported by [`tracing_subscriber::filter::
 > [!WARNING]
 > A normal Next.js canary/stable release only includes the info level tracing. This is the tracing level intended for user-facing tracing.
 >
-> For the more detailed tracing a custom Next.js build is required. See [Developing] for more information how to create one.
+> For the more detailed tracing a custom Next.js build is required. See [Developing] for more information on how to create one.
 
 With this environment variable, Next.js will write a `.next-profiles/trace-turbopack` file with the tracing information in a binary format.
 
@@ -54,13 +54,13 @@ The trace viewer allows to switch between multiple different visualization modes
 - **... by value:** Spans are sorted and spans with the largest value are shown first.
 - **Bottom-up view:** Instead of showing the total value, the self value is shown.
 
-And there different value modes:
+And there are different value modes:
 
 - **Duration:** The CPU time of each span is shown.
 - **Allocated Memory:** How much memory was allocated during the span.
 - **Allocations:** How many allocations were made during the span.
 - **Deallocated Memory:** How much memory was deallocated during the span.
-- **Persistently allocated Memory:** How much memory was allocated but not deallocated during the span. It survives the span.
+- **Persistently Allocated Memory:** How much memory was allocated but not deallocated during the span. It survives the span.
 
 [turbo-trace-viewer]: https://turbo-trace-viewer.vercel.app/
 [youtube-tutorial]: https://www.youtube.com/watch?v=PGO2szAye7A


### PR DESCRIPTION
Fixed two missing words and inconsistent capitalization in `contributing/turbopack/tracing.md`:

- "And there different value modes" → "And there `are` different value modes"
- "more information how to create one" → "more information `on` how to create one"
- "Persistently `allocated` Memory" → "Persistently `Allocated` Memory"