### PR TITLE
[App Shells] Track session data usage during static prerender

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -102,6 +102,9 @@ export function createInitialRouterState({
   // The following only applies in the browser (location !== null) since neither
   // route learning nor segment cache state persists from SSR to client.
   if (location !== null && metadataVaryPath !== null) {
+    // TODO(app-shells): track shell kind for dynamic responses
+    const shellKind = null
+
     // Learn the route pattern so we can predict it for future navigations.
     discoverKnownRoute(
       Date.now(),
@@ -114,7 +117,8 @@ export function createInitialRouterState({
       initialCouldBeIntercepted,
       canonicalUrl,
       initialSupportsPerSegmentPrefetching,
-      false // hasDynamicRewrite
+      false, // hasDynamicRewrite,
+      shellKind
     )
 
     // TODO: Implement Shell extraction as part of Cached Navigations.

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1632,6 +1632,9 @@ function dispatchRetryDueToTreeMismatch(
     // route prediction, but still needs to mark the pattern.
     const metadataVaryPath = seed.metadataVaryPath
     if (metadataVaryPath !== null) {
+      // TODO(app-shells): track shell kind for dynamic responses
+      const shellKind = null
+
       const now = Date.now()
       discoverKnownRoute(
         now,
@@ -1644,7 +1647,8 @@ function dispatchRetryDueToTreeMismatch(
         false, // couldBeIntercepted - doesn't matter, we're just marking hasDynamicRewrite
         createHrefFromUrl(retryUrl),
         false, // supportsPerSegmentPrefetching - doesn't matter, we're just marking hasDynamicRewrite
-        true // hasDynamicRewrite
+        true, // hasDynamicRewrite
+        shellKind
       )
     }
   }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -482,6 +482,9 @@ export function serverActionReducer(
         // Learn the route pattern so we can predict it for future navigations.
         const metadataVaryPath = redirectSeed.metadataVaryPath
         if (metadataVaryPath !== null) {
+          // TODO(app-shells): track shell kind for dynamic responses
+          const shellKind = null
+
           discoverKnownRoute(
             now,
             redirectUrl.pathname,
@@ -493,7 +496,8 @@ export function serverActionReducer(
             couldBeIntercepted,
             redirectCanonicalUrl,
             isPrerender,
-            false // hasDynamicRewrite
+            false, // hasDynamicRewrite,
+            shellKind
           )
         }
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -104,7 +104,7 @@ import {
 import { STATIC_STALETIME_MS } from '../router-reducer/reducers/navigate-reducer'
 import { pingVisibleLinks } from '../links'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
-import { FetchStrategy } from './types'
+import { FetchStrategy, ShellKind } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 import { readFromBFCache, UnknownDynamicStaleTime } from './bfcache'
 import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
@@ -214,6 +214,7 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
+  shellKind: ShellKind | null
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
   // to a different route structure (e.g., /foo was rewritten to /bar). Since
@@ -715,6 +716,7 @@ export function deprecated_requestOptimisticRouteCacheEntry(
     supportsPerSegmentPrefetching:
       routeWithNoSearchParams.supportsPerSegmentPrefetching,
     hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
+    shellKind: routeWithNoSearchParams.shellKind,
 
     // Override the rendered search with the optimistic value.
     renderedSearch: optimisticRenderedSearch,
@@ -1106,7 +1108,8 @@ export function fulfillRouteCacheEntry(
   metadataVaryPath: PageVaryPath,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
-  supportsPerSegmentPrefetching: boolean
+  supportsPerSegmentPrefetching: boolean,
+  shellKind: ShellKind | null
 ): FulfilledRouteCacheEntry {
   // Get the rendered search from the vary path
   const renderedSearch =
@@ -1135,6 +1138,7 @@ export function fulfillRouteCacheEntry(
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
   fulfilledEntry.hasDynamicRewrite = false
+  fulfilledEntry.shellKind = shellKind
   pingBlockedTasks(entry)
   return fulfilledEntry
 }
@@ -1148,7 +1152,8 @@ export function writeRouteIntoCache(
   metadataVaryPath: PageVaryPath,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
-  supportsPerSegmentPrefetching: boolean
+  supportsPerSegmentPrefetching: boolean,
+  shellKind: ShellKind | null
 ): FulfilledRouteCacheEntry {
   const pendingEntry = createDetachedRouteCacheEntry()
   const fulfilledEntry = fulfillRouteCacheEntry(
@@ -1158,7 +1163,8 @@ export function writeRouteIntoCache(
     metadataVaryPath,
     couldBeIntercepted,
     canonicalUrl,
-    supportsPerSegmentPrefetching
+    supportsPerSegmentPrefetching,
+    shellKind
   )
   const varyPath = getFulfilledRouteVaryPath(
     pathname,
@@ -1794,6 +1800,12 @@ export async function fetchRouteOnCacheMiss(
         rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
         return null
       }
+      const shellKind =
+        serverData.sessionShell === undefined
+          ? null
+          : serverData.sessionShell
+            ? ShellKind.SessionShell
+            : ShellKind.StaticShell
 
       discoverKnownRoute(
         Date.now(),
@@ -1806,7 +1818,8 @@ export async function fetchRouteOnCacheMiss(
         couldBeIntercepted,
         canonicalUrl,
         routeIsPPREnabled,
-        false // hasDynamicRewrite
+        false, // hasDynamicRewrite,
+        shellKind
       )
     } else {
       // PPR is not enabled for this route. The server responds with a
@@ -2489,6 +2502,9 @@ function writeDynamicTreeResponseIntoCache(
     return
   }
 
+  // TODO(app-shells): track shell kind for dynamic responses
+  const shellKind = null
+
   discoverKnownRoute(
     now,
     originalPathname,
@@ -2500,7 +2516,8 @@ function writeDynamicTreeResponseIntoCache(
     couldBeIntercepted,
     canonicalUrl,
     routeIsPPREnabled,
-    false // hasDynamicRewrite
+    false, // hasDynamicRewrite
+    shellKind
   )
 
   // If the server sent segment data as part of the response, we should write

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -434,6 +434,9 @@ async function navigateToUnknownRoute(
   // retrying after a tree mismatch (see dispatchRetryDueToTreeMismatch).
   const metadataVaryPath = navigationSeed.metadataVaryPath
   if (metadataVaryPath !== null) {
+    // TODO(app-shells): track shell kind for dynamic responses
+    const shellKind = null
+
     discoverKnownRoute(
       now,
       url.pathname,
@@ -445,7 +448,8 @@ async function navigateToUnknownRoute(
       couldBeIntercepted,
       createHrefFromUrl(canonicalUrl),
       supportsPerSegmentPrefetching,
-      false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
+      false, // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
+      shellKind
     )
 
     if (staticStageData !== null) {

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -64,6 +64,7 @@ import {
   type PartialSegmentVaryPath,
   type PageVaryPath,
 } from './vary-path'
+import type { ShellKind } from './types'
 
 /**
  * The known route tree is analogous to a route table. A different routing
@@ -205,7 +206,8 @@ export function discoverKnownRoute(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   supportsPerSegmentPrefetching: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  shellKind: ShellKind | null
 ): FulfilledRouteCacheEntry {
   const tree = routeTree
 
@@ -220,7 +222,8 @@ export function discoverKnownRoute(
       metadataVaryPath,
       couldBeIntercepted,
       canonicalUrl,
-      supportsPerSegmentPrefetching
+      supportsPerSegmentPrefetching,
+      shellKind
     )
     if (hasDynamicRewrite) {
       fulfilledEntry.hasDynamicRewrite = true
@@ -243,7 +246,8 @@ export function discoverKnownRoute(
       couldBeIntercepted,
       canonicalUrl,
       supportsPerSegmentPrefetching,
-      hasDynamicRewrite
+      hasDynamicRewrite,
+      shellKind
     )
     return fulfilledEntry
   }
@@ -265,7 +269,8 @@ export function discoverKnownRoute(
     couldBeIntercepted,
     canonicalUrl,
     supportsPerSegmentPrefetching,
-    hasDynamicRewrite
+    hasDynamicRewrite,
+    shellKind
   )
 }
 
@@ -285,7 +290,8 @@ function handleMismatchDueToRewrite(
   metadataVaryPath: PageVaryPath,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
-  supportsPerSegmentPrefetching: boolean
+  supportsPerSegmentPrefetching: boolean,
+  shellKind: ShellKind | null
 ): FulfilledRouteCacheEntry {
   if (existingEntry !== null) {
     return existingEntry
@@ -299,7 +305,8 @@ function handleMismatchDueToRewrite(
     metadataVaryPath,
     couldBeIntercepted,
     canonicalUrl,
-    supportsPerSegmentPrefetching
+    supportsPerSegmentPrefetching,
+    shellKind
   )
 }
 
@@ -356,7 +363,8 @@ function discoverKnownRoutePart(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   supportsPerSegmentPrefetching: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  shellKind: ShellKind | null
 ): FulfilledRouteCacheEntry {
   const segment = routeTree.segment
   const urlPart =
@@ -382,7 +390,8 @@ function discoverKnownRoutePart(
           metadataVaryPath,
           couldBeIntercepted,
           canonicalUrl,
-          supportsPerSegmentPrefetching
+          supportsPerSegmentPrefetching,
+          shellKind
         )
       }
 
@@ -422,7 +431,8 @@ function discoverKnownRoutePart(
         metadataVaryPath,
         couldBeIntercepted,
         canonicalUrl,
-        supportsPerSegmentPrefetching
+        supportsPerSegmentPrefetching,
+        shellKind
       )
     }
 
@@ -443,7 +453,8 @@ function discoverKnownRoutePart(
         metadataVaryPath,
         couldBeIntercepted,
         canonicalUrl,
-        supportsPerSegmentPrefetching
+        supportsPerSegmentPrefetching,
+        shellKind
       )
     }
 
@@ -512,7 +523,8 @@ function discoverKnownRoutePart(
         couldBeIntercepted,
         canonicalUrl,
         supportsPerSegmentPrefetching,
-        hasDynamicRewrite
+        hasDynamicRewrite,
+        shellKind
       )
       // All parallel route branches share the same URL, so they should all
       // reach compatible leaf nodes. We capture any result.
@@ -533,7 +545,8 @@ function discoverKnownRoutePart(
       metadataVaryPath,
       couldBeIntercepted,
       canonicalUrl,
-      supportsPerSegmentPrefetching
+      supportsPerSegmentPrefetching,
+      shellKind
     )
   }
 
@@ -551,7 +564,8 @@ function discoverKnownRoutePart(
       metadataVaryPath,
       couldBeIntercepted,
       canonicalUrl,
-      supportsPerSegmentPrefetching
+      supportsPerSegmentPrefetching,
+      shellKind
     )
   }
 
@@ -583,7 +597,8 @@ function discoverKnownRoutePart(
       metadataVaryPath,
       couldBeIntercepted,
       canonicalUrl,
-      supportsPerSegmentPrefetching
+      supportsPerSegmentPrefetching,
+      shellKind
     )
   }
 
@@ -678,6 +693,7 @@ export function matchKnownRoute(
     couldBeIntercepted: pattern.couldBeIntercepted,
     supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
     hasDynamicRewrite: false,
+    shellKind: pattern.shellKind,
     renderedSearch: search,
     ref: null,
     size: pattern.size,

--- a/packages/next/src/client/components/segment-cache/types.ts
+++ b/packages/next/src/client/components/segment-cache/types.ts
@@ -42,6 +42,11 @@ export const enum FetchStrategy {
   Full = 4,
 }
 
+export const enum ShellKind {
+  StaticShell = 1,
+  SessionShell = 2,
+}
+
 /**
  * A subset of fetch strategies used for prefetch tasks.
  * A prefetch task can't know if it should use `PPR` or `LoadingBoundary`

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -166,6 +166,7 @@ import {
   createInstantValidationState,
   type NavigationValidationResult,
   throwIfSyncIOUsed,
+  createSessionDataTrackingState,
 } from './dynamic-rendering'
 import { logBuildDebugHint } from './blocking-route-messages'
 import {
@@ -7732,6 +7733,7 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
         // We don't track vary params during initial prerender, only the final one
         varyParamsAccumulator: null,
+        sessionDataTracking: null,
       }
 
       // We're not going to use the result of this render because the only time it could be used
@@ -7766,6 +7768,7 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
         // We don't track vary params during initial prerender, only the final one
         varyParamsAccumulator: null,
+        sessionDataTracking: null,
       })
 
       const initialPrerenderOptions = {
@@ -7981,6 +7984,9 @@ async function prerenderToStream(
       const finalServerRenderController = new AbortController()
 
       const varyParamsAccumulator = createResponseVaryParamsAccumulator()
+      const sessionDataTracking = appShells
+        ? createSessionDataTrackingState()
+        : null
 
       const finalStageController = new StagedRenderingController({
         abortSignal: finalServerRenderController.signal,
@@ -8015,6 +8021,7 @@ async function prerenderToStream(
         resumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator,
+        sessionDataTracking,
       }
 
       const shellByteLengthDeferred = appShells
@@ -8062,6 +8069,7 @@ async function prerenderToStream(
         resumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator,
+        sessionDataTracking,
       })
 
       if (staleTimeIterable !== undefined) {
@@ -8077,6 +8085,7 @@ async function prerenderToStream(
       const collectedChunksByStage = createStageChunksAccumulator()
       let debugEndTime: number | undefined = undefined
       let didLinkDataUnblockNewContent = false
+      let shellUsedSessionData: boolean | null = null
 
       await runInSequentialTasks(
         async () => {
@@ -8142,6 +8151,12 @@ async function prerenderToStream(
           )
         },
         () => {
+          // We've finished rendering the shell. Check if session data was accessed.
+          if (sessionDataTracking) {
+            shellUsedSessionData = sessionDataTracking.didAccessSessionData
+            sessionDataTracking.isEnabled = false // Stop instrumenting promises after this point
+          }
+
           finalStageController.advanceStage(RenderStage.Static)
         },
         async () => {
@@ -8243,7 +8258,8 @@ async function prerenderToStream(
           ComponentMod,
           renderOpts,
           ctx.pagePath,
-          metadata
+          metadata,
+          shellUsedSessionData
         )
         if (appShells) {
           // If link data (static params) unblocked new content, then the shell has to be partial.
@@ -8592,7 +8608,8 @@ async function prerenderToStream(
           ComponentMod,
           renderOpts,
           ctx.pagePath,
-          metadata
+          metadata,
+          null
         )
       }
 
@@ -8804,7 +8821,8 @@ async function prerenderToStream(
           ComponentMod,
           renderOpts,
           ctx.pagePath,
-          metadata
+          metadata,
+          null
         )
       }
 
@@ -8977,6 +8995,7 @@ async function prerenderToStream(
         resumeDataCache: originalResumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator: null,
+        sessionDataTracking: null,
       }
 
       const errorRSCPayload = await workUnitAsyncStorage.run(
@@ -9334,7 +9353,8 @@ async function prerenderToStream(
           ComponentMod,
           renderOpts,
           ctx.pagePath,
-          metadata
+          metadata,
+          null
         )
       }
 
@@ -9523,7 +9543,8 @@ async function collectSegmentData(
   ComponentMod: AppPageModule,
   renderOpts: RenderOpts,
   pagePath: string,
-  metadata: AppPageRenderResultMetadata
+  metadata: AppPageRenderResultMetadata,
+  shellUsedSessionData: boolean | null
 ): Promise<void> {
   // Per-segment prefetch data
   //
@@ -9615,6 +9636,7 @@ async function collectSegmentData(
     renderOpts.cacheComponents,
     fullPageDataBuffer,
     staleTime,
+    shellUsedSessionData,
     clientModules,
     serverConsumerManifest,
     Boolean(renderOpts.experimental.prefetchInlining),

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -45,6 +45,7 @@ export type RootTreePrefetch = {
   buildId?: string
   tree: TreePrefetch
   staleTime: number
+  sessionShell?: boolean
 }
 
 export type TreePrefetchParam = {
@@ -181,6 +182,7 @@ export async function collectSegmentData(
   isCacheComponentsEnabled: boolean,
   fullPageDataBuffer: Buffer,
   staleTime: number,
+  shellUsedSessionData: boolean | null,
   clientModules: ManifestNode,
   serverConsumerManifest: any,
   prefetchInlining: boolean,
@@ -219,17 +221,24 @@ export async function collectSegmentData(
   // The promises for these tasks are pushed to a mutable array that we will
   // await once the route tree is fully rendered.
   const segmentTasks: Array<Promise<[SegmentRequestKey, Buffer]>> = []
+
+  // RootTreePrefetch is not a valid return type for a React component, but
+  // we need to use a component so that when we decode the original stream
+  // inside of it, the side effects are transferred to the new stream.
+  // (note: we're using a cast instead of a `ts-expect-error` directive,
+  // because a directive also hides errors from incorrect/missing props)
+  const PrefetchTreeDataAsValidComponent = PrefetchTreeData as (
+    props: Parameters<typeof PrefetchTreeData>[0]
+  ) => Promise<any>
+
   const { prelude: treeStream } = await prerender(
-    // RootTreePrefetch is not a valid return type for a React component, but
-    // we need to use a component so that when we decode the original stream
-    // inside of it, the side effects are transferred to the new stream.
-    // @ts-expect-error
-    <PrefetchTreeData
+    <PrefetchTreeDataAsValidComponent
       isClientParamParsingEnabled={isCacheComponentsEnabled}
       fullPageDataBuffer={fullPageDataBuffer}
       serverConsumerManifest={serverConsumerManifest}
       clientModules={clientModules}
       staleTime={staleTime}
+      shellUsedSessionData={shellUsedSessionData}
       segmentTasks={segmentTasks}
       onCompletedProcessingRouteTree={onCompletedProcessingRouteTree}
       prefetchInlining={prefetchInlining}
@@ -661,6 +670,7 @@ async function PrefetchTreeData({
   serverConsumerManifest,
   clientModules,
   staleTime,
+  shellUsedSessionData,
   segmentTasks,
   onCompletedProcessingRouteTree,
   prefetchInlining,
@@ -671,6 +681,7 @@ async function PrefetchTreeData({
   serverConsumerManifest: any
   clientModules: ManifestNode
   staleTime: number
+  shellUsedSessionData: boolean | null
   segmentTasks: Array<Promise<[SegmentRequestKey, Buffer]>>
   onCompletedProcessingRouteTree: () => void
   prefetchInlining: boolean
@@ -764,6 +775,12 @@ async function PrefetchTreeData({
   if (buildId) {
     treePrefetch.buildId = buildId
   }
+  // We currently can't track whether a given segment needs session data,
+  // so we only set this bit for the whole route.
+  if (shellUsedSessionData === true) {
+    treePrefetch.sessionShell = true
+  }
+
   return treePrefetch
 }
 

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -73,6 +73,7 @@ import {
   allRequiredBoundariesRendered,
 } from './instant-validation/boundary-tracking'
 import type { InstantValidationSampleTracking } from './instant-validation/instant-samples'
+import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 
 const hasPostpone = typeof React.unstable_postpone === 'function'
 
@@ -1519,4 +1520,67 @@ export function getNavigationDisallowedDynamicReasons(
 
   // We had a non-empty prelude and there are no dynamic holes
   return []
+}
+
+export type SessionDataTrackingState = {
+  isEnabled: boolean
+  didAccessSessionData: boolean
+}
+
+export function createSessionDataTrackingState(): SessionDataTrackingState {
+  return {
+    isEnabled: true,
+    didAccessSessionData: false,
+  }
+}
+
+export function trackSessionDataAccessWhenChained<T>(
+  state: SessionDataTrackingState,
+  promise: Promise<T>
+): Promise<T> {
+  // If we already accessed session data, we can skip the wrapper --
+  // we only need to know *if* any session data was accessed, so
+  // it won't provide us any new information.
+  if (!state.isEnabled || state.didAccessSessionData) {
+    return promise
+  }
+
+  type AnyFunction = (...args: any[]) => any
+  const methodCache: Record<string, AnyFunction> = {}
+
+  // Whenever then/catch/finally is called on the promise, we consider that an access of session data
+  // and track it on the state object.
+  // Note that this is imperfect, e.g. `Promise.resolve(cookies())` will trigger this too
+  // even if the promise ultimately wasn't awaited
+  return new Proxy(promise, {
+    get: function get(target, prop, receiver) {
+      if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+        // No need for ReflectAdapter's bind logic, we pass the receiver manually
+        const originalMethod = Reflect.get(
+          target,
+          prop,
+          receiver
+        ) as AnyFunction
+
+        let patchedMethod = methodCache[prop]
+        if (patchedMethod !== undefined) {
+          return patchedMethod
+        }
+
+        patchedMethod = {
+          [prop]: (...args: unknown[]) => {
+            state.didAccessSessionData = true
+            // There is no need to instrument the resulting promise --
+            // we already know that session data was accessed, so it won't tell us anything new.
+            return originalMethod.apply(target, args)
+          },
+        }[prop]
+        methodCache[prop] = patchedMethod
+
+        return patchedMethod
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+  })
 }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -5,7 +5,10 @@ import type { ReadonlyHeaders } from '../web/spec-extension/adapters/headers'
 import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
 import type { CacheSignal } from './cache-signal'
 import type { ResponseVaryParamsAccumulator } from './vary-params'
-import type { DynamicTrackingState } from './dynamic-rendering'
+import type {
+  DynamicTrackingState,
+  SessionDataTrackingState,
+} from './dynamic-rendering'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 
 // Share the instance module in the next-shared layer
@@ -184,6 +187,7 @@ export interface PrerenderStoreModernServer
   readonly type: 'prerender'
 
   readonly stagedRendering: StagedRenderingController | null
+  readonly sessionDataTracking: SessionDataTrackingState | null
 }
 
 export interface PrerenderStoreModernRuntime

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -19,6 +19,7 @@ import {
   postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
+  trackSessionDataAccessWhenChained,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
@@ -80,8 +81,17 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
           throw new Error(
             `Route ${workStore.route} used \`cookies()\` inside \`generateStaticParams\`. This is not supported because \`generateStaticParams\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
           )
-        case 'prerender':
+        case 'prerender': {
+          const { sessionDataTracking } = workUnitStore
+          if (sessionDataTracking) {
+            return trackSessionDataAccessWhenChained(
+              sessionDataTracking,
+              makeHangingCookies(workStore, workUnitStore)
+            )
+          }
+
           return makeHangingCookies(workStore, workUnitStore)
+        }
         case 'prerender-client':
         case 'validation-client':
           const exportName = '`cookies`'
@@ -119,6 +129,8 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
         case 'private-cache':
           // Private caches are delayed until the runtime stage in use-cache-wrapper,
           // so we don't need an additional delay here.
+          // We consider accessing a private cache itself to be a session data access,
+          // so we don't need to further track cookies() here.
           return makeUntrackedCookies(workUnitStore.cookies)
         case 'request':
           trackDynamicDataInDynamicRender(workUnitStore)

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -17,6 +17,7 @@ import {
   postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
+  trackSessionDataAccessWhenChained,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
@@ -103,8 +104,16 @@ export function headers(): Promise<ReadonlyHeaders> {
 
     if (workUnitStore) {
       switch (workUnitStore.type) {
-        case 'prerender':
+        case 'prerender': {
+          const { sessionDataTracking } = workUnitStore
+          if (sessionDataTracking) {
+            return trackSessionDataAccessWhenChained(
+              sessionDataTracking,
+              makeHangingHeaders(workStore, workUnitStore)
+            )
+          }
           return makeHangingHeaders(workStore, workUnitStore)
+        }
         case 'prerender-client':
         case 'validation-client':
           const exportName = '`headers`'
@@ -146,6 +155,8 @@ export function headers(): Promise<ReadonlyHeaders> {
         case 'private-cache':
           // Private caches are delayed until the runtime stage in use-cache-wrapper,
           // so we don't need an additional delay here.
+          // We consider accessing a private cache itself to be a session data access,
+          // so we don't need to further track headers() here.
           return makeUntrackedHeaders(workUnitStore.headers)
         case 'request':
           trackDynamicDataInDynamicRender(workUnitStore)

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -521,6 +521,7 @@ export class AppRouteRouteModule extends RouteModule<
               resumeDataCache: prerenderResumeDataCache,
               hmrRefreshHash: undefined,
               varyParamsAccumulator: null,
+              sessionDataTracking: null,
             })
 
           let prospectiveResult
@@ -617,6 +618,7 @@ export class AppRouteRouteModule extends RouteModule<
             resumeDataCache: prerenderResumeDataCache,
             hmrRefreshHash: undefined,
             varyParamsAccumulator: null,
+            sessionDataTracking: null,
           })
 
           let responseHandled = false

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -70,6 +70,7 @@ import {
   createHangingInputAbortSignal,
   postponeWithTracking,
   throwToInterruptStaticGeneration,
+  trackSessionDataAccessWhenChained,
 } from '../app-render/dynamic-rendering'
 import {
   makeErroringSearchParamsForUseCache,
@@ -1535,12 +1536,25 @@ export async function cache(
 
     switch (workUnitStore.type) {
       // "use cache: private" is dynamic in prerendering contexts.
-      case 'prerender':
+      case 'prerender': {
+        const { sessionDataTracking } = workUnitStore
+        if (sessionDataTracking) {
+          return trackSessionDataAccessWhenChained(
+            sessionDataTracking,
+            makeHangingPromise(
+              workUnitStore.renderSignal,
+              workStore.route,
+              expression
+            )
+          )
+        }
+
         return makeHangingPromise(
           workUnitStore.renderSignal,
           workStore.route,
           expression
         )
+      }
       case 'prerender-ppr':
         return postponeWithTracking(
           workStore.route,


### PR DESCRIPTION
Tracks whether session data was accessed during build. If it was, we should use a session shell (i.e. a runtime prefetch). If not, we should prefetch a static shell instead (available as a `/_shell` segment since #94442). Exposed as `sessionShell?: boolean` on the `/_tree` response.
