### PR TITLE
fix(dev-overlay): Tidy up issues/insight menu and tab overlay

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.css
@@ -79,6 +79,12 @@
   margin-left: auto;
 }
 
+.dev-tools-indicator-issue-counts {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .dev-tools-indicator-issue-count {
   --color-primary: var(--color-gray-800);
   --color-secondary: var(--color-gray-100);

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.css
@@ -105,6 +105,11 @@
     --color-secondary: var(--color-red-100);
   }
 
+  &[data-has-issues='true'][data-variant='insight'] {
+    --color-primary: var(--color-amber-800);
+    --color-secondary: var(--color-amber-100);
+  }
+
   .dev-tools-indicator-issue-count-indicator {
     width: var(--size-8);
     height: var(--size-8);

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
@@ -13,6 +13,7 @@ import {
   ACTION_ERROR_OVERLAY_OPEN,
 } from '../../shared'
 import { usePanelRouterContext } from '../../menu/context'
+import { getIssueBucketState } from '../../menu/dev-overlay-menu'
 import { BASE_LOGO_SIZE } from '../../utils/indicator-metrics'
 import { StatusIndicator, Status, getCurrentStatus } from './status-indicator'
 
@@ -84,9 +85,10 @@ export function NextLogo({
   const isMenuOpen = panel === 'panel-selector'
 
   const hasError = totalErrorCount > 0
-  // Only insights remain: use amber styling instead of red.
-  const insightsOnly =
-    hasError && normalErrorCount === 0 && instantErrorCount > 0
+  const { insightsOnly } = getIssueBucketState(
+    normalErrorCount,
+    instantErrorCount
+  )
   const [isErrorExpanded, setIsErrorExpanded] = useState(hasError)
   const [previousHasError, setPreviousHasError] = useState(hasError)
   if (previousHasError !== hasError) {

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
@@ -13,7 +13,7 @@ import {
   ACTION_ERROR_OVERLAY_OPEN,
 } from '../../shared'
 import { usePanelRouterContext } from '../../menu/context'
-import { getIssueBucketState } from '../../menu/dev-overlay-menu'
+import { getIssueBucketState } from '../../menu/issue-bucket-state'
 import { BASE_LOGO_SIZE } from '../../utils/indicator-metrics'
 import { StatusIndicator, Status, getCurrentStatus } from './status-indicator'
 

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -504,22 +504,28 @@ export function ErrorTabBar({
   return (
     <div className="error-overlay-tab-bar" data-nextjs-error-overlay-tab-bar>
       {previousButton}
-      {errorCount > 0 && (
-        <button
-          type="button"
-          className="error-overlay-tab"
-          data-active={activeTab === 'errors'}
-          onClick={() => onTabChange('errors')}
-        >
-          Issues
-          <span
-            className="error-overlay-tab-count"
-            data-active={activeTab === 'errors'}
-          >
-            {createCount(errorActiveIdx, errorCount, activeTab === 'errors')}
-          </span>
-        </button>
-      )}
+      <button
+        type="button"
+        className="error-overlay-tab"
+        data-active={activeTab === 'errors'}
+        disabled={errorCount === 0}
+        aria-disabled={errorCount === 0}
+        onClick={() => onTabChange('errors')}
+      >
+        {errorCount === 0 ? (
+          'No issues'
+        ) : (
+          <>
+            Issues
+            <span
+              className="error-overlay-tab-count"
+              data-active={activeTab === 'errors'}
+            >
+              {createCount(errorActiveIdx, errorCount, activeTab === 'errors')}
+            </span>
+          </>
+        )}
+      </button>
       {instantCount > 0 && (
         <button
           type="button"

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -504,36 +504,42 @@ export function ErrorTabBar({
   return (
     <div className="error-overlay-tab-bar" data-nextjs-error-overlay-tab-bar>
       {previousButton}
-      <button
-        type="button"
-        className="error-overlay-tab"
-        data-active={activeTab === 'errors'}
-        disabled={errorCount === 0}
-        onClick={() => onTabChange('errors')}
-      >
-        Issues
-        <span
-          className="error-overlay-tab-count"
+      {errorCount > 0 && (
+        <button
+          type="button"
+          className="error-overlay-tab"
           data-active={activeTab === 'errors'}
+          onClick={() => onTabChange('errors')}
         >
-          {createCount(errorActiveIdx, errorCount, activeTab === 'errors')}
-        </span>
-      </button>
-      <button
-        type="button"
-        className="error-overlay-tab"
-        data-active={activeTab === 'instant'}
-        disabled={instantCount === 0}
-        onClick={() => onTabChange('instant')}
-      >
-        Insights
-        <span
-          className="error-overlay-tab-count"
+          Issues
+          <span
+            className="error-overlay-tab-count"
+            data-active={activeTab === 'errors'}
+          >
+            {createCount(errorActiveIdx, errorCount, activeTab === 'errors')}
+          </span>
+        </button>
+      )}
+      {instantCount > 0 && (
+        <button
+          type="button"
+          className="error-overlay-tab"
           data-active={activeTab === 'instant'}
+          onClick={() => onTabChange('instant')}
         >
-          {createCount(instantActiveIdx, instantCount, activeTab === 'instant')}
-        </span>
-      </button>
+          Insights
+          <span
+            className="error-overlay-tab-count"
+            data-active={activeTab === 'instant'}
+          >
+            {createCount(
+              instantActiveIdx,
+              instantCount,
+              activeTab === 'instant'
+            )}
+          </span>
+        </button>
+      )}
       {nextButton}
     </div>
   )
@@ -711,9 +717,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
     getErrorSource(error) || ''
   )
 
-  // Show the tab bar whenever there are instant errors so the user
-  // knows they're looking at an insight, even if the other tab is empty.
-  const showTabBar = instantErrors.length > 0
+  const showTabBar = normalErrors.length > 0 || instantErrors.length > 0
   const renderTabBar = showTabBar
     ? ({
         previousButton,

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -723,7 +723,11 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
     getErrorSource(error) || ''
   )
 
-  const showTabBar = normalErrors.length > 0 || instantErrors.length > 0
+  // Show the tab bar only when at least one Insight is present. When the only
+  // bucket with content is Issues, the red pill already conveys the count and a
+  // single-tab bar would be redundant. When Insights exist (alone or alongside
+  // Issues), the bar is shown so the user can switch between buckets.
+  const showTabBar = instantErrors.length > 0
   const renderTabBar = showTabBar
     ? ({
         previousButton,

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -1307,7 +1307,7 @@ export const styles = `
     transition: color 0.15s ease;
     border-radius: var(--rounded-md);
 
-    &:hover {
+    &:hover:not(:disabled) {
       color: var(--color-gray-1000);
     }
 

--- a/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
@@ -315,11 +315,18 @@ function getClickableItemsCount(
   return items.filter((item) => item.onClick).length
 }
 
-export function IssueCount({ children }: { children: number }) {
+export function IssueCount({
+  children,
+  variant = 'issue',
+}: {
+  children: number
+  variant?: 'issue' | 'insight'
+}) {
   return (
     <span
       className="dev-tools-indicator-issue-count"
       data-has-issues={children > 0}
+      data-variant={variant}
     >
       <span className="dev-tools-indicator-issue-count-indicator" />
       {children}

--- a/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
@@ -318,18 +318,14 @@ function getClickableItemsCount(
 export function IssueCount({
   children,
   variant = 'issue',
-  hasIssues,
 }: {
-  children: React.ReactNode
+  children: number
   variant?: 'issue' | 'insight'
-  hasIssues?: boolean
 }) {
   return (
     <span
       className="dev-tools-indicator-issue-count"
-      data-has-issues={
-        hasIssues ?? (typeof children === 'number' && children > 0)
-      }
+      data-has-issues={children > 0}
       data-variant={variant}
     >
       <span className="dev-tools-indicator-issue-count-indicator" />

--- a/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
@@ -334,30 +334,6 @@ export function IssueCount({
   )
 }
 
-export type IssueBucketState = {
-  hasNormal: boolean
-  hasInstant: boolean
-  hasAny: boolean
-  insightsOnly: boolean
-  variant: 'issue' | 'insight'
-}
-
-export function getIssueBucketState(
-  normalErrorCount: number,
-  instantErrorCount: number
-): IssueBucketState {
-  const hasNormal = normalErrorCount > 0
-  const hasInstant = instantErrorCount > 0
-  const insightsOnly = !hasNormal && hasInstant
-  return {
-    hasNormal,
-    hasInstant,
-    hasAny: hasNormal || hasInstant,
-    insightsOnly,
-    variant: insightsOnly ? 'insight' : 'issue',
-  }
-}
-
 export function ChevronRight() {
   return (
     <svg

--- a/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
@@ -318,20 +318,48 @@ function getClickableItemsCount(
 export function IssueCount({
   children,
   variant = 'issue',
+  hasIssues,
 }: {
-  children: number
+  children: React.ReactNode
   variant?: 'issue' | 'insight'
+  hasIssues?: boolean
 }) {
   return (
     <span
       className="dev-tools-indicator-issue-count"
-      data-has-issues={children > 0}
+      data-has-issues={
+        hasIssues ?? (typeof children === 'number' && children > 0)
+      }
       data-variant={variant}
     >
       <span className="dev-tools-indicator-issue-count-indicator" />
       {children}
     </span>
   )
+}
+
+export type IssueBucketState = {
+  hasNormal: boolean
+  hasInstant: boolean
+  hasAny: boolean
+  insightsOnly: boolean
+  variant: 'issue' | 'insight'
+}
+
+export function getIssueBucketState(
+  normalErrorCount: number,
+  instantErrorCount: number
+): IssueBucketState {
+  const hasNormal = normalErrorCount > 0
+  const hasInstant = instantErrorCount > 0
+  const insightsOnly = !hasNormal && hasInstant
+  return {
+    hasNormal,
+    hasInstant,
+    hasAny: hasNormal || hasInstant,
+    insightsOnly,
+    variant: insightsOnly ? 'insight' : 'issue',
+  }
 }
 
 export function ChevronRight() {

--- a/packages/next/src/next-devtools/dev-overlay/menu/issue-bucket-state.ts
+++ b/packages/next/src/next-devtools/dev-overlay/menu/issue-bucket-state.ts
@@ -1,0 +1,23 @@
+export type IssueBucketState = {
+  hasNormal: boolean
+  hasInstant: boolean
+  hasAny: boolean
+  insightsOnly: boolean
+  variant: 'issue' | 'insight'
+}
+
+export function getIssueBucketState(
+  normalErrorCount: number,
+  instantErrorCount: number
+): IssueBucketState {
+  const hasNormal = normalErrorCount > 0
+  const hasInstant = instantErrorCount > 0
+  const insightsOnly = !hasNormal && hasInstant
+  return {
+    hasNormal,
+    hasInstant,
+    hasAny: hasNormal || hasInstant,
+    insightsOnly,
+    variant: insightsOnly ? 'insight' : 'issue',
+  }
+}

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -43,14 +43,11 @@ const MenuPanel = () => {
   const { normalErrorCount, instantErrorCount } = useRenderErrorContext()
   const isAppRouter = state.routerType === 'app'
 
-  const { hasNormal, hasInstant, hasAny, insightsOnly, variant } =
-    getIssueBucketState(normalErrorCount, instantErrorCount)
-  const label =
-    hasNormal && hasInstant
-      ? 'Issues · Insights'
-      : insightsOnly
-        ? 'Insights'
-        : 'Issues'
+  const { hasNormal, hasInstant, hasAny } = getIssueBucketState(
+    normalErrorCount,
+    instantErrorCount
+  )
+
   const titleParts: string[] = []
   if (hasNormal) {
     titleParts.push(
@@ -62,6 +59,12 @@ const MenuPanel = () => {
       `${instantErrorCount} ${instantErrorCount === 1 ? 'insight' : 'insights'}`
     )
   }
+  const label =
+    hasNormal && hasInstant
+      ? 'Issues · Insights'
+      : hasInstant
+        ? 'Insights'
+        : 'Issues'
 
   return (
     <DevtoolMenu
@@ -70,27 +73,24 @@ const MenuPanel = () => {
           title: `${titleParts.join(' · ')} found. Click to view details in the dev overlay.`,
           label,
           value: (
-            <IssueCount variant={variant} hasIssues={hasAny}>
-              {hasNormal && hasInstant
-                ? `${normalErrorCount} · ${instantErrorCount}`
-                : hasNormal
-                  ? normalErrorCount
-                  : instantErrorCount}
-            </IssueCount>
+            <span className="dev-tools-indicator-issue-counts">
+              {hasNormal && (
+                <IssueCount variant="issue">{normalErrorCount}</IssueCount>
+              )}
+              {hasInstant && (
+                <IssueCount variant="insight">{instantErrorCount}</IssueCount>
+              )}
+            </span>
           ),
           onClick: () => {
             if (state.isErrorOverlayOpen) {
-              dispatch({
-                type: ACTION_ERROR_OVERLAY_CLOSE,
-              })
+              dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
               setPanel(null)
               return
             }
             setPanel(null)
             setSelectedIndex(-1)
-            dispatch({
-              type: ACTION_ERROR_OVERLAY_OPEN,
-            })
+            dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
           },
         },
         state.staticIndicator === 'disabled'

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -1,5 +1,10 @@
 import { usePanelRouterContext, type PanelStateKind } from './context'
-import { ChevronRight, DevtoolMenu, IssueCount } from './dev-overlay-menu'
+import {
+  ChevronRight,
+  DevtoolMenu,
+  IssueCount,
+  getIssueBucketState,
+} from './dev-overlay-menu'
 import { DynamicPanel } from '../panel/dynamic-panel'
 import {
   learnMoreLink,
@@ -38,22 +43,39 @@ const MenuPanel = () => {
   const { normalErrorCount, instantErrorCount } = useRenderErrorContext()
   const isAppRouter = state.routerType === 'app'
 
-  const hasNormal = normalErrorCount > 0
-  const hasInstant = instantErrorCount > 0
-  const insightsOnly = !hasNormal && hasInstant
-  const visibleErrorCount = hasNormal ? normalErrorCount : instantErrorCount
-  const label = insightsOnly ? 'Insights' : 'Issues'
-  const noun = insightsOnly ? 'insight' : 'issue'
+  const { hasNormal, hasInstant, hasAny, insightsOnly, variant } =
+    getIssueBucketState(normalErrorCount, instantErrorCount)
+  const label =
+    hasNormal && hasInstant
+      ? 'Issues · Insights'
+      : insightsOnly
+        ? 'Insights'
+        : 'Issues'
+  const titleParts: string[] = []
+  if (hasNormal) {
+    titleParts.push(
+      `${normalErrorCount} ${normalErrorCount === 1 ? 'issue' : 'issues'}`
+    )
+  }
+  if (hasInstant) {
+    titleParts.push(
+      `${instantErrorCount} ${instantErrorCount === 1 ? 'insight' : 'insights'}`
+    )
+  }
 
   return (
     <DevtoolMenu
       items={[
-        (hasNormal || hasInstant) && {
-          title: `${visibleErrorCount} ${visibleErrorCount === 1 ? noun : `${noun}s`} found. Click to view details in the dev overlay.`,
+        hasAny && {
+          title: `${titleParts.join(' · ')} found. Click to view details in the dev overlay.`,
           label,
           value: (
-            <IssueCount variant={insightsOnly ? 'insight' : 'issue'}>
-              {visibleErrorCount}
+            <IssueCount variant={variant} hasIssues={hasAny}>
+              {hasNormal && hasInstant
+                ? `${normalErrorCount} · ${instantErrorCount}`
+                : hasNormal
+                  ? normalErrorCount
+                  : instantErrorCount}
             </IssueCount>
           ),
           onClick: () => {

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -35,16 +35,27 @@ import { CacheDisabledBody } from '../components/errors/dev-tools-indicator/dev-
 const MenuPanel = () => {
   const { setPanel, setSelectedIndex } = usePanelRouterContext()
   const { state, dispatch } = useDevOverlayContext()
-  const { totalErrorCount } = useRenderErrorContext()
+  const { normalErrorCount, instantErrorCount } = useRenderErrorContext()
   const isAppRouter = state.routerType === 'app'
+
+  const hasNormal = normalErrorCount > 0
+  const hasInstant = instantErrorCount > 0
+  const insightsOnly = !hasNormal && hasInstant
+  const visibleErrorCount = hasNormal ? normalErrorCount : instantErrorCount
+  const label = insightsOnly ? 'Insights' : 'Issues'
+  const noun = insightsOnly ? 'insight' : 'issue'
 
   return (
     <DevtoolMenu
       items={[
-        totalErrorCount > 0 && {
-          title: `${totalErrorCount} ${totalErrorCount === 1 ? 'issue' : 'issues'} found. Click to view details in the dev overlay.`,
-          label: 'Issues',
-          value: <IssueCount>{totalErrorCount}</IssueCount>,
+        (hasNormal || hasInstant) && {
+          title: `${visibleErrorCount} ${visibleErrorCount === 1 ? noun : `${noun}s`} found. Click to view details in the dev overlay.`,
+          label,
+          value: (
+            <IssueCount variant={insightsOnly ? 'insight' : 'issue'}>
+              {visibleErrorCount}
+            </IssueCount>
+          ),
           onClick: () => {
             if (state.isErrorOverlayOpen) {
               dispatch({
@@ -55,11 +66,9 @@ const MenuPanel = () => {
             }
             setPanel(null)
             setSelectedIndex(-1)
-            if (totalErrorCount > 0) {
-              dispatch({
-                type: ACTION_ERROR_OVERLAY_OPEN,
-              })
-            }
+            dispatch({
+              type: ACTION_ERROR_OVERLAY_OPEN,
+            })
           },
         },
         state.staticIndicator === 'disabled'

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -1,10 +1,6 @@
 import { usePanelRouterContext, type PanelStateKind } from './context'
-import {
-  ChevronRight,
-  DevtoolMenu,
-  IssueCount,
-  getIssueBucketState,
-} from './dev-overlay-menu'
+import { ChevronRight, DevtoolMenu, IssueCount } from './dev-overlay-menu'
+import { getIssueBucketState } from './issue-bucket-state'
 import { DynamicPanel } from '../panel/dynamic-panel'
 import {
   learnMoreLink,


### PR DESCRIPTION
### What?

Tidies up how the dev overlay surfaces Issues vs Insights:

- Tab bar: when there are no insights, the Insights tab is hidden. When there are no issues but there are insights, the Issues tab stays in place but reads `No issues` (disabled, no hover).
- Menu row: shows one row labeled `Issues`, `Insights`, or `Issues · Insights` with a red badge for issues and an amber badge for insights, matching the trigger pill colors.

### Verification

Test-app scenarios on the [error-messages-overhaul demo](https://error-messages-overhaul-ibsl.labs.vercel.dev/): [41-subnav-cookies](https://error-messages-overhaul-ibsl.labs.vercel.dev/scenario/41-subnav-cookies), [42-subnav-fetch](https://error-messages-overhaul-ibsl.labs.vercel.dev/scenario/42-subnav-fetch).

### Why?

Reported by icyJoseph in Slack. The red `Issues 1` chip on an insights-only state looked like a real error; the `0/0` placeholder was inconsistent.

<!-- NEXT_JS_LLM_PR -->