### PR TITLE
Rename prefetch option `force-runtime` to `allow-runtime`

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
@@ -10,7 +10,7 @@ related:
     - app/api-reference/file-conventions/route-segment-config/instant
 ---
 
-The `unstable_prefetch` route segment config controls how a segment is prefetched during client-side navigation. The default (`'auto'`) lets Next.js manage the strategy on your behalf — today that always means a static prefetch. The `force-*` options let you declare a specific behavior — use them with care, since they can affect both navigation latency and prefetch cost.
+The `unstable_prefetch` route segment config controls how a segment is prefetched during client-side navigation. The default (`'auto'`) lets Next.js manage the strategy on your behalf — today that always means a static prefetch. The other options let you declare which prefetch behavior is appropriate for the segment. Use them with care, since they can affect both navigation latency and prefetch cost.
 
 When you do set this export, consider pairing it with [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) so validation can confirm that navigations to this segment actually produce an instant UI from the prefetched data. This is especially important for runtime prefetching.
 
@@ -20,7 +20,7 @@ When you do set this export, consider pairing it with [`unstable_instant`](/docs
 > - `unstable_prefetch` cannot be used when the segment is a Client Component.
 
 ```tsx filename="layout.tsx | page.tsx" switcher
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return <div>...</div>
@@ -28,7 +28,7 @@ export default function Page() {
 ```
 
 ```jsx filename="layout.js | page.js" switcher
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return <div>...</div>
@@ -39,20 +39,20 @@ export default function Page() {
 
 ### `'auto'` (default)
 
-Lets Next.js manage prefetching for this segment. Today this always means a static prefetch — to try runtime prefetching, opt in explicitly with [`'force-runtime'`](#force-runtime).
+Lets Next.js manage prefetching for this segment. Today this always means a static prefetch — to permit runtime prefetching, opt in explicitly with [`'allow-runtime'`](#allow-runtime).
 
 A future release will use [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) validation to choose between static and runtime prefetching automatically. Leaving the default in place means your app will pick up that improvement without code changes.
 
 You typically don't need to set this explicitly — omitting the export has the same effect.
 
-### `'force-runtime'`
+### `'allow-runtime'`
 
-Always prefetch this segment at runtime. The server renders a fresh response for the segment during prefetch, allowing runtime data like cookies, headers, and search params to be included. This is useful for personalized content that should still be available instantly on navigation.
+Allows Next.js to prefetch this segment at runtime. Today, setting this option causes Next.js to issue a runtime prefetch request, so the server can render a fresh response that includes runtime data like cookies, headers, and search params. Use this for personalized content when the latency and cost of runtime prefetching are appropriate for the segment.
 
-> **Good to know**: When a segment uses runtime prefetching, all downstream segments are included in the same runtime prefetch request. This means segments deeper in the tree that are configured with `'force-static'` or `'force-disabled'` will still be prefetched as part of the runtime response.
+> **Good to know**: When Next.js runtime-prefetches a segment, all downstream segments are included in the same runtime prefetch request. This means segments deeper in the tree that are configured with `'force-static'` or `'force-disabled'` will still be prefetched as part of the runtime response.
 
 ```tsx filename="page.tsx"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 ```
 
 ### `'force-static'`
@@ -69,7 +69,7 @@ Never prefetch this segment. The client will not request segment data ahead of n
 
 The `unstable_prefetch` segment config and the [`<Link prefetch>` prop](/docs/app/api-reference/components/link#prefetch) control different aspects of prefetching:
 
-- The **segment config** informs Next.js about a segment's caching characteristics — whether its data can be prefetched statically, requires a runtime prefetch with the user's session, or should be skipped entirely. This applies to the segment regardless of which link points to it.
+- The **segment config** informs Next.js about a segment's caching characteristics — whether its data can be prefetched statically, is suitable for a runtime prefetch with the user's session, or should be skipped entirely. This applies to the segment regardless of which link points to it.
 - The **`<Link prefetch>` prop** reflects the anticipated intent of a specific link on a specific page. A link that users rarely click can be deprioritized with `prefetch={false}`, independent of how the destination segments are configured.
 
 In general, both of these are special circumstances. The default behavior — where Next.js manages prefetching for you — is optimized to provide a good navigation experience without manual configuration.
@@ -77,9 +77,9 @@ In general, both of these are special circumstances. The default behavior — wh
 ## TypeScript
 
 ```tsx
-type Prefetch = 'auto' | 'force-disabled' | 'force-static' | 'force-runtime'
+type Prefetch = 'auto' | 'force-disabled' | 'force-static' | 'allow-runtime'
 
-export const unstable_prefetch: Prefetch = 'force-runtime'
+export const unstable_prefetch: Prefetch = 'allow-runtime'
 ```
 
 ## Version History

--- a/errors/next-prerender-runtime-crypto.mdx
+++ b/errors/next-prerender-runtime-crypto.mdx
@@ -19,7 +19,7 @@ If you are generating a token to talk to a database that itself should be cached
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function getCachedData(token: string, userId: string) {
   "use cache"
@@ -37,7 +37,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function getCachedData(userId: string) {
   "use cache"
@@ -59,7 +59,7 @@ If you require this random value to be unique per Request and an async version o
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 import { generateKeySync } from 'node:crypto'
 
@@ -75,7 +75,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 import { generateKey } from 'node:crypto'
 
@@ -95,7 +95,7 @@ If you require this random value to be unique per Request and an async version o
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({ params }) {
   const { sessionId } = await params
@@ -107,7 +107,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 import { connection } from 'next/server'
 

--- a/errors/next-prerender-runtime-current-time.mdx
+++ b/errors/next-prerender-runtime-current-time.mdx
@@ -23,7 +23,7 @@ If you are using the current time for performance tracking with elapsed time use
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({ params }) {
   const { id } = await params
@@ -39,7 +39,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({ params }) {
   const { id } = await params
@@ -61,7 +61,7 @@ If you want to read the time when some cache entry is created (such as when a Ne
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function InformationTable({ id }) {
   const data = await fetch(urlFrom(id))
@@ -87,7 +87,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function InformationTable({ id }) {
   'use cache'
@@ -124,7 +124,7 @@ If you go with this approach you will need to ensure the Client Component which 
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 function RelativeTime({ when }) {
   return computeTimeAgo(new Date(), when)
@@ -178,7 +178,7 @@ export function RelativeTime({ when }) {
 ```
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 import { RelativeTime } from './relative-time'
 
@@ -212,7 +212,7 @@ Next.js enforces that it can always produce at least a partially static initial 
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   const lastImpressionTime = (await cookies()).get(
@@ -230,7 +230,7 @@ export default async function Page() {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 import { Suspense } from 'react'
 import { connection } from 'next/server'

--- a/errors/next-prerender-runtime-random.mdx
+++ b/errors/next-prerender-runtime-random.mdx
@@ -23,7 +23,7 @@ If your random value is cacheable, move the `Math.random()` call to a `"use cach
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({ params }) {
   const { category } = await params
@@ -37,7 +37,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function RandomizedProductsView({ category }) {
   'use cache'
@@ -62,7 +62,7 @@ If you want the random value to be evaluated on each Request precede it with `aw
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({ params }) {
   const { category } = await params
@@ -76,7 +76,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 import { connection } from 'next/server'
 

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -41,7 +41,7 @@ const PrefetchSchema = z.enum([
   'partial',
   'unstable_eager',
   'force-disabled',
-  'force-runtime',
+  'allow-runtime',
 ])
 
 export type Instant = InstantConfig | true | false
@@ -51,7 +51,7 @@ export type Prefetch =
   | 'partial'
   | 'unstable_eager'
   | 'force-disabled'
-  | 'force-runtime'
+  | 'allow-runtime'
 
 export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
 // the __GenericInstantConfig type is used to avoid type widening issues with
@@ -146,8 +146,8 @@ const AppSegmentConfigSchema = z.object({
    * - 'unstable_eager' behaves like 'partial' but, when App Shells are enabled,
    *   keeps eagerly prefetching the route's segments instead of relying on the
    *   shared app shell. Internal migration aid; not part of the public API.
-   * - 'force-runtime' is a superset of 'partial' and prefetches using a
-   *   runtime request, instead of a static one.
+   * - 'allow-runtime' is a superset of 'partial' and permits prefetching with
+   *   a runtime request instead of a static one.
    * - 'force-disabled' disables prefetching for the segment.
    */
   unstable_prefetch: PrefetchSchema.optional(),
@@ -204,7 +204,7 @@ export function parseAppSegmentConfig(
           }
           case 'unstable_prefetch': {
             return {
-              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be "auto", "partial", "unstable_eager", "force-disabled", or "force-runtime".`,
+              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be "auto", "partial", "unstable_eager", "force-disabled", or "allow-runtime".`,
             }
           }
           case 'unstable_dynamicStaleTime': {
@@ -274,8 +274,8 @@ export type AppSegmentConfig = {
    * - 'unstable_eager' behaves like 'partial' but, when App Shells are enabled,
    *   keeps eagerly prefetching the route's segments instead of relying on the
    *   shared app shell. Internal migration aid; not part of the public API.
-   * - 'force-runtime' is a superset of 'partial' and prefetches using a
-   *   runtime request, instead of a static one.
+   * - 'allow-runtime' is a superset of 'partial' and permits prefetching with
+   *   a runtime request instead of a static one.
    * - 'force-disabled' disables prefetching for the segment.
    */
   unstable_prefetch?: Prefetch

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -239,7 +239,7 @@ async function createComponentTreeInternal(
   const prefetchConfig = layoutOrPageMod
     ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
     : undefined
-  const hasRuntimePrefetch = prefetchConfig === 'force-runtime'
+  const hasRuntimePrefetch = prefetchConfig === 'allow-runtime'
   const isRuntimePrefetchable = hasRuntimePrefetch || parentRuntimePrefetchable
 
   const [Forbidden, forbiddenStyles] =

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -115,19 +115,19 @@ async function createFlightRouterStateFromLoaderTreeImpl(
       PrefetchHint.SubtreeHasEagerPrefetch
   } else if (prefetchConfig === 'force-disabled') {
     prefetchHints |= PrefetchHint.PrefetchDisabled
-  } else if (prefetchConfig === 'force-runtime') {
+  } else if (prefetchConfig === 'allow-runtime') {
     prefetchHints |= PrefetchHint.HasRuntimePrefetch
   }
 
   // Mark the segment as "eager" unless its effective prefetch strategy is
-  // 'partial' or 'force-runtime'. A truthy unstable_instant is treated as
+  // 'partial' or 'allow-runtime'. A truthy unstable_instant is treated as
   // 'partial' (not eager). 'unstable_eager' already set the bit above. Under
   // App Shells, a subtree with no eager segment skips its Speculative prefetch
   // and relies on the shared app shell instead.
   if (
     !isInstant &&
     prefetchConfig !== 'partial' &&
-    prefetchConfig !== 'force-runtime'
+    prefetchConfig !== 'allow-runtime'
   ) {
     prefetchHints |= PrefetchHint.SubtreeHasEagerPrefetch
   }

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -59,7 +59,7 @@ export async function anySegmentHasRuntimePrefetchEnabled(
   const prefetchConfig = layoutOrPageMod
     ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
     : undefined
-  if (prefetchConfig === 'force-runtime') {
+  if (prefetchConfig === 'allow-runtime') {
     return true
   }
 

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -1220,7 +1220,7 @@ export async function createCombinedPayloadAtDepth(
       }
     }
 
-    const segmentHasRuntimePrefetch = prefetchConfig === 'force-runtime'
+    const segmentHasRuntimePrefetch = prefetchConfig === 'allow-runtime'
 
     let childIsInsideRuntimePrefetch = isInsideRuntimePrefetch
     let stage: SegmentStage

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -159,7 +159,7 @@ const API_DOCS: Record<
   unstable_prefetch: {
     description: `Controls prefetching behavior for this segment. This configuration is currently under development and will change.`,
     link: '(docs coming soon)',
-    type: `"auto" | "partial" | "unstable_eager" | "force-disabled" | "force-runtime"`,
+    type: `"auto" | "partial" | "unstable_eager" | "force-disabled" | "allow-runtime"`,
     options: {
       auto: 'Default. Framework decides based on instant validation and segment configuration. You do not need to set this explicitly.',
       partial: 'Enables Partial Prefetching for this segment.',
@@ -169,10 +169,10 @@ const API_DOCS: Record<
         'adopted Partial Prefetching in canary before the behavior changed to ' +
         'only fetch the shell by default.',
       'force-disabled': 'Never prefetch this segment.',
-      'force-runtime':
-        'Prefetch this segment with a runtime server request so it can access session data, such as cookies.',
+      'allow-runtime':
+        'Allows Next.js to prefetch this segment with a runtime server request so it can access session data, such as cookies.',
     },
-    insertText: `unstable_prefetch = 'force-runtime';`,
+    insertText: `unstable_prefetch = 'allow-runtime';`,
   },
   unstable_dynamicStaleTime: {
     description: `Controls how long the client-side router cache retains dynamic page data (in seconds). Pages only — not allowed in layouts. Cannot be combined with \`unstable_instant\`.`,

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -224,7 +224,7 @@ export const enum PrefetchHint {
   SubtreeHasRuntimePrefetch = 0b100000000000,
   // This segment or one of its descendants prefetches "eagerly" — i.e. its
   // effective prefetch strategy is anything other than 'partial' or
-  // 'force-runtime'. Used by App Shells: a non-eager subtree relies on the
+  // 'allow-runtime'. Used by App Shells: a non-eager subtree relies on the
   // shared app shell and skips its Speculative prefetch. Propagates upward so
   // the root reflects the entire subtree.
   SubtreeHasEagerPrefetch = 0b1000000000000,

--- a/skills/next-cache-components-optimizer/instant-nav-loop.md
+++ b/skills/next-cache-components-optimizer/instant-nav-loop.md
@@ -47,11 +47,11 @@ Set the instant cookie (per shared `instant cookie` section) any time after the 
 
 Apply the shared lever rules from SKILL.md; push-down recipes work at layouts too.
 
-**Nav-only third lever: private cache + runtime prefetch.** For I/O that reads `cookies()` / `headers()` / `searchParams`, shared `'use cache'` won't help — those reads bail to dynamic. Use `'use cache: private'` + `cacheLife({ stale: N })` on **the scope that encloses the request-API read** (see scope rule below), plus `unstable_prefetch = 'force-runtime'` as a route segment config (page or layout export) on the segment that owns the private content. Private-cache results live only in the browser — **never stored on the server** — which is why runtime prefetch can resolve them at link-visibility time with the user's session; the click commits with cookie-derived data already in place.
+**Nav-only third lever: private cache + runtime prefetch.** For I/O that reads `cookies()` / `headers()` / `searchParams`, shared `'use cache'` won't help — those reads bail to dynamic. Use `'use cache: private'` + `cacheLife({ stale: N })` on **the scope that encloses the request-API read** (see scope rule below), plus `unstable_prefetch = 'allow-runtime'` as a route segment config (page or layout export) on the segment that owns the private content. Private-cache results live only in the browser — **never stored on the server** — so allowing runtime prefetching lets Next.js resolve them at link-visibility time with the user's session; the click commits with cookie-derived data already in place.
 
 **Scope rule when cookie-read and data-fetch live in different frames.** The directive's semantics are about the cache scope enclosing the request-API call, not "the I/O function" as a label. If a page reads `cookies()` and passes the value into a separate fetch helper, putting `'use cache: private'` on the helper alone leaves the cookie read outside any cache scope and the segment stays dynamic. Either move the directive up to the frame that reads cookies, or move the cookie read down into the helper. Compiles and typechecks either way — only runtime behavior tells you which is correct.
 
-The `unstable_prefetch` flag applies to the segment plus every descendant — put it on the most ancestral segment with runtime-cacheable content (layout-level covers all child pages; page-level covers only that page). Server Component only (not allowed with `"use client"`); requires `cacheComponents: true`. Valid values: `'auto'` (default) / `'force-disabled'` / `'force-static'` / `'force-runtime'`. It doesn't make any segment cacheable on its own (each still needs `'use cache: private'`), doesn't help cold loads (no `<Link>` to prefetch from), and doesn't override `await connection()`.
+The `unstable_prefetch` flag applies to the segment plus every descendant — put it on the most ancestral segment with runtime-cacheable content (layout-level covers all child pages; page-level covers only that page). Server Component only (not allowed with `"use client"`); requires `cacheComponents: true`. Valid values: `'auto'` (default) / `'force-disabled'` / `'force-static'` / `'allow-runtime'`. It doesn't make any segment cacheable on its own (each still needs `'use cache: private'`), doesn't help cold loads (no `<Link>` to prefetch from), and doesn't override `await connection()`.
 
 ### verify
 
@@ -80,8 +80,8 @@ agent-browser pushstate <url>            client-side navigation (no
 'use cache: private'                     per-session cache; cookies /
                                          headers / searchParams reads ok
 
-unstable_prefetch = 'force-runtime'      route-level: framework actively
-                                         prefetches private-cached
+unstable_prefetch = 'allow-runtime'      route-level: permits runtime
+                                         prefetching of private-cached
                                          content when <Link> is visible
 
 unstable_instant = false                 layout-level opt-out; escape

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
@@ -3,7 +3,7 @@ import { UncachedFetch, CachedData } from '../data-fetching'
 import { PrivateCachedData } from './data-fetching'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 const CACHE_KEY = '/private-cache/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
@@ -3,7 +3,7 @@ import { UncachedFetch, CachedData } from '../data-fetching'
 import { ShortLivedCache } from './data-fetching'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedFetch, CachedData } from '../data-fetching'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
@@ -3,7 +3,7 @@ import { CachedData, getCachedData } from '../../data-fetching'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
@@ -1,7 +1,7 @@
 import { CachedData, getCachedData } from '../../data-fetching'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { Static, Runtime, Dynamic } from '../shared'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Root({ children }: { children: React.ReactNode }) {
   return (

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/blocking-page/page.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/blocking-page/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/target-page/[slug]/page.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/target-page/[slug]/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { ClientFeatures } from './client'
 import { HydrationMarker } from '../../hydration-marker'
 
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 function Box({
   label,

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ searchParams: { myParam: 'testValue' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type SearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/ungenerated-params-runtime/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/ungenerated-params-runtime/[slug]/page.tsx
@@ -9,7 +9,7 @@ export const unstable_instant: {
 } = {
   unstable_samples: [{ params: { slug: 'anything' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function UngeneratedParamsRuntimePage({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
@@ -15,7 +15,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
@@ -16,7 +16,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export function generateStaticParams() {
   return [{ slug: 'foo' }, { slug: 'bar' }]

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ headers: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ headers: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ headers: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
@@ -15,7 +15,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   const c = await cookies()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
@@ -13,7 +13,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
@@ -13,7 +13,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
@@ -12,7 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant: Instant = {
   level: 'experimental-error',
   unstable_samples: [{ params: { slug: 'hello' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant: Instant = {
   level: 'experimental-error',
   unstable_samples: [{ params: { slug: 'hello' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ searchParams: { q: 'test' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ searchParams: { q: 'test' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
@@ -12,7 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
@@ -11,7 +11,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
@@ -16,7 +16,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type SearchParams = Record<string, string | string[]>
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
@@ -12,7 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
@@ -14,7 +14,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
@@ -14,7 +14,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { IgnoreServerContent } from './client'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await cachedIO('static')

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await privateCachedIO()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant: Instant = {
   // no samples
   unstable_samples: [{}],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant: Instant = {
   // no samples
   unstable_samples: [{}],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant: Instant = {
   level: 'experimental-error',
   unstable_samples: [{ params: { lang: 'en-from-samples' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
@@ -2,7 +2,7 @@ export const unstable_instant = {
   unstable_samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   unstable_samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   unstable_samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 // Note that we're inside a root layout with suspense, so we skip the static shell
 export async function generateViewport(): Promise<Viewport> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export async function generateMetadata(): Promise<Metadata> {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
@@ -2,7 +2,7 @@ import type { Viewport } from 'next'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export async function generateViewport(): Promise<Viewport> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { connection } from 'next/server'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function RuntimeLayout({ children }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/layout.tsx
@@ -1,6 +1,6 @@
 // Avoid static shell validation -- we only want to test the validation of `prefetch: 'runtime'` here.
 export const unstable_instant = false
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function DisableStaticShell({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 // This page HAS runtime prefetch enabled. cookies() is passed as a promise
 // input to a public "use cache" function. The cache doesn't read the cookies

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function Runtime() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 // This page HAS runtime prefetch enabled. The sync IO (Date.now()) after
 // cookies() is invalid here because during a runtime prefetch, cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
@@ -2,7 +2,7 @@ import { connection } from 'next/server'
 import { ReactNode } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Layout({ children }: { children: ReactNode }) {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 // runtime prefetching to handle dynamic data, but the parent layout
 // above this one gets static prefetching by default and blocks.
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function InnerLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
@@ -3,7 +3,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function RuntimeLayout({ children }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ cookies: [], params: { param: '123' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   level: 'experimental-error',
   unstable_samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
 export const unstable_instant = { level: 'experimental-error' }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function Runtime() {
   await cookies()

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <div>{children}</div>

--- a/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
@@ -5,7 +5,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
@@ -12,7 +12,7 @@ export const unstable_instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/page.tsx
@@ -6,7 +6,7 @@ export default function Page() {
     <main>
       <h1>Home</h1>
 
-      <h2>Dynamic posts (force-runtime)</h2>
+      <h2>Dynamic posts (allow-runtime)</h2>
       <p>
         These posts read request-time data (cookies). Their App Shell is the
         part of the page that doesn&apos;t depend on the URL params, so it can

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/posts/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/posts/[id]/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 
 type Params = { id: string }
 
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page({ params }: { params: Promise<Params> }) {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -61,7 +61,7 @@ describe('App Shell prefetching', () => {
     )
   })
 
-  it('skips the per-link Speculative prefetch for a non-eager (force-runtime) route', async () => {
+  it('skips the per-link Speculative prefetch for a non-eager (allow-runtime) route', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       beforePageLoad(p: Playwright.Page) {
@@ -70,7 +70,7 @@ describe('App Shell prefetching', () => {
     })
     const act = createRouterAct(page)
 
-    // Reveal /posts/1 (default/auto prefetch). The route is force-runtime, which
+    // Reveal /posts/1 (default/auto prefetch). The route is allow-runtime, which
     // is NOT eager, so under App Shells only the shared App Shell is prefetched.
     await act(
       async () => {

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
@@ -14,7 +14,7 @@ export const unstable_instant = {
     },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function LayoutContent({ children }: { children: ReactNode }) {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function RuntimeBailoutPage() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
@@ -8,7 +8,7 @@ import { cookies } from 'next/headers'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function DynamicContent() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
@@ -8,7 +8,7 @@ import { cookies } from 'next/headers'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 async function DynamicContent() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { DebugRenderKind } from '../../shared'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 export default async function Layout({ children }) {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   unstable_samples: [{ cookies: [{ name: 'user-agent', value: null }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   unstable_samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   unstable_samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({ params }: { params: Promise<Params> }) {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   unstable_samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   unstable_samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   unstable_samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   unstable_samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
@@ -4,7 +4,7 @@
 // In the future, this test can be used to check whether we correctly
 // *skip* a runtime prefetch if a page was prerendered as static.
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -5,7 +5,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -6,7 +6,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -5,7 +5,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ params: { id: 'test' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
@@ -6,7 +6,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ headers: [['host', 'test-host']] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -5,7 +5,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ searchParams: { searchParam: 'value' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -5,7 +5,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -6,7 +6,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -5,7 +5,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ params: { id: 'test' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
@@ -6,7 +6,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ headers: [['host', 'test-host']] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -5,7 +5,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ searchParams: { searchParam: 'value' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -5,7 +5,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -6,7 +6,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -6,7 +6,7 @@ import { cookies } from 'next/headers'
 export const unstable_instant = {
   unstable_samples: [{ params: { id: 'test' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
@@ -6,7 +6,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ headers: [['host', 'test-host']] }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -6,7 +6,7 @@ import { cookies } from 'next/headers'
 export const unstable_instant = {
   unstable_samples: [{ searchParams: { searchParam: 'value' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -7,7 +7,7 @@ import { cookies } from 'next/headers'
 export const unstable_instant = {
   unstable_samples: [{ params: { lang: 'en' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -6,7 +6,7 @@ import { lang } from 'next/root-params'
 export const unstable_instant = {
   unstable_samples: [{ params: { lang: 'en' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -6,7 +6,7 @@ import { lang } from 'next/root-params'
 export const unstable_instant = {
   unstable_samples: [{ params: { lang: 'en' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
@@ -3,7 +3,7 @@ import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
@@ -3,7 +3,7 @@ import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = true
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
@@ -16,7 +16,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
@@ -17,7 +17,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
@@ -15,7 +15,7 @@ export const unstable_instant: {
 } = {
   unstable_samples: [{ params: { slug: 'aaa' } }, { params: { slug: 'bbb' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { slug: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
@@ -16,7 +16,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
@@ -10,7 +10,7 @@ import { connection } from 'next/server'
 export const unstable_instant = {
   unstable_samples: [{ searchParams: { q: '1' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 export default async function RuntimePrefetchSearchParamsTargetPage() {
   // Intentionally NOT accessing searchParams

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
@@ -19,7 +19,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
@@ -17,7 +17,7 @@ import { Suspense } from 'react'
 export const unstable_instant = {
   unstable_samples: [{ searchParams: { foo: '1' } }],
 }
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 type SearchParams = { foo?: string }
 

--- a/test/production/app-dir/use-cache-non-deterministic-args/app/[slug]/page.tsx
+++ b/test/production/app-dir/use-cache-non-deterministic-args/app/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense, cacheSignal } from 'react'
 import { setTimeout } from 'timers/promises'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = 'force-runtime'
+export const unstable_prefetch = 'allow-runtime'
 
 const callCounts = new Map<string, number>()
 


### PR DESCRIPTION
While force-runtime does opt you into runtime prefetching today (i.e. it does force) the intended semantic is shifting to convey that the Segment itself is designed for and makes sense (i.e. cost / performance tradeoff) to runtime prefetch. In the future segments that may be runtime prefetched might not be for various optimization reasons. We therefore are renaming the option from force-runtime to allow-runtime. In the future if we change allow-runtime to sometimes not runtime prefetch we can always ship a new force-runtime as a codemod option that recovers the current behavior.

This wording also better demonstrates why this is a feature of the Segment and not say an option on the link like `<Link prefetch="force-runtime" />`.