### PR TITLE
[turbopack] Drop data while serializing in `next build`

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -170,6 +170,35 @@ pub enum TurboTasksBackendJob {
     Snapshot,
 }
 
+/// Why a snapshot/persist is being performed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SnapshotReason {
+    Test,
+    Stop,
+    InitialSnapshotTimeout,
+    RegularSnapshotInterval,
+    IdleTimeout,
+}
+
+impl SnapshotReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            SnapshotReason::Test => "test",
+            SnapshotReason::Stop => "stop",
+            SnapshotReason::InitialSnapshotTimeout => "initial snapshot timeout",
+            SnapshotReason::RegularSnapshotInterval => "regular snapshot interval",
+            SnapshotReason::IdleTimeout => "idle timeout",
+        }
+    }
+
+    /// True only for `Stop`: at shutdown the whole map is dropped right after, so each task
+    /// entry can be drained from the map and freed as it is serialized instead of after the
+    /// whole batch is written. This reduces peak memory during `next build` shutdown.
+    fn drain_entries(self) -> bool {
+        matches!(self, SnapshotReason::Stop)
+    }
+}
+
 pub struct TurboTasksBackend {
     options: BackendOptions,
 
@@ -296,7 +325,7 @@ impl TurboTasksBackend {
             self.should_persist(),
             "snapshot_and_evict requires persistence"
         );
-        let snapshot_result = self.snapshot_and_persist(None, "test", turbo_tasks);
+        let snapshot_result = self.snapshot_and_persist(None, SnapshotReason::Test, turbo_tasks);
         let had_new_data = match snapshot_result {
             Ok((_, new_data)) => new_data,
             Err(_) => {
@@ -915,11 +944,11 @@ impl TurboTasksBackend {
     fn snapshot_and_persist(
         &self,
         parent_span: Option<tracing::Id>,
-        reason: &str,
+        reason: SnapshotReason,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
     ) -> Result<(Instant, bool), anyhow::Error> {
         let snapshot_span =
-            tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason)
+            tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason.as_str())
                 .entered();
         // Serialize snapshots. The internal protocol (snapshot_mode, snapshot
         // request bit, suspended_operations) assumes only one snapshot runs at
@@ -1201,7 +1230,9 @@ impl TurboTasksBackend {
             }
         };
 
-        let task_snapshots = self.storage.take_snapshot(snapshot_guard, &process);
+        let task_snapshots =
+            self.storage
+                .take_snapshot(snapshot_guard, &process, reason.drain_entries());
 
         drop(snapshot_span);
         let snapshot_duration = start.elapsed();
@@ -1218,7 +1249,7 @@ impl TurboTasksBackend {
         let span = tracing::info_span!(
             parent: parent_span,
             "persist",
-            reason = reason,
+            reason = reason.as_str(),
             data_items= tracing::field::Empty,
             meta_items= tracing::field::Empty,
             task_cache_items= tracing::field::Empty,
@@ -1338,7 +1369,7 @@ impl TurboTasksBackend {
             wall_start_ms,
             wall_end_ms,
             vec![
-                ("reason", serde_json::Value::from(reason)),
+                ("reason", serde_json::Value::from(reason.as_str())),
                 (
                     "snapshot_duration_ms",
                     serde_json::Value::from(snapshot_duration.as_secs_f64() * 1000.0),
@@ -1393,10 +1424,17 @@ impl TurboTasksBackend {
             self.is_idle.store(false, Ordering::Release);
             self.verify_aggregation_graph(turbo_tasks, false);
         }
-        if self.should_persist()
-            && let Err(err) = self.snapshot_and_persist(Span::current().into(), "stop", turbo_tasks)
-        {
-            eprintln!("Persisting failed during shutdown: {err:?}");
+        // eagerly drop the task cache before persisting
+        self.storage.drop_task_cache();
+        if self.should_persist() {
+            // The task_cache is a pure perf cache backed by the DB and isn't read during the
+            // stop snapshot (no task creation runs concurrently with stop). Drop it before
+            // persisting to lower peak memory during the serialization/write.
+            if let Err(err) =
+                self.snapshot_and_persist(Span::current().into(), SnapshotReason::Stop, turbo_tasks)
+            {
+                eprintln!("Persisting failed during shutdown: {err:?}");
+            }
         }
         self.storage.drop_contents();
         if let Err(err) = self.backing_storage.shutdown() {
@@ -2786,9 +2824,9 @@ impl TurboTasksBackend {
                         const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(120);
                         let idle_timeout = *IDLE_TIMEOUT;
                         let (time, mut reason) = if is_first {
-                            (FIRST_SNAPSHOT_WAIT, "initial snapshot timeout")
+                            (FIRST_SNAPSHOT_WAIT, SnapshotReason::InitialSnapshotTimeout)
                         } else {
-                            (SNAPSHOT_INTERVAL, "regular snapshot interval")
+                            (SNAPSHOT_INTERVAL, SnapshotReason::RegularSnapshotInterval)
                         };
 
                         let until = last_snapshot + time;
@@ -2820,7 +2858,7 @@ impl TurboTasksBackend {
                                     },
                                     _ = tokio::time::sleep_until(idle_time) => {
                                         if turbo_tasks.is_idle() {
-                                            reason = "idle timeout";
+                                            reason = SnapshotReason::IdleTimeout;
                                             break;
                                         }
                                     },

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -9,6 +9,8 @@ use std::{
     },
 };
 
+use dashmap::SharedValue;
+use hashbrown::raw::RawIntoIter;
 use thread_local::ThreadLocal;
 use tracing::span::Id;
 use turbo_bincode::TurboBincodeBuffer;
@@ -271,8 +273,10 @@ impl Storage {
     /// entries) are filtered out, but shards may still yield no items if all entries produce
     /// empty `SnapshotItem`s (this is rare and only happens under error conditions).
     ///
-    /// When `drain_entries` is true, each task entry is removed from the map and dropped as soon as
-    /// it has been serialized, draining the core datastructures.
+    /// When `drain_entries` is true (shutdown only), the scan drains the map: unmodified entries
+    /// are erased and freed immediately, and the modified entries are moved out into the
+    /// returned shard iterators, which free each task's memory as it is serialized rather than
+    /// after the whole batch is written.
     pub fn take_snapshot<
         'l,
         P: for<'a> Fn(TaskId, &'a TaskStorage, &mut TurboBincodeBuffer) -> SnapshotItem + Sync,
@@ -301,51 +305,70 @@ impl Storage {
                 return None;
             }
 
-            let mut modified = Vec::with_capacity(modified_count as usize);
-            {
+            // Scan the shard once, building the work this shard's iterator will perform. The two
+            // modes carry different data so that `next` has no per-item `drain` branch:
+            // - keep mode collects the modified `TaskId`s and looks them up again while iterating.
+            // - drain mode erases the unmodified entries here and then moves the remaining
+            //   (modified-only) table out of the map, so the iterator owns and drains it directly.
+            let work = {
                 let mut shard_guard = shard.write();
-                // SAFETY: shard_guard outlives the iterator and we hold it for the whole scan.
-                for bucket in unsafe { shard_guard.iter() } {
-                    // Read the key and modified flag, then drop the borrow before any erase.
-                    // SAFETY: the guard outlives the bucket reference.
-                    let (key, modified_task) = {
-                        let (key, shared_value) = unsafe { bucket.as_ref() };
-                        // Only check modified flags — transient tasks never have modified flags
-                        // set (track_modification guards against it), so this naturally excludes
-                        // them. new_task always comes with modified flags (set_persistent_task_type
-                        // calls track_modification), so any_modified() is sufficient.
-                        (*key, shared_value.get().flags.any_modified())
-                    };
-                    if modified_task {
-                        debug_assert!(
-                            !key.is_transient(),
-                            "found a modified transient task: {key:?}"
-                        );
-                        modified.push(key);
-                    } else if drain_entries {
-                        unsafe { shard_guard.erase(bucket) };
+                if drain_entries {
+                    // SAFETY: shard_guard outlives the iterator and we hold it for the whole scan.
+                    for bucket in unsafe { shard_guard.iter() } {
+                        // Read the key and modified flag, then drop the borrow before any erase.
+                        // SAFETY: the guard outlives the bucket reference.
+                        let (key, modified_task) = {
+                            let (key, shared_value) = unsafe { bucket.as_ref() };
+                            (*key, shared_value.get().flags.any_modified())
+                        };
+                        if modified_task {
+                            debug_assert!(
+                                !key.is_transient(),
+                                "found a modified transient task: {key:?}"
+                            );
+                        } else {
+                            // Unmodified entries are not part of the snapshot. Erase and free them
+                            // now so the table we move out below holds only modified entries.
+                            unsafe { shard_guard.erase(bucket) };
+                        }
                     }
+                    if shard_guard.is_empty() {
+                        // The shard held only unmodified entries, which we've now erased and freed.
+                        // No iterator is created for an empty shard.
+                        return None;
+                    }
+                    // Move the modified-only table out of the map. Iterating it frees each task box
+                    // as it is serialized, and the shard's table allocation is released here.
+                    ShardWork::Drain(std::mem::take(&mut *shard_guard).into_iter())
+                } else {
+                    let mut modified = Vec::with_capacity(modified_count as usize);
+                    // SAFETY: shard_guard outlives the iterator and we hold it for the whole scan.
+                    for bucket in unsafe { shard_guard.iter() } {
+                        // SAFETY: the guard outlives the bucket reference.
+                        let (key, shared_value) = unsafe { bucket.as_ref() };
+                        // Only check modified flags — transient tasks never have modified flags set
+                        // (track_modification guards against it), so this naturally excludes them.
+                        // new_task always comes with modified flags (set_persistent_task_type calls
+                        // track_modification), so any_modified() is sufficient.
+                        if shared_value.get().flags.any_modified() {
+                            debug_assert!(
+                                !key.is_transient(),
+                                "found a modified transient task: {key:?}"
+                            );
+                            modified.push(*key);
+                        }
+                    }
+                    // modified_count > 0 (we returned early otherwise), so this is never empty.
+                    debug_assert!(!modified.is_empty());
+                    ShardWork::Keep(modified)
                 }
-                if drain_entries && shard_guard.is_empty() {
-                    // Drop the whole map shard
-                    drop(std::mem::take(&mut *shard_guard));
-                }
-            }
-
-            if modified.is_empty() {
-                // Only reachable in drain mode (otherwise modified_count > 0): the shard held
-                // only unmodified entries, which we've now erased and freed above. No iterator
-                // is created for an empty shard.
-                debug_assert!(drain_entries);
-                return None;
-            }
+            };
 
             Some(SnapshotShard {
                 shard_idx,
-                modified,
+                work,
                 storage: self,
                 process,
-                drain_entries,
                 _guard: guard.clone(),
             })
         })
@@ -494,16 +517,6 @@ impl Storage {
     /// Drop the `task_cache` map, freeing its memory.
     pub(crate) fn drop_task_cache(&self) {
         drop_contents(&self.task_cache);
-    }
-
-    /// If the `map` shard at `shard_idx` is empty, release its table allocation.
-    ///
-    /// Useful for our 'draining persistence' strategy.
-    fn reset_map_shard_if_empty(&self, shard_idx: usize) {
-        let mut shard_guard = self.map.shards()[shard_idx].write();
-        if shard_guard.is_empty() {
-            drop(std::mem::take(&mut *shard_guard));
-        }
     }
 
     /// Evict tasks from in-memory storage after a successful snapshot.
@@ -824,14 +837,24 @@ impl Drop for SnapshotGuard<'_> {
     }
 }
 
+/// The work a single shard's iterator performs, with the snapshot mode encoded in the data rather
+/// than a runtime flag re-checked per item. Built by `take_snapshot`'s scan.
+enum ShardWork {
+    /// Normal snapshot: look each task up in the map while iterating, serialize it, then clear and
+    /// promote its modified flags so it stays dirty for the next snapshot cycle.
+    Keep(Vec<TaskId>),
+    /// Shutdown drain: the scan already erased the unmodified entries and moved the remaining
+    /// (modified-only) shard table out of the map. The iterator owns that table and drains it
+    /// directly, freeing each task box as it is serialized. No second map lookup, no flag
+    /// bookkeeping (the whole map is discarded right after this snapshot).
+    Drain(RawIntoIter<(TaskId, SharedValue<Box<TaskStorage>>)>),
+}
+
 pub struct SnapshotShard<'l, P> {
     shard_idx: usize,
-    modified: Vec<TaskId>,
+    work: ShardWork,
     storage: &'l Storage,
     process: &'l P,
-    /// When true, remove and drop each task entry from the map as it is serialized
-    /// (shutdown only). See `take_snapshot` for details.
-    drain_entries: bool,
     /// Held for its `Drop` impl — ensures snapshot mode ends when all shards are done.
     _guard: Arc<SnapshotGuard<'l>>,
 }
@@ -866,9 +889,6 @@ where
     type Item = SnapshotItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let task_id = self.shard.modified.pop()?;
-
-        // Serialize a single task into a `SnapshotItem`.
         let process = self.shard.process;
         let snapshots = &self.shard.storage.snapshots;
         let buffer = &mut self.buffer;
@@ -887,30 +907,34 @@ where
             }
         };
 
-        if self.shard.drain_entries {
-            // Shutdown only: `remove` instead of `get_mut`. It returns the owned
-            // `Box<TaskStorage>` and releases the shard lock before returning, so we
-            // serialize from a borrow of the owned box and let it drop at the end of this
-            // branch — freeing the task's memory as it is persisted rather than after the
-            // whole batch is written. We skip the flag bookkeeping the normal path does,
-            // since the entire map is discarded right after this snapshot.
-            let (_, inner) = self.shard.storage.map.remove(&task_id).unwrap();
-            let item = serialize_task(task_id, &inner);
-            // we don't need to update any bits because everything is getting dropped.
-            Some(item)
-        } else {
-            let mut inner = self.shard.storage.map.get_mut(&task_id).unwrap();
-            let item = serialize_task(task_id, &inner);
-            // Clear the modified flags that were captured into the snapshot copy,
-            // then promote modified_during_snapshot → modified so the task stays
-            // dirty for the next snapshot cycle.
-            inner.flags.set_data_modified(false);
-            inner.flags.set_meta_modified(false);
-            inner.flags.set_new_task(false);
-            self.shard
-                .storage
-                .promote_during_snapshot_flags(&mut inner, self.shard.shard_idx);
-            Some(item)
+        match &mut self.shard.work {
+            ShardWork::Keep(modified) => {
+                let task_id = modified.pop()?;
+                let mut inner = self.shard.storage.map.get_mut(&task_id).unwrap();
+                let item = serialize_task(task_id, &inner);
+                // Clear the modified flags that were captured into the snapshot copy,
+                // then promote modified_during_snapshot → modified so the task stays
+                // dirty for the next snapshot cycle.
+                inner.flags.set_data_modified(false);
+                inner.flags.set_meta_modified(false);
+                inner.flags.set_new_task(false);
+                self.shard
+                    .storage
+                    .promote_during_snapshot_flags(&mut inner, self.shard.shard_idx);
+                Some(item)
+            }
+            ShardWork::Drain(entries) => {
+                // Shutdown only: the scan already moved this shard's modified entries out of the
+                // map, so we own each `Box<TaskStorage>` here. Serialize from a borrow of the owned
+                // box and let it drop at the end of this branch — freeing the task's memory as it
+                // is persisted rather than after the whole batch is written. We skip the flag
+                // bookkeeping the normal path does, since the entire map is discarded right after
+                // this snapshot.
+                let (task_id, inner) = entries.next()?;
+                let inner = inner.into_inner();
+                Some(serialize_task(task_id, &inner))
+                // we don't need to update any bits because everything is getting dropped.
+            }
         }
     }
 }
@@ -920,15 +944,6 @@ impl<P> Drop for SnapshotShardIter<'_, P> {
         self.shard
             ._guard
             .return_scratch_buffer(std::mem::take(&mut self.buffer));
-        if self.shard.drain_entries {
-            // In drain mode `next` removed this shard's modified entries from the map. Once it
-            // has consumed them all the shard is empty, so release its table allocation now
-            // rather than waiting for the wholesale `drop_contents`. No-op if the iterator was
-            // dropped before fully draining (entries remain) — the reset is gated on emptiness.
-            self.shard
-                .storage
-                .reset_map_shard_if_empty(self.shard.shard_idx);
-        }
     }
 }
 
@@ -1106,9 +1121,10 @@ mod tests {
         );
     }
 
-    /// With `drain_entries = true` (shutdown path), the iterator must serialize each
-    /// modified task and then remove it from the map so its memory is freed as it is
-    /// persisted, rather than being retained until the whole snapshot is written.
+    /// With `drain_entries = true` (shutdown path), the modified entries are moved out of the map
+    /// (during the scan) and serialized by the iterator, freeing each task's memory as it is
+    /// persisted rather than retaining it until the whole snapshot is written. Either way the
+    /// entry must be gone from the map by the time the snapshot is consumed.
     #[tokio::test(flavor = "multi_thread")]
     async fn drain_entries_removes_entry_from_map() {
         let storage = Storage::new(2, true);
@@ -1187,17 +1203,19 @@ mod tests {
         }
     }
 
-    /// In drain mode, `take_snapshot` removes *unmodified* entries from the map during the scan
-    /// (freeing them before serialization), while modified entries are still serialized and then
-    /// removed by the iterator.
+    /// In drain mode, `take_snapshot`'s scan removes *both* kinds of entry from the map: unmodified
+    /// entries are erased and freed (never serialized), and the remaining modified-only table is
+    /// moved out into the shard iterators (to be serialized, then freed as each is consumed). So
+    /// the map is already empty when `take_snapshot` returns, and only the modified task is
+    /// yielded.
     #[tokio::test(flavor = "multi_thread")]
     async fn drain_entries_removes_unmodified_during_take_snapshot() {
         let storage = Storage::new(2, true);
         let modified_id = non_transient_task(1);
         let unmodified_id = non_transient_task(2);
 
-        // One modified task (lands in the modified list) and one unmodified task (e.g. restored
-        // from disk but never dirtied) that just occupies memory.
+        // One modified task (gets serialized) and one unmodified task (e.g. restored from disk but
+        // never dirtied) that just occupies memory and must not be serialized.
         {
             let mut guard = storage.access_mut(modified_id);
             guard.track_modification(SpecificTaskDataCategory::Data, "test");
@@ -1211,21 +1229,24 @@ mod tests {
 
         let shards = storage.take_snapshot(snapshot_guard, &dummy_process, true);
 
-        // The unmodified entry is removed during the scan, before we consume any iterator.
+        // The scan moved the modified table out and freed the unmodified entry, so both ids are
+        // already absent from the map before any iterator is consumed.
         assert!(
             storage.map.get(&unmodified_id).is_none(),
             "unmodified entry should be removed during take_snapshot in drain mode"
         );
-        // The modified entry is still present, awaiting serialization.
-        assert!(storage.map.get(&modified_id).is_some());
+        assert!(
+            storage.map.get(&modified_id).is_none(),
+            "modified entry should be moved out of the map during take_snapshot in drain mode"
+        );
 
-        // Consuming the iterators serializes the modified task and removes it too.
+        // Consuming the iterators yields only the modified task (the unmodified one was never part
+        // of the snapshot).
         let items: Vec<_> = shards
             .into_iter()
             .flat_map(|shard| shard.into_iter())
             .collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].task_id, modified_id);
-        assert!(storage.map.get(&modified_id).is_none());
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -270,6 +270,9 @@ impl Storage {
     /// The returned shards implement `IntoIterator`. Empty shards (no modified or snapshot
     /// entries) are filtered out, but shards may still yield no items if all entries produce
     /// empty `SnapshotItem`s (this is rare and only happens under error conditions).
+    ///
+    /// When `drain_entries` is true, each task entry is removed from the map and dropped as soon as
+    /// it has been serialized, draining the core datastructures.
     pub fn take_snapshot<
         'l,
         P: for<'a> Fn(TaskId, &'a TaskStorage, &mut TurboBincodeBuffer) -> SnapshotItem + Sync,
@@ -277,6 +280,7 @@ impl Storage {
         &'l self,
         guard: SnapshotGuard<'l>,
         process: &'l P,
+        drain_entries: bool,
     ) -> Vec<SnapshotShard<'l, P>> {
         let guard = Arc::new(guard);
 
@@ -289,47 +293,59 @@ impl Storage {
             // snapshot_mode, there are no racing writes
             // So we can safely clear it out now that we are processing the modifications
             let modified_count = self.shard_modified_counts[shard_idx].swap(0, Ordering::Relaxed);
-            if modified_count == 0 {
+
+            if modified_count == 0 && !drain_entries {
+                // Nothing to persist in this shard and we're keeping the map, so skip the scan.
+                // TODO: when not draining but eviction is enabled we should run that logic here as
+                // well
                 return None;
             }
+
             let mut modified = Vec::with_capacity(modified_count as usize);
             {
-                let shard_guard = shard.read();
-                // Safety: shard_guard must outlive the iterator.
+                let mut shard_guard = shard.write();
+                // SAFETY: shard_guard outlives the iterator and we hold it for the whole scan.
                 for bucket in unsafe { shard_guard.iter() } {
-                    // Safety: the guard guarantees that the bucket is not removed and the ptr
-                    // is valid.
-                    let (key, shared_value) = unsafe { bucket.as_ref() };
-                    let flags = &shared_value.get().flags;
-                    // Only check modified flags here — transient tasks never have
-                    // modified flags set (track_modification guards against it), so
-                    // this naturally excludes them. new_task is always
-                    // accompanied by modified flags (set_persistent_task_type calls
-                    // track_modification), so any_modified() is sufficient.
-                    if flags.any_modified() {
-                        if key.is_transient() {
-                            debug_assert!(
-                                false,
-                                "found a modified transient task: {:?}",
-                                shared_value.get().get_persistent_task_type()
-                            );
-                            continue;
-                        }
-
-                        modified.push(*key);
+                    // Read the key and modified flag, then drop the borrow before any erase.
+                    // SAFETY: the guard outlives the bucket reference.
+                    let (key, modified_task) = {
+                        let (key, shared_value) = unsafe { bucket.as_ref() };
+                        // Only check modified flags — transient tasks never have modified flags
+                        // set (track_modification guards against it), so this naturally excludes
+                        // them. new_task always comes with modified flags (set_persistent_task_type
+                        // calls track_modification), so any_modified() is sufficient.
+                        (*key, shared_value.get().flags.any_modified())
+                    };
+                    if modified_task {
+                        debug_assert!(
+                            !key.is_transient(),
+                            "found a modified transient task: {key:?}"
+                        );
+                        modified.push(key);
+                    } else if drain_entries {
+                        unsafe { shard_guard.erase(bucket) };
                     }
                 }
-                // Safety: shard_guard must outlive the iterator.
-                drop(shard_guard);
+                if drain_entries && shard_guard.is_empty() {
+                    // Drop the whole map shard
+                    drop(std::mem::take(&mut *shard_guard));
+                }
             }
 
-            debug_assert!(!modified.is_empty());
+            if modified.is_empty() {
+                // Only reachable in drain mode (otherwise modified_count > 0): the shard held
+                // only unmodified entries, which we've now erased and freed above. No iterator
+                // is created for an empty shard.
+                debug_assert!(drain_entries);
+                return None;
+            }
 
             Some(SnapshotShard {
                 shard_idx,
                 modified,
                 storage: self,
                 process,
+                drain_entries,
                 _guard: guard.clone(),
             })
         })
@@ -473,7 +489,21 @@ impl Storage {
     pub fn drop_contents(&self) {
         drop_contents(&self.map);
         drop_contents(&self.snapshots);
+    }
+
+    /// Drop the `task_cache` map, freeing its memory.
+    pub(crate) fn drop_task_cache(&self) {
         drop_contents(&self.task_cache);
+    }
+
+    /// If the `map` shard at `shard_idx` is empty, release its table allocation.
+    ///
+    /// Useful for our 'draining persistence' strategy.
+    fn reset_map_shard_if_empty(&self, shard_idx: usize) {
+        let mut shard_guard = self.map.shards()[shard_idx].write();
+        if shard_guard.is_empty() {
+            drop(std::mem::take(&mut *shard_guard));
+        }
     }
 
     /// Evict tasks from in-memory storage after a successful snapshot.
@@ -799,6 +829,9 @@ pub struct SnapshotShard<'l, P> {
     modified: Vec<TaskId>,
     storage: &'l Storage,
     process: &'l P,
+    /// When true, remove and drop each task entry from the map as it is serialized
+    /// (shutdown only). See `take_snapshot` for details.
+    drain_entries: bool,
     /// Held for its `Drop` impl — ensures snapshot mode ends when all shards are done.
     _guard: Arc<SnapshotGuard<'l>>,
 }
@@ -833,24 +866,41 @@ where
     type Item = SnapshotItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(task_id) = self.shard.modified.pop() {
-            let mut inner = self.shard.storage.map.get_mut(&task_id).unwrap();
+        let task_id = self.shard.modified.pop()?;
+
+        // Serialize a single task into a `SnapshotItem`.
+        let process = self.shard.process;
+        let snapshots = &self.shard.storage.snapshots;
+        let buffer = &mut self.buffer;
+        let mut serialize_task = |task_id: TaskId, inner: &TaskStorage| {
             // If the task was re-modified during snapshot, the snapshots map may
             // hold a pre-modification copy we must serialize instead of the live
             // data. Remove the entry so end_snapshot doesn't double-promote it;
             // we promote manually below.
-            let item = if inner.flags.any_modified_during_snapshot() {
-                match self.shard.storage.snapshots.remove(&task_id) {
-                    Some((_, Some(snapshot))) => {
-                        (self.shard.process)(task_id, &snapshot, &mut self.buffer)
-                    }
-                    Some((_, None)) | None => {
-                        (self.shard.process)(task_id, &inner, &mut self.buffer)
-                    }
+            if inner.flags.any_modified_during_snapshot() {
+                match snapshots.remove(&task_id) {
+                    Some((_, Some(snapshot))) => process(task_id, &snapshot, buffer),
+                    Some((_, None)) | None => process(task_id, inner, buffer),
                 }
             } else {
-                (self.shard.process)(task_id, &inner, &mut self.buffer)
-            };
+                process(task_id, inner, buffer)
+            }
+        };
+
+        if self.shard.drain_entries {
+            // Shutdown only: `remove` instead of `get_mut`. It returns the owned
+            // `Box<TaskStorage>` and releases the shard lock before returning, so we
+            // serialize from a borrow of the owned box and let it drop at the end of this
+            // branch — freeing the task's memory as it is persisted rather than after the
+            // whole batch is written. We skip the flag bookkeeping the normal path does,
+            // since the entire map is discarded right after this snapshot.
+            let (_, inner) = self.shard.storage.map.remove(&task_id).unwrap();
+            let item = serialize_task(task_id, &inner);
+            // we don't need to update any bits because everything is getting dropped.
+            Some(item)
+        } else {
+            let mut inner = self.shard.storage.map.get_mut(&task_id).unwrap();
+            let item = serialize_task(task_id, &inner);
             // Clear the modified flags that were captured into the snapshot copy,
             // then promote modified_during_snapshot → modified so the task stays
             // dirty for the next snapshot cycle.
@@ -860,9 +910,8 @@ where
             self.shard
                 .storage
                 .promote_during_snapshot_flags(&mut inner, self.shard.shard_idx);
-            return Some(item);
+            Some(item)
         }
-        None
     }
 }
 
@@ -871,6 +920,15 @@ impl<P> Drop for SnapshotShardIter<'_, P> {
         self.shard
             ._guard
             .return_scratch_buffer(std::mem::take(&mut self.buffer));
+        if self.shard.drain_entries {
+            // In drain mode `next` removed this shard's modified entries from the map. Once it
+            // has consumed them all the shard is empty, so release its table allocation now
+            // rather than waiting for the wholesale `drop_contents`. No-op if the iterator was
+            // dropped before fully draining (entries remain) — the reset is gated on emptiness.
+            self.shard
+                .storage
+                .reset_map_shard_if_empty(self.shard.shard_idx);
+        }
     }
 }
 
@@ -939,7 +997,7 @@ mod tests {
         // Step 3: `take_snapshot` scans the shard. At this point the task has
         // `any_modified()=true` and `any_modified_during_snapshot()=false`, so it
         // goes into the `modified` list inside the returned `SnapshotShard`.
-        let shards = storage.take_snapshot(snapshot_guard, &dummy_process);
+        let shards = storage.take_snapshot(snapshot_guard, &dummy_process, false);
 
         // Step 4: now that the scan is done but before we consume the iterator,
         // modify the task again. We're still in snapshot mode, the task is already
@@ -1011,7 +1069,7 @@ mod tests {
         assert!(has_modifications);
 
         // Step 3: take_snapshot — task goes into modified list (meta_modified = true).
-        let shards = storage.take_snapshot(snapshot_guard, &dummy_process);
+        let shards = storage.take_snapshot(snapshot_guard, &dummy_process, false);
 
         // Step 4: modify data during snapshot. The `(true, false)` branch fires:
         // data was not previously modified, so snapshots gets a None entry.
@@ -1046,5 +1104,128 @@ mod tests {
             has_modifications,
             "shard_modified_counts must be non-zero after promoting data_modified_during_snapshot"
         );
+    }
+
+    /// With `drain_entries = true` (shutdown path), the iterator must serialize each
+    /// modified task and then remove it from the map so its memory is freed as it is
+    /// persisted, rather than being retained until the whole snapshot is written.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drain_entries_removes_entry_from_map() {
+        let storage = Storage::new(2, true);
+        let task_id = non_transient_task(1);
+
+        // Modify the task outside snapshot mode so it lands in the modified list.
+        {
+            let mut guard = storage.access_mut(task_id);
+            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        }
+        assert!(storage.map.get(&task_id).is_some());
+
+        let (snapshot_guard, has_modifications) = storage.start_snapshot();
+        assert!(has_modifications);
+
+        // Take the snapshot in drain mode.
+        let shards = storage.take_snapshot(snapshot_guard, &dummy_process, true);
+
+        // Consume the iterator: the task is serialized and then removed from the map.
+        let items: Vec<_> = shards
+            .into_iter()
+            .flat_map(|shard| shard.into_iter())
+            .collect();
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].task_id, task_id);
+
+        // The entry must be gone from the map now that it has been persisted.
+        assert!(
+            storage.map.get(&task_id).is_none(),
+            "task entry should be removed from the map after being persisted in drain mode"
+        );
+    }
+
+    /// In drain mode, fully consuming the iterators should release each drained shard's table
+    /// allocation entirely (reset-to-empty in `SnapshotShardIter::drop`), not just shrink it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drain_entries_releases_drained_shards() {
+        // dashmap requires at least 2 shards.
+        let storage = Storage::new(2, true);
+
+        // Insert and modify enough tasks to grow the shards' tables beyond their minimum.
+        let task_ids: Vec<_> = (1..=256).map(non_transient_task).collect();
+        for &task_id in &task_ids {
+            let mut guard = storage.access_mut(task_id);
+            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        }
+        let grown_capacity: usize = storage
+            .map
+            .shards()
+            .iter()
+            .map(|s| s.read().capacity())
+            .sum();
+        assert!(grown_capacity >= task_ids.len());
+
+        let (snapshot_guard, has_modifications) = storage.start_snapshot();
+        assert!(has_modifications);
+
+        let shards = storage.take_snapshot(snapshot_guard, &dummy_process, true);
+        let items: Vec<_> = shards
+            .into_iter()
+            .flat_map(|shard| shard.into_iter())
+            .collect();
+        assert_eq!(items.len(), task_ids.len());
+
+        // Every shard is now empty and its table allocation has been released (capacity 0),
+        // since the reset swaps in the allocation-free default table.
+        for shard in storage.map.shards() {
+            let shard = shard.read();
+            assert_eq!(shard.len(), 0);
+            assert_eq!(
+                shard.capacity(),
+                0,
+                "drained shard should have released its table allocation"
+            );
+        }
+    }
+
+    /// In drain mode, `take_snapshot` removes *unmodified* entries from the map during the scan
+    /// (freeing them before serialization), while modified entries are still serialized and then
+    /// removed by the iterator.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drain_entries_removes_unmodified_during_take_snapshot() {
+        let storage = Storage::new(2, true);
+        let modified_id = non_transient_task(1);
+        let unmodified_id = non_transient_task(2);
+
+        // One modified task (lands in the modified list) and one unmodified task (e.g. restored
+        // from disk but never dirtied) that just occupies memory.
+        {
+            let mut guard = storage.access_mut(modified_id);
+            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        }
+        // `access_mut` inserts an entry; leaving it without track_modification keeps it unmodified.
+        let _ = storage.access_mut(unmodified_id);
+        assert!(storage.map.get(&unmodified_id).is_some());
+
+        let (snapshot_guard, has_modifications) = storage.start_snapshot();
+        assert!(has_modifications);
+
+        let shards = storage.take_snapshot(snapshot_guard, &dummy_process, true);
+
+        // The unmodified entry is removed during the scan, before we consume any iterator.
+        assert!(
+            storage.map.get(&unmodified_id).is_none(),
+            "unmodified entry should be removed during take_snapshot in drain mode"
+        );
+        // The modified entry is still present, awaiting serialization.
+        assert!(storage.map.get(&modified_id).is_some());
+
+        // Consuming the iterators serializes the modified task and removes it too.
+        let items: Vec<_> = shards
+            .into_iter()
+            .flat_map(|shard| shard.into_iter())
+            .collect();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].task_id, modified_id);
+        assert!(storage.map.get(&modified_id).is_none());
     }
 }


### PR DESCRIPTION
When turbopack persists it needs to allocate scratch buffers and gather and sort large amounts of data before it can start writing to disk.  Fundamentally this is because in memory the data is organized by FxHash and on disk it is by a different hash function and sorted. We get more efficient output files if we buffer more entries in ram before flushing thus persistence tends to consume a lot of additional ram.

To mitigate that cost we need to proactively drop data as we go treating persistence as a terminal operation in `next build`.

Currently this doesn't do anything for `next dev` however a future PR will attempt to integrate 'eviction' logic into these same locations to mitigate the same concern.

With this PR

![image.png](https://app.graphite.com/user-attachments/assets/7ab22808-afe3-4ea8-b77e-4d448eab6ecb.png)

Without this PR

![image.png](https://app.graphite.com/user-attachments/assets/5f147675-3cd6-40b9-b919-aee82c43b8ca.png)

