### PR TITLE
Fix non-RSC router prefetch handling

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -395,20 +395,23 @@ function parseRequestHeaders(
   headers: IncomingHttpHeaders,
   options: ParseRequestHeadersOptions
 ): ParsedRequestHeaders {
+  const isRSCRequest = isRSCRequestHeader(headers[RSC_HEADER])
+
   // runtime prefetch requests are *not* treated as prefetch requests
   // (TODO: this is confusing, we should refactor this to express this better)
-  const isPrefetchRequest = headers[NEXT_ROUTER_PREFETCH_HEADER] === '1'
+  const isPrefetchRequest =
+    isRSCRequest && headers[NEXT_ROUTER_PREFETCH_HEADER] === '1'
 
-  const isAppShellPrefetchRequest = headers[NEXT_ROUTER_PREFETCH_HEADER] === '3'
+  const isAppShellPrefetchRequest =
+    isRSCRequest && headers[NEXT_ROUTER_PREFETCH_HEADER] === '3'
 
   // App Shell prefetches are a subtype of runtime prefetch — same code path,
   // but with less resolved content (omitting link data)
   const isRuntimePrefetchRequest =
-    headers[NEXT_ROUTER_PREFETCH_HEADER] === '2' || isAppShellPrefetchRequest
+    isRSCRequest &&
+    (headers[NEXT_ROUTER_PREFETCH_HEADER] === '2' || isAppShellPrefetchRequest)
 
   const isHmrRefresh = headers[NEXT_HMR_REFRESH_HEADER] !== undefined
-
-  const isRSCRequest = isRSCRequestHeader(headers[RSC_HEADER])
 
   const shouldProvideFlightRouterState =
     isRSCRequest && (!isPrefetchRequest || !options.isRoutePPREnabled)
@@ -419,7 +422,7 @@ function parseRequestHeaders(
 
   // Checks if this is a prefetch of the Route Tree by the Segment Cache
   const isRouteTreePrefetchRequest =
-    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === '/_tree'
+    isRSCRequest && headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === '/_tree'
 
   const csp =
     headers['content-security-policy'] ||

--- a/test/e2e/app-dir/non-rsc-router-prefetch/app/layout.tsx
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/non-rsc-router-prefetch/app/page.tsx
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/app/page.tsx
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/non-rsc-router-prefetch/next.config.js
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/non-rsc-router-prefetch/next.config.js
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/next.config.js
@@ -1,6 +1,11 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  cacheComponents: false,
+  experimental: {
+    cachedNavigations: false,
+  },
+}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
@@ -9,6 +9,11 @@ describe('non-rsc-router-prefetch', () => {
     files: __dirname,
   })
 
+  beforeAll(async () => {
+    const res = await next.fetch('/')
+    await res.text()
+  })
+
   it('ignores the router prefetch header for HTML requests', async () => {
     const res = await next.fetch('/', {
       headers: {

--- a/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  NEXT_ROUTER_PREFETCH_HEADER,
+  RSC_HEADER,
+} from 'next/dist/client/components/app-router-headers'
+
+describe('non-rsc-router-prefetch', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('ignores the router prefetch header for HTML requests', async () => {
+    const res = await next.fetch('/', {
+      headers: {
+        [NEXT_ROUTER_PREFETCH_HEADER]: '1',
+      },
+      signal: AbortSignal.timeout(5_000),
+    })
+    const html = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(html).toContain('hello world')
+  })
+
+  it('honors the router prefetch header for RSC requests', async () => {
+    const res = await next.fetch('/', {
+      headers: {
+        [RSC_HEADER]: '1',
+        [NEXT_ROUTER_PREFETCH_HEADER]: '1',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/x-component')
+  })
+})

--- a/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
@@ -5,9 +5,14 @@ import {
 } from 'next/dist/client/components/app-router-headers'
 
 describe('non-rsc-router-prefetch', () => {
-  const { next } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
   })
+
+  if (skipped) {
+    return
+  }
 
   beforeAll(async () => {
     const res = await next.fetch('/')


### PR DESCRIPTION
### What?

Ignore router prefetch protocol headers when the request is not classified as an RSC request. Add a dedicated force-dynamic App Router fixture that verifies HTML and valid RSC prefetch behavior.

### Why?

A non-RSC HTML request with `Next-Router-Prefetch: 1` could enter the partial prefetch tree path, produce a null active cache node, and suspend the HTML render until timeout.

### How?

Determine `isRSCRequest` before parsing prefetch modes, then require it for prefetch modes `1`, `2`, and `3`, including route-tree prefetch classification. The regression fixture uses an abort timeout to fail quickly if the HTML response hangs and separately confirms RSC prefetches remain valid.

### Verification

- `pnpm build-all`
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-turbo test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts`
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-webpack test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts`
- `pnpm --filter=next types`

<!-- NEXT_JS_LLM_PR -->