### PR TITLE
Revert internal ast-grep lint rule change

### DIFF
--- a/.config/ast-grep/rules/resolved-vc-in-return-type.yml
+++ b/.config/ast-grep/rules/resolved-vc-in-return-type.yml
@@ -1,24 +1,52 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
 
 id: resolved-vc-in-return-type
-message: Returning a `ResolvedVc` in a turbo task is not recommended. Consider replacing `ResolvedVc<$A>` in `$FN_NAME` with `Vc<$A>` instead.
+message: Returning a `ResolvedVc` in a turbo task is not recommended. Consider replacing `$TYPE` in `$FN_NAME` with `$RESOLVED_VC` instead.
 severity: warning # error, warning, info, hint
 language: Rust
 rule:
-  # The `ResolvedVc<$A>` generic type itself, captured as $TYPE.
-  pattern:
-    context: 'let x: ResolvedVc<$A> = 1;'
-    selector: generic_type
-  # ...appearing in the return type of a `#[turbo_tasks::function]`.
-  inside:
-    kind: function_item
-    field: return_type
-    stopBy: end
-    follows:
-      pattern: '#[turbo_tasks::function]'
-      stopBy: end
-    has:
-      kind: identifier
-      pattern: $FN_NAME
-
-fix: Vc<$A>
+  any:
+    # turbo tasks function
+    - all:
+        - pattern:
+            context: 'let x: ResolvedVc<$A> = 1;'
+            selector: generic_type
+        - pattern: $TYPE
+      inside:
+        kind: function_item
+        field: return_type
+        stopBy: end
+        follows:
+          pattern: '#[turbo_tasks::function]'
+        has:
+          kind: identifier
+          pattern: $FN_NAME
+      # turbo tasks value trait
+    - all:
+        - pattern:
+            context: 'let x: ResolvedVc<$A> = 1;'
+            selector: generic_type
+        - pattern: $TYPE
+      inside:
+        kind: function_signature_item
+        field: return_type
+        stopBy: end
+        inside:
+          inside:
+            kind: trait_item
+            follows:
+              pattern: '#[turbo_tasks::value_trait]'
+        has:
+          kind: identifier
+          pattern: $FN_NAME
+rewriters:
+  - id: rewrite-vc
+    rule:
+      pattern: $TYPE
+    fix: Vc<$A>
+transform:
+  RESOLVED_VC:
+    rewrite:
+      rewriters: [rewrite-vc]
+      source: $TYPE
+fix: $RESOLVED_VC


### PR DESCRIPTION
@lukesandberg changed this in https://github.com/vercel/next.js/pull/94324


There were many false lint warnings after that, e.g. on this non-turbotask-function:
```rust
async fn create_app_paths_manifest(
    node_root: FileSystemPath,
    original_name: &str,
    filename: RcStr,
) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {  // <----
```

or

```rust
async fn merge_modules(
    mut contents: Vec<(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>, CodeGenResult)>,
    entry_points: &Vec<(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>, usize)>,
    globals_merged: &'_ Globals,
) -> Result<(
    Program,
    Vec<CodeGenResultComments>,
    Vec<CodeGenResultSourceMap>,
    SmallVec<[ResolvedVc<Box<dyn GenerateSourceMap>>; 1]>, // <----
    Arc<Mutex<Vec<ModulePosition>>>,
)> {
```