### PR TITLE
server component HMR: skip inactive route refreshes (2/3)

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -247,6 +247,9 @@ export function getDefineEnv({
     'process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION': Boolean(
       config.experimental.serverComponentsHmrCancellation
     ),
+    'process.env.__NEXT_SERVER_COMPONENTS_HMR_ROUTE_FILTERING': Boolean(
+      config.experimental.serverComponentsHmrRouteFiltering
+    ),
     'process.env.__NEXT_DYNAMIC_ON_HOVER': Boolean(
       config.experimental.dynamicOnHover
     ),

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -481,7 +481,7 @@ export const publicAppRouterInstance: AppRouterInstance = {
       })
     })
   },
-  hmrRefresh: () => {
+  hmrRefresh: (options?: { invalidateOnly?: boolean }) => {
     if (process.env.NODE_ENV !== 'development') {
       throw new Error(
         'hmrRefresh can only be used in development mode. Please use refresh instead.'
@@ -492,7 +492,10 @@ export const publicAppRouterInstance: AppRouterInstance = {
       resetKnownRoutes()
       let signal: AbortSignal | undefined
       let previousController: AbortController | null = null
-      if (process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION) {
+      if (
+        !options?.invalidateOnly &&
+        process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION
+      ) {
         const controller = new AbortController()
         signal = controller.signal
         previousController = activeHmrRefreshController
@@ -502,6 +505,7 @@ export const publicAppRouterInstance: AppRouterInstance = {
         dispatchAppRouterAction({
           type: ACTION_HMR_REFRESH,
           signal,
+          invalidateOnly: options?.invalidateOnly,
         })
       })
       previousController?.abort()

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -5,6 +5,8 @@ import type {
 } from '../router-reducer-types'
 import { refreshDynamicData } from './refresh-reducer'
 import { FreshnessPolicy } from '../ppr-navigations'
+import { invalidatePrefetchCacheEntries } from '../../segment-cache/cache'
+import { invalidateBfCache } from '../../segment-cache/bfcache'
 
 export function hmrRefreshReducer(
   state: ReadonlyReducerState,
@@ -14,6 +16,12 @@ export function hmrRefreshReducer(
   // newer generation superseded this one before it started, do not install a
   // refresh tree whose request is already canceled.
   if (action.signal?.aborted) {
+    return state
+  }
+
+  if (action.invalidateOnly) {
+    invalidatePrefetchCacheEntries()
+    invalidateBfCache()
     return state
   }
 

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -38,6 +38,7 @@ export interface RefreshAction {
 export interface HmrRefreshAction {
   type: typeof ACTION_HMR_REFRESH
   signal?: AbortSignal
+  invalidateOnly?: boolean
 }
 
 export type ServerActionDispatcher = (

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -339,11 +339,18 @@ export function invalidateEntirePrefetchCache(
   nextUrl: string | null,
   tree: FlightRouterState
 ): void {
-  currentRouteCacheVersion++
-  currentSegmentCacheVersion++
+  invalidatePrefetchCacheEntries()
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
+}
+
+/**
+ * Invalidates all prefetch cache entries without scheduling new prefetches.
+ */
+export function invalidatePrefetchCacheEntries(): void {
+  currentRouteCacheVersion++
+  currentSegmentCacheVersion++
 }
 
 /**

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -45,6 +45,7 @@ import {
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createFromReadableStream as createFromReadableStreamBrowser } from 'react-server-dom-webpack/client'
 import { findSourceMapURL } from '../../../app-find-source-map-url'
+import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 
 export interface StaticIndicatorState {
   pathname: string | null
@@ -412,6 +413,16 @@ export function processMessage(
       // Store the latest hash in a session cookie so that it's sent back to the
       // server with any subsequent requests.
       document.cookie = `${NEXT_HMR_REFRESH_HASH_COOKIE}=${message.hash};path=/`
+
+      const sourcePage = window.next.__internal_src_page
+      if (
+        process.env.__NEXT_SERVER_COMPONENTS_HMR_ROUTE_FILTERING &&
+        message.refreshScope.type === 'routes' &&
+        sourcePage !== undefined &&
+        !message.refreshScope.routes.includes(normalizeAppPath(sourcePage))
+      ) {
+        return
+      }
 
       if (
         RuntimeErrorHandler.hadRuntimeError ||

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -421,6 +421,7 @@ export function processMessage(
         sourcePage !== undefined &&
         !message.refreshScope.routes.includes(normalizeAppPath(sourcePage))
       ) {
+        publicAppRouterInstance.hmrRefresh({ invalidateOnly: true })
         return
       }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -425,6 +425,7 @@ export const experimentalSchema = {
   typedEnv: z.boolean().optional(),
   serverComponentsHmrCache: z.boolean().optional(),
   serverComponentsHmrCancellation: z.boolean().optional(),
+  serverComponentsHmrRouteFiltering: z.boolean().optional(),
   authInterrupts: z.boolean().optional(),
   useCache: z.boolean().optional(),
   useCacheTimeout: z.number().positive().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1108,6 +1108,7 @@ export interface ExperimentalConfig {
    */
   serverComponentsHmrCache?: boolean
   serverComponentsHmrCancellation?: boolean
+  serverComponentsHmrRouteFiltering?: boolean
 
   /**
    * Render <style> tags inline in the HTML for imported CSS assets.
@@ -2038,6 +2039,7 @@ export const defaultConfig = Object.freeze({
     staticGenerationRetryCount: undefined,
     serverComponentsHmrCache: true,
     serverComponentsHmrCancellation: true,
+    serverComponentsHmrRouteFiltering: true,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
     transitionIndicator: false,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1632,6 +1632,7 @@ export async function createHotReloaderTurbopack(
         this.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
           hash: String(++hmrHash),
+          refreshScope: { type: 'all' },
         })
       }
     },
@@ -1795,6 +1796,9 @@ export async function createHotReloaderTurbopack(
               devRewrites: opts.fsChecker.rewrites,
               productionRewrites: undefined,
               logErrors: true,
+              serverComponentsHmrRouteFiltering: Boolean(
+                nextConfig.experimental.serverComponentsHmrRouteFiltering
+              ),
 
               hooks: {
                 // Pass a no-o subscribeToChanges to skip wiring HMR subscriptions for
@@ -1972,6 +1976,7 @@ export async function createHotReloaderTurbopack(
         hotReloader.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
           hash: String(++hmrHash),
+          refreshScope: { type: 'all' },
         })
       },
     })

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -108,9 +108,14 @@ export interface ReloadPageMessage {
   data: string
 }
 
+export type ServerComponentRefreshScope =
+  | { type: 'all' }
+  | { type: 'routes'; routes: string[] }
+
 export interface ServerComponentChangesMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
   hash: string
+  refreshScope: ServerComponentRefreshScope
 }
 
 export interface MiddlewareChangesMessage {

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -54,6 +54,7 @@ import {
 } from './on-demand-entry-handler'
 import { denormalizePagePath } from '../../shared/lib/page-path/denormalize-page-path'
 import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
+import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import getRouteFromEntrypoint from '../get-route-from-entrypoint'
 import {
   difference,
@@ -79,7 +80,10 @@ import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   type NextJsHotReloaderInterface,
 } from './hot-reloader-types'
-import type { HmrMessageSentToBrowser } from './hot-reloader-types'
+import type {
+  HmrMessageSentToBrowser,
+  ServerComponentRefreshScope,
+} from './hot-reloader-types'
 import type { WebpackError } from 'webpack'
 import { PAGE_TYPES } from '../../lib/page-types'
 import { FAST_REFRESH_RUNTIME_RELOAD } from './messages'
@@ -430,12 +434,14 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     }
   }
 
-  protected async refreshServerComponents(hash: string): Promise<void> {
+  protected async refreshServerComponents(
+    hash: string,
+    refreshScope: ServerComponentRefreshScope
+  ): Promise<void> {
     this.send({
       type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
       hash,
-      // TODO: granular reloading of changes
-      // entrypoints: serverComponentChanges,
+      refreshScope,
     })
   }
 
@@ -1543,7 +1549,21 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
         reloadAfterInvalidation
       ) {
         this.resetFetch()
-        this.refreshServerComponents(stats.hash)
+        const changedRoutes =
+          reloadAfterInvalidation ||
+          !this.config.experimental.serverComponentsHmrRouteFiltering
+            ? undefined
+            : Array.from(
+                new Set(
+                  [...changedServerComponentPages, ...changedCSSImportPages]
+                    .filter((key) => key.startsWith('app/'))
+                    .map((key) => normalizeAppPath(key.slice('app'.length)))
+                )
+              )
+        const refreshScope: ServerComponentRefreshScope = changedRoutes?.length
+          ? { type: 'routes', routes: changedRoutes }
+          : { type: 'all' }
+        this.refreshServerComponents(stats.hash, refreshScope)
       }
 
       changedClientPages.clear()

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -878,6 +878,7 @@ export default class DevServer extends Server {
             this.bundlerService.sendHmrMessage({
               type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
               hash: `generateStaticParams-${Date.now()}`,
+              refreshScope: { type: 'all' },
             })
           }
         }

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -156,6 +156,7 @@ export async function handleRouteType({
   productionRewrites,
   hooks,
   logErrors,
+  serverComponentsHmrRouteFiltering,
 }: {
   dev: boolean
   page: string
@@ -168,6 +169,7 @@ export async function handleRouteType({
   devRewrites: SetupOpts['fsChecker']['rewrites'] | undefined
   productionRewrites: CustomRoutes['rewrites'] | undefined
   logErrors: boolean
+  serverComponentsHmrRouteFiltering: boolean
 
   readyIds?: ReadyIds // dev
 
@@ -367,6 +369,9 @@ export async function handleRouteType({
             return {
               type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
               hash,
+              refreshScope: serverComponentsHmrRouteFiltering
+                ? { type: 'routes', routes: [pathname] }
+                : { type: 'all' },
             }
           },
           (e) => {

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -47,7 +47,7 @@ export interface AppRouterInstance {
    * Refresh the current page. Use in development only.
    * @internal
    */
-  hmrRefresh(): void
+  hmrRefresh(options?: { invalidateOnly?: boolean }): void
   /**
    * Navigate to the provided href.
    * Pushes a new history entry.

--- a/test/development/app-dir/route-aware-hmr-refresh/app/a/page.tsx
+++ b/test/development/app-dir/route-aware-hmr-refresh/app/a/page.tsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+
+const marker = 'a-initial'
+
+export default async function PageA() {
+  await connection()
+
+  return <p id="marker">{marker}</p>
+}

--- a/test/development/app-dir/route-aware-hmr-refresh/app/a/page.tsx
+++ b/test/development/app-dir/route-aware-hmr-refresh/app/a/page.tsx
@@ -1,9 +1,17 @@
 import { connection } from 'next/server'
+import Link from 'next/link'
 
 const marker = 'a-initial'
 
 export default async function PageA() {
   await connection()
 
-  return <p id="marker">{marker}</p>
+  return (
+    <>
+      <p id="marker">{marker}</p>
+      <Link id="to-b" href="/b">
+        B
+      </Link>
+    </>
+  )
 }

--- a/test/development/app-dir/route-aware-hmr-refresh/app/b/page.tsx
+++ b/test/development/app-dir/route-aware-hmr-refresh/app/b/page.tsx
@@ -1,9 +1,17 @@
 import { connection } from 'next/server'
+import Link from 'next/link'
 
 const marker = 'b-initial'
 
 export default async function PageB() {
   await connection()
 
-  return <p id="marker">{marker}</p>
+  return (
+    <>
+      <p id="marker">{marker}</p>
+      <Link id="to-a" href="/a">
+        A
+      </Link>
+    </>
+  )
 }

--- a/test/development/app-dir/route-aware-hmr-refresh/app/b/page.tsx
+++ b/test/development/app-dir/route-aware-hmr-refresh/app/b/page.tsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+
+const marker = 'b-initial'
+
+export default async function PageB() {
+  await connection()
+
+  return <p id="marker">{marker}</p>
+}

--- a/test/development/app-dir/route-aware-hmr-refresh/app/layout.tsx
+++ b/test/development/app-dir/route-aware-hmr-refresh/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/route-aware-hmr-refresh/next.config.js
+++ b/test/development/app-dir/route-aware-hmr-refresh/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/route-aware-hmr-refresh/route-aware-hmr-refresh.test.ts
+++ b/test/development/app-dir/route-aware-hmr-refresh/route-aware-hmr-refresh.test.ts
@@ -12,7 +12,7 @@ describe('route-aware-hmr-refresh', () => {
       expect(await browser.elementById('marker').text()).toBe('a-initial')
     })
 
-    await browser.get(`${next.url}/b`)
+    await browser.elementById('to-b').click()
     await retry(async () => {
       expect(await browser.elementById('marker').text()).toBe('b-initial')
     })
@@ -40,6 +40,19 @@ describe('route-aware-hmr-refresh', () => {
     expect(await browser.eval(() => (window as any).__hmrRscRequestCount)).toBe(
       0
     )
+
+    await browser.elementById('to-a').click()
+    await retry(async () => {
+      expect(await browser.elementById('marker').text()).toBe('a-updated')
+    })
+    expect(await browser.eval(() => (window as any).__hmrRscRequestCount)).toBe(
+      0
+    )
+
+    await browser.elementById('to-b').click()
+    await retry(async () => {
+      expect(await browser.elementById('marker').text()).toBe('b-initial')
+    })
 
     await next.patchFile('app/b/page.tsx', (source) =>
       source.replace('b-initial', 'b-updated')

--- a/test/development/app-dir/route-aware-hmr-refresh/route-aware-hmr-refresh.test.ts
+++ b/test/development/app-dir/route-aware-hmr-refresh/route-aware-hmr-refresh.test.ts
@@ -1,0 +1,55 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('route-aware-hmr-refresh', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('refreshes only when the active route changed', async () => {
+    const browser = await next.browser('/a')
+    await retry(async () => {
+      expect(await browser.elementById('marker').text()).toBe('a-initial')
+    })
+
+    await browser.get(`${next.url}/b`)
+    await retry(async () => {
+      expect(await browser.elementById('marker').text()).toBe('b-initial')
+    })
+
+    await browser.eval(() => {
+      const originalFetch = window.fetch
+      ;(window as any).__hmrRscRequestCount = 0
+      window.fetch = (input, init) => {
+        const headers = new Headers(init?.headers)
+        if (headers.get('next-hmr-refresh') === '1') {
+          ;(window as any).__hmrRscRequestCount++
+        }
+        return originalFetch(input, init)
+      }
+    })
+
+    await next.patchFile('app/a/page.tsx', (source) =>
+      source.replace('a-initial', 'a-updated')
+    )
+
+    const routeAHtml = await next.render('/a')
+    expect(routeAHtml).toContain('a-updated')
+
+    expect(await browser.elementById('marker').text()).toBe('b-initial')
+    expect(await browser.eval(() => (window as any).__hmrRscRequestCount)).toBe(
+      0
+    )
+
+    await next.patchFile('app/b/page.tsx', (source) =>
+      source.replace('b-initial', 'b-updated')
+    )
+
+    await retry(async () => {
+      expect(await browser.elementById('marker').text()).toBe('b-updated')
+      expect(
+        await browser.eval(() => (window as any).__hmrRscRequestCount)
+      ).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
### What?

Include affected App Router routes in Server Component HMR messages and skip the active-route RSC refresh when the browser route was not affected.

### Why?

The development client currently refreshes every open route after any Server Component edit. That performs server rendering and data fetching for browser tabs whose route did not change.

### How?

- Enable the behavior by default, with `experimental.serverComponentsHmrRouteFiltering: false` as an opt-out.
- Attach affected routes to Server Component HMR messages from both Turbopack and webpack.
- Compare those routes with the active App Router route before starting a refresh.
- Preserve the latest HMR hash cookie even when the active route is skipped.
- Invalidate route, segment, and back-forward caches without fetching or rendering the active route, so a later navigation observes the edit.
- Fall back to the existing refresh behavior when route information is unavailable.

### vercel-site Validation

Two edits to an inactive page while another route remained active:

| Metric | Baseline | This PR |
| --- | ---: | ---: |
| Active-route HMR requests | 2 | 0 |
| RSC response bytes | 295,292 | 0 |
| Cumulative request wall time | 585.2 ms | 0 |
| Sampled server CPU | 53.1 ms | 0 |

After each skipped refresh, navigating through `next/link` to the edited route returned fresh content. This verifies that the optimization does not leave stale prefetched or back-forward cached results.

### Stack

1. #94521: cancel superseded refreshes
2. **This PR:** skip inactive route refreshes
3. #94526: refresh affected route segments

### Verification

- `HEADLESS=true pnpm test-dev-turbo test/development/app-dir/route-aware-hmr-refresh/route-aware-hmr-refresh.test.ts`
- `HEADLESS=true pnpm test-dev-webpack test/development/app-dir/route-aware-hmr-refresh/route-aware-hmr-refresh.test.ts`
- `__NEXT_CACHE_COMPONENTS=true HEADLESS=true pnpm test-dev-turbo test/development/app-dir/route-aware-hmr-refresh/route-aware-hmr-refresh.test.ts`
- The test verifies zero HMR RSC requests for an inactive route edit, fresh content on a later client navigation, and a normal refresh for an active route edit.

<!-- NEXT_JS_LLM_PR -->
