### PR TITLE
docs: fix verb consistency in `videos.mdx`

### DIFF
--- a/docs/01-app/02-guides/videos.mdx
+++ b/docs/01-app/02-guides/videos.mdx
@@ -76,7 +76,7 @@ export default function Page() {
 | `height`          | Sets the height of the iframe.                                         | `<iframe height="300" />`              |
 | `allowFullScreen` | Allows the iframe content to be displayed in full-screen mode.         | `<iframe allowFullScreen />`           |
 | `sandbox`         | Enables an extra set of restrictions on the content within the iframe. | `<iframe sandbox />`                   |
-| `loading`         | Optimize loading behavior (e.g., lazy loading).                        | `<iframe loading="lazy" />`            |
+| `loading`         | Optimizes loading behavior (e.g., lazy loading).                       | `<iframe loading="lazy" />`            |
 | `title`           | Provides a title for the iframe to support accessibility.              | `<iframe title="Description" />`       |
 
 For a comprehensive list of iframe attributes, refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attributes).


### PR DESCRIPTION
Fixed verb inconsistency in `<iframe>` attributes table — changed `Optimize` to `Optimizes` to match the third-person pattern of all other rows.