### PR TITLE
disallow reads from .next-profiles

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1069,16 +1069,9 @@ impl Project {
 
         // CPU profiles are written to `.next-profiles/` at the project root (see `--cpu-prof`).
         // Deny access to it so the bundler doesn't traverse into the profiling output directory.
-        let denied_profiles_path = match join_path(&self.project_path, DIST_PROFILES_DIR_NAME) {
-            Some(profiles_path) => profiles_path.into(),
-            None => {
-                bail!(
-                    "Invalid projectPath: {:?}. Unable to resolve the {} directory.",
-                    self.project_path,
-                    DIST_PROFILES_DIR_NAME
-                );
-            }
-        };
+        let denied_profiles_path = join_path(&self.project_path, DIST_PROFILES_DIR_NAME)
+            .unwrap()
+            .into();
 
         Ok(DiskFileSystem::new_with_denied_paths(
             PROJECT_FILESYSTEM_NAME,

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -16,7 +16,8 @@ use next_core::{
         ClientChunkingContextOptions, get_client_chunking_context, get_client_compile_time_info,
     },
     next_config::{
-        ModuleIds as ModuleIdStrategyConfig, NextConfig, TurbopackPluginRuntimeStrategy,
+        DIST_PROFILES_DIR_NAME, ModuleIds as ModuleIdStrategyConfig, NextConfig,
+        TurbopackPluginRuntimeStrategy,
     },
     next_edge::context::EdgeChunkingContextOptions,
     next_server::{
@@ -1066,10 +1067,23 @@ impl Project {
             }
         };
 
+        // CPU profiles are written to `.next-profiles/` at the project root (see `--cpu-prof`).
+        // Deny access to it so the bundler doesn't traverse into the profiling output directory.
+        let denied_profiles_path = match join_path(&self.project_path, DIST_PROFILES_DIR_NAME) {
+            Some(profiles_path) => profiles_path.into(),
+            None => {
+                bail!(
+                    "Invalid projectPath: {:?}. Unable to resolve the {} directory.",
+                    self.project_path,
+                    DIST_PROFILES_DIR_NAME
+                );
+            }
+        };
+
         Ok(DiskFileSystem::new_with_denied_paths(
             PROJECT_FILESYSTEM_NAME,
             *self.root_path,
-            vec![denied_path],
+            vec![denied_path, denied_profiles_path],
         ))
     }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -46,6 +46,11 @@ use crate::{
     util::relativize_glob,
 };
 
+/// Name of the directory at the project root where CPU profiles are written when profiling is
+/// enabled (see the `--cpu-prof` CLI flag). It is a fixed-name sibling of `distDir`, not
+/// configurable. Kept here so the bundler and the napi bindings agree on the path.
+pub const DIST_PROFILES_DIR_NAME: &str = ".next-profiles";
+
 #[turbo_tasks::value(transparent)]
 pub struct ModularizeImports(
     #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<String, ModularizeImportPackageConfig>,

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -34,6 +34,7 @@ use next_api::{
 };
 use next_core::{
     app_structure::find_app_dir,
+    next_config::DIST_PROFILES_DIR_NAME,
     next_telemetry::ProjectFeatureUsageSummary,
     tracing_presets::{
         TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBO_TASKS_TARGETS,
@@ -463,7 +464,7 @@ pub fn project_new(
         } else {
             PathBuf::from(&options.root_path)
                 .join(&options.project_path)
-                .join(".next-profiles")
+                .join(DIST_PROFILES_DIR_NAME)
                 .join("trace-turbopack")
         };
         let trace_dir = trace_file


### PR DESCRIPTION
`next` already disallows reading out of `.next` during a build, this extends that to the new `.next-profiles` directory

This is currently hardcoded (not end user configurable), so we just hardcode the path in the next entrypoints.