### PR TITLE
Enable experimental.appShells by default with cacheComponents

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -532,12 +532,12 @@ function assignDefaultsAndValidate(
     // defaults, so we don't support enabling App Shells against arbitrary
     // subsets of them — the validation goes away once each becomes a
     // default.
+    // Note: `prefetchInlining` is intentionally NOT required. App Shells works
+    // correctly whether or not prefetch inlining is enabled, so disabling it
+    // (e.g. to exercise non-inlined prefetch paths) must not force App Shells off.
     const missing: string[] = []
     if (!result.cacheComponents) {
       missing.push('`cacheComponents`')
-    }
-    if (!result.experimental.prefetchInlining) {
-      missing.push('`experimental.prefetchInlining`')
     }
     if (!result.experimental.varyParams) {
       missing.push('`experimental.varyParams`')
@@ -2223,6 +2223,32 @@ function enforceExperimentalFeatures(
       (isDefaultConfig && !config.experimental.cachedNavigations))
   ) {
     config.experimental.cachedNavigations = true
+  }
+
+  // Enable appShells by default when cacheComponents is enabled, unless
+  // explicitly disabled. App Shells builds on Cache Components rendering, so
+  // the two features are tied together: we only flip the default for projects
+  // that are already using Cache Components. Done silently for the same reasons
+  // as the cachedNavigations default above.
+  //
+  // We only auto-enable when App Shells's required dependencies are satisfied.
+  // If a project has explicitly disabled one of them, we leave App Shells off
+  // rather than force it on — otherwise the validation in
+  // `assignDefaultsAndValidate` would turn a previously-valid config into a
+  // hard error. Users who want App Shells in that situation can still enable it
+  // explicitly and get the actionable validation message. `prefetchInlining` is
+  // intentionally not part of this gate (App Shells works without it). This runs
+  // after the cachedNavigations default above so that dependency is already set.
+  // TODO: Remove this once appShells is unconditionally the default.
+  if (
+    config.cacheComponents &&
+    config.experimental.varyParams !== false &&
+    config.experimental.optimisticRouting !== false &&
+    config.experimental.cachedNavigations !== false &&
+    (config.experimental.appShells === undefined ||
+      (isDefaultConfig && !config.experimental.appShells))
+  ) {
+    config.experimental.appShells = true
   }
 
   // TODO: Remove this once appNewScrollHandler is the default.

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
@@ -4,6 +4,9 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
+    // TODO(appShells): migrate this test to the two-phase (app shell +
+    // per-page data) prefetch behavior, then remove this override. See #94516.
+    appShells: false,
     // Enable the testing API in production builds for these tests
     exposeTestingApiInProductionBuild: true,
     prefetchInlining: false,

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/root-params/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/root-params/next.config.js
@@ -4,6 +4,9 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
+    // TODO(appShells): migrate this test to the two-phase (app shell +
+    // per-page data) prefetch behavior, then remove this override. See #94516.
+    appShells: false,
     exposeTestingApiInProductionBuild: true,
     prefetchInlining: false,
   },

--- a/test/e2e/app-dir/parallel-route-navigations/next.config.js
+++ b/test/e2e/app-dir/parallel-route-navigations/next.config.js
@@ -1,6 +1,12 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    // TODO(appShells): migrate this test to the two-phase (app shell +
+    // per-page data) prefetch behavior, then remove this override. See #94516.
+    appShells: false,
+  },
+}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts
@@ -25,9 +25,11 @@ describe('max prefetch inlining', () => {
     //   /shared/a/b/c  and  /shared/a/d/e
     // Without inlining, prefetching each route would issue one request per
     // segment plus one for the head (6+ requests). With inlining enabled,
-    // all segment data is bundled into a single response, so revealing a
-    // link should produce at most 2 prefetch requests per route: one for
-    // /_tree and one for the inlined segment data.
+    // all segment data is bundled into a single response. Under App Shells a
+    // route is prefetched in two phases (App Shell + per-link), and each phase
+    // may issue a /_tree request plus an inlined segment-data request, so
+    // revealing a link produces at most 4 prefetch requests per route — still
+    // far fewer than the un-inlined per-segment requests.
 
     let rscRequestCount = 0
     let page: Playwright.Page
@@ -71,10 +73,13 @@ describe('max prefetch inlining', () => {
       }
     )
 
-    // The delta should be at most 2 requests (/_tree + /_inlined).
-    // Without inlining, there would be 6+ individual segment requests.
+    // The delta counts raw `rsc` requests via the listener above (NOT through
+    // `act`, which ignores App Shell requests), so it includes the App Shell
+    // prefetch as well as the per-link prefetch. Each may issue a /_tree request
+    // plus an inlined segment-data request, so the delta is at most 4. Without
+    // inlining there would be 6+ individual segment requests.
     const delta = rscRequestCount - countBeforeSecondPrefetch
-    expect(delta).toBeLessThanOrEqual(2)
+    expect(delta).toBeLessThanOrEqual(4)
 
     // Navigate to the second route. Because the data was fully prefetched,
     // there should be no additional requests.

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -569,9 +569,13 @@ describe('prefetch inlining', () => {
       { includes: 'Static layout content' }
     )
 
+    // Navigate to the route. The static layout was prefetched (and is cached),
+    // but the runtime leaf page has no static descendants and is not
+    // speculatively prefetched under App Shells — it is fetched here, on
+    // navigation.
     await act(async () => {
       await browser.elementByCss('a[href="/test-runtime-bailout"]').click()
-    }, 'no-requests')
+    })
 
     expect(await browser.elementByCss('#layout-runtime-bailout').text()).toBe(
       'Static layout content'
@@ -777,29 +781,32 @@ describe('prefetch inlining', () => {
     // Now we're on route A. Reveal the sibling link to route B. The
     // runtime layout is shared between A and B, so it's already cached
     // and won't be re-fetched. The only new segment is the [item] page,
-    // which is static. But the head differs (title includes "Item: b")
-    // and depends on runtime data, so it must still be fetched via a
-    // runtime prefetch even though no other runtime request is needed.
+    // which is static, so it IS prefetched. But the head depends on the
+    // [item] param (and searchParams), so it is param-dependent and is NOT
+    // part of the App Shell. Under App Shells, a speculative per-link
+    // prefetch does not request the param-dependent head — it is deferred
+    // to navigation. So the static page is prefetched here, but the title
+    // for B is not.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/test-independent-head/b"]')
+        .click()
+    }, [
+      // The static page below the runtime layout is prefetched.
+      { includes: 'page-independent-head' },
+      // The param-dependent head must NOT be prefetched — it is not part
+      // of the App Shell and arrives on navigation instead.
+      { includes: 'Independent Head Title: b', block: 'reject' },
+    ])
+
+    // Navigate to route B. The param-dependent head was not prefetched, so
+    // it is fetched now, on navigation.
     await act(
       async () => {
-        await browser
-          .elementByCss('input[data-link-accordion="/test-independent-head/b"]')
-          .click()
+        await browser.elementByCss('a[href="/test-independent-head/b"]').click()
       },
       { includes: 'Independent Head Title: b' }
     )
-
-    // Navigate to route B. The page segment is unnecessarily marked as
-    // partial because the metadata outlet in the page's RSC data
-    // contains an unresolved reference to the dynamic metadata. This
-    // causes navigation to re-fetch the page even though the actual
-    // page content is fully static.
-    // TODO: The page segment should not be considered partial just
-    // because the metadata is dynamic. Once this is fixed, this
-    // navigation should not require any network requests.
-    await act(async () => {
-      await browser.elementByCss('a[href="/test-independent-head/b"]').click()
-    })
 
     expect(await browser.elementByCss('#page-independent-head').text()).toBe(
       'Independent head page'

--- a/test/e2e/app-dir/segment-cache/search-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/search-params/next.config.js
@@ -4,6 +4,9 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
+    // TODO(appShells): migrate this test to the two-phase (app shell +
+    // per-page data) prefetch behavior, then remove this override. See #94516.
+    appShells: false,
     // TODO: This test asserts on the pre-`optimisticRouting` prefetch and
     // search-param-rewrite behavior. Pin the fixture to the old default
     // until the test is updated (or until the flag is removed).

--- a/test/e2e/app-dir/segment-cache/staleness/next.config.js
+++ b/test/e2e/app-dir/segment-cache/staleness/next.config.js
@@ -4,6 +4,11 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
+    // The "runtime prefetch" stale-time test relies on a runtime prefetch
+    // firing when a link is revealed. App Shells defers a non-eager route's
+    // dynamic content to navigation rather than prefetching it speculatively,
+    // so keep App Shells off here to exercise runtime-prefetch staleness.
+    appShells: false,
     staleTimes: {
       dynamic: 30,
     },

--- a/test/e2e/app-dir/segment-cache/vary-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params/next.config.js
@@ -4,6 +4,12 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
+    // These tests assert on per-link/runtime prefetch responses to verify
+    // varyParams cache-key behavior. App Shells skips the per-link Speculative
+    // prefetch for non-eager routes (deferring param-dependent content to
+    // navigation), which makes that behavior unobservable via prefetch. Keep
+    // App Shells off here so the varyParams feature is exercised in isolation.
+    appShells: false,
     optimisticRouting: true,
     prefetchInlining: false,
     varyParams: true,

--- a/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   experimental: {
+    // TODO(appShells): migrate this test to the two-phase (app shell +
+    // per-page data) prefetch behavior, then remove this override. See #94516.
+    appShells: false,
     prefetchInlining: false,
     useCache: true,
   },

--- a/test/production/app-dir/use-cache-non-deterministic-args/next.config.ts
+++ b/test/production/app-dir/use-cache-non-deterministic-args/next.config.ts
@@ -1,6 +1,12 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  experimental: {
+    // TODO(appShells): migrate this test to the two-phase (app shell +
+    // per-page data) prefetch behavior, then remove this override. See #94516.
+    appShells: false,
+  },
+
   cacheComponents: true,
 }
 


### PR DESCRIPTION
Turns on `experimental.appShells` by default for projects already on `cacheComponents`, unless explicitly disabled.

Thanks to the preceding router-act change, most prefetch tests pass unchanged once App Shells is enabled. A few tests are genuinely coupled to the non-App-Shells behavior — they assert on per-link or runtime prefetch responses that App Shells instead defers to navigation — so the fixtures for those tests set `appShells` back to `false`. I'll address those in follow-ups.

<!-- NEXT_JS_LLM_PR -->
