### PR TITLE
fix: preserve original sourcesContent in React Compiler sourcemaps

### DIFF
--- a/packages/next/src/build/babel/loader/transform.ts
+++ b/packages/next/src/build/babel/loader/transform.ts
@@ -72,6 +72,45 @@ function transformAst(file: any, babelConfig: any, parentSpan: Span) {
   }
 }
 
+function normalizeSourceMapPath(filename: string): string {
+  return filename.replace(/\\/g, '/')
+}
+
+function findLoaderInputSourceIndex(
+  sources: string[],
+  filename: string
+): number {
+  const normalizedFilename = normalizeSourceMapPath(filename)
+  const sourceIndex = sources.findIndex(
+    (sourceName) => normalizeSourceMapPath(sourceName) === normalizedFilename
+  )
+
+  if (sourceIndex !== -1) {
+    return sourceIndex
+  }
+
+  return sources.length === 1 ? 0 : -1
+}
+
+function preserveLoaderInputSourceContent(
+  map: GeneratorResult['map'],
+  source: string,
+  filename: string
+) {
+  const sources = map?.sources
+  if (!sources) {
+    return
+  }
+
+  const sourceIndex = findLoaderInputSourceIndex(sources, filename)
+  if (sourceIndex === -1) {
+    return
+  }
+
+  map.sourcesContent ??= []
+  map.sourcesContent[sourceIndex] = source
+}
+
 export default async function transform(
   ctx: NextJsLoaderContext,
   source: string,
@@ -108,6 +147,8 @@ export default async function transform(
   const generateSpan = parentSpan.traceChild('babel-turbo-generate')
   const { code, map } = generate(file.ast, file.opts.generatorOpts, file.code)
   generateSpan.stop()
+
+  preserveLoaderInputSourceContent(map, source, filename)
 
   return { code, map }
 }

--- a/test/production/production-browser-sourcemaps/app/client.js
+++ b/test/production/production-browser-sourcemaps/app/client.js
@@ -1,0 +1,14 @@
+'use client'
+
+import { useState } from 'react'
+
+export function ReactCompilerSourceMapClient() {
+  const [count, setCount] = useState(0)
+  const originalSourceMapMarker = 'original-source-map-marker'
+
+  return (
+    <button onClick={() => setCount(count + 1)}>
+      {originalSourceMapMarker}: {count}
+    </button>
+  )
+}

--- a/test/production/production-browser-sourcemaps/app/page.js
+++ b/test/production/production-browser-sourcemaps/app/page.js
@@ -1,3 +1,10 @@
+import { ReactCompilerSourceMapClient } from './client'
+
 export default function page() {
-  return <div>hello</div>
+  return (
+    <div>
+      hello
+      <ReactCompilerSourceMapClient />
+    </div>
+  )
 }

--- a/test/production/production-browser-sourcemaps/index.test.ts
+++ b/test/production/production-browser-sourcemaps/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import { getBuildManifest } from 'next-test-utils'
 import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 function extractSourceMappingURL(jsContent: string): string | null {
   // Matches both //# and //@ sourceMappingURL=...
@@ -49,6 +49,42 @@ async function validateSourceMapForChunk(
   if ((await fs.pathExists(mapPath)) !== productionBrowserSourceMaps) {
     throw new Error(`Source map presence mismatch for ${jsFilePath}.`)
   }
+}
+
+async function getBrowserSourceMaps(distDir: string) {
+  const sourceMaps: any[] = []
+
+  for (let dir of ['static', 'static/immutable']) {
+    const chunksDir = path.join(distDir, dir, 'chunks')
+    if (!fs.existsSync(chunksDir)) {
+      continue
+    }
+
+    const browserFiles = await recursiveReadDir(chunksDir)
+    const sourceMapFiles = browserFiles.filter((file) =>
+      file.endsWith('.js.map')
+    )
+
+    for (const file of sourceMapFiles) {
+      sourceMaps.push(await fs.readJSON(path.join(chunksDir, file)))
+    }
+  }
+
+  return sourceMaps
+}
+
+function findSourceContent(sourceMaps: any[], sourceSuffix: string) {
+  for (const sourceMap of sourceMaps) {
+    const sourceIndex = sourceMap.sources?.findIndex((source: string) =>
+      source.endsWith(sourceSuffix)
+    )
+
+    if (sourceIndex >= 0) {
+      return sourceMap.sourcesContent?.[sourceIndex]
+    }
+  }
+
+  return undefined
 }
 
 describe('Production browser sourcemaps', () => {
@@ -101,4 +137,35 @@ describe('Production browser sourcemaps', () => {
       })
     }
   )
+})
+
+describe('Production browser sourcemaps with React Compiler', () => {
+  const { next, isTurbopack, skipped } = nextTestSetup({
+    files: __dirname,
+    nextConfig: {
+      productionBrowserSourceMaps: true,
+      reactCompiler: true,
+    },
+    dependencies: {
+      'babel-plugin-react-compiler': '0.0.0-experimental-3fde738-20250918',
+      ...(isReact18 ? { 'react-compiler-runtime': 'latest' } : {}),
+    },
+  })
+
+  if (!skipped) {
+    it('preserves original client sourcesContent after React Compiler transforms', async () => {
+      const sourceMaps = await getBrowserSourceMaps(
+        path.join(next.testDir, '.next')
+      )
+      const sourceContent = findSourceContent(sourceMaps, '/app/client.js')
+
+      expect(sourceContent).toContain('original-source-map-marker')
+      expect(sourceContent).toContain('useState')
+
+      if (isTurbopack) {
+        expect(sourceContent).not.toContain('react/compiler-runtime')
+        expect(sourceContent).not.toContain('_c(')
+      }
+    })
+  }
 })

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -206,6 +206,9 @@ pub async fn resolve_source_map_sources(
 
     if let Some(file) = &mut map.file {
         resolve_source(file, None).await?;
+    } else {
+        let origin_str = &origin.path;
+        map.file = Some(format!("{SOURCE_URL_PROTOCOL_STR}///{fs_str}/{origin_str}"));
     }
 
     resolve_map(&mut map).await?;
@@ -359,6 +362,7 @@ mod tests {
         tt.run_once(async move {
             #[turbo_tasks::value]
             struct SourceMapSourcesOutput {
+                resolved_file: Option<String>,
                 resolved_sources: Vec<Option<String>>,
                 rooted_sources: Vec<Option<String>>,
             }
@@ -428,6 +432,7 @@ mod tests {
                 )?;
 
                 Ok(SourceMapSourcesOutput {
+                    resolved_file: resolved_source_map.file,
                     resolved_sources: resolved_source_map.sources.unwrap_or_default(),
                     rooted_sources: rooted_source_map.sources.unwrap_or_default(),
                 }
@@ -439,6 +444,11 @@ mod tests {
                 .await?;
 
             let prefix = format!("{SOURCE_URL_PROTOCOL_STR}///[mock]");
+            assert_eq!(
+                resolved_source_maps.resolved_file,
+                Some(format!("{prefix}/app/source%20mapped/page.js"))
+            );
+
             assert_eq!(
                 resolved_source_maps.resolved_sources,
                 vec![


### PR DESCRIPTION
### What?

Fixes #94450.

Preserves original source content in production browser source maps when React Compiler transforms client components under Turbopack.

### Why?

React Compiler transforms can carry source maps whose `sourcesContent` still points back to the original client source, but final browser source-map composition can lose that source authority and expose compiler output instead. That makes generated browser source maps point at transformed compiler code rather than the original component source.

### How?

- Preserve the original loader input source in the Babel loader source map.
- Populate a missing source-map `file` from the resolved origin path so Turbopack composition can match the transform map back to the generated intermediate source.
- Add regression coverage for React Compiler production browser source maps.

### Tests

- `scripts/run-jest.sh --mode=start --bundler=turbo --headless -- test/production/production-browser-sourcemaps -t "React Compiler"`
- `cargo test -p turbopack-core --lib source_map::utils::tests::test_resolve_source_map_sources`
- `rustfmt --check turbopack/crates/turbopack-core/src/source_map/utils.rs`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->
