### PR TITLE
[ci] Switch release-next-rspack to a more explicit environment name

### DIFF
--- a/.github/workflows/release-next-rspack.yml
+++ b/.github/workflows/release-next-rspack.yml
@@ -38,7 +38,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    environment: npm
+    environment: npm-release-next-rspack
     name: Release
     permissions:
       contents: write


### PR DESCRIPTION
Matches the environment name I asked IT to use for NPM trusted publishing: https://vercel.slack.com/archives/C01LN7C5QR5/p1780600987032909

Nothing else uses the `npm` environment, but the name is confusing. We want to use separate environments for these publishing workflows as they allow us to define things like reviewers, if we want to block the release on a manual review.