### PR TITLE
migrate turbo-tasks to scattered collect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3732,15 +3732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inventory"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9853,19 +9844,18 @@ dependencies = [
  "bincode 2.0.1",
  "codspeed-criterion-compat",
  "concurrent-queue",
- "ctor 1.0.7",
  "dashmap 6.1.0",
  "either",
  "erased-serde",
  "event-listener",
  "futures",
  "indexmap 2.13.0",
- "inventory",
  "parking_lot",
  "pin-project-lite",
  "rayon",
  "regex",
  "rustc-hash 2.1.1",
+ "scattered-collect",
  "serde",
  "serde_json",
  "shrink-to-fit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,7 +277,6 @@ hashbrown = "0.14.5"
 image = { version = "0.25.8", default-features = false }
 indexmap = "2.13.0"
 indoc = "2.0.0"
-inventory = "0.3.21"
 itertools = "0.10.5"
 lightningcss = { version = "1.0.0-alpha.70", features = [
   "serde",

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -1119,10 +1119,6 @@ pub struct NativeFn {
 }
 
 impl NativeFn {
-    pub fn ty(&self) -> TokenStream {
-        quote! { turbo_tasks::macro_helpers::NativeFunction }
-    }
-
     pub fn definition(&self) -> TokenStream {
         let Self {
             function_global_name,

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -70,7 +70,6 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         is_session_dependent,
     };
     let native_function_ident = get_native_function_ident(ident);
-    let native_function_ty = native_fn.ty();
     let native_function_def = native_fn.definition();
 
     let exposed_signature = turbo_fn.signature();
@@ -84,8 +83,8 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         #[doc(hidden)]
         #inline_signature #inline_block
 
-        turbo_tasks::macro_helpers::turbo_register!(
-            #native_function_ident: #native_function_ty = #native_function_def
+        turbo_tasks::macro_helpers::register_function!(
+            #native_function_ident = #native_function_def
         );
 
         #(#errors)*

--- a/turbopack/crates/turbo-tasks-macros/src/ident.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/ident.rs
@@ -15,17 +15,28 @@ pub fn get_trait_type_ident(ident: &Ident) -> Ident {
     )
 }
 
-/// Name of the per-trait `VTableRegistry` static, populated by `#[ctor::ctor]` functions emitted
-/// by each `value_impl` expansion.
+/// Name of the per-trait `VTableRegistry` static, populated during `register_all_trait_methods`
+/// from the link-time `TRAIT_IMPLS_SLICE`.
 pub fn get_trait_vtable_registry_ident(ident: &Ident) -> Ident {
     Ident::new(&format!("__TurboTasksVTableRegistry_{ident}"), ident.span())
 }
 
-/// Name of the `#[ctor::ctor]` function that registers a per-impl vtable into its trait's
-/// registry. Unique per (concrete-type, trait) pair.
-pub fn get_vtable_register_fn_ident(struct_ident: &Ident, trait_ident: &Ident) -> Ident {
+/// Name of the `static` holding the link-time `TraitImplRecord` for one `impl Trait for Concrete`.
+/// Unique per (concrete-type, trait) pair — a named static (rather than an anonymous `const _`) so
+/// that multiple impls emitted in a single proc-macro expansion get distinct symbols.
+///
+/// The type/trait idents are upper-cased so the emitted static satisfies `non_upper_case_globals`
+/// without needing an `#[allow(..)]` attribute on it: the declarative `scatter!` macro mis-parses
+/// items that carry a second attribute after `#[scatter(..)]`, so the scattered static must have
+/// exactly one attribute. Type and trait names are `CamelCase` by convention, so upper-casing the
+/// concatenation keeps it unique in practice.
+pub fn get_trait_impl_record_ident(struct_ident: &Ident, trait_ident: &Ident) -> Ident {
     Ident::new(
-        &format!("__turbo_tasks_vtable_register_{struct_ident}_{trait_ident}"),
+        &format!(
+            "__TURBO_TASKS_TRAIT_IMPL_{}_{}",
+            struct_ident.to_string().to_uppercase(),
+            trait_ident.to_string().to_uppercase(),
+        ),
         trait_ident.span(),
     )
 }

--- a/turbopack/crates/turbo-tasks-macros/src/ident.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/ident.rs
@@ -21,26 +21,6 @@ pub fn get_trait_vtable_registry_ident(ident: &Ident) -> Ident {
     Ident::new(&format!("__TurboTasksVTableRegistry_{ident}"), ident.span())
 }
 
-/// Name of the `static` holding the link-time `TraitImplRecord` for one `impl Trait for Concrete`.
-/// Unique per (concrete-type, trait) pair — a named static (rather than an anonymous `const _`) so
-/// that multiple impls emitted in a single proc-macro expansion get distinct symbols.
-///
-/// The type/trait idents are upper-cased so the emitted static satisfies `non_upper_case_globals`
-/// without needing an `#[allow(..)]` attribute on it: the declarative `scatter!` macro mis-parses
-/// items that carry a second attribute after `#[scatter(..)]`, so the scattered static must have
-/// exactly one attribute. Type and trait names are `CamelCase` by convention, so upper-casing the
-/// concatenation keeps it unique in practice.
-pub fn get_trait_impl_record_ident(struct_ident: &Ident, trait_ident: &Ident) -> Ident {
-    Ident::new(
-        &format!(
-            "__TURBO_TASKS_TRAIT_IMPL_{}_{}",
-            struct_ident.to_string().to_uppercase(),
-            trait_ident.to_string().to_uppercase(),
-        ),
-        trait_ident.span(),
-    )
-}
-
 pub fn get_inherent_impl_function_ident(ty_ident: &Ident, fn_ident: &Ident) -> Ident {
     Ident::new(
         &format!(

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -297,11 +297,8 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         value_type: <#ty as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::ValueType>>::DEF,
                         trait_type: <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::TraitType>>::DEF,
                         methods: &METHODS,
-                        install_vtable: |value_type: &'static turbo_tasks::ValueType, id: turbo_tasks::ValueTypeId| {
-                            // Materialize the vtable pointer via the null-fat-ptr trick. We
-                            // pass the metadata through `macro_helpers::metadata` without ever
-                            // naming `DynMetadata` here, so this crate doesn't need
-                            // `#![feature(ptr_metadata)]`.
+                        install_vtable: |id: turbo_tasks::ValueTypeId| {
+                            // Materialize the vtable pointer via the null-fat-ptr trick.
                             let p: *const #ty = ::std::ptr::null();
                             let fat: *const dyn #trait_path = p;
                             <::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::IMPL_VTABLES

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -17,7 +17,7 @@ use crate::{
     global_name::{global_name_for_method, global_name_for_trait_method_impl},
     ident::{
         get_inherent_impl_function_ident, get_path_ident, get_trait_impl_function_ident,
-        get_type_ident, get_vtable_register_fn_ident,
+        get_trait_impl_record_ident, get_type_ident,
     },
     self_filter::is_self_used,
 };
@@ -129,7 +129,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             };
 
             let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
-            let native_function_ty = native_fn.ty();
             let native_function_def = native_fn.definition();
 
             let turbo_signature = turbo_fn.signature();
@@ -151,8 +150,8 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         pub(self) #inline_signature #inline_block
                     }
 
-                    turbo_tasks::macro_helpers::turbo_register!(
-                        #native_function_ident: #native_function_ty = #native_function_def
+                    turbo_tasks::macro_helpers::register_function!(
+                        #native_function_ident = #native_function_def
                     );
                 })
         }
@@ -175,7 +174,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         items: &[ImplItem],
     ) -> TokenStream2 {
         let trait_ident = get_path_ident(trait_path);
-        let vtable_register_ident = get_vtable_register_fn_ident(ty_ident, &trait_ident);
+        let trait_impl_record_ident = get_trait_impl_record_ident(ty_ident, &trait_ident);
 
         let (impl_generics, _, where_clause) = generics.split_for_impl();
 
@@ -248,7 +247,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 let native_function_ident =
                     get_trait_impl_function_ident(ty_ident, &trait_ident, ident);
-                let native_function_ty = native_fn.ty();
                 let native_function_def = native_fn.definition();
 
                 let turbo_signature = turbo_fn.signature();
@@ -276,8 +274,8 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         #inline_signature #inline_block
                     }
 
-                    turbo_tasks::macro_helpers::turbo_register!(
-                        #native_function_ident: #native_function_ty = #native_function_def
+                    turbo_tasks::macro_helpers::register_function!(
+                        #native_function_ident = #native_function_def
                     );
                 });
 
@@ -288,50 +286,49 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
         quote! {
-            // Register all the function impls so the ValueType can find them
-            // This means objects resolve as
-            // 1 NativeFunctions
-            // 2 TraitTypes (requires functions)
-            // 3 ValueTypes (requires functions and TraitTypeIds)
-            // 4.VTableRegistries (requires ValueTypeIds)
-            turbo_tasks::macro_helpers::inventory_submit!{{
-                const LEN: usize = <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::TraitVtablePrototype>::LEN;
-                static METHODS: [&turbo_tasks::macro_helpers::NativeFunction; LEN] = turbo_tasks::macro_helpers::build_trait_vtable::<::std::boxed::Box<dyn #trait_path>, LEN>(&[#(#trait_methods),*]);
-
-                turbo_tasks::macro_helpers::CollectableTraitMethods {
-                    value_type: <#ty as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::ValueType>>::DEF,
-                    trait_type: <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::TraitType>>::DEF,
-                    methods: &METHODS,
-                    finalize_vtable_registry: || {
-                        <::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::IMPL_VTABLES
-                            .finalize();
-                    },
-                }
-            }}
-
-            // Queue this `impl Trait for Concrete` into the trait's `VTableRegistry` at program
-            // load. The ctor runs before `ValueType` ids are assigned, so it just appends to a
-            // `Vec`; the map keyed by `ValueTypeId` is built lazily inside the `VALUES`
-            // `LazyLock` initializer (via `CollectableTraitMethods::finalize_vtable_registry`).
-            // The vtable pointer is materialized at compile time via the null-fat-ptr trick, so
-            // there's no runtime `transmute` or indirect fn call.
-
+            // Register this `impl Trait for Concrete` into the link-time `TRAIT_IMPLS_SLICE`.
+            // This carries both the trait method table AND the Rust vtable metadata, so a single
+            // pass over the (always-complete) link-time slice in `register_all_trait_methods`
+            // populates everything. There is no constructor and no `inventory` live list, so the
+            // registry can never observe a partial set of impls. Resolution order at init:
+            // 1 NativeFunctions, 2 TraitTypes, 3 ValueTypes (ids), 4 VTableRegistries (need ids).
+            //
+            // A named static (`#trait_impl_record_ident`, unique per type/trait) is used rather
+            // than an anonymous `const _` so multiple impls in one expansion get distinct symbols.
+            // The declarative `scatter!` form is used (not the `#[scatter(..)]` attribute) so the
+            // emitted code routes through `scattered_collect`'s own `$crate` rather than an
+            // absolute `::scattered_collect` path the downstream crate doesn't have. The collection
+            // is named by the fully-qualified `$crate::macro_helpers::TRAIT_IMPLS_SLICE` path.
             #[cfg(not(rust_analyzer))]
-            turbo_tasks::macro_helpers::ctor::declarative::ctor! {
-                #[ctor(unsafe)]
-                #[allow(non_snake_case)]
-                fn #vtable_register_ident() {
-                    <::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::IMPL_VTABLES
-                        .register(
-                            <#ty as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::ValueType>>::DEF,
-                            {
-                                let p: *const #ty = ::std::ptr::null();
-                                // This attaches a fat pointer to the null pointer.
-                                let fat: *const dyn #trait_path = p;
-                                fat
-                            },
-                        );
-                }
+            turbo_tasks::macro_helpers::scattered_collect::declarative::scatter! {
+                #[scatter(turbo_tasks::macro_helpers::TRAIT_IMPLS_SLICE)]
+                static #trait_impl_record_ident: turbo_tasks::macro_helpers::TraitImplRecord = {
+                    const LEN: usize = <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::TraitVtablePrototype>::LEN;
+                    static METHODS: [&turbo_tasks::macro_helpers::NativeFunction; LEN] = turbo_tasks::macro_helpers::build_trait_vtable::<::std::boxed::Box<dyn #trait_path>, LEN>(&[#(#trait_methods),*]);
+
+                    turbo_tasks::macro_helpers::TraitImplRecord {
+                        value_type: <#ty as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::ValueType>>::DEF,
+                        trait_type: <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::TraitType>>::DEF,
+                        methods: &METHODS,
+                        install_vtable: |value_type: &'static turbo_tasks::ValueType| {
+                            // SAFETY: called from `register_all_trait_methods`, inside the
+                            // `VALUES` `LazyLock` init after `init_registry` assigned ids.
+                            // Reading the id cell directly (rather than `get_value_type_id`)
+                            // avoids re-entering `LazyLock::force` and deadlocking.
+                            let id = unsafe {
+                                turbo_tasks::registry::get_value_type_id_unchecked(value_type)
+                            };
+                            // Materialize the vtable pointer via the null-fat-ptr trick. We
+                            // pass the metadata through `macro_helpers::metadata` without ever
+                            // naming `DynMetadata` here, so this crate doesn't need
+                            // `#![feature(ptr_metadata)]`.
+                            let p: *const #ty = ::std::ptr::null();
+                            let fat: *const dyn #trait_path = p;
+                            <::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::IMPL_VTABLES
+                                .insert(id, turbo_tasks::macro_helpers::metadata(fat));
+                        },
+                    }
+                };
             }
 
             // NOTE(alexkirsz) We can't have a general `turbo_tasks::Upcast<Box<dyn Trait>> for T where T: Trait` because

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -17,7 +17,7 @@ use crate::{
     global_name::{global_name_for_method, global_name_for_trait_method_impl},
     ident::{
         get_inherent_impl_function_ident, get_path_ident, get_trait_impl_function_ident,
-        get_trait_impl_record_ident, get_type_ident,
+        get_type_ident,
     },
     self_filter::is_self_used,
 };
@@ -174,7 +174,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         items: &[ImplItem],
     ) -> TokenStream2 {
         let trait_ident = get_path_ident(trait_path);
-        let trait_impl_record_ident = get_trait_impl_record_ident(ty_ident, &trait_ident);
 
         let (impl_generics, _, where_clause) = generics.split_for_impl();
 
@@ -287,22 +286,10 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         }
         quote! {
             // Register this `impl Trait for Concrete` into the link-time `TRAIT_IMPLS_SLICE`.
-            // This carries both the trait method table AND the Rust vtable metadata, so a single
-            // pass over the (always-complete) link-time slice in `register_all_trait_methods`
-            // populates everything. There is no constructor and no `inventory` live list, so the
-            // registry can never observe a partial set of impls. Resolution order at init:
-            // 1 NativeFunctions, 2 TraitTypes, 3 ValueTypes (ids), 4 VTableRegistries (need ids).
-            //
-            // A named static (`#trait_impl_record_ident`, unique per type/trait) is used rather
-            // than an anonymous `const _` so multiple impls in one expansion get distinct symbols.
-            // The declarative `scatter!` form is used (not the `#[scatter(..)]` attribute) so the
-            // emitted code routes through `scattered_collect`'s own `$crate` rather than an
-            // absolute `::scattered_collect` path the downstream crate doesn't have. The collection
-            // is named by the fully-qualified `$crate::macro_helpers::TRAIT_IMPLS_SLICE` path.
             #[cfg(not(rust_analyzer))]
             turbo_tasks::macro_helpers::scattered_collect::declarative::scatter! {
                 #[scatter(turbo_tasks::macro_helpers::TRAIT_IMPLS_SLICE)]
-                static #trait_impl_record_ident: turbo_tasks::macro_helpers::TraitImplRecord = {
+                const _: turbo_tasks::macro_helpers::TraitImplRecord = {
                     const LEN: usize = <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::TraitVtablePrototype>::LEN;
                     static METHODS: [&turbo_tasks::macro_helpers::NativeFunction; LEN] = turbo_tasks::macro_helpers::build_trait_vtable::<::std::boxed::Box<dyn #trait_path>, LEN>(&[#(#trait_methods),*]);
 
@@ -310,14 +297,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         value_type: <#ty as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::ValueType>>::DEF,
                         trait_type: <::std::boxed::Box<dyn #trait_path> as turbo_tasks::macro_helpers::RegistryDef::<turbo_tasks::TraitType>>::DEF,
                         methods: &METHODS,
-                        install_vtable: |value_type: &'static turbo_tasks::ValueType| {
-                            // SAFETY: called from `register_all_trait_methods`, inside the
-                            // `VALUES` `LazyLock` init after `init_registry` assigned ids.
-                            // Reading the id cell directly (rather than `get_value_type_id`)
-                            // avoids re-entering `LazyLock::force` and deadlocking.
-                            let id = unsafe {
-                                turbo_tasks::registry::get_value_type_id_unchecked(value_type)
-                            };
+                        install_vtable: |value_type: &'static turbo_tasks::ValueType, id: turbo_tasks::ValueTypeId| {
                             // Materialize the vtable pointer via the null-fat-ptr trick. We
                             // pass the metadata through `macro_helpers::metadata` without ever
                             // naming `DynMetadata` here, so this crate doesn't need

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -619,8 +619,8 @@ pub fn value_type_and_register(
     };
 
     quote! {
-        turbo_tasks::macro_helpers::turbo_register!(
-            #ty => #value_type_ident: turbo_tasks::ValueType = #new_value_type
+        turbo_tasks::macro_helpers::register_value!(
+            #ty => #value_type_ident = #new_value_type
         );
 
         #[automatically_derived]

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -222,7 +222,6 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             };
 
             let native_function_ident = get_trait_default_impl_function_ident(trait_ident, ident);
-            let native_function_ty = native_function.ty();
             let native_function_def = native_function.definition();
 
             let method_name_str = syn::LitStr::new(&ident.to_string(), ident.span());
@@ -256,8 +255,8 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                     #inline_signature #inline_block
                 }
 
-                turbo_tasks::macro_helpers::turbo_register!(
-                    #native_function_ident: #native_function_ty = #native_function_def
+                turbo_tasks::macro_helpers::register_function!(
+                    #native_function_ident = #native_function_def
                 );
             });
 
@@ -328,8 +327,8 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
         #(#native_functions)*
 
-        turbo_tasks::macro_helpers::turbo_register!(
-            Box<dyn #trait_ident> => #trait_type_ident: turbo_tasks::TraitType =
+        turbo_tasks::macro_helpers::register_trait!(
+            Box<dyn #trait_ident> => #trait_type_ident =
                 turbo_tasks::TraitType::new::<&'static dyn #trait_ident>(
                     stringify!(#trait_ident),
                     #trait_name,
@@ -343,10 +342,10 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             const DEFAULTS: &[Option<&turbo_tasks::macro_helpers::NativeFunction>] = &[#(#default_methods),*];
         }
 
-        // Per-trait `VTableRegistry`, populated during the ctor phase by `value_impl`
-        // expansions. `const`-constructible, so no `LazyLock` / first-access init. Kept
-        // private — the only reference is from the `VcValueTrait::IMPL_VTABLES` assoc const
-        // below.
+        // Per-trait `VTableRegistry`, populated during `register_all_trait_methods` (inside the
+        // `VALUES` `LazyLock` init) from the link-time `TRAIT_IMPLS_SLICE`. `const`-constructible,
+        // so no `LazyLock` / first-access init of its own. Kept private — the only reference is
+        // from the `VcValueTrait::IMPL_VTABLES` assoc const below.
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         static #trait_vtable_registry_ident:

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -29,19 +29,18 @@ async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 bincode = { workspace = true }
 concurrent-queue = { workspace = true }
-ctor = { workspace = true }
 dashmap = { workspace = true }
 either = { workspace = true }
 erased-serde = { workspace = true }
 event-listener = "5.4.0"
 futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
-inventory = { workspace = true }
 parking_lot = { workspace = true, features = ["serde"]}
 pin-project-lite = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
+scattered-collect = { workspace = true }
 serde = { workspace = true, features = ["rc", "derive"] }
 serde_json = { workspace = true }
 shrink-to-fit = { workspace = true, features = ["indexmap", "serde_json", "smallvec", "nightly"] }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -174,17 +174,6 @@ pub const fn strip_trailing_segments(s: &str, count: usize) -> &str {
 }
 
 /// A registry of all the impl vtables for a given VcValue trait.
-///
-/// `const`-constructed as a plain `static`. The map (`inner`) is built once during
-/// [`crate::value_type::register_all_trait_methods`], which runs inside the `VALUES` `LazyLock`
-/// initializer after `ValueType` ids are assigned. Each `impl Trait for Concrete` contributes via
-/// a [`TraitImplRecord`] gathered at link time (see [`TRAIT_IMPLS_SLICE`]); its
-/// `install_vtable` thunk calls [`Self::insert`].
-///
-/// The cast path is a single hashmap `.get()` keyed by `u16` — no `LazyLock` check, no
-/// `get_value_type(id)` indirection. The vtable pointer for each `impl Trait for Concrete` is
-/// materialized at compile time (a `const DynMetadata`), so there's no runtime `transmute` or
-/// indirect fn-pointer call on the cast path either.
 pub struct VTableRegistry<T>
 where
     T: Pointee<Metadata = DynMetadata<T>> + ?Sized,

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -7,9 +7,9 @@ use std::{
 
 pub use async_trait::async_trait;
 pub use bincode;
-pub use ctor;
-pub use inventory;
 use rustc_hash::FxHashMap;
+pub use scattered_collect;
+use scattered_collect::slice::ScatteredSlice;
 pub use shrink_to_fit;
 pub use tracing;
 
@@ -22,15 +22,15 @@ use crate::{
 pub use crate::{
     dyn_task_inputs::DynTaskInputs,
     global_name_for_method, global_name_for_scope, global_name_for_trait_method,
-    global_name_for_trait_method_impl, global_name_for_type, inventory_submit,
+    global_name_for_trait_method_impl, global_name_for_type,
     manager::{find_cell_by_id, find_cell_by_type, spawn_detached_for_testing},
     native_function::{
         ArgMeta, NativeFunction, VTABLE_DEFAULT, downcast_args_owned, downcast_args_ref,
         downcast_stack_args_owned,
     },
+    register_function, register_trait, register_value,
     registry::RegistryDef,
     task::function::{into_task_fn, into_task_fn_with_this},
-    turbo_register,
     value_type::{TraitVtablePrototype, build_trait_vtable, index_of_method_name},
 };
 
@@ -175,35 +175,29 @@ pub const fn strip_trailing_segments(s: &str, count: usize) -> &str {
 
 /// A registry of all the impl vtables for a given VcValue trait.
 ///
-/// `const`-constructed as a plain `static`. Populated in two phases:
+/// `const`-constructed as a plain `static`. The map (`inner`) is built once during
+/// [`crate::value_type::register_all_trait_methods`], which runs inside the `VALUES` `LazyLock`
+/// initializer after `ValueType` ids are assigned. Each `impl Trait for Concrete` contributes via
+/// a [`TraitImplRecord`] gathered at link time (see [`TRAIT_IMPLS_SLICE`]); its
+/// `install_vtable` thunk calls [`Self::insert`].
 ///
-/// 1. **ctor phase** (before `main`): `value_impl`-emitted `#[ctor::ctor]` functions push
-///    `(value_type, DynMetadata)` pairs into `pending`. `ValueType` ids are not yet assigned here —
-///    we just accumulate.
-/// 2. **`finalize` phase** (inside the `VALUES` `LazyLock` initializer, after ids are assigned):
-///    `pending` is drained into `inner`, keyed by `ValueTypeId`. Idempotent.
-///
-/// After finalize, the cast path is a single hashmap `.get()` keyed by `u16` — no `LazyLock`
-/// check, no `get_value_type(id)` indirection. The vtable pointer for each
-/// `impl Trait for Concrete` is materialized at compile time, so there's no runtime `transmute`
-/// or indirect fn-pointer call either.
+/// The cast path is a single hashmap `.get()` keyed by `u16` — no `LazyLock` check, no
+/// `get_value_type(id)` indirection. The vtable pointer for each `impl Trait for Concrete` is
+/// materialized at compile time (a `const DynMetadata`), so there's no runtime `transmute` or
+/// indirect fn-pointer call on the cast path either.
 pub struct VTableRegistry<T>
 where
     T: Pointee<Metadata = DynMetadata<T>> + ?Sized,
 {
-    /// Accumulator written from ctors. `Some` until `finalize` runs, then `take`n and left
-    /// `None` so any post-finalize call to `register` panics rather than silently dropping
-    /// the registration. The `None` state also makes subsequent `finalize` calls cheap no-ops.
-    #[allow(clippy::type_complexity)]
-    pending: SyncUnsafeCell<Option<Vec<(&'static ValueType, DynMetadata<T>)>>>,
-    /// Built once by `finalize`, read-only thereafter. `None` until finalize runs.
+    /// Built once during `register_all_trait_methods`, read-only thereafter. `None` until that
+    /// runs.
     inner: SyncUnsafeCell<Option<FxHashMap<ValueTypeId, DynMetadata<T>>>>,
 }
 
-// SAFETY: writes to `pending` happen only from `#[ctor::ctor]` functions, which run serially on
-// the main thread before `main`. Writes to `inner` happen only from `finalize`, which runs once
-// inside the `VALUES` `LazyLock` initializer (synchronized by the `LazyLock`). Reads of `inner`
-// from `cast` are published by that same `LazyLock` — see the `cast` safety comment.
+// SAFETY: writes to `inner` happen only from `insert`, which is called only from
+// `register_all_trait_methods` (inside the `VALUES` `LazyLock` initializer, single-threaded and
+// synchronized by the `LazyLock`). Reads of `inner` from `cast` are published by that same
+// `LazyLock` — see the `cast` safety comment.
 unsafe impl<T> Sync for VTableRegistry<T> where T: Pointee<Metadata = DynMetadata<T>> + ?Sized {}
 
 impl<T> VTableRegistry<T>
@@ -212,63 +206,34 @@ where
 {
     pub const fn new() -> Self {
         Self {
-            pending: SyncUnsafeCell::new(Some(Vec::new())),
             inner: SyncUnsafeCell::new(None),
         }
     }
 
-    /// Queue an `impl Trait for Concrete` registration. Called from a `#[ctor::ctor]` function
-    /// at program load, before `ValueType` ids are assigned. The actual map is built later by
-    /// [`Self::finalize`].
+    /// Insert one `impl Trait for Concrete`'s vtable metadata, keyed by `ValueTypeId`. Called from
+    /// a [`TraitImplRecord::install_vtable`] thunk during `register_all_trait_methods`, after
+    /// `init_registry` has assigned ids.
     ///
-    /// Panics if called after `finalize`. Since all `value_impl` ctors run before `main` and
-    /// `finalize` runs lazily after `main`, this should be unreachable in normal use; the
-    /// panic guards against future changes that might violate that ordering.
-    pub fn register(&'static self, value_type: &'static ValueType, fat_ptr: *const T) {
-        // SAFETY: ctors run single-threaded at load; no concurrent readers or writers.
-        let pending = unsafe { &mut *self.pending.get() };
-        let Some(pending) = pending.as_mut() else {
-            panic!("VTableRegistry::register called after finalize for {value_type}");
-        };
-        pending.push((value_type, std::ptr::metadata(fat_ptr)));
-    }
-
-    /// Take `pending` into `inner`, resolving each `&'static ValueType` to its assigned
-    /// `ValueTypeId`. Must be called after `VALUES` ids are assigned (i.e. from inside the
-    /// `VALUES` `LazyLock` initializer). Idempotent: a second call is a no-op, which lets
-    /// `register_all_trait_methods` invoke `finalize_vtable_registry` once per impl without
-    /// having to dedup.
-    pub fn finalize(&'static self) {
-        // SAFETY: invoked from inside the `VALUES` `LazyLock` initializer (single-threaded
-        // section synchronized by the `LazyLock`). All ctors completed before `main`.
-        let pending = unsafe { &mut *self.pending.get() };
-        // `take` makes any later `register` call (which would otherwise be silently dropped)
-        // hit the `None` branch and panic; subsequent `finalize` calls also short-circuit here.
-        let Some(pending) = pending.take() else {
-            return;
-        };
+    /// The `DynMetadata` is produced by the caller via [`metadata`] (the null-fat-ptr trick) so
+    /// downstream crates that invoke `value_impl` don't need `#![feature(ptr_metadata)]` — they
+    /// pass the value through without ever naming the `DynMetadata` type.
+    pub fn insert(&'static self, id: ValueTypeId, metadata: DynMetadata<T>) {
+        // SAFETY: called only from `register_all_trait_methods` inside the `VALUES` `LazyLock`
+        // initializer — single-threaded, no concurrent readers or writers.
         let inner = unsafe { &mut *self.inner.get() };
-        debug_assert!(inner.is_none(), "inner already populated");
-        let mut map = FxHashMap::with_capacity_and_hasher(pending.len(), Default::default());
-        for (value_type, metadata) in pending {
-            // SAFETY: we're called from inside the `VALUES` `LazyLock` initializer, after
-            // `init_registry` has assigned ids. Calling `get_value_type_id` here would re-enter
-            // `LazyLock::force` and deadlock; read the id cell directly instead.
-            let id = unsafe { crate::registry::get_value_type_id_unchecked(value_type) };
-            let prev = map.insert(id, metadata);
-            debug_assert!(
-                prev.is_none(),
-                "multiple trait impls registered for {value_type}"
-            );
-        }
-        *inner = Some(map);
+        let map = inner.get_or_insert_with(FxHashMap::default);
+        let prev = map.insert(id, metadata);
+        debug_assert!(
+            prev.is_none(),
+            "multiple trait impls registered for value type id {id}"
+        );
     }
 
     pub(crate) fn cast(&self, id: ValueTypeId, raw: *const ()) -> *const T {
         // SAFETY: any caller in possession of a `ValueTypeId` must have already forced the
-        // `VALUES` `LazyLock` (that's the only way to obtain one). `finalize` ran inside that
-        // initializer, so its write to `inner` happens-before this read via the `LazyLock`'s
-        // acquire fence.
+        // `VALUES` `LazyLock` (that's the only way to obtain one). `register_all_trait_methods`
+        // ran inside that initializer, so its writes to `inner` happen-before this read via the
+        // `LazyLock`'s acquire fence.
         let inner = unsafe { &*self.inner.get() };
         let Some(metadata) = inner.as_ref().and_then(|map| map.get(&id)) else {
             panic!(
@@ -289,34 +254,31 @@ where
     }
 }
 
-pub struct CollectableTraitMethods {
+/// One `impl Trait for ConcreteType` registration, gathered at link time into
+/// [`TRAIT_IMPLS_SLICE`]. Replaces the old `inventory`-collected `CollectableTraitMethods` plus the
+/// per-impl `#[ctor]` that seeded the vtable: both the method table and the Rust vtable now come
+/// from the same link-time record, so a partial view is impossible regardless of constructor order.
+pub struct TraitImplRecord {
     pub value_type: &'static ValueType,
     pub trait_type: &'static TraitType,
     pub methods: &'static [&'static NativeFunction],
-    /// Calls `<Box<dyn Trait>>::IMPL_VTABLES.finalize()` for the trait this entry corresponds
-    /// to. Invoked from `register_all_trait_methods` after `VALUES` ids are assigned. The same
-    /// trait's registry will be finalized once per impl, but `VTableRegistry::finalize` is
-    /// idempotent.
-    pub finalize_vtable_registry: fn(),
-}
-inventory::collect! {CollectableTraitMethods}
-
-/// Submit an item to the inventory.
-///
-/// This macro is a wrapper around `inventory::submit` that adds a `#[not(cfg(rust_analyzer))]`
-/// attribute to the item. This is to avoid warnings about unused items when using Rust Analyzer.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! inventory_submit {
-    ($($item:tt)*) => {
-        #[cfg(not(rust_analyzer))]
-        $crate::macro_helpers::inventory_submit_inner! { $($item)* }
-    }
+    /// Installs this impl's Rust vtable `DynMetadata` into its trait's [`VTableRegistry`] (via
+    /// [`VTableRegistry::insert`]). Type-erased (the record is not generic over the trait); the
+    /// concrete `DynMetadata` is materialized as a `const` inside this thunk. Invoked once from
+    /// `register_all_trait_methods` after `VALUES` ids are assigned. The argument is
+    /// [`Self::value_type`], passed so the thunk can resolve the `ValueTypeId`.
+    pub install_vtable: fn(&'static ValueType),
 }
 
-/// Exported so the above macro can reference it.
+// Link-time collection of every `impl Trait for Concrete`. Like the definition slices in
+// `registry`, this is populated by the linker — complete at process start, no constructors, no
+// ordering. It is iterated exactly once, in `register_all_trait_methods`.
+//
+// `pub` so the `value_impl`-emitted scatter (which expands in downstream crates) can name it as
+// `$crate::macro_helpers::TRAIT_IMPLS_SLICE`; the data is `#[doc(hidden)]`.
 #[doc(hidden)]
-pub use inventory::submit as inventory_submit_inner;
+#[scattered_collect::gather]
+pub static TRAIT_IMPLS_SLICE: ScatteredSlice<TraitImplRecord>;
 
 /// Use `type_name` to get globally unique identifier that's stable across multiple executions of
 /// the same Turbopack version, potentially allowing cache sharing across platforms/architectures.

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -244,9 +244,7 @@ where
 }
 
 /// One `impl Trait for ConcreteType` registration, gathered at link time into
-/// [`TRAIT_IMPLS_SLICE`]. Replaces the old `inventory`-collected `CollectableTraitMethods` plus the
-/// per-impl `#[ctor]` that seeded the vtable: both the method table and the Rust vtable now come
-/// from the same link-time record, so a partial view is impossible regardless of constructor order.
+/// [`TRAIT_IMPLS_SLICE`].
 pub struct TraitImplRecord {
     pub value_type: &'static ValueType,
     pub trait_type: &'static TraitType,

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -267,7 +267,7 @@ pub struct TraitImplRecord {
     /// concrete `DynMetadata` is materialized as a `const` inside this thunk. Invoked once from
     /// `register_all_trait_methods` after `VALUES` ids are assigned. The argument is
     /// [`Self::value_type`], passed so the thunk can resolve the `ValueTypeId`.
-    pub install_vtable: fn(&'static ValueType),
+    pub install_vtable: fn(&'static ValueType, ValueTypeId),
 }
 
 // Link-time collection of every `impl Trait for Concrete`. Like the definition slices in

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -263,11 +263,8 @@ pub struct TraitImplRecord {
     pub trait_type: &'static TraitType,
     pub methods: &'static [&'static NativeFunction],
     /// Installs this impl's Rust vtable `DynMetadata` into its trait's [`VTableRegistry`] (via
-    /// [`VTableRegistry::insert`]). Type-erased (the record is not generic over the trait); the
-    /// concrete `DynMetadata` is materialized as a `const` inside this thunk. Invoked once from
-    /// `register_all_trait_methods` after `VALUES` ids are assigned. The argument is
-    /// [`Self::value_type`], passed so the thunk can resolve the `ValueTypeId`.
-    pub install_vtable: fn(&'static ValueType, ValueTypeId),
+    /// [`VTableRegistry::insert`]).
+    pub install_vtable: fn(ValueTypeId),
 }
 
 // Link-time collection of every `impl Trait for Concrete`. Like the definition slices in

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -16,7 +16,7 @@ use crate::{
         any_as_encode,
     },
     macro_helpers::into_task_fn,
-    registry::{RegistryType, turbo_registry},
+    registry::{RegistryType, impl_ptr_identity},
     task::{TaskFn, TaskFnInputs, function::NativeTaskFuture},
 };
 
@@ -218,6 +218,7 @@ pub struct NativeFunction {
     /// (filesystem, environment, network) that may change between sessions.
     pub is_session_dependent: bool,
 }
+impl_ptr_identity!(NativeFunction);
 
 impl Debug for NativeFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -315,5 +316,3 @@ impl NativeFunction {
         tracing::trace_span!("turbo_tasks::resolve_call", name = self.ty.name, priority = %priority)
     }
 }
-
-turbo_registry!("Function", NativeFunction);

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -273,7 +273,7 @@ pub fn get_value_type_id(value: &'static ValueType) -> ValueTypeId {
 ///
 /// # Safety
 ///
-/// The only legitimate caller is a [`crate::macro_helpers::register_all_trait_methods`] thunk,
+/// The only legitimate caller is a [`crate::value_type::register_all_trait_methods`] thunk,
 /// which runs inside the `VALUES` `LazyLock` initializer (via `register_all_trait_methods`), after
 /// `init_registry` has assigned ids. Calling `get_value_type_id` from there would re-enter
 /// `LazyLock::force` and deadlock.

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -1,6 +1,7 @@
 use std::{cell::SyncUnsafeCell, num::NonZeroU16, sync::LazyLock};
 
 use anyhow::Error;
+use scattered_collect::slice::ScatteredSlice;
 
 use crate::{
     TraitType, ValueType,
@@ -14,12 +15,13 @@ pub use registry_type::RegistryType;
 
 /// Declare a type as a compile-time-collected registry item.
 ///
-/// Generates pointer-based `Eq`, `PartialEq`, `Hash`, `Ord`, `PartialOrd` impls
-/// and an `inventory::collect!` call for `&'static $ty`.
+/// Generates pointer-based `Eq`, `PartialEq`, `Hash`, `Ord`, `PartialOrd` impls.
+///
+/// The actual link-time gather slice for each registry is declared separately (see
+/// [`FUNCTIONS_SLICE`], [`VALUES_SLICE`], [`TRAITS_SLICE`]) because each needs a distinct
+/// module-level static and a wrapping [`LazyLock`].
 macro_rules! turbo_registry {
     ($name:literal, $ty:ty) => {
-        inventory::collect!(&'static $ty);
-
         impl ::core::cmp::Eq for $ty {}
         impl ::core::cmp::PartialEq for $ty {
             fn eq(&self, other: &$ty) -> bool {
@@ -46,19 +48,72 @@ macro_rules! turbo_registry {
 
 pub(crate) use turbo_registry;
 
+// Link-time gather slices, one per registry. Each item is a `&'static T` reference scattered by
+// the `register_*!` macros below. Unlike `inventory`, these are populated by the linker into a
+// contiguous section in the binary image: the full set is available at process start with no
+// constructors and no ordering. This is what makes forcing the `VALUES` `LazyLock` during the
+// load-time constructor phase safe — the slice is always complete, so we can never observe a
+// partial registry (the bug that the old `inventory::iter` live-linked-list approach had).
+//
+// These are `pub` (not `pub(crate)`): `#[gather]` re-exports each collection's scatter macro with
+// the static's visibility, and the `register_*!` macros — which expand in arbitrary downstream
+// crates — reference the collection as `$crate::<SLICE>` (see those macros below). The data is
+// `#[doc(hidden)]`; only the macro re-export needs to be reachable.
+#[doc(hidden)]
+#[scattered_collect::gather]
+pub static FUNCTIONS_SLICE: ScatteredSlice<&'static NativeFunction>;
+#[doc(hidden)]
+#[scattered_collect::gather]
+pub static VALUES_SLICE: ScatteredSlice<&'static ValueType>;
+#[doc(hidden)]
+#[scattered_collect::gather]
+pub static TRAITS_SLICE: ScatteredSlice<&'static TraitType>;
+
+/// Register a [`NativeFunction`] definition into the link-time [`FUNCTIONS_SLICE`].
 #[macro_export]
 #[doc(hidden)]
-macro_rules! turbo_register {
-    ($name:ident : $ty:ty = $value:expr) => {
-        static $name: $ty = $value;
-        $crate::macro_helpers::inventory_submit! { &$name }
+macro_rules! register_function {
+    ($name:ident = $value:expr) => {
+        static $name: $crate::macro_helpers::NativeFunction = $value;
+        $crate::macro_helpers::scattered_collect::declarative::scatter! {
+            #[scatter($crate::registry::FUNCTIONS_SLICE)]
+            const _: &'static $crate::macro_helpers::NativeFunction = &$name;
+        }
     };
-    ($reg:ty => $name:ident : $ty:ty = $value:expr) => {
-        static $name: $ty = $value;
-        $crate::macro_helpers::inventory_submit! { &$name }
+}
 
-        impl $crate::macro_helpers::RegistryDef<$ty> for $reg {
-            const DEF: &'static $ty = &$name;
+/// Register a [`ValueType`] definition into the link-time [`VALUES_SLICE`], and provide its
+/// `RegistryDef` so the impl macros can recover the `&'static ValueType` for a Vc type.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! register_value {
+    ($reg:ty => $name:ident = $value:expr) => {
+        static $name: $crate::ValueType = $value;
+        $crate::macro_helpers::scattered_collect::declarative::scatter! {
+            #[scatter($crate::registry::VALUES_SLICE)]
+            const _: &'static $crate::ValueType = &$name;
+        }
+
+        impl $crate::macro_helpers::RegistryDef<$crate::ValueType> for $reg {
+            const DEF: &'static $crate::ValueType = &$name;
+        }
+    };
+}
+
+/// Register a [`TraitType`] definition into the link-time [`TRAITS_SLICE`], and provide its
+/// `RegistryDef` so the impl macros can recover the `&'static TraitType` for a `Box<dyn Trait>`.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! register_trait {
+    ($reg:ty => $name:ident = $value:expr) => {
+        static $name: $crate::TraitType = $value;
+        $crate::macro_helpers::scattered_collect::declarative::scatter! {
+            #[scatter($crate::registry::TRAITS_SLICE)]
+            const _: &'static $crate::TraitType = &$name;
+        }
+
+        impl $crate::macro_helpers::RegistryDef<$crate::TraitType> for $reg {
+            const DEF: &'static $crate::TraitType = &$name;
         }
     };
 }
@@ -182,14 +237,8 @@ fn validate_id<T: Registerable>(
     }
 }
 
-static FUNCTIONS: LazyLock<Box<[&'static NativeFunction]>> = LazyLock::new(|| {
-    init_registry(
-        inventory::iter::<&'static NativeFunction>
-            .into_iter()
-            .copied()
-            .collect(),
-    )
-});
+static FUNCTIONS: LazyLock<Box<[&'static NativeFunction]>> =
+    LazyLock::new(|| init_registry(FUNCTIONS_SLICE.iter().copied().collect()));
 
 #[inline]
 pub fn get_native_function(id: FunctionId) -> &'static NativeFunction {
@@ -205,13 +254,8 @@ pub fn validate_function_id(id: FunctionId) -> Option<Error> {
     validate_id(&FUNCTIONS, id)
 }
 
-pub(crate) static VALUES: LazyLock<Box<[&'static ValueType]>> = LazyLock::new(|| {
-    let items = init_registry(
-        inventory::iter::<&'static ValueType>
-            .into_iter()
-            .copied()
-            .collect(),
-    );
+static VALUES: LazyLock<Box<[&'static ValueType]>> = LazyLock::new(|| {
+    let items = init_registry(VALUES_SLICE.iter().copied().collect());
     crate::value_type::register_all_trait_methods(&items);
     items
 });
@@ -224,14 +268,17 @@ pub fn get_value_type_id(value: &'static ValueType) -> ValueTypeId {
 /// Read a `ValueType`'s assigned id directly, without touching `LazyLock`. See
 /// [`get_id_unchecked`] for the safety contract.
 ///
+/// Public because the `value_impl` macro emits calls to it from the `install_vtable` thunk of each
+/// `TraitImplRecord` (which is defined in the downstream crate).
+///
 /// # Safety
 ///
-/// The only legitimate caller is `VTableRegistry::finalize`, which runs inside the `VALUES`
-/// `LazyLock` initializer (via `register_all_trait_methods`), after `init_registry` has
-/// assigned ids. Calling `get_value_type_id` from there would re-enter `LazyLock::force` and
-/// deadlock.
+/// The only legitimate caller is a [`crate::macro_helpers::TraitImplRecord::install_vtable`] thunk,
+/// which runs inside the `VALUES` `LazyLock` initializer (via `register_all_trait_methods`), after
+/// `init_registry` has assigned ids. Calling `get_value_type_id` from there would re-enter
+/// `LazyLock::force` and deadlock.
 #[inline]
-pub(crate) unsafe fn get_value_type_id_unchecked(value: &'static ValueType) -> ValueTypeId {
+pub unsafe fn get_value_type_id_unchecked(value: &'static ValueType) -> ValueTypeId {
     unsafe { get_id_unchecked(value) }
 }
 
@@ -250,14 +297,8 @@ pub(crate) fn trait_type_count() -> usize {
     TRAITS.len()
 }
 
-static TRAITS: LazyLock<Box<[&'static TraitType]>> = LazyLock::new(|| {
-    init_registry(
-        inventory::iter::<&'static TraitType>
-            .into_iter()
-            .copied()
-            .collect(),
-    )
-});
+static TRAITS: LazyLock<Box<[&'static TraitType]>> =
+    LazyLock::new(|| init_registry(TRAITS_SLICE.iter().copied().collect()));
 
 #[inline]
 pub fn get_trait_type_id(trait_type: &'static TraitType) -> TraitTypeId {

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -49,16 +49,7 @@ macro_rules! turbo_registry {
 pub(crate) use turbo_registry;
 
 // Link-time gather slices, one per registry. Each item is a `&'static T` reference scattered by
-// the `register_*!` macros below. Unlike `inventory`, these are populated by the linker into a
-// contiguous section in the binary image: the full set is available at process start with no
-// constructors and no ordering. This is what makes forcing the `VALUES` `LazyLock` during the
-// load-time constructor phase safe — the slice is always complete, so we can never observe a
-// partial registry (the bug that the old `inventory::iter` live-linked-list approach had).
-//
-// These are `pub` (not `pub(crate)`): `#[gather]` re-exports each collection's scatter macro with
-// the static's visibility, and the `register_*!` macros — which expand in arbitrary downstream
-// crates — reference the collection as `$crate::<SLICE>` (see those macros below). The data is
-// `#[doc(hidden)]`; only the macro re-export needs to be reachable.
+// the `register_*!` macros below.
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static FUNCTIONS_SLICE: ScatteredSlice<&'static NativeFunction>;
@@ -268,15 +259,11 @@ pub fn get_value_type_id(value: &'static ValueType) -> ValueTypeId {
 /// Read a `ValueType`'s assigned id directly, without touching `LazyLock`. See
 /// [`get_id_unchecked`] for the safety contract.
 ///
-/// Public because the `value_impl` macro emits calls to it from the `install_vtable` thunk of each
-/// `TraitImplRecord` (which is defined in the downstream crate).
-///
 /// # Safety
 ///
-/// The only legitimate caller is a [`crate::value_type::register_all_trait_methods`] thunk,
-/// which runs inside the `VALUES` `LazyLock` initializer (via `register_all_trait_methods`), after
-/// `init_registry` has assigned ids. Calling `get_value_type_id` from there would re-enter
-/// `LazyLock::force` and deadlock.
+/// The only legitimate caller is [`crate::value_type::register_all_trait_methods`],
+/// which runs inside the `VALUES` `LazyLock` initializer, after `init_registry` has assigned ids.
+/// Calling `get_value_type_id` from there would re-enter `LazyLock::force` and deadlock.
 #[inline]
 pub(crate) unsafe fn get_value_type_id_unchecked(value: &'static ValueType) -> ValueTypeId {
     unsafe { get_id_unchecked(value) }

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -13,15 +13,9 @@ mod registry_type;
 
 pub use registry_type::RegistryType;
 
-/// Declare a type as a compile-time-collected registry item.
-///
 /// Generates pointer-based `Eq`, `PartialEq`, `Hash`, `Ord`, `PartialOrd` impls.
-///
-/// The actual link-time gather slice for each registry is declared separately (see
-/// [`FUNCTIONS_SLICE`], [`VALUES_SLICE`], [`TRAITS_SLICE`]) because each needs a distinct
-/// module-level static and a wrapping [`LazyLock`].
-macro_rules! turbo_registry {
-    ($name:literal, $ty:ty) => {
+macro_rules! impl_ptr_identity {
+    ($ty:ty) => {
         impl ::core::cmp::Eq for $ty {}
         impl ::core::cmp::PartialEq for $ty {
             fn eq(&self, other: &$ty) -> bool {
@@ -46,16 +40,17 @@ macro_rules! turbo_registry {
     };
 }
 
-pub(crate) use turbo_registry;
+pub(crate) use impl_ptr_identity;
 
-// Link-time gather slices, one per registry. Each item is a `&'static T` reference scattered by
-// the `register_*!` macros below.
+// Link-time gather slices, one per registry.
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static FUNCTIONS_SLICE: ScatteredSlice<&'static NativeFunction>;
+
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static VALUES_SLICE: ScatteredSlice<&'static ValueType>;
+
 #[doc(hidden)]
 #[scattered_collect::gather]
 pub static TRAITS_SLICE: ScatteredSlice<&'static TraitType>;

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -256,7 +256,7 @@ pub fn validate_function_id(id: FunctionId) -> Option<Error> {
 
 static VALUES: LazyLock<Box<[&'static ValueType]>> = LazyLock::new(|| {
     let items = init_registry(VALUES_SLICE.iter().copied().collect());
-    crate::value_type::register_all_trait_methods(&items);
+    crate::value_type::register_all_trait_methods();
     items
 });
 
@@ -273,12 +273,12 @@ pub fn get_value_type_id(value: &'static ValueType) -> ValueTypeId {
 ///
 /// # Safety
 ///
-/// The only legitimate caller is a [`crate::macro_helpers::TraitImplRecord::install_vtable`] thunk,
+/// The only legitimate caller is a [`crate::macro_helpers::register_all_trait_methods`] thunk,
 /// which runs inside the `VALUES` `LazyLock` initializer (via `register_all_trait_methods`), after
 /// `init_registry` has assigned ids. Calling `get_value_type_id` from there would re-enter
 /// `LazyLock::force` and deadlock.
 #[inline]
-pub unsafe fn get_value_type_id_unchecked(value: &'static ValueType) -> ValueTypeId {
+pub(crate) unsafe fn get_value_type_id_unchecked(value: &'static ValueType) -> ValueTypeId {
     unsafe { get_id_unchecked(value) }
 }
 

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -13,7 +13,7 @@ use crate::{
     RawVc, SharedReference, TaskPriority, VcValueType,
     dyn_task_inputs::any_as_encode,
     id::TraitTypeId,
-    macro_helpers::{CollectableTraitMethods, NativeFunction},
+    macro_helpers::{NativeFunction, TRAIT_IMPLS_SLICE},
     registry::{RegistryType, get_trait_type_id, trait_type_count, turbo_registry},
     task::shared_reference::TypedSharedReference,
     vc::VcCellMode,
@@ -269,8 +269,12 @@ turbo_registry!("Value", ValueType);
 
 // Called during ValueType registry post_init to register all trait methods.
 // Single-threaded during Lazy init.
+//
+// Iterates the link-time `TRAIT_IMPLS_SLICE` exactly once. The slice is complete at process start
+// (it is gathered by the linker, not built incrementally by constructors), so this can never
+// observe a partial set of trait impls regardless of when the `VALUES` `LazyLock` is first forced.
 pub(crate) fn register_all_trait_methods(_: &[&'static ValueType]) {
-    for entry in inventory::iter::<CollectableTraitMethods> {
+    for entry in TRAIT_IMPLS_SLICE.iter() {
         for (i, impl_method) in entry.methods.iter().enumerate() {
             let trait_method = &entry.trait_type.methods[i];
             if trait_method.is_root != impl_method.is_root {
@@ -292,8 +296,10 @@ pub(crate) fn register_all_trait_methods(_: &[&'static ValueType]) {
         entry
             .value_type
             .register_trait(entry.trait_type, entry.methods);
-        // Reigster all the rust vtables to support into_trait_ref calling stryles
-        (entry.finalize_vtable_registry)();
+        // Install the Rust vtable so `into_trait_ref`-style calls can downcast. The thunk resolves
+        // the value type's id (already assigned by `init_registry` above) and inserts the
+        // compile-time `DynMetadata` into the trait's `VTableRegistry`.
+        (entry.install_vtable)(entry.value_type);
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -14,7 +14,10 @@ use crate::{
     dyn_task_inputs::any_as_encode,
     id::TraitTypeId,
     macro_helpers::{NativeFunction, TRAIT_IMPLS_SLICE},
-    registry::{RegistryType, get_trait_type_id, trait_type_count, turbo_registry},
+    registry::{
+        RegistryType, get_trait_type_id, get_value_type_id_unchecked, trait_type_count,
+        turbo_registry,
+    },
     task::shared_reference::TypedSharedReference,
     vc::VcCellMode,
 };
@@ -269,11 +272,7 @@ turbo_registry!("Value", ValueType);
 
 // Called during ValueType registry post_init to register all trait methods.
 // Single-threaded during Lazy init.
-//
-// Iterates the link-time `TRAIT_IMPLS_SLICE` exactly once. The slice is complete at process start
-// (it is gathered by the linker, not built incrementally by constructors), so this can never
-// observe a partial set of trait impls regardless of when the `VALUES` `LazyLock` is first forced.
-pub(crate) fn register_all_trait_methods(_: &[&'static ValueType]) {
+pub(crate) fn register_all_trait_methods() {
     for entry in TRAIT_IMPLS_SLICE.iter() {
         for (i, impl_method) in entry.methods.iter().enumerate() {
             let trait_method = &entry.trait_type.methods[i];
@@ -293,13 +292,16 @@ pub(crate) fn register_all_trait_methods(_: &[&'static ValueType]) {
                 );
             }
         }
-        entry
-            .value_type
-            .register_trait(entry.trait_type, entry.methods);
+        let value_type = entry.value_type;
+        value_type.register_trait(entry.trait_type, entry.methods);
+        // SAFETY: We are inside the `VALUES` `LazyLock` init after `init_registry` assigned
+        // ids. Reading the id cell directly (rather than `get_value_type_id`)
+        // avoids re-entering `LazyLock::force` and deadlocking.
+        let id = unsafe { get_value_type_id_unchecked(value_type) };
         // Install the Rust vtable so `into_trait_ref`-style calls can downcast. The thunk resolves
         // the value type's id (already assigned by `init_registry` above) and inserts the
         // compile-time `DynMetadata` into the trait's `VTableRegistry`.
-        (entry.install_vtable)(entry.value_type);
+        (entry.install_vtable)(value_type, id);
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -301,7 +301,7 @@ pub(crate) fn register_all_trait_methods() {
         // Install the Rust vtable so `into_trait_ref`-style calls can downcast. The thunk resolves
         // the value type's id (already assigned by `init_registry` above) and inserts the
         // compile-time `DynMetadata` into the trait's `VTableRegistry`.
-        (entry.install_vtable)(value_type, id);
+        (entry.install_vtable)(id);
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -298,9 +298,7 @@ pub(crate) fn register_all_trait_methods() {
         // ids. Reading the id cell directly (rather than `get_value_type_id`)
         // avoids re-entering `LazyLock::force` and deadlocking.
         let id = unsafe { get_value_type_id_unchecked(value_type) };
-        // Install the Rust vtable so `into_trait_ref`-style calls can downcast. The thunk resolves
-        // the value type's id (already assigned by `init_registry` above) and inserts the
-        // compile-time `DynMetadata` into the trait's `VTableRegistry`.
+        // Register all the rust vtables to support into_trait_ref calling stryles
         (entry.install_vtable)(id);
     }
 }

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -15,8 +15,8 @@ use crate::{
     id::TraitTypeId,
     macro_helpers::{NativeFunction, TRAIT_IMPLS_SLICE},
     registry::{
-        RegistryType, get_trait_type_id, get_value_type_id_unchecked, trait_type_count,
-        turbo_registry,
+        RegistryType, get_trait_type_id, get_value_type_id_unchecked, impl_ptr_identity,
+        trait_type_count,
     },
     task::shared_reference::TypedSharedReference,
     vc::VcCellMode,
@@ -106,6 +106,7 @@ pub struct ValueType {
 
     traits: SyncUnsafeCell<ValueTypeTraits>,
 }
+impl_ptr_identity!(ValueType);
 
 impl Debug for ValueType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -268,8 +269,6 @@ impl ValueType {
     }
 }
 
-turbo_registry!("Value", ValueType);
-
 // Called during ValueType registry post_init to register all trait methods.
 // Single-threaded during Lazy init.
 pub(crate) fn register_all_trait_methods() {
@@ -360,6 +359,7 @@ pub struct TraitType {
     pub methods: &'static [TraitMethod],
     pub default_methods: &'static [Option<&'static NativeFunction>],
 }
+impl_ptr_identity!(TraitType);
 
 impl Debug for TraitType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -400,8 +400,6 @@ impl TraitType {
             .expect("Method not found!")
     }
 }
-
-turbo_registry!("Trait", TraitType);
 
 pub trait TraitVtablePrototype {
     const LEN: usize;

--- a/turbopack/crates/turbo-tasks/src/vc/traits.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/traits.rs
@@ -125,8 +125,7 @@ pub trait VcValueTrait: NonLocalValue + Send + Sync + 'static {
     // The concrete type of the value_trait implementing VcValueTrait
     type ValueTrait: ?Sized + std::ptr::Pointee<Metadata = std::ptr::DynMetadata<Self::ValueTrait>>;
 
-    /// The per-trait vtable registry, populated at program load by `#[ctor::ctor]`
-    /// functions emitted by each `#[turbo_tasks::value_impl]` expansion.
+    /// The per-trait vtable registry, populated by [crate::value_type::register_all_trait_methods]
     ///
     /// [`VTableRegistry::cast`] panics if the value type being cast doesn't implement this
     /// trait.


### PR DESCRIPTION
# What
This uses `scatter_collect` from @mmastrac to register all values, traits and value impls of traits.  now all data can be consistently accessed when constructing the VALUEs registry, eliminating a number of racy access opportunities.


# Why
Scatter collect uses link sections to gather registries at link time, this resolve some inherent brittleness in constructor functions since the relative execution order is **not guaranteed** and it is also not even possible to  _detect_ execution that is too early (early access to an `inventory` collection will miss some entries silently)

We have a single report that appears to be due to a race like this

```
web:dev: thread 'tokio-rt-worker' (41574444) panicked at turbopack/crates/turbo-tasks/src/macro_helpers.rs:274:13:
web:dev: no trait impl registered for value type turbopack_core::module_graph::ModuleGraphImportTracer
web:dev: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I do not entirely understand how this is possible since constructors should complete prior to the first napi entry point (other than `napi::module_init` which is itself a constructor).

Our initialization logic is fundamentally brittle since it relies on

* an `inventory` of all value types
* an `inventory `of all trait types
* a set of ctor functions to register trait implementations (basically (value, trait) pairs)

All of these need to be initialized/invoked before the `VALUES` registry is accessed, but the above panic implies that the ctor function for `ModuleGraphImportTracer` to register its implementation of `ImportTracer` hasn't occurred yet.

By moving the registies to link time we completely eliminate all startup races since the linker does all the 'gathering', now the only possible concern is that we attempt to downcast a trait prior the the `VALUES` registry completing which does not appear to be possible.


# Binary size impact

Measured on `next-swc.darwin-arm64.node` built with `pnpm --filter @next/swc build-native-release` (release profile), this branch vs `canary`. Stripped = `strip -x`; gzip = `gzip -9` of the stripped binary.

| Metric | branch | canary | Δ | Δ% |
|---|---:|---:|---:|---:|
| **raw** | 122,879,888 B | 124,184,976 B | **−1,305,088 B** | **−1.051%** |
| **stripped** | 83,505,264 B | 84,127,232 B | **−621,968 B** | **−0.739%** |
| **gzip+stripped** | 28,800,547 B | 28,925,679 B | **−125,132 B** | **−0.433%** |

The addon shrinks on every metric. Replacing the generated per-impl registration functions (and their `ctor`/`inventory` machinery) with link-time scattered collection removes real code/data — ~622 KB even after stripping — and laying the registries out contiguously at link time compresses better, so the gzip win holds up too.

<!-- NEXT_JS_LLM_PR -->
