### PR TITLE
docs: fix onRequestError error type example

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
@@ -48,10 +48,12 @@ export const onRequestError: Instrumentation.onRequestError = async (
   request,
   context
 ) => {
+  const message = err instanceof Error ? err.message : String(err)
+
   await fetch('https://.../report-error', {
     method: 'POST',
     body: JSON.stringify({
-      message: err.message,
+      message,
       request,
       context,
     }),
@@ -64,10 +66,12 @@ export const onRequestError: Instrumentation.onRequestError = async (
 
 ```js filename="instrumentation.js" switcher
 export async function onRequestError(err, request, context) {
+  const message = err instanceof Error ? err.message : String(err)
+
   await fetch('https://.../report-error', {
     method: 'POST',
     body: JSON.stringify({
-      message: err.message,
+      message,
       request,
       context,
     }),
@@ -84,7 +88,7 @@ The function accepts three parameters: `error`, `request`, and `context`.
 
 ```ts filename="Types"
 export function onRequestError(
-  error: { digest: string } & Error,
+  error: unknown,
   request: {
     path: string // resource path, e.g. /blog?name=foo
     method: string // request method. e.g. GET, POST, etc
@@ -104,7 +108,7 @@ export function onRequestError(
 ): void | Promise<void>
 ```
 
-- `error`: The caught error itself (type is always `Error`), and a `digest` property which is the unique ID of the error.
+- `error`: The caught value is typed as `unknown`. Narrow it before reading properties like `message` or `digest`.
 - `request`: Read-only request information associated with the error.
 - `context`: The context in which the error occurred. This can be the type of router (App or Pages Router), and/or (Server Components (`'render'`), Route Handlers (`'route'`), Server Actions (`'action'`), or Proxy (`'proxy'`)).
 

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
@@ -49,11 +49,16 @@ export const onRequestError: Instrumentation.onRequestError = async (
   context
 ) => {
   const message = err instanceof Error ? err.message : String(err)
+  const digest =
+    typeof err === 'object' && err !== null && 'digest' in err
+      ? String(err.digest)
+      : undefined
 
   await fetch('https://.../report-error', {
     method: 'POST',
     body: JSON.stringify({
       message,
+      digest,
       request,
       context,
     }),
@@ -67,11 +72,16 @@ export const onRequestError: Instrumentation.onRequestError = async (
 ```js filename="instrumentation.js" switcher
 export async function onRequestError(err, request, context) {
   const message = err instanceof Error ? err.message : String(err)
+  const digest =
+    typeof err === 'object' && err !== null && 'digest' in err
+      ? String(err.digest)
+      : undefined
 
   await fetch('https://.../report-error', {
     method: 'POST',
     body: JSON.stringify({
       message,
+      digest,
       request,
       context,
     }),


### PR DESCRIPTION
### Fixes #94499


### Summary

The `Instrumentation.onRequestError` type currently exposes the error parameter as `unknown`, but the docs described it as `Error & { digest: string }` and the example accessed `err.message` directly.

This updates the docs/example to match the current type and narrows the caught value before reading `message`.

### Tests:
- `git diff --check`