### PR TITLE
[ci] Always upload canary tarballs from the canary branch

### DIFF
--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -35,7 +35,7 @@ jobs:
       # matches that, ensuring the upload script is trusted.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: canary
           fetch-depth: 1
           persist-credentials: false
 


### PR DESCRIPTION
`canary` is the branch we reference in protected environments and the branch we work on. 

The default branch in the private mirror is not functional so this needs changing.