### PR TITLE
fix(eslint-plugin-next): Support pageExtensions in no-html-link-for-pages and resolve app directory static route bug

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -83,7 +83,9 @@ export default defineRule({
     if (typeof pageExtensions === 'string') {
       pageExtensions = [pageExtensions]
     }
-    pageExtensions = pageExtensions.map((ext) => ext.trim().replace(/^\.+/, ''))
+    pageExtensions = pageExtensions.map((ext) =>
+      ext.trim().replace(/^\.+/, '').toLowerCase()
+    )
 
     const rootDirs = getRootDirs(context)
 

--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -72,6 +72,18 @@ export default defineRule({
     const ruleOptions: (string | string[])[] = context.options
     const [customPagesDirectory] = ruleOptions
 
+    const nextSettings: { pageExtensions?: string | string[] } =
+      context.settings.next || {}
+    let pageExtensions = nextSettings.pageExtensions || [
+      'tsx',
+      'ts',
+      'jsx',
+      'js',
+    ]
+    if (typeof pageExtensions === 'string') {
+      pageExtensions = [pageExtensions]
+    }
+
     const rootDirs = getRootDirs(context)
 
     const pagesDirs = (
@@ -107,8 +119,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -83,6 +83,7 @@ export default defineRule({
     if (typeof pageExtensions === 'string') {
       pageExtensions = [pageExtensions]
     }
+    pageExtensions = pageExtensions.map((ext) => ext.trim().replace(/^\.+/, ''))
 
     const rootDirs = getRootDirs(context)
 

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -11,21 +11,21 @@ const fsReadDirSyncCache = {}
 function parseUrlForPages(
   urlprefix: string,
   directory: string,
-  pageExtensions: string[]
+  pageExtensions: RegExp
 ) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    const extension = pageExtensions.find((ext) =>
-      dirent.name.endsWith(`.${ext}`)
-    )
-    if (extension) {
-      if (dirent.name === `index.${extension}`) {
+    const extensionMatch = dirent.name.match(pageExtensions)
+    if (extensionMatch) {
+      if (dirent.name === `index${extensionMatch[0]}`) {
         res.push(`${urlprefix}`)
       } else {
-        res.push(`${urlprefix}${dirent.name.slice(0, -(extension.length + 1))}`)
+        res.push(
+          `${urlprefix}${dirent.name.slice(0, -extensionMatch[0].length)}`
+        )
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
@@ -49,21 +49,21 @@ function parseUrlForPages(
 function parseUrlForAppDir(
   urlprefix: string,
   directory: string,
-  pageExtensions: string[]
+  pageExtensions: RegExp
 ) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    const extension = pageExtensions.find((ext) =>
-      dirent.name.endsWith(`.${ext}`)
-    )
-    if (extension) {
-      if (dirent.name === `page.${extension}`) {
+    const extensionMatch = dirent.name.match(pageExtensions)
+    if (extensionMatch) {
+      if (dirent.name === `page${extensionMatch[0]}`) {
         res.push(`${urlprefix}`)
-      } else if (dirent.name !== `layout.${extension}`) {
-        res.push(`${urlprefix}${dirent.name.slice(0, -(extension.length + 1))}`)
+      } else if (dirent.name !== `layout${extensionMatch[0]}`) {
+        res.push(
+          `${urlprefix}${dirent.name.slice(0, -extensionMatch[0].length)}`
+        )
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
@@ -160,12 +160,18 @@ export function getUrlFromPagesDirectories(
   directories: string[],
   pageExtensions: string[]
 ) {
+  const escapeRegex = (str: string) =>
+    str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pageExtensionsRegex = new RegExp(
+    `\\.(${pageExtensions.map(escapeRegex).join('|')})$`
+  )
+
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
         .flatMap((directory) =>
-          parseUrlForPages(urlPrefix, directory, pageExtensions)
+          parseUrlForPages(urlPrefix, directory, pageExtensionsRegex)
         )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
@@ -183,12 +189,18 @@ export function getUrlFromAppDirectory(
   directories: string[],
   pageExtensions: string[]
 ) {
+  const escapeRegex = (str: string) =>
+    str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pageExtensionsRegex = new RegExp(
+    `\\.(${pageExtensions.map(escapeRegex).join('|')})$`
+  )
+
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
         .map((directory) =>
-          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+          parseUrlForAppDir(urlPrefix, directory, pageExtensionsRegex)
         )
         .flat()
         .map(

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -24,8 +24,9 @@ function parseUrlForPages(
     if (extension) {
       if (dirent.name === `index.${extension}`) {
         res.push(`${urlprefix}`)
+      } else {
+        res.push(`${urlprefix}${dirent.name.slice(0, -(extension.length + 1))}`)
       }
-      res.push(`${urlprefix}${dirent.name.slice(0, -(extension.length + 1))}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -8,25 +8,34 @@ const fsReadDirSyncCache = {}
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    const extension = pageExtensions.find((ext) =>
+      dirent.name.endsWith(`.${ext}`)
+    )
+    if (extension) {
+      if (dirent.name === `index.${extension}`) {
+        res.push(`${urlprefix}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.slice(0, -(extension.length + 1))}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +45,35 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    const extension = pageExtensions.find((ext) =>
+      dirent.name.endsWith(`.${ext}`)
+    )
+    if (extension) {
+      if (dirent.name === `page.${extension}`) {
+        res.push(`${urlprefix}`)
+      } else if (dirent.name !== `layout.${extension}`) {
+        res.push(`${urlprefix}${dirent.name.slice(0, -(extension.length + 1))}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(
+          ...parseUrlForAppDir(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +156,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,17 +179,20 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
-          (url) => `^${normalizeAppPath(url)}$`
+          (url) => `^${normalizeURL(normalizeAppPath(url))}$`
         )
     )
   ).map((urlReg) => {


### PR DESCRIPTION
### What?
Updates the `@next/next/no-html-link-for-pages` ESLint rule to dynamically support custom `pageExtensions`. Additionally, this fixes two URL resolution bugs in the App Router linting logic.

### Why?
The rule previously hardcoded regex checks for standard extensions and ignored custom `pageExtensions` (e.g., `.page.tsx`), resulting in false negatives for invalid internal HTML links. 

Furthermore, while investigating, I found two bugs in the `app` directory linting logic:
1. `parseUrlForAppDir` was erroneously calling `parseUrlForPages` recursively on its subdirectories.
2. `normalizeAppPath` omitted trailing slashes for static app routes (e.g. `/about`). Because `hrefPath` normalizes with a trailing slash (e.g. `/about/`), the regex mismatch meant that an invalid `<a href="/about">` inside the `app` directory would silently bypass linting checks without warning the user.

### How?
- Extracts `pageExtensions` from `context.settings.next.pageExtensions` within the ESLint config (defaulting to standard extensions if not provided).
- Refactors `parseUrlForPages` and `parseUrlForAppDir` to dynamically strip these configured extensions instead of relying on a hardcoded `/(\.(j|t)sx?)$/` regex.
- Fixes the recursive bug in `parseUrlForAppDir` to properly call itself instead of `parseUrlForPages`.
- Wraps `normalizeAppPath` with `normalizeURL` in `getUrlFromAppDirectory` to ensure static app directory routes consistently match the trailing slash format of normalized `href` paths.

Fixes #53473
