### PR TITLE
Turbopack: fixup cache handler tracing

### DIFF
--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -508,7 +508,7 @@ pub async fn analyze_module_graphs(module_graph: Vc<ModuleGraph>) -> Result<Vc<F
 
     let module_graph = module_graph.await?;
     module_graph.traverse_edges_dfs(
-        module_graph.graphs.iter().flat_map(|g| g.entry_modules()),
+        module_graph.all_entry_modules(),
         &mut (),
         |parent, node, _| {
             all_modules.insert(node);

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -910,7 +910,7 @@ impl AppProject {
                     // SEGMENT: client_shared_entries and server utils shared by the layout segments
                     // and the page
                     let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                        vec![
+                        GraphEntries::from_chunk_groups(vec![
                             ChunkGroupEntry::Entry(client_shared_entries),
                             ChunkGroupEntry::SharedMultiple(
                                 server_utils
@@ -919,7 +919,7 @@ impl AppProject {
                                     .try_join()
                                     .await?,
                             ),
-                        ],
+                        ]),
                         visited_modules,
                         should_trace,
                         should_read_binding_usage,
@@ -936,7 +936,9 @@ impl AppProject {
                     {
                         // SEGMENT: layout segment
                         let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                            vec![ChunkGroupEntry::Shared(ResolvedVc::upcast(*module))],
+                            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Shared(
+                                ResolvedVc::upcast(*module),
+                            )]),
                             visited_modules,
                             should_trace,
                             should_read_binding_usage,
@@ -959,7 +961,7 @@ impl AppProject {
 
                 // SEGMENT: rsc entry chunk group
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                    vec![rsc_entry_chunk_group],
+                    GraphEntries::from_chunk_groups(vec![rsc_entry_chunk_group]),
                     visited_modules,
                     should_trace,
                     should_read_binding_usage,
@@ -2151,7 +2153,7 @@ impl Endpoint for AppEndpoint {
     #[turbo_tasks::function]
     async fn entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
         let this = self.await?;
-        Ok(Vc::cell(vec![
+        Ok(GraphEntries::from_chunk_groups(vec![
             ChunkGroupEntry::Entry(vec![self.app_endpoint_entry().await?.rsc_entry]),
             ChunkGroupEntry::Entry(
                 this.app_project
@@ -2162,7 +2164,8 @@ impl Endpoint for AppEndpoint {
                     .map(ResolvedVc::upcast)
                     .collect(),
             ),
-        ]))
+        ])
+        .cell())
     }
 
     #[turbo_tasks::function]
@@ -2201,9 +2204,10 @@ impl Endpoint for AppEndpoint {
             .await?,
         );
 
-        Ok(Vc::cell(vec![ChunkGroupEntry::Shared(
-            server_actions_loader,
-        )]))
+        Ok(
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Shared(server_actions_loader)])
+                .cell(),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -256,7 +256,10 @@ impl Endpoint for InstrumentationEndpoint {
     #[turbo_tasks::function]
     async fn entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
         let entry_module = self.entry_module().to_resolved().await?;
-        Ok(Vc::cell(vec![ChunkGroupEntry::Entry(vec![entry_module])]))
+        Ok(
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![entry_module])])
+                .cell(),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -406,9 +406,12 @@ impl Endpoint for MiddlewareEndpoint {
 
     #[turbo_tasks::function]
     async fn entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
-        Ok(Vc::cell(vec![ChunkGroupEntry::Entry(vec![
-            self.entry_module().to_resolved().await?,
-        ])]))
+        Ok(
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
+                self.entry_module().to_resolved().await?,
+            ])])
+            .cell(),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -170,7 +170,7 @@ impl NextDynamicGraph {
                 }
                 Either::Left(std::iter::once(entry))
             } else {
-                Either::Right(graph.graphs.first().unwrap().entry_modules())
+                Either::Right(graph.graphs.first().unwrap().chunk_group_modules())
             };
 
             let mut result = vec![];
@@ -557,7 +557,7 @@ impl ClientReferencesGraph {
                 }
                 Either::Left(std::iter::once(entry))
             } else {
-                Either::Right(graph.graphs.first().unwrap().entry_modules())
+                Either::Right(graph.graphs.first().unwrap().chunk_group_modules())
             };
 
             // Because we care about 'evaluation order' we need to collect client references in the
@@ -784,7 +784,7 @@ async fn validate_pages_css_imports_individual(
         }
         Either::Left(std::iter::once(entry))
     } else {
-        Either::Right(graph.graphs.first().unwrap().entry_modules())
+        Either::Right(graph.graphs.first().unwrap().chunk_group_modules())
     };
 
     let mut candidates = vec![];

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -14,7 +14,7 @@ use turbopack::externals_tracing_module_context;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     module::{Module, Modules},
-    module_graph::{ModuleGraph, SingleModuleGraph, chunk_group_info::ChunkGroupEntry},
+    module_graph::{GraphEntries, ModuleGraph, SingleModuleGraph},
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
     reference_type::CommonJsReferenceSubType,
     resolve::{ResolveErrorMode, origin::PlainResolveOrigin, parse::Request},
@@ -106,8 +106,8 @@ impl Asset for ServerNftJsonAsset {
             .join(&this.project.node_root().await?.path)?;
 
         let module_graph = ModuleGraph::from_graphs(
-            vec![SingleModuleGraph::new_with_traced_entries(
-                ResolvedVc::cell(vec![ChunkGroupEntry::Entry(self.entries().owned().await?)]),
+            vec![SingleModuleGraph::new_with_entries(
+                GraphEntries::new(vec![], self.entries().owned().await?).resolved_cell(),
                 true,
                 false,
             )],

--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -381,7 +381,7 @@ pub async fn traced_module_data_for_graph(
     // This function is very similar to traced_modules_for_entries, but doesn't apply the glob and
     // is executed only once for the whole graph.
     let module_graph = module_graph.await?;
-    let entries = module_graph.graphs.iter().flat_map(|g| g.entry_modules());
+    let entries = module_graph.all_entry_modules();
 
     let traced_entries = traced_entries.await?.into_iter().collect::<FxHashSet<_>>();
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -735,7 +735,7 @@ impl PageEndpoint {
             .flatten()
             {
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                    vec![ChunkGroupEntry::Shared(module)],
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Shared(module)]),
                     visited_modules,
                     should_trace,
                     should_read_binding_usage,
@@ -745,7 +745,9 @@ impl PageEndpoint {
             }
 
             let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                vec![ChunkGroupEntry::Entry(vec![ssr_chunk_module.ssr_module])],
+                GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
+                    ssr_chunk_module.ssr_module,
+                ])]),
                 visited_modules,
                 should_trace,
                 should_read_binding_usage,
@@ -1732,7 +1734,7 @@ impl Endpoint for PageEndpoint {
             })
             .collect::<Vec<_>>();
 
-        Ok(Vc::cell(modules))
+        Ok(GraphEntries::from_chunk_groups(modules).cell())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1421,22 +1421,25 @@ impl Project {
 
     #[turbo_tasks::function]
     pub async fn get_all_entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
-        let mut modules = self
+        let endpoint_entries = self
             .get_all_endpoints(false)
             .await?
             .iter()
-            .map(async |endpoint| Ok(endpoint.entries().owned().await?))
-            .try_flat_join()
+            .map(|endpoint| endpoint.entries().owned())
+            .try_join()
             .await?;
-        modules.extend(self.client_main_modules().await?.iter().cloned());
-        modules.extend(
-            self.additional_traced_modules()
-                .await?
-                .iter()
-                .cloned()
-                .map(|m| ChunkGroupEntry::Entry(vec![m])),
+
+        let result = GraphEntries::concatenate(
+            endpoint_entries
+                .into_iter()
+                .chain(std::iter::once(self.client_main_modules().owned().await?))
+                .chain(std::iter::once(GraphEntries::new(
+                    vec![],
+                    self.additional_traced_modules().owned().await?,
+                ))),
         );
-        Ok(Vc::cell(modules))
+
+        Ok(result.cell())
     }
 
     #[turbo_tasks::function]
@@ -1444,14 +1447,15 @@ impl Project {
         self: Vc<Self>,
         graphs: Vc<ModuleGraph>,
     ) -> Result<Vc<GraphEntries>> {
-        let modules = self
-            .get_all_endpoints(false)
-            .await?
-            .iter()
-            .map(async |endpoint| Ok(endpoint.additional_entries(graphs).owned().await?))
-            .try_flat_join()
-            .await?;
-        Ok(Vc::cell(modules))
+        let result = GraphEntries::concatenate(
+            self.get_all_endpoints(false)
+                .await?
+                .iter()
+                .map(|endpoint| endpoint.additional_entries(graphs).owned())
+                .try_join()
+                .await?,
+        );
+        Ok(result.cell())
     }
 
     #[turbo_tasks::function]
@@ -1490,7 +1494,8 @@ impl Project {
                 .collect();
             ModuleGraph::from_graphs(
                 vec![SingleModuleGraph::new_with_entries(
-                    ResolvedVc::cell(vec![ChunkGroupEntry::Entry(entries)]),
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(entries)])
+                        .resolved_cell(),
                     is_production,
                     is_production,
                 )],
@@ -2506,17 +2511,17 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn client_main_modules(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
         let pages_project = self.pages_project();
-        let mut modules = vec![ChunkGroupEntry::Entry(vec![
+        let mut chunk_groups = vec![ChunkGroupEntry::Entry(vec![
             pages_project.client_main_module().to_resolved().await?,
         ])];
 
         if let Some(app_project) = *self.app_project().await? {
-            modules.push(ChunkGroupEntry::Entry(vec![
+            chunk_groups.push(ChunkGroupEntry::Entry(vec![
                 app_project.client_main_module().to_resolved().await?,
             ]));
         }
 
-        Ok(Vc::cell(modules))
+        Ok(GraphEntries::from_chunk_groups(chunk_groups).cell())
     }
 
     /// Gets the module id strategy for the project.

--- a/crates/next-api/src/routes_hashes_manifest.rs
+++ b/crates/next-api/src/routes_hashes_manifest.rs
@@ -88,9 +88,8 @@ pub async fn endpoint_entry_modules(
     let entries = endpoint.entries().await?;
     let additional_entries = endpoint.additional_entries(base_module_graph).await?;
     let modules = entries
-        .iter()
-        .chain(additional_entries.iter())
-        .flat_map(|e| e.entries())
+        .chunk_group_modules()
+        .chain(additional_entries.chunk_group_modules())
         .collect::<FxIndexSet<_>>();
     Ok(Vc::cell(modules.into_iter().collect()))
 }
@@ -114,9 +113,8 @@ pub async fn endpoints_entry_modules(
         .iter()
         .flat_map(|(entries, additional_entries)| {
             entries
-                .iter()
-                .chain(additional_entries.iter())
-                .flat_map(|e| e.entries())
+                .chunk_group_modules()
+                .chain(additional_entries.chunk_group_modules())
         })
         .collect::<FxIndexSet<_>>();
     Ok(Vc::cell(modules.into_iter().collect()))

--- a/test/production/chunking/chunking.test.ts
+++ b/test/production/chunking/chunking.test.ts
@@ -7,7 +7,7 @@ import { join } from 'path'
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      lodash: 'latest',
+      lodash: '4.18.1',
       'webpack-bundle-analyzer': 'latest',
     },
   })

--- a/test/production/standalone-mode/required-server-files/cache-handler.js
+++ b/test/production/standalone-mode/required-server-files/cache-handler.js
@@ -1,8 +1,9 @@
 const cache = new Map()
+const { add } = require('lodash')
 
 module.exports = class CacheHandler {
   constructor() {
-    console.log('initialized custom cache-handler')
+    console.log('initialized custom cache-handler: ', add(1, 2))
   }
 
   async get(key, ctx) {

--- a/test/production/standalone-mode/required-server-files/cache-handler.js
+++ b/test/production/standalone-mode/required-server-files/cache-handler.js
@@ -1,9 +1,9 @@
 const cache = new Map()
-const { add } = require('lodash')
+const isEven = require('is-even')
 
 module.exports = class CacheHandler {
   constructor() {
-    console.log('initialized custom cache-handler: ', add(1, 2))
+    console.log('initialized custom cache-handler: ', isEven(3))
   }
 
   async get(key, ctx) {

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -30,6 +30,9 @@ describe('required server files app router', () => {
       cacheMaxMemorySize: 0,
       output: 'standalone',
     },
+    dependencies: {
+      'is-even': '1.0.0',
+    },
     skipStart: true,
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -33,7 +33,7 @@ describe('required server files i18n', () => {
       },
     },
     dependencies: {
-      lodash: '4.18.1',
+      'is-even': '1.0.0',
     },
     installCommand: 'pnpm i',
     buildCommand: 'pnpm build',

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -32,6 +32,9 @@ describe('required server files i18n', () => {
         build: 'next build',
       },
     },
+    dependencies: {
+      lodash: '4.18.1',
+    },
     installCommand: 'pnpm i',
     buildCommand: 'pnpm build',
     nextConfig: {

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -58,7 +58,7 @@ describe.skip('required server files app router', () => {
       output: 'standalone',
     },
     dependencies: {
-      lodash: '4.18.1',
+      'is-even': '1.0.0',
     },
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -57,6 +57,9 @@ describe.skip('required server files app router', () => {
       cacheComponents: true,
       output: 'standalone',
     },
+    dependencies: {
+      lodash: '4.18.1',
+    },
   })
 
   beforeAll(async () => {

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -72,6 +72,9 @@ describe('required server files', () => {
         }
       },
     },
+    dependencies: {
+      lodash: 'latest',
+    },
     skipStart: true,
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -73,7 +73,7 @@ describe('required server files', () => {
       },
     },
     dependencies: {
-      lodash: 'latest',
+      lodash: '4.18.1',
     },
     skipStart: true,
   })

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -73,7 +73,7 @@ describe('required server files', () => {
       },
     },
     dependencies: {
-      lodash: '4.18.1',
+      'is-even': '1.0.0',
     },
     skipStart: true,
   })

--- a/test/production/transpile-packages/transpile-packages.test.ts
+++ b/test/production/transpile-packages/transpile-packages.test.ts
@@ -5,7 +5,7 @@ describe('app fetch build cache', () => {
     files: __dirname,
     dependencies: {
       '@aws-sdk/client-s3': 'latest',
-      lodash: 'latest',
+      lodash: '4.18.1',
     },
   })
 

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -33,7 +33,7 @@ use turbopack_core::{
     issue::{IssueReporter, IssueSeverity, handle_issues},
     module::Module,
     module_graph::{
-        ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
@@ -312,7 +312,8 @@ async fn build_internal(
     .await?;
 
     let single_graph = SingleModuleGraph::new_with_entries(
-        ResolvedVc::cell(vec![ChunkGroupEntry::Entry(entries.clone())]),
+        GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(entries.clone())])
+            .resolved_cell(),
         false,
         true,
     );

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -12,7 +12,9 @@ use turbopack_core::{
     environment::Environment,
     file_source::FileSource,
     module::Module,
-    module_graph::{ModuleGraph, SingleModuleGraph, chunk_group_info::ChunkGroupEntry},
+    module_graph::{
+        GraphEntries, ModuleGraph, SingleModuleGraph, chunk_group_info::ChunkGroupEntry,
+    },
     reference_type::{EntryReferenceSubType, ReferenceType},
     resolve::{
         origin::{PlainResolveOrigin, ResolveOrigin, ResolveOriginExt},
@@ -160,7 +162,8 @@ pub async fn create_web_entry_source(
         .collect::<Vec<ResolvedVc<Box<dyn Module>>>>();
     let module_graph = ModuleGraph::from_graphs(
         vec![SingleModuleGraph::new_with_entries(
-            ResolvedVc::cell(vec![ChunkGroupEntry::Entry(all_modules)]),
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(all_modules)])
+                .resolved_cell(),
             false,
             false,
         )],

--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -144,7 +144,7 @@ pub async fn compute_binding_usage_info(
             None
         };
 
-        let entries = graph_ref.graphs.iter().flat_map(|g| g.entry_modules());
+        let entries = graph_ref.all_chunk_group_entry_modules();
 
         let visit_count = graph_ref.traverse_edges_fixed_point_with_priority(
             entries.map(|m| (m, 0)),

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -428,11 +428,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
         span.record("module_count", module_count);
 
         // use all entries from all graphs
-        let entries = graph
-            .graphs
-            .iter()
-            .flat_map(|g| g.entries.iter())
-            .collect::<Vec<_>>();
+        let entries = graph.all_chunk_group_entries().collect::<Vec<_>>();
 
         // First, compute the depth for each module in the graph
         let module_depth: FxHashMap<ResolvedVc<Box<dyn Module>>, usize> = {
@@ -511,11 +507,9 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
             }
         }
 
-        let entry_chunk_group_keys = graph
-            .graphs
+        let entry_chunk_group_keys = entries
             .iter()
-            .flat_map(|g| g.entries.iter())
-            .flat_map(|chunk_group| {
+            .flat_map(|&chunk_group| {
                 let chunk_group_key =
                     entry_to_chunk_group_id(chunk_group.clone(), &mut chunk_groups_map);
                 chunk_group

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -96,10 +96,8 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         span.record("module_count", module_count);
 
         // Use all entries from all graphs
-        let entries = graphs
-            .iter()
-            .flat_map(|g| g.entries.iter())
-            .flat_map(|g| g.entries())
+        let entries = module_graph
+            .all_chunk_group_entry_modules()
             .collect::<Vec<_>>();
 
         // First, compute the depth for each module in the graph

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -219,16 +219,78 @@ impl VisitedModules {
     }
 }
 
-pub type GraphEntriesT = Vec<ChunkGroupEntry>;
-
-#[turbo_tasks::value(transparent)]
-pub struct GraphEntries(GraphEntriesT);
+#[turbo_tasks::value(shared, task_input)]
+#[derive(Debug, Clone, Hash, Default)]
+pub struct GraphEntries {
+    /// The bundled chunk groups (listing their entry modules)
+    chunk_groups: Vec<ChunkGroupEntry>,
+    /// Traced top-level modules, which are not referenced by chunk_groups but should still be
+    /// considered as part of the graph.
+    traced_modules: Vec<ResolvedVc<Box<dyn Module>>>,
+}
 
 #[turbo_tasks::value_impl]
 impl GraphEntries {
     #[turbo_tasks::function]
     pub fn empty() -> Vc<Self> {
-        Vc::cell(Vec::new())
+        Self::default().cell()
+    }
+}
+
+impl GraphEntries {
+    pub fn new(
+        chunk_groups: Vec<ChunkGroupEntry>,
+        traced_modules: Vec<ResolvedVc<Box<dyn Module>>>,
+    ) -> Self {
+        Self {
+            chunk_groups,
+            traced_modules,
+        }
+    }
+    pub fn from_chunk_groups(chunk_groups: Vec<ChunkGroupEntry>) -> Self {
+        Self {
+            chunk_groups,
+            traced_modules: vec![],
+        }
+    }
+
+    pub fn concatenate(entries: impl IntoIterator<Item = GraphEntries>) -> Self {
+        let (chunk_groups, traced_modules): (Vec<_>, Vec<_>) = entries
+            .into_iter()
+            .map(|e| (e.chunk_groups, e.traced_modules))
+            .unzip();
+        Self {
+            chunk_groups: chunk_groups.into_iter().flatten().collect(),
+            traced_modules: traced_modules.into_iter().flatten().collect(),
+        }
+    }
+
+    /// Returns both chunk group modules and traced modules.
+    pub fn all_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
+        self.chunk_groups
+            .iter()
+            .flat_map(|e| e.entries())
+            .chain(self.traced_modules.iter().cloned())
+    }
+
+    /// Like all_modules, but with a boolean whether the module came from `traced_modules`
+    pub fn all_modules_with_is_traced(
+        &self,
+    ) -> impl Iterator<Item = (ResolvedVc<Box<dyn Module>>, bool)> + '_ {
+        self.chunk_groups
+            .iter()
+            .flat_map(|e| e.entries().map(|m| (m, false)))
+            .chain(self.traced_modules.iter().cloned().map(|m| (m, true)))
+    }
+
+    /// Returns only the bundled modules, not the traced modules.
+    pub fn chunk_group_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
+        self.chunk_groups.iter().flat_map(|e| e.entries())
+    }
+
+    /// Returns only the traced modules, not the bundled modules.
+    pub fn traced_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
+        self.traced_modules.iter().cloned()
     }
 }
 
@@ -251,7 +313,7 @@ pub struct SingleModuleGraph {
     modules: FxHashMap<ResolvedVc<Box<dyn Module>>, NodeIndex>,
 
     #[turbo_tasks(trace_ignore)]
-    pub entries: GraphEntriesT,
+    pub entries: GraphEntries,
 }
 
 #[derive(
@@ -277,17 +339,17 @@ impl SingleModuleGraph {
     /// nodes listed in `visited_modules`
     /// The resulting graph's outgoing edges are in reverse order.
     async fn new_inner(
-        entries: Vec<ChunkGroupEntry>,
+        entries: &GraphEntries,
         visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
         include_traced: bool,
         include_binding_usage: bool,
-        entries_are_traced: bool,
     ) -> Result<Vc<Self>> {
         let emit_spans = tracing::enabled!(Level::INFO);
         let root_nodes = entries
-            .iter()
-            .flat_map(|e| e.entries())
-            .map(|e| SingleModuleGraphBuilderNode::new_module(emit_spans, e, entries_are_traced))
+            .all_modules_with_is_traced()
+            .map(|(e, is_traced)| {
+                SingleModuleGraphBuilderNode::new_module(emit_spans, e, is_traced)
+            })
             .try_join()
             .await?;
 
@@ -472,8 +534,8 @@ impl SingleModuleGraph {
     }
 
     /// Iterate over graph entry points
-    pub fn entry_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
-        self.entries.iter().flat_map(|e| e.entries())
+    pub fn chunk_group_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
+        self.entries.chunk_group_modules()
     }
 
     /// WARNING: using this is discouraged, as it doesn't filter out unused or traced references.
@@ -950,8 +1012,25 @@ impl ModuleGraphSnapshot {
         Ok(idx)
     }
 
-    pub fn entries(&self) -> impl Iterator<Item = ChunkGroupEntry> + '_ {
-        self.graphs.iter().flat_map(|g| g.entries.iter().cloned())
+    /// The entry modules of all chunk groups of all graphs.
+    pub fn all_chunk_group_entries(&self) -> impl Iterator<Item = &ChunkGroupEntry> + '_ {
+        self.graphs
+            .iter()
+            .flat_map(|g| g.entries.chunk_groups.iter())
+    }
+
+    /// The entry modules of all chunk groups of all graphs.
+    pub fn all_chunk_group_entry_modules(
+        &self,
+    ) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
+        self.graphs
+            .iter()
+            .flat_map(|g| g.entries.chunk_group_modules())
+    }
+
+    /// The entry modules of all chunk groups of all graphs. Includes traced entry modules
+    pub fn all_entry_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
+        self.graphs.iter().flat_map(|g| g.entries.all_modules())
     }
 
     fn get_graph(&self, graph_idx: u32) -> &ReadRef<SingleModuleGraph> {
@@ -1177,12 +1256,10 @@ impl ModuleGraphSnapshot {
             ResolvedVc<Box<dyn Module>>,
         ) -> Result<()>,
     ) -> Result<()> {
-        let entries = self.graphs.iter().flat_map(|g| g.entry_modules());
-
         // Despite the name we need to do a DFS to respect 'reachability' if an edge was trimmed we
         // should not follow it, and this is a reasonable way to do that.
         self.traverse_edges_dfs(
-            entries,
+            self.all_chunk_group_entry_modules(),
             &mut (),
             |parent, target, _| {
                 visitor(parent, target)?;
@@ -1521,7 +1598,7 @@ impl<'a> ModuleGraphSnapshotNodeIterator<'a> {
         let entries = graph
             .graphs
             .iter()
-            .flat_map(|g| g.entry_modules())
+            .flat_map(|g| g.chunk_group_modules())
             .map(|e| graph.get_entry(e))
             .collect::<Result<VecDeque<_>>>()?;
 
@@ -1570,11 +1647,10 @@ impl SingleModuleGraph {
         include_binding_usage: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
-            vec![entry],
+            &GraphEntries::from_chunk_groups(vec![entry]),
             &Default::default(),
             include_traced,
             include_binding_usage,
-            false,
         )
         .await
     }
@@ -1586,11 +1662,10 @@ impl SingleModuleGraph {
         include_binding_usage: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
-            entries.owned().await?,
+            &*entries.await?,
             &Default::default(),
             include_traced,
             include_binding_usage,
-            false,
         )
         .await
     }
@@ -1603,11 +1678,10 @@ impl SingleModuleGraph {
         include_binding_usage: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
-            entries.owned().await?,
+            &*entries.await?,
             &visited_modules.connect().await?.modules,
             include_traced,
             include_binding_usage,
-            false,
         )
         .await
     }
@@ -1615,33 +1689,16 @@ impl SingleModuleGraph {
     #[turbo_tasks::function(operation)]
     pub async fn new_with_entries_visited_intern(
         // This must not be a Vc<Vec<_>> to ensure layout segment optimization hits the cache
-        entries: GraphEntriesT,
+        entries: GraphEntries,
         visited_modules: OperationVc<VisitedModules>,
         include_traced: bool,
         include_binding_usage: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
-            entries,
+            &entries,
             &visited_modules.connect().await?.modules,
             include_traced,
             include_binding_usage,
-            false,
-        )
-        .await
-    }
-
-    #[turbo_tasks::function(operation)]
-    pub async fn new_with_traced_entries(
-        entries: ResolvedVc<GraphEntries>,
-        include_traced: bool,
-        include_binding_usage: bool,
-    ) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(
-            entries.owned().await?,
-            &Default::default(),
-            include_traced,
-            include_binding_usage,
-            true,
         )
         .await
     }
@@ -2234,7 +2291,8 @@ pub mod tests {
                 let b_module = make_module("b.js").await?;
 
                 let parent_graph = SingleModuleGraph::new_with_entries(
-                    ResolvedVc::cell(vec![ChunkGroupEntry::Entry(vec![b_module])]),
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![b_module])])
+                        .resolved_cell(),
                     false,
                     false,
                 );
@@ -2243,7 +2301,10 @@ pub mod tests {
                     vec![
                         parent_graph,
                         SingleModuleGraph::new_with_entries_visited(
-                            ResolvedVc::cell(vec![ChunkGroupEntry::Entry(vec![a_module])]),
+                            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
+                                a_module,
+                            ])])
+                            .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
                             false,
                             false,
@@ -2407,7 +2468,8 @@ pub mod tests {
                 let a_module = make_module("a.js").await?;
 
                 let parent_graph = SingleModuleGraph::new_with_entries(
-                    ResolvedVc::cell(vec![ChunkGroupEntry::Entry(vec![x_module])]),
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![x_module])])
+                        .resolved_cell(),
                     true,
                     false,
                 );
@@ -2416,7 +2478,10 @@ pub mod tests {
                     vec![
                         parent_graph,
                         SingleModuleGraph::new_with_entries_visited(
-                            ResolvedVc::cell(vec![ChunkGroupEntry::Entry(vec![a_module])]),
+                            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
+                                a_module,
+                            ])])
+                            .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
                             true,
                             false,
@@ -2764,9 +2829,10 @@ pub mod tests {
                 .try_join()
                 .await?;
             let graph = SingleModuleGraph::new_with_entries(
-                GraphEntries::resolved_cell(GraphEntries(vec![ChunkGroupEntry::Entry(
-                    entry_modules.clone(),
-                )])),
+                GraphEntries::resolved_cell(GraphEntries::new(
+                    vec![ChunkGroupEntry::Entry(entry_modules.clone())],
+                    vec![],
+                )),
                 false,
                 false,
             );

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -287,11 +287,6 @@ impl GraphEntries {
     pub fn chunk_group_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
         self.chunk_groups.iter().flat_map(|e| e.entries())
     }
-
-    /// Returns only the traced modules, not the bundled modules.
-    pub fn traced_modules(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
-        self.traced_modules.iter().cloned()
-    }
 }
 
 #[turbo_tasks::value(cell = "new", eq = "manual")]
@@ -980,14 +975,16 @@ pub struct ModuleGraphLayers(Vec<OperationVc<ModuleGraphLayer>>);
 /// - traverse_edges_dfs is the only function with include_traced
 #[derive(TraceRawVcs, ValueDebugFormat, NonLocalValue)]
 pub struct ModuleGraphSnapshot {
+    // TODO make this non-public
     pub graphs: Vec<ReadRef<SingleModuleGraph>>,
-    // Whether to simply ignore SingleModuleGraphNode::VisitedModule during traversals. For single
-    // module graph usecases, this is what you want. For the whole graph, there should be an error.
+    /// Whether to simply ignore SingleModuleGraphNode::VisitedModule during traversals. For single
+    /// module graph usecases, this is what you want. For the whole graph, there should be an
+    /// error.
     skip_visited_module_children: bool,
 
-    pub graph_idx_override: Option<u32>,
+    graph_idx_override: Option<u32>,
 
-    pub binding_usage: Option<ReadRef<BindingUsageInfo>>,
+    binding_usage: Option<ReadRef<BindingUsageInfo>>,
 }
 
 impl ModuleGraphSnapshot {

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -421,14 +421,15 @@ pub struct EvaluateEntries {
 impl EvaluateEntries {
     #[turbo_tasks::function]
     pub async fn graph_entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
-        Ok(Vc::cell(vec![ChunkGroupEntry::Entry(
+        Ok(GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(
             self.await?
                 .entries
                 .iter()
                 .cloned()
                 .map(ResolvedVc::upcast)
                 .collect(),
-        )]))
+        )])
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -45,7 +45,7 @@ use turbopack_core::{
     issue::{CollectibleIssuesExt, IssueFilter, IssueSeverity},
     module::Module,
     module_graph::{
-        ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
@@ -456,7 +456,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .collect();
 
     let single_graph = SingleModuleGraph::new_with_entries(
-        ResolvedVc::cell(vec![ChunkGroupEntry::Entry(entry_modules.clone())]),
+        GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(entry_modules.clone())])
+            .resolved_cell(),
         false,
         true,
     );


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/94197 had a bug in the Turbopack case, where it didn't properly trace all necessary files referenced from `cacheHandler` and `cacheHandlers`.

If you imported `lodash` in the cache handler, then
- `node_modules/.pnpm/lodash@4.18.1/node_modules/lodash/lodash.js` was correctly traced
but missing were
- `node_modules/.pnpm/lodash@4.18.1/node_modules/lodash/package.json` and
- `node_modules/lodash` (the symlink)

The problem was that it wasn't including affecting sources of these entrypoints, because it was treating those entrypoints as bundled:

```
SingleModuleGraph::new_inner(
        entries: Vec<ChunkGroupEntry>,
        visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
        include_traced: bool,
        include_binding_usage: bool,
        entries_are_traced: bool, // <------ problematic
    ) -> Result<Vc<Self>>
```

should really have been 

```
SingleModuleGraph::new_inner(
        entries: &GraphEntries, // contains Vec<ChunkGroupEntry> and traced_modules: Vec<Modules
        visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
        include_traced: bool,
        include_binding_usage: bool,
    ) -> Result<Vc<Self>> {
```
because the single `entries_are_traced: bool` can be different per entry.