### PR TITLE
fix(app-router): mark statically prerendered interception targets as interceptable

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -170,6 +170,8 @@ import { isStaticMetadataFile } from '../lib/metadata/is-metadata-route'
 import { createClientRouterFilter } from '../lib/create-client-router-filter'
 import { startTypeChecking } from './type-check'
 import { generateInterceptionRoutesRewrites } from '../lib/generate-interception-routes-rewrites'
+import { isInterceptionRouteRewrite } from '../lib/is-interception-route-rewrite'
+import { isInterceptionRouteAppPath } from '../shared/lib/router/utils/interception-routes'
 
 import { buildDataRoute } from '../server/lib/router-utils/build-data-route'
 import type { BuildTraceContext } from './webpack/plugins/next-trace-entrypoints-plugin'
@@ -2936,6 +2938,23 @@ export default async function build(
                 }
               }
 
+              // A statically prerendered route targeted by an interception
+              // route must be marked as interceptable in its RSC payload,
+              // because the `Vary: next-url` header used at runtime to derive
+              // `couldBeIntercepted` isn't set during prerendering.
+              const interceptionRouteRegexes = rewrites.beforeFiles
+                .filter(isInterceptionRouteRewrite)
+                .map((rewrite) => rewrite.regex)
+                .filter((regex): regex is string => typeof regex === 'string')
+                .map((regex) => new RegExp(regex))
+
+              const basePath = config.basePath || ''
+              const pathCouldBeIntercepted = (pathname: string): boolean =>
+                isInterceptionRouteAppPath(pathname) ||
+                interceptionRouteRegexes.some((regex) =>
+                  regex.test(basePath + pathname)
+                )
+
               // TODO: output manifest specific to app paths and their
               // revalidate periods and dynamicParams settings
               sortedStaticPaths.forEach(([originalAppPath, routes]) => {
@@ -2972,6 +2991,7 @@ export default async function build(
                     _isAppDir: true,
                     _isRoutePPREnabled: isRoutePPREnabled,
                     _allowEmptyStaticShell: !route.throwOnEmptyStaticShell,
+                    _couldBeIntercepted: pathCouldBeIntercepted(route.pathname),
                   }
                 })
               })

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -29,6 +29,7 @@ import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 
 import { createRequestResponseMocks } from '../server/lib/mock-request'
+import { NEXT_URL } from '../client/components/app-router-headers'
 import { isAppRouteRoute } from '../lib/is-app-route-route'
 import { hasNextSupport } from '../server/ci-info'
 import { exportAppRoute } from './routes/app-route'
@@ -120,6 +121,9 @@ async function exportPageImpl(
     // When true, attempt to run build-time instant validation for this export path.
     _runInstantValidation: runInstantValidation = false,
 
+    // When true, mark this route as interceptable in its prerendered payload.
+    _couldBeIntercepted: couldBeIntercepted = false,
+
     // Pull the original query out.
     query: originalQuery = {},
   } = exportPath
@@ -165,6 +169,14 @@ async function exportPageImpl(
   }
 
   const { req, res } = createRequestResponseMocks({ url: updatedPath })
+
+  // At runtime `setVaryHeader` adds `Next-URL` to the `Vary` header for routes
+  // that an interception route can target, which is how the render derives
+  // `couldBeIntercepted`. That doesn't run during static prerendering, so set it
+  // here to avoid baking `couldBeIntercepted: false` into the prerendered RSC.
+  if (couldBeIntercepted) {
+    res.appendHeader('vary', NEXT_URL)
+  }
 
   // If this is a status code page, then set the response code.
   for (const statusCode of [404, 500]) {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -43,6 +43,7 @@ const zExportMap: zod.ZodType<ExportPathMap> = z.record(
     _isDynamicError: z.boolean().optional(),
     _isRoutePPREnabled: z.boolean().optional(),
     _allowEmptyStaticShell: z.boolean().optional(),
+    _couldBeIntercepted: z.boolean().optional(),
   })
 )
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1351,6 +1351,14 @@ export type ExportPathMap = {
      * @internal
      */
     _runInstantValidation?: boolean
+
+    /**
+     * When true, this route can be an interception target and must be marked
+     * interceptable in its prerendered RSC payload.
+     *
+     * @internal
+     */
+    _couldBeIntercepted?: boolean
   }
 }
 

--- a/test/e2e/app-dir/interception-static-prerender/app/@modal/(.)login/page.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/@modal/(.)login/page.tsx
@@ -1,0 +1,3 @@
+export default function LoginModal() {
+  return <p id="login-modal">login modal (intercepted)</p>
+}

--- a/test/e2e/app-dir/interception-static-prerender/app/@modal/(.)login/page.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/@modal/(.)login/page.tsx
@@ -1,3 +1,3 @@
 export default function LoginModal() {
-  return <p id="login-modal">login modal (intercepted)</p>
+  return <p>login modal</p>
 }

--- a/test/e2e/app-dir/interception-static-prerender/app/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null
+}

--- a/test/e2e/app-dir/interception-static-prerender/app/layout.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/layout.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react'
-import Link from 'next/link'
 
 export default function Root({
   children,
@@ -11,14 +10,6 @@ export default function Root({
   return (
     <html>
       <body>
-        <nav>
-          <Link href="/login" id="to-login" prefetch={false}>
-            Login
-          </Link>
-          <Link href="/" id="to-home" prefetch={false}>
-            Home
-          </Link>
-        </nav>
         {children}
         {modal}
       </body>

--- a/test/e2e/app-dir/interception-static-prerender/app/layout.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/layout.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react'
+import Link from 'next/link'
+
+export default function Root({
+  children,
+  modal,
+}: {
+  children: ReactNode
+  modal: ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <nav>
+          <Link href="/login" id="to-login" prefetch={false}>
+            Login
+          </Link>
+          <Link href="/" id="to-home" prefetch={false}>
+            Home
+          </Link>
+        </nav>
+        {children}
+        {modal}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-static-prerender/app/login/page.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/login/page.tsx
@@ -1,3 +1,3 @@
 export default function LoginPage() {
-  return <p id="login-full-page">login full page</p>
+  return <p>login</p>
 }

--- a/test/e2e/app-dir/interception-static-prerender/app/login/page.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/login/page.tsx
@@ -1,0 +1,3 @@
+export default function LoginPage() {
+  return <p id="login-full-page">login full page</p>
+}

--- a/test/e2e/app-dir/interception-static-prerender/app/page.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">home page</p>
+}

--- a/test/e2e/app-dir/interception-static-prerender/app/page.tsx
+++ b/test/e2e/app-dir/interception-static-prerender/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p id="home">home page</p>
+  return <p>home</p>
 }

--- a/test/e2e/app-dir/interception-static-prerender/interception-static-prerender.test.ts
+++ b/test/e2e/app-dir/interception-static-prerender/interception-static-prerender.test.ts
@@ -1,0 +1,60 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('interception-static-prerender', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Regression test for https://github.com/vercel/next.js/issues/94533.
+  // A statically prerendered interception target used to bake
+  // `couldBeIntercepted: false` (the `i` field) because the `Vary: next-url`
+  // header isn't set during prerendering. A CDN serving that static artifact
+  // then taught the client the route wasn't interceptable. The prerendered
+  // `.rsc` is what a CDN serves, so asserting on it is the deterministic guard
+  // (at runtime the server re-adds `Vary`, masking the bug in `next start`).
+  if (isNextStart) {
+    it('marks the statically prerendered intercepted target as interceptable', async () => {
+      expect(await next.readFile('.next/server/app/login.rsc')).toMatch(
+        /"i":true/
+      )
+      // Non-target routes must not be marked.
+      expect(await next.readFile('.next/server/app/index.rsc')).toMatch(
+        /"i":false/
+      )
+    })
+  }
+
+  it('intercepts client navigations to the target route', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementByCss('#to-login').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#login-modal').text()).toBe(
+        'login modal (intercepted)'
+      )
+    })
+    expect(await browser.hasElementByCssSelector('#login-full-page')).toBe(
+      false
+    )
+
+    // After a full-page visit to `/login`, client navigations must still
+    // intercept (rather than reuse a stale non-intercepted tree).
+    await browser.get(`${next.url}/login`)
+    await retry(async () => {
+      expect(await browser.elementByCss('#login-full-page').text()).toBe(
+        'login full page'
+      )
+    })
+    await browser.elementByCss('#to-home').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#home').text()).toBe('home page')
+    })
+    await browser.elementByCss('#to-login').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#login-modal').text()).toBe(
+        'login modal (intercepted)'
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/interception-static-prerender/interception-static-prerender.test.ts
+++ b/test/e2e/app-dir/interception-static-prerender/interception-static-prerender.test.ts
@@ -15,16 +15,16 @@ describe('interception-static-prerender', () => {
   //
   // The prerendered `.rsc` is exactly what a CDN serves, so asserting on it is
   // the deterministic guard: at runtime the server re-adds `Vary: next-url`,
-  // which masks the bug in `next start` and a browser flow.
-  if (isNextStart) {
-    it('marks the statically prerendered intercepted target as interceptable', async () => {
-      expect(await next.readFile('.next/server/app/login.rsc')).toMatch(
-        /"i":true/
-      )
-      // Non-target routes must not be marked.
-      expect(await next.readFile('.next/server/app/index.rsc')).toMatch(
-        /"i":false/
-      )
-    })
-  }
+  // which masks the bug in `next start` and a browser flow. Only `next start`
+  // writes that artifact, so the assertion is a no-op in dev/deploy.
+  it('marks the statically prerendered intercepted target as interceptable', async () => {
+    if (!isNextStart) return
+    expect(await next.readFile('.next/server/app/login.rsc')).toMatch(
+      /"i":true/
+    )
+    // Non-target routes must not be marked.
+    expect(await next.readFile('.next/server/app/index.rsc')).toMatch(
+      /"i":false/
+    )
+  })
 })

--- a/test/e2e/app-dir/interception-static-prerender/interception-static-prerender.test.ts
+++ b/test/e2e/app-dir/interception-static-prerender/interception-static-prerender.test.ts
@@ -1,5 +1,4 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
 
 describe('interception-static-prerender', () => {
   const { next, isNextStart } = nextTestSetup({
@@ -7,12 +6,16 @@ describe('interception-static-prerender', () => {
   })
 
   // Regression test for https://github.com/vercel/next.js/issues/94533.
-  // A statically prerendered interception target used to bake
-  // `couldBeIntercepted: false` (the `i` field) because the `Vary: next-url`
-  // header isn't set during prerendering. A CDN serving that static artifact
-  // then taught the client the route wasn't interceptable. The prerendered
-  // `.rsc` is what a CDN serves, so asserting on it is the deterministic guard
-  // (at runtime the server re-adds `Vary`, masking the bug in `next start`).
+  //
+  // The intercepted target (`/login`) is statically prerendered. During static
+  // prerendering the `Vary: next-url` header isn't set, so `couldBeIntercepted`
+  // (the `i` field in the RSC payload) used to bake in as `false`. A CDN serving
+  // that static artifact then taught the client the route wasn't interceptable,
+  // and later client navigations served a stale, non-intercepted tree.
+  //
+  // The prerendered `.rsc` is exactly what a CDN serves, so asserting on it is
+  // the deterministic guard: at runtime the server re-adds `Vary: next-url`,
+  // which masks the bug in `next start` and a browser flow.
   if (isNextStart) {
     it('marks the statically prerendered intercepted target as interceptable', async () => {
       expect(await next.readFile('.next/server/app/login.rsc')).toMatch(
@@ -24,37 +27,4 @@ describe('interception-static-prerender', () => {
       )
     })
   }
-
-  it('intercepts client navigations to the target route', async () => {
-    const browser = await next.browser('/')
-
-    await browser.elementByCss('#to-login').click()
-    await retry(async () => {
-      expect(await browser.elementByCss('#login-modal').text()).toBe(
-        'login modal (intercepted)'
-      )
-    })
-    expect(await browser.hasElementByCssSelector('#login-full-page')).toBe(
-      false
-    )
-
-    // After a full-page visit to `/login`, client navigations must still
-    // intercept (rather than reuse a stale non-intercepted tree).
-    await browser.get(`${next.url}/login`)
-    await retry(async () => {
-      expect(await browser.elementByCss('#login-full-page').text()).toBe(
-        'login full page'
-      )
-    })
-    await browser.elementByCss('#to-home').click()
-    await retry(async () => {
-      expect(await browser.elementByCss('#home').text()).toBe('home page')
-    })
-    await browser.elementByCss('#to-login').click()
-    await retry(async () => {
-      expect(await browser.elementByCss('#login-modal').text()).toBe(
-        'login modal (intercepted)'
-      )
-    })
-  })
 })


### PR DESCRIPTION
Closes #94533

<!-- NEXT_JS_LLM_PR -->
## What
When an interceptable page (like a `/login` modal) is statically prerendered, Next.js bakes "can't be intercepted" into the output  because the `Vary: next-url` signal it depends on only exists at runtime, not build time.

Served from a CDN, that makes the client treat the route as non-interceptable, so the modal stops appearing on later client navigations.

## Changes
- Detect interception-target routes at build time and carry the flag into the prerendered output.
- Added a regression test covering Turbopack and webpack

Note:  The fix only affects static prerendering. At runtime the Vary header is already set so the build-time signal is just filling the gap where that header doesn't exist yet. Prod (next start) behavior is unchanged.

## Testing
`pnpm test-start-turbo test/e2e/app-dir/interception-static-prerender`

### Before Implementation
<img width="807" height="169" alt="Screenshot 2026-06-08 at 4 54 42 PM" src="https://github.com/user-attachments/assets/69d10627-ad18-4793-87d3-a3e300d2b8b1" />

### After Implementation 
<img width="805" height="159" alt="Screenshot 2026-06-08 at 4 51 01 PM" src="https://github.com/user-attachments/assets/1acdf8f8-8a05-44ec-91ca-04d46215bcdc" />

  <!-- NEXT_JS_LLM_PR -->
  
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.

Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
