### PR TITLE
[ci] Disable on-call notification if manual deploy e2e tests failed

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -41,12 +41,11 @@ jobs:
   report-failure:
     name: report failure to slack
     # Report the failure to Slack if the test-e2e-deploy-release workflow has failed 2 times
+    # Manual runs (workflow_dispatch) are likely personal tests and don't
+    # require action by the on-call.
     if: >-
       ${{
-        (
-          github.event.workflow_run.event == 'release' ||
-          github.event.workflow_run.display_title == 'test-e2e-deploy canary'
-        ) &&
+        github.event.workflow_run.event == 'release' &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt >= 2 &&
         !github.event.workflow_run.head_repository.fork


### PR DESCRIPTION
They're still retried but the notification is just noise in the channel it goes to.