### PR TITLE
Turbopack: refactor into `get_next_client_transforms_rules`

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -6,9 +6,8 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
-    CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleRule,
-    TypescriptTransformOptions, module_options_context::ModuleOptionsContext,
-    side_effect_free_packages_glob,
+    CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, TypescriptTransformOptions,
+    module_options_context::ModuleOptionsContext, side_effect_free_packages_glob,
 };
 use turbopack_browser::{
     BrowserChunkingContext, CurrentChunkMethod, react_refresh::assert_can_resolve_react_refresh,
@@ -54,14 +53,6 @@ use crate::{
     },
     next_shared::{
         resolve::NextSharedRuntimeResolvePlugin,
-        transforms::{
-            emotion::get_emotion_transform_rule,
-            react_remove_properties::get_react_remove_properties_transform_rule,
-            relay::get_relay_transform_rule, remove_console::get_remove_console_transform_rule,
-            styled_components::get_styled_components_transform_rule,
-            styled_jsx::get_styled_jsx_transform_rule,
-            swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
-        },
         webpack_rules::{WebpackLoaderBuiltinCondition, webpack_loader_options},
     },
     transform_options::{
@@ -286,26 +277,26 @@ pub async fn get_client_module_options_context(
         .await?;
     let target_browsers = env.runtime_versions();
 
-    let mut next_client_rules =
-        get_next_client_transforms_rules(next_config, ty.clone(), mode, false, encryption_key)
-            .await?;
-    let foreign_next_client_rules =
-        get_next_client_transforms_rules(next_config, ty.clone(), mode, true, encryption_key)
-            .await?;
-    let additional_rules: Vec<ModuleRule> = vec![
-        get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?,
-        get_relay_transform_rule(next_config, project_path.clone()).await?,
-        get_emotion_transform_rule(next_config).await?,
-        get_styled_components_transform_rule(next_config).await?,
-        get_styled_jsx_transform_rule(next_config, target_browsers).await?,
-        get_react_remove_properties_transform_rule(next_config).await?,
-        get_remove_console_transform_rule(next_config).await?,
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
-
-    next_client_rules.extend(additional_rules);
+    let next_client_rules = get_next_client_transforms_rules(
+        next_config,
+        &project_path,
+        ty.clone(),
+        mode,
+        false,
+        encryption_key,
+        target_browsers,
+    )
+    .await?;
+    let foreign_next_client_rules = get_next_client_transforms_rules(
+        next_config,
+        &project_path,
+        ty.clone(),
+        mode,
+        true,
+        encryption_key,
+        target_browsers,
+    )
+    .await?;
 
     let local_postcss_config = *next_config
         .experimental_turbopack_local_postcss_config()

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -2,19 +2,27 @@ use anyhow::Result;
 use next_custom_transforms::transforms::strip_page_exports::ExportFilter;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
+use turbopack_core::environment::RuntimeVersions;
 
 use crate::{
     mode::NextMode,
     next_client::context::ClientContextType,
     next_config::NextConfig,
     next_shared::transforms::{
-        debug_fn_name::get_debug_fn_name_rule, get_next_dynamic_transform_rule,
-        get_next_font_transform_rule, get_next_image_rule, get_next_lint_transform_rule,
-        get_next_modularize_imports_rule, get_next_pages_transforms_rule,
-        get_server_actions_transform_rule, next_cjs_optimizer::get_next_cjs_optimizer_rule,
+        debug_fn_name::get_debug_fn_name_rule, emotion::get_emotion_transform_rule,
+        get_next_dynamic_transform_rule, get_next_font_transform_rule, get_next_image_rule,
+        get_next_lint_transform_rule, get_next_modularize_imports_rule,
+        get_next_pages_transforms_rule, get_server_actions_transform_rule,
+        next_cjs_optimizer::get_next_cjs_optimizer_rule,
         next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
-        next_pure::get_next_pure_rule, server_actions::ActionsTransform,
+        next_pure::get_next_pure_rule,
+        react_remove_properties::get_react_remove_properties_transform_rule,
+        relay::get_relay_transform_rule, remove_console::get_remove_console_transform_rule,
+        server_actions::ActionsTransform, styled_components::get_styled_components_transform_rule,
+        styled_jsx::get_styled_jsx_transform_rule,
+        swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
     },
     raw_ecmascript_module::RawEcmascriptModuleType,
 };
@@ -23,10 +31,12 @@ use crate::{
 /// transforms.
 pub async fn get_next_client_transforms_rules(
     next_config: Vc<NextConfig>,
+    project_path: &FileSystemPath,
     context_ty: ClientContextType,
     mode: Vc<NextMode>,
     foreign_code: bool,
     encryption_key: ResolvedVc<RcStr>,
+    target_browsers: Vc<RuntimeVersions>,
 ) -> Result<Vec<ModuleRule>> {
     let mut rules = vec![];
 
@@ -113,6 +123,14 @@ pub async fn get_next_client_transforms_rules(
         );
 
         rules.push(get_next_image_rule().await?);
+
+        rules.extend(get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?);
+        rules.extend(get_relay_transform_rule(next_config, project_path.clone()).await?);
+        rules.extend(get_emotion_transform_rule(next_config).await?);
+        rules.extend(get_styled_components_transform_rule(next_config).await?);
+        rules.extend(get_styled_jsx_transform_rule(next_config, target_browsers).await?);
+        rules.extend(get_react_remove_properties_transform_rule(next_config).await?);
+        rules.extend(get_remove_console_transform_rule(next_config).await?);
     }
 
     Ok(rules)


### PR DESCRIPTION
Straight up moving that `.extend()` into the function that produced the vector a few lines before.