### PR TITLE
fix(@edge-runtime/cookies): fall back to raw value on malformed percent-encoding in cookie values

### DIFF
--- a/packages/next/src/compiled/@edge-runtime/cookies/index.js
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.js
@@ -59,6 +59,7 @@ function parseCookie(cookie) {
     try {
       map.set(key, decodeURIComponent(value != null ? value : "true"));
     } catch {
+      map.set(key, value != null ? value : "true");
     }
   }
   return map;
@@ -86,7 +87,7 @@ function parseSetCookie(setCookie) {
   );
   const cookie = {
     name,
-    value: decodeURIComponent(value),
+    value: (() => { try { return decodeURIComponent(value) } catch { return value } })(),
     domain,
     ...expires && { expires: new Date(expires) },
     ...httponly && { httpOnly: true },

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
@@ -55,6 +55,17 @@ describe('RequestCookiesAdapter', () => {
   })
 })
 
+describe('ResponseCookies', () => {
+  it('does not throw when a Set-Cookie value contains a bare % character', () => {
+    const headers = new Headers({
+      'set-cookie': 'discount=50% off; Path=/',
+    })
+    const cookies = new ResponseCookies(headers)
+    expect(() => cookies.get('discount')).not.toThrow()
+    expect(cookies.get('discount')?.value).toBe('50% off')
+  })
+})
+
 describe('MutableRequestCookiesAdapter', () => {
   it('supports chained set calls and preserves wrapping', () => {
     const headers = new Headers({})


### PR DESCRIPTION
fixes #70523.

**problem:** `parseCookie` silently drops cookie entries when `decodeURIComponent` throws (e.g. a value like `50% off` contains a bare `%`). `parseSetCookie` then destructures from an empty map, losing the cookie entirely. `ResponseCookies` set from middleware headers with such values would crash the app with `URIError: URI malformed`.

**fix:** `parseCookie`'s catch block now falls back to the raw value instead of swallowing the entry. `parseSetCookie` gets the same treatment with a try/catch around its own `decodeURIComponent` call.

regression test: `ResponseCookies` constructed from a `set-cookie: discount=50% off; Path=/` header no longer throws and returns the raw value.

<!-- NEXT_JS_LLM_PR -->
