### PR TITLE
Turbopack: content hash polyfill sourcemap file

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -52,7 +52,7 @@ use turbopack_core::{
     asset::AssetContent,
     chunk::{
         ChunkGroupResult, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssets,
-        SourceMapsType, availability_info::AvailabilityInfo,
+        availability_info::AvailabilityInfo,
     },
     file_source::FileSource,
     ident::{AssetIdent, Layer},
@@ -66,8 +66,6 @@ use turbopack_core::{
     reference::all_assets_from_entries,
     reference_type::{CommonJsReferenceSubType, CssReferenceSubType, ReferenceTypeCondition},
     resolve::{ResolveErrorMode, origin::PlainResolveOrigin, parse::Request, pattern::Pattern},
-    source::Source,
-    source_map::SourceMapAsset,
     virtual_output::VirtualOutputAsset,
 };
 use turbopack_ecmascript::single_file_ecmascript_output::SingleFileEcmascriptOutput;
@@ -1395,43 +1393,20 @@ impl AppEndpoint {
         let polyfill_output_asset = if matches!(this.ty, AppEndpointType::Page { .. }) {
             // polyfill-nomodule.js is a pre-compiled asset distributed as part of next
             let next_package = get_next_package(project.project_path().owned().await?).await?;
-            let polyfill_source_path =
-                next_package.join("dist/build/polyfills/polyfill-nomodule.js")?;
-            let polyfill_source = FileSource::new(polyfill_source_path.clone());
-            let polyfill_output_path = client_chunking_context
-                .chunk_path(
-                    Some(Vc::upcast(polyfill_source)),
-                    polyfill_source.ident(),
-                    None,
-                    rcstr!(".js"),
-                )
-                .owned()
-                .await?;
+            let polyfill_source =
+                FileSource::new(next_package.join("dist/build/polyfills/polyfill-nomodule.js")?);
 
-            let polyfill_output = SingleFileEcmascriptOutput::new(
-                polyfill_output_path.clone(),
-                polyfill_source_path,
-                Vc::upcast(polyfill_source),
-            )
-            .to_resolved()
-            .await?;
-
-            let polyfill_output_asset = ResolvedVc::upcast(polyfill_output);
-            client_assets.insert(polyfill_output_asset);
-
-            let client_source_maps = project
-                .next_config()
-                .client_source_maps(project.next_mode())
-                .await?;
-            if *client_source_maps != SourceMapsType::None {
-                let polyfill_source_map_asset = SourceMapAsset::new_fixed(
-                    polyfill_output_path.clone(),
-                    *ResolvedVc::upcast(polyfill_output),
+            let polyfill_output_asset = ResolvedVc::upcast(
+                SingleFileEcmascriptOutput::new(
+                    *client_chunking_context,
+                    Vc::upcast(polyfill_source),
                 )
                 .to_resolved()
-                .await?;
-                client_assets.insert(ResolvedVc::upcast(polyfill_source_map_asset));
-            }
+                .await?,
+            );
+
+            client_assets.insert(polyfill_output_asset);
+
             Some(polyfill_output_asset)
         } else {
             None

--- a/test/production/deployment-id-handling/app/next.config.js
+++ b/test/production/deployment-id-handling/app/next.config.js
@@ -12,4 +12,6 @@ module.exports = {
   },
   adapterPath:
     process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.mjs'),
+  // To generate all sourcemaps
+  productionBrowserSourceMaps: true,
 }

--- a/test/production/deployment-id-handling/app/next.config.js
+++ b/test/production/deployment-id-handling/app/next.config.js
@@ -9,9 +9,10 @@ module.exports = {
     supportsImmutableAssets: process.env.NEXT_DEPLOYMENT_ID_IMMUTABLE
       ? true
       : false,
+    serverSourceMaps: true,
   },
   adapterPath:
     process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.mjs'),
-  // To generate all sourcemaps
+  // To generate all sourcemaps and ensure that they are content hashed
   productionBrowserSourceMaps: true,
 }

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -201,7 +201,10 @@ describe.each([
         expect(immutableAssets).not.toBeEmpty()
         expect(immutableAssets).toSatisfyAll(
           (f) =>
-            // Should be same hash as in the filename, for better build performance
+            // Should be same hash as in the filename, for better build performance.
+            // This check also ensure that we don't accidentally forget to content hash sourcemap
+            // files (i.e. 0cz1d0mv5g_q7.js is content hashed, but 0cz1d0mv5g_q7.js.map is not a
+            // content hash of itself)..
             f.immutableHash && f.pathname.includes(f.immutableHash.slice(0, 13))
         )
       })

--- a/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
@@ -3,13 +3,15 @@ use std::sync::Arc;
 use anyhow::Result;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
 use tokio::io::AsyncReadExt;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_rcstr::rcstr;
+use turbo_tasks::{ResolvedVc, ValueToStringRef, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    output::{OutputAsset, OutputAssetsReference},
+    chunk::ChunkingContext,
+    output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
     source::Source,
-    source_map::GenerateSourceMap,
+    source_map::{GenerateSourceMap, SourceMapAsset},
 };
 
 use crate::parse::generate_js_source_map;
@@ -18,21 +20,35 @@ use crate::parse::generate_js_source_map;
 /// map to the original file.
 #[turbo_tasks::value]
 pub struct SingleFileEcmascriptOutput {
-    output_path: FileSystemPath,
-    source_path: FileSystemPath,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     source: ResolvedVc<Box<dyn Source>>,
+}
+
+#[turbo_tasks::value_impl]
+impl SingleFileEcmascriptOutput {
+    #[turbo_tasks::function]
+    async fn source_map(self: Vc<Self>) -> Result<Vc<SourceMapAsset>> {
+        let this = self.await?;
+        Ok(SourceMapAsset::new(
+            *this.chunking_context,
+            this.source.ident(),
+            Vc::upcast(self),
+        ))
+    }
 }
 
 #[turbo_tasks::value_impl]
 impl OutputAsset for SingleFileEcmascriptOutput {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        self.output_path.clone().cell()
+        self.chunking_context.chunk_path(
+            Some(Vc::upcast(*self.source)),
+            self.source.ident(),
+            None,
+            rcstr!(".js"),
+        )
     }
 }
-
-#[turbo_tasks::value_impl]
-impl OutputAssetsReference for SingleFileEcmascriptOutput {}
 
 #[turbo_tasks::value_impl]
 impl Asset for SingleFileEcmascriptOutput {
@@ -46,14 +62,12 @@ impl Asset for SingleFileEcmascriptOutput {
 impl SingleFileEcmascriptOutput {
     #[turbo_tasks::function]
     pub fn new(
-        output_path: FileSystemPath,
-        source_path: FileSystemPath,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         source: ResolvedVc<Box<dyn Source>>,
     ) -> Vc<SingleFileEcmascriptOutput> {
         SingleFileEcmascriptOutput {
-            output_path,
-            source_path,
             source,
+            chunking_context,
         }
         .cell()
     }
@@ -87,11 +101,17 @@ impl GenerateSourceMap for SingleFileEcmascriptOutput {
             pos += line.len() as u32;
         }
 
+        let source_path = self
+            .source
+            .ident()
+            .await?
+            .path
+            .to_string_ref()
+            .await?
+            .to_string();
+
         let sm: Arc<SourceMap> = Default::default();
-        sm.new_source_file(
-            FileName::Custom(self.source_path.to_string()).into(),
-            file_source,
-        );
+        sm.new_source_file(FileName::Custom(source_path).into(), file_source);
 
         let map = generate_js_source_map(
             &*sm,
@@ -102,5 +122,28 @@ impl GenerateSourceMap for SingleFileEcmascriptOutput {
             Default::default(),
         )?;
         Ok(FileContent::Content(File::from(map)).cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAssetsReference for SingleFileEcmascriptOutput {
+    #[turbo_tasks::function]
+    async fn references(self: Vc<Self>) -> Result<Vc<OutputAssetsWithReferenced>> {
+        let this = self.await?;
+
+        let include_source_map = *this
+            .chunking_context
+            .reference_chunk_source_maps(Vc::upcast(self))
+            .await?;
+
+        let references = if include_source_map {
+            Vc::cell(vec![ResolvedVc::upcast(
+                self.source_map().to_resolved().await?,
+            )])
+        } else {
+            OutputAssets::empty()
+        };
+
+        Ok(OutputAssetsWithReferenced::from_assets(references))
     }
 }


### PR DESCRIPTION
The sourcemap file of the polyfill chunk wasn't actually content hashed. it just used the name of the corresponding JS chunk.
It was still emitted into `_next/static/immutable`. So it wasn't actually immutable.

Now, it's content hashed (and this also removed the ad-hoc sourcemap construction from app.rs and instead uses the usual pattern that all other chunks use to reference their corresponding sourcemap chunks).


We didn't catch this because it only happens with `nextConfig.productionBrowserSourceMaps: true` which isn't the default. The test now covers this as well
