### PR TITLE
server component HMR: cancel superseded refreshes (1/3)

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -244,6 +244,9 @@ export function getDefineEnv({
     'process.env.__NEXT_CLIENT_VALIDATE_RSC_REQUEST_HEADERS': Boolean(
       config.experimental.validateRSCRequestHeaders
     ),
+    'process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION': Boolean(
+      config.experimental.serverComponentsHmrCancellation
+    ),
     'process.env.__NEXT_DYNAMIC_ON_HOVER': Boolean(
       config.experimental.dynamicOnHover
     ),

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -895,6 +895,9 @@ export async function handler(
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
             authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
+            serverComponentsHmrCancellation: Boolean(
+              nextConfig.experimental.serverComponentsHmrCancellation
+            ),
             useCacheTimeout: nextConfig.experimental.useCacheTimeout,
             cachedNavigations: Boolean(
               nextConfig.experimental.cachedNavigations

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -169,6 +169,7 @@ async function requestHandler(
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
         prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
+        serverComponentsHmrCancellation: false,
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
         cachedNavigations: Boolean(nextConfig.experimental.cachedNavigations),
         appShells: nextConfig.experimental.appShells,

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -389,6 +389,8 @@ function gesturePush(href: string, options?: NavigateOptions): void {
  * methods. Internal Next.js code should call the lower level methods directly
  * (although there's lots of existing code that doesn't do that).
  */
+let activeHmrRefreshController: AbortController | null = null
+
 export const publicAppRouterInstance: AppRouterInstance = {
   back: () => window.history.back(),
   forward: () => window.history.forward(),
@@ -488,11 +490,21 @@ export const publicAppRouterInstance: AppRouterInstance = {
       // Reset the known routes table so that route predictions are cleared
       // when routes change during development.
       resetKnownRoutes()
+      let signal: AbortSignal | undefined
+      let previousController: AbortController | null = null
+      if (process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION) {
+        const controller = new AbortController()
+        signal = controller.signal
+        previousController = activeHmrRefreshController
+        activeHmrRefreshController = controller
+      }
       startTransition(() => {
         dispatchAppRouterAction({
           type: ACTION_HMR_REFRESH,
+          signal,
         })
       })
+      previousController?.abort()
     }
   },
   // Default value. Each route segment provides its own value at runtime. Refer

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -66,6 +66,7 @@ export interface FetchServerResponseOptions {
   readonly flightRouterState: FlightRouterState
   readonly nextUrl: string | null
   readonly isHmrRefresh?: boolean
+  readonly signal?: AbortSignal
 }
 
 export type StaticStageData<
@@ -189,7 +190,8 @@ export async function fetchServerResponse(
       url,
       headers,
       'auto',
-      shouldImmediatelyDecode
+      shouldImmediatelyDecode,
+      options.signal
     )
 
     // If the fetch succeeds while we're in the offline state, notify the
@@ -303,6 +305,10 @@ export async function fetchServerResponse(
       debugInfo: flightResponsePromise._debugInfo ?? null,
     }
   } catch (err) {
+    if (options.signal?.aborted) {
+      throw err
+    }
+
     // If the fetch rejected due to a network error, wait for connectivity
     // to be restored and then retry. checkOfflineError returns true for
     // network errors (and starts the polling loop); returns false for

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -102,6 +102,10 @@ const enum NavigationTaskStatus {
  */
 const enum NavigationTaskExitStatus {
   /**
+   * The request was superseded by a newer navigation. No retry is needed.
+   */
+  Canceled = -1,
+  /**
    * No additional navigation is required.
    */
   Done = 0,
@@ -1383,7 +1387,8 @@ export function spawnDynamicRequests(
   // The original navigation's push/replace intent. Threaded through to the
   // server-patch retry logic so it can inherit the intent if the original
   // transition hasn't committed yet.
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  signal?: AbortSignal
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
   if (dynamicRequestTree === null) {
@@ -1407,7 +1412,8 @@ export function spawnDynamicRequests(
     primaryUrl,
     nextUrl,
     freshnessPolicy,
-    routeCacheEntry
+    routeCacheEntry,
+    signal
   )
 
   const separateRefreshUrls = accumulation.separateRefreshUrls
@@ -1459,7 +1465,8 @@ export function spawnDynamicRequests(
             // hard refresh.
             nextUrl,
             freshnessPolicy,
-            routeCacheEntry
+            routeCacheEntry,
+            signal
           )
         )
       }
@@ -1508,6 +1515,13 @@ async function finishNavigationTask(
   }
 
   switch (exitStatus) {
+    case NavigationTaskExitStatus.Canceled: {
+      // This navigation was superseded. Its cache nodes may already be reused
+      // by the next navigation, so leave them for the newer request to fulfill.
+      // If the tree was abandoned entirely, it can be garbage collected along
+      // with its unresolved promises.
+      return
+    }
     case NavigationTaskExitStatus.Done: {
       // The task has completely finished. There's no missing data. Exit.
       previousNavigationDidMismatch = false
@@ -1697,7 +1711,8 @@ async function fetchMissingDynamicData(
   url: URL,
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
-  routeCacheEntry: FulfilledRouteCacheEntry | null
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  signal?: AbortSignal
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
   url: URL
@@ -1708,6 +1723,7 @@ async function fetchMissingDynamicData(
       flightRouterState: dynamicRequestTree,
       nextUrl,
       isHmrRefresh: freshnessPolicy === FreshnessPolicy.HMRRefresh,
+      signal,
     })
     if (typeof result === 'string') {
       // fetchServerResponse will return an href to indicate that the SPA
@@ -1817,6 +1833,14 @@ async function fetchMissingDynamicData(
       seed,
     }
   } catch {
+    if (signal?.aborted) {
+      return {
+        exitStatus: NavigationTaskExitStatus.Canceled,
+        url,
+        seed: null,
+      }
+    }
+
     // This shouldn't happen because fetchServerResponse's entire body is
     // wrapped in a try/catch. If it does, though, it implies the server failed
     // to respond with any tree at all. So we must fall back to a hard retry.

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -1,10 +1,21 @@
 import type {
+  HmrRefreshAction,
   ReadonlyReducerState,
   ReducerState,
 } from '../router-reducer-types'
 import { refreshDynamicData } from './refresh-reducer'
 import { FreshnessPolicy } from '../ppr-navigations'
 
-export function hmrRefreshReducer(state: ReadonlyReducerState): ReducerState {
-  return refreshDynamicData(state, FreshnessPolicy.HMRRefresh)
+export function hmrRefreshReducer(
+  state: ReadonlyReducerState,
+  action: HmrRefreshAction
+): ReducerState {
+  // HMR actions may wait behind a Server Action in the router queue. If a
+  // newer generation superseded this one before it started, do not install a
+  // refresh tree whose request is already canceled.
+  if (action.signal?.aborted) {
+    return state
+  }
+
+  return refreshDynamicData(state, FreshnessPolicy.HMRRefresh, action.signal)
 }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -40,7 +40,8 @@ export function refreshReducer(
 
 export function refreshDynamicData(
   state: ReadonlyReducerState,
-  freshnessPolicy: FreshnessPolicy.RefreshAll | FreshnessPolicy.HMRRefresh
+  freshnessPolicy: FreshnessPolicy.RefreshAll | FreshnessPolicy.HMRRefresh,
+  signal?: AbortSignal
 ): ReducerState {
   // During a refresh, invalidate the BFCache, which may contain dynamic data.
   invalidateBfCache()
@@ -97,6 +98,7 @@ export function refreshDynamicData(
     // cache entry to mark as having a dynamic rewrite on mismatch. If a
     // mismatch occurs, the retry handler will traverse the known route tree
     // to find and mark the entry.
-    null
+    null,
+    signal
   )
 }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -37,6 +37,7 @@ export interface RefreshAction {
 
 export interface HmrRefreshAction {
   type: typeof ACTION_HMR_REFRESH
+  signal?: AbortSignal
 }
 
 export type ServerActionDispatcher = (

--- a/packages/next/src/client/components/router-reducer/router-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer.ts
@@ -41,7 +41,7 @@ function clientReducer(
       if (process.env.NODE_ENV === 'development') {
         const { hmrRefreshReducer } =
           require('./reducers/hmr-refresh-reducer') as typeof import('./reducers/hmr-refresh-reducer')
-        return hmrRefreshReducer(state)
+        return hmrRefreshReducer(state, action)
       } else {
         throw new Error(
           'hmrRefresh can only be used in development mode. Please use refresh instead.'

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -221,7 +221,8 @@ export function navigateToKnownRoute(
   // In these cases, if a mismatch occurs, we still mark the route as having a
   // dynamic rewrite by traversing the known route tree (see
   // dispatchRetryDueToTreeMismatch).
-  routeCacheEntry: FulfilledRouteCacheEntry | null
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  signal?: AbortSignal
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
@@ -272,7 +273,8 @@ export function navigateToKnownRoute(
         freshnessPolicy,
         accumulation,
         routeCacheEntry,
-        navigateType
+        navigateType,
+        signal
       )
     }
     return completeSoftNavigation(

--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -6,7 +6,13 @@ export interface DebugChannelReadableWriterPair {
   readonly writer: WritableStreamDefaultWriter<Uint8Array>
 }
 
+interface CancellationSafeDebugChannel {
+  readonly readable: ReadableStream<Uint8Array>
+  write(chunk: Uint8Array | null): void
+}
+
 const pairs = new Map<string, DebugChannelReadableWriterPair>()
+const cancellationSafeChannels = new Map<string, CancellationSafeDebugChannel>()
 
 const DB_NAME = '__next_debug_channel'
 const STORE_NAME = 'channels'
@@ -347,8 +353,6 @@ export function getOrCreateDebugChannelReadableWriterPair(
       })
       .finally(() => {
         pairs.delete(requestId)
-        // Release the buffered chunk bytes once the channel is done, whether or
-        // not we were able to persist them.
         if (chunks) {
           chunks.length = 0
         }
@@ -356,6 +360,80 @@ export function getOrCreateDebugChannelReadableWriterPair(
   }
 
   return pair
+}
+
+function getOrCreateCancellationSafeDebugChannel(
+  requestId: string
+): CancellationSafeDebugChannel {
+  let channel = cancellationSafeChannels.get(requestId)
+
+  if (!channel) {
+    const pair = getOrCreateDebugChannelReadableWriterPair(requestId)
+    let acceptingChunks = true
+    let serverClosed = false
+    let pendingWrite = Promise.resolve()
+
+    pair.writer.closed.then(
+      () => {
+        acceptingChunks = false
+      },
+      () => {
+        acceptingChunks = false
+      }
+    )
+
+    channel = {
+      readable: pair.readable,
+      write(chunk) {
+        if (serverClosed || (!acceptingChunks && chunk !== null)) {
+          return
+        }
+        if (chunk === null) {
+          serverClosed = true
+        }
+
+        pendingWrite = pendingWrite
+          .then(async () => {
+            if (!acceptingChunks) {
+              return
+            }
+            await pair.writer.ready
+            if (chunk === null) {
+              acceptingChunks = false
+              await pair.writer.close()
+            } else {
+              await pair.writer.write(chunk)
+            }
+          })
+          .catch(() => {
+            acceptingChunks = false
+          })
+          .finally(() => {
+            if (chunk === null) {
+              cancellationSafeChannels.delete(requestId)
+            }
+          })
+      },
+    }
+    cancellationSafeChannels.set(requestId, channel)
+  }
+
+  return channel
+}
+
+export function writeDebugChannelChunk(
+  requestId: string,
+  chunk: Uint8Array | null
+): void {
+  getOrCreateCancellationSafeDebugChannel(requestId).write(chunk)
+}
+
+function getDebugChannelReadable(
+  requestId: string
+): ReadableStream<Uint8Array> {
+  return process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION
+    ? getOrCreateCancellationSafeDebugChannel(requestId).readable
+    : getOrCreateDebugChannelReadableWriterPair(requestId).readable
 }
 
 export function createDebugChannel(
@@ -402,9 +480,7 @@ export function createDebugChannel(
     }
   }
 
-  const { readable } = getOrCreateDebugChannelReadableWriterPair(requestId)
-
-  return { readable }
+  return { readable: getDebugChannelReadable(requestId) }
 }
 
 /**
@@ -449,7 +525,7 @@ function createDeferredDebugChannelReadable(
 
       const source = wasServedFromCacheAtPageshow(getNavigationEntry())
         ? restoreDebugChannelOrReload(requestId)
-        : getOrCreateDebugChannelReadableWriterPair(requestId).readable
+        : getDebugChannelReadable(requestId)
 
       const reader = source.getReader()
       try {

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -37,7 +37,10 @@ import {
   type GlobalErrorState,
 } from '../../../components/app-router-instance'
 import { InvariantError } from '../../../../shared/lib/invariant-error'
-import { getOrCreateDebugChannelReadableWriterPair } from '../../debug-channel'
+import {
+  getOrCreateDebugChannelReadableWriterPair,
+  writeDebugChannelChunk,
+} from '../../debug-channel'
 // TODO: Explicitly import from client.browser (doesn't work with Webpack).
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createFromReadableStream as createFromReadableStreamBrowser } from 'react-server-dom-webpack/client'
@@ -470,18 +473,20 @@ export function processMessage(
     }
     case HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK: {
       const { requestId, chunk } = message
-      const { writer } = getOrCreateDebugChannelReadableWriterPair(requestId)
-
-      if (chunk) {
-        writer.ready.then(() => writer.write(chunk)).catch(console.error)
-      } else {
-        // A null chunk signals that no more chunks will be sent, which allows
-        // us to close the writer.
-        // TODO: Revisit this cleanup logic when we integrate the return channel
-        // that keeps the connection open to be able to lazily retrieve debug
-        // objects.
-        writer.ready.then(() => writer.close()).catch(console.error)
+      if (!process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION) {
+        const { writer } = getOrCreateDebugChannelReadableWriterPair(requestId)
+        writer.ready
+          .then(() => (chunk ? writer.write(chunk) : writer.close()))
+          .catch(console.error)
+        return
       }
+
+      // A null chunk signals that no more chunks will be sent, which allows
+      // us to close the writer.
+      // TODO: Revisit this cleanup logic when we integrate the return channel
+      // that keeps the connection open to be able to lazily retrieve debug
+      // objects.
+      writeDebugChannelChunk(requestId, chunk)
 
       return
     }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -172,7 +172,9 @@ import {
   getClientComponentLoaderMetrics,
   wrapClientComponentLoader,
 } from '../client-component-renderer-logger'
-import { isNodeNextRequest } from '../base-http/helpers'
+import { isNodeNextRequest, isNodeNextResponse } from '../base-http/helpers'
+import { signalFromNodeResponse } from '../web/spec-extension/adapters/next-request'
+import { isAbortError } from '../pipe-readable'
 import {
   parseRelativeUrl,
   type ParsedRelativeUrl,
@@ -1489,6 +1491,25 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     setCacheStatus,
     isBuildTimePrerendering = false,
   } = renderOpts
+  const hmrRequestAbortSignal =
+    renderOpts.experimental.serverComponentsHmrCancellation &&
+    initialRequestStore.isHmrRefresh === true &&
+    isNodeNextResponse(ctx.res)
+      ? signalFromNodeResponse(ctx.res.originalResponse)
+      : undefined
+  const createAbortedRenderResult = () =>
+    new FlightRenderResult(
+      new ReadableStream({
+        start(controller) {
+          controller.close()
+        },
+      }),
+      { fetchMetrics: workStore.fetchMetrics }
+    )
+
+  if (hmrRequestAbortSignal?.aborted) {
+    return createAbortedRenderResult()
+  }
 
   let didErrorObservably = false
   function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
@@ -1512,6 +1533,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
   // instant configs exist, since we render all the layouts necessary to perform
   // the validation in those cases.
   const shouldValidate =
+    !hmrRequestAbortSignal?.aborted &&
     !isBypassingCachesInDev(initialRequestStore, workStore) &&
     (initialRequestStore.isHmrRefresh === true ||
       (await anySegmentNeedsInstantValidationInDev(loaderTree)))
@@ -1559,6 +1581,35 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       setCacheStatus('ready', htmlRequestId)
     }
 
+    const renderResult = await (
+      process.env.__NEXT_USE_NODE_STREAMS
+        ? renderWithRestartOnCacheMissInDevNode(
+            ctx,
+            initialRequestStore,
+            createRequestStore,
+            getPayload,
+            onError,
+            hmrRequestAbortSignal
+          )
+        : renderWithRestartOnCacheMissInDevWeb(
+            ctx,
+            initialRequestStore,
+            createRequestStore,
+            getPayload,
+            onError,
+            hmrRequestAbortSignal
+          )
+    ).catch((err) => {
+      if (hmrRequestAbortSignal?.aborted && isAbortError(err)) {
+        return null
+      }
+      throw err
+    })
+
+    if (renderResult === null) {
+      return createAbortedRenderResult()
+    }
+
     const {
       stream: serverStream,
       accumulatedChunksPromise,
@@ -1568,21 +1619,14 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       runtimeStageEndTime,
       debugChannel: returnedDebugChannel,
       requestStore: finalRequestStore,
-    } = await (process.env.__NEXT_USE_NODE_STREAMS
-      ? renderWithRestartOnCacheMissInDevNode(
-          ctx,
-          initialRequestStore,
-          createRequestStore,
-          getPayload,
-          onError
-        )
-      : renderWithRestartOnCacheMissInDevWeb(
-          ctx,
-          initialRequestStore,
-          createRequestStore,
-          getPayload,
-          onError
-        ))
+    } = renderResult
+
+    if (hmrRequestAbortSignal?.aborted) {
+      accumulatedChunksPromise.catch(() => {})
+      return new FlightRenderResult(serverStream, {
+        fetchMetrics: workStore.fetchMetrics,
+      })
+    }
 
     if (shouldValidate) {
       let validationDebugChannelClient: AnyStream | undefined = undefined
@@ -1603,7 +1647,8 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
         finalRequestStore,
         fallbackParams,
         validationDebugChannelClient,
-        didErrorObservably
+        didErrorObservably,
+        hmrRequestAbortSignal
       )
     } else {
       logValidationSkipped(ctx)
@@ -1617,6 +1662,10 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       // for the full stream to finish accumulating so we also catch errors from
       // the dynamic stage.
       void accumulatedChunksPromise.then(() => {
+        if (hmrRequestAbortSignal?.aborted) {
+          return
+        }
+
         const { invalidDynamicUsageError } = workStore
         // Forward only if userland caught the rejection. If userland didn't
         // catch, the rejection propagated into the React render and React's
@@ -4767,12 +4816,82 @@ async function renderToStream(
   /* eslint-enable @next/internal/no-ambiguous-jsx */
 }
 
+function abortControllerOnSignal(
+  controller: AbortController,
+  signal: AbortSignal | undefined
+): void {
+  if (!signal) {
+    return
+  }
+
+  const abort = () => controller.abort(signal.reason)
+  if (signal.aborted) {
+    abort()
+  } else {
+    signal.addEventListener('abort', abort, { once: true })
+  }
+}
+
+function abortRenderControllersOnSignal(
+  reactController: AbortController,
+  dataController: AbortController,
+  signal: AbortSignal | undefined
+): void {
+  if (!signal) {
+    return
+  }
+
+  const abortOutput = () => {
+    const reason = signal.reason
+
+    // Stop consuming output before aborting React. React emits terminal Flight
+    // chunks during abort, which must not race with a closing HMR response.
+    dataController.abort(reason)
+    return reason
+  }
+  if (signal.aborted) {
+    reactController.abort(abortOutput())
+  } else {
+    signal.addEventListener(
+      'abort',
+      () => {
+        const reason = abortOutput()
+        queueMicrotask(() => reactController.abort(reason))
+      },
+      { once: true }
+    )
+  }
+}
+
+async function waitForCacheReadyOrRequestAbort(
+  cacheSignal: CacheSignal,
+  requestAbortSignal: AbortSignal | undefined
+): Promise<boolean> {
+  if (!requestAbortSignal) {
+    await cacheSignal.cacheReady()
+    return false
+  }
+  if (requestAbortSignal.aborted) {
+    return true
+  }
+
+  return new Promise((resolve) => {
+    const onAbort = () => resolve(true)
+    requestAbortSignal.addEventListener('abort', onAbort, { once: true })
+    cacheSignal.cacheReady().then(() => {
+      requestAbortSignal.removeEventListener('abort', onAbort)
+      resolve(false)
+    })
+  })
+}
+
 async function renderWithRestartOnCacheMissInDevWeb(
   ctx: AppRenderContext,
   initialRequestStore: RequestStore,
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
-  onError: (error: unknown) => void
+  onError: (error: unknown) => void,
+  requestAbortSignal?: AbortSignal
 ) {
   const { htmlRequestId, renderOpts } = ctx
 
@@ -4873,13 +4992,9 @@ async function renderWithRestartOnCacheMissInDevWeb(
       // If we abort the render, we want to reject the stage-dependent promises as well.
       // Note that we want to install this listener after the render is started
       // so that it runs after react is finished running its abort code.
-      initialReactController.signal.addEventListener(
-        'abort',
-        () => {
-          const { reason } = initialReactController.signal
-          initialDataController.abort(reason)
-        },
-        { once: true }
+      abortControllerOnSignal(
+        initialDataController,
+        initialReactController.signal
       )
 
       const stream = streamPair[0]
@@ -4894,12 +5009,17 @@ async function renderWithRestartOnCacheMissInDevWeb(
         () => {
           accumulatedChunksPromise.catch(() => {})
           if (stream instanceof ReadableStream) {
-            stream.cancel()
+            void stream.cancel().catch(() => {})
           } else {
             stream.destroy()
           }
         },
         { once: true }
+      )
+      abortRenderControllersOnSignal(
+        initialReactController,
+        initialDataController,
+        requestAbortSignal
       )
 
       return {
@@ -4932,19 +5052,20 @@ async function renderWithRestartOnCacheMissInDevWeb(
       advanceStageIfNoCacheMiss(RenderStage.Dynamic)
     }
   )
+  const getInitialRenderResult = () => ({
+    stream: initialStreamResult.stream,
+    accumulatedChunksPromise: initialStreamResult.accumulatedChunksPromise,
+    syncInterruptReason: initialStageController.getSyncInterruptReason(),
+    startTime,
+    staticStageEndTime: initialStageController.getStaticStageEndTime(),
+    runtimeStageEndTime: initialStageController.getRuntimeStageEndTime(),
+    debugChannel,
+    requestStore,
+  })
 
   if (initialStageController.currentStage !== RenderStage.Abandoned) {
     // No cache misses. We can use the result as-is.
-    return {
-      stream: initialStreamResult.stream,
-      accumulatedChunksPromise: initialStreamResult.accumulatedChunksPromise,
-      syncInterruptReason: initialStageController.getSyncInterruptReason(),
-      startTime,
-      staticStageEndTime: initialStageController.getStaticStageEndTime(),
-      runtimeStageEndTime: initialStageController.getRuntimeStageEndTime(),
-      debugChannel,
-      requestStore,
-    }
+    return getInitialRenderResult()
   }
 
   if (process.env.__NEXT_DEV_SERVER && setCacheStatus) {
@@ -4960,7 +5081,9 @@ async function renderWithRestartOnCacheMissInDevWeb(
   // Ideally we'd only wait for caches that are needed in the static stage.
   // This will be optimized in the future by not allowing runtime/dynamic APIs to resolve.
 
-  await cacheSignal.cacheReady()
+  if (await waitForCacheReadyOrRequestAbort(cacheSignal, requestAbortSignal)) {
+    return getInitialRenderResult()
+  }
   workUnitAsyncStorage.run(
     requestStore,
     initialReactController.abort.bind(initialReactController)
@@ -4975,12 +5098,15 @@ async function renderWithRestartOnCacheMissInDevWeb(
 
   const finalStageController = new StagedRenderingController({
     // We are going to render this pass all the way through because we've already
-    // filled any caches so we won't be aborting this time.
+    // filled any caches so cache misses won't abort this time. The response signal
+    // independently aborts the React render and stream accumulation.
     abortSignal: null,
     abandonController: null,
     shouldTrackSyncIO: true,
     finalStage: null,
   })
+  const finalReactController = new AbortController()
+  const finalDataController = new AbortController()
 
   // We've filled the caches, so now we can render as usual,
   // without any cache-filling mechanics.
@@ -5003,6 +5129,9 @@ async function renderWithRestartOnCacheMissInDevWeb(
   // Note: The stage controller starts out in the `Before` stage,
   // where sync IO does not cause aborts, so it's okay if it happens before render.
   const finalRscPayload = await getPayload(requestStore)
+  if (requestAbortSignal?.aborted) {
+    return getInitialRenderResult()
+  }
 
   const finalStreamResult = await runInSequentialTasks(
     () => {
@@ -5022,17 +5151,39 @@ async function renderWithRestartOnCacheMissInDevWeb(
             startTime,
             filterStackFrame,
             debugChannel: debugChannel?.serverSide,
+            signal: finalReactController.signal,
           }
         )
       )
 
+      abortControllerOnSignal(finalDataController, finalReactController.signal)
+      const stream = streamPair[0]
+      const accumulatedChunksPromise = accumulateStreamChunks(
+        streamPair[1],
+        finalStageController,
+        finalDataController.signal
+      )
+      finalDataController.signal.addEventListener(
+        'abort',
+        () => {
+          accumulatedChunksPromise.catch(() => {})
+          if (stream instanceof ReadableStream) {
+            void stream.cancel().catch(() => {})
+          } else {
+            stream.destroy()
+          }
+        },
+        { once: true }
+      )
+      abortRenderControllersOnSignal(
+        finalReactController,
+        finalDataController,
+        requestAbortSignal
+      )
+
       return {
-        stream: streamPair[0],
-        accumulatedChunksPromise: accumulateStreamChunks(
-          streamPair[1],
-          finalStageController,
-          null
-        ),
+        stream,
+        accumulatedChunksPromise,
       }
     },
     () => {
@@ -5105,7 +5256,8 @@ async function renderWithRestartOnCacheMissInDevNode(
   initialRequestStore: RequestStore,
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
-  onError: (error: unknown) => void
+  onError: (error: unknown) => void,
+  requestAbortSignal?: AbortSignal
 ) {
   const { htmlRequestId, renderOpts } = ctx
 
@@ -5205,13 +5357,9 @@ async function renderWithRestartOnCacheMissInDevNode(
       // If we abort the render, we want to reject the stage-dependent promises as well.
       // Note that we want to install this listener after the render is started
       // so that it runs after react is finished running its abort code.
-      initialReactController.signal.addEventListener(
-        'abort',
-        () => {
-          const { reason } = initialReactController.signal
-          initialDataController.abort(reason)
-        },
-        { once: true }
+      abortControllerOnSignal(
+        initialDataController,
+        initialReactController.signal
       )
 
       const stream = replayable.createReplayStream()
@@ -5228,6 +5376,11 @@ async function renderWithRestartOnCacheMissInDevNode(
           stream.destroy()
         },
         { once: true }
+      )
+      abortRenderControllersOnSignal(
+        initialReactController,
+        initialDataController,
+        requestAbortSignal
       )
 
       return {
@@ -5260,19 +5413,20 @@ async function renderWithRestartOnCacheMissInDevNode(
       advanceStageIfNoCacheMiss(RenderStage.Dynamic)
     }
   )
+  const getInitialRenderResult = () => ({
+    stream: initialStreamResult.stream,
+    accumulatedChunksPromise: initialStreamResult.accumulatedChunksPromise,
+    syncInterruptReason: initialStageController.getSyncInterruptReason(),
+    startTime,
+    staticStageEndTime: initialStageController.getStaticStageEndTime(),
+    runtimeStageEndTime: initialStageController.getRuntimeStageEndTime(),
+    debugChannel,
+    requestStore,
+  })
 
   if (initialStageController.currentStage !== RenderStage.Abandoned) {
     // No cache misses. We can use the result as-is.
-    return {
-      stream: initialStreamResult.stream,
-      accumulatedChunksPromise: initialStreamResult.accumulatedChunksPromise,
-      syncInterruptReason: initialStageController.getSyncInterruptReason(),
-      startTime,
-      staticStageEndTime: initialStageController.getStaticStageEndTime(),
-      runtimeStageEndTime: initialStageController.getRuntimeStageEndTime(),
-      debugChannel,
-      requestStore,
-    }
+    return getInitialRenderResult()
   }
 
   if (process.env.__NEXT_DEV_SERVER && setCacheStatus) {
@@ -5288,7 +5442,9 @@ async function renderWithRestartOnCacheMissInDevNode(
   // Ideally we'd only wait for caches that are needed in the static stage.
   // This will be optimized in the future by not allowing runtime/dynamic APIs to resolve.
 
-  await cacheSignal.cacheReady()
+  if (await waitForCacheReadyOrRequestAbort(cacheSignal, requestAbortSignal)) {
+    return getInitialRenderResult()
+  }
   workUnitAsyncStorage.run(
     requestStore,
     initialReactController.abort.bind(initialReactController)
@@ -5303,12 +5459,15 @@ async function renderWithRestartOnCacheMissInDevNode(
 
   const finalStageController = new StagedRenderingController({
     // We are going to render this pass all the way through because we've already
-    // filled any caches so we won't be aborting this time.
+    // filled any caches so cache misses won't abort this time. The response signal
+    // independently aborts the React render and stream accumulation.
     abortSignal: null,
     abandonController: null,
     shouldTrackSyncIO: true,
     finalStage: null,
   })
+  const finalReactController = new AbortController()
+  const finalDataController = new AbortController()
 
   // We've filled the caches, so now we can render as usual,
   // without any cache-filling mechanics.
@@ -5331,6 +5490,9 @@ async function renderWithRestartOnCacheMissInDevNode(
   // Note: The stage controller starts out in the `Before` stage,
   // where sync IO does not cause aborts, so it's okay if it happens before render.
   const finalRscPayload = await getPayload(requestStore)
+  if (requestAbortSignal?.aborted) {
+    return getInitialRenderResult()
+  }
 
   const finalStreamResult = await runInSequentialTasks(
     () => {
@@ -5349,17 +5511,34 @@ async function renderWithRestartOnCacheMissInDevNode(
           startTime,
           filterStackFrame,
           debugChannel: debugChannel?.serverSide,
+          signal: finalReactController.signal,
         }
       ) as Readable
       const finalReplayable = new ReplayableNodeStream(finalSourceStream)
+      abortControllerOnSignal(finalDataController, finalReactController.signal)
+      const stream = finalReplayable.createReplayStream()
+      const accumulatedChunksPromise = accumulateStreamChunks(
+        finalReplayable.createReplayStream(),
+        finalStageController,
+        finalDataController.signal
+      )
+      finalDataController.signal.addEventListener(
+        'abort',
+        () => {
+          accumulatedChunksPromise.catch(() => {})
+          stream.destroy()
+        },
+        { once: true }
+      )
+      abortRenderControllersOnSignal(
+        finalReactController,
+        finalDataController,
+        requestAbortSignal
+      )
 
       return {
-        stream: finalReplayable.createReplayStream(),
-        accumulatedChunksPromise: accumulateStreamChunks(
-          finalReplayable.createReplayStream(),
-          finalStageController,
-          null
-        ),
+        stream,
+        accumulatedChunksPromise,
       }
     },
     () => {
@@ -5819,26 +5998,35 @@ function logValidationSkipped(ctx: AppRenderContext) {
 async function spawnStaticShellValidationInDev(
   ...args: Parameters<typeof spawnStaticShellValidationInDevImpl>
 ) {
-  if (process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION) {
-    const ctx: AppRenderContext = args[5]
-    const requestId = ctx.requestId
-    const url = ctx.url.href
-    console.log(
-      '<VALIDATION_MESSAGE>' +
-        JSON.stringify({ type: 'validation_start', requestId, url }) +
-        '</VALIDATION_MESSAGE>'
-    )
-    try {
-      return await spawnStaticShellValidationInDevImpl(...args)
-    } finally {
+  const requestAbortSignal = args[10]
+
+  try {
+    if (process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION) {
+      const ctx: AppRenderContext = args[5]
+      const requestId = ctx.requestId
+      const url = ctx.url.href
       console.log(
         '<VALIDATION_MESSAGE>' +
-          JSON.stringify({ type: 'validation_end', requestId, url }) +
+          JSON.stringify({ type: 'validation_start', requestId, url }) +
           '</VALIDATION_MESSAGE>'
       )
+      try {
+        return await spawnStaticShellValidationInDevImpl(...args)
+      } finally {
+        console.log(
+          '<VALIDATION_MESSAGE>' +
+            JSON.stringify({ type: 'validation_end', requestId, url }) +
+            '</VALIDATION_MESSAGE>'
+        )
+      }
+    } else {
+      return await spawnStaticShellValidationInDevImpl(...args)
     }
-  } else {
-    return await spawnStaticShellValidationInDevImpl(...args)
+  } catch (err) {
+    if (requestAbortSignal?.aborted && isAbortError(err)) {
+      return
+    }
+    throw err
   }
 }
 
@@ -5858,8 +6046,14 @@ async function spawnStaticShellValidationInDevImpl(
   requestStore: RequestStore,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   debugChannelClient: AnyStream | undefined,
-  devRenderDidError: boolean
+  devRenderDidError: boolean,
+  requestAbortSignal?: AbortSignal
 ): Promise<void> {
+  if (requestAbortSignal?.aborted) {
+    return
+  }
+  const isRequestAborted = () => requestAbortSignal?.aborted === true
+
   const debug =
     process.env.NEXT_PRIVATE_DEBUG_VALIDATION === '1' ? console.log : undefined
 
@@ -5889,14 +6083,20 @@ async function spawnStaticShellValidationInDevImpl(
     // `serverComponentsErrorHandler` already stamped a digest on the error and
     // emitted it as a Flight error chunk — surfacing it again here would
     // duplicate the entry in the dev overlay.
-    if (!(invalidDynamicUsageError as { digest?: unknown }).digest) {
+    if (
+      !isRequestAborted() &&
+      !(invalidDynamicUsageError as { digest?: unknown }).digest
+    ) {
       return logMessagesAndSendErrorsToBrowser([invalidDynamicUsageError], ctx)
     }
     return
   }
 
   if (syncInterruptReason) {
-    return logMessagesAndSendErrorsToBrowser([syncInterruptReason], ctx)
+    if (!isRequestAborted()) {
+      return logMessagesAndSendErrorsToBrowser([syncInterruptReason], ctx)
+    }
+    return
   }
 
   let debugChunks: Uint8Array[] | null = null
@@ -5910,10 +6110,17 @@ async function spawnStaticShellValidationInDevImpl(
   }
 
   const accumulatedChunks = await accumulatedChunksPromise
+  if (requestAbortSignal?.aborted) {
+    return
+  }
+
   const { staticChunks, runtimeChunks, dynamicChunks } = accumulatedChunks
 
   const needsInstantValidation =
     await anySegmentNeedsInstantValidationInDev(loaderTree)
+  if (isRequestAborted()) {
+    return
+  }
 
   // `samples` from instant config are only used during build
   const validationSamples = null
@@ -5933,8 +6140,12 @@ async function spawnStaticShellValidationInDevImpl(
     fallbackRouteParams,
     ctx,
     validationSamples,
-    validationSampleTracking
+    validationSampleTracking,
+    requestAbortSignal
   )
+  if (isRequestAborted()) {
+    return
+  }
 
   debug?.(`Starting static shell validation...`)
 
@@ -5948,14 +6159,21 @@ async function spawnStaticShellValidationInDevImpl(
     allowEmptyStaticShell,
     ctx,
     hmrRefreshHash,
-    trackDynamicHoleInRuntimeShell
+    trackDynamicHoleInRuntimeShell,
+    requestAbortSignal
   )
+  if (isRequestAborted()) {
+    return
+  }
 
   if (runtimeResult.length > 0) {
     debug?.(`❌ Failed - ${runtimeResult.length} errors from runtime stage`)
     // We have something to report from the runtime validation
     // We can skip the rest
-    return logMessagesAndSendErrorsToBrowser(runtimeResult, ctx)
+    if (!isRequestAborted()) {
+      return logMessagesAndSendErrorsToBrowser(runtimeResult, ctx)
+    }
+    return
   }
 
   const staticResult = await validateStagedShell(
@@ -5968,14 +6186,21 @@ async function spawnStaticShellValidationInDevImpl(
     allowEmptyStaticShell,
     ctx,
     hmrRefreshHash,
-    trackDynamicHoleInStaticShell
+    trackDynamicHoleInStaticShell,
+    requestAbortSignal
   )
+  if (isRequestAborted()) {
+    return
+  }
 
   if (staticResult.length > 0) {
     debug?.(`❌ Failed - ${staticResult.length} errors from static stage`)
     // We have something to report from the static validation
     // We can skip the rest
-    return logMessagesAndSendErrorsToBrowser(staticResult, ctx)
+    if (!isRequestAborted()) {
+      return logMessagesAndSendErrorsToBrowser(staticResult, ctx)
+    }
+    return
   }
   debug?.(`✅ Passed`)
 
@@ -5989,10 +6214,11 @@ async function spawnStaticShellValidationInDevImpl(
       ctx,
       hmrRefreshHash,
       validationSamples,
-      devRenderDidError
+      devRenderDidError,
+      requestAbortSignal
     )
 
-    if (instantConfigsResult.length > 0) {
+    if (!isRequestAborted() && instantConfigsResult.length > 0) {
       return logMessagesAndSendErrorsToBrowser(instantConfigsResult, ctx)
     }
   }
@@ -6006,7 +6232,8 @@ async function warmupClientModulesForStagedValidation(
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   ctx: AppRenderContext,
   validationSamples: ValidationStoreClient['validationSamples'],
-  validationSampleTracking: ValidationStoreClient['validationSampleTracking']
+  validationSampleTracking: ValidationStoreClient['validationSampleTracking'],
+  requestAbortSignal?: AbortSignal
 ) {
   const { implicitTags, nonce, workStore } = ctx
 
@@ -6014,6 +6241,7 @@ async function warmupClientModulesForStagedValidation(
   const initialClientPrerenderController = new AbortController()
   const initialClientReactController = new AbortController()
   const initialClientRenderController = new AbortController()
+  abortControllerOnSignal(initialClientReactController, requestAbortSignal)
 
   const preinitScripts = () => {}
   const { ServerInsertedHTMLProvider } = createServerInsertedHTML()
@@ -6132,12 +6360,9 @@ async function warmupClientModulesForStagedValidation(
   // The listener to abort our own render controller must be added after React
   // has added its listener, to ensure that pending I/O is not
   // aborted/rejected too early.
-  initialClientReactController.signal.addEventListener(
-    'abort',
-    () => {
-      initialClientRenderController.abort()
-    },
-    { once: true }
+  abortControllerOnSignal(
+    initialClientRenderController,
+    initialClientReactController.signal
   )
 
   pendingInitialClientResult.catch((err: unknown) => {
@@ -6164,7 +6389,9 @@ async function warmupClientModulesForStagedValidation(
   // Promises passed to client were already awaited above (assuming that they came from cached functions)
   const cacheSignal = new CacheSignal()
   trackPendingModules(cacheSignal)
-  await cacheSignal.cacheReady()
+  if (await waitForCacheReadyOrRequestAbort(cacheSignal, requestAbortSignal)) {
+    return
+  }
   workUnitAsyncStorage.run(
     initialClientPrerenderStore,
     initialClientReactController.abort.bind(initialClientReactController)
@@ -6183,7 +6410,8 @@ async function validateStagedShell(
   hmrRefreshHash: string | undefined,
   trackDynamicHole:
     | typeof trackDynamicHoleInStaticShell
-    | typeof trackDynamicHoleInRuntimeShell
+    | typeof trackDynamicHoleInRuntimeShell,
+  requestAbortSignal?: AbortSignal
 ): Promise<Array<unknown>> {
   const { implicitTags, nonce, workStore } = ctx
 
@@ -6192,6 +6420,7 @@ async function validateStagedShell(
   )
   const clientReactController = new AbortController()
   const clientRenderController = new AbortController()
+  abortControllerOnSignal(clientReactController, requestAbortSignal)
 
   const preinitScripts = () => {}
   const { ServerInsertedHTMLProvider } = createServerInsertedHTML()
@@ -6285,12 +6514,9 @@ async function validateStagedShell(
         // The listener to abort our own render controller must be added after
         // React has added its listener, to ensure that pending I/O is not
         // aborted/rejected too early.
-        clientReactController.signal.addEventListener(
-          'abort',
-          () => {
-            clientRenderController.abort()
-          },
-          { once: true }
+        abortControllerOnSignal(
+          clientRenderController,
+          clientReactController.signal
         )
 
         return pendingFinalClientResult
@@ -6311,6 +6537,10 @@ async function validateStagedShell(
       allowEmptyStaticShell
     )
   } catch (thrownValue) {
+    if (requestAbortSignal?.aborted) {
+      return []
+    }
+
     // Even if the root errors we still want to report any cache components errors
     // that were discovered before the root errored.
     let errors: Array<unknown> = getStaticShellDisallowedDynamicReasons(
@@ -6348,8 +6578,13 @@ async function validateInstantConfigs(
   ctx: AppRenderContext,
   hmrRefreshHash: string | undefined,
   validationSamples: ValidationStoreClient['validationSamples'] | null,
-  devRenderDidError: boolean
+  devRenderDidError: boolean,
+  requestAbortSignal?: AbortSignal
 ): Promise<Array<unknown>> {
+  if (requestAbortSignal?.aborted) {
+    return []
+  }
+
   const debug =
     process.env.NEXT_PRIVATE_DEBUG_VALIDATION === '1' ? console.log : undefined
 
@@ -6379,24 +6614,37 @@ async function validateInstantConfigs(
     ? createNodeDebugChannel
     : createWebDebugChannel
 
+  let collectedSegmentData: Awaited<ReturnType<typeof collectStagedSegmentData>>
+  try {
+    collectedSegmentData = await collectStagedSegmentData(
+      ctx.componentMod,
+      renderFlightStream,
+      {
+        [RenderStage.Static]: accumulatedChunks.staticChunks,
+        [RenderStage.Runtime]: accumulatedChunks.runtimeChunks,
+        [RenderStage.Dynamic]: accumulatedChunks.dynamicChunks,
+      },
+      debugChunks,
+      startTime,
+      hasRuntimePrefetch,
+      clientReferenceManifest,
+      createDebugChannel,
+      requestAbortSignal
+    )
+  } catch (thrownValue) {
+    if (requestAbortSignal?.aborted) {
+      return []
+    }
+    throw thrownValue
+  }
   const {
     cache,
     payload: initialRscPayload,
     stageEndTimes,
-  } = await collectStagedSegmentData(
-    ctx.componentMod,
-    renderFlightStream,
-    {
-      [RenderStage.Static]: accumulatedChunks.staticChunks,
-      [RenderStage.Runtime]: accumulatedChunks.runtimeChunks,
-      [RenderStage.Dynamic]: accumulatedChunks.dynamicChunks,
-    },
-    debugChunks,
-    startTime,
-    hasRuntimePrefetch,
-    clientReferenceManifest,
-    createDebugChannel
-  )
+  } = collectedSegmentData
+  if (requestAbortSignal?.aborted) {
+    return []
+  }
 
   const { implicitTags, nonce, workStore } = ctx
   const isDebugChannelEnabled = !!ctx.renderOpts.setReactDebugChannel
@@ -6413,7 +6661,12 @@ async function validateInstantConfigs(
     groupDepthForValidation: number,
     previousBoundaryState: null | ValidationBoundaryTracking
   ): Promise<null | NavigationValidationResult> {
+    if (requestAbortSignal?.aborted) {
+      return null
+    }
+
     const extraChunksController = new AbortController()
+    abortControllerOnSignal(extraChunksController, requestAbortSignal)
 
     const boundaryState = createValidationBoundaryTracking()
     let useRuntimeStageForPartialSegments = false
@@ -6440,12 +6693,13 @@ async function validateInstantConfigs(
       useRuntimeStageForPartialSegments
     )
 
-    if (payloadResult === null) {
+    if (requestAbortSignal?.aborted || payloadResult === null) {
       return null
     }
 
     const reactController = new AbortController()
     const renderController = new AbortController()
+    abortControllerOnSignal(reactController, requestAbortSignal)
     const preinitScripts = () => {}
     const { ServerInsertedHTMLProvider } = createServerInsertedHTML()
 
@@ -6461,6 +6715,9 @@ async function validateInstantConfigs(
         isDebugChannelEnabled,
         createDebugChannel
       )
+    if (requestAbortSignal?.aborted) {
+      return null
+    }
 
     const instantValidationState = createInstantValidationState(
       payloadResult.slotStacks
@@ -6572,13 +6829,7 @@ async function validateInstantConfigs(
             }
           )
 
-          reactController.signal.addEventListener(
-            'abort',
-            () => {
-              renderController.abort()
-            },
-            { once: true }
-          )
+          abortControllerOnSignal(renderController, reactController.signal)
 
           return pendingResult
         },
@@ -6601,6 +6852,10 @@ async function validateInstantConfigs(
         devRenderDidError
       )
     } catch (thrownValue) {
+      if (requestAbortSignal?.aborted) {
+        return null
+      }
+
       result = getNavigationDisallowedDynamicReasons(
         workStore,
         PreludeState.Errored,
@@ -6620,7 +6875,11 @@ async function validateInstantConfigs(
       return result
     }
 
-    if (previousBoundaryState === null && payloadResult.hasAmbiguousErrors) {
+    if (
+      !requestAbortSignal?.aborted &&
+      previousBoundaryState === null &&
+      payloadResult.hasAmbiguousErrors
+    ) {
       // This is the first validation attempt. we prepared a payload where dynamic holes might be runtime data dependencies
       // or dynamic data dependencies. We do a followup validation using a payload with only Runtime segments to discriminate
       const dynamicOnlyResult = await validateAtDepthImpl(
@@ -6648,6 +6907,10 @@ async function validateInstantConfigs(
   let impairedValidation: null | Error | AggregateError = null
 
   for (let depth = maxDepth - 1; depth >= 0; depth--) {
+    if (requestAbortSignal?.aborted) {
+      return []
+    }
+
     const maxGroupDepth = groupDepthsByUrlDepth[depth]
 
     for (
@@ -6655,6 +6918,10 @@ async function validateInstantConfigs(
       currentGroupDepth >= 0;
       currentGroupDepth--
     ) {
+      if (requestAbortSignal?.aborted) {
+        return []
+      }
+
       debug?.(
         `Trying depth ${depth}` +
           (currentGroupDepth > 0

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -222,7 +222,8 @@ export async function collectStagedSegmentData(
   startTime: number,
   hasRuntimePrefetch: boolean,
   clientReferenceManifest: ClientReferenceManifest,
-  createDebugChannel: () => DebugChannelPair | undefined
+  createDebugChannel: () => DebugChannelPair | undefined,
+  abortSignal?: AbortSignal
 ) {
   const debugChannelAbortController = new AbortController()
   const debugStream = fullPageDebugChunks
@@ -233,6 +234,17 @@ export async function collectStagedSegmentData(
     : null
 
   const { stream, controller } = createStagedStreamFromChunks(fullPageChunks)
+  if (abortSignal) {
+    const abort = () => {
+      debugChannelAbortController.abort(abortSignal.reason)
+      stream.destroy(abortSignal.reason)
+    }
+    if (abortSignal.aborted) {
+      abort()
+    } else {
+      abortSignal.addEventListener('abort', abort, { once: true })
+    }
+  }
   stream.on('end', () => {
     // When the stream finishes, we have to close the debug stream too,
     // but delay it to avoid "Connection closed." errors.
@@ -314,6 +326,7 @@ export async function collectStagedSegmentData(
         debugChannel: segmentDebugChannel?.serverSide,
         environmentName,
         startTime,
+        signal: abortSignal,
         onError(error: unknown) {
           const digest = getDigestForWellKnownError(error)
           if (digest) {
@@ -556,6 +569,7 @@ export async function createCombinedPayloadStream(
           filterStackFrame,
           debugChannel: debugChannel?.serverSide,
           startTime,
+          signal: renderSignal,
           onError(error: unknown) {
             const digest = getDigestForWellKnownError(error)
             if (digest) {

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -551,6 +551,20 @@ export function renderToNodeFlightStream(
     opts
   )
   pipeable.pipe(pt)
+
+  const signal = opts.signal as AbortSignal | undefined
+  if (signal) {
+    const abort = () => pipeable.abort(signal.reason)
+    if (signal.aborted) {
+      abort()
+    } else {
+      signal.addEventListener('abort', abort, { once: true })
+      pt.once('close', () => {
+        signal.removeEventListener('abort', abort)
+      })
+    }
+  }
+
   return pt
 }
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -168,6 +168,7 @@ export interface RenderOptsPartial {
     inlineCss: boolean
     prefetchInlining: PrefetchInliningConfig
     authInterrupts: boolean
+    serverComponentsHmrCancellation?: boolean
     useCacheTimeout: number
     cachedNavigations: boolean
     appShells: ExperimentalConfig['appShells']

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -583,6 +583,8 @@ export default abstract class Server<
         prefetchInlining:
           this.nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,
+        serverComponentsHmrCancellation:
+          this.nextConfig.experimental.serverComponentsHmrCancellation,
         useCacheTimeout: this.nextConfig.experimental.useCacheTimeout,
         cachedNavigations:
           this.nextConfig.experimental.cachedNavigations ?? false,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -424,6 +424,7 @@ export const experimentalSchema = {
   staticGenerationMinPagesPerWorker: z.number().int().optional(),
   typedEnv: z.boolean().optional(),
   serverComponentsHmrCache: z.boolean().optional(),
+  serverComponentsHmrCancellation: z.boolean().optional(),
   authInterrupts: z.boolean().optional(),
   useCache: z.boolean().optional(),
   useCacheTimeout: z.number().positive().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1107,6 +1107,7 @@ export interface ExperimentalConfig {
    * Allows previously fetched data to be re-used when editing server components.
    */
   serverComponentsHmrCache?: boolean
+  serverComponentsHmrCancellation?: boolean
 
   /**
    * Render <style> tags inline in the HTML for imported CSS assets.
@@ -2036,6 +2037,7 @@ export const defaultConfig = Object.freeze({
     reactDebugChannel: true,
     staticGenerationRetryCount: undefined,
     serverComponentsHmrCache: true,
+    serverComponentsHmrCancellation: true,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
     transitionIndicator: false,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -2142,6 +2142,7 @@ export interface NextConfigRuntime {
     | 'disableOptimizedLoading'
     | 'largePageDataBytes'
     | 'serverComponentsHmrCache'
+    | 'serverComponentsHmrCancellation'
     | 'caseSensitiveRoutes'
     | 'validateRSCRequestHeaders'
     | 'sri'
@@ -2211,6 +2212,7 @@ export function getNextConfigRuntime(
     disableOptimizedLoading: ex.disableOptimizedLoading,
     largePageDataBytes: ex.largePageDataBytes,
     serverComponentsHmrCache: ex.serverComponentsHmrCache,
+    serverComponentsHmrCancellation: ex.serverComponentsHmrCancellation,
     caseSensitiveRoutes: ex.caseSensitiveRoutes,
     validateRSCRequestHeaders: ex.validateRSCRequestHeaders,
     sri: ex.sri,

--- a/test/development/app-dir/hmr-rsc-cancellation/app/layout.tsx
+++ b/test/development/app-dir/hmr-rsc-cancellation/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
+++ b/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
@@ -5,11 +5,21 @@ import { Suspense } from 'react'
 const delayMs = 0
 const marker = 'initial'
 
+async function getCachedMarker() {
+  'use cache'
+
+  console.log(`[hmr-rsc-cancellation] cache fill started: ${marker}`)
+  await new Promise((resolve) => setTimeout(resolve, delayMs))
+  console.log(`[hmr-rsc-cancellation] cache fill finished: ${marker}`)
+  return marker
+}
+
 async function DynamicContent() {
   await connection()
-  await new Promise((resolve) => setTimeout(resolve, delayMs))
+  console.log(`[hmr-rsc-cancellation] render started: ${marker}`)
+  const cachedMarker = await getCachedMarker()
 
-  return <p id="marker">{marker}</p>
+  return <p id="marker">{cachedMarker}</p>
 }
 
 async function redirectToTarget() {

--- a/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
+++ b/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
@@ -1,0 +1,31 @@
+import { connection } from 'next/server'
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+
+const delayMs = 0
+const marker = 'initial'
+
+async function DynamicContent() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, delayMs))
+
+  return <p id="marker">{marker}</p>
+}
+
+async function redirectToTarget() {
+  'use server'
+  redirect('/redirect-target')
+}
+
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<p id="marker">loading</p>}>
+        <DynamicContent />
+      </Suspense>
+      <form action={redirectToTarget}>
+        <button id="redirect-to-target">redirect</button>
+      </form>
+    </>
+  )
+}

--- a/test/development/app-dir/hmr-rsc-cancellation/app/redirect-target/page.tsx
+++ b/test/development/app-dir/hmr-rsc-cancellation/app/redirect-target/page.tsx
@@ -1,0 +1,3 @@
+export default function TargetPage() {
+  return <p id="target">target</p>
+}

--- a/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
+++ b/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
@@ -7,101 +7,167 @@ describe('hmr-rsc-cancellation', () => {
     skipStart: true,
   })
 
-  it('cancels a superseded Server Component HMR request', async () => {
+  async function runCancellationScenario(useNodeStreams = true) {
+    await next.patchFile(
+      'next.config.js',
+      `/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    useNodeStreams: ${useNodeStreams},
+  },
+}
+
+module.exports = nextConfig
+`
+    )
+    await next.patchFile('app/page.tsx', (source) =>
+      source
+        .replace(/const delayMs = \d+/, 'const delayMs = 0')
+        .replace(
+          /const marker = '(?:initial|slow|latest)'/,
+          "const marker = 'initial'"
+        )
+    )
     await next.start()
-    const browser = await next.browser('/')
-    await retry(async () => {
-      expect(await browser.elementById('marker').text()).toBe('initial')
-    })
+    try {
+      const browser = await next.browser('/')
+      await retry(async () => {
+        expect(await browser.elementById('marker').text()).toBe('initial')
+      })
 
-    await browser.eval(() => {
-      const originalFetch = window.fetch
-      const requests: Array<{ aborted: boolean; settled: boolean }> = []
+      await browser.eval(() => {
+        const originalFetch = window.fetch
+        const requests: Array<{ aborted: boolean; settled: boolean }> = []
 
-      ;(window as any).__hmrRscRequests = requests
-      ;(window as any).__hmrReloadSentinel = true
-      window.fetch = (input, init) => {
-        const headers = new Headers(init?.headers)
-        if (headers.get('next-hmr-refresh') === '1') {
-          const request = {
-            aborted: init?.signal?.aborted ?? false,
-            settled: false,
-          }
-          requests.push(request)
-          init?.signal?.addEventListener(
-            'abort',
-            () => {
-              request.aborted = true
-            },
-            { once: true }
-          )
-
-          const result = originalFetch(input, init)
-          result.then(
-            () => {
-              request.settled = true
-            },
-            () => {
-              request.settled = true
+        ;(window as any).__hmrRscRequests = requests
+        ;(window as any).__hmrReloadSentinel = true
+        window.fetch = (input, init) => {
+          const headers = new Headers(init?.headers)
+          if (headers.get('next-hmr-refresh') === '1') {
+            const request = {
+              aborted: init?.signal?.aborted ?? false,
+              settled: false,
             }
-          )
-          return result
+            requests.push(request)
+            init?.signal?.addEventListener(
+              'abort',
+              () => {
+                request.aborted = true
+              },
+              { once: true }
+            )
+
+            const result = originalFetch(input, init)
+            result.then(
+              () => {
+                request.settled = true
+              },
+              () => {
+                request.settled = true
+              }
+            )
+            return result
+          }
+          return originalFetch(input, init)
         }
-        return originalFetch(input, init)
-      }
-    })
-    const cliOutputStart = next.cliOutput.length
+      })
+      const cliOutputStart = next.cliOutput.length
 
-    const originalSource = await next.readFile('app/page.tsx')
-    const slowSource = originalSource
-      .replace('const delayMs = 0', 'const delayMs = 5000')
-      .replace("const marker = 'initial'", "const marker = 'slow'")
-    const latestSource = originalSource.replace(
-      "const marker = 'initial'",
-      "const marker = 'latest'"
-    )
-
-    await next.patchFile('app/page.tsx', slowSource)
-
-    await retry(async () => {
-      const requestCount = await browser.eval(
-        () => (window as any).__hmrRscRequests.length
+      const originalSource = await next.readFile('app/page.tsx')
+      const slowSource = originalSource
+        .replace('const delayMs = 0', 'const delayMs = 5000')
+        .replace("const marker = 'initial'", "const marker = 'slow'")
+      const latestSource = originalSource.replace(
+        "const marker = 'initial'",
+        "const marker = 'latest'"
       )
-      expect(requestCount).toBe(1)
-    })
 
-    await next.patchFile('app/page.tsx', latestSource)
+      await next.patchFile('app/page.tsx', slowSource)
 
-    await retry(async () => {
-      expect(await browser.elementById('marker').text()).toBe('latest')
-    })
+      await retry(async () => {
+        const requestCount = await browser.eval(
+          () => (window as any).__hmrRscRequests.length
+        )
+        expect(requestCount).toBe(1)
+      })
 
-    const result = await browser.eval(() => ({
-      requests: (window as any).__hmrRscRequests,
-      didReload: (window as any).__hmrReloadSentinel !== true,
-    }))
+      await next.patchFile('app/page.tsx', latestSource)
 
-    expect(result.didReload).toBe(false)
-    expect(result.requests.length).toBeGreaterThanOrEqual(2)
-    expect(result.requests[0]).toMatchObject({
-      aborted: true,
-      settled: true,
-    })
-    expect(result.requests.at(-1)).toMatchObject({
-      aborted: false,
-      settled: true,
-    })
+      if (useNodeStreams) {
+        await retry(async () => {
+          expect(await browser.elementById('marker').text()).toBe('latest')
+        })
+      } else {
+        await retry(async () => {
+          expect(
+            await browser.eval(
+              () =>
+                (window as any).__hmrRscRequests.length >= 2 &&
+                (window as any).__hmrRscRequests.at(-1)?.settled === true
+            )
+          ).toBe(true)
+          expect(next.cliOutput.slice(cliOutputStart)).toContain(
+            '[hmr-rsc-cancellation] render started: latest'
+          )
+        })
+      }
 
-    const cliOutput = next.cliOutput.slice(cliOutputStart)
-    expect(cliOutput).not.toContain(
-      'Failed to fetch RSC payload for http://localhost'
-    )
-    expect(cliOutput).not.toContain('Cannot write to a closing writable stream')
+      await retry(async () => {
+        expect(next.cliOutput.slice(cliOutputStart)).toContain(
+          '[hmr-rsc-cancellation] cache fill finished: slow'
+        )
+      }, 7000)
+      await browser.eval(async () => {
+        const response = await fetch('/redirect-target')
+        await response.arrayBuffer()
+      })
+      const result = await browser.eval(() => ({
+        requests: (window as any).__hmrRscRequests,
+        didReload: (window as any).__hmrReloadSentinel !== true,
+      }))
 
-    await next.stop()
+      expect(result.didReload).toBe(false)
+      expect(result.requests.length).toBeGreaterThanOrEqual(2)
+      expect(result.requests[0]).toMatchObject({
+        aborted: true,
+        settled: true,
+      })
+      expect(result.requests.at(-1)).toMatchObject({
+        aborted: false,
+        settled: true,
+      })
+      const cliOutput = next.cliOutput.slice(cliOutputStart)
+      expect(cliOutput).not.toContain(
+        'Failed to fetch RSC payload for http://localhost'
+      )
+      expect(cliOutput).not.toContain(
+        'Cannot write to a closing writable stream'
+      )
+      expect(cliOutput).not.toContain('unhandledRejection: ResponseAborted')
+      expect(
+        cliOutput.match(/\[hmr-rsc-cancellation\] render started: slow/g)
+      ).toHaveLength(1)
+    } finally {
+      await next.stop()
+    }
+  }
+
+  it('cancels a superseded Server Component HMR request', async () => {
+    await runCancellationScenario()
+  })
+
+  it('cancels a superseded HMR request with web streams', async () => {
+    await runCancellationScenario(false)
   })
 
   it('preserves a Server Action redirect while the target route compiles', async () => {
+    await next.patchFile(
+      'next.config.js',
+      `module.exports = { cacheComponents: true }\n`
+    )
     await next.start()
     const browser = await next.browser('/')
 
@@ -115,14 +181,22 @@ describe('hmr-rsc-cancellation', () => {
   })
 
   it('preserves the existing behavior when cancellation is disabled', async () => {
-    await next.patchFile('next.config.js', (source) =>
-      source.replace(
-        'cacheComponents: true,',
-        `cacheComponents: true,
+    await next.patchFile(
+      'next.config.js',
+      `module.exports = {
+  cacheComponents: true,
   experimental: {
     serverComponentsHmrCancellation: false,
-  },`
-      )
+  },
+}\n`
+    )
+    await next.patchFile('app/page.tsx', (source) =>
+      source
+        .replace(/const delayMs = \d+/, 'const delayMs = 0')
+        .replace(
+          /const marker = '(?:initial|slow|latest)'/,
+          "const marker = 'initial'"
+        )
     )
     await next.start()
 
@@ -178,10 +252,8 @@ describe('hmr-rsc-cancellation', () => {
     )
     await retry(async () => {
       expect(
-        await browser.eval(
-          () => (window as any).__hmrRscRequests.at(-1)?.settled
-        )
-      ).toBe(true)
+        await browser.eval(() => (window as any).__hmrRscRequests.length)
+      ).toBeGreaterThanOrEqual(2)
     })
     await retry(async () => {
       expect(
@@ -192,6 +264,9 @@ describe('hmr-rsc-cancellation', () => {
     expect(
       await browser.eval(() => (window as any).__hmrRscRequests[0].aborted)
     ).toBe(false)
+    expect(
+      await browser.eval(() => (window as any).__hmrRscRequests.at(-1)?.settled)
+    ).toBe(true)
 
     await next.stop()
   })

--- a/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
+++ b/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
@@ -1,0 +1,198 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('hmr-rsc-cancellation', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  it('cancels a superseded Server Component HMR request', async () => {
+    await next.start()
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await browser.elementById('marker').text()).toBe('initial')
+    })
+
+    await browser.eval(() => {
+      const originalFetch = window.fetch
+      const requests: Array<{ aborted: boolean; settled: boolean }> = []
+
+      ;(window as any).__hmrRscRequests = requests
+      ;(window as any).__hmrReloadSentinel = true
+      window.fetch = (input, init) => {
+        const headers = new Headers(init?.headers)
+        if (headers.get('next-hmr-refresh') === '1') {
+          const request = {
+            aborted: init?.signal?.aborted ?? false,
+            settled: false,
+          }
+          requests.push(request)
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              request.aborted = true
+            },
+            { once: true }
+          )
+
+          const result = originalFetch(input, init)
+          result.then(
+            () => {
+              request.settled = true
+            },
+            () => {
+              request.settled = true
+            }
+          )
+          return result
+        }
+        return originalFetch(input, init)
+      }
+    })
+    const cliOutputStart = next.cliOutput.length
+
+    const originalSource = await next.readFile('app/page.tsx')
+    const slowSource = originalSource
+      .replace('const delayMs = 0', 'const delayMs = 5000')
+      .replace("const marker = 'initial'", "const marker = 'slow'")
+    const latestSource = originalSource.replace(
+      "const marker = 'initial'",
+      "const marker = 'latest'"
+    )
+
+    await next.patchFile('app/page.tsx', slowSource)
+
+    await retry(async () => {
+      const requestCount = await browser.eval(
+        () => (window as any).__hmrRscRequests.length
+      )
+      expect(requestCount).toBe(1)
+    })
+
+    await next.patchFile('app/page.tsx', latestSource)
+
+    await retry(async () => {
+      expect(await browser.elementById('marker').text()).toBe('latest')
+    })
+
+    const result = await browser.eval(() => ({
+      requests: (window as any).__hmrRscRequests,
+      didReload: (window as any).__hmrReloadSentinel !== true,
+    }))
+
+    expect(result.didReload).toBe(false)
+    expect(result.requests.length).toBeGreaterThanOrEqual(2)
+    expect(result.requests[0]).toMatchObject({
+      aborted: true,
+      settled: true,
+    })
+    expect(result.requests.at(-1)).toMatchObject({
+      aborted: false,
+      settled: true,
+    })
+
+    const cliOutput = next.cliOutput.slice(cliOutputStart)
+    expect(cliOutput).not.toContain(
+      'Failed to fetch RSC payload for http://localhost'
+    )
+    expect(cliOutput).not.toContain('Cannot write to a closing writable stream')
+
+    await next.stop()
+  })
+
+  it('preserves a Server Action redirect while the target route compiles', async () => {
+    await next.start()
+    const browser = await next.browser('/')
+
+    await browser.elementById('redirect-to-target').click()
+
+    await retry(async () => {
+      expect(await browser.elementById('target').text()).toBe('target')
+    })
+
+    await next.stop()
+  })
+
+  it('preserves the existing behavior when cancellation is disabled', async () => {
+    await next.patchFile('next.config.js', (source) =>
+      source.replace(
+        'cacheComponents: true,',
+        `cacheComponents: true,
+  experimental: {
+    serverComponentsHmrCancellation: false,
+  },`
+      )
+    )
+    await next.start()
+
+    const browser = await next.browser('/')
+    await browser.eval(() => {
+      const originalFetch = window.fetch
+      const requests: Array<{ aborted: boolean; settled: boolean }> = []
+      ;(window as any).__hmrRscRequests = requests
+      window.fetch = (input, init) => {
+        const headers = new Headers(init?.headers)
+        if (headers.get('next-hmr-refresh') === '1') {
+          const request = {
+            aborted: init?.signal?.aborted ?? false,
+            settled: false,
+          }
+          requests.push(request)
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              request.aborted = true
+            },
+            { once: true }
+          )
+          const result = originalFetch(input, init)
+          result.finally(() => {
+            request.settled = true
+          })
+          return result
+        }
+        return originalFetch(input, init)
+      }
+    })
+
+    const originalSource = await next.readFile('app/page.tsx')
+    await next.patchFile(
+      'app/page.tsx',
+      originalSource
+        .replace('const delayMs = 0', 'const delayMs = 1000')
+        .replace("const marker = 'initial'", "const marker = 'slow'")
+    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => (window as any).__hmrRscRequests.length)
+      ).toBe(1)
+    })
+
+    await next.patchFile(
+      'app/page.tsx',
+      originalSource.replace(
+        "const marker = 'initial'",
+        "const marker = 'latest'"
+      )
+    )
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          () => (window as any).__hmrRscRequests.at(-1)?.settled
+        )
+      ).toBe(true)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(() => (window as any).__hmrRscRequests[0]?.settled)
+      ).toBe(true)
+    })
+
+    expect(
+      await browser.eval(() => (window as any).__hmrRscRequests[0].aborted)
+    ).toBe(false)
+
+    await next.stop()
+  })
+})

--- a/test/development/app-dir/hmr-rsc-cancellation/next.config.js
+++ b/test/development/app-dir/hmr-rsc-cancellation/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What?

Cancel an in-flight App Router HMR RSC request when a newer Server Component refresh supersedes it, including request-local Cache Components render and resume work when the Next.js server observes the response closing.

### Why?

Rapid edits can start overlapping HMR renders. Only the latest response can be committed, but older requests previously continued transferring RSC payloads and could keep running Cache Components warmup and restarted renders after they were no longer useful.

### How?

- Enable the behavior by default, with `experimental.serverComponentsHmrCancellation: false` as an opt-out.
- Create an `AbortController` for each HMR refresh and abort the previous generation after scheduling the latest one.
- Thread the signal through the refresh navigation and RSC fetch.
- Treat an aborted navigation as canceled so it resolves abandoned pending nodes without retrying.
- Ignore expected late debug-channel writes after a superseded request stops consuming its stream.
- On Node.js, derive an abort signal from the HMR response closing and propagate it through the initial React render, cache-readiness wait, restarted render, stream accumulation, static shell validation, and Instant validation segment work.
- Abort both Node `renderToPipeableStream` and Web Flight streams when the response closes.
- Skip the staged Cache Components render entirely when the HMR response is already closed.
- Stop consuming output before aborting React so terminal Flight chunks cannot race the closed response.
- Preserve independently running `"use cache"` fills so a canceled request does not discard reusable cache work.
- Keep Edge rendering unchanged because it does not expose the Node response-close signal.

### Validation

#### vercel-site

Four edits at a 3.5 second cadence against a Server Component route with 5 seconds of async I/O:

| Metric | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| HMR requests issued | 4 | 4 | None |
| Completed superseded payloads | 3 | 0 | Eliminated |
| Completed HMR response bytes | 544,432 | 0 | Eliminated |
| Overlapping request wall time | 15.18 s | 9.29 s | 38.8% lower |
| Sampled server CPU | 1,289.6 ms | 1,773.7 ms | 37.5% higher |

The latest edit committed correctly. This path is a clear browser and network win, but the vercel-site development proxy retains the upstream request after the browser disconnects. Next.js therefore cannot observe the response close and cannot reclaim the inner server render on this path. Proxies need to propagate downstream cancellation for the server-side optimization to apply.

#### v0

Direct Next.js development server, eight edits at a 500 ms cadence, refreshed after wiring the Node Flight stream to `pipeable.abort()`:

| Projects pair | Client cancellation only | With response-close propagation |
| --- | ---: | ---: |
| Server CPU, run 1 | 6,772.7 ms | 7,518.4 ms |
| RSC requests, run 1 | 5, 4 canceled | 4, 2 canceled |
| Latest marker, run 1 | Not committed | Committed |
| Server CPU, run 2 | 7,682.6 ms | 7,883.3 ms |
| RSC requests, run 2 | 5, 4 canceled | 5, 4 canceled |
| Latest marker, run 2 | Not committed | Committed |

Run 2 matched request and cancellation counts exactly. Whole-process CPU was 2.6% higher, React/RSC development runtime CPU was 26.9% higher, and garbage collection CPU was 10.0% lower. The final runtime also completed the latest Server Component output, while the client-only baseline did not do so within the measurement window.

The refreshed v0 profile does not establish a server CPU improvement. It does validate the transport path: browser cancellation closes the direct Next.js response, obsolete request-local render and resume work is stopped, reusable cache fills continue, and the latest response still commits. CPU impact remains workload-dependent because cache fills and unrelated process work intentionally continue.

### Stack

1. **This PR:** cancel superseded refreshes
2. #94525: skip inactive route refreshes
3. #94526: refresh affected route segments

### Verification

- `HEADLESS=true pnpm test-dev-turbo test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts`
- `HEADLESS=true pnpm test-dev-webpack test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts`
- `__NEXT_CACHE_COMPONENTS=true __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true NEXT_EXTERNAL_TESTS_FILTERS=test/cache-components-tests-manifest.json NEXT_TEST_MODE=dev IS_TURBOPACK_TEST=1 TURBOPACK_DEV=1 pnpm test-dev-turbo test/e2e/app-dir/hmr-intercept-routes/hmr-intercept-routes.test.ts`
- `pnpm --filter=next types`
- Prettier and ESLint on all changed files
- The test fixture verifies the default-on behavior, the explicit opt-out, Server Action redirects, Node and Web Flight stream cancellation, latest-response completion, preservation of the independent cache fill, no late full reload after the cache fill, and no unhandled `ResponseAborted` rejection.

<!-- NEXT_JS_LLM_PR -->
