### PR TITLE
Reduce new test concurrency to five

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -657,7 +657,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/10, 2/10, 3/10, 4/10, 5/10, 6/10, 7/10, 8/10, 9/10, 10/10]
+        group: [1/5, 2/5, 3/5, 4/5, 5/5]
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -683,7 +683,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/10, 2/10, 3/10, 4/10, 5/10, 6/10, 7/10, 8/10, 9/10, 10/10]
+        group: [1/5, 2/5, 3/5, 4/5, 5/5]
 
     uses: ./.github/workflows/build_reusable.yml
     with:


### PR DESCRIPTION
### What?

Reduce the `test-new-tests-dev` and `test-new-tests-start` workflow matrices from ten groups to five.

### Why?

Restore these flake-detection jobs to five concurrent shards.

### How?

Change each matrix group list from `1/10` through `10/10` to `1/5` through `5/5`.

### Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --check .github/workflows/build_and_test.yml`
- `git diff --cached --check`

<!-- NEXT_JS_LLM_PR -->