### PR TITLE
fix(typo): rename type `GroupNameToDirectAndRecusiveSpans` to `GroupNameToDirectAndRecursiveSpans`

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
@@ -10,7 +10,7 @@ use crate::{
     FxIndexMap,
     span::{SpanBottomUp, SpanGraphEvent},
     span_graph_ref::{SpanGraphEventRef, SpanGraphRef, event_map_to_list},
-    span_ref::{GroupNameToDirectAndRecusiveSpans, SpanRef},
+    span_ref::{GroupNameToDirectAndRecursiveSpans, SpanRef},
     store::{SpanId, Store},
     timestamp::Timestamp,
 };
@@ -87,7 +87,7 @@ impl<'a> SpanBottomUpRef<'a> {
                     let _ = self.first_span().graph();
                     self.first_span().extra().graph.get().unwrap().clone()
                 } else {
-                    let mut map: GroupNameToDirectAndRecusiveSpans = FxIndexMap::default();
+                    let mut map: GroupNameToDirectAndRecursiveSpans = FxIndexMap::default();
                     let mut queue = VecDeque::with_capacity(8);
                     for child in self.spans() {
                         let name = child.group_name();

--- a/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
@@ -12,7 +12,7 @@ use crate::{
     bottom_up::build_bottom_up_graph,
     span::{SpanGraph, SpanGraphEvent},
     span_bottom_up_ref::SpanBottomUpRef,
-    span_ref::{GroupNameToDirectAndRecusiveSpans, SpanRef},
+    span_ref::{GroupNameToDirectAndRecursiveSpans, SpanRef},
     store::{SpanId, Store},
     timestamp::Timestamp,
 };
@@ -88,7 +88,7 @@ impl<'a> SpanGraphRef<'a> {
                 self.first_span().extra().graph.get().unwrap().clone()
             } else {
                 let self_group = self.first_span().group_name();
-                let mut map: GroupNameToDirectAndRecusiveSpans = FxIndexMap::default();
+                let mut map: GroupNameToDirectAndRecursiveSpans = FxIndexMap::default();
                 let mut queue = VecDeque::with_capacity(8);
                 for span in self.recursive_spans() {
                     for span in span.children() {
@@ -303,7 +303,7 @@ impl<'a> SpanGraphRef<'a> {
     }
 }
 
-pub fn event_map_to_list(map: GroupNameToDirectAndRecusiveSpans) -> Vec<SpanGraphEvent> {
+pub fn event_map_to_list(map: GroupNameToDirectAndRecursiveSpans) -> Vec<SpanGraphEvent> {
     map.into_iter()
         .map(|(_, (root_spans, recursive_spans))| {
             let graph = SpanGraph {

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -23,7 +23,7 @@ use crate::{
     timestamp::Timestamp,
 };
 
-pub type GroupNameToDirectAndRecusiveSpans<'l> =
+pub type GroupNameToDirectAndRecursiveSpans<'l> =
     FxIndexMap<(&'l RcStr, &'l RcStr), (Vec<SpanIndex>, Vec<SpanIndex>)>;
 
 #[derive(Copy, Clone)]
@@ -301,7 +301,7 @@ impl<'a> SpanRef<'a> {
                         Entry { span, recursive }
                     })
                     .collect_vec_list();
-                let mut map: GroupNameToDirectAndRecusiveSpans = FxIndexMap::default();
+                let mut map: GroupNameToDirectAndRecursiveSpans = FxIndexMap::default();
                 for Entry {
                     span,
                     mut recursive,


### PR DESCRIPTION
Renamed `GroupNameToDirectAndRecusiveSpans` to `GroupNameToDirectAndRecursiveSpans` everywhere it is used. Fixed the typo `Recusive` -> `Recursive`.