### PR TITLE
Fix repoRoot for adapters

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -469,7 +469,8 @@ export async function handleBuildComplete({
   distDir,
   pageKeys,
   bundler,
-  tracingRoot,
+  repoRoot,
+  outputFileTracingRoot,
   adapterPath,
   appPageKeys,
   staticPages,
@@ -485,13 +486,18 @@ export async function handleBuildComplete({
   hasInstrumentationHook,
   functionsConfigManifest,
 }: {
+  /** The folder containing the next.config.js file */
   dir: string
   appType: 'app' | 'pages' | 'hybrid'
+  /** The .next folder */
   distDir: string
   buildId: string
   configOutDir: string
   adapterPath: string
-  tracingRoot: string
+  /** The repository root. The base for relative output paths. */
+  repoRoot: string
+  /** A normalized version of config.outputFileTracingRoot  */
+  outputFileTracingRoot: string
   nextVersion: string
   hasStatic404: boolean
   hasStatic500: boolean
@@ -580,7 +586,8 @@ export async function handleBuildComplete({
         distDir,
         requiredServerFiles,
         dir,
-        tracingRoot,
+        repoRoot,
+        outputFileTracingRoot,
         bundler,
         hasInstrumentationHook,
         config,
@@ -595,7 +602,7 @@ export async function handleBuildComplete({
         const { entryHash } = await loadNFT(
           assets,
           assetsHashes,
-          tracingRoot,
+          repoRoot,
           `${entryFilePath}.nft.json`
         )
         Object.assign(
@@ -611,7 +618,7 @@ export async function handleBuildComplete({
           type === 'app' ? appPagesSharedNodeAssetsHashes : {}
         )
         if (entryHash) {
-          assetsHashes[path.relative(tracingRoot, entryFilePath)] = entryHash
+          assetsHashes[path.relative(repoRoot, entryFilePath)] = entryHash
         }
         return { assets, assetsHashes, entryHash }
       }
@@ -684,7 +691,7 @@ export async function handleBuildComplete({
           const originalPath = path.join(distDir, file)
           const fileOutputPath = path.relative(
             config.distDir,
-            path.join(path.relative(tracingRoot, distDir), file)
+            path.join(path.relative(repoRoot, distDir), file)
           )
           output.assets[fileOutputPath] = originalPath
         }
@@ -1026,7 +1033,7 @@ export async function handleBuildComplete({
             await pushAsset(
               existingOutput.assets,
               existingOutput.assetsHashes,
-              path.relative(tracingRoot, pageFile),
+              path.relative(repoRoot, pageFile),
               pageFile,
               bundler
             )
@@ -2112,7 +2119,7 @@ export async function handleBuildComplete({
         buildId,
         nextVersion,
         projectDir: dir,
-        repoRoot: tracingRoot,
+        repoRoot: repoRoot,
       })
     } catch (err) {
       Log.error(`Failed to run onBuildComplete from ${adapterMod.name}`)
@@ -2125,7 +2132,8 @@ async function getSharedNodeAssets({
   dir,
   bundler,
   distDir,
-  tracingRoot,
+  repoRoot,
+  outputFileTracingRoot,
   requiredServerFiles,
   hasInstrumentationHook,
   config,
@@ -2133,7 +2141,8 @@ async function getSharedNodeAssets({
   dir: string
   bundler: Bundler
   distDir: string
-  tracingRoot: string
+  repoRoot: string
+  outputFileTracingRoot: string
   requiredServerFiles: string[]
   hasInstrumentationHook: boolean
   config: NextConfigComplete
@@ -2167,14 +2176,14 @@ async function getSharedNodeAssets({
     }
 
     for (const dependencyPath of currentDependencies) {
-      const rootRelativeFilePath = path.relative(tracingRoot, dependencyPath)
+      const rootRelativeFilePath = path.relative(repoRoot, dependencyPath)
 
       if (type === 'pages') {
         await pushAsset(
           pagesSharedNodeAssets,
           pagesSharedNodeAssetsHashes,
           rootRelativeFilePath,
-          path.join(tracingRoot, rootRelativeFilePath),
+          path.join(repoRoot, rootRelativeFilePath),
           bundler
         )
       } else {
@@ -2182,7 +2191,7 @@ async function getSharedNodeAssets({
           appPagesSharedNodeAssets,
           appPagesSharedNodeAssetsHashes,
           rootRelativeFilePath,
-          path.join(tracingRoot, rootRelativeFilePath),
+          path.join(repoRoot, rootRelativeFilePath),
           bundler
         )
       }
@@ -2198,7 +2207,7 @@ async function getSharedNodeAssets({
   await pushAsset(
     sharedNodeAssets,
     sharedNodeAssetsHashes,
-    path.relative(tracingRoot, setupNodeStubPath),
+    path.relative(repoRoot, setupNodeStubPath),
     require.resolve('next/dist/build/adapter/setup-node-env.external'),
     bundler
   )
@@ -2226,7 +2235,10 @@ async function getSharedNodeAssets({
       '**/next/dist/server/web/sandbox/**/*',
       '**/next/dist/server/post-process.js',
     ]
-    const sharedIgnoreFn = makeIgnoreFn(tracingRoot, sharedTraceIgnores)
+    const sharedIgnoreFn = makeIgnoreFn(
+      outputFileTracingRoot,
+      sharedTraceIgnores
+    )
 
     // These are modules that are necessary for bootstrapping node env
     const necessaryNodeDependencies = [
@@ -2266,7 +2278,7 @@ async function getSharedNodeAssets({
     const { fileList, esmFileList } = await nodeFileTrace(
       necessaryNodeDependencies,
       {
-        base: tracingRoot,
+        base: outputFileTracingRoot,
         ignore: sharedIgnoreFn,
         moduleSyncCatchall: true,
       }
@@ -2278,7 +2290,7 @@ async function getSharedNodeAssets({
         sharedNodeAssets,
         sharedNodeAssetsHashes,
         rootRelativeFilePath,
-        path.join(tracingRoot, rootRelativeFilePath),
+        path.join(repoRoot, rootRelativeFilePath),
         bundler
       )
     }
@@ -2288,12 +2300,12 @@ async function getSharedNodeAssets({
     const { entryHash: instrumentationEntryHash } = await loadNFT(
       sharedNodeAssets,
       sharedNodeAssetsHashes,
-      tracingRoot,
+      repoRoot,
       path.join(distDir, 'server', 'instrumentation.js.nft.json')
     )
 
     const fileOutputPath = path.relative(
-      tracingRoot,
+      repoRoot,
       path.join(distDir, 'server', 'instrumentation.js')
     )
     await pushAsset(
@@ -2310,7 +2322,7 @@ async function getSharedNodeAssets({
   for (const file of requiredServerFiles) {
     // add to shared node assets
     const filePath = path.join(dir, file)
-    const fileOutputPath = path.relative(tracingRoot, filePath)
+    const fileOutputPath = path.relative(repoRoot, filePath)
     await pushAsset(
       sharedNodeAssets,
       sharedNodeAssetsHashes,
@@ -2350,7 +2362,7 @@ async function pushAsset(
 async function loadNFT(
   assets: Record<string, string>,
   assetsHashes: Record<string, string>,
-  tracingRoot: string,
+  repoRoot: string,
   traceFilePath: string
 ): Promise<{ entryHash?: string }> {
   const { files, fileHashes, entryHash } = (await JSON.parse(
@@ -2366,7 +2378,7 @@ async function loadNFT(
     const relativeFile = files[i]
     const contentHash = fileHashes?.[i]
     const tracedFilePath = path.join(traceFileDir, relativeFile)
-    const fileOutputPath = path.relative(tracingRoot, tracedFilePath)
+    const fileOutputPath = path.relative(repoRoot, tracedFilePath)
     assets[fileOutputPath] = tracedFilePath
     if (contentHash) {
       assetsHashes[fileOutputPath] = contentHash

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -2285,12 +2285,19 @@ async function getSharedNodeAssets({
     )
     esmFileList.forEach((item) => fileList.add(item))
 
-    for (const rootRelativeFilePath of fileList) {
+    for (const tracingRootRelativeFilePath of fileList) {
+      // nodeFileTrace returns paths relative to `base` (outputFileTracingRoot),
+      // so resolve to an absolute path and re-relativize against repoRoot, which
+      // is the root all adapter output keys/source paths are based on.
+      const absoluteFilePath = path.join(
+        outputFileTracingRoot,
+        tracingRootRelativeFilePath
+      )
       await pushAsset(
         sharedNodeAssets,
         sharedNodeAssetsHashes,
-        rootRelativeFilePath,
-        path.join(repoRoot, rootRelativeFilePath),
+        path.relative(repoRoot, absoluteFilePath),
+        absoluteFilePath,
         bundler
       )
     }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4195,7 +4195,9 @@ export default async function build(
               staticPages,
               serverPropsPages,
               nextVersion: process.env.__NEXT_VERSION as string,
-              tracingRoot: outputFileTracingRoot,
+              // TODO this should not be outputFileTracingRoot but use findRootDirAndLockFiles() instead
+              repoRoot: outputFileTracingRoot,
+              outputFileTracingRoot,
               hasNodeMiddleware,
               hasInstrumentationHook,
               adapterPath,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4195,8 +4195,7 @@ export default async function build(
               staticPages,
               serverPropsPages,
               nextVersion: process.env.__NEXT_VERSION as string,
-              // TODO this should not be outputFileTracingRoot but use findRootDirAndLockFiles() instead
-              repoRoot: outputFileTracingRoot,
+              repoRoot: config.repoRoot,
               outputFileTracingRoot,
               hasNodeMiddleware,
               hasInstrumentationHook,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -48,6 +48,8 @@ export type NextConfigComplete = Required<Omit<NextConfig, 'configFile'>> & {
   // since development builds use `{distDir}/dev`. This is used to ensure that the bundler doesn't
   // traverse into the output directory.
   distDirRoot: string
+  // The repository root, regardless of overwritten outputFileTracingRoot or turbopack.root.
+  repoRoot: string
 }
 
 export type I18NDomains = readonly DomainLocale[]
@@ -1960,7 +1962,7 @@ export const defaultConfig = Object.freeze({
   staticPageGenerationTimeout: 60,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
-  outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
+  outputFileTracingRoot: '',
   allowedDevOrigins: undefined,
   enablePrerenderSourceMaps: true,
   cacheComponents: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1174,12 +1174,11 @@ function assignDefaultsAndValidate(
   const turbopackRoot = result?.turbopack?.root
 
   let repoRoot = process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT
+  let lockFiles: string[] | undefined = undefined
   if (!repoRoot) {
-    const { rootDir, lockFiles } = findRootDirAndLockFiles(dir)
-    repoRoot = rootDir
-    if (!silent) {
-      warnDuplicatedLockFiles(lockFiles)
-    }
+    const rootDirResult = findRootDirAndLockFiles(dir)
+    repoRoot = rootDirResult.rootDir
+    lockFiles = rootDirResult.lockFiles
   }
   ;(result as NextConfigComplete).repoRoot = repoRoot
 
@@ -1193,6 +1192,9 @@ function assignDefaultsAndValidate(
   let rootDir = tracingRoot || turbopackRoot
   if (!rootDir) {
     rootDir = repoRoot
+    if (lockFiles && !silent) {
+      warnDuplicatedLockFiles(lockFiles)
+    }
   }
   if (!rootDir) {
     throw new Error(

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1173,6 +1173,16 @@ function assignDefaultsAndValidate(
   const tracingRoot = result?.outputFileTracingRoot
   const turbopackRoot = result?.turbopack?.root
 
+  let repoRoot = process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT
+  if (!repoRoot) {
+    const { rootDir, lockFiles } = findRootDirAndLockFiles(dir)
+    repoRoot = rootDir
+    if (!silent) {
+      warnDuplicatedLockFiles(lockFiles)
+    }
+  }
+  ;(result as NextConfigComplete).repoRoot = repoRoot
+
   // If both provided, validate they match. If not, use outputFileTracingRoot.
   if (tracingRoot && turbopackRoot && tracingRoot !== turbopackRoot) {
     Log.warn(
@@ -1180,22 +1190,15 @@ function assignDefaultsAndValidate(
         `Using \`outputFileTracingRoot\` value: ${tracingRoot}.`
     )
   }
-
   let rootDir = tracingRoot || turbopackRoot
   if (!rootDir) {
-    const { rootDir: foundRootDir, lockFiles } = findRootDirAndLockFiles(dir)
-    rootDir = foundRootDir
-    if (!silent) {
-      warnDuplicatedLockFiles(lockFiles)
-    }
+    rootDir = repoRoot
   }
-
   if (!rootDir) {
     throw new Error(
       'Failed to find the root directory of the project. This is a bug in Next.js.'
     )
   }
-
   // Ensure both properties are set to the same value
   result.outputFileTracingRoot = rootDir
   dset(result, ['turbopack', 'root'], rootDir)
@@ -2120,7 +2123,7 @@ export default async function loadConfig(
     { ...clonedDefaultConfig, configFileName },
     silent,
     phase
-  ) as NextConfigComplete
+  )
 
   setHttpClientAndAgentOptions(completeConfig)
 

--- a/test/production/adapter-root/adapter-root.test.ts
+++ b/test/production/adapter-root/adapter-root.test.ts
@@ -30,6 +30,16 @@ describe('adapter-root', () => {
       }
       await next.build()
 
+      if (setEnvVar) {
+        expect(next.cliOutput).not.toContain(
+          'We detected multiple lockfiles and selected the directory'
+        )
+      } else {
+        expect(next.cliOutput).toContain(
+          'We detected multiple lockfiles and selected the directory'
+        )
+      }
+
       const {
         outputs,
         repoRoot,
@@ -47,12 +57,11 @@ describe('adapter-root', () => {
         ...outputs.pages,
         ...outputs.pagesApi,
       ]
-      console.log(combinedRouteOutputs)
-      // for (const output of combinedRouteOutputs) {
-      //   for (const asset of Object.keys(output.assets)) {
-      //     expect(fs.existsSync(path.join(repoRoot, output.assets))).toBeTrue()
-      //   }
-      // }
+      for (const output of combinedRouteOutputs) {
+        for (const asset of Object.keys(output.assets)) {
+          expect(asset).toStartWith('sub/')
+        }
+      }
     })
   })
 })

--- a/test/production/adapter-root/adapter-root.test.ts
+++ b/test/production/adapter-root/adapter-root.test.ts
@@ -32,15 +32,9 @@ describe('adapter-root', () => {
       }
       await next.build()
 
-      if (setEnvVar) {
-        expect(next.cliOutput).not.toContain(
-          'We detected multiple lockfiles and selected the directory'
-        )
-      } else {
-        expect(next.cliOutput).toContain(
-          'We detected multiple lockfiles and selected the directory'
-        )
-      }
+      expect(next.cliOutput).not.toContain(
+        'We detected multiple lockfiles and selected the directory'
+      )
 
       const {
         outputs,

--- a/test/production/adapter-root/adapter-root.test.ts
+++ b/test/production/adapter-root/adapter-root.test.ts
@@ -1,0 +1,58 @@
+// import fs from 'fs'
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import type { NextAdapter } from 'next'
+
+describe('adapter-root', () => {
+  describe.each([
+    { name: 'via lockfile', env: {} },
+    // The Vercel CLI sets this to the repo root
+    { name: 'via NEXT_PRIVATE_OUTPUT_TRACE_ROOT', setEnvVar: true },
+  ])('$name', ({ setEnvVar }) => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixture'),
+      subDir: 'sub',
+      skipStart: true,
+      overrideFiles: {
+        '../package-lock.json': JSON.stringify({
+          name: 'parent-workspace',
+          version: '1.0.0',
+          lockfileVersion: 3,
+        }),
+      },
+    })
+
+    it('should correctly determine repoRoot', async () => {
+      const expectedRepoRoot = path.dirname(next.testDir)
+
+      if (setEnvVar) {
+        next.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT = expectedRepoRoot
+      }
+      await next.build()
+
+      const {
+        outputs,
+        repoRoot,
+        projectDir,
+      }: Parameters<NextAdapter['onBuildComplete']>[0] = await next.readJSON(
+        'build-complete.json'
+      )
+
+      expect(projectDir).toBe(next.testDir)
+      expect(repoRoot).toBe(expectedRepoRoot)
+
+      const combinedRouteOutputs = [
+        ...outputs.appPages,
+        ...outputs.appRoutes,
+        ...outputs.pages,
+        ...outputs.pagesApi,
+      ]
+      console.log(combinedRouteOutputs)
+      // for (const output of combinedRouteOutputs) {
+      //   for (const asset of Object.keys(output.assets)) {
+      //     expect(fs.existsSync(path.join(repoRoot, output.assets))).toBeTrue()
+      //   }
+      // }
+    })
+  })
+})

--- a/test/production/adapter-root/adapter-root.test.ts
+++ b/test/production/adapter-root/adapter-root.test.ts
@@ -13,13 +13,15 @@ describe('adapter-root', () => {
       files: path.join(__dirname, 'fixture'),
       subDir: 'sub',
       skipStart: true,
-      overrideFiles: {
-        '../package-lock.json': JSON.stringify({
-          name: 'parent-workspace',
-          version: '1.0.0',
-          lockfileVersion: 3,
-        }),
-      },
+      overrideFiles: setEnvVar
+        ? undefined
+        : {
+            '../package-lock.json': JSON.stringify({
+              name: 'parent-workspace',
+              version: '1.0.0',
+              lockfileVersion: 3,
+            }),
+          },
     })
 
     it('should correctly determine repoRoot', async () => {

--- a/test/production/adapter-root/adapter-root.test.ts
+++ b/test/production/adapter-root/adapter-root.test.ts
@@ -1,4 +1,4 @@
-// import fs from 'fs'
+import fs from 'fs'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import type { NextAdapter } from 'next'
@@ -58,8 +58,9 @@ describe('adapter-root', () => {
         ...outputs.pagesApi,
       ]
       for (const output of combinedRouteOutputs) {
-        for (const asset of Object.keys(output.assets)) {
+        for (const [asset, source] of Object.entries(output.assets)) {
           expect(asset).toStartWith('sub/')
+          expect(fs.existsSync(source)).toBeTrue()
         }
       }
     })

--- a/test/production/adapter-root/fixture/app/layout.tsx
+++ b/test/production/adapter-root/fixture/app/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/adapter-root/fixture/app/page.tsx
+++ b/test/production/adapter-root/fixture/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      <p>Hello</p>
+    </>
+  )
+}

--- a/test/production/adapter-root/fixture/my-adapter.mjs
+++ b/test/production/adapter-root/fixture/my-adapter.mjs
@@ -1,0 +1,15 @@
+import fs from 'fs'
+
+// @ts-check
+/** @type {import('next').NextAdapter } */
+const myAdapter = {
+  name: 'my-custom-adapter',
+  onBuildComplete: async (ctx) => {
+    await fs.promises.writeFile(
+      'build-complete.json',
+      JSON.stringify(ctx, null, 2)
+    )
+  },
+}
+
+export default myAdapter

--- a/test/production/adapter-root/fixture/next.config.js
+++ b/test/production/adapter-root/fixture/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  adapterPath: require.resolve('./my-adapter.mjs'),
+  outputFileTracingRoot: __dirname,
+  turbopack: { root: __dirname },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
`repoRoot` shouldn't be `outputFileTracingRoot`. The user can configure that to arbitrary values, which shouldn't change the adapter output.

The adapter now uses `NextConfigComplete.repoRoot` instead of `outputFileTracingRoot`.

Closes NEXT-4942