### PR TITLE
Warn on prefetch={true} navigation without Partial Prefetching (dev)

### DIFF
--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -39,13 +39,19 @@ const InstantConfigSchema = z.union([
 const PrefetchSchema = z.enum([
   'auto',
   'partial',
+  'unstable_eager',
   'force-disabled',
   'force-runtime',
 ])
 
 export type Instant = InstantConfig | true | false
 
-export type Prefetch = 'auto' | 'partial' | 'force-disabled' | 'force-runtime'
+export type Prefetch =
+  | 'auto'
+  | 'partial'
+  | 'unstable_eager'
+  | 'force-disabled'
+  | 'force-runtime'
 
 export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
 // the __GenericInstantConfig type is used to avoid type widening issues with
@@ -137,6 +143,9 @@ const AppSegmentConfigSchema = z.object({
    * - 'auto' (default) is a noop.
    * - 'partial' enables Partial Prefetching. Only Cache Components are
    *   prefetched, not dynamic ones.
+   * - 'unstable_eager' behaves like 'partial' but, when App Shells are enabled,
+   *   keeps eagerly prefetching the route's segments instead of relying on the
+   *   shared app shell. Internal migration aid; not part of the public API.
    * - 'force-runtime' is a superset of 'partial' and prefetches using a
    *   runtime request, instead of a static one.
    * - 'force-disabled' disables prefetching for the segment.
@@ -195,7 +204,7 @@ export function parseAppSegmentConfig(
           }
           case 'unstable_prefetch': {
             return {
-              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be "auto", "partial", "force-disabled", or "force-runtime".`,
+              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be "auto", "partial", "unstable_eager", "force-disabled", or "force-runtime".`,
             }
           }
           case 'unstable_dynamicStaleTime': {
@@ -262,6 +271,9 @@ export type AppSegmentConfig = {
    * - 'auto' (default) is a noop.
    * - 'partial' enables Partial Prefetching. Only Cache Components are
    *   prefetched, not dynamic ones.
+   * - 'unstable_eager' behaves like 'partial' but, when App Shells are enabled,
+   *   keeps eagerly prefetching the route's segments instead of relying on the
+   *   shared app shell. Internal migration aid; not part of the public API.
    * - 'force-runtime' is a superset of 'partial' and prefetches using a
    *   runtime request, instead of a static one.
    * - 'force-disabled' disables prefetching for the segment.

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -7,6 +7,7 @@ import type {
 import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type { HeadData } from '../../../shared/lib/app-router-types'
 import {
+  PrefetchHint,
   SubtreePrefetchHints,
   propagateSubtreeBits,
 } from '../../../shared/lib/app-router-types'
@@ -229,6 +230,37 @@ export function navigateToKnownRoute(
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.__NEXT_CACHE_COMPONENTS
+  ) {
+    // Warn when navigating via a `<Link prefetch={true}>` to a route that has
+    // not opted into Partial Prefetching. Such a link does a legacy "full"
+    // prefetch that includes the route's dynamic data, defeating the
+    // static/dynamic split that Cache Components provides.
+    //
+    // This runs at navigation time (rather than prefetch time) so that, in dev
+    // where we don't prefetch, the warning only appears when you actually
+    // navigate to the route — existing apps with many `prefetch={true}` links
+    // aren't flooded with warnings the moment they enable Cache Components.
+    const link = getLinkForCurrentNavigation()
+    if (
+      link !== null &&
+      link.fetchStrategy === FetchStrategy.Full &&
+      (navigationSeed.routeTree.prefetchHints &
+        PrefetchHint.SubtreeHasPartialPrefetching) ===
+        0
+    ) {
+      console.error(
+        `A <Link prefetch={true}> navigated to "${url.pathname}", but Partial ` +
+          `Prefetching is not enabled for that route, so its dynamic data was ` +
+          `included in the prefetch. Enable Partial Prefetching app-wide by ` +
+          `setting \`partialPrefetching: true\` in next.config, or per-route by ` +
+          `exporting \`const unstable_prefetch = 'partial'\` from the page or a ` +
+          `layout segment.`
+      )
+    }
+  }
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -776,6 +776,16 @@ function pingRootRouteTree(
           //
           // Then, if there are any segments that need a runtime request,
           // do another pass to perform a runtime prefetch.
+
+          if (
+            task.phase === PrefetchPhase.Speculative &&
+            !subtreeHasSpeculativePrefetch(task, tree.prefetchHints)
+          ) {
+            // Nothing in the target route needs to be speculatively prefetched.
+            // Bail out.
+            return PrefetchTaskExitStatus.Done
+          }
+
           pingStaticHead(now, task, route)
           const exitStatus = pingSharedPartOfCacheComponentsTree(
             now,
@@ -797,15 +807,15 @@ function pingRootRouteTree(
             // Do any segments have runtime prefetching configured? This is
             // sent by the server as part of the prefetch hints.
             tree.prefetchHints & PrefetchHint.SubtreeHasRuntimePrefetch ||
-            // Are we in the Shell prefetching phase? The Shell phase is allowed
-            // to perform runtime prefetches even without an explicit opt-in
-            // because the Shell for a given route is reusable across all given
-            // params, by definition. So it does not lead to an explosion in
-            // prefetching costs.
+            // Are we in the Shell prefetching phase? The Shell phase is
+            // allowed to perform runtime prefetches even without an explicit
+            // opt-in because the Shell for a given route is reusable across
+            // all given params, by definition. So it does not lead to an
+            // explosion in prefetching costs.
             // TODO: In the future, the server could emit a hint to tell us
             // *not* to prefetch via a runtime request, via build-time
-            // heuristics, like if no `cookies()` call was detected. We'll leave
-            // this optimization for later.
+            // heuristics, like if no `cookies()` call was detected. We'll
+            // leave this optimization for later.
             task.phase === PrefetchPhase.Shell
           ) {
             const runtimeStrategy =
@@ -1101,6 +1111,16 @@ function pingNewPartOfCacheComponentsTree(
   // runtime shell request. For fully static pages, it doesn't matter since
   // server will respond to even a runtime request with a static response. For
   // a partially static page, we can send down a hint from the server.
+
+  if (
+    task.phase === PrefetchPhase.Speculative &&
+    !subtreeHasSpeculativePrefetch(task, tree.prefetchHints)
+  ) {
+    // Nothing in the new part of the tree needs to be speculatively prefetched.
+    // Bail out.
+    return PrefetchTaskExitStatus.Done
+  }
+
   if (
     tree.prefetchHints & PrefetchHint.HasRuntimePrefetch ||
     task.phase === PrefetchPhase.Shell
@@ -1917,6 +1937,31 @@ function doesCurrentSegmentMatchCachedSegment(
   }
   // Non-page segments are compared using the same function as the server
   return matchSegment(cachedSegment, currentSegment)
+}
+
+/**
+ * Decides whether to skip the speculative prefetch of a subtree. Usually we
+ * only perform a speculative prefetch if the Link's prefetch prop is set to
+ * true. However, we also will do a speculative prefetch if the prefetching
+ * mode of the segment is set to "unstable_eager".
+ */
+function subtreeHasSpeculativePrefetch(
+  task: PrefetchTask,
+  prefetchHints: number
+): boolean {
+  if (!process.env.__NEXT_APP_SHELLS) {
+    // When App Shells is disabled, all prefetches implicitly include the
+    // speculative (non-shell) part of the target.
+    return true
+  }
+
+  return (
+    // Check if this is a "full" prefetch (<Link prefetch={true}>).
+    task.fetchStrategy === FetchStrategy.Full ||
+    // Check if something in this subtree is configured to be eagerly
+    // prefetched at the route level.
+    (prefetchHints & PrefetchHint.SubtreeHasEagerPrefetch) !== 0
+  )
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -14,7 +14,7 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   cacheComponents: boolean,
-  partialPrefetching: boolean | undefined,
+  partialPrefetching: boolean | 'unstable_eager' | undefined,
   isStaticGeneration: boolean,
   isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
@@ -40,7 +40,11 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     : undefined
   const prefetchConfig =
     (mod ? (mod as AppSegmentConfig).unstable_prefetch : undefined) ??
-    (partialPrefetching ? 'partial' : undefined)
+    (partialPrefetching === 'unstable_eager'
+      ? 'unstable_eager'
+      : partialPrefetching
+        ? 'partial'
+        : undefined)
   let prefetchHints = 0
 
   // Union in the precomputed build-time hints (e.g. segment inlining
@@ -93,19 +97,39 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     prefetchHints |= PrefetchHint.IsRootLayout
   }
 
-  if (
+  const isInstant =
     instantConfig === true ||
     (typeof instantConfig === 'object' && instantConfig !== null)
-  ) {
+  if (isInstant) {
     prefetchHints |= PrefetchHint.SubtreeHasPartialPrefetching
   }
 
   if (prefetchConfig === 'partial') {
     prefetchHints |= PrefetchHint.SubtreeHasPartialPrefetching
+  } else if (prefetchConfig === 'unstable_eager') {
+    // Like 'partial' (uses the PPR fetch strategy) but also marks the segment
+    // as eager, so App Shells keeps prefetching it instead of relying on the
+    // shared app shell.
+    prefetchHints |=
+      PrefetchHint.SubtreeHasPartialPrefetching |
+      PrefetchHint.SubtreeHasEagerPrefetch
   } else if (prefetchConfig === 'force-disabled') {
     prefetchHints |= PrefetchHint.PrefetchDisabled
   } else if (prefetchConfig === 'force-runtime') {
     prefetchHints |= PrefetchHint.HasRuntimePrefetch
+  }
+
+  // Mark the segment as "eager" unless its effective prefetch strategy is
+  // 'partial' or 'force-runtime'. A truthy unstable_instant is treated as
+  // 'partial' (not eager). 'unstable_eager' already set the bit above. Under
+  // App Shells, a subtree with no eager segment skips its Speculative prefetch
+  // and relies on the shared app shell instead.
+  if (
+    !isInstant &&
+    prefetchConfig !== 'partial' &&
+    prefetchConfig !== 'force-runtime'
+  ) {
+    prefetchHints |= PrefetchHint.SubtreeHasEagerPrefetch
   }
 
   // Check if this segment has a loading boundary
@@ -151,7 +175,7 @@ export async function createFlightRouterStateFromLoaderTree(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   cacheComponents: boolean,
-  partialPrefetching: boolean | undefined,
+  partialPrefetching: boolean | 'unstable_eager' | undefined,
   isStaticGeneration: boolean,
   isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
@@ -177,7 +201,7 @@ export async function createRouteTreePrefetch(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   cacheComponents: boolean,
-  partialPrefetching: boolean | undefined,
+  partialPrefetching: boolean | 'unstable_eager' | undefined,
   isStaticGeneration: boolean,
   isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -764,7 +764,9 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .optional(),
     pageExtensions: z.array(z.string()).min(1).optional(),
     instrumentationClientInject: z.array(z.string()).optional(),
-    partialPrefetching: z.boolean().optional(),
+    partialPrefetching: z
+      .union([z.boolean(), z.literal('unstable_eager')])
+      .optional(),
     poweredByHeader: z.boolean().optional(),
     productionBrowserSourceMaps: z.boolean().optional(),
     reactCompiler: z.union([

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1772,8 +1772,12 @@ export interface NextConfig {
    *
    * When `false` or omitted, this does nothing (the legacy behavior, where
    * dynamic data is included in the prefetch).
+   *
+   * `'unstable_eager'` is like `true`, except the default becomes
+   * `'unstable_eager'` instead of `'partial'`: every Link has an implied
+   * prefetch={true}. Internal migration aid; not part of the public API.
    */
-  partialPrefetching?: boolean
+  partialPrefetching?: boolean | 'unstable_eager'
 
   cacheLife?: {
     [profile: string]: {

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -159,10 +159,15 @@ const API_DOCS: Record<
   unstable_prefetch: {
     description: `Controls prefetching behavior for this segment. This configuration is currently under development and will change.`,
     link: '(docs coming soon)',
-    type: `"auto" | "partial" | "force-disabled" | "force-runtime"`,
+    type: `"auto" | "partial" | "unstable_eager" | "force-disabled" | "force-runtime"`,
     options: {
       auto: 'Default. Framework decides based on instant validation and segment configuration. You do not need to set this explicitly.',
       partial: 'Enables Partial Prefetching for this segment.',
+      unstable_eager:
+        'Like "partial", but adds an implied prop of prefetch={true} to ' +
+        'every Link. This option only exists to aid migration of apps that ' +
+        'adopted Partial Prefetching in canary before the behavior changed to ' +
+        'only fetch the shell by default.',
       'force-disabled': 'Never prefetch this segment.',
       'force-runtime':
         'Prefetch this segment with a runtime server request so it can access session data, such as cookies.',

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -222,6 +222,12 @@ export const enum PrefetchHint {
   // (HasRuntimePrefetch). Propagates upward so the root reflects the
   // entire subtree.
   SubtreeHasRuntimePrefetch = 0b100000000000,
+  // This segment or one of its descendants prefetches "eagerly" — i.e. its
+  // effective prefetch strategy is anything other than 'partial' or
+  // 'force-runtime'. Used by App Shells: a non-eager subtree relies on the
+  // shared app shell and skips its Speculative prefetch. Propagates upward so
+  // the root reflects the entire subtree.
+  SubtreeHasEagerPrefetch = 0b1000000000000,
 }
 
 /**
@@ -245,7 +251,8 @@ export const StaticPrefetchDisabled =
 export const SubtreePrefetchHints =
   PrefetchHint.SubtreeHasPartialPrefetching |
   PrefetchHint.SubtreeHasLoadingBoundary |
-  PrefetchHint.SubtreeHasRuntimePrefetch
+  PrefetchHint.SubtreeHasRuntimePrefetch |
+  PrefetchHint.SubtreeHasEagerPrefetch
 
 /**
  * Folds a child segment's prefetch hints into its parent's, propagating the
@@ -280,6 +287,11 @@ export function propagateSubtreeBits(
     (PrefetchHint.HasRuntimePrefetch | PrefetchHint.SubtreeHasRuntimePrefetch)
   ) {
     parentHints |= PrefetchHint.SubtreeHasRuntimePrefetch
+  }
+  // And for eager prefetch. The bit is set directly on each eager segment, so
+  // there's no separate segment-local flag — propagate it as-is.
+  if (childHints & PrefetchHint.SubtreeHasEagerPrefetch) {
+    parentHints |= PrefetchHint.SubtreeHasEagerPrefetch
   }
   return parentHints
 }

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/control-route/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/control-route/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// No partial prefetching opt-in, same as /default-route. The difference is the
+// link to this route uses the default prefetch (not `prefetch={true}`), so the
+// warning should NOT fire even though the route hasn't opted in.
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Control static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Control dynamic</div>
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/default-route/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/default-route/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// No partial prefetching opt-in. Navigating here via a `prefetch={true}` link
+// should emit the dev warning.
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Default static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Default dynamic</div>
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/page.tsx
@@ -1,0 +1,29 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          {/* prefetch={true} + no partial prefetching opt-in => should warn */}
+          <LinkAccordion href="/default-route" prefetch={true}>
+            /default-route
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* prefetch={true} but the route opts into partial prefetching =>
+              should NOT warn */}
+          <LinkAccordion href="/partial-route" prefetch={true}>
+            /partial-route
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* default prefetch (not a "full" prefetch) => should NOT warn,
+              even though the route has no partial prefetching opt-in */}
+          <LinkAccordion href="/control-route">/control-route</LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/partial-route/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/partial-route/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// Opts into partial prefetching at the segment level. Navigating here via a
+// `prefetch={true}` link should NOT warn.
+export const unstable_prefetch = 'partial'
+
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Partial static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Partial dynamic</div>
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/components/link-accordion.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/next.config.js
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/prefetch-true-partial-warning/prefetch-true-partial-warning.test.ts
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/prefetch-true-partial-warning.test.ts
@@ -1,0 +1,83 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('prefetch-true-partial-warning', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // The warning is only emitted in development. In dev we don't prefetch, so it
+  // fires at navigation time instead.
+  if (!isNextDev) {
+    it('is skipped outside of dev', () => {})
+    return
+  }
+
+  // A stable substring of the dev warning emitted from navigation.ts.
+  const WARNING = 'Partial Prefetching is not enabled'
+
+  async function navigateViaAccordion(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    href: string
+  ) {
+    const toggle = await browser.elementByCss(
+      `input[data-link-accordion="${href}"]`
+    )
+    await toggle.click()
+    const link = await browser.elementByCss(`a[href="${href}"]`)
+    await link.click()
+  }
+
+  it('warns when a prefetch={true} link navigates to a route without partial prefetching', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/default-route')
+
+    // Wait for the navigation to fully complete (dynamic content rendered).
+    // The warning fires synchronously at the start of the navigation, so by
+    // now it must already be in the console log.
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Default dynamic'
+    )
+
+    expect(await browser.log()).toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
+
+  it('does not warn when the target route opts into partial prefetching', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/partial-route')
+
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Partial dynamic'
+    )
+
+    expect(await browser.log()).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
+
+  it('does not warn for a default (non-full) prefetch link', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/control-route')
+
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Control dynamic'
+    )
+
+    expect(await browser.log()).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
+})

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/app/page.tsx
@@ -1,0 +1,17 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/posts/1">Post 1 (default)</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/posts/2">Post 2 (default)</LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/app/posts/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/app/posts/[id]/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+
+type Params = { id: string }
+
+// No per-segment `unstable_prefetch`. The route's prefetch config comes from
+// the global `partialPrefetching: 'unstable_eager'` in next.config, which makes
+// it eager — so the App Shells skip does NOT apply.
+export function generateStaticParams() {
+  return [{ id: '1' }, { id: '2' }, { id: '3' }]
+}
+
+export default function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="shell">App shell</p>}>
+        <ParamContent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ParamContent({ params }: { params: Promise<Params> }) {
+  const { id } = await params
+  return <p id="param-value">{`Eager post ${id}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/next.config.ts
@@ -1,0 +1,19 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  // Opt the whole app into Partial Prefetching in "eager" mode. Every route's
+  // default prefetch config becomes 'unstable_eager', so under App Shells the
+  // per-link Speculative prefetch is NOT skipped — even for routes with no
+  // per-segment `unstable_prefetch` export.
+  partialPrefetching: 'unstable_eager',
+  experimental: {
+    prefetchInlining: true,
+    optimisticRouting: true,
+    cachedNavigations: true,
+    appShells: true,
+    varyParams: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/prefetch-app-shell-global-eager.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/prefetch-app-shell-global-eager.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('App Shell prefetching - global unstable_eager', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('is skipped', () => {})
+    return
+  }
+
+  it('does NOT skip the Speculative prefetch when partialPrefetching is "unstable_eager" globally', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // /posts/[id] has no per-segment prefetch config, but the global
+    // `partialPrefetching: 'unstable_eager'` makes it eager. Reveal /posts/1 to
+    // prime the shared app shell.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/posts/1"]')
+        .click()
+    })
+
+    // Reveal /posts/2 — a different param, shell already cached. Because the
+    // global config makes the route eager, the per-link Speculative prefetch
+    // still fires for param 2 (a single request carrying "Eager post 2"),
+    // rather than firing no requests as a non-eager route's second link would.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/posts/2"]')
+          .click()
+      },
+      { includes: 'Eager post 2' }
+    )
+  })
+})

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/eager-instant/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/eager-instant/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from 'react'
+
+type Params = { id: string }
+
+// Combines both segment-level opt-ins: `unstable_instant` (which on its own
+// behaves like 'partial' — not eager) AND `unstable_prefetch = 'unstable_eager'`.
+// 'unstable_eager' wins: the segment is marked eager, so under App Shells the
+// per-link Speculative prefetch still fires and the param-specific content
+// below IS prefetched.
+export const unstable_instant = true
+export const unstable_prefetch = 'unstable_eager'
+
+export function generateStaticParams() {
+  return [{ id: '1' }, { id: '2' }, { id: '3' }]
+}
+
+export default function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      {/* The fallback is the param-independent app shell. */}
+      <Suspense fallback={<p id="shell">Eager-instant app shell</p>}>
+        <ParamContent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ParamContent({ params }: { params: Promise<Params> }) {
+  const { id } = await params
+  return <p id="param-value">{`Eager-instant post ${id}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/eager/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/eager/[id]/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+
+type Params = { id: string }
+
+// Opts into Partial Prefetching in "eager" mode. Behaves like 'partial', but
+// under App Shells it keeps prefetching the route's segments instead of relying
+// on the shared app shell — so the param-specific content below IS prefetched.
+export const unstable_prefetch = 'unstable_eager'
+
+export function generateStaticParams() {
+  return [{ id: '1' }, { id: '2' }, { id: '3' }]
+}
+
+export default function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      {/* The fallback is the param-independent app shell. */}
+      <Suspense fallback={<p id="shell">Eager app shell</p>}>
+        <ParamContent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ParamContent({ params }: { params: Promise<Params> }) {
+  const { id } = await params
+  return <p id="param-value">{`Eager post ${id}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/page.tsx
@@ -6,7 +6,7 @@ export default function Page() {
     <main>
       <h1>Home</h1>
 
-      <h2>Dynamic posts</h2>
+      <h2>Dynamic posts (force-runtime)</h2>
       <p>
         These posts read request-time data (cookies). Their App Shell is the
         part of the page that doesn&apos;t depend on the URL params, so it can
@@ -51,6 +51,41 @@ export default function Page() {
           <Link href="/static-posts/124" prefetch={false}>
             Unprefetched static post
           </Link>
+        </li>
+      </ul>
+
+      <h2>Partial posts</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/partial/1">Partial 1 (default)</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/partial/2">Partial 2 (default)</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/partial/3" prefetch={true}>
+            Partial 3 (prefetch=true)
+          </LinkAccordion>
+        </li>
+      </ul>
+
+      <h2>Eager posts</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/eager/1">Eager 1 (default)</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/eager/2">Eager 2 (default)</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/eager-instant/1">
+            Eager-instant 1 (unstable_instant + unstable_eager)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/eager-instant/2">
+            Eager-instant 2 (unstable_instant + unstable_eager)
+          </LinkAccordion>
         </li>
       </ul>
     </main>

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/partial/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/partial/[id]/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+
+type Params = { id: string }
+
+// Opts into Partial Prefetching. Under App Shells, a partial (non-Full)
+// prefetch of this route relies on the shared app shell and skips the per-link
+// Speculative prefetch — so the param-specific content below is NOT prefetched.
+export const unstable_prefetch = 'partial'
+
+export function generateStaticParams() {
+  return [{ id: '1' }, { id: '2' }, { id: '3' }]
+}
+
+export default function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      {/* The fallback is the param-independent app shell. */}
+      <Suspense fallback={<p id="shell">Partial app shell</p>}>
+        <ParamContent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ParamContent({ params }: { params: Promise<Params> }) {
+  const { id } = await params
+  return <p id="param-value">{`Partial post ${id}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -22,20 +22,17 @@ describe('App Shell prefetching', () => {
 
     // Reveal the LinkAccordion for /posts/1. This caches the App Shell
     // for the route — the param-independent content of the page that's
-    // reusable for any /posts/[id].
-    //
-    // The "App shell for posts" substring appears in two responses: one
-    // for the App Shell itself and one for the per-link prefetch of
-    // /posts/1 (which, for a dynamic page, also includes the shell
-    // content above its inner Suspense fallback).
-    await act(async () => {
-      await browser
-        .elementByCss('input[data-link-accordion="/posts/1"]')
-        .click()
-    }, [
-      { includes: 'App shell for posts' },
-      { includes: 'App shell for posts' },
-    ])
+    // reusable for any /posts/[id]. The link uses the default (auto)
+    // prefetch, so under App Shells it prefetches only the shared shell;
+    // the per-link Speculative prefetch is skipped.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/posts/1"]')
+          .click()
+      },
+      { includes: 'App shell for posts' }
+    )
 
     await act(async () => {
       // Click the link to /posts/124. This link is rendered with
@@ -64,7 +61,7 @@ describe('App Shell prefetching', () => {
     )
   })
 
-  it('reuses the app shell across different search param values', async () => {
+  it('skips the per-link Speculative prefetch for a non-eager (force-runtime) route', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       beforePageLoad(p: Playwright.Page) {
@@ -73,64 +70,166 @@ describe('App Shell prefetching', () => {
     })
     const act = createRouterAct(page)
 
-    // Reveal the LinkAccordion for /posts/1. This caches the App Shell.
-    // Because the App Shell does not depend on params or search params,
-    // it should be reusable across all combinations of either.
-    await act(async () => {
-      await browser
-        .elementByCss('input[data-link-accordion="/posts/1"]')
-        .click()
-    }, [
-      { includes: 'App shell for posts' },
-      { includes: 'App shell for posts' },
-    ])
-
-    // Navigate to /posts/125?foo=bar — a different param AND a different
-    // search-params value than what was prefetched. The cached App Shell
-    // should be reused since it doesn't vary on either.
-    await act(async () => {
-      await browser.elementByCss('a[href="/posts/125?foo=bar"]').click()
-
-      // While the navigation response is blocked, the cached App Shell
-      // should already be visible.
-      expect(await browser.elementById('shell').text()).toEqual(
-        'App shell for posts'
-      )
-    })
-  })
-
-  it('issues a concrete prefetch for a second link with a different param, even though the shell is already cached', async () => {
-    let page: Playwright.Page
-    const browser = await next.browser('/', {
-      beforePageLoad(p: Playwright.Page) {
-        page = p
+    // Reveal /posts/1 (default/auto prefetch). The route is force-runtime, which
+    // is NOT eager, so under App Shells only the shared App Shell is prefetched.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/posts/1"]')
+          .click()
       },
-    })
-    const act = createRouterAct(page)
+      { includes: 'App shell for posts' }
+    )
 
-    // Reveal the LinkAccordion for /posts/1. The "App shell for posts"
-    // substring appears in two responses: one for the App Shell itself
-    // and one for the per-link prefetch of /posts/1 (which, for a
-    // dynamic page, also includes the shell content above its inner
-    // Suspense fallback).
-    await act(async () => {
-      await browser
-        .elementByCss('input[data-link-accordion="/posts/1"]')
-        .click()
-    }, [
-      { includes: 'App shell for posts' },
-      { includes: 'App shell for posts' },
-    ])
-
-    // Reveal the LinkAccordion for /posts/2. The App Shell is already
-    // cached and reused, but a per-link prefetch should still fire for
-    // /posts/2 so that its param-specific content lands in the cache.
-    // We assert on that param-specific content to confirm.
+    // Reveal /posts/2 — a different param that shares the same App Shell. The
+    // shell is already cached and the per-link Speculative prefetch is skipped,
+    // so this fires NO requests at all. This is the clearest signal that the
+    // Speculative phase was skipped: a subsequent link to the same route needs
+    // nothing from the server.
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/posts/2"]')
         .click()
-    }, [{ includes: 'Post 2' }])
+    }, 'no-requests')
+  })
+
+  it('skips the per-link Speculative prefetch for a route with unstable_prefetch = "partial"', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal /partial/1. /partial/[id] is fully static and opts into Partial
+    // Prefetching, so this prefetches the shared app shell ("Partial app
+    // shell"). We assert on the shell text — not the page content. (A fully
+    // static prerender can't be truncated, so this response also happens to
+    // carry "Partial post 1", but that's incidental to how static prerenders
+    // work, not part of the App Shells model, so we don't assert on it.)
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/partial/1"]')
+          .click()
+      },
+      { includes: 'Partial app shell' }
+    )
+
+    // Reveal /partial/2 — a different param that shares the same app shell. The
+    // shell is already cached and the per-link Speculative prefetch is skipped,
+    // so this fires NO requests at all. This is the clearest signal that the
+    // Speculative phase was skipped: a subsequent link to the same route needs
+    // nothing from the server.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/partial/2"]')
+        .click()
+    }, 'no-requests')
+  })
+
+  it('does NOT skip the Speculative prefetch for a route with unstable_prefetch = "unstable_eager"', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal /eager/1. /eager/[id] opts into Partial Prefetching in "eager"
+    // mode, so this primes the shared app shell. (Because the route is eager it
+    // also speculatively prefetches param 1 here, but the assertion that
+    // demonstrates the eager behavior is on the second link below, where the
+    // shell is already cached and only the Speculative prefetch can fire.)
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/eager/1"]')
+        .click()
+    })
+
+    // Reveal /eager/2 — a different param that shares the same app shell. The
+    // shell is already cached, so it is NOT re-fetched. Because the route is
+    // eager, the per-link Speculative prefetch fires for param 2 — a single
+    // request carrying that param's content ("Eager post 2"). This is the
+    // counterpart to the partial route's second link, which fired no requests:
+    // an eager route keeps speculatively prefetching each new param.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/eager/2"]')
+          .click()
+      },
+      { includes: 'Eager post 2' }
+    )
+  })
+
+  it('treats a segment with both unstable_instant and unstable_prefetch = "unstable_eager" as eager', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // /eager-instant/[id] sets BOTH unstable_instant (which alone behaves like
+    // 'partial' — not eager) and unstable_prefetch = 'unstable_eager'. The eager
+    // opt-in wins, so the segment is treated as eager. Same two-link pattern as
+    // the plain eager test: the first link primes the shared shell...
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/eager-instant/1"]')
+        .click()
+    })
+
+    // ...and the second link (different param, shell already cached) fires the
+    // per-link Speculative prefetch for param 2, proving the route is treated as
+    // eager rather than skipping the Speculative phase.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/eager-instant/2"]')
+          .click()
+      },
+      { includes: 'Eager-instant post 2' }
+    )
+  })
+
+  it('does NOT skip the Speculative prefetch for a prefetch={true} link, even on a partial route', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal /partial/1 (default). /partial/[id] opts into Partial Prefetching,
+    // so the default link primes the shared shell and skips the Speculative
+    // prefetch (asserted by the other partial test). Here we just prime.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/partial/1"]')
+        .click()
+    })
+
+    // Reveal /partial/3 — a different param, but this link is prefetch={true}
+    // (a Full prefetch). prefetch={true} always prefetches the route's segments,
+    // bypassing the App Shells skip. The shell is already cached, so the only
+    // request is the Speculative prefetch for param 3, carrying its content
+    // ("Partial post 3"). Contrast with the default partial link, whose second
+    // link fires no requests: prefetch={true} opts back into per-link
+    // prefetching even on a partial route.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/partial/3"]')
+          .click()
+      },
+      { includes: 'Partial post 3' }
+    )
   })
 
   it('extracts the App Shell from a fully-static prerender response', async () => {


### PR DESCRIPTION
Under Cache Components, a `<Link prefetch={true}>` pointing at a route that hasn't enabled Partial Prefetching quietly falls back to a legacy full prefetch: it pulls down the route's dynamic data instead of just the static shell, defeating the static/dynamic split. In development we now surface this with a console error that explains the fallback and points at how to opt in — app-wide with `partialPrefetching`, or per-route with `unstable_prefetch = 'partial'`.

The check runs when the navigation happens, not when the link is prefetched. Dev doesn't prefetch, so navigation is the only point where both the originating link's fetch strategy and the resolved route tree are in hand; it also means an app that has just turned on Cache Components isn't flooded with warnings for every `prefetch={true}` link on the page, since you only hear about a route when you actually navigate to it. The decision reads a single hint at the root of the resolved route tree that records whether any segment in the route opted into Partial Prefetching.

Scope: the warning fires on every qualifying navigation, including ones to fully static routes where a full prefetch costs nothing. Suppressing it for fully-static targets is deferred — the route-level "has dynamic data" signal isn't cheaply available on cache-served repeat navigations.

<!-- NEXT_JS_LLM_PR -->
