### PR TITLE
Revert "[ci] Increase TEST_CONCURRENCY from 8 to 12 (#94138)"

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -131,7 +131,7 @@ env:
   NODE_LTS_VERSION: 20.9.0
   # run-tests.js reads `TEST_CONCURRENCY` if no explicit `--concurrency` or `-c`
   # argument is provided
-  TEST_CONCURRENCY: 12
+  TEST_CONCURRENCY: 8
   # overrides `turbo_tasks::parallel::available_parallelism`. Smaller values are more CPU and memory
   # efficient, but won't fully utilize all available CPU cores. A small value here makes sense since
   # we're running many tests in parallel.


### PR DESCRIPTION
There's some evidence that this was meaningfully increasing flakiness: https://vercel.slack.com/archives/C04KC8A53T7/p1780773226831399