### PR TITLE
fix(instrumentation): update onRequestError error type to match docs

### DIFF
--- a/packages/next/src/server/instrumentation/types.ts
+++ b/packages/next/src/server/instrumentation/types.ts
@@ -11,7 +11,7 @@ export type RequestErrorContext = {
 }
 
 export type InstrumentationOnRequestError = (
-  error: unknown,
+  error: Error & { digest?: string },
   errorRequest: Readonly<{
     path: string
     method: string


### PR DESCRIPTION
## Summary
Fixes the type signature for `onRequestError` within `InstrumentationModule` to reflect the documentation and reality of the Next.js runtime, solving #94499.

Currently, the error parameter is typed as `unknown`, forcing developers to implement unnatural casting when using the framework's own boilerplate code. This updates it to `Error & { digest?: string }` to exactly mirror the documentation at https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation#onrequesterror-optional

## Testing
Verified against TS compiler.