### PR TITLE
[ci] Switch e2e tests to 32 core machines

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -376,7 +376,7 @@ jobs:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
-        group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+        group: [1/3, 2/3, 3/3]
         # Empty value uses default
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
@@ -416,7 +416,7 @@ jobs:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
-        group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+        group: [1/3, 2/3, 3/3]
         # Empty value uses default
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
@@ -452,7 +452,7 @@ jobs:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        group: [1/3, 2/3, 3/3]
         # Empty value uses default
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
@@ -497,7 +497,7 @@ jobs:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
-        group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+        group: [1/3, 2/3, 3/3]
         # Empty value uses default
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
@@ -665,7 +665,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        group: [1/3, 2/3, 3/3]
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -691,7 +691,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        group: [1/3, 2/3, 3/3]
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -717,7 +717,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        group: [1/3, 2/3, 3/3]
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -750,7 +750,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        group: [1/3, 2/3, 3/3]
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -787,7 +787,7 @@ jobs:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
-        group: [1/10, 2/10, 3/10, 4/10, 5/10, 6/10, 7/10, 8/10, 9/10, 10/10]
+        group: [1/5, 2/5, 3/5, 4/5, 5/5]
         # Empty value uses default
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
@@ -898,7 +898,7 @@ jobs:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
-        group: [1/10, 2/10, 3/10, 4/10, 5/10, 6/10, 7/10, 8/10, 9/10, 10/10]
+        group: [1/5, 2/5, 3/5, 4/5, 5/5]
         # Empty value uses default
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
@@ -964,7 +964,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
+        group: [1/3, 2/3, 3/3]
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -1000,7 +1000,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+        group: [1/3, 2/3, 3/3]
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -62,7 +62,7 @@ on:
         description: 'List of runner labels'
         required: false
         type: string
-        default: '["ubuntu-latest-16-core-oss"]'
+        default: '["ubuntu-latest-32-core-oss"]'
       buildNativeTarget:
         description: 'Target for build-native step'
         required: false
@@ -108,7 +108,7 @@ env:
   NODE_LTS_VERSION: 20.9.0
   # run-tests.js reads `TEST_CONCURRENCY` if no explicit `--concurrency` or `-c`
   # argument is provided
-  TEST_CONCURRENCY: 8
+  TEST_CONCURRENCY: 16
   # overrides `turbo_tasks::parallel::available_parallelism`. Smaller values are more CPU and memory
   # efficient, but won't fully utilize all available CPU cores. A small value here makes sense since
   # we're running many tests in parallel.

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -20,13 +20,13 @@ on:
         description: >
           Size of the matrix used for running e2e tests (controls parallelism)
         type: number
-        default: 6
+        default: 3
       integration_groups:
         description: >
           Size of the matrix used for running legacy integration tests (controls
           parallelism)
         type: number
-        default: 6
+        default: 3
       e2e_timeout_minutes:
         type: number
         default: 30

--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -18,8 +18,8 @@ jobs:
       # Failing tests take longer (due to timeouts and retries). Since we have
       # many failing tests, we need smaller groups and longer timeouts, in case
       # a group gets stuck with a cluster of failing tests.
-      e2e_groups: 12
-      integration_groups: 12
+      e2e_groups: 6
+      integration_groups: 6
       e2e_timeout_minutes: 90
       integration_timeout_minutes: 90
     secrets: inherit

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -18,8 +18,8 @@ jobs:
       # Failing tests take longer (due to timeouts and retries). Since we have
       # many failing tests, we need smaller groups and longer timeouts, in case
       # a group gets stuck with a cluster of failing tests.
-      e2e_groups: 16
-      integration_groups: 16
+      e2e_groups: 8
+      integration_groups: 8
       e2e_timeout_minutes: 90
       integration_timeout_minutes: 90
     secrets: inherit

--- a/.github/workflows/turbopack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-build-integration-tests.yml
@@ -17,8 +17,8 @@ jobs:
       # Failing tests take longer (due to timeouts and retries). Since we have
       # many failing tests, we need smaller groups and longer timeouts, in case
       # a group gets stuck with a cluster of failing tests.
-      e2e_groups: 12
-      integration_groups: 12
+      e2e_groups: 6
+      integration_groups: 6
       e2e_timeout_minutes: 60
       integration_timeout_minutes: 60
     secrets: inherit


### PR DESCRIPTION
This slightly increases our cost (using public GH actions pricing numbers):

https://app.datadoghq.com/ddsql/editor?ddsql_dataset_id=707abf45-4033-454e-9105-8911d1116ed1

```
SELECT
  --labels,
  branch,
  commit_date,
  SUM(duration) / 1000 / 1000 / 1000 / 60 as minutes,
  SUM(
    (duration / 1000 / 1000 / 1000 / 60.0) * CASE 
      WHEN labels = 'ubuntu-latest' THEN 0.006
      WHEN labels = 'windows-latest-8-core-oss' THEN 0.042
      WHEN labels = 'ubuntu-latest-16-core-oss' THEN 0.042
      WHEN labels = 'ubuntu-latest-32-core-oss' THEN 0.082
      ELSE 0 
    END
  ) as cost,
  ci_pipeline_id
FROM dd.ci_pipelines(
    columns => ARRAY ['@git.commit.committer.date', '@ci.pipeline.id', '@duration', '@git.branch', '@ci.node.labels'],
    event_type => 'job',
    filter => '@git.repository.id_v2:github.com/vercel/next.js @ci.pipeline.name:build-and-test @ci.provider.instance:github-actions @ci.pipeline.id:(27172470364-1 OR 27170842282-1 OR 27442726067-1 OR 27442739932-1)',
    from_timestamp => now() - INTERVAL '30 days',
    to_timestamp => now()
  ) AS (
    commit_date VARCHAR,
    ci_pipeline_id VARCHAR,
    duration BIGINT,
    branch VARCHAR,
    labels VARCHAR
  )
GROUP BY
  --labels,
  commit_date,
  branch, 
  ci_pipeline_id
ORDER BY 
  branch,
  commit_date,
  minutes;
```

<img width="924" height="220" alt="Screenshot 2026-06-12 at 3 06 14 PM" src="https://github.com/user-attachments/assets/c5c36f44-d99f-480d-bd89-563c8a9945f0" />


---

Baseline PR (16 cores): https://github.com/vercel/next.js/pull/94566

**What about test retries?** Historically, an argument for smaller shards is that less tests have to be retried if you retry a test shard. But these days we cache passed tests across runs, so we won't re-run any more tests in the shard than we have to: https://github.com/vercel/next.js/pull/93954