### PR TITLE
[ci] DO NOT MERGE measure baseline 16 core CI performance

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -62,7 +62,7 @@ on:
         description: 'List of runner labels'
         required: false
         type: string
-        default: '["ubuntu-latest-16-core-oss"]'
+        default: '["ubuntu-latest-16-core-oss"]' # baseline 16 cores
       buildNativeTarget:
         description: 'Target for build-native step'
         required: false


### PR DESCRIPTION
This is intended to provide a baseline for comparison with https://github.com/vercel/next.js/pull/94565