### PR TITLE
[cna] Use `allowBuilds` instead of `ignoredBuiltDependencies` when using PNPM 11+

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -338,7 +338,26 @@ export const installTemplate = async ({
     // If we can't determine the version, assume latest (v10+) since we already
     // know pnpm is being used at this point.
     const pnpmMajorVersion = getPnpmMajorVersion();
-    if (pnpmMajorVersion === null || pnpmMajorVersion >= 10) {
+    if (pnpmMajorVersion === null || pnpmMajorVersion >= 11) {
+      // In pnpm v11, `ignoredBuiltDependencies` (and the other build-script
+      // settings) were removed in favor of a single `allowBuilds` map where
+      // `false` denies a package from running build scripts. See
+      // https://pnpm.io/blog/releases/11.0
+      const pnpmWorkspaceYaml = [
+        "allowBuilds:",
+        // Sharp has prebuilt binaries for the platforms next-swc has binaries.
+        // If it needs to build binaries from source, next-swc wouldn't work either.
+        // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
+        "  sharp: false",
+        // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
+        "  unrs-resolver: false",
+        "",
+      ].join(os.EOL);
+      await fs.writeFile(
+        path.join(root, "pnpm-workspace.yaml"),
+        pnpmWorkspaceYaml,
+      );
+    } else if (pnpmMajorVersion >= 10) {
       const pnpmWorkspaceYaml = [
         "ignoredBuiltDependencies:",
         // Sharp has prebuilt binaries for the platforms next-swc has binaries.

--- a/test/production/create-next-app/package-manager/pnpm.test.ts
+++ b/test/production/create-next-app/package-manager/pnpm.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import {
   command,
   DEFAULT_FILES,
@@ -91,7 +93,7 @@ describe('create-next-app with package manager pnpm', () => {
   // 1. We only need to verify the workspace file is created/not created
   // 2. The CI runs pnpm v9, but when testing v10 behavior, the workspace file
   //    created for v10 (without packages field) would fail with pnpm v9
-  it('should create pnpm-workspace.yaml for pnpm v10+', async () => {
+  it('should create pnpm-workspace.yaml with ignoredBuiltDependencies for pnpm v10', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pnpm-v10-workspace'
       const res = await run(
@@ -120,6 +122,54 @@ describe('create-next-app with package manager pnpm', () => {
         projectName,
         files: ['package.json', 'pnpm-workspace.yaml'],
       })
+      const workspaceYaml = fs.readFileSync(
+        path.join(cwd, projectName, 'pnpm-workspace.yaml'),
+        'utf8'
+      )
+      expect(workspaceYaml).toContain('ignoredBuiltDependencies:')
+      expect(workspaceYaml).toContain('- sharp')
+      expect(workspaceYaml).toContain('- unrs-resolver')
+      expect(workspaceYaml).not.toContain('allowBuilds:')
+    })
+  })
+
+  it('should create pnpm-workspace.yaml with allowBuilds for pnpm v11+', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'pnpm-v11-workspace'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--no-linter',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+          '--no-react-compiler',
+          '--no-agents-md',
+          '--skip-install',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+          env: { npm_config_user_agent: 'pnpm/11.0.0 npm/? node/v20.0.0' },
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files: ['package.json', 'pnpm-workspace.yaml'],
+      })
+      const workspaceYaml = fs.readFileSync(
+        path.join(cwd, projectName, 'pnpm-workspace.yaml'),
+        'utf8'
+      )
+      expect(workspaceYaml).toContain('allowBuilds:')
+      expect(workspaceYaml).toContain('sharp: false')
+      expect(workspaceYaml).toContain('unrs-resolver: false')
+      expect(workspaceYaml).not.toContain('ignoredBuiltDependencies:')
     })
   })
 


### PR DESCRIPTION
`ignoreBuiltDependencies` was removed in v11. We're now using the equivalent `allowBuilds` in v11+.

## test plan

- [x] `pnpm create next-app@http://vercel-packages.vercel.app/next/commits/2483781d4bf288e492865fc0eb434e84773d3414/create-next-app` creates a config with `allowBuilds` (pnpm@11)
- [x] `pnpm create next-app@http://vercel-packages.vercel.app/next/commits/2483781d4bf288e492865fc0eb434e84773d3414/create-next-app` creates a config with `ignoredBuiltDependencies` (pnpm@10)