### PR TITLE
docs: align redirect comment with website docs

### DIFF
--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -26,6 +26,7 @@ export function getRedirectError(
 /**
  * This function allows you to redirect the user to another URL. It can be used in
  * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
+ * [Client Components](https://nextjs.org/docs/app/building-your-application/rendering/client-components),
  * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
  * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
  *


### PR DESCRIPTION
## Summary
Align the inline `redirect` comment with the website docs by mentioning client components.

## Why
The docs page already states that `redirect` can be used from client components, but the code comment only listed server components, route handlers, and server actions.

## What changed
- Added `Client Components` to the `redirect` comment block

## Verification
- Documentation-only change; no runtime behavior changed