### PR TITLE
[ci] DO NOT MERGE temporarily add some telemetry the build_and_test job

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -163,7 +163,16 @@ jobs:
     outputs:
       input_step_key: ${{ steps.var.outputs.input_step_key }}
 
+    permissions:
+      contents: read
+      actions: read
+
     steps:
+      # https://vercel.slack.com/archives/C01SKER9S1G/p1780960030985239?thread_ts=1780343660.304449&cid=C01SKER9S1G
+      - uses: austenstone/workflow-telemetry-action@942cbbef2291cdecf839e28e6525486ea47253c6
+        with:
+          comment_on_pr: false
+
       # enforce consistent line endings for git on windows
       - name: Configure git to use LF endings
         if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
We want to see where our potential bottlenecks are.

We don't need to merge this, I just want to see one-off results.

Uses https://github.com/catchpoint/workflow-telemetry-action/