### PR TITLE
Fix: Subtree hints not propagating correctly

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -6,6 +6,10 @@ import type {
 } from '../../../shared/lib/app-router-types'
 import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type { HeadData } from '../../../shared/lib/app-router-types'
+import {
+  SubtreePrefetchHints,
+  propagateSubtreeBits,
+} from '../../../shared/lib/app-router-types'
 import type { NormalizedFlightData } from '../../flight-data-helpers'
 import { fetchServerResponse } from '../router-reducer/fetch-server-response'
 import {
@@ -914,8 +918,18 @@ function convertServerPatchToFullTreeImpl(
   if (3 in baseRouterState) {
     clonedTree[3] = baseRouterState[3]
   }
-  if (4 in baseRouterState) {
-    clonedTree[4] = baseRouterState[4]
+  // Recompute the propagated "subtree" prefetch hints for this segment. Mirrors
+  // the propagation done on the server in
+  // createFlightRouterStateFromLoaderTree.
+  let prefetchHints = (baseRouterState[4] ?? 0) & ~SubtreePrefetchHints
+  for (const parallelRouteKey in newTreeChildren) {
+    const childHints = newTreeChildren[parallelRouteKey][4]
+    if (childHints !== undefined) {
+      prefetchHints = propagateSubtreeBits(prefetchHints, childHints)
+    }
+  }
+  if (prefetchHints !== 0) {
+    clonedTree[4] = prefetchHints
   }
 
   // Clone the CacheNodeSeedData tree.

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,6 +1,7 @@
 import type { LoaderTree } from '../lib/app-dir-module'
 import {
   PrefetchHint,
+  propagateSubtreeBits,
   type FlightRouterState,
   type PrefetchHints,
 } from '../../shared/lib/app-router-types'
@@ -132,29 +133,7 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     )
     // Propagate subtree flags from children
     if (child[4] !== undefined) {
-      prefetchHints |=
-        child[4] &
-        (PrefetchHint.SubtreeHasPartialPrefetching |
-          PrefetchHint.SubtreeHasLoadingBoundary |
-          PrefetchHint.SubtreeHasRuntimePrefetch)
-      // If a child has a loading boundary (either directly or in its subtree),
-      // propagate that as SubtreeHasLoadingBoundary to this segment.
-      if (
-        child[4] &
-        (PrefetchHint.SegmentHasLoadingBoundary |
-          PrefetchHint.SubtreeHasLoadingBoundary)
-      ) {
-        prefetchHints |= PrefetchHint.SubtreeHasLoadingBoundary
-      }
-      // If a child has runtime prefetch (either directly or in its subtree),
-      // propagate that as SubtreeHasRuntimePrefetch to this segment.
-      if (
-        child[4] &
-        (PrefetchHint.HasRuntimePrefetch |
-          PrefetchHint.SubtreeHasRuntimePrefetch)
-      ) {
-        prefetchHints |= PrefetchHint.SubtreeHasRuntimePrefetch
-      }
+      prefetchHints = propagateSubtreeBits(prefetchHints, child[4])
     }
     children[parallelRouteKey] = child
   }

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -237,6 +237,54 @@ export const StaticPrefetchDisabled =
   PrefetchHint.HasRuntimePrefetch | PrefetchHint.PrefetchDisabled
 
 /**
+ * The subset of PrefetchHint bits that propagate upward from a child segment to
+ * its ancestors (as opposed to segment-local bits like SegmentHasLoadingBoundary
+ * or IsRootLayout). Used to clear stale propagated bits before re-deriving them
+ * from a node's children.
+ */
+export const SubtreePrefetchHints =
+  PrefetchHint.SubtreeHasPartialPrefetching |
+  PrefetchHint.SubtreeHasLoadingBoundary |
+  PrefetchHint.SubtreeHasRuntimePrefetch
+
+/**
+ * Folds a child segment's prefetch hints into its parent's, propagating the
+ * "subtree" flags. A child's segment-local flag (e.g. it has a loading boundary,
+ * or it has a runtime prefetch) becomes the corresponding "subtree" flag on the
+ * parent, so the root segment ends up reflecting the entire subtree.
+ *
+ * Used wherever a route tree is assembled bottom-up: on the server when building
+ * a prefetch tree (createFlightRouterStateFromLoaderTree) and on the client when
+ * merging a navigation patch into the existing tree (convertServerPatchToFullTree).
+ * Keep these in sync by routing both through this helper.
+ */
+export function propagateSubtreeBits(
+  parentHints: number,
+  childHints: number
+): number {
+  if (childHints & PrefetchHint.SubtreeHasPartialPrefetching) {
+    parentHints |= PrefetchHint.SubtreeHasPartialPrefetching
+  }
+  // A child with a loading boundary (directly, or anywhere in its subtree) makes
+  // this a SubtreeHasLoadingBoundary on the parent.
+  if (
+    childHints &
+    (PrefetchHint.SegmentHasLoadingBoundary |
+      PrefetchHint.SubtreeHasLoadingBoundary)
+  ) {
+    parentHints |= PrefetchHint.SubtreeHasLoadingBoundary
+  }
+  // Likewise for runtime prefetch.
+  if (
+    childHints &
+    (PrefetchHint.HasRuntimePrefetch | PrefetchHint.SubtreeHasRuntimePrefetch)
+  ) {
+    parentHints |= PrefetchHint.SubtreeHasRuntimePrefetch
+  }
+  return parentHints
+}
+
+/**
  * Individual Flight response path
  */
 export type FlightSegmentPath =

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/app/a/b/c/page.tsx
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/app/a/b/c/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// Opt into Partial Prefetching on this deeply nested leaf page. The
+// `SubtreeHasPartialPrefetching` hint originates here and must propagate up
+// through the /a/b and /a layouts to the root for the scheduler to downgrade a
+// `prefetch={true}` link into a partial (PPR) prefetch.
+export const unstable_prefetch = 'partial'
+
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Deep static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Deep dynamic</div>
+}

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/app/a/b/layout.tsx
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/app/a/b/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+
+export default function BLayout({ children }: { children: ReactNode }) {
+  return (
+    <div data-layout="b">
+      <div id="b-layout">B layout</div>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/app/a/layout.tsx
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/app/a/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+
+export default function ALayout({ children }: { children: ReactNode }) {
+  return (
+    <div data-layout="a">
+      <div id="a-layout">A layout</div>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/app/layout.tsx
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/app/page.tsx
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/app/page.tsx
@@ -1,0 +1,21 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+// The partial-prefetch opt-in lives on the deeply nested /a/b/c page. For a
+// `prefetch={true}` link to be downgraded to a partial (PPR) prefetch, the
+// `SubtreeHasPartialPrefetching` hint must propagate from that leaf up through
+// the /a/b and /a layout segments to the root, where the prefetch scheduler
+// reads it.
+export default function Page() {
+  return (
+    <main>
+      <h1 id="home">Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/a/b/c" prefetch={true}>
+            Deep route
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/components/link-accordion.tsx
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: LinkProps['href']
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/next.config.js
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  // Note: Partial Prefetching is NOT enabled globally. The target route opts
+  // in per-segment via `unstable_prefetch = 'partial'` on a deeply nested page.
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/partial-prefetching-deep-propagation/partial-prefetching-deep-propagation.test.ts
+++ b/test/e2e/app-dir/partial-prefetching-deep-propagation/partial-prefetching-deep-propagation.test.ts
@@ -1,0 +1,54 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('partial prefetching - deep subtree-hint propagation', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    // Prefetching only happens in production builds.
+    it('is skipped in dev mode', () => {})
+    return
+  }
+
+  // NOTE: This is a regression test, so the description mentions implementation
+  // details. However, it's written in such a way that it should still be value
+  // even if the implementation details change.
+  //
+  // The route `/a/b/c` opts into Partial Prefetching on its leaf page via
+  // `export const unstable_prefetch = 'partial'`. The
+  // `SubtreeHasPartialPrefetching` hint originates on that leaf and must
+  // propagate up through the `/a/b` and `/a` layout segments to the ROOT of
+  // the route tree, because the prefetch scheduler reads the hint at the root
+  // to decide whether a `prefetch={true}` link does a full prefetch (which
+  // includes dynamic data) or a partial/PPR prefetch (static only).
+  //
+  // If propagation is broken at any level, the root is missing the hint, the
+  // prefetch becomes a full prefetch, and "Deep dynamic" arrives — failing the
+  // `block: 'reject'` assertion below.
+  it('downgrades a prefetch={true} to a partial prefetch when a deeply nested segment opts in', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal the link to trigger its prefetch. The Link has prefetch={true},
+    // and the target route opts into partial prefetching on a deeply nested
+    // segment. The prefetch should include the static shell, but NOT the
+    // dynamic data.
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/a/b/c"]'
+      )
+      await toggle.click()
+    }, [
+      { includes: 'Deep static' },
+      { includes: 'Deep dynamic', block: 'reject' },
+    ])
+  })
+})


### PR DESCRIPTION
Fixes a mistake in the client when constructing a route tree from a partial server response. When applying the patch, we must propagate the new subtree hints all the way up to the root.

This was an existing bug that I found when implementing the next PR in the stack, which relies on the subtree hint mechanism. I've split it out into its own step and confirmed the bug + fix using a regression test expressed via existing behavior.

<!-- NEXT_JS_LLM_PR -->
