### PR TITLE
Turbopack: vendor react_compiler_swc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -639,7 +639,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -702,11 +702,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2328,6 +2328,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -3097,6 +3098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,7 +3680,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "inotify-sys",
  "libc",
 ]
@@ -4124,7 +4134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efb6a77b2389e62735b0b8157be9cc10a159eb4d1c3b864e99db9f297ada1b0"
 dependencies = [
  "ahash 0.8.12",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "browserslist-rs",
  "const-str",
  "cssparser",
@@ -4608,7 +4618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214f07a80874bb96a8433b3cdfc84980d56c7b02e1a0d7ba4ba0db5cef785e2b"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "ctor 0.2.0",
  "napi-derive",
  "napi-sys",
@@ -4962,7 +4972,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5015,7 +5025,7 @@ version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -5044,11 +5054,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
  "serde",
@@ -5083,11 +5092,10 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -5105,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -5174,7 +5182,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "objc2",
 ]
 
@@ -5231,7 +5239,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5356,7 +5364,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cssparser",
  "log",
  "phf",
@@ -5452,9 +5460,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -5659,7 +5667,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -6258,6 +6266,161 @@ dependencies = [
 ]
 
 [[package]]
+name = "react_compiler"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler_ast",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "react_compiler_inference",
+ "react_compiler_lowering",
+ "react_compiler_optimization",
+ "react_compiler_reactive_scopes",
+ "react_compiler_ssa",
+ "react_compiler_typeinference",
+ "react_compiler_validation",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "react_compiler_ast"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "react_compiler_diagnostics"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "react_compiler_hir"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler_diagnostics",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "react_compiler_inference"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "react_compiler_lowering",
+ "react_compiler_optimization",
+ "react_compiler_ssa",
+ "react_compiler_utils",
+]
+
+[[package]]
+name = "react_compiler_lowering"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler_ast",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "serde_json",
+]
+
+[[package]]
+name = "react_compiler_optimization"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "react_compiler_lowering",
+ "react_compiler_ssa",
+]
+
+[[package]]
+name = "react_compiler_reactive_scopes"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "hmac",
+ "indexmap 2.13.0",
+ "react_compiler_ast",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "react_compiler_ssa"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "react_compiler_lowering",
+]
+
+[[package]]
+name = "react_compiler_swc"
+version = "0.1.0"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler",
+ "react_compiler_ast",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "serde",
+ "serde_json",
+ "swc_core",
+]
+
+[[package]]
+name = "react_compiler_typeinference"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+ "react_compiler_ssa",
+]
+
+[[package]]
+name = "react_compiler_utils"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "react_compiler_validation"
+version = "0.1.0"
+source = "git+https://github.com/josephsavona/react.git?branch=rust-research#c83f20b11a813e8ed954de7d61f2ecf3fab985c2"
+dependencies = [
+ "indexmap 2.13.0",
+ "react_compiler_diagnostics",
+ "react_compiler_hir",
+]
+
+[[package]]
 name = "react_remove_properties"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6635,7 +6798,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -6648,7 +6811,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -6872,7 +7035,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -6885,7 +7048,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6904,9 +7067,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.0.3"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -7782,7 +7945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aadad5a5d4dd5f08a3e772e325974dc9df2498dbc262093ba80fcb8304c004c"
 dependencies = [
  "auto_impl",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
@@ -7808,7 +7971,7 @@ version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aea25a7967900779f91066a3afe13f598e81bbcc3cff667a0dbe4e7c48f6e9ba"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "serde",
  "swc_atoms",
  "swc_common",
@@ -7897,7 +8060,7 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f4173ab7e676eed4938d5ad8bbdf14418f87c9a8d36e6cdda82ac9645912b0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cbor4ii",
  "is-macro",
  "num-bigint",
@@ -8197,7 +8360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4011c4a9b320a73ac8ff27beb209a39700873b7f7492cfd8184eaf7bd71f8271"
 dependencies = [
  "arrayvec 0.7.6",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "indexmap 2.13.0",
  "num-bigint",
  "num_cpus",
@@ -8232,7 +8395,7 @@ version = "39.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b13829b24cbdb2d7a08282bd968af8a258fd762c918df9a7b82291d44068bbc"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "either",
  "num-bigint",
  "phf",
@@ -8312,7 +8475,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e01fc6155c5fcdce85f253c96fe764877ebaa1dc50ab0639b383dafb46a6427"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "is-macro",
  "swc_atoms",
  "swc_common",
@@ -8472,7 +8635,7 @@ checksum = "f8386f38a7474c642f5afa14e99b12b1b3ff2194122d7bf9c70fbda9dc4ebff6"
 dependencies = [
  "Inflector",
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "indexmap 2.13.0",
  "is-macro",
  "path-clean 1.0.1",
@@ -8936,7 +9099,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -9092,12 +9255,12 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "unicode-linebreak",
- "unicode-width 0.1.13",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -9486,7 +9649,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http 1.1.0",
@@ -10887,9 +11050,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -11277,7 +11440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7178030744403adba447b07cd5c1d683e4b01c5521dd96e14d082f3ed2c1f29c"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cap-fs-ext",
  "cap-rand",
  "cap-std",
@@ -11762,7 +11925,7 @@ version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -11771,7 +11934,7 @@ version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.4",
  "indexmap 2.13.0",
  "semver",
@@ -11784,7 +11947,7 @@ version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.4",
  "indexmap 2.13.0",
  "semver",
@@ -11797,7 +11960,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.4",
  "indexmap 2.13.0",
  "semver",
@@ -11823,7 +11986,7 @@ dependencies = [
  "addr2line 0.25.1",
  "anyhow",
  "async-trait",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -12131,7 +12294,7 @@ checksum = "d9ee0c6dd73bdf0aff4404059bdc24ca61ad92056d20f4e59b8b0780789cafb4"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "thiserror 2.0.12",
  "tracing",
  "wasmtime",
@@ -12611,7 +12774,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "windows-sys 0.59.0",
 ]
 
@@ -12641,7 +12804,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -12682,7 +12845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "indexmap 2.13.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,9 @@ turbopack-trace-server = { path = "turbopack/crates/turbopack-trace-server" }
 turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
+react_compiler_swc = { path = "turbopack/crates/react_compiler_swc" }
+react_compiler = { git = "https://github.com/josephsavona/react.git", branch = "rust-research", package = "react_compiler" }
+
 # SWC crates
 swc_core = { version = "65.0.3", default-features = false, features = [
   "ecma_loader_lru",
@@ -371,3 +374,4 @@ virtue = { git = "https://github.com/bgw/virtue.git", branch = "bgw/fix-generic-
 mdxjs = { git = "https://github.com/vercel-labs/mdxjs-rs-turbopack.git", branch = "turbopack" }
 # Doesn't compile on recent nightly versions because of https://github.com/Michael-F-Bryan/include_dir/pull/117
 include_dir = { git = "https://github.com/vercel-labs/include_dir", branch = "turbopack" }
+

--- a/turbopack/crates/react_compiler_swc/Cargo.toml
+++ b/turbopack/crates/react_compiler_swc/Cargo.toml
@@ -1,0 +1,17 @@
+# Vendored fork of react_compiler_swc, retargeted to swc_core (v23 AST) so # turbopack can call transform() directly on the AST
+# The core compiler logic (react_compiler, react_compiler_ast) stays stays as a git dependency on upstream.
+
+[package]
+name = "react_compiler_swc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+react_compiler_ast = { git = "https://github.com/josephsavona/react.git", branch = "rust-research", package = "react_compiler_ast" }
+react_compiler = { git = "https://github.com/josephsavona/react.git", branch = "rust-research", package = "react_compiler" }
+react_compiler_diagnostics = { git = "https://github.com/josephsavona/react.git", branch = "rust-research", package = "react_compiler_diagnostics" }
+react_compiler_hir = { git = "https://github.com/josephsavona/react.git", branch = "rust-research", package = "react_compiler_hir" }
+swc_core = { workspace = true, features = ["ecma_ast", "ecma_visit", "ecma_parser", "ecma_codegen", "common"] }
+indexmap = { version = "2", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/turbopack/crates/react_compiler_swc/LICENSE.txt
+++ b/turbopack/crates/react_compiler_swc/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/turbopack/crates/react_compiler_swc/src/apply_renames.rs
+++ b/turbopack/crates/react_compiler_swc/src/apply_renames.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use std::collections::HashMap;
+
+use react_compiler::entrypoint::compile_result::BindingRenameInfo;
+use react_compiler_ast::scope::BindingId;
+use swc_core::{
+    atoms::Atom,
+    ecma::{
+        ast::*,
+        visit::{VisitMut, VisitMutWith},
+    },
+};
+
+use crate::convert_scope::build_scope_info;
+
+pub fn apply_renames(module: &mut Module, renames: &[BindingRenameInfo]) {
+    if renames.is_empty() {
+        return;
+    }
+
+    let scope_info = build_scope_info(module);
+    let renames_by_declaration: HashMap<u32, &BindingRenameInfo> = renames
+        .iter()
+        .map(|rename| (rename.declaration_start, rename))
+        .collect();
+    let mut renamed_bindings: HashMap<BindingId, String> = HashMap::new();
+
+    for binding in &scope_info.bindings {
+        let Some(rename) = binding
+            .declaration_start
+            .and_then(|start| renames_by_declaration.get(&start))
+        else {
+            continue;
+        };
+        if binding.name == rename.original {
+            renamed_bindings.insert(binding.id, rename.renamed.clone());
+        }
+    }
+
+    if renamed_bindings.is_empty() {
+        return;
+    }
+
+    let rewrite_plan: HashMap<u32, String> = scope_info
+        .reference_to_binding
+        .iter()
+        .filter_map(|(&position, binding_id)| {
+            renamed_bindings
+                .get(binding_id)
+                .map(|renamed| (position, renamed.clone()))
+        })
+        .collect();
+
+    module.visit_mut_with(&mut RenameApplyVisitor { rewrite_plan });
+}
+
+struct RenameApplyVisitor {
+    rewrite_plan: HashMap<u32, String>,
+}
+
+impl RenameApplyVisitor {
+    fn renamed_at(&self, position: u32) -> Option<String> {
+        self.rewrite_plan.get(&position).cloned()
+    }
+}
+
+impl VisitMut for RenameApplyVisitor {
+    fn visit_mut_ident(&mut self, ident: &mut Ident) {
+        if let Some(renamed) = self.renamed_at(ident.span.lo.0) {
+            ident.sym = Atom::from(renamed);
+        }
+    }
+
+    fn visit_mut_member_expr(&mut self, member: &mut MemberExpr) {
+        member.obj.visit_mut_with(self);
+        if let MemberProp::Computed(computed) = &mut member.prop {
+            computed.visit_mut_with(self);
+        }
+    }
+
+    fn visit_mut_prop(&mut self, prop: &mut Prop) {
+        match prop {
+            Prop::Shorthand(ident) => {
+                if let Some(renamed) = self.renamed_at(ident.span.lo.0) {
+                    let mut value = ident.clone();
+                    value.sym = Atom::from(renamed);
+                    // Shorthand `{ref}` must become `{ref: ref_0}` to preserve property semantics.
+                    *prop = Prop::KeyValue(KeyValueProp {
+                        key: PropName::Ident(IdentName {
+                            span: ident.span,
+                            sym: ident.sym.clone(),
+                        }),
+                        value: Box::new(Expr::Ident(value)),
+                    });
+                }
+            }
+            Prop::Assign(assign) => {
+                assign.value.visit_mut_with(self);
+            }
+            _ => prop.visit_mut_children_with(self),
+        }
+    }
+
+    fn visit_mut_object_pat_prop(&mut self, prop: &mut ObjectPatProp) {
+        match prop {
+            ObjectPatProp::Assign(assign) => {
+                if let Some(value) = &mut assign.value {
+                    value.visit_mut_with(self);
+                }
+
+                if let Some(renamed) = self.renamed_at(assign.key.id.span.lo.0) {
+                    let mut binding = assign.key.clone();
+                    binding.id.sym = Atom::from(renamed);
+                    let value = match assign.value.take() {
+                        Some(default_value) => Pat::Assign(AssignPat {
+                            span: assign.span,
+                            left: Box::new(Pat::Ident(binding)),
+                            right: default_value,
+                        }),
+                        None => Pat::Ident(binding),
+                    };
+
+                    *prop = ObjectPatProp::KeyValue(KeyValuePatProp {
+                        key: PropName::Ident(IdentName {
+                            span: assign.key.id.span,
+                            sym: assign.key.id.sym.clone(),
+                        }),
+                        value: Box::new(value),
+                    });
+                }
+            }
+            _ => prop.visit_mut_children_with(self),
+        }
+    }
+}

--- a/turbopack/crates/react_compiler_swc/src/convert_ast.rs
+++ b/turbopack/crates/react_compiler_swc/src/convert_ast.rs
@@ -1,0 +1,2352 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use react_compiler_ast::{
+    File, Program, SourceType,
+    common::{BaseNode, Position, SourceLocation},
+    declarations::*,
+    expressions::*,
+    jsx::*,
+    literals::*,
+    operators::*,
+    patterns::*,
+    statements::*,
+};
+use swc_core::{
+    common::{Span, Spanned},
+    ecma::ast as swc,
+};
+
+/// Helper to convert SWC's Wtf8Atom (which doesn't impl Display) to a String.
+fn wtf8_to_string(value: &swc_core::atoms::Wtf8Atom) -> String {
+    value.to_string_lossy().into_owned()
+}
+
+/// Wrap a raw Babel-shaped JSON node in [`Statement::Unknown`]. The caller
+/// constructs `raw` with a `type` tag, so `from_raw` cannot fail.
+fn unknown_statement(raw: serde_json::Value) -> Statement {
+    Statement::Unknown(
+        UnknownStatement::from_raw(raw).expect("raw unknown node is constructed with a `type` tag"),
+    )
+}
+
+/// Converts an SWC Module AST to the React compiler's Babel-compatible AST.
+pub fn convert_module(module: &swc::Module, source_text: &str) -> File {
+    convert_module_with_source_type(module, source_text, SourceType::Module)
+}
+
+/// Converts an SWC Module AST to the React compiler's Babel-compatible AST
+/// with an explicit source type.
+pub fn convert_module_with_source_type(
+    module: &swc::Module,
+    source_text: &str,
+    source_type: SourceType,
+) -> File {
+    let ctx = ConvertCtx::new(source_text);
+    let base = ctx.make_base_node(module.span);
+
+    let mut body: Vec<Statement> = Vec::new();
+    let mut directives: Vec<Directive> = Vec::new();
+    let mut past_directives = false;
+
+    for item in &module.body {
+        if !past_directives {
+            if let Some(dir) = try_extract_directive(item, &ctx) {
+                directives.push(dir);
+                continue;
+            }
+            past_directives = true;
+        }
+        body.push(ctx.convert_module_item(item));
+    }
+
+    // Extract comments from source text for suppression detection
+    let comments = extract_comments_from_source(source_text);
+
+    File {
+        base: ctx.make_base_node(module.span),
+        program: Program {
+            base,
+            body,
+            directives,
+            source_type,
+            interpreter: None,
+            source_file: None,
+        },
+        comments,
+        errors: vec![],
+    }
+}
+
+/// Extract comments from source text for suppression detection.
+/// This uses simple regex-style parsing to find block and line comments.
+fn extract_comments_from_source(source: &str) -> Vec<react_compiler_ast::common::Comment> {
+    use react_compiler_ast::common::{Comment, CommentData};
+    let mut comments = Vec::new();
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    let mut line_offsets = vec![0u32];
+    for (i, ch) in source.char_indices() {
+        if ch == '\n' {
+            line_offsets.push((i + 1) as u32);
+        }
+    }
+    let position = |offset: u32| {
+        let line_idx = match line_offsets.binary_search(&offset) {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        };
+        let line_start = line_offsets[line_idx];
+        Position {
+            line: (line_idx as u32) + 1,
+            column: offset - line_start,
+            index: Some(offset),
+        }
+    };
+    let source_location = |start: u32, end: u32| SourceLocation {
+        start: position(start),
+        end: position(end),
+        filename: None,
+        identifier_name: None,
+    };
+
+    while i < len {
+        if bytes[i] == b'/' && i + 1 < len {
+            if bytes[i + 1] == b'/' {
+                // Line comment
+                let start = i as u32;
+                let content_start = i + 2;
+                let mut end = content_start;
+                while end < len && bytes[end] != b'\n' {
+                    end += 1;
+                }
+                let value = String::from_utf8_lossy(&bytes[content_start..end]).to_string();
+                let end_u32 = end as u32;
+                comments.push(Comment::CommentLine(CommentData {
+                    value: value.trim().to_string(),
+                    start: Some(start),
+                    end: Some(end_u32),
+                    loc: Some(source_location(start, end_u32)),
+                }));
+                i = end;
+                continue;
+            } else if bytes[i + 1] == b'*' {
+                // Block comment
+                let start = i as u32;
+                let content_start = i + 2;
+                let mut end = content_start;
+                while end + 1 < len {
+                    if bytes[end] == b'*' && bytes[end + 1] == b'/' {
+                        break;
+                    }
+                    end += 1;
+                }
+                let value = String::from_utf8_lossy(&bytes[content_start..end]).to_string();
+                let comment_end = if end + 1 < len { end + 2 } else { end };
+                let comment_end_u32 = comment_end as u32;
+                comments.push(Comment::CommentBlock(CommentData {
+                    value: value.trim().to_string(),
+                    start: Some(start),
+                    end: Some(comment_end_u32),
+                    loc: Some(source_location(start, comment_end_u32)),
+                }));
+                i = comment_end;
+                continue;
+            }
+        }
+        // Skip string literals to avoid matching // inside strings
+        if bytes[i] == b'"' || bytes[i] == b'\'' || bytes[i] == b'`' {
+            let quote = bytes[i];
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' {
+                    i += 2; // skip escaped char
+                    continue;
+                }
+                if bytes[i] == quote {
+                    break;
+                }
+                i += 1;
+            }
+        }
+        i += 1;
+    }
+
+    comments
+}
+
+fn try_extract_directive(item: &swc::ModuleItem, ctx: &ConvertCtx) -> Option<Directive> {
+    if let swc::ModuleItem::Stmt(swc::Stmt::Expr(expr_stmt)) = item {
+        if let swc::Expr::Lit(swc::Lit::Str(s)) = &*expr_stmt.expr {
+            return Some(Directive {
+                base: ctx.make_base_node(expr_stmt.span),
+                value: DirectiveLiteral {
+                    base: ctx.make_base_node(s.span),
+                    value: wtf8_to_string(&s.value),
+                },
+            });
+        }
+    }
+    None
+}
+
+struct ConvertCtx<'a> {
+    #[allow(dead_code)]
+    source_text: &'a str,
+    line_offsets: Vec<u32>,
+    utf16_offsets: Vec<u32>,
+}
+
+impl<'a> ConvertCtx<'a> {
+    fn new(source_text: &'a str) -> Self {
+        let mut line_offsets = vec![0u32];
+        let mut utf16_offsets = vec![0u32; source_text.len() + 1];
+        let mut utf16_offset = 0u32;
+        for (i, ch) in source_text.char_indices() {
+            let next = i + ch.len_utf8();
+            utf16_offsets[i..next].fill(utf16_offset);
+            utf16_offset += ch.len_utf16() as u32;
+            if ch == '\n' {
+                line_offsets.push(next as u32);
+            }
+        }
+        utf16_offsets[source_text.len()] = utf16_offset;
+        Self {
+            source_text,
+            line_offsets,
+            utf16_offsets,
+        }
+    }
+
+    fn make_base_node(&self, span: Span) -> BaseNode {
+        BaseNode {
+            node_type: None,
+            start: Some(span.lo.0),
+            end: Some(span.hi.0),
+            loc: Some(self.source_location(span)),
+            range: None,
+            extra: None,
+            node_id: Some(span.lo.0),
+            leading_comments: None,
+            inner_comments: None,
+            trailing_comments: None,
+        }
+    }
+
+    /// `BytePos` is 1-based; emit 0-based UTF-16 `loc` to match Babel.
+    /// (`BaseNode.start`/`end` stays 1-based: `convert_scope` keys on it.)
+    fn position(&self, offset: u32) -> Position {
+        let zero_based = offset.saturating_sub(1);
+        let line_idx = match self.line_offsets.binary_search(&zero_based) {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        };
+        let line_start = self.line_offsets[line_idx];
+        // Synthetic spans can point past EOF; clamp to the sentinel.
+        let byte_idx = (zero_based as usize).min(self.utf16_offsets.len() - 1);
+        let utf16_offset = self.utf16_offsets[byte_idx];
+        let line_start_utf16 = self.utf16_offsets[line_start as usize];
+        Position {
+            line: (line_idx as u32) + 1,
+            column: utf16_offset - line_start_utf16,
+            index: Some(utf16_offset),
+        }
+    }
+
+    fn source_location(&self, span: Span) -> SourceLocation {
+        SourceLocation {
+            start: self.position(span.lo.0),
+            end: self.position(span.hi.0),
+            filename: None,
+            identifier_name: None,
+        }
+    }
+
+    fn convert_module_item(&self, item: &swc::ModuleItem) -> Statement {
+        match item {
+            swc::ModuleItem::Stmt(stmt) => self.convert_statement(stmt),
+            swc::ModuleItem::ModuleDecl(decl) => self.convert_module_decl(decl),
+        }
+    }
+
+    fn convert_module_decl(&self, decl: &swc::ModuleDecl) -> Statement {
+        match decl {
+            swc::ModuleDecl::Import(d) => {
+                Statement::ImportDeclaration(self.convert_import_declaration(d))
+            }
+            swc::ModuleDecl::ExportDecl(d) => {
+                Statement::ExportNamedDeclaration(self.convert_export_decl(d))
+            }
+            swc::ModuleDecl::ExportNamed(d) => {
+                Statement::ExportNamedDeclaration(self.convert_export_named(d))
+            }
+            swc::ModuleDecl::ExportDefaultDecl(d) => {
+                Statement::ExportDefaultDeclaration(self.convert_export_default_decl(d))
+            }
+            swc::ModuleDecl::ExportDefaultExpr(d) => {
+                Statement::ExportDefaultDeclaration(self.convert_export_default_expr(d))
+            }
+            swc::ModuleDecl::ExportAll(d) => {
+                Statement::ExportAllDeclaration(self.convert_export_all(d))
+            }
+            // These TS module-interop statements are not modeled by the
+            // typed AST. Carry them as raw Babel-compatible
+            // `Statement::Unknown` nodes (field names and nesting match
+            // `@babel/parser`, not byte-exact details like `extra`) so they
+            // survive the pipeline the same way Babel/NAPI input does.
+            swc::ModuleDecl::TsImportEquals(d) => self.convert_ts_import_equals(d),
+            swc::ModuleDecl::TsExportAssignment(d) => self.convert_ts_export_assignment(d),
+            swc::ModuleDecl::TsNamespaceExport(d) => self.convert_ts_namespace_export(d),
+        }
+    }
+
+    // ===== TS module interop (raw unknown statements) =====
+
+    /// Build the base of a raw Babel-shaped JSON node: the `type` tag plus
+    /// the same `start`/`end`/`loc` fields the converter emits on typed
+    /// nodes via [`Self::make_base_node`].
+    fn raw_node_json(&self, node_type: &str, span: Span) -> serde_json::Value {
+        let mut base = self.make_base_node(span);
+        base.node_type = Some(node_type.to_string());
+        serde_json::to_value(base).expect("BaseNode serializes to JSON")
+    }
+
+    fn identifier_to_json(&self, id: &swc::Ident) -> serde_json::Value {
+        serde_json::to_value(Expression::Identifier(self.convert_ident_to_identifier(id)))
+            .expect("Identifier serializes to JSON")
+    }
+
+    fn ident_name_to_json(&self, id: &swc::IdentName) -> serde_json::Value {
+        serde_json::to_value(Expression::Identifier(Identifier {
+            base: self.make_base_node(id.span),
+            name: id.sym.to_string(),
+            type_annotation: None,
+            optional: None,
+            decorators: None,
+        }))
+        .expect("Identifier serializes to JSON")
+    }
+
+    /// Serialize a TS entity name (`a` or `a.b.c`) as the Babel
+    /// `Identifier` / `TSQualifiedName` shape.
+    fn ts_entity_name_to_json(&self, name: &swc::TsEntityName) -> serde_json::Value {
+        match name {
+            swc::TsEntityName::Ident(id) => self.identifier_to_json(id),
+            swc::TsEntityName::TsQualifiedName(q) => {
+                let mut raw = self.raw_node_json("TSQualifiedName", q.span);
+                raw["left"] = self.ts_entity_name_to_json(&q.left);
+                raw["right"] = self.ident_name_to_json(&q.right);
+                raw
+            }
+        }
+    }
+
+    /// `import x = require("mod")` / `import a = b.c` →
+    /// `TSImportEqualsDeclaration`.
+    fn convert_ts_import_equals(&self, d: &swc::TsImportEqualsDecl) -> Statement {
+        let mut raw = self.raw_node_json("TSImportEqualsDeclaration", d.span);
+        raw["importKind"] = serde_json::json!(if d.is_type_only { "type" } else { "value" });
+        raw["isExport"] = serde_json::json!(d.is_export);
+        raw["id"] = self.identifier_to_json(&d.id);
+        raw["moduleReference"] = match &d.module_ref {
+            swc::TsModuleRef::TsExternalModuleRef(r) => {
+                let mut module_ref = self.raw_node_json("TSExternalModuleReference", r.span);
+                module_ref["expression"] =
+                    serde_json::to_value(Expression::StringLiteral(StringLiteral {
+                        base: self.make_base_node(r.expr.span),
+                        value: wtf8_to_string(&r.expr.value),
+                    }))
+                    .expect("StringLiteral serializes to JSON");
+                module_ref
+            }
+            swc::TsModuleRef::TsEntityName(name) => self.ts_entity_name_to_json(name),
+        };
+        unknown_statement(raw)
+    }
+
+    /// `export = x` → `TSExportAssignment`. The expression goes through the
+    /// normal forward conversion; the typed AST serializes to the Babel
+    /// shape by construction.
+    fn convert_ts_export_assignment(&self, d: &swc::TsExportAssignment) -> Statement {
+        let mut raw = self.raw_node_json("TSExportAssignment", d.span);
+        raw["expression"] = serde_json::to_value(self.convert_expression(&d.expr))
+            .expect("Expression serializes to JSON");
+        unknown_statement(raw)
+    }
+
+    /// `export as namespace X` → `TSNamespaceExportDeclaration`.
+    fn convert_ts_namespace_export(&self, d: &swc::TsNamespaceExportDecl) -> Statement {
+        let mut raw = self.raw_node_json("TSNamespaceExportDeclaration", d.span);
+        raw["id"] = self.identifier_to_json(&d.id);
+        unknown_statement(raw)
+    }
+
+    // ===== Statements =====
+
+    fn convert_statement(&self, stmt: &swc::Stmt) -> Statement {
+        match stmt {
+            swc::Stmt::Block(s) => Statement::BlockStatement(self.convert_block_statement(s)),
+            swc::Stmt::Break(s) => Statement::BreakStatement(BreakStatement {
+                base: self.make_base_node(s.span),
+                label: s
+                    .label
+                    .as_ref()
+                    .map(|l| self.convert_ident_to_identifier(l)),
+            }),
+            swc::Stmt::Continue(s) => Statement::ContinueStatement(ContinueStatement {
+                base: self.make_base_node(s.span),
+                label: s
+                    .label
+                    .as_ref()
+                    .map(|l| self.convert_ident_to_identifier(l)),
+            }),
+            swc::Stmt::Debugger(s) => Statement::DebuggerStatement(DebuggerStatement {
+                base: self.make_base_node(s.span),
+            }),
+            swc::Stmt::DoWhile(s) => Statement::DoWhileStatement(DoWhileStatement {
+                base: self.make_base_node(s.span),
+                test: Box::new(self.convert_expression(&s.test)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            swc::Stmt::Empty(s) => Statement::EmptyStatement(EmptyStatement {
+                base: self.make_base_node(s.span),
+            }),
+            swc::Stmt::Expr(s) => Statement::ExpressionStatement(ExpressionStatement {
+                base: self.make_base_node(s.span),
+                expression: Box::new(self.convert_expression(&s.expr)),
+            }),
+            swc::Stmt::ForIn(s) => Statement::ForInStatement(ForInStatement {
+                base: self.make_base_node(s.span),
+                left: Box::new(self.convert_for_head(&s.left)),
+                right: Box::new(self.convert_expression(&s.right)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            swc::Stmt::ForOf(s) => Statement::ForOfStatement(ForOfStatement {
+                base: self.make_base_node(s.span),
+                left: Box::new(self.convert_for_head(&s.left)),
+                right: Box::new(self.convert_expression(&s.right)),
+                body: Box::new(self.convert_statement(&s.body)),
+                is_await: s.is_await,
+            }),
+            swc::Stmt::For(s) => Statement::ForStatement(ForStatement {
+                base: self.make_base_node(s.span),
+                init: s
+                    .init
+                    .as_ref()
+                    .map(|i| Box::new(self.convert_var_decl_or_expr_to_for_init(i))),
+                test: s
+                    .test
+                    .as_ref()
+                    .map(|t| Box::new(self.convert_expression(t))),
+                update: s
+                    .update
+                    .as_ref()
+                    .map(|u| Box::new(self.convert_expression(u))),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            swc::Stmt::If(s) => Statement::IfStatement(IfStatement {
+                base: self.make_base_node(s.span),
+                test: Box::new(self.convert_expression(&s.test)),
+                consequent: Box::new(self.convert_statement(&s.cons)),
+                alternate: s.alt.as_ref().map(|a| Box::new(self.convert_statement(a))),
+            }),
+            swc::Stmt::Labeled(s) => Statement::LabeledStatement(LabeledStatement {
+                base: self.make_base_node(s.span),
+                label: self.convert_ident_to_identifier(&s.label),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            swc::Stmt::Return(s) => Statement::ReturnStatement(ReturnStatement {
+                base: self.make_base_node(s.span),
+                argument: s.arg.as_ref().map(|a| Box::new(self.convert_expression(a))),
+            }),
+            swc::Stmt::Switch(s) => Statement::SwitchStatement(SwitchStatement {
+                base: self.make_base_node(s.span),
+                discriminant: Box::new(self.convert_expression(&s.discriminant)),
+                cases: s
+                    .cases
+                    .iter()
+                    .map(|c| SwitchCase {
+                        base: self.make_base_node(c.span),
+                        test: c
+                            .test
+                            .as_ref()
+                            .map(|t| Box::new(self.convert_expression(t))),
+                        consequent: c.cons.iter().map(|s| self.convert_statement(s)).collect(),
+                    })
+                    .collect(),
+            }),
+            swc::Stmt::Throw(s) => Statement::ThrowStatement(ThrowStatement {
+                base: self.make_base_node(s.span),
+                argument: Box::new(self.convert_expression(&s.arg)),
+            }),
+            swc::Stmt::Try(s) => Statement::TryStatement(TryStatement {
+                base: self.make_base_node(s.span),
+                block: self.convert_block_statement(&s.block),
+                handler: s.handler.as_ref().map(|h| self.convert_catch_clause(h)),
+                finalizer: s
+                    .finalizer
+                    .as_ref()
+                    .map(|f| self.convert_block_statement(f)),
+            }),
+            swc::Stmt::While(s) => Statement::WhileStatement(WhileStatement {
+                base: self.make_base_node(s.span),
+                test: Box::new(self.convert_expression(&s.test)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            swc::Stmt::With(s) => Statement::WithStatement(WithStatement {
+                base: self.make_base_node(s.span),
+                object: Box::new(self.convert_expression(&s.obj)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            swc::Stmt::Decl(d) => self.convert_decl_to_statement(d),
+        }
+    }
+
+    fn convert_decl_to_statement(&self, decl: &swc::Decl) -> Statement {
+        match decl {
+            swc::Decl::Var(v) => {
+                Statement::VariableDeclaration(self.convert_variable_declaration(v))
+            }
+            swc::Decl::Fn(f) => Statement::FunctionDeclaration(self.convert_fn_decl(f)),
+            swc::Decl::Class(c) => Statement::ClassDeclaration(self.convert_class_decl(c)),
+            swc::Decl::TsTypeAlias(d) => {
+                Statement::TSTypeAliasDeclaration(self.convert_ts_type_alias(d))
+            }
+            swc::Decl::TsInterface(d) => {
+                Statement::TSInterfaceDeclaration(self.convert_ts_interface(d))
+            }
+            swc::Decl::TsEnum(d) => Statement::TSEnumDeclaration(self.convert_ts_enum(d)),
+            swc::Decl::TsModule(d) => Statement::TSModuleDeclaration(self.convert_ts_module(d)),
+            swc::Decl::Using(u) => Statement::VariableDeclaration(self.convert_using_decl(u)),
+        }
+    }
+
+    fn convert_block_statement(&self, block: &swc::BlockStmt) -> BlockStatement {
+        let mut body: Vec<Statement> = Vec::new();
+        let mut directives: Vec<Directive> = Vec::new();
+        let mut past_directives = false;
+
+        for stmt in &block.stmts {
+            if !past_directives {
+                if let Some(dir) = self.try_extract_block_directive(stmt) {
+                    directives.push(dir);
+                    continue;
+                }
+                past_directives = true;
+            }
+            body.push(self.convert_statement(stmt));
+        }
+
+        BlockStatement {
+            base: self.make_base_node(block.span),
+            body,
+            directives,
+        }
+    }
+
+    /// Try to extract a directive from a statement in a block body.
+    /// Directives are expression statements whose expression is a string literal.
+    fn try_extract_block_directive(&self, stmt: &swc::Stmt) -> Option<Directive> {
+        if let swc::Stmt::Expr(expr_stmt) = stmt {
+            if let swc::Expr::Lit(swc::Lit::Str(s)) = &*expr_stmt.expr {
+                return Some(Directive {
+                    base: self.make_base_node(expr_stmt.span),
+                    value: DirectiveLiteral {
+                        base: self.make_base_node(s.span),
+                        value: wtf8_to_string(&s.value),
+                    },
+                });
+            }
+        }
+        None
+    }
+
+    fn convert_catch_clause(&self, clause: &swc::CatchClause) -> CatchClause {
+        CatchClause {
+            base: self.make_base_node(clause.span),
+            param: clause.param.as_ref().map(|p| self.convert_pat(p)),
+            body: self.convert_block_statement(&clause.body),
+        }
+    }
+
+    fn convert_var_decl_or_expr_to_for_init(&self, init: &swc::VarDeclOrExpr) -> ForInit {
+        match init {
+            swc::VarDeclOrExpr::VarDecl(v) => {
+                ForInit::VariableDeclaration(self.convert_variable_declaration(v))
+            }
+            swc::VarDeclOrExpr::Expr(e) => {
+                ForInit::Expression(Box::new(self.convert_expression(e)))
+            }
+        }
+    }
+
+    fn convert_for_head(&self, head: &swc::ForHead) -> ForInOfLeft {
+        match head {
+            swc::ForHead::VarDecl(v) => {
+                ForInOfLeft::VariableDeclaration(self.convert_variable_declaration(v))
+            }
+            swc::ForHead::Pat(p) => ForInOfLeft::Pattern(Box::new(self.convert_pat(p))),
+            swc::ForHead::UsingDecl(u) => {
+                ForInOfLeft::VariableDeclaration(self.convert_using_decl(u))
+            }
+        }
+    }
+
+    fn convert_variable_declaration(&self, decl: &swc::VarDecl) -> VariableDeclaration {
+        VariableDeclaration {
+            base: self.make_base_node(decl.span),
+            declarations: decl
+                .decls
+                .iter()
+                .map(|d| self.convert_variable_declarator(d))
+                .collect(),
+            kind: match decl.kind {
+                swc::VarDeclKind::Var => VariableDeclarationKind::Var,
+                swc::VarDeclKind::Let => VariableDeclarationKind::Let,
+                swc::VarDeclKind::Const => VariableDeclarationKind::Const,
+            },
+            declare: if decl.declare { Some(true) } else { None },
+        }
+    }
+
+    fn convert_using_decl(&self, decl: &swc::UsingDecl) -> VariableDeclaration {
+        VariableDeclaration {
+            base: self.make_base_node(decl.span),
+            declarations: decl
+                .decls
+                .iter()
+                .map(|d| self.convert_variable_declarator(d))
+                .collect(),
+            kind: VariableDeclarationKind::Using,
+            declare: None,
+        }
+    }
+
+    fn convert_variable_declarator(&self, d: &swc::VarDeclarator) -> VariableDeclarator {
+        VariableDeclarator {
+            base: self.make_base_node(d.span),
+            id: self.convert_pat(&d.name),
+            init: d
+                .init
+                .as_ref()
+                .map(|e| Box::new(self.convert_expression(e))),
+            definite: if d.definite { Some(true) } else { None },
+        }
+    }
+
+    // ===== Expressions =====
+
+    fn convert_expression(&self, expr: &swc::Expr) -> Expression {
+        match expr {
+            swc::Expr::Lit(lit) => self.convert_lit(lit),
+            swc::Expr::Ident(id) => Expression::Identifier(self.convert_ident_to_identifier(id)),
+            swc::Expr::This(t) => Expression::ThisExpression(ThisExpression {
+                base: self.make_base_node(t.span),
+            }),
+            swc::Expr::Array(arr) => {
+                Expression::ArrayExpression(self.convert_array_expression(arr))
+            }
+            swc::Expr::Object(obj) => {
+                Expression::ObjectExpression(self.convert_object_expression(obj))
+            }
+            swc::Expr::Fn(f) => Expression::FunctionExpression(self.convert_fn_expr(f)),
+            swc::Expr::Unary(un) => Expression::UnaryExpression(UnaryExpression {
+                base: self.make_base_node(un.span),
+                operator: self.convert_unary_operator(un.op),
+                prefix: true,
+                argument: Box::new(self.convert_expression(&un.arg)),
+            }),
+            swc::Expr::Update(up) => Expression::UpdateExpression(UpdateExpression {
+                base: self.make_base_node(up.span),
+                operator: self.convert_update_operator(up.op),
+                argument: Box::new(self.convert_expression(&up.arg)),
+                prefix: up.prefix,
+            }),
+            swc::Expr::Bin(bin) => {
+                if let Some(log_op) = self.try_convert_logical_operator(bin.op) {
+                    Expression::LogicalExpression(LogicalExpression {
+                        base: self.make_base_node(bin.span),
+                        operator: log_op,
+                        left: Box::new(self.convert_expression(&bin.left)),
+                        right: Box::new(self.convert_expression(&bin.right)),
+                    })
+                } else {
+                    Expression::BinaryExpression(BinaryExpression {
+                        base: self.make_base_node(bin.span),
+                        operator: self.convert_binary_operator(bin.op),
+                        left: Box::new(self.convert_expression(&bin.left)),
+                        right: Box::new(self.convert_expression(&bin.right)),
+                    })
+                }
+            }
+            swc::Expr::Assign(a) => {
+                Expression::AssignmentExpression(self.convert_assignment_expression(a))
+            }
+            swc::Expr::Member(m) => Expression::MemberExpression(self.convert_member_expression(m)),
+            swc::Expr::SuperProp(sp) => {
+                let (property, computed) = self.convert_super_prop(&sp.prop);
+                Expression::MemberExpression(MemberExpression {
+                    base: self.make_base_node(sp.span),
+                    object: Box::new(Expression::Super(Super {
+                        base: self.make_base_node(sp.obj.span),
+                    })),
+                    property: Box::new(property),
+                    computed,
+                })
+            }
+            swc::Expr::Cond(c) => Expression::ConditionalExpression(ConditionalExpression {
+                base: self.make_base_node(c.span),
+                test: Box::new(self.convert_expression(&c.test)),
+                consequent: Box::new(self.convert_expression(&c.cons)),
+                alternate: Box::new(self.convert_expression(&c.alt)),
+            }),
+            swc::Expr::Call(call) => Expression::CallExpression(self.convert_call_expression(call)),
+            swc::Expr::New(n) => Expression::NewExpression(NewExpression {
+                base: self.make_base_node(n.span),
+                callee: Box::new(self.convert_expression(&n.callee)),
+                arguments: n.args.as_ref().map_or_else(Vec::new, |args| {
+                    args.iter()
+                        .map(|a| self.convert_expr_or_spread(a))
+                        .collect()
+                }),
+                type_parameters: None,
+                type_arguments: None,
+            }),
+            swc::Expr::Seq(seq) => Expression::SequenceExpression(SequenceExpression {
+                base: self.make_base_node(seq.span),
+                expressions: seq
+                    .exprs
+                    .iter()
+                    .map(|e| self.convert_expression(e))
+                    .collect(),
+            }),
+            swc::Expr::Arrow(arrow) => {
+                Expression::ArrowFunctionExpression(self.convert_arrow_function(arrow))
+            }
+            swc::Expr::Class(class) => {
+                Expression::ClassExpression(self.convert_class_expression(class))
+            }
+            swc::Expr::Yield(y) => Expression::YieldExpression(YieldExpression {
+                base: self.make_base_node(y.span),
+                argument: y.arg.as_ref().map(|a| Box::new(self.convert_expression(a))),
+                delegate: y.delegate,
+            }),
+            swc::Expr::Await(a) => Expression::AwaitExpression(AwaitExpression {
+                base: self.make_base_node(a.span),
+                argument: Box::new(self.convert_expression(&a.arg)),
+            }),
+            swc::Expr::MetaProp(mp) => {
+                let (meta_name, prop_name) = match mp.kind {
+                    swc::MetaPropKind::NewTarget => ("new", "target"),
+                    swc::MetaPropKind::ImportMeta => ("import", "meta"),
+                };
+                Expression::MetaProperty(MetaProperty {
+                    base: self.make_base_node(mp.span),
+                    meta: Identifier {
+                        base: self.make_base_node(mp.span),
+                        name: meta_name.to_string(),
+                        type_annotation: None,
+                        optional: None,
+                        decorators: None,
+                    },
+                    property: Identifier {
+                        base: self.make_base_node(mp.span),
+                        name: prop_name.to_string(),
+                        type_annotation: None,
+                        optional: None,
+                        decorators: None,
+                    },
+                })
+            }
+            swc::Expr::Tpl(tpl) => Expression::TemplateLiteral(self.convert_template_literal(tpl)),
+            swc::Expr::TaggedTpl(tag) => {
+                Expression::TaggedTemplateExpression(TaggedTemplateExpression {
+                    base: self.make_base_node(tag.span),
+                    tag: Box::new(self.convert_expression(&tag.tag)),
+                    quasi: self.convert_template_literal(&tag.tpl),
+                    type_parameters: None,
+                })
+            }
+            swc::Expr::Paren(p) => Expression::ParenthesizedExpression(ParenthesizedExpression {
+                base: self.make_base_node(p.span),
+                expression: Box::new(self.convert_expression(&p.expr)),
+            }),
+            swc::Expr::OptChain(chain) => self.convert_opt_chain_expression(chain),
+            swc::Expr::PrivateName(p) => Expression::PrivateName(PrivateName {
+                base: self.make_base_node(p.span),
+                id: Identifier {
+                    base: self.make_base_node(p.span),
+                    name: p.name.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                },
+            }),
+            swc::Expr::JSXElement(el) => {
+                Expression::JSXElement(Box::new(self.convert_jsx_element(el)))
+            }
+            swc::Expr::JSXFragment(frag) => {
+                Expression::JSXFragment(self.convert_jsx_fragment(frag))
+            }
+            swc::Expr::JSXEmpty(e) => Expression::Identifier(Identifier {
+                base: self.make_base_node(e.span),
+                name: "undefined".to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+            swc::Expr::JSXMember(m) => Expression::Identifier(Identifier {
+                base: self.make_base_node(m.prop.span),
+                name: m.prop.sym.to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+            swc::Expr::JSXNamespacedName(n) => Expression::Identifier(Identifier {
+                base: self.make_base_node(n.name.span),
+                name: format!("{}:{}", n.ns.sym, n.name.sym),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+            swc::Expr::TsAs(e) => Expression::TSAsExpression(TSAsExpression {
+                base: self.make_base_node(e.span),
+                expression: Box::new(self.convert_expression(&e.expr)),
+                type_annotation: Box::new(
+                    self.convert_ts_type_to_json(&e.type_ann)
+                        .unwrap_or(serde_json::Value::Null),
+                ),
+            }),
+            swc::Expr::TsSatisfies(e) => Expression::TSSatisfiesExpression(TSSatisfiesExpression {
+                base: self.make_base_node(e.span),
+                expression: Box::new(self.convert_expression(&e.expr)),
+                type_annotation: Box::new(
+                    self.convert_ts_type_to_json(&e.type_ann)
+                        .unwrap_or(serde_json::Value::Null),
+                ),
+            }),
+            swc::Expr::TsTypeAssertion(e) => Expression::TSTypeAssertion(TSTypeAssertion {
+                base: self.make_base_node(e.span),
+                expression: Box::new(self.convert_expression(&e.expr)),
+                type_annotation: Box::new(
+                    self.convert_ts_type_to_json(&e.type_ann)
+                        .unwrap_or(serde_json::Value::Null),
+                ),
+            }),
+            swc::Expr::TsNonNull(e) => Expression::TSNonNullExpression(TSNonNullExpression {
+                base: self.make_base_node(e.span),
+                expression: Box::new(self.convert_expression(&e.expr)),
+            }),
+            swc::Expr::TsInstantiation(e) => {
+                Expression::TSInstantiationExpression(TSInstantiationExpression {
+                    base: self.make_base_node(e.span),
+                    expression: Box::new(self.convert_expression(&e.expr)),
+                    type_parameters: Box::new(serde_json::Value::Null),
+                })
+            }
+            swc::Expr::TsConstAssertion(e) => {
+                // "as const" → TSAsExpression with typeAnnotation: TSTypeReference { typeName:
+                // Identifier { name: "const" } } This matches Babel's AST
+                // representation of `as const`.
+                let type_ann = serde_json::json!({
+                    "type": "TSTypeReference",
+                    "typeName": {
+                        "type": "Identifier",
+                        "name": "const"
+                    }
+                });
+                Expression::TSAsExpression(TSAsExpression {
+                    base: self.make_base_node(e.span),
+                    expression: Box::new(self.convert_expression(&e.expr)),
+                    type_annotation: Box::new(type_ann),
+                })
+            }
+            swc::Expr::Invalid(i) => Expression::Identifier(Identifier {
+                base: self.make_base_node(i.span),
+                name: "__invalid__".to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+        }
+    }
+
+    fn convert_lit(&self, lit: &swc::Lit) -> Expression {
+        match lit {
+            swc::Lit::Str(s) => Expression::StringLiteral(StringLiteral {
+                base: self.make_base_node(s.span),
+                value: wtf8_to_string(&s.value),
+            }),
+            swc::Lit::Bool(b) => Expression::BooleanLiteral(BooleanLiteral {
+                base: self.make_base_node(b.span),
+                value: b.value,
+            }),
+            swc::Lit::Null(n) => Expression::NullLiteral(NullLiteral {
+                base: self.make_base_node(n.span),
+            }),
+            swc::Lit::Num(n) => Expression::NumericLiteral(NumericLiteral {
+                base: self.make_base_node(n.span),
+                value: n.value,
+                extra: None,
+            }),
+            swc::Lit::BigInt(b) => Expression::BigIntLiteral(BigIntLiteral {
+                base: self.make_base_node(b.span),
+                value: b.value.to_string(),
+            }),
+            swc::Lit::Regex(r) => Expression::RegExpLiteral(RegExpLiteral {
+                base: self.make_base_node(r.span),
+                pattern: r.exp.to_string(),
+                flags: r.flags.to_string(),
+            }),
+            swc::Lit::JSXText(t) => Expression::StringLiteral(StringLiteral {
+                base: self.make_base_node(t.span),
+                value: t.value.to_string(),
+            }),
+        }
+    }
+
+    // ===== Optional chaining =====
+
+    fn convert_opt_chain_expression(&self, chain: &swc::OptChainExpr) -> Expression {
+        match &*chain.base {
+            swc::OptChainBase::Member(m) => {
+                let (property, computed) = self.convert_member_prop(&m.prop);
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(chain.span),
+                    object: Box::new(self.convert_opt_chain_callee(&m.obj)),
+                    property: Box::new(property),
+                    computed,
+                    optional: chain.optional,
+                })
+            }
+            swc::OptChainBase::Call(call) => {
+                Expression::OptionalCallExpression(OptionalCallExpression {
+                    base: self.make_base_node(chain.span),
+                    callee: Box::new(self.convert_opt_chain_callee(&call.callee)),
+                    arguments: call
+                        .args
+                        .iter()
+                        .map(|a| self.convert_expr_or_spread(a))
+                        .collect(),
+                    optional: chain.optional,
+                    type_parameters: None,
+                    type_arguments: None,
+                })
+            }
+        }
+    }
+
+    fn convert_opt_chain_callee(&self, expr: &swc::Expr) -> Expression {
+        if let swc::Expr::OptChain(chain) = expr {
+            return self.convert_opt_chain_expression(chain);
+        }
+        self.convert_expression(expr)
+    }
+
+    // ===== Member expression =====
+
+    fn convert_member_expression(&self, m: &swc::MemberExpr) -> MemberExpression {
+        let (property, computed) = self.convert_member_prop(&m.prop);
+        MemberExpression {
+            base: self.make_base_node(m.span),
+            object: Box::new(self.convert_expression(&m.obj)),
+            property: Box::new(property),
+            computed,
+        }
+    }
+
+    fn convert_member_prop(&self, prop: &swc::MemberProp) -> (Expression, bool) {
+        match prop {
+            swc::MemberProp::Ident(id) => (
+                Expression::Identifier(Identifier {
+                    base: self.make_base_node(id.span),
+                    name: id.sym.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                }),
+                false,
+            ),
+            swc::MemberProp::Computed(c) => (self.convert_expression(&c.expr), true),
+            swc::MemberProp::PrivateName(p) => (
+                Expression::PrivateName(PrivateName {
+                    base: self.make_base_node(p.span),
+                    id: Identifier {
+                        base: self.make_base_node(p.span),
+                        name: p.name.to_string(),
+                        type_annotation: None,
+                        optional: None,
+                        decorators: None,
+                    },
+                }),
+                false,
+            ),
+        }
+    }
+
+    fn convert_super_prop(&self, prop: &swc::SuperProp) -> (Expression, bool) {
+        match prop {
+            swc::SuperProp::Ident(id) => (
+                Expression::Identifier(Identifier {
+                    base: self.make_base_node(id.span),
+                    name: id.sym.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                }),
+                false,
+            ),
+            swc::SuperProp::Computed(c) => (self.convert_expression(&c.expr), true),
+        }
+    }
+
+    // ===== Call expression =====
+
+    fn convert_call_expression(&self, call: &swc::CallExpr) -> CallExpression {
+        CallExpression {
+            base: self.make_base_node(call.span),
+            callee: Box::new(self.convert_callee(&call.callee)),
+            arguments: call
+                .args
+                .iter()
+                .map(|a| self.convert_expr_or_spread(a))
+                .collect(),
+            type_parameters: None,
+            type_arguments: None,
+            optional: None,
+        }
+    }
+
+    fn convert_callee(&self, callee: &swc::Callee) -> Expression {
+        match callee {
+            swc::Callee::Expr(e) => self.convert_expression(e),
+            swc::Callee::Super(s) => Expression::Super(Super {
+                base: self.make_base_node(s.span),
+            }),
+            swc::Callee::Import(i) => Expression::Import(Import {
+                base: self.make_base_node(i.span),
+            }),
+        }
+    }
+
+    fn convert_expr_or_spread(&self, arg: &swc::ExprOrSpread) -> Expression {
+        if let Some(spread_span) = arg.spread {
+            Expression::SpreadElement(SpreadElement {
+                base: self.make_base_node(Span::new(spread_span.lo, arg.expr.span().hi)),
+                argument: Box::new(self.convert_expression(&arg.expr)),
+            })
+        } else {
+            self.convert_expression(&arg.expr)
+        }
+    }
+
+    // ===== Function helpers =====
+
+    fn convert_fn_decl(&self, func: &swc::FnDecl) -> FunctionDeclaration {
+        let f = &func.function;
+        let body = f
+            .body
+            .as_ref()
+            .map(|b| self.convert_block_statement(b))
+            .unwrap_or_else(|| BlockStatement {
+                base: self.make_base_node(f.span),
+                body: vec![],
+                directives: vec![],
+            });
+        FunctionDeclaration {
+            base: self.make_base_node(f.span),
+            id: Some(self.convert_ident_to_identifier(&func.ident)),
+            params: self.convert_params(&f.params),
+            body,
+            generator: f.is_generator,
+            is_async: f.is_async,
+            declare: if func.declare { Some(true) } else { None },
+            return_type: f
+                .return_type
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            type_parameters: f
+                .type_params
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            predicate: None,
+            component_declaration: false,
+            hook_declaration: false,
+        }
+    }
+
+    fn convert_fn_expr(&self, func: &swc::FnExpr) -> FunctionExpression {
+        let f = &func.function;
+        let body = f
+            .body
+            .as_ref()
+            .map(|b| self.convert_block_statement(b))
+            .unwrap_or_else(|| BlockStatement {
+                base: self.make_base_node(f.span),
+                body: vec![],
+                directives: vec![],
+            });
+        FunctionExpression {
+            base: self.make_base_node(f.span),
+            id: func
+                .ident
+                .as_ref()
+                .map(|id| self.convert_ident_to_identifier(id)),
+            params: self.convert_params(&f.params),
+            body,
+            generator: f.is_generator,
+            is_async: f.is_async,
+            return_type: f
+                .return_type
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            type_parameters: f
+                .type_params
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            predicate: None,
+        }
+    }
+
+    fn convert_arrow_function(&self, arrow: &swc::ArrowExpr) -> ArrowFunctionExpression {
+        let is_expression = matches!(&*arrow.body, swc::BlockStmtOrExpr::Expr(_));
+        let body = match &*arrow.body {
+            swc::BlockStmtOrExpr::BlockStmt(block) => {
+                ArrowFunctionBody::BlockStatement(self.convert_block_statement(block))
+            }
+            swc::BlockStmtOrExpr::Expr(expr) => {
+                ArrowFunctionBody::Expression(Box::new(self.convert_expression(expr)))
+            }
+        };
+        ArrowFunctionExpression {
+            base: self.make_base_node(arrow.span),
+            params: arrow.params.iter().map(|p| self.convert_pat(p)).collect(),
+            body: Box::new(body),
+            id: None,
+            generator: arrow.is_generator,
+            is_async: arrow.is_async,
+            expression: Some(is_expression),
+            return_type: arrow
+                .return_type
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            type_parameters: arrow
+                .type_params
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            predicate: None,
+        }
+    }
+
+    fn convert_params(&self, params: &[swc::Param]) -> Vec<PatternLike> {
+        params.iter().map(|p| self.convert_pat(&p.pat)).collect()
+    }
+
+    // ===== Patterns =====
+
+    fn convert_pat(&self, pat: &swc::Pat) -> PatternLike {
+        match pat {
+            swc::Pat::Ident(id) => PatternLike::Identifier(self.convert_binding_ident(id)),
+            swc::Pat::Array(arr) => PatternLike::ArrayPattern(self.convert_array_pattern(arr)),
+            swc::Pat::Object(obj) => PatternLike::ObjectPattern(self.convert_object_pattern(obj)),
+            swc::Pat::Assign(a) => PatternLike::AssignmentPattern(AssignmentPattern {
+                base: self.make_base_node(a.span),
+                left: Box::new(self.convert_pat(&a.left)),
+                right: Box::new(self.convert_expression(&a.right)),
+                type_annotation: None,
+                decorators: None,
+            }),
+            swc::Pat::Rest(r) => PatternLike::RestElement(RestElement {
+                base: self.make_base_node(r.span),
+                argument: Box::new(self.convert_pat(&r.arg)),
+                type_annotation: None,
+                decorators: None,
+            }),
+            swc::Pat::Expr(e) => self.convert_expression_to_pattern(e),
+            swc::Pat::Invalid(i) => PatternLike::Identifier(Identifier {
+                base: self.make_base_node(i.span),
+                name: "__invalid__".to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+        }
+    }
+
+    fn convert_expression_to_pattern(&self, expr: &swc::Expr) -> PatternLike {
+        match expr {
+            swc::Expr::Ident(id) => PatternLike::Identifier(self.convert_ident_to_identifier(id)),
+            swc::Expr::Member(m) => {
+                PatternLike::MemberExpression(self.convert_member_expression(m))
+            }
+            _ => PatternLike::Identifier(Identifier {
+                base: self.make_base_node(expr.span()),
+                name: "__unknown_target__".to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+        }
+    }
+
+    fn convert_object_pattern(&self, obj: &swc::ObjectPat) -> ObjectPattern {
+        let properties = obj
+            .props
+            .iter()
+            .map(|p| match p {
+                swc::ObjectPatProp::KeyValue(kv) => {
+                    ObjectPatternProperty::ObjectProperty(ObjectPatternProp {
+                        base: self.make_base_node(kv.span()),
+                        key: Box::new(self.convert_prop_name(&kv.key)),
+                        value: Box::new(self.convert_pat(&kv.value)),
+                        computed: matches!(kv.key, swc::PropName::Computed(_)),
+                        shorthand: false,
+                        decorators: None,
+                        method: None,
+                    })
+                }
+                swc::ObjectPatProp::Assign(a) => {
+                    let id = self.convert_ident_to_identifier(&a.key.id);
+                    let (value, shorthand) = if let Some(ref init) = a.value {
+                        (
+                            Box::new(PatternLike::AssignmentPattern(AssignmentPattern {
+                                base: self.make_base_node(a.span),
+                                left: Box::new(PatternLike::Identifier(id.clone())),
+                                right: Box::new(self.convert_expression(init)),
+                                type_annotation: None,
+                                decorators: None,
+                            })),
+                            true,
+                        )
+                    } else {
+                        (Box::new(PatternLike::Identifier(id.clone())), true)
+                    };
+                    ObjectPatternProperty::ObjectProperty(ObjectPatternProp {
+                        base: self.make_base_node(a.span),
+                        key: Box::new(Expression::Identifier(id)),
+                        value,
+                        computed: false,
+                        shorthand,
+                        decorators: None,
+                        method: None,
+                    })
+                }
+                swc::ObjectPatProp::Rest(r) => ObjectPatternProperty::RestElement(RestElement {
+                    base: self.make_base_node(r.span),
+                    argument: Box::new(self.convert_pat(&r.arg)),
+                    type_annotation: None,
+                    decorators: None,
+                }),
+            })
+            .collect();
+        ObjectPattern {
+            base: self.make_base_node(obj.span),
+            properties,
+            type_annotation: obj
+                .type_ann
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            decorators: None,
+        }
+    }
+
+    fn convert_array_pattern(&self, arr: &swc::ArrayPat) -> ArrayPattern {
+        ArrayPattern {
+            base: self.make_base_node(arr.span),
+            elements: arr
+                .elems
+                .iter()
+                .map(|e| e.as_ref().map(|p| self.convert_pat(p)))
+                .collect(),
+            type_annotation: arr
+                .type_ann
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            decorators: None,
+        }
+    }
+
+    // ===== AssignmentTarget =====
+
+    fn convert_assign_target(&self, target: &swc::AssignTarget) -> PatternLike {
+        match target {
+            swc::AssignTarget::Simple(s) => self.convert_simple_assign_target(s),
+            swc::AssignTarget::Pat(p) => self.convert_assign_target_pat(p),
+        }
+    }
+
+    fn convert_simple_assign_target(&self, target: &swc::SimpleAssignTarget) -> PatternLike {
+        match target {
+            swc::SimpleAssignTarget::Ident(id) => {
+                PatternLike::Identifier(self.convert_binding_ident(id))
+            }
+            swc::SimpleAssignTarget::Member(m) => {
+                PatternLike::MemberExpression(self.convert_member_expression(m))
+            }
+            swc::SimpleAssignTarget::SuperProp(sp) => {
+                let (property, computed) = self.convert_super_prop(&sp.prop);
+                PatternLike::MemberExpression(MemberExpression {
+                    base: self.make_base_node(sp.span),
+                    object: Box::new(Expression::Super(Super {
+                        base: self.make_base_node(sp.obj.span),
+                    })),
+                    property: Box::new(property),
+                    computed,
+                })
+            }
+            swc::SimpleAssignTarget::Paren(p) => self.convert_expression_to_pattern(&p.expr),
+            swc::SimpleAssignTarget::OptChain(o) => PatternLike::Identifier(Identifier {
+                base: self.make_base_node(o.span),
+                name: "__unknown_target__".to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+            swc::SimpleAssignTarget::TsAs(e) => self.convert_expression_to_pattern(&e.expr),
+            swc::SimpleAssignTarget::TsSatisfies(e) => self.convert_expression_to_pattern(&e.expr),
+            swc::SimpleAssignTarget::TsNonNull(e) => self.convert_expression_to_pattern(&e.expr),
+            swc::SimpleAssignTarget::TsTypeAssertion(e) => {
+                self.convert_expression_to_pattern(&e.expr)
+            }
+            swc::SimpleAssignTarget::TsInstantiation(e) => {
+                self.convert_expression_to_pattern(&e.expr)
+            }
+            swc::SimpleAssignTarget::Invalid(i) => PatternLike::Identifier(Identifier {
+                base: self.make_base_node(i.span),
+                name: "__invalid__".to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+        }
+    }
+
+    fn convert_assign_target_pat(&self, target: &swc::AssignTargetPat) -> PatternLike {
+        match target {
+            swc::AssignTargetPat::Array(a) => {
+                PatternLike::ArrayPattern(self.convert_array_pattern(a))
+            }
+            swc::AssignTargetPat::Object(o) => {
+                PatternLike::ObjectPattern(self.convert_object_pattern(o))
+            }
+            swc::AssignTargetPat::Invalid(i) => PatternLike::Identifier(Identifier {
+                base: self.make_base_node(i.span),
+                name: "__invalid__".to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+        }
+    }
+
+    fn convert_assignment_expression(&self, assign: &swc::AssignExpr) -> AssignmentExpression {
+        AssignmentExpression {
+            base: self.make_base_node(assign.span),
+            operator: self.convert_assignment_operator(assign.op),
+            left: Box::new(self.convert_assign_target(&assign.left)),
+            right: Box::new(self.convert_expression(&assign.right)),
+        }
+    }
+
+    // ===== Object expression =====
+
+    fn convert_object_expression(&self, obj: &swc::ObjectLit) -> ObjectExpression {
+        ObjectExpression {
+            base: self.make_base_node(obj.span),
+            properties: obj
+                .props
+                .iter()
+                .map(|p| self.convert_prop_or_spread(p))
+                .collect(),
+        }
+    }
+
+    fn convert_prop_or_spread(&self, prop: &swc::PropOrSpread) -> ObjectExpressionProperty {
+        match prop {
+            swc::PropOrSpread::Spread(s) => {
+                ObjectExpressionProperty::SpreadElement(SpreadElement {
+                    base: self.make_base_node(s.span()),
+                    argument: Box::new(self.convert_expression(&s.expr)),
+                })
+            }
+            swc::PropOrSpread::Prop(p) => self.convert_prop(p),
+        }
+    }
+
+    fn convert_prop(&self, prop: &swc::Prop) -> ObjectExpressionProperty {
+        match prop {
+            swc::Prop::Shorthand(id) => {
+                let ident = self.convert_ident_to_identifier(id);
+                ObjectExpressionProperty::ObjectProperty(ObjectProperty {
+                    base: self.make_base_node(id.span),
+                    key: Box::new(Expression::Identifier(ident.clone())),
+                    value: Box::new(Expression::Identifier(ident)),
+                    computed: false,
+                    shorthand: true,
+                    decorators: None,
+                    method: Some(false),
+                })
+            }
+            swc::Prop::KeyValue(kv) => ObjectExpressionProperty::ObjectProperty(ObjectProperty {
+                base: self.make_base_node(kv.span()),
+                key: Box::new(self.convert_prop_name(&kv.key)),
+                value: Box::new(self.convert_expression(&kv.value)),
+                computed: matches!(kv.key, swc::PropName::Computed(_)),
+                shorthand: false,
+                decorators: None,
+                method: Some(false),
+            }),
+            swc::Prop::Getter(g) => ObjectExpressionProperty::ObjectMethod(ObjectMethod {
+                base: self.make_base_node(g.span),
+                method: false,
+                kind: ObjectMethodKind::Get,
+                key: Box::new(self.convert_prop_name(&g.key)),
+                params: vec![],
+                body: g
+                    .body
+                    .as_ref()
+                    .map(|b| self.convert_block_statement(b))
+                    .unwrap_or_else(|| BlockStatement {
+                        base: self.make_base_node(g.span),
+                        body: vec![],
+                        directives: vec![],
+                    }),
+                computed: matches!(g.key, swc::PropName::Computed(_)),
+                id: None,
+                generator: false,
+                is_async: false,
+                decorators: None,
+                return_type: g
+                    .type_ann
+                    .as_ref()
+                    .map(|_| Box::new(serde_json::Value::Null)),
+                type_parameters: None,
+                predicate: None,
+            }),
+            swc::Prop::Setter(s) => ObjectExpressionProperty::ObjectMethod(ObjectMethod {
+                base: self.make_base_node(s.span),
+                method: false,
+                kind: ObjectMethodKind::Set,
+                key: Box::new(self.convert_prop_name(&s.key)),
+                params: vec![self.convert_pat(&s.param)],
+                body: s
+                    .body
+                    .as_ref()
+                    .map(|b| self.convert_block_statement(b))
+                    .unwrap_or_else(|| BlockStatement {
+                        base: self.make_base_node(s.span),
+                        body: vec![],
+                        directives: vec![],
+                    }),
+                computed: matches!(s.key, swc::PropName::Computed(_)),
+                id: None,
+                generator: false,
+                is_async: false,
+                decorators: None,
+                return_type: None,
+                type_parameters: None,
+                predicate: None,
+            }),
+            swc::Prop::Method(m) => ObjectExpressionProperty::ObjectMethod(ObjectMethod {
+                base: self.make_base_node(m.span()),
+                method: true,
+                kind: ObjectMethodKind::Method,
+                key: Box::new(self.convert_prop_name(&m.key)),
+                params: self.convert_params(&m.function.params),
+                body: m
+                    .function
+                    .body
+                    .as_ref()
+                    .map(|b| self.convert_block_statement(b))
+                    .unwrap_or_else(|| BlockStatement {
+                        base: self.make_base_node(m.function.span),
+                        body: vec![],
+                        directives: vec![],
+                    }),
+                computed: matches!(m.key, swc::PropName::Computed(_)),
+                id: None,
+                generator: m.function.is_generator,
+                is_async: m.function.is_async,
+                decorators: None,
+                return_type: m
+                    .function
+                    .return_type
+                    .as_ref()
+                    .map(|_| Box::new(serde_json::Value::Null)),
+                type_parameters: m
+                    .function
+                    .type_params
+                    .as_ref()
+                    .map(|_| Box::new(serde_json::Value::Null)),
+                predicate: None,
+            }),
+            swc::Prop::Assign(a) => {
+                let ident = self.convert_ident_to_identifier(&a.key);
+                ObjectExpressionProperty::ObjectProperty(ObjectProperty {
+                    base: self.make_base_node(a.span),
+                    key: Box::new(Expression::Identifier(ident.clone())),
+                    value: Box::new(Expression::AssignmentExpression(AssignmentExpression {
+                        base: self.make_base_node(a.span),
+                        operator: AssignmentOperator::Assign,
+                        left: Box::new(PatternLike::Identifier(ident)),
+                        right: Box::new(self.convert_expression(&a.value)),
+                    })),
+                    computed: false,
+                    shorthand: true,
+                    decorators: None,
+                    method: Some(false),
+                })
+            }
+        }
+    }
+
+    fn convert_array_expression(&self, arr: &swc::ArrayLit) -> ArrayExpression {
+        ArrayExpression {
+            base: self.make_base_node(arr.span),
+            elements: arr
+                .elems
+                .iter()
+                .map(|e| e.as_ref().map(|elem| self.convert_expr_or_spread(elem)))
+                .collect(),
+        }
+    }
+
+    fn convert_template_literal(&self, tpl: &swc::Tpl) -> TemplateLiteral {
+        TemplateLiteral {
+            base: self.make_base_node(tpl.span),
+            quasis: tpl
+                .quasis
+                .iter()
+                .map(|q| TemplateElement {
+                    base: self.make_base_node(q.span),
+                    value: TemplateElementValue {
+                        raw: q.raw.to_string(),
+                        cooked: q.cooked.as_ref().map(|c| wtf8_to_string(c)),
+                    },
+                    tail: q.tail,
+                })
+                .collect(),
+            expressions: tpl
+                .exprs
+                .iter()
+                .map(|e| self.convert_expression(e))
+                .collect(),
+        }
+    }
+
+    // ===== Class =====
+
+    fn convert_class_decl(&self, class: &swc::ClassDecl) -> ClassDeclaration {
+        let c = &class.class;
+        ClassDeclaration {
+            base: self.make_base_node(c.span),
+            id: Some(self.convert_ident_to_identifier(&class.ident)),
+            super_class: c
+                .super_class
+                .as_ref()
+                .map(|s| Box::new(self.convert_expression(s))),
+            body: ClassBody {
+                base: self.make_base_node(c.span),
+                body: vec![],
+            },
+            decorators: None,
+            is_abstract: if c.is_abstract { Some(true) } else { None },
+            declare: if class.declare { Some(true) } else { None },
+            implements: None,
+            super_type_parameters: None,
+            type_parameters: c
+                .type_params
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            mixins: None,
+        }
+    }
+
+    fn convert_class_expression(&self, class: &swc::ClassExpr) -> ClassExpression {
+        let c = &class.class;
+        ClassExpression {
+            base: self.make_base_node(c.span),
+            id: class
+                .ident
+                .as_ref()
+                .map(|id| self.convert_ident_to_identifier(id)),
+            super_class: c
+                .super_class
+                .as_ref()
+                .map(|s| Box::new(self.convert_expression(s))),
+            body: ClassBody {
+                base: self.make_base_node(c.span),
+                body: vec![],
+            },
+            decorators: None,
+            implements: None,
+            super_type_parameters: None,
+            type_parameters: c
+                .type_params
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+        }
+    }
+
+    // ===== JSX =====
+
+    fn convert_jsx_element(&self, el: &swc::JSXElement) -> JSXElement {
+        let self_closing = el.closing.is_none();
+        JSXElement {
+            base: self.make_base_node(el.span),
+            opening_element: self.convert_jsx_opening_element(&el.opening, self_closing),
+            closing_element: el
+                .closing
+                .as_ref()
+                .map(|c| self.convert_jsx_closing_element(c)),
+            children: el
+                .children
+                .iter()
+                .map(|c| self.convert_jsx_child(c))
+                .collect(),
+            self_closing: Some(self_closing),
+        }
+    }
+
+    fn convert_jsx_opening_element(
+        &self,
+        el: &swc::JSXOpeningElement,
+        self_closing: bool,
+    ) -> JSXOpeningElement {
+        JSXOpeningElement {
+            base: self.make_base_node(el.span),
+            name: self.convert_jsx_element_name(&el.name),
+            attributes: el
+                .attrs
+                .iter()
+                .map(|a| self.convert_jsx_attr_or_spread(a))
+                .collect(),
+            self_closing,
+            type_parameters: el
+                .type_args
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+        }
+    }
+
+    fn convert_jsx_closing_element(&self, el: &swc::JSXClosingElement) -> JSXClosingElement {
+        JSXClosingElement {
+            base: self.make_base_node(el.span),
+            name: self.convert_jsx_element_name(&el.name),
+        }
+    }
+
+    fn convert_jsx_element_name(&self, name: &swc::JSXElementName) -> JSXElementName {
+        match name {
+            swc::JSXElementName::Ident(id) => JSXElementName::JSXIdentifier(JSXIdentifier {
+                base: self.make_base_node(id.span),
+                name: id.sym.to_string(),
+            }),
+            swc::JSXElementName::JSXMemberExpr(m) => {
+                JSXElementName::JSXMemberExpression(self.convert_jsx_member_expression(m))
+            }
+            swc::JSXElementName::JSXNamespacedName(ns) => {
+                JSXElementName::JSXNamespacedName(JSXNamespacedName {
+                    base: self.make_base_node(ns.span()),
+                    namespace: JSXIdentifier {
+                        base: self.make_base_node(ns.ns.span),
+                        name: ns.ns.sym.to_string(),
+                    },
+                    name: JSXIdentifier {
+                        base: self.make_base_node(ns.name.span),
+                        name: ns.name.sym.to_string(),
+                    },
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_member_expression(&self, m: &swc::JSXMemberExpr) -> JSXMemberExpression {
+        JSXMemberExpression {
+            base: self.make_base_node(m.span()),
+            object: Box::new(self.convert_jsx_object(&m.obj)),
+            property: JSXIdentifier {
+                base: self.make_base_node(m.prop.span),
+                name: m.prop.sym.to_string(),
+            },
+        }
+    }
+
+    fn convert_jsx_object(&self, obj: &swc::JSXObject) -> JSXMemberExprObject {
+        match obj {
+            swc::JSXObject::Ident(id) => JSXMemberExprObject::JSXIdentifier(JSXIdentifier {
+                base: self.make_base_node(id.span),
+                name: id.sym.to_string(),
+            }),
+            swc::JSXObject::JSXMemberExpr(m) => JSXMemberExprObject::JSXMemberExpression(Box::new(
+                self.convert_jsx_member_expression(m),
+            )),
+        }
+    }
+
+    fn convert_jsx_attr_or_spread(&self, attr: &swc::JSXAttrOrSpread) -> JSXAttributeItem {
+        match attr {
+            swc::JSXAttrOrSpread::JSXAttr(a) => {
+                JSXAttributeItem::JSXAttribute(self.convert_jsx_attribute(a))
+            }
+            swc::JSXAttrOrSpread::SpreadElement(s) => {
+                JSXAttributeItem::JSXSpreadAttribute(JSXSpreadAttribute {
+                    base: self.make_base_node(s.span()),
+                    argument: Box::new(self.convert_expression(&s.expr)),
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_attribute(&self, attr: &swc::JSXAttr) -> JSXAttribute {
+        JSXAttribute {
+            base: self.make_base_node(attr.span),
+            name: self.convert_jsx_attr_name(&attr.name),
+            value: attr.value.as_ref().map(|v| self.convert_jsx_attr_value(v)),
+        }
+    }
+
+    fn convert_jsx_attr_name(&self, name: &swc::JSXAttrName) -> JSXAttributeName {
+        match name {
+            swc::JSXAttrName::Ident(id) => JSXAttributeName::JSXIdentifier(JSXIdentifier {
+                base: self.make_base_node(id.span),
+                name: id.sym.to_string(),
+            }),
+            swc::JSXAttrName::JSXNamespacedName(ns) => {
+                JSXAttributeName::JSXNamespacedName(JSXNamespacedName {
+                    base: self.make_base_node(ns.span()),
+                    namespace: JSXIdentifier {
+                        base: self.make_base_node(ns.ns.span),
+                        name: ns.ns.sym.to_string(),
+                    },
+                    name: JSXIdentifier {
+                        base: self.make_base_node(ns.name.span),
+                        name: ns.name.sym.to_string(),
+                    },
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_attr_value(&self, value: &swc::JSXAttrValue) -> JSXAttributeValue {
+        match value {
+            swc::JSXAttrValue::Str(s) => JSXAttributeValue::StringLiteral(StringLiteral {
+                base: self.make_base_node(s.span),
+                value: wtf8_to_string(&s.value),
+            }),
+            swc::JSXAttrValue::JSXExprContainer(ec) => {
+                JSXAttributeValue::JSXExpressionContainer(self.convert_jsx_expr_container(ec))
+            }
+            swc::JSXAttrValue::JSXElement(el) => {
+                JSXAttributeValue::JSXElement(Box::new(self.convert_jsx_element(el)))
+            }
+            swc::JSXAttrValue::JSXFragment(frag) => {
+                JSXAttributeValue::JSXFragment(self.convert_jsx_fragment(frag))
+            }
+        }
+    }
+
+    fn convert_jsx_expr_container(&self, ec: &swc::JSXExprContainer) -> JSXExpressionContainer {
+        JSXExpressionContainer {
+            base: self.make_base_node(ec.span),
+            expression: match &ec.expr {
+                swc::JSXExpr::JSXEmptyExpr(e) => {
+                    JSXExpressionContainerExpr::JSXEmptyExpression(JSXEmptyExpression {
+                        base: self.make_base_node(e.span),
+                    })
+                }
+                swc::JSXExpr::Expr(e) => {
+                    JSXExpressionContainerExpr::Expression(Box::new(self.convert_expression(e)))
+                }
+            },
+        }
+    }
+
+    fn convert_jsx_child(&self, child: &swc::JSXElementChild) -> JSXChild {
+        match child {
+            swc::JSXElementChild::JSXText(t) => JSXChild::JSXText(JSXText {
+                base: self.make_base_node(t.span),
+                value: t.value.to_string(),
+            }),
+            swc::JSXElementChild::JSXExprContainer(ec) => {
+                JSXChild::JSXExpressionContainer(self.convert_jsx_expr_container(ec))
+            }
+            swc::JSXElementChild::JSXSpreadChild(s) => JSXChild::JSXSpreadChild(JSXSpreadChild {
+                base: self.make_base_node(s.span),
+                expression: Box::new(self.convert_expression(&s.expr)),
+            }),
+            swc::JSXElementChild::JSXElement(el) => {
+                JSXChild::JSXElement(Box::new(self.convert_jsx_element(el)))
+            }
+            swc::JSXElementChild::JSXFragment(frag) => {
+                JSXChild::JSXFragment(self.convert_jsx_fragment(frag))
+            }
+        }
+    }
+
+    fn convert_jsx_fragment(&self, frag: &swc::JSXFragment) -> JSXFragment {
+        JSXFragment {
+            base: self.make_base_node(frag.span),
+            opening_fragment: JSXOpeningFragment {
+                base: self.make_base_node(frag.opening.span),
+            },
+            closing_fragment: JSXClosingFragment {
+                base: self.make_base_node(frag.closing.span),
+            },
+            children: frag
+                .children
+                .iter()
+                .map(|c| self.convert_jsx_child(c))
+                .collect(),
+        }
+    }
+
+    // ===== Import/Export =====
+
+    fn convert_import_declaration(&self, decl: &swc::ImportDecl) -> ImportDeclaration {
+        ImportDeclaration {
+            base: self.make_base_node(decl.span),
+            specifiers: decl
+                .specifiers
+                .iter()
+                .map(|s| self.convert_import_specifier(s))
+                .collect(),
+            source: StringLiteral {
+                base: self.make_base_node(decl.src.span),
+                value: wtf8_to_string(&decl.src.value),
+            },
+            import_kind: if decl.type_only {
+                Some(ImportKind::Type)
+            } else {
+                Some(ImportKind::Value)
+            },
+            assertions: None,
+            attributes: decl
+                .with
+                .as_ref()
+                .map(|with| self.convert_object_lit_to_import_attributes(with)),
+        }
+    }
+
+    fn convert_object_lit_to_import_attributes(
+        &self,
+        obj: &swc::ObjectLit,
+    ) -> Vec<ImportAttribute> {
+        obj.props
+            .iter()
+            .filter_map(|prop| {
+                if let swc::PropOrSpread::Prop(p) = prop {
+                    if let swc::Prop::KeyValue(kv) = &**p {
+                        let (key_name, key_span) = match &kv.key {
+                            swc::PropName::Ident(id) => (id.sym.to_string(), id.span),
+                            swc::PropName::Str(s) => (wtf8_to_string(&s.value), s.span),
+                            swc::PropName::Num(n) => (n.value.to_string(), n.span),
+                            _ => return None,
+                        };
+                        if let swc::Expr::Lit(swc::Lit::Str(s)) = &*kv.value {
+                            return Some(ImportAttribute {
+                                base: self.make_base_node(kv.span()),
+                                key: Identifier {
+                                    base: self.make_base_node(key_span),
+                                    name: key_name,
+                                    type_annotation: None,
+                                    optional: None,
+                                    decorators: None,
+                                },
+                                value: StringLiteral {
+                                    base: self.make_base_node(s.span),
+                                    value: wtf8_to_string(&s.value),
+                                },
+                            });
+                        }
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
+    fn convert_import_specifier(&self, spec: &swc::ImportSpecifier) -> ImportSpecifier {
+        match spec {
+            swc::ImportSpecifier::Named(s) => {
+                let local = self.convert_ident_to_identifier(&s.local);
+                let imported = s
+                    .imported
+                    .as_ref()
+                    .map(|i| match i {
+                        swc::ModuleExportName::Ident(id) => {
+                            ModuleExportName::Identifier(self.convert_ident_to_identifier(id))
+                        }
+                        swc::ModuleExportName::Str(s) => {
+                            ModuleExportName::StringLiteral(StringLiteral {
+                                base: self.make_base_node(s.span),
+                                value: wtf8_to_string(&s.value),
+                            })
+                        }
+                    })
+                    .unwrap_or_else(|| ModuleExportName::Identifier(local.clone()));
+                ImportSpecifier::ImportSpecifier(ImportSpecifierData {
+                    base: self.make_base_node(s.span),
+                    local,
+                    imported,
+                    import_kind: if s.is_type_only {
+                        Some(ImportKind::Type)
+                    } else {
+                        Some(ImportKind::Value)
+                    },
+                })
+            }
+            swc::ImportSpecifier::Default(s) => {
+                ImportSpecifier::ImportDefaultSpecifier(ImportDefaultSpecifierData {
+                    base: self.make_base_node(s.span),
+                    local: self.convert_ident_to_identifier(&s.local),
+                })
+            }
+            swc::ImportSpecifier::Namespace(s) => {
+                ImportSpecifier::ImportNamespaceSpecifier(ImportNamespaceSpecifierData {
+                    base: self.make_base_node(s.span),
+                    local: self.convert_ident_to_identifier(&s.local),
+                })
+            }
+        }
+    }
+
+    fn convert_export_decl(&self, decl: &swc::ExportDecl) -> ExportNamedDeclaration {
+        ExportNamedDeclaration {
+            base: self.make_base_node(decl.span),
+            declaration: Some(Box::new(self.convert_decl_to_declaration(&decl.decl))),
+            specifiers: vec![],
+            source: None,
+            export_kind: Some(ExportKind::Value),
+            assertions: None,
+            attributes: None,
+        }
+    }
+
+    fn convert_export_named(&self, decl: &swc::NamedExport) -> ExportNamedDeclaration {
+        ExportNamedDeclaration {
+            base: self.make_base_node(decl.span),
+            declaration: None,
+            specifiers: decl
+                .specifiers
+                .iter()
+                .map(|s| self.convert_export_specifier(s))
+                .collect(),
+            source: decl.src.as_ref().map(|s| StringLiteral {
+                base: self.make_base_node(s.span),
+                value: wtf8_to_string(&s.value),
+            }),
+            export_kind: if decl.type_only {
+                Some(ExportKind::Type)
+            } else {
+                Some(ExportKind::Value)
+            },
+            assertions: None,
+            attributes: decl
+                .with
+                .as_ref()
+                .map(|with| self.convert_object_lit_to_import_attributes(with)),
+        }
+    }
+
+    fn convert_export_default_decl(
+        &self,
+        decl: &swc::ExportDefaultDecl,
+    ) -> ExportDefaultDeclaration {
+        let declaration = match &decl.decl {
+            swc::DefaultDecl::Fn(f) => {
+                let func = &f.function;
+                let body = func
+                    .body
+                    .as_ref()
+                    .map(|b| self.convert_block_statement(b))
+                    .unwrap_or_else(|| BlockStatement {
+                        base: self.make_base_node(func.span),
+                        body: vec![],
+                        directives: vec![],
+                    });
+                ExportDefaultDecl::FunctionDeclaration(FunctionDeclaration {
+                    base: self.make_base_node(func.span),
+                    id: f
+                        .ident
+                        .as_ref()
+                        .map(|id| self.convert_ident_to_identifier(id)),
+                    params: self.convert_params(&func.params),
+                    body,
+                    generator: func.is_generator,
+                    is_async: func.is_async,
+                    declare: None,
+                    return_type: func
+                        .return_type
+                        .as_ref()
+                        .map(|_| Box::new(serde_json::Value::Null)),
+                    type_parameters: func
+                        .type_params
+                        .as_ref()
+                        .map(|_| Box::new(serde_json::Value::Null)),
+                    predicate: None,
+                    component_declaration: false,
+                    hook_declaration: false,
+                })
+            }
+            swc::DefaultDecl::Class(c) => {
+                let class = &c.class;
+                ExportDefaultDecl::ClassDeclaration(ClassDeclaration {
+                    base: self.make_base_node(class.span),
+                    id: c
+                        .ident
+                        .as_ref()
+                        .map(|id| self.convert_ident_to_identifier(id)),
+                    super_class: class
+                        .super_class
+                        .as_ref()
+                        .map(|s| Box::new(self.convert_expression(s))),
+                    body: ClassBody {
+                        base: self.make_base_node(class.span),
+                        body: vec![],
+                    },
+                    decorators: None,
+                    is_abstract: if class.is_abstract { Some(true) } else { None },
+                    declare: None,
+                    implements: None,
+                    super_type_parameters: None,
+                    type_parameters: class
+                        .type_params
+                        .as_ref()
+                        .map(|_| Box::new(serde_json::Value::Null)),
+                    mixins: None,
+                })
+            }
+            swc::DefaultDecl::TsInterfaceDecl(_) => {
+                ExportDefaultDecl::Expression(Box::new(Expression::NullLiteral(NullLiteral {
+                    base: self.make_base_node(decl.span),
+                })))
+            }
+        };
+        ExportDefaultDeclaration {
+            base: self.make_base_node(decl.span),
+            declaration: Box::new(declaration),
+            export_kind: None,
+        }
+    }
+
+    fn convert_export_default_expr(
+        &self,
+        decl: &swc::ExportDefaultExpr,
+    ) -> ExportDefaultDeclaration {
+        ExportDefaultDeclaration {
+            base: self.make_base_node(decl.span),
+            declaration: Box::new(ExportDefaultDecl::Expression(Box::new(
+                self.convert_expression(&decl.expr),
+            ))),
+            export_kind: None,
+        }
+    }
+
+    fn convert_export_all(&self, decl: &swc::ExportAll) -> ExportAllDeclaration {
+        ExportAllDeclaration {
+            base: self.make_base_node(decl.span),
+            source: StringLiteral {
+                base: self.make_base_node(decl.src.span),
+                value: wtf8_to_string(&decl.src.value),
+            },
+            export_kind: if decl.type_only {
+                Some(ExportKind::Type)
+            } else {
+                Some(ExportKind::Value)
+            },
+            assertions: None,
+            attributes: decl
+                .with
+                .as_ref()
+                .map(|with| self.convert_object_lit_to_import_attributes(with)),
+        }
+    }
+
+    fn convert_decl_to_declaration(&self, decl: &swc::Decl) -> Declaration {
+        match decl {
+            swc::Decl::Var(v) => {
+                Declaration::VariableDeclaration(self.convert_variable_declaration(v))
+            }
+            swc::Decl::Fn(f) => Declaration::FunctionDeclaration(self.convert_fn_decl(f)),
+            swc::Decl::Class(c) => Declaration::ClassDeclaration(self.convert_class_decl(c)),
+            swc::Decl::TsTypeAlias(d) => {
+                Declaration::TSTypeAliasDeclaration(self.convert_ts_type_alias(d))
+            }
+            swc::Decl::TsInterface(d) => {
+                Declaration::TSInterfaceDeclaration(self.convert_ts_interface(d))
+            }
+            swc::Decl::TsEnum(d) => Declaration::TSEnumDeclaration(self.convert_ts_enum(d)),
+            swc::Decl::TsModule(d) => Declaration::TSModuleDeclaration(self.convert_ts_module(d)),
+            swc::Decl::Using(u) => Declaration::VariableDeclaration(self.convert_using_decl(u)),
+        }
+    }
+
+    fn convert_export_specifier(&self, spec: &swc::ExportSpecifier) -> ExportSpecifier {
+        match spec {
+            swc::ExportSpecifier::Named(s) => {
+                let local = self.convert_module_export_name(&s.orig);
+                let exported = s
+                    .exported
+                    .as_ref()
+                    .map(|e| self.convert_module_export_name(e))
+                    .unwrap_or_else(|| local.clone());
+                ExportSpecifier::ExportSpecifier(ExportSpecifierData {
+                    base: self.make_base_node(s.span),
+                    local,
+                    exported,
+                    export_kind: if s.is_type_only {
+                        Some(ExportKind::Type)
+                    } else {
+                        Some(ExportKind::Value)
+                    },
+                })
+            }
+            swc::ExportSpecifier::Default(s) => {
+                ExportSpecifier::ExportDefaultSpecifier(ExportDefaultSpecifierData {
+                    base: self.make_base_node(s.exported.span),
+                    exported: self.convert_ident_to_identifier(&s.exported),
+                })
+            }
+            swc::ExportSpecifier::Namespace(s) => {
+                ExportSpecifier::ExportNamespaceSpecifier(ExportNamespaceSpecifierData {
+                    base: self.make_base_node(s.span),
+                    exported: self.convert_module_export_name(&s.name),
+                })
+            }
+        }
+    }
+
+    fn convert_module_export_name(&self, name: &swc::ModuleExportName) -> ModuleExportName {
+        match name {
+            swc::ModuleExportName::Ident(id) => {
+                ModuleExportName::Identifier(self.convert_ident_to_identifier(id))
+            }
+            swc::ModuleExportName::Str(s) => ModuleExportName::StringLiteral(StringLiteral {
+                base: self.make_base_node(s.span),
+                value: wtf8_to_string(&s.value),
+            }),
+        }
+    }
+
+    // ===== TS declarations =====
+
+    fn convert_ts_type_alias(&self, d: &swc::TsTypeAliasDecl) -> TSTypeAliasDeclaration {
+        TSTypeAliasDeclaration {
+            base: self.make_base_node(d.span),
+            id: self.convert_ident_to_identifier(&d.id),
+            type_annotation: Box::new(serde_json::Value::Null),
+            type_parameters: d
+                .type_params
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            declare: if d.declare { Some(true) } else { None },
+        }
+    }
+
+    fn convert_ts_interface(&self, d: &swc::TsInterfaceDecl) -> TSInterfaceDeclaration {
+        TSInterfaceDeclaration {
+            base: self.make_base_node(d.span),
+            id: self.convert_ident_to_identifier(&d.id),
+            body: Box::new(serde_json::Value::Null),
+            type_parameters: d
+                .type_params
+                .as_ref()
+                .map(|_| Box::new(serde_json::Value::Null)),
+            extends: if d.extends.is_empty() {
+                None
+            } else {
+                Some(vec![])
+            },
+            declare: if d.declare { Some(true) } else { None },
+        }
+    }
+
+    fn convert_ts_enum(&self, d: &swc::TsEnumDecl) -> TSEnumDeclaration {
+        TSEnumDeclaration {
+            base: self.make_base_node(d.span),
+            id: self.convert_ident_to_identifier(&d.id),
+            members: vec![],
+            declare: if d.declare { Some(true) } else { None },
+            is_const: if d.is_const { Some(true) } else { None },
+        }
+    }
+
+    fn convert_ts_module(&self, d: &swc::TsModuleDecl) -> TSModuleDeclaration {
+        TSModuleDeclaration {
+            base: self.make_base_node(d.span),
+            id: Box::new(serde_json::Value::Null),
+            body: Box::new(serde_json::Value::Null),
+            declare: if d.declare { Some(true) } else { None },
+            global: if d.global { Some(true) } else { None },
+        }
+    }
+
+    // ===== TS type JSON (binding ident annotations) =====
+
+    fn convert_ts_type_to_json(&self, ty: &swc::TsType) -> Option<serde_json::Value> {
+        match ty {
+            swc::TsType::TsKeywordType(k) if k.kind == swc::TsKeywordTypeKind::TsNumberKeyword => {
+                Some(serde_json::json!({ "type": "TSNumberKeyword" }))
+            }
+            // Skip generics: `convert_ts_type_annotation_from_json` ignores
+            // type params, so silently emitting `Foo` for `Foo<T>` loses
+            // information. Fall back to `Null` instead.
+            swc::TsType::TsTypeRef(r) if r.type_params.is_none() => match &r.type_name {
+                swc::TsEntityName::Ident(id) => Some(serde_json::json!({
+                    "type": "TSTypeReference",
+                    "typeName": {
+                        "type": "Identifier",
+                        "name": id.sym.to_string()
+                    }
+                })),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn convert_ts_type_ann_to_json(&self, ann: &swc::TsTypeAnn) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "type": "TSTypeAnnotation",
+            "typeAnnotation": self.convert_ts_type_to_json(&ann.type_ann)?,
+        }))
+    }
+
+    // ===== Identifiers =====
+
+    fn convert_ident_to_identifier(&self, id: &swc::Ident) -> Identifier {
+        Identifier {
+            base: self.make_base_node(id.span),
+            name: id.sym.to_string(),
+            type_annotation: None,
+            optional: if id.optional { Some(true) } else { None },
+            decorators: None,
+        }
+    }
+
+    fn convert_binding_ident(&self, id: &swc::BindingIdent) -> Identifier {
+        Identifier {
+            base: self.make_base_node(id.id.span),
+            name: id.id.sym.to_string(),
+            type_annotation: id.type_ann.as_ref().map(|ann| {
+                Box::new(
+                    self.convert_ts_type_ann_to_json(ann)
+                        .unwrap_or(serde_json::Value::Null),
+                )
+            }),
+            optional: if id.id.optional { Some(true) } else { None },
+            decorators: None,
+        }
+    }
+
+    fn convert_prop_name(&self, key: &swc::PropName) -> Expression {
+        match key {
+            swc::PropName::Ident(id) => Expression::Identifier(Identifier {
+                base: self.make_base_node(id.span),
+                name: id.sym.to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            }),
+            swc::PropName::Str(s) => Expression::StringLiteral(StringLiteral {
+                base: self.make_base_node(s.span),
+                value: wtf8_to_string(&s.value),
+            }),
+            swc::PropName::Num(n) => Expression::NumericLiteral(NumericLiteral {
+                base: self.make_base_node(n.span),
+                value: n.value,
+                extra: None,
+            }),
+            swc::PropName::Computed(c) => self.convert_expression(&c.expr),
+            swc::PropName::BigInt(b) => Expression::BigIntLiteral(BigIntLiteral {
+                base: self.make_base_node(b.span),
+                value: b.value.to_string(),
+            }),
+        }
+    }
+
+    // ===== Operators =====
+
+    fn convert_binary_operator(&self, op: swc::BinaryOp) -> BinaryOperator {
+        match op {
+            swc::BinaryOp::EqEq => BinaryOperator::Eq,
+            swc::BinaryOp::NotEq => BinaryOperator::Neq,
+            swc::BinaryOp::EqEqEq => BinaryOperator::StrictEq,
+            swc::BinaryOp::NotEqEq => BinaryOperator::StrictNeq,
+            swc::BinaryOp::Lt => BinaryOperator::Lt,
+            swc::BinaryOp::LtEq => BinaryOperator::Lte,
+            swc::BinaryOp::Gt => BinaryOperator::Gt,
+            swc::BinaryOp::GtEq => BinaryOperator::Gte,
+            swc::BinaryOp::LShift => BinaryOperator::Shl,
+            swc::BinaryOp::RShift => BinaryOperator::Shr,
+            swc::BinaryOp::ZeroFillRShift => BinaryOperator::UShr,
+            swc::BinaryOp::Add => BinaryOperator::Add,
+            swc::BinaryOp::Sub => BinaryOperator::Sub,
+            swc::BinaryOp::Mul => BinaryOperator::Mul,
+            swc::BinaryOp::Div => BinaryOperator::Div,
+            swc::BinaryOp::Mod => BinaryOperator::Rem,
+            swc::BinaryOp::Exp => BinaryOperator::Exp,
+            swc::BinaryOp::BitOr => BinaryOperator::BitOr,
+            swc::BinaryOp::BitXor => BinaryOperator::BitXor,
+            swc::BinaryOp::BitAnd => BinaryOperator::BitAnd,
+            swc::BinaryOp::In => BinaryOperator::In,
+            swc::BinaryOp::InstanceOf => BinaryOperator::Instanceof,
+            swc::BinaryOp::LogicalOr
+            | swc::BinaryOp::LogicalAnd
+            | swc::BinaryOp::NullishCoalescing => BinaryOperator::Eq,
+        }
+    }
+
+    fn try_convert_logical_operator(&self, op: swc::BinaryOp) -> Option<LogicalOperator> {
+        match op {
+            swc::BinaryOp::LogicalOr => Some(LogicalOperator::Or),
+            swc::BinaryOp::LogicalAnd => Some(LogicalOperator::And),
+            swc::BinaryOp::NullishCoalescing => Some(LogicalOperator::NullishCoalescing),
+            _ => None,
+        }
+    }
+
+    fn convert_unary_operator(&self, op: swc::UnaryOp) -> UnaryOperator {
+        match op {
+            swc::UnaryOp::Minus => UnaryOperator::Neg,
+            swc::UnaryOp::Plus => UnaryOperator::Plus,
+            swc::UnaryOp::Bang => UnaryOperator::Not,
+            swc::UnaryOp::Tilde => UnaryOperator::BitNot,
+            swc::UnaryOp::TypeOf => UnaryOperator::TypeOf,
+            swc::UnaryOp::Void => UnaryOperator::Void,
+            swc::UnaryOp::Delete => UnaryOperator::Delete,
+        }
+    }
+
+    fn convert_update_operator(&self, op: swc::UpdateOp) -> UpdateOperator {
+        match op {
+            swc::UpdateOp::PlusPlus => UpdateOperator::Increment,
+            swc::UpdateOp::MinusMinus => UpdateOperator::Decrement,
+        }
+    }
+
+    fn convert_assignment_operator(&self, op: swc::AssignOp) -> AssignmentOperator {
+        match op {
+            swc::AssignOp::Assign => AssignmentOperator::Assign,
+            swc::AssignOp::AddAssign => AssignmentOperator::AddAssign,
+            swc::AssignOp::SubAssign => AssignmentOperator::SubAssign,
+            swc::AssignOp::MulAssign => AssignmentOperator::MulAssign,
+            swc::AssignOp::DivAssign => AssignmentOperator::DivAssign,
+            swc::AssignOp::ModAssign => AssignmentOperator::RemAssign,
+            swc::AssignOp::ExpAssign => AssignmentOperator::ExpAssign,
+            swc::AssignOp::LShiftAssign => AssignmentOperator::ShlAssign,
+            swc::AssignOp::RShiftAssign => AssignmentOperator::ShrAssign,
+            swc::AssignOp::ZeroFillRShiftAssign => AssignmentOperator::UShrAssign,
+            swc::AssignOp::BitOrAssign => AssignmentOperator::BitOrAssign,
+            swc::AssignOp::BitXorAssign => AssignmentOperator::BitXorAssign,
+            swc::AssignOp::BitAndAssign => AssignmentOperator::BitAndAssign,
+            swc::AssignOp::OrAssign => AssignmentOperator::OrAssign,
+            swc::AssignOp::AndAssign => AssignmentOperator::AndAssign,
+            swc::AssignOp::NullishAssign => AssignmentOperator::NullishAssign,
+        }
+    }
+}

--- a/turbopack/crates/react_compiler_swc/src/convert_ast_reverse.rs
+++ b/turbopack/crates/react_compiler_swc/src/convert_ast_reverse.rs
@@ -1,0 +1,2731 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Reverse AST converter: react_compiler_ast (Babel format) → SWC AST.
+//!
+//! This is the inverse of `convert_ast.rs`. It takes a `react_compiler_ast::File`
+//! (which represents the compiler's Babel-compatible output) and produces SWC AST
+//! nodes suitable for code generation via `swc_codegen`.
+
+use react_compiler_ast::{
+    common::{BaseNode, Comment as BabelComment},
+    declarations::{
+        ExportAllDeclaration, ExportDefaultDecl as BabelExportDefaultDecl,
+        ExportDefaultDeclaration, ExportKind, ExportNamedDeclaration, ImportDeclaration,
+        ImportKind,
+    },
+    expressions::{
+        Expression as BabelExpr, {self as babel_expr},
+    },
+    operators::*,
+    patterns::*,
+    statements::{
+        Statement as BabelStmt, {self as babel_stmt},
+    },
+};
+use swc_core::{
+    atoms::{Atom, Wtf8Atom},
+    common::{
+        BytePos, DUMMY_SP, Span, Spanned, SyntaxContext,
+        comments::{Comment as SwcComment, CommentKind, Comments, SingleThreadedComments},
+    },
+    ecma::ast::*,
+};
+
+/// Result of converting a Babel AST back to SWC, including extracted comments.
+pub struct SwcConversionResult {
+    pub module: Module,
+    pub comments: SingleThreadedComments,
+}
+
+/// Convert a `react_compiler_ast::File` into an SWC `Module` and extracted comments.
+pub fn convert_program_to_swc(file: &react_compiler_ast::File) -> SwcConversionResult {
+    convert_program_to_swc_with_source(file, None)
+}
+
+/// Convert a `react_compiler_ast::File` into an SWC `Module` and extracted comments.
+/// When `source_text` is provided, type declarations can be extracted from the
+/// original source for perfect fidelity.
+pub fn convert_program_to_swc_with_source(
+    file: &react_compiler_ast::File,
+    source_text: Option<&str>,
+) -> SwcConversionResult {
+    let ctx = ReverseCtx {
+        comments: SingleThreadedComments::default(),
+        source_text: source_text.map(|s| s.to_string()),
+    };
+    let module = ctx.convert_program(&file.program);
+    SwcConversionResult {
+        module,
+        comments: ctx.comments,
+    }
+}
+
+struct ReverseCtx {
+    comments: SingleThreadedComments,
+    source_text: Option<String>,
+}
+
+impl ReverseCtx {
+    /// Convert a BaseNode's start/end to an SWC Span, and extract any comments.
+    fn span(&self, base: &BaseNode) -> Span {
+        let span = match (base.start, base.end) {
+            (Some(start), Some(end)) => Span::new(BytePos(start), BytePos(end)),
+            _ => DUMMY_SP,
+        };
+        self.extract_comments(base, span);
+        span
+    }
+
+    /// Convert a BaseNode's start/end to an SWC Span without extracting comments.
+    /// Use this for sub-nodes where comments should not be duplicated.
+    fn span_no_comments(&self, base: &BaseNode) -> Span {
+        match (base.start, base.end) {
+            (Some(start), Some(end)) => Span::new(BytePos(start), BytePos(end)),
+            _ => DUMMY_SP,
+        }
+    }
+
+    /// Convert a Babel comment to an SWC comment.
+    fn convert_babel_comment(babel_comment: &BabelComment) -> SwcComment {
+        let (kind, text) = match babel_comment {
+            BabelComment::CommentBlock(data) => (CommentKind::Block, &data.value),
+            BabelComment::CommentLine(data) => (CommentKind::Line, &data.value),
+        };
+        SwcComment {
+            kind,
+            span: DUMMY_SP,
+            text: Atom::from(text.as_str()),
+        }
+    }
+
+    /// Extract comments from a BaseNode and register them with the SWC comments store.
+    fn extract_comments(&self, base: &BaseNode, span: Span) {
+        if let Some(ref leading) = base.leading_comments {
+            let pos = span.lo;
+            for c in leading {
+                self.comments
+                    .add_leading(pos, Self::convert_babel_comment(c));
+            }
+        }
+        if let Some(ref trailing) = base.trailing_comments {
+            let pos = span.hi;
+            for c in trailing {
+                self.comments
+                    .add_trailing(pos, Self::convert_babel_comment(c));
+            }
+        }
+        if let Some(ref inner) = base.inner_comments {
+            // Inner comments are typically leading comments of the next token
+            let pos = span.lo;
+            for c in inner {
+                self.comments
+                    .add_leading(pos, Self::convert_babel_comment(c));
+            }
+        }
+    }
+
+    fn atom(&self, s: &str) -> Atom {
+        Atom::from(s)
+    }
+
+    fn wtf8(&self, s: &str) -> Wtf8Atom {
+        Wtf8Atom::from(s)
+    }
+
+    /// Escape non-ASCII characters and special characters (like tab) in a string
+    /// value to \uXXXX or \xXX sequences, matching Babel's codegen output.
+    /// Returns the raw string representation wrapped in double quotes.
+    fn escape_string_raw(&self, value: &str) -> Option<Atom> {
+        let mut needs_escape = false;
+        for ch in value.chars() {
+            if !ch.is_ascii() || ch == '\t' || ch == '\'' || ch == '"' || ch == '\\' {
+                needs_escape = true;
+                break;
+            }
+        }
+        if !needs_escape {
+            return None;
+        }
+        let mut escaped = String::with_capacity(value.len() + 16);
+        escaped.push('"');
+        for ch in value.chars() {
+            match ch {
+                '"' => escaped.push_str("\\\""),
+                '\\' => escaped.push_str("\\\\"),
+                '\n' => escaped.push_str("\\n"),
+                '\r' => escaped.push_str("\\r"),
+                '\t' => escaped.push_str("\\t"),
+                c if !c.is_ascii() => {
+                    // Encode using \uXXXX (or surrogate pairs for chars > U+FFFF)
+                    let mut buf = [0u16; 2];
+                    let encoded = c.encode_utf16(&mut buf);
+                    for unit in encoded {
+                        escaped.push_str(&format!("\\u{:04X}", unit));
+                    }
+                }
+                c => escaped.push(c),
+            }
+        }
+        escaped.push('"');
+        Some(Atom::from(escaped.as_str()))
+    }
+
+    /// Extract the original source text for a node and re-parse it as a
+    /// statement using SWC's TypeScript parser. This is used for type
+    /// declarations (type aliases, interfaces, enums) that the compiler
+    /// preserves verbatim from the original source.
+    fn extract_source_stmt(&self, base: &react_compiler_ast::common::BaseNode) -> Option<Stmt> {
+        let source = self.source_text.as_deref()?;
+        let start = base.start? as usize;
+        let end = base.end? as usize;
+        // SWC BytePos is 1-based
+        let start_idx = start.saturating_sub(1);
+        let end_idx = end.saturating_sub(1);
+        if start_idx >= source.len() || end_idx > source.len() || start_idx >= end_idx {
+            return None;
+        }
+        let text = &source[start_idx..end_idx];
+        self.parse_ts_stmt(text, base)
+    }
+
+    /// Parse a string as a TypeScript statement using SWC's parser.
+    fn parse_ts_stmt(
+        &self,
+        text: &str,
+        base: &react_compiler_ast::common::BaseNode,
+    ) -> Option<Stmt> {
+        let cm = swc_core::common::sync::Lrc::new(swc_core::common::SourceMap::default());
+        let fm = cm.new_source_file(
+            swc_core::common::sync::Lrc::new(swc_core::common::FileName::Anon),
+            text.to_string(),
+        );
+        let mut errors = vec![];
+        let module = swc_core::ecma::parser::parse_file_as_module(
+            &fm,
+            swc_core::ecma::parser::Syntax::Typescript(swc_core::ecma::parser::TsSyntax {
+                tsx: true,
+                ..Default::default()
+            }),
+            swc_core::ecma::ast::EsVersion::latest(),
+            None,
+            &mut errors,
+        )
+        .ok()?;
+
+        if let Some(item) = module.body.into_iter().next() {
+            match item {
+                ModuleItem::Stmt(stmt) => {
+                    // Assign the original span so blank line computation works
+                    let span = self.span(base);
+                    return Some(self.assign_span_to_stmt(stmt, span));
+                }
+                ModuleItem::ModuleDecl(_) => {}
+            }
+        }
+        None
+    }
+
+    /// Assign a span to a statement's outermost node.
+    fn assign_span_to_stmt(&self, stmt: Stmt, span: Span) -> Stmt {
+        match stmt {
+            Stmt::Decl(Decl::TsTypeAlias(mut d)) => {
+                d.span = span;
+                Stmt::Decl(Decl::TsTypeAlias(d))
+            }
+            Stmt::Decl(Decl::TsInterface(mut d)) => {
+                d.span = span;
+                Stmt::Decl(Decl::TsInterface(d))
+            }
+            Stmt::Decl(Decl::TsEnum(mut d)) => {
+                d.span = span;
+                Stmt::Decl(Decl::TsEnum(d))
+            }
+            other => other,
+        }
+    }
+
+    fn ident(&self, name: &str, span: Span) -> Ident {
+        Ident {
+            sym: self.atom(name),
+            span,
+            ctxt: SyntaxContext::empty(),
+            optional: false,
+        }
+    }
+
+    fn ident_name(&self, name: &str, span: Span) -> IdentName {
+        IdentName {
+            sym: self.atom(name),
+            span,
+        }
+    }
+
+    fn binding_ident(&self, name: &str, span: Span) -> BindingIdent {
+        BindingIdent {
+            id: self.ident(name, span),
+            type_ann: None,
+        }
+    }
+
+    // ===== Program =====
+
+    fn convert_program(&self, program: &react_compiler_ast::Program) -> Module {
+        let mut body: Vec<ModuleItem> = Vec::new();
+
+        // Convert directives to expression statements at the beginning
+        for dir in &program.directives {
+            let span = self.span(&dir.base);
+            let str_span = self.span(&dir.value.base);
+            body.push(ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                span,
+                expr: Box::new(Expr::Lit(Lit::Str(Str {
+                    span: str_span,
+                    value: self.wtf8(&dir.value.value),
+                    raw: None,
+                }))),
+            })));
+        }
+
+        for s in &program.body {
+            body.push(self.convert_statement_to_module_item(s));
+        }
+
+        Module {
+            span: DUMMY_SP,
+            body,
+            shebang: None,
+        }
+    }
+
+    fn convert_statement_to_module_item(&self, stmt: &BabelStmt) -> ModuleItem {
+        match stmt {
+            BabelStmt::ImportDeclaration(d) => {
+                ModuleItem::ModuleDecl(ModuleDecl::Import(self.convert_import_declaration(d)))
+            }
+            BabelStmt::ExportNamedDeclaration(d) => self.convert_export_named_to_module_item(d),
+            BabelStmt::ExportDefaultDeclaration(d) => self.convert_export_default_to_module_item(d),
+            BabelStmt::ExportAllDeclaration(d) => ModuleItem::ModuleDecl(ModuleDecl::ExportAll(
+                self.convert_export_all_declaration(d),
+            )),
+            // The preserved TS module-interop statements are module
+            // declarations in swc, which `convert_statement` (returning
+            // `Stmt`) cannot represent, so they are rebuilt here.
+            BabelStmt::Unknown(unknown) => match self.convert_unknown_to_module_decl(unknown) {
+                Some(decl) => ModuleItem::ModuleDecl(decl),
+                None => ModuleItem::Stmt(self.convert_statement(stmt)),
+            },
+            _ => ModuleItem::Stmt(self.convert_statement(stmt)),
+        }
+    }
+
+    /// Rebuild the TS module-interop statements carried as raw
+    /// [`BabelStmt::Unknown`] nodes. `None` (other node types, malformed raw
+    /// JSON) routes the caller to the runtime-throw tripwire; silently
+    /// dropping the statement is the failure mode this path exists to avoid.
+    fn convert_unknown_to_module_decl(
+        &self,
+        unknown: &babel_stmt::UnknownStatement,
+    ) -> Option<ModuleDecl> {
+        let raw = unknown.raw();
+        match unknown.node_type() {
+            "TSImportEqualsDeclaration" => {
+                let id = self.ident_from_raw(raw.get("id")?)?;
+                let module_ref = self.ts_module_ref_from_raw(raw.get("moduleReference")?)?;
+                // Some Babel versions omit `importKind` for value imports,
+                // so an absent key defaults to value.
+                let is_type_only = match raw.get("importKind") {
+                    None => false,
+                    Some(kind) => match kind.as_str() {
+                        Some("type") => true,
+                        Some("value") => false,
+                        _ => return None,
+                    },
+                };
+                let is_export = match raw.get("isExport") {
+                    None => false,
+                    Some(value) => value.as_bool()?,
+                };
+                Some(ModuleDecl::TsImportEquals(Box::new(TsImportEqualsDecl {
+                    span: self.span(unknown.base()),
+                    is_export,
+                    is_type_only,
+                    id,
+                    module_ref,
+                })))
+            }
+            "TSExportAssignment" => {
+                let expr: BabelExpr =
+                    serde_json::from_value(raw.get("expression")?.clone()).ok()?;
+                Some(ModuleDecl::TsExportAssignment(TsExportAssignment {
+                    span: self.span(unknown.base()),
+                    expr: Box::new(self.convert_expression(&expr)),
+                }))
+            }
+            "TSNamespaceExportDeclaration" => {
+                let id = self.ident_from_raw(raw.get("id")?)?;
+                Some(ModuleDecl::TsNamespaceExport(TsNamespaceExportDecl {
+                    span: self.span(unknown.base()),
+                    id,
+                }))
+            }
+            _ => None,
+        }
+    }
+
+    fn ident_from_raw(&self, raw: &serde_json::Value) -> Option<Ident> {
+        if raw.get("type").and_then(serde_json::Value::as_str) != Some("Identifier") {
+            return None;
+        }
+        let id: babel_expr::Identifier = serde_json::from_value(raw.clone()).ok()?;
+        Some(self.ident(&id.name, self.span_no_comments(&id.base)))
+    }
+
+    fn ts_module_ref_from_raw(&self, raw: &serde_json::Value) -> Option<TsModuleRef> {
+        match raw.get("type").and_then(serde_json::Value::as_str)? {
+            "TSExternalModuleReference" => {
+                let expr = raw.get("expression")?;
+                if expr.get("type").and_then(serde_json::Value::as_str) != Some("StringLiteral") {
+                    return None;
+                }
+                let lit: react_compiler_ast::literals::StringLiteral =
+                    serde_json::from_value(expr.clone()).ok()?;
+                let ref_base: BaseNode = serde_json::from_value(raw.clone()).ok()?;
+                Some(TsModuleRef::TsExternalModuleRef(TsExternalModuleRef {
+                    span: self.span_no_comments(&ref_base),
+                    expr: Str {
+                        span: self.span_no_comments(&lit.base),
+                        value: self.wtf8(&lit.value),
+                        raw: None,
+                    },
+                }))
+            }
+            "TSQualifiedName" | "Identifier" => self
+                .ts_entity_name_from_raw(raw)
+                .map(TsModuleRef::TsEntityName),
+            _ => None,
+        }
+    }
+
+    fn ts_entity_name_from_raw(&self, raw: &serde_json::Value) -> Option<TsEntityName> {
+        match raw.get("type").and_then(serde_json::Value::as_str)? {
+            "Identifier" => self.ident_from_raw(raw).map(TsEntityName::Ident),
+            "TSQualifiedName" => {
+                let base: BaseNode = serde_json::from_value(raw.clone()).ok()?;
+                let left = self.ts_entity_name_from_raw(raw.get("left")?)?;
+                let right: babel_expr::Identifier =
+                    serde_json::from_value(raw.get("right")?.clone()).ok()?;
+                Some(TsEntityName::TsQualifiedName(Box::new(TsQualifiedName {
+                    span: self.span_no_comments(&base),
+                    left,
+                    right: self.ident_name(&right.name, self.span_no_comments(&right.base)),
+                })))
+            }
+            _ => None,
+        }
+    }
+
+    // ===== Statements =====
+
+    fn convert_statement(&self, stmt: &BabelStmt) -> Stmt {
+        match stmt {
+            BabelStmt::BlockStatement(s) => Stmt::Block(self.convert_block_statement(s)),
+            BabelStmt::ReturnStatement(s) => Stmt::Return(ReturnStmt {
+                span: self.span(&s.base),
+                arg: s
+                    .argument
+                    .as_ref()
+                    .map(|a| Box::new(self.convert_expression(a))),
+            }),
+            BabelStmt::ExpressionStatement(s) => {
+                let expr = self.convert_expression(&s.expression);
+                // Wrap in parens if the expression starts with `{` (object pattern
+                // in assignment) or `function` (IIFE), which would be ambiguous
+                // with a block statement or function declaration.
+                let needs_paren = match &expr {
+                    Expr::Assign(a) => {
+                        matches!(&a.left, AssignTarget::Pat(AssignTargetPat::Object(_)))
+                    }
+                    Expr::Call(c) => match &c.callee {
+                        Callee::Expr(e) => matches!(e.as_ref(), Expr::Fn(_)),
+                        _ => false,
+                    },
+                    _ => false,
+                };
+                let expr = if needs_paren {
+                    Expr::Paren(ParenExpr {
+                        span: self.span_no_comments(&s.base),
+                        expr: Box::new(expr),
+                    })
+                } else {
+                    expr
+                };
+                Stmt::Expr(ExprStmt {
+                    span: self.span(&s.base),
+                    expr: Box::new(expr),
+                })
+            }
+            BabelStmt::IfStatement(s) => Stmt::If(IfStmt {
+                span: self.span(&s.base),
+                test: Box::new(self.convert_expression(&s.test)),
+                cons: Box::new(self.convert_statement(&s.consequent)),
+                alt: s
+                    .alternate
+                    .as_ref()
+                    .map(|a| Box::new(self.convert_statement(a))),
+            }),
+            BabelStmt::ForStatement(s) => {
+                let init = s.init.as_ref().map(|i| self.convert_for_init(i));
+                let test = s
+                    .test
+                    .as_ref()
+                    .map(|t| Box::new(self.convert_expression(t)));
+                let update = s
+                    .update
+                    .as_ref()
+                    .map(|u| Box::new(self.convert_expression(u)));
+                let body = Box::new(self.convert_statement(&s.body));
+                Stmt::For(ForStmt {
+                    span: self.span(&s.base),
+                    init,
+                    test,
+                    update,
+                    body,
+                })
+            }
+            BabelStmt::WhileStatement(s) => Stmt::While(WhileStmt {
+                span: self.span(&s.base),
+                test: Box::new(self.convert_expression(&s.test)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            BabelStmt::DoWhileStatement(s) => Stmt::DoWhile(DoWhileStmt {
+                span: self.span(&s.base),
+                test: Box::new(self.convert_expression(&s.test)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            BabelStmt::ForInStatement(s) => Stmt::ForIn(ForInStmt {
+                span: self.span(&s.base),
+                left: self.convert_for_in_of_left(&s.left),
+                right: Box::new(self.convert_expression(&s.right)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            BabelStmt::ForOfStatement(s) => Stmt::ForOf(ForOfStmt {
+                span: self.span(&s.base),
+                is_await: s.is_await,
+                left: self.convert_for_in_of_left(&s.left),
+                right: Box::new(self.convert_expression(&s.right)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            BabelStmt::SwitchStatement(s) => {
+                let cases = s
+                    .cases
+                    .iter()
+                    .map(|c| SwitchCase {
+                        span: self.span(&c.base),
+                        test: c
+                            .test
+                            .as_ref()
+                            .map(|t| Box::new(self.convert_expression(t))),
+                        cons: c
+                            .consequent
+                            .iter()
+                            .map(|s| self.convert_statement(s))
+                            .collect(),
+                    })
+                    .collect();
+                Stmt::Switch(SwitchStmt {
+                    span: self.span(&s.base),
+                    discriminant: Box::new(self.convert_expression(&s.discriminant)),
+                    cases,
+                })
+            }
+            BabelStmt::ThrowStatement(s) => Stmt::Throw(ThrowStmt {
+                span: self.span(&s.base),
+                arg: Box::new(self.convert_expression(&s.argument)),
+            }),
+            BabelStmt::TryStatement(s) => {
+                let block = self.convert_block_statement(&s.block);
+                let handler = s.handler.as_ref().map(|h| self.convert_catch_clause(h));
+                let finalizer = s
+                    .finalizer
+                    .as_ref()
+                    .map(|f| self.convert_block_statement(f));
+                Stmt::Try(Box::new(TryStmt {
+                    span: self.span(&s.base),
+                    block,
+                    handler,
+                    finalizer,
+                }))
+            }
+            BabelStmt::BreakStatement(s) => Stmt::Break(BreakStmt {
+                span: self.span(&s.base),
+                label: s.label.as_ref().map(|l| self.ident(&l.name, DUMMY_SP)),
+            }),
+            BabelStmt::ContinueStatement(s) => Stmt::Continue(ContinueStmt {
+                span: self.span(&s.base),
+                label: s.label.as_ref().map(|l| self.ident(&l.name, DUMMY_SP)),
+            }),
+            BabelStmt::LabeledStatement(s) => Stmt::Labeled(LabeledStmt {
+                span: self.span(&s.base),
+                label: self.ident(&s.label.name, DUMMY_SP),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            BabelStmt::EmptyStatement(s) => Stmt::Empty(EmptyStmt {
+                span: self.span(&s.base),
+            }),
+            BabelStmt::DebuggerStatement(s) => Stmt::Debugger(DebuggerStmt {
+                span: self.span(&s.base),
+            }),
+            BabelStmt::WithStatement(s) => Stmt::With(WithStmt {
+                span: self.span(&s.base),
+                obj: Box::new(self.convert_expression(&s.object)),
+                body: Box::new(self.convert_statement(&s.body)),
+            }),
+            BabelStmt::VariableDeclaration(d) => {
+                Stmt::Decl(Decl::Var(Box::new(self.convert_variable_declaration(d))))
+            }
+            BabelStmt::FunctionDeclaration(f) => {
+                Stmt::Decl(Decl::Fn(self.convert_function_declaration(f)))
+            }
+            BabelStmt::ClassDeclaration(c) => {
+                let ident =
+                    c.id.as_ref()
+                        .map(|id| self.ident(&id.name, self.span(&id.base)))
+                        .unwrap_or_else(|| self.ident("_anonymous", DUMMY_SP));
+                let super_class = c
+                    .super_class
+                    .as_ref()
+                    .map(|s| Box::new(self.convert_expression(s)));
+                Stmt::Decl(Decl::Class(ClassDecl {
+                    ident,
+                    declare: c.declare.unwrap_or(false),
+                    class: Box::new(Class {
+                        span: self.span(&c.base),
+                        ctxt: SyntaxContext::empty(),
+                        decorators: vec![],
+                        body: vec![],
+                        super_class,
+                        is_abstract: false,
+                        type_params: None,
+                        super_type_params: None,
+                        implements: vec![],
+                    }),
+                }))
+            }
+            // Import/export handled in convert_statement_to_module_item
+            BabelStmt::ImportDeclaration(_)
+            | BabelStmt::ExportNamedDeclaration(_)
+            | BabelStmt::ExportDefaultDeclaration(_)
+            | BabelStmt::ExportAllDeclaration(_) => Stmt::Empty(EmptyStmt { span: DUMMY_SP }),
+            // TS declarations - extract from source text if available
+            BabelStmt::TSTypeAliasDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+            BabelStmt::TSInterfaceDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+            BabelStmt::TSEnumDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+            // Flow type declarations - extract from source text if available
+            BabelStmt::TypeAlias(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+            BabelStmt::OpaqueType(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+            BabelStmt::InterfaceDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+            BabelStmt::EnumDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+            // Other TS/Flow declarations
+            BabelStmt::TSModuleDeclaration(_)
+            | BabelStmt::TSDeclareFunction(_)
+            | BabelStmt::DeclareVariable(_)
+            | BabelStmt::DeclareFunction(_)
+            | BabelStmt::DeclareClass(_)
+            | BabelStmt::DeclareModule(_)
+            | BabelStmt::DeclareModuleExports(_)
+            | BabelStmt::DeclareExportDeclaration(_)
+            | BabelStmt::DeclareExportAllDeclaration(_)
+            | BabelStmt::DeclareInterface(_)
+            | BabelStmt::DeclareTypeAlias(_)
+            | BabelStmt::DeclareOpaqueType(_) => Stmt::Empty(EmptyStmt { span: DUMMY_SP }),
+            // Only unknown node types without a reverse mapping reach this
+            // arm. Degrading to EmptyStatement would silently drop the node,
+            // so emit a deliberate runtime tripwire (a `throw` in generated
+            // code) instead.
+            BabelStmt::Unknown(unknown) => {
+                let message = format!(
+                    "[react-compiler] internal error: unmodeled statement `{}` reached the SWC \
+                     reverse converter",
+                    unknown.node_type()
+                );
+                Stmt::Throw(ThrowStmt {
+                    span: DUMMY_SP,
+                    arg: Box::new(Expr::Lit(Lit::Str(Str {
+                        span: DUMMY_SP,
+                        value: self.wtf8(&message),
+                        raw: None,
+                    }))),
+                })
+            }
+        }
+    }
+
+    fn convert_block_statement(&self, block: &babel_stmt::BlockStatement) -> BlockStmt {
+        let mut stmts: Vec<Stmt> = Vec::new();
+
+        // Convert directives to expression statements at the beginning
+        for dir in &block.directives {
+            let span = self.span(&dir.base);
+            let str_span = self.span(&dir.value.base);
+            stmts.push(Stmt::Expr(ExprStmt {
+                span,
+                expr: Box::new(Expr::Lit(Lit::Str(Str {
+                    span: str_span,
+                    value: self.wtf8(&dir.value.value),
+                    raw: None,
+                }))),
+            }));
+        }
+
+        for s in &block.body {
+            stmts.push(self.convert_statement(s));
+        }
+
+        BlockStmt {
+            span: self.span(&block.base),
+            ctxt: SyntaxContext::empty(),
+            stmts,
+        }
+    }
+
+    fn convert_catch_clause(&self, clause: &babel_stmt::CatchClause) -> CatchClause {
+        let param = clause.param.as_ref().map(|p| self.convert_pattern(p));
+        CatchClause {
+            span: self.span(&clause.base),
+            param,
+            body: self.convert_block_statement(&clause.body),
+        }
+    }
+
+    fn convert_for_init(&self, init: &babel_stmt::ForInit) -> VarDeclOrExpr {
+        match init {
+            babel_stmt::ForInit::VariableDeclaration(v) => {
+                VarDeclOrExpr::VarDecl(Box::new(self.convert_variable_declaration(v)))
+            }
+            babel_stmt::ForInit::Expression(e) => {
+                VarDeclOrExpr::Expr(Box::new(self.convert_expression(e)))
+            }
+        }
+    }
+
+    fn convert_for_in_of_left(&self, left: &babel_stmt::ForInOfLeft) -> ForHead {
+        match left {
+            babel_stmt::ForInOfLeft::VariableDeclaration(v) => {
+                ForHead::VarDecl(Box::new(self.convert_variable_declaration(v)))
+            }
+            babel_stmt::ForInOfLeft::Pattern(p) => ForHead::Pat(Box::new(self.convert_pattern(p))),
+        }
+    }
+
+    fn convert_variable_declaration(&self, decl: &babel_stmt::VariableDeclaration) -> VarDecl {
+        let kind = match decl.kind {
+            babel_stmt::VariableDeclarationKind::Var => VarDeclKind::Var,
+            babel_stmt::VariableDeclarationKind::Let => VarDeclKind::Let,
+            babel_stmt::VariableDeclarationKind::Const => VarDeclKind::Const,
+            babel_stmt::VariableDeclarationKind::Using => VarDeclKind::Var, /* SWC doesn't have
+                                                                             * Using */
+        };
+        let decls = decl
+            .declarations
+            .iter()
+            .map(|d| self.convert_variable_declarator(d))
+            .collect();
+        let declare = decl.declare.unwrap_or(false);
+        VarDecl {
+            span: self.span(&decl.base),
+            ctxt: SyntaxContext::empty(),
+            kind,
+            declare,
+            decls,
+        }
+    }
+
+    fn convert_variable_declarator(&self, d: &babel_stmt::VariableDeclarator) -> VarDeclarator {
+        let name = self.convert_pattern(&d.id);
+        let init = d
+            .init
+            .as_ref()
+            .map(|e| Box::new(self.convert_expression(e)));
+        let definite = d.definite.unwrap_or(false);
+        VarDeclarator {
+            span: self.span(&d.base),
+            name,
+            init,
+            definite,
+        }
+    }
+
+    // ===== Expressions =====
+
+    fn convert_expression(&self, expr: &BabelExpr) -> Expr {
+        match expr {
+            BabelExpr::Identifier(id) => {
+                let span = self.span(&id.base);
+                Expr::Ident(self.ident(&id.name, span))
+            }
+            BabelExpr::StringLiteral(lit) => Expr::Lit(Lit::Str(Str {
+                span: self.span(&lit.base),
+                value: self.wtf8(&lit.value),
+                raw: self.escape_string_raw(&lit.value),
+            })),
+            BabelExpr::NumericLiteral(lit) => {
+                // Convert -0.0 to 0.0 to match Babel's codegen behavior.
+                // Babel outputs `0` for both `-0` and `0`.
+                let value = if lit.value == 0.0 && lit.value.is_sign_negative() {
+                    0.0
+                } else {
+                    lit.value
+                };
+                Expr::Lit(Lit::Num(Number {
+                    span: self.span(&lit.base),
+                    value,
+                    raw: None,
+                }))
+            }
+            BabelExpr::BooleanLiteral(lit) => Expr::Lit(Lit::Bool(Bool {
+                span: self.span(&lit.base),
+                value: lit.value,
+            })),
+            BabelExpr::NullLiteral(lit) => Expr::Lit(Lit::Null(Null {
+                span: self.span(&lit.base),
+            })),
+            BabelExpr::BigIntLiteral(lit) => Expr::Lit(Lit::BigInt(BigInt {
+                span: self.span(&lit.base),
+                value: Box::new(lit.value.parse().unwrap_or_default()),
+                raw: None,
+            })),
+            BabelExpr::RegExpLiteral(lit) => Expr::Lit(Lit::Regex(Regex {
+                span: self.span(&lit.base),
+                exp: self.atom(&lit.pattern),
+                flags: self.atom(&lit.flags),
+            })),
+            BabelExpr::CallExpression(call) => {
+                let callee = self.convert_expression(&call.callee);
+                let args = self.convert_arguments(&call.arguments);
+                // Wrap arrow/function expressions in parens when used as
+                // call targets (IIFEs). SWC codegen does not add parens for
+                // `(() => ...)()`, resulting in incorrect code.
+                let callee = match &callee {
+                    Expr::Arrow(_) | Expr::Fn(_) => Expr::Paren(ParenExpr {
+                        span: callee.span(),
+                        expr: Box::new(callee),
+                    }),
+                    _ => callee,
+                };
+                Expr::Call(CallExpr {
+                    span: self.span(&call.base),
+                    ctxt: SyntaxContext::empty(),
+                    callee: Callee::Expr(Box::new(callee)),
+                    args,
+                    type_args: None,
+                })
+            }
+            BabelExpr::MemberExpression(m) => self.convert_member_expression(m),
+            BabelExpr::OptionalCallExpression(call) => {
+                let callee = self.convert_expression_for_chain(&call.callee);
+                let args = self.convert_arguments(&call.arguments);
+                let base = OptChainBase::Call(OptCall {
+                    span: self.span(&call.base),
+                    ctxt: SyntaxContext::empty(),
+                    callee: Box::new(callee),
+                    args,
+                    type_args: None,
+                });
+                Expr::OptChain(OptChainExpr {
+                    span: self.span(&call.base),
+                    optional: call.optional,
+                    base: Box::new(base),
+                })
+            }
+            BabelExpr::OptionalMemberExpression(m) => {
+                let base = self.convert_optional_member_to_chain_base(m);
+                Expr::OptChain(OptChainExpr {
+                    span: self.span(&m.base),
+                    optional: m.optional,
+                    base: Box::new(base),
+                })
+            }
+            BabelExpr::BinaryExpression(bin) => {
+                let op = self.convert_binary_operator(&bin.operator);
+                Expr::Bin(BinExpr {
+                    span: self.span(&bin.base),
+                    op,
+                    left: Box::new(self.convert_expression(&bin.left)),
+                    right: Box::new(self.convert_expression(&bin.right)),
+                })
+            }
+            BabelExpr::LogicalExpression(log) => {
+                let op = self.convert_logical_operator(&log.operator);
+                let span = self.span(&log.base);
+                let bin = Expr::Bin(BinExpr {
+                    span,
+                    op,
+                    left: Box::new(self.convert_expression(&log.left)),
+                    right: Box::new(self.convert_expression(&log.right)),
+                });
+                // Wrap all logical expressions in parentheses. Logical
+                // operators (||, &&, ??) have lower precedence than most
+                // binary operators, but SWC's codegen does not always insert
+                // parens correctly (e.g., `a + b || c` vs `a + (b || c)`).
+                // Wrapping unconditionally is safe.
+                Expr::Paren(ParenExpr {
+                    span,
+                    expr: Box::new(bin),
+                })
+            }
+            BabelExpr::UnaryExpression(un) => {
+                let op = self.convert_unary_operator(&un.operator);
+                Expr::Unary(UnaryExpr {
+                    span: self.span(&un.base),
+                    op,
+                    arg: Box::new(self.convert_expression(&un.argument)),
+                })
+            }
+            BabelExpr::UpdateExpression(up) => {
+                let op = self.convert_update_operator(&up.operator);
+                Expr::Update(UpdateExpr {
+                    span: self.span(&up.base),
+                    op,
+                    prefix: up.prefix,
+                    arg: Box::new(self.convert_expression(&up.argument)),
+                })
+            }
+            BabelExpr::ConditionalExpression(cond) => {
+                let span = self.span(&cond.base);
+                // Wrap conditional expressions in parentheses. SWC's codegen
+                // does not always insert parens for ternaries inside binary
+                // or assignment expressions (e.g., `x + cond ? a : b` instead
+                // of `x + (cond ? a : b)`).
+                Expr::Paren(ParenExpr {
+                    span,
+                    expr: Box::new(Expr::Cond(CondExpr {
+                        span,
+                        test: Box::new(self.convert_expression(&cond.test)),
+                        cons: Box::new(self.convert_expression(&cond.consequent)),
+                        alt: Box::new(self.convert_expression(&cond.alternate)),
+                    })),
+                })
+            }
+            BabelExpr::AssignmentExpression(assign) => {
+                let op = self.convert_assignment_operator(&assign.operator);
+                let left = self.convert_pattern_to_assign_target(&assign.left);
+                let span = self.span(&assign.base);
+                let assign_expr = Expr::Assign(AssignExpr {
+                    span,
+                    op,
+                    left,
+                    right: Box::new(self.convert_expression(&assign.right)),
+                });
+                // Wrap assignment expressions in parentheses. SWC's codegen
+                // does not always insert necessary parens for assignments
+                // when they appear as operands of binary/logical expressions
+                // (e.g., `x + x = 2` instead of `x + (x = 2)`).
+                Expr::Paren(ParenExpr {
+                    span,
+                    expr: Box::new(assign_expr),
+                })
+            }
+            BabelExpr::SequenceExpression(seq) => {
+                let exprs = seq
+                    .expressions
+                    .iter()
+                    .map(|e| Box::new(self.convert_expression(e)))
+                    .collect();
+                let span = self.span(&seq.base);
+                // Wrap sequence expressions in parentheses. SWC's codegen
+                // does not always insert necessary parens for sequence
+                // expressions (e.g., in ternary consequent position), so
+                // wrapping unconditionally is safe and prevents parse errors.
+                Expr::Paren(ParenExpr {
+                    span,
+                    expr: Box::new(Expr::Seq(SeqExpr { span, exprs })),
+                })
+            }
+            BabelExpr::ArrowFunctionExpression(arrow) => self.convert_arrow_function(arrow),
+            BabelExpr::FunctionExpression(func) => {
+                let ident = func
+                    .id
+                    .as_ref()
+                    .map(|id| self.ident(&id.name, self.span(&id.base)));
+                let params = self.convert_params(&func.params);
+                let body = Some(self.convert_block_statement(&func.body));
+                Expr::Fn(FnExpr {
+                    ident,
+                    function: Box::new(Function {
+                        params,
+                        decorators: vec![],
+                        span: self.span(&func.base),
+                        ctxt: SyntaxContext::empty(),
+                        body,
+                        is_generator: func.generator,
+                        is_async: func.is_async,
+                        type_params: None,
+                        return_type: None,
+                    }),
+                })
+            }
+            BabelExpr::ObjectExpression(obj) => {
+                let props = obj
+                    .properties
+                    .iter()
+                    .map(|p| self.convert_object_expression_property(p))
+                    .collect();
+                Expr::Object(ObjectLit {
+                    span: self.span(&obj.base),
+                    props,
+                })
+            }
+            BabelExpr::ArrayExpression(arr) => {
+                let elems = arr
+                    .elements
+                    .iter()
+                    .map(|e| self.convert_array_element(e))
+                    .collect();
+                Expr::Array(ArrayLit {
+                    span: self.span(&arr.base),
+                    elems,
+                })
+            }
+            BabelExpr::NewExpression(n) => {
+                let callee = Box::new(self.convert_expression(&n.callee));
+                let args = Some(self.convert_arguments(&n.arguments));
+                Expr::New(NewExpr {
+                    span: self.span(&n.base),
+                    ctxt: SyntaxContext::empty(),
+                    callee,
+                    args,
+                    type_args: None,
+                })
+            }
+            BabelExpr::TemplateLiteral(tl) => {
+                let template = self.convert_template_literal(tl);
+                Expr::Tpl(template)
+            }
+            BabelExpr::TaggedTemplateExpression(tag) => {
+                let t = Box::new(self.convert_expression(&tag.tag));
+                let tpl = Box::new(self.convert_template_literal(&tag.quasi));
+                Expr::TaggedTpl(TaggedTpl {
+                    span: self.span(&tag.base),
+                    ctxt: SyntaxContext::empty(),
+                    tag: t,
+                    type_params: None,
+                    tpl,
+                })
+            }
+            BabelExpr::AwaitExpression(a) => Expr::Await(AwaitExpr {
+                span: self.span(&a.base),
+                arg: Box::new(self.convert_expression(&a.argument)),
+            }),
+            BabelExpr::YieldExpression(y) => Expr::Yield(YieldExpr {
+                span: self.span(&y.base),
+                delegate: y.delegate,
+                arg: y
+                    .argument
+                    .as_ref()
+                    .map(|a| Box::new(self.convert_expression(a))),
+            }),
+            BabelExpr::SpreadElement(s) => {
+                // SpreadElement can't be a standalone expression in SWC.
+                // Return the argument directly as a fallback.
+                self.convert_expression(&s.argument)
+            }
+            BabelExpr::MetaProperty(mp) => Expr::MetaProp(MetaPropExpr {
+                span: self.span(&mp.base),
+                kind: match (mp.meta.name.as_str(), mp.property.name.as_str()) {
+                    ("new", "target") => MetaPropKind::NewTarget,
+                    ("import", "meta") => MetaPropKind::ImportMeta,
+                    _ => MetaPropKind::NewTarget,
+                },
+            }),
+            BabelExpr::ClassExpression(c) => {
+                let ident =
+                    c.id.as_ref()
+                        .map(|id| self.ident(&id.name, self.span(&id.base)));
+                let super_class = c
+                    .super_class
+                    .as_ref()
+                    .map(|s| Box::new(self.convert_expression(s)));
+                Expr::Class(ClassExpr {
+                    ident,
+                    class: Box::new(Class {
+                        span: self.span(&c.base),
+                        ctxt: SyntaxContext::empty(),
+                        decorators: vec![],
+                        body: vec![],
+                        super_class,
+                        is_abstract: false,
+                        type_params: None,
+                        super_type_params: None,
+                        implements: vec![],
+                    }),
+                })
+            }
+            BabelExpr::PrivateName(p) => Expr::PrivateName(PrivateName {
+                span: self.span(&p.base),
+                name: self.atom(&p.id.name),
+            }),
+            BabelExpr::Super(s) => Expr::Ident(self.ident("super", self.span(&s.base))),
+            BabelExpr::Import(i) => Expr::Ident(self.ident("import", self.span(&i.base))),
+            BabelExpr::ThisExpression(t) => Expr::This(ThisExpr {
+                span: self.span(&t.base),
+            }),
+            BabelExpr::ParenthesizedExpression(p) => Expr::Paren(ParenExpr {
+                span: self.span(&p.base),
+                expr: Box::new(self.convert_expression(&p.expression)),
+            }),
+            BabelExpr::JSXElement(el) => {
+                let element = self.convert_jsx_element(el.as_ref());
+                Expr::JSXElement(Box::new(element))
+            }
+            BabelExpr::JSXFragment(frag) => {
+                let fragment = self.convert_jsx_fragment(frag);
+                Expr::JSXFragment(fragment)
+            }
+            // TS expressions - preserve as SWC TS nodes
+            BabelExpr::TSAsExpression(e) => {
+                let expr = Box::new(self.convert_expression(&e.expression));
+                let span = self.span(&e.base);
+                // Check if this is "as const" — Babel represents it as
+                // TSAsExpression with typeAnnotation: TSTypeReference { typeName: Identifier {
+                // name: "const" } }
+                let is_as_const = e.type_annotation.get("type").and_then(|v| v.as_str())
+                    == Some("TSTypeReference")
+                    && e.type_annotation
+                        .get("typeName")
+                        .and_then(|tn| tn.get("name"))
+                        .and_then(|n| n.as_str())
+                        == Some("const");
+
+                if is_as_const {
+                    Expr::TsConstAssertion(TsConstAssertion { span, expr })
+                } else {
+                    let type_ann = self.convert_ts_type_from_json(&e.type_annotation, span);
+                    Expr::TsAs(TsAsExpr {
+                        span,
+                        expr,
+                        type_ann: Box::new(type_ann),
+                    })
+                }
+            }
+            BabelExpr::TSSatisfiesExpression(e) => self.convert_expression(&e.expression),
+            BabelExpr::TSNonNullExpression(e) => Expr::TsNonNull(TsNonNullExpr {
+                span: self.span(&e.base),
+                expr: Box::new(self.convert_expression(&e.expression)),
+            }),
+            BabelExpr::TSTypeAssertion(e) => self.convert_expression(&e.expression),
+            BabelExpr::TSInstantiationExpression(e) => self.convert_expression(&e.expression),
+            BabelExpr::TypeCastExpression(e) => self.convert_expression(&e.expression),
+            BabelExpr::AssignmentPattern(p) => {
+                let left = self.convert_pattern_to_assign_target(&p.left);
+                Expr::Assign(AssignExpr {
+                    span: self.span(&p.base),
+                    op: AssignOp::Assign,
+                    left,
+                    right: Box::new(self.convert_expression(&p.right)),
+                })
+            }
+        }
+    }
+
+    /// Convert an expression that may be used inside a chain (optional chaining).
+    ///
+    /// In Babel, a chain like `a?.b.c()` is represented as nested
+    /// OptionalMemberExpression / OptionalCallExpression nodes. Each node
+    /// has an `optional` flag indicating whether it uses `?.` at that point.
+    ///
+    /// In SWC, each `?.` point is wrapped in an `OptChainExpr`. Nodes in
+    /// the chain that do NOT have `?.` are plain `MemberExpr` / `CallExpr`.
+    ///
+    /// So when `optional: true`, we still need to emit `OptChainExpr`.
+    /// When `optional: false`, we emit a plain expr (part of the parent chain).
+    fn convert_expression_for_chain(&self, expr: &BabelExpr) -> Expr {
+        match expr {
+            BabelExpr::OptionalMemberExpression(m) => {
+                if m.optional {
+                    // This node uses `?.`, wrap in OptChainExpr
+                    let base = self.convert_optional_member_to_chain_base(m);
+                    Expr::OptChain(OptChainExpr {
+                        span: self.span(&m.base),
+                        optional: true,
+                        base: Box::new(base),
+                    })
+                } else {
+                    // Part of a chain but no `?.` here — plain MemberExpr
+                    self.convert_optional_member_to_member_expr(m)
+                }
+            }
+            BabelExpr::OptionalCallExpression(call) => {
+                let callee = self.convert_expression_for_chain(&call.callee);
+                let args = self.convert_arguments(&call.arguments);
+                if call.optional {
+                    // This node uses `?.()`, wrap in OptChainExpr
+                    let base = OptChainBase::Call(OptCall {
+                        span: self.span(&call.base),
+                        ctxt: SyntaxContext::empty(),
+                        callee: Box::new(callee),
+                        args,
+                        type_args: None,
+                    });
+                    Expr::OptChain(OptChainExpr {
+                        span: self.span(&call.base),
+                        optional: true,
+                        base: Box::new(base),
+                    })
+                } else {
+                    // Part of a chain but no `?.` here — plain CallExpr
+                    Expr::Call(CallExpr {
+                        span: self.span(&call.base),
+                        ctxt: SyntaxContext::empty(),
+                        callee: Callee::Expr(Box::new(callee)),
+                        args,
+                        type_args: None,
+                    })
+                }
+            }
+            _ => self.convert_expression(expr),
+        }
+    }
+
+    fn convert_member_expression(&self, m: &babel_expr::MemberExpression) -> Expr {
+        let object = self.convert_expression(&m.object);
+        // When an optional chain expression is used as the object of a
+        // non-optional member expression (e.g., `(props?.a).b`), wrap it
+        // in parens to properly terminate the optional chain. Without
+        // parens, SWC codegen emits `props?.a.b` which extends the chain.
+        let object = match &object {
+            Expr::OptChain(_) => Box::new(Expr::Paren(ParenExpr {
+                span: object.span(),
+                expr: Box::new(object),
+            })),
+            _ => Box::new(object),
+        };
+        if m.computed {
+            let property = self.convert_expression(&m.property);
+            Expr::Member(MemberExpr {
+                span: self.span(&m.base),
+                obj: object,
+                prop: MemberProp::Computed(ComputedPropName {
+                    span: DUMMY_SP,
+                    expr: Box::new(property),
+                }),
+            })
+        } else {
+            let prop_name = self.expression_to_ident_name(&m.property);
+            Expr::Member(MemberExpr {
+                span: self.span(&m.base),
+                obj: object,
+                prop: MemberProp::Ident(prop_name),
+            })
+        }
+    }
+
+    fn convert_optional_member_to_chain_base(
+        &self,
+        m: &babel_expr::OptionalMemberExpression,
+    ) -> OptChainBase {
+        let object = Box::new(self.convert_expression_for_chain(&m.object));
+        if m.computed {
+            let property = self.convert_expression(&m.property);
+            OptChainBase::Member(MemberExpr {
+                span: self.span(&m.base),
+                obj: object,
+                prop: MemberProp::Computed(ComputedPropName {
+                    span: DUMMY_SP,
+                    expr: Box::new(property),
+                }),
+            })
+        } else {
+            let prop_name = self.expression_to_ident_name(&m.property);
+            OptChainBase::Member(MemberExpr {
+                span: self.span(&m.base),
+                obj: object,
+                prop: MemberProp::Ident(prop_name),
+            })
+        }
+    }
+
+    fn convert_optional_member_to_member_expr(
+        &self,
+        m: &babel_expr::OptionalMemberExpression,
+    ) -> Expr {
+        let object = Box::new(self.convert_expression_for_chain(&m.object));
+        if m.computed {
+            let property = self.convert_expression(&m.property);
+            Expr::Member(MemberExpr {
+                span: self.span(&m.base),
+                obj: object,
+                prop: MemberProp::Computed(ComputedPropName {
+                    span: DUMMY_SP,
+                    expr: Box::new(property),
+                }),
+            })
+        } else {
+            let prop_name = self.expression_to_ident_name(&m.property);
+            Expr::Member(MemberExpr {
+                span: self.span(&m.base),
+                obj: object,
+                prop: MemberProp::Ident(prop_name),
+            })
+        }
+    }
+
+    fn expression_to_ident_name(&self, expr: &BabelExpr) -> IdentName {
+        match expr {
+            BabelExpr::Identifier(id) => self.ident_name(&id.name, self.span(&id.base)),
+            _ => self.ident_name("__unknown__", DUMMY_SP),
+        }
+    }
+
+    fn convert_arguments(&self, args: &[BabelExpr]) -> Vec<ExprOrSpread> {
+        args.iter().map(|a| self.convert_argument(a)).collect()
+    }
+
+    fn convert_argument(&self, arg: &BabelExpr) -> ExprOrSpread {
+        match arg {
+            BabelExpr::SpreadElement(s) => ExprOrSpread {
+                spread: Some(self.span(&s.base)),
+                expr: Box::new(self.convert_expression(&s.argument)),
+            },
+            _ => ExprOrSpread {
+                spread: None,
+                expr: Box::new(self.convert_expression(arg)),
+            },
+        }
+    }
+
+    fn convert_array_element(&self, elem: &Option<BabelExpr>) -> Option<ExprOrSpread> {
+        match elem {
+            None => None,
+            Some(BabelExpr::SpreadElement(s)) => Some(ExprOrSpread {
+                spread: Some(self.span(&s.base)),
+                expr: Box::new(self.convert_expression(&s.argument)),
+            }),
+            Some(e) => Some(ExprOrSpread {
+                spread: None,
+                expr: Box::new(self.convert_expression(e)),
+            }),
+        }
+    }
+
+    fn convert_object_expression_property(
+        &self,
+        prop: &babel_expr::ObjectExpressionProperty,
+    ) -> PropOrSpread {
+        match prop {
+            babel_expr::ObjectExpressionProperty::ObjectProperty(p) => {
+                let key = if p.computed {
+                    // Computed property key: [expr]
+                    PropName::Computed(ComputedPropName {
+                        span: DUMMY_SP,
+                        expr: Box::new(self.convert_expression(&p.key)),
+                    })
+                } else {
+                    self.convert_expression_to_prop_name(&p.key)
+                };
+                let value = self.convert_expression(&p.value);
+                let method = p.method.unwrap_or(false);
+
+                if p.shorthand {
+                    PropOrSpread::Prop(Box::new(Prop::Shorthand(match &*p.key {
+                        BabelExpr::Identifier(id) => self.ident(&id.name, self.span(&id.base)),
+                        _ => self.ident("__unknown__", DUMMY_SP),
+                    })))
+                } else if method {
+                    // Method shorthand: { foo() {} }
+                    // The value should be a function expression
+                    let func = match value {
+                        Expr::Fn(fn_expr) => *fn_expr.function,
+                        _ => {
+                            // Fallback: wrap in a key-value
+                            return PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                                key,
+                                value: Box::new(value),
+                            })));
+                        }
+                    };
+                    PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
+                        key,
+                        function: Box::new(func),
+                    })))
+                } else {
+                    PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                        key,
+                        value: Box::new(value),
+                    })))
+                }
+            }
+            babel_expr::ObjectExpressionProperty::ObjectMethod(m) => {
+                let key = if m.computed {
+                    PropName::Computed(ComputedPropName {
+                        span: DUMMY_SP,
+                        expr: Box::new(self.convert_expression(&m.key)),
+                    })
+                } else {
+                    self.convert_expression_to_prop_name(&m.key)
+                };
+                let func = self.convert_object_method_to_function(m);
+                match m.kind {
+                    babel_expr::ObjectMethodKind::Get => {
+                        PropOrSpread::Prop(Box::new(Prop::Getter(GetterProp {
+                            span: self.span(&m.base),
+                            key,
+                            type_ann: None,
+                            body: func.body,
+                        })))
+                    }
+                    babel_expr::ObjectMethodKind::Set => {
+                        let param = func
+                            .params
+                            .into_iter()
+                            .next()
+                            .map(|p| Box::new(p.pat))
+                            .unwrap_or_else(|| {
+                                Box::new(Pat::Ident(self.binding_ident("_", DUMMY_SP)))
+                            });
+                        PropOrSpread::Prop(Box::new(Prop::Setter(SetterProp {
+                            span: self.span(&m.base),
+                            key,
+                            this_param: None,
+                            param,
+                            body: func.body,
+                        })))
+                    }
+                    babel_expr::ObjectMethodKind::Method => {
+                        PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
+                            key,
+                            function: Box::new(func),
+                        })))
+                    }
+                }
+            }
+            babel_expr::ObjectExpressionProperty::SpreadElement(s) => {
+                PropOrSpread::Spread(SpreadElement {
+                    dot3_token: self.span(&s.base),
+                    expr: Box::new(self.convert_expression(&s.argument)),
+                })
+            }
+        }
+    }
+
+    fn convert_expression_to_prop_name(&self, expr: &BabelExpr) -> PropName {
+        match expr {
+            BabelExpr::Identifier(id) => {
+                PropName::Ident(self.ident_name(&id.name, self.span(&id.base)))
+            }
+            BabelExpr::StringLiteral(s) => PropName::Str(Str {
+                span: self.span(&s.base),
+                value: self.wtf8(&s.value),
+                raw: None,
+            }),
+            BabelExpr::NumericLiteral(n) => PropName::Num(Number {
+                span: self.span(&n.base),
+                value: n.value,
+                raw: None,
+            }),
+            _ => PropName::Computed(ComputedPropName {
+                span: DUMMY_SP,
+                expr: Box::new(self.convert_expression(expr)),
+            }),
+        }
+    }
+
+    fn convert_template_literal(&self, tl: &babel_expr::TemplateLiteral) -> Tpl {
+        let quasis = tl
+            .quasis
+            .iter()
+            .map(|q| {
+                let cooked = q.value.cooked.as_ref().map(|c| self.wtf8(c));
+                TplElement {
+                    span: self.span(&q.base),
+                    tail: q.tail,
+                    cooked,
+                    raw: self.atom(&q.value.raw),
+                }
+            })
+            .collect();
+        let exprs = tl
+            .expressions
+            .iter()
+            .map(|e| Box::new(self.convert_expression(e)))
+            .collect();
+        Tpl {
+            span: self.span(&tl.base),
+            exprs,
+            quasis,
+        }
+    }
+
+    // ===== Functions =====
+
+    fn convert_function_declaration(&self, f: &babel_stmt::FunctionDeclaration) -> FnDecl {
+        let ident =
+            f.id.as_ref()
+                .map(|id| self.ident(&id.name, self.span(&id.base)))
+                .unwrap_or_else(|| self.ident("_anonymous", DUMMY_SP));
+        let params = self.convert_params(&f.params);
+        let body = Some(self.convert_block_statement(&f.body));
+        let declare = f.declare.unwrap_or(false);
+        FnDecl {
+            ident,
+            declare,
+            function: Box::new(Function {
+                params,
+                decorators: vec![],
+                span: self.span(&f.base),
+                ctxt: SyntaxContext::empty(),
+                body,
+                is_generator: f.generator,
+                is_async: f.is_async,
+                type_params: None,
+                return_type: None,
+            }),
+        }
+    }
+
+    fn convert_object_method_to_function(&self, m: &babel_expr::ObjectMethod) -> Function {
+        let params = self.convert_params(&m.params);
+        let body = Some(self.convert_block_statement(&m.body));
+        Function {
+            params,
+            decorators: vec![],
+            span: self.span(&m.base),
+            ctxt: SyntaxContext::empty(),
+            body,
+            is_generator: m.generator,
+            is_async: m.is_async,
+            type_params: None,
+            return_type: None,
+        }
+    }
+
+    fn convert_arrow_function(&self, arrow: &babel_expr::ArrowFunctionExpression) -> Expr {
+        let is_expression = arrow.expression.unwrap_or(false);
+        let params = arrow
+            .params
+            .iter()
+            .map(|p| self.convert_pattern(p))
+            .collect();
+
+        let body: Box<BlockStmtOrExpr> = match &*arrow.body {
+            babel_expr::ArrowFunctionBody::BlockStatement(block) => Box::new(
+                BlockStmtOrExpr::BlockStmt(self.convert_block_statement(block)),
+            ),
+            babel_expr::ArrowFunctionBody::Expression(expr) => {
+                if is_expression {
+                    let converted = self.convert_expression(expr);
+                    // Wrap object expressions in parens to prevent ambiguity
+                    // with block bodies: `() => ({...})` vs `() => {...}`
+                    let converted = if matches!(&converted, Expr::Object(_)) {
+                        Expr::Paren(ParenExpr {
+                            span: converted.span(),
+                            expr: Box::new(converted),
+                        })
+                    } else {
+                        converted
+                    };
+                    Box::new(BlockStmtOrExpr::Expr(Box::new(converted)))
+                } else {
+                    // Wrap in block with return
+                    let ret_stmt = Stmt::Return(ReturnStmt {
+                        span: DUMMY_SP,
+                        arg: Some(Box::new(self.convert_expression(expr))),
+                    });
+                    Box::new(BlockStmtOrExpr::BlockStmt(BlockStmt {
+                        span: DUMMY_SP,
+                        ctxt: SyntaxContext::empty(),
+                        stmts: vec![ret_stmt],
+                    }))
+                }
+            }
+        };
+
+        Expr::Arrow(ArrowExpr {
+            span: self.span(&arrow.base),
+            ctxt: SyntaxContext::empty(),
+            params,
+            body,
+            is_async: arrow.is_async,
+            is_generator: arrow.generator,
+            return_type: None,
+            type_params: None,
+        })
+    }
+
+    fn convert_params(&self, params: &[PatternLike]) -> Vec<Param> {
+        params
+            .iter()
+            .map(|p| Param {
+                span: DUMMY_SP,
+                decorators: vec![],
+                pat: self.convert_pattern(p),
+            })
+            .collect()
+    }
+
+    // ===== Patterns =====
+
+    fn convert_pattern(&self, pattern: &PatternLike) -> Pat {
+        match pattern {
+            PatternLike::Identifier(id) => {
+                let mut bi = self.binding_ident(&id.name, self.span(&id.base));
+                bi.id.optional = id.optional.unwrap_or(false);
+                // Preserve type annotations if present
+                if let Some(ref type_ann) = id.type_annotation {
+                    bi.type_ann = self.convert_ts_type_annotation_from_json(type_ann);
+                }
+                Pat::Ident(bi)
+            }
+            PatternLike::ObjectPattern(obj) => {
+                let mut props: Vec<ObjectPatProp> = Vec::new();
+
+                for prop in &obj.properties {
+                    match prop {
+                        ObjectPatternProperty::ObjectProperty(p) => {
+                            if p.shorthand {
+                                // Shorthand: { x } or { x = default }
+                                let value = self.convert_pattern(&p.value);
+                                match &*p.key {
+                                    BabelExpr::Identifier(id) => {
+                                        let key_ident =
+                                            self.binding_ident(&id.name, self.span(&id.base));
+                                        match value {
+                                            Pat::Assign(assign_pat) => {
+                                                props.push(ObjectPatProp::Assign(AssignPatProp {
+                                                    span: self.span(&p.base),
+                                                    key: key_ident,
+                                                    value: Some(assign_pat.right),
+                                                }));
+                                            }
+                                            _ => {
+                                                props.push(ObjectPatProp::Assign(AssignPatProp {
+                                                    span: self.span(&p.base),
+                                                    key: key_ident,
+                                                    value: None,
+                                                }));
+                                            }
+                                        }
+                                    }
+                                    _ => {
+                                        // Fallback to key-value
+                                        let key = self.convert_expression_to_prop_name(&p.key);
+                                        props.push(ObjectPatProp::KeyValue(KeyValuePatProp {
+                                            key,
+                                            value: Box::new(value),
+                                        }));
+                                    }
+                                }
+                            } else {
+                                let key = self.convert_expression_to_prop_name(&p.key);
+                                let value = self.convert_pattern(&p.value);
+                                props.push(ObjectPatProp::KeyValue(KeyValuePatProp {
+                                    key,
+                                    value: Box::new(value),
+                                }));
+                            }
+                        }
+                        ObjectPatternProperty::RestElement(r) => {
+                            let arg = Box::new(self.convert_pattern(&r.argument));
+                            props.push(ObjectPatProp::Rest(RestPat {
+                                span: self.span(&r.base),
+                                dot3_token: self.span(&r.base),
+                                arg,
+                                type_ann: None,
+                            }));
+                        }
+                    }
+                }
+
+                Pat::Object(ObjectPat {
+                    span: self.span(&obj.base),
+                    props,
+                    optional: false,
+                    type_ann: None,
+                })
+            }
+            PatternLike::ArrayPattern(arr) => {
+                let elems = arr
+                    .elements
+                    .iter()
+                    .map(|e| e.as_ref().map(|p| self.convert_pattern(p)))
+                    .collect();
+                Pat::Array(ArrayPat {
+                    span: self.span(&arr.base),
+                    elems,
+                    optional: false,
+                    type_ann: None,
+                })
+            }
+            PatternLike::AssignmentPattern(ap) => {
+                let left = Box::new(self.convert_pattern(&ap.left));
+                let right = Box::new(self.convert_expression(&ap.right));
+                Pat::Assign(AssignPat {
+                    span: self.span(&ap.base),
+                    left,
+                    right,
+                })
+            }
+            PatternLike::RestElement(r) => {
+                let arg = Box::new(self.convert_pattern(&r.argument));
+                Pat::Rest(RestPat {
+                    span: self.span(&r.base),
+                    dot3_token: self.span(&r.base),
+                    arg,
+                    type_ann: None,
+                })
+            }
+            PatternLike::MemberExpression(m) => {
+                // MemberExpression in pattern position - convert to an expression pattern
+                Pat::Expr(Box::new(self.convert_member_expression(m)))
+            }
+            // TS wrappers in pattern position: strip the type wrapper, keep the
+            // inner expression (unreachable for unsupported targets; non-panicking).
+            PatternLike::TSAsExpression(e) => {
+                Pat::Expr(Box::new(self.convert_expression(&e.expression)))
+            }
+            PatternLike::TSSatisfiesExpression(e) => {
+                Pat::Expr(Box::new(self.convert_expression(&e.expression)))
+            }
+            PatternLike::TSNonNullExpression(e) => {
+                Pat::Expr(Box::new(self.convert_expression(&e.expression)))
+            }
+            PatternLike::TSTypeAssertion(e) => {
+                Pat::Expr(Box::new(self.convert_expression(&e.expression)))
+            }
+            PatternLike::TypeCastExpression(e) => {
+                Pat::Expr(Box::new(self.convert_expression(&e.expression)))
+            }
+        }
+    }
+
+    // ===== Patterns → AssignmentTarget =====
+
+    fn convert_pattern_to_assign_target(&self, pattern: &PatternLike) -> AssignTarget {
+        match pattern {
+            PatternLike::Identifier(id) => AssignTarget::Simple(SimpleAssignTarget::Ident(
+                self.binding_ident(&id.name, self.span(&id.base)),
+            )),
+            PatternLike::MemberExpression(m) => {
+                let expr = self.convert_member_expression(m);
+                match expr {
+                    Expr::Member(member) => {
+                        AssignTarget::Simple(SimpleAssignTarget::Member(member))
+                    }
+                    _ => AssignTarget::Simple(SimpleAssignTarget::Ident(
+                        self.binding_ident("__unknown__", DUMMY_SP),
+                    )),
+                }
+            }
+            PatternLike::ObjectPattern(_obj) => {
+                let pat = self.convert_pattern(pattern);
+                match pat {
+                    Pat::Object(obj_pat) => AssignTarget::Pat(AssignTargetPat::Object(obj_pat)),
+                    _ => AssignTarget::Simple(SimpleAssignTarget::Ident(
+                        self.binding_ident("__unknown__", DUMMY_SP),
+                    )),
+                }
+            }
+            PatternLike::ArrayPattern(_arr) => {
+                let pat = self.convert_pattern(pattern);
+                match pat {
+                    Pat::Array(arr_pat) => AssignTarget::Pat(AssignTargetPat::Array(arr_pat)),
+                    _ => AssignTarget::Simple(SimpleAssignTarget::Ident(
+                        self.binding_ident("__unknown__", DUMMY_SP),
+                    )),
+                }
+            }
+            PatternLike::AssignmentPattern(ap) => {
+                // For assignment LHS, use the left side
+                self.convert_pattern_to_assign_target(&ap.left)
+            }
+            PatternLike::RestElement(r) => self.convert_pattern_to_assign_target(&r.argument),
+            PatternLike::TSAsExpression(_)
+            | PatternLike::TSSatisfiesExpression(_)
+            | PatternLike::TSNonNullExpression(_)
+            | PatternLike::TSTypeAssertion(_)
+            | PatternLike::TypeCastExpression(_) => AssignTarget::Simple(
+                SimpleAssignTarget::Ident(self.binding_ident("__unknown__", DUMMY_SP)),
+            ),
+        }
+    }
+
+    // ===== JSX =====
+
+    fn convert_jsx_element(
+        &self,
+        el: &react_compiler_ast::jsx::JSXElement,
+    ) -> swc_core::ecma::ast::JSXElement {
+        let opening = self.convert_jsx_opening_element(&el.opening_element);
+        let children: Vec<swc_core::ecma::ast::JSXElementChild> = el
+            .children
+            .iter()
+            .map(|c| self.convert_jsx_child(c))
+            .collect();
+        let closing = el
+            .closing_element
+            .as_ref()
+            .map(|c| self.convert_jsx_closing_element(c));
+        swc_core::ecma::ast::JSXElement {
+            span: self.span(&el.base),
+            opening,
+            children,
+            closing,
+        }
+    }
+
+    fn convert_jsx_opening_element(
+        &self,
+        el: &react_compiler_ast::jsx::JSXOpeningElement,
+    ) -> swc_core::ecma::ast::JSXOpeningElement {
+        let name = self.convert_jsx_element_name(&el.name);
+        let attrs = el
+            .attributes
+            .iter()
+            .map(|a| self.convert_jsx_attribute_item(a))
+            .collect();
+        swc_core::ecma::ast::JSXOpeningElement {
+            span: self.span(&el.base),
+            name,
+            attrs,
+            self_closing: el.self_closing,
+            type_args: None,
+        }
+    }
+
+    fn convert_jsx_closing_element(
+        &self,
+        el: &react_compiler_ast::jsx::JSXClosingElement,
+    ) -> swc_core::ecma::ast::JSXClosingElement {
+        let name = self.convert_jsx_element_name(&el.name);
+        swc_core::ecma::ast::JSXClosingElement {
+            span: self.span(&el.base),
+            name,
+        }
+    }
+
+    fn convert_jsx_element_name(
+        &self,
+        name: &react_compiler_ast::jsx::JSXElementName,
+    ) -> swc_core::ecma::ast::JSXElementName {
+        match name {
+            react_compiler_ast::jsx::JSXElementName::JSXIdentifier(id) => {
+                swc_core::ecma::ast::JSXElementName::Ident(
+                    self.ident(&id.name, self.span(&id.base)),
+                )
+            }
+            react_compiler_ast::jsx::JSXElementName::JSXMemberExpression(m) => {
+                let member = self.convert_jsx_member_expression(m);
+                swc_core::ecma::ast::JSXElementName::JSXMemberExpr(member)
+            }
+            react_compiler_ast::jsx::JSXElementName::JSXNamespacedName(ns) => {
+                let namespace = self.ident_name(&ns.namespace.name, self.span(&ns.namespace.base));
+                let name = self.ident_name(&ns.name.name, self.span(&ns.name.base));
+                swc_core::ecma::ast::JSXElementName::JSXNamespacedName(
+                    swc_core::ecma::ast::JSXNamespacedName {
+                        span: DUMMY_SP,
+                        ns: namespace,
+                        name,
+                    },
+                )
+            }
+        }
+    }
+
+    fn convert_jsx_member_expression(
+        &self,
+        m: &react_compiler_ast::jsx::JSXMemberExpression,
+    ) -> swc_core::ecma::ast::JSXMemberExpr {
+        let obj = self.convert_jsx_member_expression_object(&m.object);
+        let prop = self.ident_name(&m.property.name, self.span(&m.property.base));
+        swc_core::ecma::ast::JSXMemberExpr {
+            span: DUMMY_SP,
+            obj,
+            prop,
+        }
+    }
+
+    fn convert_jsx_member_expression_object(
+        &self,
+        obj: &react_compiler_ast::jsx::JSXMemberExprObject,
+    ) -> swc_core::ecma::ast::JSXObject {
+        match obj {
+            react_compiler_ast::jsx::JSXMemberExprObject::JSXIdentifier(id) => {
+                swc_core::ecma::ast::JSXObject::Ident(self.ident(&id.name, self.span(&id.base)))
+            }
+            react_compiler_ast::jsx::JSXMemberExprObject::JSXMemberExpression(m) => {
+                let member = self.convert_jsx_member_expression(m);
+                swc_core::ecma::ast::JSXObject::JSXMemberExpr(Box::new(member))
+            }
+        }
+    }
+
+    fn convert_jsx_attribute_item(
+        &self,
+        item: &react_compiler_ast::jsx::JSXAttributeItem,
+    ) -> swc_core::ecma::ast::JSXAttrOrSpread {
+        match item {
+            react_compiler_ast::jsx::JSXAttributeItem::JSXAttribute(attr) => {
+                let name = self.convert_jsx_attribute_name(&attr.name);
+                let value = attr
+                    .value
+                    .as_ref()
+                    .map(|v| self.convert_jsx_attribute_value(v));
+                swc_core::ecma::ast::JSXAttrOrSpread::JSXAttr(swc_core::ecma::ast::JSXAttr {
+                    span: self.span(&attr.base),
+                    name,
+                    value,
+                })
+            }
+            react_compiler_ast::jsx::JSXAttributeItem::JSXSpreadAttribute(s) => {
+                swc_core::ecma::ast::JSXAttrOrSpread::SpreadElement(SpreadElement {
+                    dot3_token: self.span(&s.base),
+                    expr: Box::new(self.convert_expression(&s.argument)),
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_attribute_name(
+        &self,
+        name: &react_compiler_ast::jsx::JSXAttributeName,
+    ) -> swc_core::ecma::ast::JSXAttrName {
+        match name {
+            react_compiler_ast::jsx::JSXAttributeName::JSXIdentifier(id) => {
+                swc_core::ecma::ast::JSXAttrName::Ident(
+                    self.ident_name(&id.name, self.span(&id.base)),
+                )
+            }
+            react_compiler_ast::jsx::JSXAttributeName::JSXNamespacedName(ns) => {
+                let namespace = self.ident_name(&ns.namespace.name, self.span(&ns.namespace.base));
+                let name = self.ident_name(&ns.name.name, self.span(&ns.name.base));
+                swc_core::ecma::ast::JSXAttrName::JSXNamespacedName(
+                    swc_core::ecma::ast::JSXNamespacedName {
+                        span: DUMMY_SP,
+                        ns: namespace,
+                        name,
+                    },
+                )
+            }
+        }
+    }
+
+    fn convert_jsx_attribute_value(
+        &self,
+        value: &react_compiler_ast::jsx::JSXAttributeValue,
+    ) -> swc_core::ecma::ast::JSXAttrValue {
+        match value {
+            react_compiler_ast::jsx::JSXAttributeValue::StringLiteral(s) => {
+                // For JSX attributes, if the value contains double quotes,
+                // use single quotes to avoid escaping issues that prettier
+                // can't parse (e.g., name="\"user\" name").
+                let raw = if s.value.contains('"') {
+                    Some(Atom::from(format!(
+                        "'{}'",
+                        s.value.replace('\\', "\\\\").replace('\'', "\\'")
+                    )))
+                } else {
+                    self.escape_string_raw(&s.value)
+                };
+                swc_core::ecma::ast::JSXAttrValue::Str(Str {
+                    span: self.span(&s.base),
+                    value: self.wtf8(&s.value),
+                    raw,
+                })
+            }
+            react_compiler_ast::jsx::JSXAttributeValue::JSXExpressionContainer(ec) => {
+                let expr = self.convert_jsx_expression_container_expr(&ec.expression);
+                swc_core::ecma::ast::JSXAttrValue::JSXExprContainer(
+                    swc_core::ecma::ast::JSXExprContainer {
+                        span: self.span(&ec.base),
+                        expr,
+                    },
+                )
+            }
+            react_compiler_ast::jsx::JSXAttributeValue::JSXElement(el) => {
+                let element = self.convert_jsx_element(el.as_ref());
+                swc_core::ecma::ast::JSXAttrValue::JSXElement(Box::new(element))
+            }
+            react_compiler_ast::jsx::JSXAttributeValue::JSXFragment(frag) => {
+                let fragment = self.convert_jsx_fragment(frag);
+                swc_core::ecma::ast::JSXAttrValue::JSXFragment(fragment)
+            }
+        }
+    }
+
+    fn convert_jsx_expression_container_expr(
+        &self,
+        expr: &react_compiler_ast::jsx::JSXExpressionContainerExpr,
+    ) -> swc_core::ecma::ast::JSXExpr {
+        match expr {
+            react_compiler_ast::jsx::JSXExpressionContainerExpr::JSXEmptyExpression(e) => {
+                swc_core::ecma::ast::JSXExpr::JSXEmptyExpr(swc_core::ecma::ast::JSXEmptyExpr {
+                    span: self.span(&e.base),
+                })
+            }
+            react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(e) => {
+                swc_core::ecma::ast::JSXExpr::Expr(Box::new(self.convert_expression(e)))
+            }
+        }
+    }
+
+    fn convert_jsx_child(
+        &self,
+        child: &react_compiler_ast::jsx::JSXChild,
+    ) -> swc_core::ecma::ast::JSXElementChild {
+        match child {
+            react_compiler_ast::jsx::JSXChild::JSXText(t) => {
+                swc_core::ecma::ast::JSXElementChild::JSXText(swc_core::ecma::ast::JSXText {
+                    span: self.span(&t.base),
+                    value: self.atom(&t.value),
+                    raw: self.atom(&t.value),
+                })
+            }
+            react_compiler_ast::jsx::JSXChild::JSXElement(el) => {
+                let element = self.convert_jsx_element(el.as_ref());
+                swc_core::ecma::ast::JSXElementChild::JSXElement(Box::new(element))
+            }
+            react_compiler_ast::jsx::JSXChild::JSXFragment(frag) => {
+                let fragment = self.convert_jsx_fragment(frag);
+                swc_core::ecma::ast::JSXElementChild::JSXFragment(fragment)
+            }
+            react_compiler_ast::jsx::JSXChild::JSXExpressionContainer(ec) => {
+                let expr = self.convert_jsx_expression_container_expr(&ec.expression);
+                swc_core::ecma::ast::JSXElementChild::JSXExprContainer(
+                    swc_core::ecma::ast::JSXExprContainer {
+                        span: self.span(&ec.base),
+                        expr,
+                    },
+                )
+            }
+            react_compiler_ast::jsx::JSXChild::JSXSpreadChild(s) => {
+                swc_core::ecma::ast::JSXElementChild::JSXSpreadChild(
+                    swc_core::ecma::ast::JSXSpreadChild {
+                        span: self.span(&s.base),
+                        expr: Box::new(self.convert_expression(&s.expression)),
+                    },
+                )
+            }
+        }
+    }
+
+    fn convert_jsx_fragment(
+        &self,
+        frag: &react_compiler_ast::jsx::JSXFragment,
+    ) -> swc_core::ecma::ast::JSXFragment {
+        let children = frag
+            .children
+            .iter()
+            .map(|c| self.convert_jsx_child(c))
+            .collect();
+        swc_core::ecma::ast::JSXFragment {
+            span: self.span(&frag.base),
+            opening: swc_core::ecma::ast::JSXOpeningFragment {
+                span: self.span(&frag.opening_fragment.base),
+            },
+            children,
+            closing: swc_core::ecma::ast::JSXClosingFragment {
+                span: self.span(&frag.closing_fragment.base),
+            },
+        }
+    }
+
+    // ===== Import/Export =====
+
+    fn convert_import_declaration(
+        &self,
+        decl: &ImportDeclaration,
+    ) -> swc_core::ecma::ast::ImportDecl {
+        let specifiers = decl
+            .specifiers
+            .iter()
+            .map(|s| self.convert_import_specifier(s))
+            .collect();
+        let src = Box::new(Str {
+            span: self.span(&decl.source.base),
+            value: self.wtf8(&decl.source.value),
+            raw: None,
+        });
+        let type_only = matches!(decl.import_kind.as_ref(), Some(ImportKind::Type));
+        swc_core::ecma::ast::ImportDecl {
+            span: self.span(&decl.base),
+            specifiers,
+            src,
+            type_only,
+            with: None,
+            phase: Default::default(),
+        }
+    }
+
+    fn convert_import_specifier(
+        &self,
+        spec: &react_compiler_ast::declarations::ImportSpecifier,
+    ) -> swc_core::ecma::ast::ImportSpecifier {
+        match spec {
+            react_compiler_ast::declarations::ImportSpecifier::ImportSpecifier(s) => {
+                let local = self.ident(&s.local.name, self.span(&s.local.base));
+                // Only set `imported` if it differs from `local` — otherwise
+                // SWC emits `foo as foo` instead of just `foo`.
+                let imported_name = match &s.imported {
+                    react_compiler_ast::declarations::ModuleExportName::Identifier(id) => {
+                        Some(&id.name)
+                    }
+                    react_compiler_ast::declarations::ModuleExportName::StringLiteral(_) => None,
+                };
+                let imported = if imported_name == Some(&s.local.name) {
+                    None
+                } else {
+                    Some(self.convert_module_export_name(&s.imported))
+                };
+                let is_type_only = matches!(s.import_kind.as_ref(), Some(ImportKind::Type));
+                swc_core::ecma::ast::ImportSpecifier::Named(ImportNamedSpecifier {
+                    span: self.span(&s.base),
+                    local,
+                    imported,
+                    is_type_only,
+                })
+            }
+            react_compiler_ast::declarations::ImportSpecifier::ImportDefaultSpecifier(s) => {
+                let local = self.ident(&s.local.name, self.span(&s.local.base));
+                swc_core::ecma::ast::ImportSpecifier::Default(ImportDefaultSpecifier {
+                    span: self.span(&s.base),
+                    local,
+                })
+            }
+            react_compiler_ast::declarations::ImportSpecifier::ImportNamespaceSpecifier(s) => {
+                let local = self.ident(&s.local.name, self.span(&s.local.base));
+                swc_core::ecma::ast::ImportSpecifier::Namespace(ImportStarAsSpecifier {
+                    span: self.span(&s.base),
+                    local,
+                })
+            }
+        }
+    }
+
+    fn convert_module_export_name(
+        &self,
+        name: &react_compiler_ast::declarations::ModuleExportName,
+    ) -> swc_core::ecma::ast::ModuleExportName {
+        match name {
+            react_compiler_ast::declarations::ModuleExportName::Identifier(id) => {
+                swc_core::ecma::ast::ModuleExportName::Ident(
+                    self.ident(&id.name, self.span(&id.base)),
+                )
+            }
+            react_compiler_ast::declarations::ModuleExportName::StringLiteral(s) => {
+                swc_core::ecma::ast::ModuleExportName::Str(Str {
+                    span: self.span(&s.base),
+                    value: self.wtf8(&s.value),
+                    raw: None,
+                })
+            }
+        }
+    }
+
+    fn convert_export_named_to_module_item(&self, decl: &ExportNamedDeclaration) -> ModuleItem {
+        // If there's a declaration, emit as ExportDecl
+        if let Some(declaration) = &decl.declaration {
+            let swc_decl = self.convert_declaration(declaration);
+            return ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                span: self.span(&decl.base),
+                decl: swc_decl,
+            }));
+        }
+        self.convert_export_named_specifiers(decl)
+    }
+
+    fn convert_declaration(&self, decl: &react_compiler_ast::declarations::Declaration) -> Decl {
+        match decl {
+            react_compiler_ast::declarations::Declaration::FunctionDeclaration(f) => {
+                Decl::Fn(self.convert_function_declaration(f))
+            }
+            react_compiler_ast::declarations::Declaration::VariableDeclaration(v) => {
+                Decl::Var(Box::new(self.convert_variable_declaration(v)))
+            }
+            react_compiler_ast::declarations::Declaration::ClassDeclaration(c) => {
+                let ident =
+                    c.id.as_ref()
+                        .map(|id| self.ident(&id.name, self.span(&id.base)))
+                        .unwrap_or_else(|| self.ident("_anonymous", DUMMY_SP));
+                let super_class = c
+                    .super_class
+                    .as_ref()
+                    .map(|s| Box::new(self.convert_expression(s)));
+                Decl::Class(ClassDecl {
+                    ident,
+                    declare: c.declare.unwrap_or(false),
+                    class: Box::new(Class {
+                        span: self.span(&c.base),
+                        ctxt: SyntaxContext::empty(),
+                        decorators: vec![],
+                        body: vec![],
+                        super_class,
+                        is_abstract: false,
+                        type_params: None,
+                        super_type_params: None,
+                        implements: vec![],
+                    }),
+                })
+            }
+            _ => Decl::Var(Box::new(VarDecl {
+                span: DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
+                kind: VarDeclKind::Const,
+                declare: true,
+                decls: vec![],
+            })),
+        }
+    }
+
+    fn convert_export_named_specifiers(&self, decl: &ExportNamedDeclaration) -> ModuleItem {
+        let specifiers = decl
+            .specifiers
+            .iter()
+            .map(|s| self.convert_export_specifier(s))
+            .collect();
+        let src = decl.source.as_ref().map(|s| {
+            Box::new(Str {
+                span: self.span(&s.base),
+                value: self.wtf8(&s.value),
+                raw: None,
+            })
+        });
+        let type_only = matches!(decl.export_kind.as_ref(), Some(ExportKind::Type));
+
+        ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+            span: self.span(&decl.base),
+            specifiers,
+            src,
+            type_only,
+            with: None,
+        }))
+    }
+
+    fn convert_export_specifier(
+        &self,
+        spec: &react_compiler_ast::declarations::ExportSpecifier,
+    ) -> swc_core::ecma::ast::ExportSpecifier {
+        match spec {
+            react_compiler_ast::declarations::ExportSpecifier::ExportSpecifier(s) => {
+                let orig = self.convert_module_export_name(&s.local);
+                // Only set `exported` if it differs from `local`
+                let local_name = match &s.local {
+                    react_compiler_ast::declarations::ModuleExportName::Identifier(id) => {
+                        Some(&id.name)
+                    }
+                    _ => None,
+                };
+                let exported_name = match &s.exported {
+                    react_compiler_ast::declarations::ModuleExportName::Identifier(id) => {
+                        Some(&id.name)
+                    }
+                    _ => None,
+                };
+                let exported = if local_name.is_some() && local_name == exported_name {
+                    None
+                } else {
+                    Some(self.convert_module_export_name(&s.exported))
+                };
+                let is_type_only = matches!(s.export_kind.as_ref(), Some(ExportKind::Type));
+                swc_core::ecma::ast::ExportSpecifier::Named(ExportNamedSpecifier {
+                    span: self.span(&s.base),
+                    orig,
+                    exported,
+                    is_type_only,
+                })
+            }
+            react_compiler_ast::declarations::ExportSpecifier::ExportDefaultSpecifier(s) => {
+                swc_core::ecma::ast::ExportSpecifier::Default(
+                    swc_core::ecma::ast::ExportDefaultSpecifier {
+                        exported: self.ident(&s.exported.name, self.span(&s.exported.base)),
+                    },
+                )
+            }
+            react_compiler_ast::declarations::ExportSpecifier::ExportNamespaceSpecifier(s) => {
+                let name = self.convert_module_export_name(&s.exported);
+                swc_core::ecma::ast::ExportSpecifier::Namespace(ExportNamespaceSpecifier {
+                    span: self.span(&s.base),
+                    name,
+                })
+            }
+        }
+    }
+
+    fn convert_export_default_to_module_item(&self, decl: &ExportDefaultDeclaration) -> ModuleItem {
+        let span = self.span(&decl.base);
+        match &*decl.declaration {
+            BabelExportDefaultDecl::FunctionDeclaration(f) => {
+                let fd = self.convert_function_declaration(f);
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(
+                    swc_core::ecma::ast::ExportDefaultDecl {
+                        span,
+                        decl: swc_core::ecma::ast::DefaultDecl::Fn(FnExpr {
+                            ident: Some(fd.ident),
+                            function: fd.function,
+                        }),
+                    },
+                ))
+            }
+            BabelExportDefaultDecl::ClassDeclaration(c) => {
+                let ident =
+                    c.id.as_ref()
+                        .map(|id| self.ident(&id.name, self.span(&id.base)));
+                let super_class = c
+                    .super_class
+                    .as_ref()
+                    .map(|s| Box::new(self.convert_expression(s)));
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(
+                    swc_core::ecma::ast::ExportDefaultDecl {
+                        span,
+                        decl: swc_core::ecma::ast::DefaultDecl::Class(ClassExpr {
+                            ident,
+                            class: Box::new(Class {
+                                span,
+                                ctxt: SyntaxContext::empty(),
+                                decorators: vec![],
+                                body: vec![],
+                                super_class,
+                                is_abstract: false,
+                                type_params: None,
+                                super_type_params: None,
+                                implements: vec![],
+                            }),
+                        }),
+                    },
+                ))
+            }
+            BabelExportDefaultDecl::EnumDeclaration(_) => {
+                // Flow enum declarations cannot be represented in SWC AST;
+                // emit a null placeholder to preserve the export shape.
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
+                    span,
+                    expr: Box::new(swc_core::ecma::ast::Expr::Lit(
+                        swc_core::ecma::ast::Lit::Null(swc_core::ecma::ast::Null { span }),
+                    )),
+                }))
+            }
+            BabelExportDefaultDecl::Expression(e) => {
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
+                    span,
+                    expr: Box::new(self.convert_expression(e)),
+                }))
+            }
+        }
+    }
+
+    fn convert_export_all_declaration(
+        &self,
+        decl: &ExportAllDeclaration,
+    ) -> swc_core::ecma::ast::ExportAll {
+        let src = Box::new(Str {
+            span: self.span(&decl.source.base),
+            value: self.wtf8(&decl.source.value),
+            raw: None,
+        });
+        let type_only = matches!(decl.export_kind.as_ref(), Some(ExportKind::Type));
+        swc_core::ecma::ast::ExportAll {
+            span: self.span(&decl.base),
+            src,
+            type_only,
+            with: None,
+        }
+    }
+
+    // ===== TS type helpers =====
+
+    /// Convert a Babel TSTypeAnnotation JSON to an SWC TsTypeAnnotation.
+    /// Returns None if the JSON is not a valid type annotation.
+    fn convert_ts_type_annotation_from_json(
+        &self,
+        json: &serde_json::Value,
+    ) -> Option<Box<TsTypeAnn>> {
+        let type_name = json.get("type")?.as_str()?;
+        if type_name != "TSTypeAnnotation" && type_name != "TypeAnnotation" {
+            return None;
+        }
+        let type_annotation = json.get("typeAnnotation")?;
+        let ts_type = self.convert_ts_type_from_json(type_annotation, DUMMY_SP);
+        Some(Box::new(TsTypeAnn {
+            span: DUMMY_SP,
+            type_ann: Box::new(ts_type),
+        }))
+    }
+
+    /// Convert a JSON-serialized TypeScript type annotation to an SWC TsType.
+    /// This handles common cases from the compiler's output. For unrecognized
+    /// types, it falls back to `any`.
+    fn convert_ts_type_from_json(&self, json: &serde_json::Value, span: Span) -> TsType {
+        let type_name = json.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        match type_name {
+            "TSTypeReference" => {
+                let name = json
+                    .get("typeName")
+                    .and_then(|tn| tn.get("name"))
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("unknown");
+                if name == "const" {
+                    TsType::TsTypeRef(TsTypeRef {
+                        span,
+                        type_name: TsEntityName::Ident(self.ident("const", span)),
+                        type_params: None,
+                    })
+                } else {
+                    TsType::TsTypeRef(TsTypeRef {
+                        span,
+                        type_name: TsEntityName::Ident(self.ident(name, span)),
+                        type_params: None,
+                    })
+                }
+            }
+            "TSNumberKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsNumberKeyword,
+            }),
+            "TSStringKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsStringKeyword,
+            }),
+            "TSBooleanKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsBooleanKeyword,
+            }),
+            "TSVoidKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsVoidKeyword,
+            }),
+            "TSNullKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsNullKeyword,
+            }),
+            "TSUndefinedKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsUndefinedKeyword,
+            }),
+            "TSAnyKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsAnyKeyword,
+            }),
+            "TSNeverKeyword" => TsType::TsKeywordType(TsKeywordType {
+                span,
+                kind: TsKeywordTypeKind::TsNeverKeyword,
+            }),
+            "TSUnionType" => {
+                let types = json
+                    .get("types")
+                    .and_then(|t| t.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|t| Box::new(self.convert_ts_type_from_json(t, span)))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(
+                    TsUnionType { span, types },
+                ))
+            }
+            "TSIntersectionType" => {
+                let types = json
+                    .get("types")
+                    .and_then(|t| t.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|t| Box::new(self.convert_ts_type_from_json(t, span)))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsIntersectionType(
+                    TsIntersectionType { span, types },
+                ))
+            }
+            "TSLiteralType" => {
+                if let Some(literal) = json.get("literal") {
+                    let lit_type = literal.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    match lit_type {
+                        "StringLiteral" => {
+                            let value = literal.get("value").and_then(|v| v.as_str()).unwrap_or("");
+                            TsType::TsLitType(TsLitType {
+                                span,
+                                lit: TsLit::Str(Str {
+                                    span,
+                                    value: self.wtf8(value),
+                                    raw: None,
+                                }),
+                            })
+                        }
+                        "NumericLiteral" => {
+                            let value =
+                                literal.get("value").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                            TsType::TsLitType(TsLitType {
+                                span,
+                                lit: TsLit::Number(Number {
+                                    span,
+                                    value,
+                                    raw: None,
+                                }),
+                            })
+                        }
+                        "BooleanLiteral" => {
+                            let value = literal
+                                .get("value")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false);
+                            TsType::TsLitType(TsLitType {
+                                span,
+                                lit: TsLit::Bool(Bool { span, value }),
+                            })
+                        }
+                        _ => TsType::TsKeywordType(TsKeywordType {
+                            span,
+                            kind: TsKeywordTypeKind::TsAnyKeyword,
+                        }),
+                    }
+                } else {
+                    TsType::TsKeywordType(TsKeywordType {
+                        span,
+                        kind: TsKeywordTypeKind::TsAnyKeyword,
+                    })
+                }
+            }
+            "TSArrayType" => {
+                let elem = json
+                    .get("elementType")
+                    .map(|t| self.convert_ts_type_from_json(t, span))
+                    .unwrap_or(TsType::TsKeywordType(TsKeywordType {
+                        span,
+                        kind: TsKeywordTypeKind::TsAnyKeyword,
+                    }));
+                TsType::TsArrayType(TsArrayType {
+                    span,
+                    elem_type: Box::new(elem),
+                })
+            }
+            "TSFunctionType"
+            | "TSTypeLiteral"
+            | "TSParenthesizedType"
+            | "TSTupleType"
+            | "TSOptionalType"
+            | "TSRestType"
+            | "TSConditionalType"
+            | "TSInferType"
+            | "TSMappedType"
+            | "TSIndexedAccessType"
+            | "TSTypeOperator"
+            | "TSTypePredicate"
+            | "TSImportType"
+            | "TSQualifiedName" => {
+                // For complex types, try to extract from source text
+                if let (Some(source), Some(start), Some(end)) = (
+                    self.source_text.as_deref(),
+                    json.get("start").and_then(|v| v.as_u64()),
+                    json.get("end").and_then(|v| v.as_u64()),
+                ) {
+                    let start_idx = (start as usize).saturating_sub(1);
+                    let end_idx = (end as usize).saturating_sub(1);
+                    if start_idx < source.len() && end_idx <= source.len() && start_idx < end_idx {
+                        let text = &source[start_idx..end_idx];
+                        // Parse the type using SWC
+                        let wrapper = format!("type __T = {};", text);
+                        let cm = swc_core::common::sync::Lrc::new(
+                            swc_core::common::SourceMap::default(),
+                        );
+                        let fm = cm.new_source_file(
+                            swc_core::common::sync::Lrc::new(swc_core::common::FileName::Anon),
+                            wrapper,
+                        );
+                        let mut errors = vec![];
+                        if let Ok(module) = swc_core::ecma::parser::parse_file_as_module(
+                            &fm,
+                            swc_core::ecma::parser::Syntax::Typescript(
+                                swc_core::ecma::parser::TsSyntax {
+                                    tsx: true,
+                                    ..Default::default()
+                                },
+                            ),
+                            swc_core::ecma::ast::EsVersion::latest(),
+                            None,
+                            &mut errors,
+                        ) {
+                            if let Some(ModuleItem::Stmt(Stmt::Decl(Decl::TsTypeAlias(alias)))) =
+                                module.body.into_iter().next()
+                            {
+                                return *alias.type_ann;
+                            }
+                        }
+                    }
+                }
+                // Fallback
+                TsType::TsKeywordType(TsKeywordType {
+                    span,
+                    kind: TsKeywordTypeKind::TsAnyKeyword,
+                })
+            }
+            // Flow types
+            "NumberTypeAnnotation"
+            | "StringTypeAnnotation"
+            | "BooleanTypeAnnotation"
+            | "VoidTypeAnnotation"
+            | "NullLiteralTypeAnnotation"
+            | "AnyTypeAnnotation"
+            | "GenericTypeAnnotation"
+            | "UnionTypeAnnotation"
+            | "IntersectionTypeAnnotation"
+            | "NullableTypeAnnotation"
+            | "FunctionTypeAnnotation"
+            | "ObjectTypeAnnotation"
+            | "ArrayTypeAnnotation"
+            | "TupleTypeAnnotation"
+            | "TypeofTypeAnnotation"
+            | "NumberLiteralTypeAnnotation"
+            | "StringLiteralTypeAnnotation"
+            | "BooleanLiteralTypeAnnotation" => {
+                // For Flow types, try to extract from source text
+                if let (Some(source), Some(start), Some(end)) = (
+                    self.source_text.as_deref(),
+                    json.get("start").and_then(|v| v.as_u64()),
+                    json.get("end").and_then(|v| v.as_u64()),
+                ) {
+                    let start_idx = (start as usize).saturating_sub(1);
+                    let end_idx = (end as usize).saturating_sub(1);
+                    if start_idx < source.len() && end_idx <= source.len() && start_idx < end_idx {
+                        let text = &source[start_idx..end_idx];
+                        // For Flow types, we can use TS parser as many simple types
+                        // have the same syntax
+                        let wrapper = format!("type __T = {};", text);
+                        let cm = swc_core::common::sync::Lrc::new(
+                            swc_core::common::SourceMap::default(),
+                        );
+                        let fm = cm.new_source_file(
+                            swc_core::common::sync::Lrc::new(swc_core::common::FileName::Anon),
+                            wrapper,
+                        );
+                        let mut errors = vec![];
+                        if let Ok(module) = swc_core::ecma::parser::parse_file_as_module(
+                            &fm,
+                            swc_core::ecma::parser::Syntax::Typescript(
+                                swc_core::ecma::parser::TsSyntax {
+                                    tsx: true,
+                                    ..Default::default()
+                                },
+                            ),
+                            swc_core::ecma::ast::EsVersion::latest(),
+                            None,
+                            &mut errors,
+                        ) {
+                            if let Some(ModuleItem::Stmt(Stmt::Decl(Decl::TsTypeAlias(alias)))) =
+                                module.body.into_iter().next()
+                            {
+                                return *alias.type_ann;
+                            }
+                        }
+                    }
+                }
+                // Fallback
+                TsType::TsKeywordType(TsKeywordType {
+                    span,
+                    kind: TsKeywordTypeKind::TsAnyKeyword,
+                })
+            }
+            _ => {
+                // Fallback: emit `any` type
+                TsType::TsKeywordType(TsKeywordType {
+                    span,
+                    kind: TsKeywordTypeKind::TsAnyKeyword,
+                })
+            }
+        }
+    }
+
+    // ===== Operators =====
+
+    fn convert_binary_operator(&self, op: &BinaryOperator) -> BinaryOp {
+        match op {
+            BinaryOperator::Add => BinaryOp::Add,
+            BinaryOperator::Sub => BinaryOp::Sub,
+            BinaryOperator::Mul => BinaryOp::Mul,
+            BinaryOperator::Div => BinaryOp::Div,
+            BinaryOperator::Rem => BinaryOp::Mod,
+            BinaryOperator::Exp => BinaryOp::Exp,
+            BinaryOperator::Eq => BinaryOp::EqEq,
+            BinaryOperator::StrictEq => BinaryOp::EqEqEq,
+            BinaryOperator::Neq => BinaryOp::NotEq,
+            BinaryOperator::StrictNeq => BinaryOp::NotEqEq,
+            BinaryOperator::Lt => BinaryOp::Lt,
+            BinaryOperator::Lte => BinaryOp::LtEq,
+            BinaryOperator::Gt => BinaryOp::Gt,
+            BinaryOperator::Gte => BinaryOp::GtEq,
+            BinaryOperator::Shl => BinaryOp::LShift,
+            BinaryOperator::Shr => BinaryOp::RShift,
+            BinaryOperator::UShr => BinaryOp::ZeroFillRShift,
+            BinaryOperator::BitOr => BinaryOp::BitOr,
+            BinaryOperator::BitXor => BinaryOp::BitXor,
+            BinaryOperator::BitAnd => BinaryOp::BitAnd,
+            BinaryOperator::In => BinaryOp::In,
+            BinaryOperator::Instanceof => BinaryOp::InstanceOf,
+            BinaryOperator::Pipeline => BinaryOp::BitOr, // no pipeline in SWC
+        }
+    }
+
+    fn convert_logical_operator(&self, op: &LogicalOperator) -> BinaryOp {
+        match op {
+            LogicalOperator::Or => BinaryOp::LogicalOr,
+            LogicalOperator::And => BinaryOp::LogicalAnd,
+            LogicalOperator::NullishCoalescing => BinaryOp::NullishCoalescing,
+        }
+    }
+
+    fn convert_unary_operator(&self, op: &UnaryOperator) -> UnaryOp {
+        match op {
+            UnaryOperator::Neg => UnaryOp::Minus,
+            UnaryOperator::Plus => UnaryOp::Plus,
+            UnaryOperator::Not => UnaryOp::Bang,
+            UnaryOperator::BitNot => UnaryOp::Tilde,
+            UnaryOperator::TypeOf => UnaryOp::TypeOf,
+            UnaryOperator::Void => UnaryOp::Void,
+            UnaryOperator::Delete => UnaryOp::Delete,
+            UnaryOperator::Throw => UnaryOp::Void, // no throw-as-unary in SWC
+        }
+    }
+
+    fn convert_update_operator(&self, op: &UpdateOperator) -> UpdateOp {
+        match op {
+            UpdateOperator::Increment => UpdateOp::PlusPlus,
+            UpdateOperator::Decrement => UpdateOp::MinusMinus,
+        }
+    }
+
+    fn convert_assignment_operator(&self, op: &AssignmentOperator) -> AssignOp {
+        match op {
+            AssignmentOperator::Assign => AssignOp::Assign,
+            AssignmentOperator::AddAssign => AssignOp::AddAssign,
+            AssignmentOperator::SubAssign => AssignOp::SubAssign,
+            AssignmentOperator::MulAssign => AssignOp::MulAssign,
+            AssignmentOperator::DivAssign => AssignOp::DivAssign,
+            AssignmentOperator::RemAssign => AssignOp::ModAssign,
+            AssignmentOperator::ExpAssign => AssignOp::ExpAssign,
+            AssignmentOperator::ShlAssign => AssignOp::LShiftAssign,
+            AssignmentOperator::ShrAssign => AssignOp::RShiftAssign,
+            AssignmentOperator::UShrAssign => AssignOp::ZeroFillRShiftAssign,
+            AssignmentOperator::BitOrAssign => AssignOp::BitOrAssign,
+            AssignmentOperator::BitXorAssign => AssignOp::BitXorAssign,
+            AssignmentOperator::BitAndAssign => AssignOp::BitAndAssign,
+            AssignmentOperator::OrAssign => AssignOp::OrAssign,
+            AssignmentOperator::AndAssign => AssignOp::AndAssign,
+            AssignmentOperator::NullishAssign => AssignOp::NullishAssign,
+        }
+    }
+}

--- a/turbopack/crates/react_compiler_swc/src/convert_scope.rs
+++ b/turbopack/crates/react_compiler_swc/src/convert_scope.rs
@@ -1,0 +1,993 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use std::collections::{HashMap, HashSet};
+
+use indexmap::IndexMap;
+use react_compiler_ast::scope::*;
+use swc_core::ecma::{
+    ast::*,
+    visit::{Visit, VisitWith},
+};
+
+/// Helper to convert an SWC `Str` node's value to a Rust String.
+/// `Str.value` is a `Wtf8Atom` which doesn't implement `Display`,
+/// so we go through `Atom` via lossy conversion.
+fn str_value_to_string(s: &Str) -> String {
+    s.value.to_atom_lossy().to_string()
+}
+
+/// Build scope information from an SWC Module AST.
+///
+/// This performs two passes over the AST:
+/// 1. Build the scope tree and collect all bindings
+/// 2. Resolve identifier references to their bindings
+pub fn build_scope_info(module: &Module) -> ScopeInfo {
+    // Pass 1: Build scope tree and collect bindings
+    let mut collector = ScopeCollector::new();
+    collector.visit_module(module);
+
+    // Pass 2: Resolve references
+    // We scope the resolver borrow so we can move out of collector afterwards.
+    // Build ref_node_id_to_binding directly. In SWC, node_id == span.lo
+    // (unique positions), so the resolver's position-keyed map serves as
+    // both reference_to_binding and ref_node_id_to_binding.
+    let ref_node_id_to_binding = {
+        let mut resolver = ReferenceResolver::new(&collector);
+        resolver.visit_module(module);
+
+        // Also map declaration identifiers to their bindings
+        for binding in &collector.bindings {
+            if let Some(start) = binding.declaration_start {
+                resolver
+                    .reference_to_binding
+                    .entry(start)
+                    .or_insert(binding.id);
+            }
+        }
+
+        // Function redeclarations: resolve the second `function x()`'s ident
+        // to the first declaration's binding (overwrites any earlier entry).
+        for (start, binding_id) in &collector.redeclaration_refs {
+            resolver.reference_to_binding.insert(*start, *binding_id);
+        }
+
+        resolver.reference_to_binding
+    };
+
+    let node_id_to_scope = collector.node_to_scope.clone();
+
+    ScopeInfo {
+        scopes: collector.scopes,
+        bindings: collector.bindings,
+        node_to_scope: collector.node_to_scope,
+        node_to_scope_end: collector.node_to_scope_end,
+        reference_to_binding: indexmap::IndexMap::new(),
+        ref_node_id_to_binding,
+        node_id_to_scope,
+        program_scope: ScopeId(0),
+    }
+}
+
+// ── Pass 1: Scope tree + binding collection ─────────────────────────────────
+
+struct ScopeCollector {
+    scopes: Vec<ScopeData>,
+    bindings: Vec<BindingData>,
+    node_to_scope: HashMap<u32, ScopeId>,
+    node_to_scope_end: HashMap<u32, u32>,
+    /// Stack of scope IDs representing the current nesting.
+    scope_stack: Vec<ScopeId>,
+    /// Set of span starts for block statements that are direct function/catch bodies.
+    /// These should NOT create a separate Block scope.
+    function_body_spans: HashSet<u32>,
+    /// Function declarations that redeclare an existing hoisted name resolve to
+    /// the first binding's `BindingId` (like babel's `constantViolations`), so
+    /// the compiler treats the redeclaration as a reassignment rather than a
+    /// new binding.
+    redeclaration_refs: HashMap<u32, BindingId>,
+}
+
+impl ScopeCollector {
+    fn new() -> Self {
+        Self {
+            scopes: Vec::new(),
+            bindings: Vec::new(),
+            node_to_scope: HashMap::new(),
+            node_to_scope_end: HashMap::new(),
+            scope_stack: Vec::new(),
+            function_body_spans: HashSet::new(),
+            redeclaration_refs: HashMap::new(),
+        }
+    }
+
+    fn current_scope(&self) -> ScopeId {
+        *self.scope_stack.last().expect("scope stack is empty")
+    }
+
+    fn push_scope(&mut self, kind: ScopeKind, node_start: u32, node_end: u32) -> ScopeId {
+        let id = ScopeId(self.scopes.len() as u32);
+        let parent = self.scope_stack.last().copied();
+        self.scopes.push(ScopeData {
+            id,
+            parent,
+            kind,
+            bindings: HashMap::new(),
+        });
+        self.node_to_scope.insert(node_start, id);
+        if node_end > node_start {
+            self.node_to_scope_end.insert(node_start, node_end);
+        }
+        self.scope_stack.push(id);
+        id
+    }
+
+    fn pop_scope(&mut self) {
+        self.scope_stack.pop();
+    }
+
+    /// Find the nearest enclosing function or program scope (for hoisting `var` and function
+    /// decls).
+    fn enclosing_function_scope(&self) -> ScopeId {
+        for &scope_id in self.scope_stack.iter().rev() {
+            let scope = &self.scopes[scope_id.0 as usize];
+            match scope.kind {
+                ScopeKind::Function | ScopeKind::Program => return scope_id,
+                _ => {}
+            }
+        }
+        ScopeId(0)
+    }
+
+    fn add_binding(
+        &mut self,
+        name: String,
+        kind: BindingKind,
+        scope: ScopeId,
+        declaration_type: String,
+        declaration_start: Option<u32>,
+        import: Option<ImportBindingData>,
+    ) -> BindingId {
+        let id = BindingId(self.bindings.len() as u32);
+        self.bindings.push(BindingData {
+            id,
+            name: name.clone(),
+            kind,
+            scope,
+            declaration_type,
+            declaration_start,
+            declaration_node_id: declaration_start,
+            import,
+        });
+        self.scopes[scope.0 as usize].bindings.insert(name, id);
+        id
+    }
+
+    /// Extract all binding identifiers from a pattern, adding each as a binding.
+    fn collect_pat_bindings(
+        &mut self,
+        pat: &Pat,
+        kind: BindingKind,
+        scope: ScopeId,
+        declaration_type: &str,
+    ) {
+        match pat {
+            Pat::Ident(binding_ident) => {
+                let name = binding_ident.id.sym.to_string();
+                let start = binding_ident.id.span.lo.0;
+                self.add_binding(
+                    name,
+                    kind,
+                    scope,
+                    declaration_type.to_string(),
+                    Some(start),
+                    None,
+                );
+            }
+            Pat::Array(arr) => {
+                for elem in &arr.elems {
+                    if let Some(p) = elem {
+                        self.collect_pat_bindings(p, kind.clone(), scope, declaration_type);
+                    }
+                }
+            }
+            Pat::Object(obj) => {
+                for prop in &obj.props {
+                    match prop {
+                        ObjectPatProp::KeyValue(kv) => {
+                            self.collect_pat_bindings(
+                                &kv.value,
+                                kind.clone(),
+                                scope,
+                                declaration_type,
+                            );
+                        }
+                        ObjectPatProp::Assign(assign) => {
+                            let name = assign.key.sym.to_string();
+                            let start = assign.key.span.lo.0;
+                            self.add_binding(
+                                name,
+                                kind.clone(),
+                                scope,
+                                declaration_type.to_string(),
+                                Some(start),
+                                None,
+                            );
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.collect_pat_bindings(
+                                &rest.arg,
+                                kind.clone(),
+                                scope,
+                                declaration_type,
+                            );
+                        }
+                    }
+                }
+            }
+            Pat::Rest(rest) => {
+                self.collect_pat_bindings(&rest.arg, kind, scope, declaration_type);
+            }
+            Pat::Assign(assign) => {
+                self.collect_pat_bindings(&assign.left, kind, scope, declaration_type);
+            }
+            Pat::Expr(_) | Pat::Invalid(_) => {}
+        }
+    }
+
+    /// Visit a function's internals (params + body), creating the function scope.
+    /// Used for method definitions and other Function nodes not covered by FnDecl/FnExpr.
+    fn visit_function_inner(&mut self, function: &Function) {
+        let func_start = function.span.lo.0;
+        self.push_scope(ScopeKind::Function, func_start, function.span.hi.0);
+
+        for param in &function.params {
+            self.collect_pat_bindings(
+                &param.pat,
+                BindingKind::Param,
+                self.current_scope(),
+                "FormalParameter",
+            );
+        }
+
+        if let Some(body) = &function.body {
+            self.function_body_spans.insert(body.span.lo.0);
+            body.visit_with(self);
+        }
+
+        self.pop_scope();
+    }
+}
+
+impl Visit for ScopeCollector {
+    fn visit_module(&mut self, module: &Module) {
+        self.push_scope(ScopeKind::Program, module.span.lo.0, module.span.hi.0);
+        module.visit_children_with(self);
+        self.pop_scope();
+    }
+
+    fn visit_import_decl(&mut self, import: &ImportDecl) {
+        let source = str_value_to_string(&import.src);
+        let program_scope = ScopeId(0);
+
+        for spec in &import.specifiers {
+            match spec {
+                ImportSpecifier::Named(named) => {
+                    let local_name = named.local.sym.to_string();
+                    let start = named.local.span.lo.0;
+                    let imported_name = match &named.imported {
+                        Some(ModuleExportName::Ident(ident)) => Some(ident.sym.to_string()),
+                        Some(ModuleExportName::Str(s)) => Some(str_value_to_string(s)),
+                        None => Some(local_name.clone()),
+                    };
+                    self.add_binding(
+                        local_name,
+                        BindingKind::Module,
+                        program_scope,
+                        "ImportSpecifier".to_string(),
+                        Some(start),
+                        Some(ImportBindingData {
+                            source: source.clone(),
+                            kind: ImportBindingKind::Named,
+                            imported: imported_name,
+                        }),
+                    );
+                }
+                ImportSpecifier::Default(default) => {
+                    let local_name = default.local.sym.to_string();
+                    let start = default.local.span.lo.0;
+                    self.add_binding(
+                        local_name,
+                        BindingKind::Module,
+                        program_scope,
+                        "ImportDefaultSpecifier".to_string(),
+                        Some(start),
+                        Some(ImportBindingData {
+                            source: source.clone(),
+                            kind: ImportBindingKind::Default,
+                            imported: None,
+                        }),
+                    );
+                }
+                ImportSpecifier::Namespace(ns) => {
+                    let local_name = ns.local.sym.to_string();
+                    let start = ns.local.span.lo.0;
+                    self.add_binding(
+                        local_name,
+                        BindingKind::Module,
+                        program_scope,
+                        "ImportNamespaceSpecifier".to_string(),
+                        Some(start),
+                        Some(ImportBindingData {
+                            source: source.clone(),
+                            kind: ImportBindingKind::Namespace,
+                            imported: None,
+                        }),
+                    );
+                }
+            }
+        }
+    }
+
+    fn visit_var_decl(&mut self, var_decl: &VarDecl) {
+        let (kind, declaration_type) = match var_decl.kind {
+            VarDeclKind::Var => (BindingKind::Var, "VariableDeclarator"),
+            VarDeclKind::Let => (BindingKind::Let, "VariableDeclarator"),
+            VarDeclKind::Const => (BindingKind::Const, "VariableDeclarator"),
+        };
+
+        let target_scope = match var_decl.kind {
+            VarDeclKind::Var => self.enclosing_function_scope(),
+            VarDeclKind::Let | VarDeclKind::Const => self.current_scope(),
+        };
+
+        for declarator in &var_decl.decls {
+            self.collect_pat_bindings(
+                &declarator.name,
+                kind.clone(),
+                target_scope,
+                declaration_type,
+            );
+            // Visit initializers so nested functions/arrows get their scopes
+            if let Some(init) = &declarator.init {
+                init.visit_with(self);
+            }
+        }
+    }
+
+    fn visit_fn_decl(&mut self, fn_decl: &FnDecl) {
+        // Function declarations are hoisted to the enclosing function/program scope
+        let hoist_scope = self.enclosing_function_scope();
+        let name = fn_decl.ident.sym.to_string();
+        let start = fn_decl.ident.span.lo.0;
+        if let Some(&existing_id) = self.scopes[hoist_scope.0 as usize].bindings.get(&name) {
+            self.redeclaration_refs.insert(start, existing_id);
+        } else {
+            self.add_binding(
+                name,
+                BindingKind::Hoisted,
+                hoist_scope,
+                "FunctionDeclaration".to_string(),
+                Some(start),
+                None,
+            );
+        }
+
+        self.visit_function_inner(&fn_decl.function);
+    }
+
+    fn visit_export_default_decl(&mut self, decl: &ExportDefaultDecl) {
+        // For `export default function foo(...)`, the function name should be
+        // hoisted to the enclosing scope (like FnDecl), not bound only in the
+        // function's own scope (like FnExpr).
+        match &decl.decl {
+            DefaultDecl::Fn(fn_expr) => {
+                if let Some(ident) = &fn_expr.ident {
+                    let hoist_scope = self.enclosing_function_scope();
+                    let name = ident.sym.to_string();
+                    let start = ident.span.lo.0;
+                    self.add_binding(
+                        name,
+                        BindingKind::Hoisted,
+                        hoist_scope,
+                        "FunctionDeclaration".to_string(),
+                        Some(start),
+                        None,
+                    );
+                }
+                self.visit_function_inner(&fn_expr.function);
+            }
+            DefaultDecl::Class(class_expr) => {
+                if let Some(ident) = &class_expr.ident {
+                    let name = ident.sym.to_string();
+                    let start = ident.span.lo.0;
+                    self.add_binding(
+                        name,
+                        BindingKind::Local,
+                        self.current_scope(),
+                        "ClassDeclaration".to_string(),
+                        Some(start),
+                        None,
+                    );
+                }
+                self.push_scope(
+                    ScopeKind::Class,
+                    class_expr.class.span.lo.0,
+                    class_expr.class.span.hi.0,
+                );
+                class_expr.class.visit_children_with(self);
+                self.pop_scope();
+            }
+            DefaultDecl::TsInterfaceDecl(d) => {
+                d.visit_with(self);
+            }
+        }
+    }
+
+    fn visit_fn_expr(&mut self, fn_expr: &FnExpr) {
+        let func_start = fn_expr.function.span.lo.0;
+        self.push_scope(ScopeKind::Function, func_start, fn_expr.function.span.hi.0);
+
+        // Named function expressions bind their name in the function scope
+        if let Some(ident) = &fn_expr.ident {
+            let name = ident.sym.to_string();
+            let start = ident.span.lo.0;
+            self.add_binding(
+                name,
+                BindingKind::Local,
+                self.current_scope(),
+                "FunctionExpression".to_string(),
+                Some(start),
+                None,
+            );
+        }
+
+        for param in &fn_expr.function.params {
+            self.collect_pat_bindings(
+                &param.pat,
+                BindingKind::Param,
+                self.current_scope(),
+                "FormalParameter",
+            );
+        }
+
+        if let Some(body) = &fn_expr.function.body {
+            self.function_body_spans.insert(body.span.lo.0);
+            body.visit_with(self);
+        }
+
+        self.pop_scope();
+    }
+
+    fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
+        let func_start = arrow.span.lo.0;
+        self.push_scope(ScopeKind::Function, func_start, arrow.span.hi.0);
+
+        for param in &arrow.params {
+            self.collect_pat_bindings(
+                param,
+                BindingKind::Param,
+                self.current_scope(),
+                "FormalParameter",
+            );
+        }
+
+        match &*arrow.body {
+            BlockStmtOrExpr::BlockStmt(block) => {
+                self.function_body_spans.insert(block.span.lo.0);
+                block.visit_with(self);
+            }
+            BlockStmtOrExpr::Expr(expr) => {
+                expr.visit_with(self);
+            }
+        }
+
+        self.pop_scope();
+    }
+
+    fn visit_block_stmt(&mut self, block: &BlockStmt) {
+        if self.function_body_spans.remove(&block.span.lo.0) {
+            // This block is a function/catch body — don't create a separate scope
+            block.visit_children_with(self);
+        } else {
+            self.push_scope(ScopeKind::Block, block.span.lo.0, block.span.hi.0);
+            block.visit_children_with(self);
+            self.pop_scope();
+        }
+    }
+
+    fn visit_for_stmt(&mut self, for_stmt: &ForStmt) {
+        self.push_scope(ScopeKind::For, for_stmt.span.lo.0, for_stmt.span.hi.0);
+
+        if let Some(init) = &for_stmt.init {
+            init.visit_with(self);
+        }
+        if let Some(test) = &for_stmt.test {
+            test.visit_with(self);
+        }
+        if let Some(update) = &for_stmt.update {
+            update.visit_with(self);
+        }
+        for_stmt.body.visit_with(self);
+
+        self.pop_scope();
+    }
+
+    fn visit_for_in_stmt(&mut self, for_in: &ForInStmt) {
+        self.push_scope(ScopeKind::For, for_in.span.lo.0, for_in.span.hi.0);
+        for_in.left.visit_with(self);
+        for_in.right.visit_with(self);
+        for_in.body.visit_with(self);
+        self.pop_scope();
+    }
+
+    fn visit_for_of_stmt(&mut self, for_of: &ForOfStmt) {
+        self.push_scope(ScopeKind::For, for_of.span.lo.0, for_of.span.hi.0);
+        for_of.left.visit_with(self);
+        for_of.right.visit_with(self);
+        for_of.body.visit_with(self);
+        self.pop_scope();
+    }
+
+    fn visit_catch_clause(&mut self, catch: &CatchClause) {
+        self.push_scope(ScopeKind::Catch, catch.span.lo.0, catch.span.hi.0);
+
+        if let Some(param) = &catch.param {
+            self.collect_pat_bindings(param, BindingKind::Let, self.current_scope(), "CatchClause");
+        }
+
+        // Mark catch body as already scoped (the catch scope covers it)
+        self.function_body_spans.insert(catch.body.span.lo.0);
+        catch.body.visit_with(self);
+
+        self.pop_scope();
+    }
+
+    fn visit_switch_stmt(&mut self, switch: &SwitchStmt) {
+        // Visit the discriminant in the outer scope
+        switch.discriminant.visit_with(self);
+
+        self.push_scope(ScopeKind::Switch, switch.span.lo.0, switch.span.hi.0);
+        for case in &switch.cases {
+            case.visit_with(self);
+        }
+        self.pop_scope();
+    }
+
+    fn visit_class_decl(&mut self, class_decl: &ClassDecl) {
+        let name = class_decl.ident.sym.to_string();
+        let start = class_decl.ident.span.lo.0;
+        self.add_binding(
+            name,
+            BindingKind::Local,
+            self.current_scope(),
+            "ClassDeclaration".to_string(),
+            Some(start),
+            None,
+        );
+
+        self.push_scope(
+            ScopeKind::Class,
+            class_decl.class.span.lo.0,
+            class_decl.class.span.hi.0,
+        );
+        class_decl.class.visit_children_with(self);
+        self.pop_scope();
+    }
+
+    fn visit_class_expr(&mut self, class_expr: &ClassExpr) {
+        self.push_scope(
+            ScopeKind::Class,
+            class_expr.class.span.lo.0,
+            class_expr.class.span.hi.0,
+        );
+
+        if let Some(ident) = &class_expr.ident {
+            let name = ident.sym.to_string();
+            let start = ident.span.lo.0;
+            self.add_binding(
+                name,
+                BindingKind::Local,
+                self.current_scope(),
+                "ClassExpression".to_string(),
+                Some(start),
+                None,
+            );
+        }
+
+        class_expr.class.visit_children_with(self);
+        self.pop_scope();
+    }
+
+    // Method definitions contain a Function node. We intercept here
+    // so that the Function gets its own scope with params.
+    fn visit_function(&mut self, f: &Function) {
+        // This is reached for object/class methods via default traversal.
+        self.visit_function_inner(f);
+    }
+}
+
+// ── Pass 2: Reference resolution ────────────────────────────────────────────
+
+struct ReferenceResolver<'a> {
+    scopes: &'a [ScopeData],
+    #[allow(dead_code)]
+    bindings: &'a [BindingData],
+    node_to_scope: &'a HashMap<u32, ScopeId>,
+    reference_to_binding: IndexMap<u32, BindingId>,
+    /// Stack of scope IDs for resolution
+    scope_stack: Vec<ScopeId>,
+    /// Declaration positions to skip (these are binding sites, not references)
+    declaration_starts: HashSet<u32>,
+    /// Span starts for block statements that are direct function/catch bodies.
+    function_body_spans: HashSet<u32>,
+}
+
+impl<'a> ReferenceResolver<'a> {
+    fn new(collector: &'a ScopeCollector) -> Self {
+        let mut declaration_starts = HashSet::new();
+        for binding in &collector.bindings {
+            if let Some(start) = binding.declaration_start {
+                declaration_starts.insert(start);
+            }
+        }
+        Self {
+            scopes: &collector.scopes,
+            bindings: &collector.bindings,
+            node_to_scope: &collector.node_to_scope,
+            reference_to_binding: IndexMap::new(),
+            scope_stack: Vec::new(),
+            declaration_starts,
+            function_body_spans: HashSet::new(),
+        }
+    }
+
+    fn current_scope(&self) -> ScopeId {
+        *self.scope_stack.last().expect("scope stack is empty")
+    }
+
+    fn resolve_ident(&mut self, name: &str, start: u32) {
+        // Skip declaration sites — they'll be added separately
+        if self.declaration_starts.contains(&start) {
+            return;
+        }
+
+        // Walk up the scope chain to find the binding
+        let mut current = Some(self.current_scope());
+        while let Some(scope_id) = current {
+            let scope = &self.scopes[scope_id.0 as usize];
+            if let Some(&binding_id) = scope.bindings.get(name) {
+                self.reference_to_binding.insert(start, binding_id);
+                return;
+            }
+            current = scope.parent;
+        }
+        // Not found — it's a global, don't record it
+    }
+
+    fn find_scope_at(&self, node_start: u32) -> Option<&ScopeId> {
+        self.node_to_scope.get(&node_start)
+    }
+
+    /// Visit a pattern in parameter position: skip binding idents, but visit
+    /// default values and computed keys as references.
+    fn visit_param_pattern(&mut self, pat: &Pat) {
+        match pat {
+            Pat::Ident(_) => {
+                // Declaration — skip
+            }
+            Pat::Array(arr) => {
+                for elem in &arr.elems {
+                    if let Some(p) = elem {
+                        self.visit_param_pattern(p);
+                    }
+                }
+            }
+            Pat::Object(obj) => {
+                for prop in &obj.props {
+                    match prop {
+                        ObjectPatProp::KeyValue(kv) => {
+                            if let PropName::Computed(computed) = &kv.key {
+                                computed.visit_with(self);
+                            }
+                            self.visit_param_pattern(&kv.value);
+                        }
+                        ObjectPatProp::Assign(assign) => {
+                            if let Some(value) = &assign.value {
+                                value.visit_with(self);
+                            }
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.visit_param_pattern(&rest.arg);
+                        }
+                    }
+                }
+            }
+            Pat::Assign(assign) => {
+                self.visit_param_pattern(&assign.left);
+                // Default value IS a reference
+                assign.right.visit_with(self);
+            }
+            Pat::Rest(rest) => {
+                self.visit_param_pattern(&rest.arg);
+            }
+            Pat::Expr(expr) => {
+                expr.visit_with(self);
+            }
+            Pat::Invalid(_) => {}
+        }
+    }
+
+    /// Visit function internals for the resolver (params + body), mirroring the collector.
+    fn visit_function_inner(&mut self, function: &Function) {
+        let func_start = function.span.lo.0;
+        if let Some(&scope_id) = self.find_scope_at(func_start) {
+            self.scope_stack.push(scope_id);
+
+            for param in &function.params {
+                self.visit_param_pattern(&param.pat);
+            }
+
+            if let Some(body) = &function.body {
+                self.function_body_spans.insert(body.span.lo.0);
+                body.visit_with(self);
+            }
+
+            self.scope_stack.pop();
+        }
+    }
+}
+
+impl<'a> Visit for ReferenceResolver<'a> {
+    fn visit_module(&mut self, module: &Module) {
+        self.scope_stack.push(ScopeId(0));
+        module.visit_children_with(self);
+        self.scope_stack.pop();
+    }
+
+    fn visit_ident(&mut self, ident: &Ident) {
+        let name = ident.sym.to_string();
+        let start = ident.span.lo.0;
+        self.resolve_ident(&name, start);
+    }
+
+    fn visit_import_decl(&mut self, _import: &ImportDecl) {
+        // Don't recurse — import identifiers are declarations
+    }
+
+    fn visit_var_decl(&mut self, var_decl: &VarDecl) {
+        // Only visit initializers, not patterns (which are declarations)
+        for declarator in &var_decl.decls {
+            if let Some(init) = &declarator.init {
+                init.visit_with(self);
+            }
+        }
+    }
+
+    fn visit_fn_decl(&mut self, fn_decl: &FnDecl) {
+        // Don't resolve the function name — it's a declaration
+        self.visit_function_inner(&fn_decl.function);
+    }
+
+    fn visit_export_default_decl(&mut self, decl: &ExportDefaultDecl) {
+        // Mirror the collector: handle exported functions/classes with their own
+        // scope logic, rather than falling through to the default FnExpr visitor.
+        match &decl.decl {
+            DefaultDecl::Fn(fn_expr) => {
+                // Don't resolve the function name — it's a declaration
+                self.visit_function_inner(&fn_expr.function);
+            }
+            DefaultDecl::Class(class_expr) => {
+                if let Some(&scope_id) = self.find_scope_at(class_expr.class.span.lo.0) {
+                    self.scope_stack.push(scope_id);
+                    class_expr.class.visit_children_with(self);
+                    self.scope_stack.pop();
+                }
+            }
+            DefaultDecl::TsInterfaceDecl(d) => {
+                d.visit_with(self);
+            }
+        }
+    }
+
+    fn visit_fn_expr(&mut self, fn_expr: &FnExpr) {
+        let func_start = fn_expr.function.span.lo.0;
+        if let Some(&scope_id) = self.find_scope_at(func_start) {
+            self.scope_stack.push(scope_id);
+
+            // Don't resolve named fn expr ident — it's a declaration
+
+            for param in &fn_expr.function.params {
+                self.visit_param_pattern(&param.pat);
+            }
+
+            if let Some(body) = &fn_expr.function.body {
+                self.function_body_spans.insert(body.span.lo.0);
+                body.visit_with(self);
+            }
+
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
+        let func_start = arrow.span.lo.0;
+        if let Some(&scope_id) = self.find_scope_at(func_start) {
+            self.scope_stack.push(scope_id);
+
+            for param in &arrow.params {
+                self.visit_param_pattern(param);
+            }
+
+            match &*arrow.body {
+                BlockStmtOrExpr::BlockStmt(block) => {
+                    self.function_body_spans.insert(block.span.lo.0);
+                    block.visit_with(self);
+                }
+                BlockStmtOrExpr::Expr(expr) => {
+                    expr.visit_with(self);
+                }
+            }
+
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_block_stmt(&mut self, block: &BlockStmt) {
+        if self.function_body_spans.remove(&block.span.lo.0) {
+            // Function/catch body — scope already pushed
+            block.visit_children_with(self);
+        } else if let Some(&scope_id) = self.find_scope_at(block.span.lo.0) {
+            self.scope_stack.push(scope_id);
+            block.visit_children_with(self);
+            self.scope_stack.pop();
+        } else {
+            block.visit_children_with(self);
+        }
+    }
+
+    fn visit_for_stmt(&mut self, for_stmt: &ForStmt) {
+        if let Some(&scope_id) = self.find_scope_at(for_stmt.span.lo.0) {
+            self.scope_stack.push(scope_id);
+
+            if let Some(init) = &for_stmt.init {
+                init.visit_with(self);
+            }
+            if let Some(test) = &for_stmt.test {
+                test.visit_with(self);
+            }
+            if let Some(update) = &for_stmt.update {
+                update.visit_with(self);
+            }
+            for_stmt.body.visit_with(self);
+
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_for_in_stmt(&mut self, for_in: &ForInStmt) {
+        if let Some(&scope_id) = self.find_scope_at(for_in.span.lo.0) {
+            self.scope_stack.push(scope_id);
+            for_in.left.visit_with(self);
+            for_in.right.visit_with(self);
+            for_in.body.visit_with(self);
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_for_of_stmt(&mut self, for_of: &ForOfStmt) {
+        if let Some(&scope_id) = self.find_scope_at(for_of.span.lo.0) {
+            self.scope_stack.push(scope_id);
+            for_of.left.visit_with(self);
+            for_of.right.visit_with(self);
+            for_of.body.visit_with(self);
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_catch_clause(&mut self, catch: &CatchClause) {
+        if let Some(&scope_id) = self.find_scope_at(catch.span.lo.0) {
+            self.scope_stack.push(scope_id);
+            // Don't visit catch param — it's a declaration
+            self.function_body_spans.insert(catch.body.span.lo.0);
+            catch.body.visit_with(self);
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_switch_stmt(&mut self, switch: &SwitchStmt) {
+        switch.discriminant.visit_with(self);
+
+        if let Some(&scope_id) = self.find_scope_at(switch.span.lo.0) {
+            self.scope_stack.push(scope_id);
+            for case in &switch.cases {
+                case.visit_with(self);
+            }
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_class_decl(&mut self, class_decl: &ClassDecl) {
+        // Don't resolve the class name — it's a declaration
+        if let Some(&scope_id) = self.find_scope_at(class_decl.class.span.lo.0) {
+            self.scope_stack.push(scope_id);
+            class_decl.class.visit_children_with(self);
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_class_expr(&mut self, class_expr: &ClassExpr) {
+        if let Some(&scope_id) = self.find_scope_at(class_expr.class.span.lo.0) {
+            self.scope_stack.push(scope_id);
+            // Don't resolve named class expr ident — it's a declaration
+            class_expr.class.visit_children_with(self);
+            self.scope_stack.pop();
+        }
+    }
+
+    fn visit_function(&mut self, f: &Function) {
+        // Reached for object/class methods via default traversal
+        self.visit_function_inner(f);
+    }
+
+    // Don't resolve property idents on member expressions as references
+    fn visit_member_expr(&mut self, member: &MemberExpr) {
+        member.obj.visit_with(self);
+        if let MemberProp::Computed(computed) = &member.prop {
+            computed.visit_with(self);
+        }
+    }
+
+    // Handle property definitions — don't resolve non-computed keys
+    fn visit_prop(&mut self, prop: &Prop) {
+        match prop {
+            Prop::Shorthand(ident) => {
+                // Shorthand property `{ x }` — `x` is a reference
+                self.visit_ident(ident);
+            }
+            Prop::KeyValue(kv) => {
+                if let PropName::Computed(computed) = &kv.key {
+                    computed.visit_with(self);
+                }
+                kv.value.visit_with(self);
+            }
+            Prop::Assign(assign) => {
+                assign.value.visit_with(self);
+            }
+            Prop::Getter(getter) => {
+                if let PropName::Computed(computed) = &getter.key {
+                    computed.visit_with(self);
+                }
+                if let Some(body) = &getter.body {
+                    body.visit_with(self);
+                }
+            }
+            Prop::Setter(setter) => {
+                if let PropName::Computed(computed) = &setter.key {
+                    computed.visit_with(self);
+                }
+                setter.param.visit_with(self);
+                if let Some(body) = &setter.body {
+                    body.visit_with(self);
+                }
+            }
+            Prop::Method(method) => {
+                if let PropName::Computed(computed) = &method.key {
+                    computed.visit_with(self);
+                }
+                method.function.visit_with(self);
+            }
+        }
+    }
+
+    // Don't resolve labels
+    fn visit_labeled_stmt(&mut self, labeled: &LabeledStmt) {
+        labeled.body.visit_with(self);
+    }
+
+    fn visit_break_stmt(&mut self, _break_stmt: &BreakStmt) {}
+
+    fn visit_continue_stmt(&mut self, _continue_stmt: &ContinueStmt) {}
+}

--- a/turbopack/crates/react_compiler_swc/src/diagnostics.rs
+++ b/turbopack/crates/react_compiler_swc/src/diagnostics.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use react_compiler::entrypoint::compile_result::{
+    CompileResult, CompilerErrorDetailInfo, CompilerErrorInfo, LoggerEvent,
+};
+
+#[derive(Debug, Clone)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiagnosticMessage {
+    pub severity: Severity,
+    pub message: String,
+    pub span: Option<(u32, u32)>,
+}
+
+/// Converts a CompileResult into diagnostic messages for display
+pub fn compile_result_to_diagnostics(result: &CompileResult) -> Vec<DiagnosticMessage> {
+    let mut diagnostics = Vec::new();
+
+    match result {
+        CompileResult::Success { events, .. } => {
+            // Process logger events from successful compilation
+            for event in events {
+                if let Some(diag) = event_to_diagnostic(event) {
+                    diagnostics.push(diag);
+                }
+            }
+        }
+        CompileResult::Error { error, events, .. } => {
+            // Add the main error
+            diagnostics.push(error_info_to_diagnostic(error));
+
+            // Process logger events from failed compilation
+            for event in events {
+                if let Some(diag) = event_to_diagnostic(event) {
+                    diagnostics.push(diag);
+                }
+            }
+        }
+    }
+
+    diagnostics
+}
+
+fn error_info_to_diagnostic(error: &CompilerErrorInfo) -> DiagnosticMessage {
+    let message = if let Some(description) = &error.description {
+        format!("[ReactCompiler] {}. {}", error.reason, description)
+    } else {
+        format!("[ReactCompiler] {}", error.reason)
+    };
+
+    DiagnosticMessage {
+        severity: Severity::Error,
+        message,
+        span: None,
+    }
+}
+
+fn error_detail_to_diagnostic(
+    detail: &CompilerErrorDetailInfo,
+    is_error: bool,
+) -> DiagnosticMessage {
+    let message = if let Some(description) = &detail.description {
+        format!(
+            "[ReactCompiler] {}: {}. {}",
+            detail.category, detail.reason, description
+        )
+    } else {
+        format!("[ReactCompiler] {}: {}", detail.category, detail.reason)
+    };
+
+    DiagnosticMessage {
+        severity: if is_error {
+            Severity::Error
+        } else {
+            Severity::Warning
+        },
+        message,
+        span: None,
+    }
+}
+
+fn event_to_diagnostic(event: &LoggerEvent) -> Option<DiagnosticMessage> {
+    match event {
+        LoggerEvent::CompileSuccess { .. } => None,
+        LoggerEvent::CompileSkip { .. } => None,
+        LoggerEvent::CompileError { detail, .. }
+        | LoggerEvent::CompileErrorWithLoc { detail, .. } => {
+            Some(error_detail_to_diagnostic(detail, false))
+        }
+        LoggerEvent::CompileUnexpectedThrow { data, .. } => Some(DiagnosticMessage {
+            severity: Severity::Error,
+            message: format!("[ReactCompiler] Unexpected error: {}", data),
+            span: None,
+        }),
+        LoggerEvent::PipelineError { data, .. } => Some(DiagnosticMessage {
+            severity: Severity::Error,
+            message: format!("[ReactCompiler] Pipeline error: {}", data),
+            span: None,
+        }),
+    }
+}

--- a/turbopack/crates/react_compiler_swc/src/lib.rs
+++ b/turbopack/crates/react_compiler_swc/src/lib.rs
@@ -1,0 +1,1265 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+pub mod apply_renames;
+pub mod convert_ast;
+pub mod convert_ast_reverse;
+pub mod convert_scope;
+pub mod diagnostics;
+pub mod prefilter;
+pub(crate) mod ts_namespace_export_fixup;
+
+use std::cell::RefCell;
+
+use apply_renames::apply_renames;
+use convert_ast::convert_module_with_source_type;
+use convert_ast_reverse::convert_program_to_swc_with_source;
+use convert_scope::build_scope_info;
+use diagnostics::{DiagnosticMessage, compile_result_to_diagnostics};
+use prefilter::has_react_like_functions;
+use react_compiler::entrypoint::{compile_result::LoggerEvent, plugin_options::PluginOptions};
+use swc_core::common::comments::Comments;
+
+/// Describes where a blank line should be inserted relative to a body item.
+#[derive(Clone, Debug)]
+pub enum BlankLinePosition {
+    /// Insert blank line before the item (including its leading comments).
+    /// The `first_code_line` is the item's first code line (without comments)
+    /// used as a search anchor in the output.
+    BeforeItem { first_code_line: String },
+    /// Insert blank line between the item's leading comments and its code.
+    /// The `first_code_line` is used to find where the code starts.
+    BeforeCode { first_code_line: String },
+}
+
+thread_local! {
+    /// Thread-local storage for comments from the last compilation.
+    /// Used by `emit` to include comments without API changes.
+    static LAST_COMMENTS: RefCell<Option<swc_core::common::comments::SingleThreadedComments>> = RefCell::new(None);
+
+    /// Thread-local storage for blank line positions.
+    /// Contains information about where to insert blank lines during emit.
+    static BLANK_LINE_POSITIONS: RefCell<Vec<BlankLinePosition>> = RefCell::new(Vec::new());
+}
+
+/// Result of compiling a program via the SWC frontend.
+pub struct TransformResult {
+    /// The compiled program as an SWC Module (None if no changes needed).
+    pub module: Option<swc_core::ecma::ast::Module>,
+    /// Comments extracted from the compiled AST (for use with `emit_with_comments`).
+    pub comments: Option<swc_core::common::comments::SingleThreadedComments>,
+    pub diagnostics: Vec<DiagnosticMessage>,
+    pub events: Vec<LoggerEvent>,
+}
+
+/// Result of linting a program via the SWC frontend.
+pub struct LintResult {
+    pub diagnostics: Vec<DiagnosticMessage>,
+}
+
+/// Primary transform API — accepts pre-parsed SWC Module.
+pub fn transform(
+    module: &swc_core::ecma::ast::Module,
+    source_text: &str,
+    options: PluginOptions,
+) -> TransformResult {
+    if options.compilation_mode != "all" && !has_react_like_functions(module) {
+        return TransformResult {
+            module: None,
+            comments: None,
+            diagnostics: vec![],
+            events: vec![],
+        };
+    }
+
+    // Detect source type from pragma. The @script pragma indicates
+    // CommonJS (script) mode, which affects how imports are emitted.
+    let source_type = if source_text
+        .lines()
+        .next()
+        .map_or(false, |line| line.contains("@script"))
+    {
+        react_compiler_ast::SourceType::Script
+    } else {
+        react_compiler_ast::SourceType::Module
+    };
+    let file = convert_module_with_source_type(module, source_text, source_type);
+    let scope_info = build_scope_info(module);
+    let result = react_compiler::entrypoint::program::compile_program(file, scope_info, options);
+
+    let diagnostics = compile_result_to_diagnostics(&result);
+    let (program_json, events, renames) = match result {
+        react_compiler::entrypoint::compile_result::CompileResult::Success {
+            ast,
+            events,
+            renames,
+            ..
+        } => (ast, events, renames),
+        react_compiler::entrypoint::compile_result::CompileResult::Error { events, .. } => {
+            (None, events, Vec::new())
+        }
+    };
+
+    let conversion_result = program_json.and_then(|raw_json| {
+        // First parse to serde_json::Value which deduplicates "type" fields
+        // (the compiler output can produce duplicate "type" keys due to
+        // BaseNode.node_type + #[serde(tag = "type")] enum tagging)
+        let value: serde_json::Value = serde_json::from_str(raw_json.get()).ok()?;
+        let file: react_compiler_ast::File = serde_json::from_value(value).ok()?;
+        let result = convert_program_to_swc_with_source(&file, Some(source_text));
+        Some(result)
+    });
+
+    let (mut swc_module, mut comments) = match conversion_result {
+        Some(result) => (Some(result.module), Some(result.comments)),
+        None if !renames.is_empty() => (Some(module.clone()), None),
+        None => (None, None),
+    };
+
+    // If we have a compiled module, extract comments from the original source
+    // and merge them into the comment map. The Rust compiler does not preserve
+    // comments in its output, so we re-extract them from the source text.
+    if let Some(ref mut swc_mod) = swc_module {
+        use swc_core::common::Spanned;
+
+        // Compute blank line positions BEFORE span fixup, while spans still
+        // reflect original source positions. Babel's generator adds blank
+        // lines between consecutive items when the original source had blank
+        // lines between them (i.e., endLine(prev) + 1 < startLine(next)).
+        let blank_line_positions = compute_blank_line_positions(&swc_mod.body, source_text);
+
+        // Fix up dummy spans on compiler-generated items: SWC codegen skips
+        // comments at BytePos(0) (DUMMY), so we give generated items a real
+        // span before the original module's first item.
+        let first_source_lo = module.body.first().map(|item| item.span().lo);
+        let mut top_level_comment_target = None;
+        if first_source_lo.is_some() {
+            let mut next_synthetic_pos = swc_core::common::BytePos(1);
+            for item in &mut swc_mod.body {
+                if item.span().lo.is_dummy() {
+                    let synthetic_span =
+                        swc_core::common::Span::new(next_synthetic_pos, next_synthetic_pos);
+                    next_synthetic_pos = next_synthetic_pos + swc_core::common::BytePos(1);
+                    match item {
+                        swc_core::ecma::ast::ModuleItem::ModuleDecl(
+                            swc_core::ecma::ast::ModuleDecl::Import(import),
+                        ) => {
+                            import.span = synthetic_span;
+                            top_level_comment_target = Some(import.span.hi);
+                        }
+                        swc_core::ecma::ast::ModuleItem::Stmt(swc_core::ecma::ast::Stmt::Decl(
+                            swc_core::ecma::ast::Decl::Var(var),
+                        )) => {
+                            var.span = synthetic_span;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        apply_renames(swc_mod, &renames);
+
+        let (source_leading_comments, source_trailing_comments) =
+            extract_source_comments(source_text);
+        if !source_leading_comments.is_empty() || !source_trailing_comments.is_empty() {
+            let merged = comments.unwrap_or_default();
+
+            let source_bytes = source_text.as_bytes();
+            for (orig_pos, comment_list) in source_leading_comments {
+                // Pragma comments (e.g. `// @gating`) before the first source
+                // item need to attach AFTER any compiler-inserted imports so
+                // the gated output preserves the directive. Other leading
+                // comments (copyright, JSDoc, etc.) stay at their original
+                // position so SWC emits them before the original item.
+                let is_pragma = Some(orig_pos) == first_source_lo
+                    && comment_list
+                        .iter()
+                        .all(|c| c.text.trim_start().starts_with('@'));
+                if is_pragma {
+                    if let Some(pos) = top_level_comment_target {
+                        merged.add_trailing_comments(pos, comment_list);
+                        continue;
+                    }
+                }
+                merged.add_leading_comments(orig_pos, comment_list);
+            }
+            // Trailing comments after a `,` separator are stored by the SWC
+            // parser at the position past the comma, but codegen looks them
+            // up at the previous element's `span.hi`, which is before the
+            // comma. Shift those back by one. Trailing comments after other
+            // tokens (e.g. `;`) are already at the matching `span.hi`, so
+            // pass them through unchanged.
+            for (orig_pos, comment_list) in source_trailing_comments {
+                let idx = orig_pos.0 as usize;
+                let pos = if idx >= 2 && source_bytes.get(idx - 2) == Some(&b',') {
+                    swc_core::common::BytePos(orig_pos.0 - 1)
+                } else {
+                    orig_pos
+                };
+                merged.add_trailing_comments(pos, comment_list);
+            }
+            comments = Some(merged);
+        }
+
+        // Store blank line positions in thread-local for `emit` to use
+        BLANK_LINE_POSITIONS.with(|cell| {
+            *cell.borrow_mut() = blank_line_positions;
+        });
+    }
+
+    // Store comments in thread-local for `emit` to use
+    LAST_COMMENTS.with(|cell| {
+        *cell.borrow_mut() = comments.clone();
+    });
+
+    TransformResult {
+        module: swc_module,
+        comments,
+        diagnostics,
+        events,
+    }
+}
+
+/// Convenience wrapper — parses source text, then transforms.
+pub fn transform_source(source_text: &str, options: PluginOptions) -> TransformResult {
+    let cm = swc_core::common::sync::Lrc::new(swc_core::common::SourceMap::default());
+    let fm = cm.new_source_file(
+        swc_core::common::sync::Lrc::new(swc_core::common::FileName::Anon),
+        source_text.to_string(),
+    );
+
+    let mut errors = vec![];
+    let module = swc_core::ecma::parser::parse_file_as_module(
+        &fm,
+        swc_core::ecma::parser::Syntax::Es(swc_core::ecma::parser::EsSyntax {
+            jsx: true,
+            ..Default::default()
+        }),
+        swc_core::ecma::ast::EsVersion::latest(),
+        None,
+        &mut errors,
+    );
+
+    match module {
+        Ok(module) => transform(&module, source_text, options),
+        Err(_) => TransformResult {
+            module: None,
+            comments: None,
+            diagnostics: vec![],
+            events: vec![],
+        },
+    }
+}
+
+/// Lint API — same as transform but only collects diagnostics, no AST output.
+pub fn lint(
+    module: &swc_core::ecma::ast::Module,
+    source_text: &str,
+    options: PluginOptions,
+) -> LintResult {
+    let mut opts = options;
+    opts.no_emit = true;
+
+    let result = transform(module, source_text, opts);
+    LintResult {
+        diagnostics: result.diagnostics,
+    }
+}
+
+/// Emit an SWC Module to a string via swc_core::ecma::codegen.
+/// If `transform` was called on the same thread, any comments from the
+/// compiled AST are automatically included.
+pub fn emit(module: &swc_core::ecma::ast::Module) -> String {
+    LAST_COMMENTS.with(|cell| {
+        let borrowed = cell.borrow();
+        let positions = BLANK_LINE_POSITIONS.with(|bl| bl.borrow().clone());
+        emit_with_comments(module, borrowed.as_ref(), &positions)
+    })
+}
+
+/// Emit an SWC Module to a string, optionally including comments.
+/// `blank_line_positions` describes where blank lines should be inserted
+/// to match Babel's blank line behavior.
+pub fn emit_with_comments(
+    module: &swc_core::ecma::ast::Module,
+    comments: Option<&swc_core::common::comments::SingleThreadedComments>,
+    blank_line_positions: &[BlankLinePosition],
+) -> String {
+    // Standard emit path
+    let code = emit_module_to_string(module, comments);
+    let code = fix_block_comment_newlines(&code);
+
+    // Add blank lines after directives to match Babel's codegen behavior.
+    // Babel always emits a blank line after the last directive in a
+    // program/function body.
+    let code = add_blank_lines_after_directives(&code);
+
+    // Reposition blank lines that SWC places before comment blocks:
+    // SWC emits blank lines before leading comments, but Babel places
+    // them after the comments (between comments and the declaration).
+    // Move blank lines from before comment blocks to after them when
+    // the comment block is followed by a top-level declaration.
+    let code = reposition_comment_blank_lines(&code);
+
+    // Expand single-line object literals to multi-line format in
+    // FIXTURE_ENTRYPOINT-style structures. SWC codegen emits small objects
+    // on single lines while Babel puts them on multiple lines. Prettier
+    // preserves this choice, causing formatting differences.
+    let code = expand_fixture_entrypoint_objects(&code);
+
+    if blank_line_positions.is_empty() || module.body.is_empty() {
+        return code;
+    }
+
+    // Insert blank lines between top-level declarations to match Babel's
+    // output. Babel's generator preserves blank lines from the original
+    // source between consecutive top-level items.
+    insert_blank_lines_in_output(&code, blank_line_positions)
+}
+
+/// Emit a full module to a string.
+///
+/// Records a source map during emission so the namespace-export fixup can
+/// anchor its line rewrites to the module items that produced them (see
+/// `ts_namespace_export_fixup`).
+fn emit_module_to_string(
+    module: &swc_core::ecma::ast::Module,
+    comments: Option<&swc_core::common::comments::SingleThreadedComments>,
+) -> String {
+    let cm = swc_core::common::sync::Lrc::new(swc_core::common::SourceMap::default());
+    let mut buf = vec![];
+    let mut srcmap: Vec<(swc_core::common::BytePos, swc_core::common::LineCol)> = Vec::new();
+    {
+        let wr = swc_core::ecma::codegen::text_writer::JsWriter::new(
+            cm.clone(),
+            "\n",
+            &mut buf,
+            Some(&mut srcmap),
+        );
+        let mut emitter = swc_core::ecma::codegen::Emitter {
+            cfg: swc_core::ecma::codegen::Config::default().with_minify(false),
+            cm,
+            comments: comments.map(|c| c as &dyn swc_core::common::comments::Comments),
+            wr: Box::new(wr),
+        };
+        swc_core::ecma::codegen::Node::emit_with(module, &mut emitter).unwrap();
+    }
+    let code = String::from_utf8(buf).unwrap();
+    ts_namespace_export_fixup::fix_ts_namespace_export_decls(&module.body, &code, &srcmap)
+}
+
+/// Insert blank lines into the emitted output at positions specified by
+/// `blank_line_positions`. Each position includes a `first_code_line` that
+/// identifies the item's first line of code (without comments), used as
+/// a search anchor in the output.
+fn insert_blank_lines_in_output(code: &str, positions: &[BlankLinePosition]) -> String {
+    if positions.is_empty() {
+        return code.to_string();
+    }
+
+    let lines: Vec<&str> = code.lines().collect();
+
+    // Phase 1: Find which output line indices need a blank line inserted
+    // BEFORE them. We do this by finding each target's first_code_line in
+    // the output, then computing the actual insert line.
+    let mut insert_before: Vec<usize> = Vec::new();
+    let mut used_lines: Vec<bool> = vec![false; lines.len()];
+
+    for pos in positions {
+        let (first_code_line, before_comments) = match pos {
+            BlankLinePosition::BeforeItem { first_code_line } => (first_code_line.as_str(), true),
+            BlankLinePosition::BeforeCode { first_code_line } => (first_code_line.as_str(), false),
+        };
+
+        // Find this code line in the output (first unused match).
+        // For BeforeCode positions, also allow matching already-used lines
+        // since BeforeItem and BeforeCode may target the same code line.
+        let mut found_idx = None;
+        for (i, &line) in lines.iter().enumerate() {
+            if line == first_code_line && (!used_lines[i] || !before_comments) {
+                found_idx = Some(i);
+                if !used_lines[i] {
+                    used_lines[i] = true;
+                }
+                break;
+            }
+        }
+
+        let code_line_idx = match found_idx {
+            Some(idx) => idx,
+            None => continue,
+        };
+
+        let insert_line = if before_comments {
+            // BeforeItem: insert before the comment block that precedes
+            // this code line
+            find_comment_block_start(&lines, code_line_idx)
+        } else {
+            // BeforeCode: insert right before the code line itself
+            code_line_idx
+        };
+
+        // Only insert if the previous line is not already blank
+        if insert_line > 0 && !lines[insert_line - 1].trim().is_empty() {
+            insert_before.push(insert_line);
+        }
+    }
+
+    if insert_before.is_empty() {
+        return code.to_string();
+    }
+
+    insert_before.sort_unstable();
+    insert_before.dedup();
+
+    // Phase 2: Build the result with blank lines inserted
+    let mut result = String::with_capacity(code.len() + insert_before.len() * 2);
+    let mut insert_idx = 0;
+
+    for (line_idx, &line) in lines.iter().enumerate() {
+        // Check if we need to insert a blank line before this line
+        if insert_idx < insert_before.len() && insert_before[insert_idx] == line_idx {
+            result.push('\n');
+            insert_idx += 1;
+        }
+
+        result.push_str(line);
+        if line_idx < lines.len() - 1 || code.ends_with('\n') {
+            result.push('\n');
+        }
+    }
+
+    result
+}
+
+/// Find the start of a comment block that precedes the line at `code_line_idx`.
+/// Walks backwards from `code_line_idx - 1` as long as lines are comment
+/// lines (starting with `//`, `/*`, ` *`, `*/`, or `/**`).
+fn find_comment_block_start(lines: &[&str], code_line_idx: usize) -> usize {
+    let mut start = code_line_idx;
+    let mut i = code_line_idx;
+    while i > 0 {
+        i -= 1;
+        let trimmed = lines[i].trim();
+        if trimmed.is_empty() {
+            break; // blank line, stop
+        }
+        if trimmed.starts_with("//")
+            || trimmed.starts_with("/*")
+            || trimmed.starts_with("* ")
+            || trimmed.starts_with("*/")
+            || trimmed == "*"
+        {
+            start = i;
+        } else {
+            break;
+        }
+    }
+    start
+}
+
+/// Add blank lines after directive sequences in function/program bodies.
+///
+/// Babel's codegen emits a blank line after the last directive in a body
+/// (e.g., after `"use strict";` or `"use no memo";`). SWC's codegen
+/// does not. This function adds those blank lines to match Babel's output.
+fn add_blank_lines_after_directives(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    if lines.is_empty() {
+        return code.to_string();
+    }
+
+    let mut result: Vec<&str> = Vec::with_capacity(lines.len() + 8);
+    let mut i = 0;
+
+    while i < lines.len() {
+        result.push(lines[i]);
+
+        // Check if this line is a directive (string literal expression statement)
+        if is_directive_line(lines[i]) {
+            // Check if the next line is NOT a directive and NOT blank
+            if i + 1 < lines.len()
+                && !is_directive_line(lines[i + 1])
+                && !lines[i + 1].trim().is_empty()
+            {
+                result.push("");
+            }
+        }
+
+        i += 1;
+    }
+
+    // Rejoin, preserving trailing newline if present
+    let mut output = result.join("\n");
+    if code.ends_with('\n') && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+/// Check if a line is a directive (a string literal expression statement).
+/// Directives look like: `"use strict";` or `'use no memo';` possibly with
+/// leading whitespace (indentation for function body directives).
+fn is_directive_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    // Must start with a quote and end with the matching quote + semicolon
+    if let Some(rest) = trimmed.strip_prefix('"') {
+        rest.ends_with("\";")
+    } else if let Some(rest) = trimmed.strip_prefix('\'') {
+        rest.ends_with("';")
+    } else {
+        false
+    }
+}
+
+/// Insert newlines after `*/` when followed by code on the same line.
+/// Only applies to multiline block comments (JSDoc-style), not inline ones.
+fn fix_block_comment_newlines(code: &str) -> String {
+    let mut result = String::with_capacity(code.len());
+    let mut chars = code.char_indices().peekable();
+    let bytes = code.as_bytes();
+    let mut in_block_comment = false;
+    let mut block_comment_multiline = false;
+
+    while let Some((i, c)) = chars.next() {
+        // Track block comment state
+        if !in_block_comment && c == '/' && bytes.get(i + 1) == Some(&b'*') {
+            in_block_comment = true;
+            block_comment_multiline = false;
+            result.push(c);
+            continue;
+        }
+
+        if in_block_comment {
+            if c == '\n' {
+                block_comment_multiline = true;
+            }
+            result.push(c);
+
+            // Check for end of block comment
+            if c == '*' && bytes.get(i + 1) == Some(&b'/') {
+                chars.next();
+                result.push('/');
+                in_block_comment = false;
+
+                if block_comment_multiline {
+                    // Skip spaces after `*/`
+                    let mut spaces = String::new();
+                    while let Some(&(_, next_c)) = chars.peek() {
+                        if next_c == ' ' || next_c == '\t' {
+                            spaces.push(next_c);
+                            chars.next();
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // If followed by code on the same line, insert newline
+                    if let Some(&(_, next_c)) = chars.peek() {
+                        if next_c != '\n' && next_c != '\r' {
+                            result.push('\n');
+                        } else {
+                            result.push_str(&spaces);
+                        }
+                    } else {
+                        result.push_str(&spaces);
+                    }
+                }
+            }
+            continue;
+        }
+
+        result.push(c);
+    }
+    result
+}
+
+/// Reposition blank lines from before comment blocks to after them.
+///
+/// SWC's codegen sometimes places blank lines before leading comment blocks,
+/// but Babel's generator places them after the comments (between the comment
+/// block and the declaration). This function detects the pattern:
+///
+///   <non-comment line>
+///   <blank line>
+///   <comment lines...>
+///   <declaration line>
+///
+/// And transforms it to:
+///
+///   <non-comment line>
+///   <comment lines...>
+///   <blank line>
+///   <declaration line>
+///
+/// This only applies to top-level (non-indented) comment blocks.
+fn reposition_comment_blank_lines(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    if lines.len() < 3 {
+        return code.to_string();
+    }
+
+    let mut result: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+
+    while i < lines.len() {
+        // Look for pattern: blank line followed by comment block followed by declaration
+        if lines[i].trim().is_empty() && i + 1 < lines.len() {
+            let comment_start = i + 1;
+            let first_comment = lines[comment_start].trim();
+
+            // Check if the next line is a top-level comment (not indented)
+            let is_top_level_comment = (first_comment.starts_with("//")
+                || first_comment.starts_with("/*")
+                || first_comment.starts_with("/**"))
+                && !lines[comment_start].starts_with(' ')
+                && !lines[comment_start].starts_with('\t');
+
+            if is_top_level_comment {
+                // Find the end of the comment block
+                let mut comment_end = comment_start;
+                while comment_end < lines.len() {
+                    let trimmed = lines[comment_end].trim();
+                    if trimmed.starts_with("//")
+                        || trimmed.starts_with("/*")
+                        || trimmed.starts_with("* ")
+                        || trimmed.starts_with("*/")
+                        || trimmed == "*"
+                        || trimmed.starts_with("/**")
+                    {
+                        comment_end += 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                // Check if the line after the comment block is a top-level
+                // declaration (function, class, export, const, let, var).
+                // This is specifically for Babel's codegen which places blank
+                // lines after comment blocks before declarations, not before.
+                if comment_end < lines.len() && comment_end > comment_start {
+                    let after_comment = lines[comment_end].trim();
+                    let is_declaration = after_comment.starts_with("function ")
+                        || after_comment.starts_with("export ")
+                        || after_comment.starts_with("class ")
+                        || after_comment.starts_with("const ")
+                        || after_comment.starts_with("let ")
+                        || after_comment.starts_with("var ")
+                        || after_comment.starts_with("import ")
+                        || after_comment.starts_with("async function ")
+                        || after_comment.starts_with("async function*");
+
+                    if is_declaration {
+                        // Also check that the line before the blank line is
+                        // non-empty (end of import or end of function)
+                        let prev_non_empty = i > 0 && !lines[i - 1].trim().is_empty();
+
+                        if prev_non_empty {
+                            // Move the blank line: emit comment block first,
+                            // then blank line, then continue
+                            for j in comment_start..comment_end {
+                                result.push(lines[j]);
+                            }
+                            result.push(""); // blank line after comments
+                            i = comment_end;
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        result.push(lines[i]);
+        i += 1;
+    }
+
+    // Rejoin, preserving trailing newline if present
+    let mut output = result.join("\n");
+    if code.ends_with('\n') && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+/// Compute where blank lines should be inserted in the emitted output.
+///
+/// This replicates Babel's `@babel/generator` behavior: when consecutive
+/// top-level items had blank lines between them in the original source,
+/// the generator preserves those blank lines.
+///
+/// We check the item spans (byte positions into the original source) and
+/// determine if there was a blank line gap between consecutive items.
+/// We also determine WHERE the blank line should go: before the item's
+/// leading comments (BeforeItem) or between the comments and code (BeforeCode).
+fn compute_blank_line_positions(
+    body: &[swc_core::ecma::ast::ModuleItem],
+    source_text: &str,
+) -> Vec<BlankLinePosition> {
+    use swc_core::common::Spanned;
+
+    let mut result = Vec::new();
+
+    // Check for blank lines between leading comments and the first
+    // non-DUMMY item. This handles the case where comments from the
+    // source (e.g., pragma comments) are attached as leading comments
+    // to an import, with a blank line gap in the original source.
+    for item in body {
+        let lo = item.span().lo;
+        if lo.is_dummy() {
+            continue;
+        }
+        let lo_u = (lo.0 as usize).saturating_sub(1);
+        if lo_u > source_text.len() || lo_u == 0 {
+            break;
+        }
+        // Check the source text before this item for comments followed by blank lines
+        let before = &source_text[..lo_u];
+        if has_blank_line(before) && (before.contains("//") || before.contains("/*")) {
+            // There are comments and blank lines before this item.
+            // Check if the blank line is between the comments and this item
+            // (i.e., "BeforeCode" pattern)
+            if !is_blank_line_before_comments(before) {
+                let first_code_line = get_first_code_line(item);
+                result.push(BlankLinePosition::BeforeCode { first_code_line });
+            }
+        }
+        break; // Only check the first non-DUMMY item
+    }
+
+    for i in 1..body.len() {
+        let prev = &body[i - 1];
+        let curr = &body[i];
+
+        let prev_hi = prev.span().hi;
+        let curr_lo = curr.span().lo;
+
+        // Skip items with dummy/synthetic spans (BytePos(0))
+        if prev_hi.is_dummy() || curr_lo.is_dummy() {
+            continue;
+        }
+
+        // SWC BytePos is 1-based (BytePos(0) is DUMMY/reserved). Convert
+        // to 0-based source text indices by subtracting 1.
+        let prev_hi_u = (prev_hi.0 as usize).saturating_sub(1);
+        let curr_lo_u = (curr_lo.0 as usize).saturating_sub(1);
+
+        if prev_hi_u >= curr_lo_u || prev_hi_u > source_text.len() || curr_lo_u > source_text.len()
+        {
+            continue;
+        }
+
+        // Check the text between the two items for blank lines.
+        // Babel's generator preserves blank lines from the original source
+        // between consecutive top-level items.
+        let between = &source_text[prev_hi_u..curr_lo_u];
+        if !has_blank_line(between) {
+            continue;
+        }
+
+        // Only preserve blank lines when there are comments between the
+        // items. This matches Babel's behavior: the TS compiler's
+        // replaceWith() creates fresh nodes without position info, so
+        // Babel's generator only sees position gaps when comments with
+        // original positions are present between items. Without comments,
+        // the generated code and the next item end up close together,
+        // so Babel sees no gap and doesn't insert a blank line.
+        if !between.contains("//") && !between.contains("/*") {
+            continue;
+        }
+
+        // Determine the first code line of the current item (emitted
+        // without comments) for use as a search anchor.
+        let first_code_line = get_first_code_line(curr);
+
+        // Determine whether blank lines exist before and/or after comments.
+        let (blank_before, blank_after) = blank_line_positions_around_comments(between);
+
+        if blank_before && blank_after {
+            // Both: add blank lines before AND after comments
+            result.push(BlankLinePosition::BeforeItem {
+                first_code_line: first_code_line.clone(),
+            });
+            result.push(BlankLinePosition::BeforeCode { first_code_line });
+        } else if blank_after {
+            result.push(BlankLinePosition::BeforeCode { first_code_line });
+        } else {
+            // blank_before only, or no specific position → default to BeforeItem
+            result.push(BlankLinePosition::BeforeItem { first_code_line });
+        }
+    }
+
+    result
+}
+
+/// Check if a string contains a blank line (two consecutive newlines
+/// with only whitespace between them).
+fn has_blank_line(s: &str) -> bool {
+    let mut prev_newline = false;
+    for c in s.chars() {
+        if c == '\n' {
+            if prev_newline {
+                return true;
+            }
+            prev_newline = true;
+        } else if c == ' ' || c == '\t' || c == '\r' {
+            // whitespace between newlines is ok
+        } else {
+            prev_newline = false;
+        }
+    }
+    false
+}
+
+/// Determine where blank lines exist relative to comments in the between-text.
+///
+/// Returns (blank_before_comments, blank_after_comments):
+/// - blank_before: there's a blank line before any comment content
+/// - blank_after: there's a blank line after comment content
+fn blank_line_positions_around_comments(between: &str) -> (bool, bool) {
+    let mut found_comment = false;
+    let mut prev_newline = false;
+    let mut blank_before = false;
+    let mut blank_after = false;
+
+    for (i, c) in between.char_indices() {
+        if c == '\n' {
+            if prev_newline {
+                if found_comment {
+                    blank_after = true;
+                } else {
+                    blank_before = true;
+                }
+            }
+            prev_newline = true;
+        } else if c == ' ' || c == '\t' || c == '\r' {
+            // whitespace between newlines is ok
+        } else {
+            prev_newline = false;
+            if c == '/' {
+                let next = between.as_bytes().get(i + 1);
+                if next == Some(&b'*') || next == Some(&b'/') {
+                    found_comment = true;
+                }
+            }
+        }
+    }
+
+    (blank_before, blank_after)
+}
+
+/// Check if the blank line in the between-text should be placed before
+/// comments. Used for the first-item leading comment check.
+fn is_blank_line_before_comments(between: &str) -> bool {
+    let (blank_before, blank_after) = blank_line_positions_around_comments(between);
+    // If blank lines exist after comments, prefer BeforeCode (return false)
+    if blank_after {
+        return false;
+    }
+    blank_before
+}
+
+/// Get the first non-empty line of a ModuleItem when emitted without
+/// comments. Goes through `emit_module_to_string` so the text matches the
+/// final emitted output (including the namespace-export fixup).
+fn get_first_code_line(item: &swc_core::ecma::ast::ModuleItem) -> String {
+    let single_module = swc_core::ecma::ast::Module {
+        span: swc_core::common::DUMMY_SP,
+        body: vec![item.clone()],
+        shebang: None,
+    };
+
+    let code = emit_module_to_string(&single_module, None);
+    code.lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Extract comments from source text using SWC's parser.
+/// Returns a list of (BytePos, Vec<Comment>) pairs where the BytePos is the
+/// position of the token following the comment(s).
+fn extract_source_comments(
+    source_text: &str,
+) -> (
+    Vec<(
+        swc_core::common::BytePos,
+        Vec<swc_core::common::comments::Comment>,
+    )>,
+    Vec<(
+        swc_core::common::BytePos,
+        Vec<swc_core::common::comments::Comment>,
+    )>,
+) {
+    let cm = swc_core::common::sync::Lrc::new(swc_core::common::SourceMap::default());
+    let fm = cm.new_source_file(
+        swc_core::common::sync::Lrc::new(swc_core::common::FileName::Anon),
+        source_text.to_string(),
+    );
+
+    let comments = swc_core::common::comments::SingleThreadedComments::default();
+    let mut errors = vec![];
+    // Try parsing as JSX+TS to handle maximum syntax variety
+    let _ = swc_core::ecma::parser::parse_file_as_module(
+        &fm,
+        swc_core::ecma::parser::Syntax::Typescript(swc_core::ecma::parser::TsSyntax {
+            tsx: true,
+            ..Default::default()
+        }),
+        swc_core::ecma::ast::EsVersion::latest(),
+        Some(&comments),
+        &mut errors,
+    );
+
+    let mut leading_result = Vec::new();
+    let mut trailing_result = Vec::new();
+    let (leading, trailing) = comments.borrow_all();
+    for (pos, cmts) in leading.iter() {
+        if !cmts.is_empty() {
+            leading_result.push((*pos, cmts.clone()));
+        }
+    }
+    for (pos, cmts) in trailing.iter() {
+        if !cmts.is_empty() {
+            trailing_result.push((*pos, cmts.clone()));
+        }
+    }
+
+    (leading_result, trailing_result)
+}
+
+/// Normalize source code formatting to match Babel's codegen behavior.
+/// Applied to source text that was not modified by the compiler.
+/// Currently adds blank lines after directive sequences, matching
+/// Babel's generator which always emits a blank line after the last
+/// directive in a function/program body.
+pub fn normalize_source(source: &str) -> String {
+    let code = add_blank_lines_after_directives(source);
+    let code = remove_blank_lines_after_last_import(&code);
+    let code = remove_blank_lines_before_fixture_entrypoint(&code);
+    expand_fixture_entrypoint_objects(&code)
+}
+
+/// Remove blank lines immediately before `export const FIXTURE_ENTRYPOINT`.
+/// Babel's codegen doesn't preserve blank lines between function declarations
+/// and the FIXTURE_ENTRYPOINT export.
+fn remove_blank_lines_before_fixture_entrypoint(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    if lines.is_empty() {
+        return code.to_string();
+    }
+
+    // Find the FIXTURE_ENTRYPOINT line
+    let mut entrypoint_idx: Option<usize> = None;
+    for (i, &line) in lines.iter().enumerate() {
+        if line.trim().starts_with("export const FIXTURE_ENTRYPOINT")
+            || line.trim().starts_with("export const FIXTURE_ENTRYPOINT")
+        {
+            entrypoint_idx = Some(i);
+            break;
+        }
+    }
+
+    let entrypoint_idx = match entrypoint_idx {
+        Some(idx) if idx > 0 => idx,
+        _ => return code.to_string(),
+    };
+
+    // Check if the line before FIXTURE_ENTRYPOINT is blank
+    if !lines[entrypoint_idx - 1].trim().is_empty() {
+        return code.to_string();
+    }
+
+    // Remove the blank line
+    let mut result: Vec<&str> = Vec::with_capacity(lines.len());
+    for (i, &line) in lines.iter().enumerate() {
+        if i == entrypoint_idx - 1 {
+            continue;
+        }
+        result.push(line);
+    }
+
+    let mut output = result.join("\n");
+    if code.ends_with('\n') && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+/// Remove blank lines between the last import declaration and the first
+/// non-import statement. Babel's codegen doesn't preserve these blank lines.
+///
+/// Only removes blank lines that immediately follow the LAST import line
+/// (not blank lines between comments or between import groups).
+fn remove_blank_lines_after_last_import(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    if lines.is_empty() {
+        return code.to_string();
+    }
+
+    // Find the index of the last import statement
+    let mut last_import_idx: Option<usize> = None;
+    for (i, &line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("import ") || trimmed.starts_with("import{") {
+            last_import_idx = Some(i);
+        }
+    }
+
+    let last_import_idx = match last_import_idx {
+        Some(idx) => idx,
+        None => return code.to_string(),
+    };
+
+    // Check if there's a blank line immediately after the last import
+    let blank_idx = last_import_idx + 1;
+    if blank_idx >= lines.len() || !lines[blank_idx].trim().is_empty() {
+        return code.to_string();
+    }
+
+    // Remove this blank line
+    let mut result: Vec<&str> = Vec::with_capacity(lines.len());
+    for (i, &line) in lines.iter().enumerate() {
+        if i == blank_idx {
+            continue; // skip the blank line
+        }
+        result.push(line);
+    }
+
+    let mut output = result.join("\n");
+    if code.ends_with('\n') && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+/// Expand single-line object literals to multi-line format within
+/// FIXTURE_ENTRYPOINT structures only.
+///
+/// SWC's codegen emits small objects on a single line (e.g.,
+/// `params: [{ value: "test" }]`), while Babel's codegen puts them on
+/// multiple lines. Since prettier preserves the single-line vs multi-line
+/// choice, we need to expand them before prettier runs.
+///
+/// This function ONLY operates within FIXTURE_ENTRYPOINT blocks to avoid
+/// affecting compiled code.
+fn expand_fixture_entrypoint_objects(code: &str) -> String {
+    // Find the start of FIXTURE_ENTRYPOINT block
+    let entrypoint_marker = "FIXTURE_ENTRYPOINT";
+    if !code.contains(entrypoint_marker) {
+        return code.to_string();
+    }
+
+    // Find the byte position of FIXTURE_ENTRYPOINT
+    let entrypoint_pos = match code.find(entrypoint_marker) {
+        Some(pos) => pos,
+        None => return code.to_string(),
+    };
+
+    // Only process lines after FIXTURE_ENTRYPOINT
+    let (before, after) = code.split_at(entrypoint_pos);
+    let expanded = expand_single_line_objects_in_block(after);
+    format!("{}{}", before, expanded)
+}
+
+fn expand_single_line_objects_in_block(code: &str) -> String {
+    let mut result = String::with_capacity(code.len() + 256);
+    let lines: Vec<&str> = code.lines().collect();
+
+    for (idx, &line) in lines.iter().enumerate() {
+        if let Some(expanded) = try_expand_object_line(line) {
+            result.push_str(&expanded);
+        } else {
+            result.push_str(line);
+        }
+        if idx < lines.len() - 1 || code.ends_with('\n') {
+            result.push('\n');
+        }
+    }
+
+    result
+}
+
+/// Try to expand a single-line object literal to multi-line.
+/// Returns Some(expanded) if the line contains an expandable object, None otherwise.
+fn try_expand_object_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+
+    // Calculate indentation
+    let indent = &line[..line.len() - line.trim_start().len()];
+
+    // Pattern 1: `key: [{ prop: val, prop2: val2 }],` or `key: [{ ... }, { ... }],`
+    // Pattern 2: `[{ prop: val }, { prop: val }]` (array of objects)
+    // We need to find `[` containing `{...}` entries
+
+    // Check if this line has a [ ... ] with { ... } objects inside
+    if !trimmed.contains("[{") && !trimmed.contains("{ ") {
+        return None;
+    }
+
+    // Find the bracket-enclosed array content
+    let bracket_start = trimmed.find('[')?;
+    let bracket_end = trimmed.rfind(']')?;
+    if bracket_start >= bracket_end {
+        return None;
+    }
+
+    let array_content = &trimmed[bracket_start + 1..bracket_end];
+    let inner_trimmed = array_content.trim();
+
+    // Check if this contains objects: at least one `{ ... }`
+    if !inner_trimmed.starts_with('{') || !inner_trimmed.contains(':') {
+        return None;
+    }
+
+    // We need at least one property with a colon to expand
+    if !inner_trimmed.contains(':') {
+        return None;
+    }
+
+    // Split the array content into individual elements
+    let prefix = &trimmed[..bracket_start + 1];
+    let suffix = &trimmed[bracket_end..];
+
+    // Parse the objects - split at `}, {` boundaries
+    let elements = split_array_elements(inner_trimmed);
+
+    let inner_indent = format!("{}  ", indent);
+    let prop_indent = format!("{}    ", indent);
+
+    let mut result = String::new();
+    result.push_str(indent);
+    result.push_str(prefix);
+    result.push('\n');
+
+    for (i, elem) in elements.iter().enumerate() {
+        let elem = elem.trim();
+        if elem.starts_with('{') && elem.ends_with('}') {
+            // Expand this object
+            let obj_content = &elem[1..elem.len() - 1].trim();
+            let props = split_object_properties(obj_content);
+
+            result.push_str(&inner_indent);
+            result.push_str("{\n");
+            for (_j, prop) in props.iter().enumerate() {
+                result.push_str(&prop_indent);
+                result.push_str(prop.trim());
+                result.push_str(",\n");
+            }
+            result.push_str(&inner_indent);
+            result.push('}');
+        } else {
+            result.push_str(&inner_indent);
+            result.push_str(elem);
+        }
+        if i < elements.len() - 1 {
+            result.push(',');
+        }
+        result.push('\n');
+    }
+
+    result.push_str(indent);
+    result.push_str(suffix);
+
+    Some(result)
+}
+
+/// Split array content into individual elements, respecting nested braces/brackets.
+fn split_array_elements(s: &str) -> Vec<String> {
+    let mut elements = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0;
+
+    for ch in s.chars() {
+        match ch {
+            '{' | '[' | '(' => {
+                depth += 1;
+                current.push(ch);
+            }
+            '}' | ']' | ')' => {
+                depth -= 1;
+                current.push(ch);
+            }
+            ',' if depth == 0 => {
+                let trimmed = current.trim().to_string();
+                if !trimmed.is_empty() {
+                    elements.push(trimmed);
+                }
+                current.clear();
+            }
+            _ => {
+                current.push(ch);
+            }
+        }
+    }
+    let trimmed = current.trim().to_string();
+    if !trimmed.is_empty() {
+        elements.push(trimmed);
+    }
+    elements
+}
+
+/// Split object properties, respecting nested structures.
+fn split_object_properties(s: &str) -> Vec<String> {
+    let mut props = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0;
+
+    for ch in s.chars() {
+        match ch {
+            '{' | '[' | '(' => {
+                depth += 1;
+                current.push(ch);
+            }
+            '}' | ']' | ')' => {
+                depth -= 1;
+                current.push(ch);
+            }
+            ',' if depth == 0 => {
+                let trimmed = current.trim().to_string();
+                if !trimmed.is_empty() {
+                    props.push(trimmed);
+                }
+                current.clear();
+            }
+            _ => {
+                current.push(ch);
+            }
+        }
+    }
+    let trimmed = current.trim().to_string();
+    if !trimmed.is_empty() {
+        props.push(trimmed);
+    }
+    props
+}
+
+/// Convenience wrapper — parses source text, then lints.
+pub fn lint_source(source_text: &str, options: PluginOptions) -> LintResult {
+    let cm = swc_core::common::sync::Lrc::new(swc_core::common::SourceMap::default());
+    let fm = cm.new_source_file(
+        swc_core::common::sync::Lrc::new(swc_core::common::FileName::Anon),
+        source_text.to_string(),
+    );
+
+    let mut errors = vec![];
+    let module = swc_core::ecma::parser::parse_file_as_module(
+        &fm,
+        swc_core::ecma::parser::Syntax::Es(swc_core::ecma::parser::EsSyntax {
+            jsx: true,
+            ..Default::default()
+        }),
+        swc_core::ecma::ast::EsVersion::latest(),
+        None,
+        &mut errors,
+    );
+
+    match module {
+        Ok(module) => lint(&module, source_text, options),
+        Err(_) => LintResult {
+            diagnostics: vec![],
+        },
+    }
+}

--- a/turbopack/crates/react_compiler_swc/src/prefilter.rs
+++ b/turbopack/crates/react_compiler_swc/src/prefilter.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use swc_core::ecma::{
+    ast::{
+        ArrowExpr, AssignExpr, AssignTarget, CallExpr, Callee, Class, Expr, FnDecl, FnExpr,
+        MemberProp, Module, Pat, SimpleAssignTarget, VarDeclarator,
+    },
+    visit::Visit,
+};
+
+/// Checks if a module contains React-like functions (components or hooks).
+///
+/// A React-like function is one whose name:
+/// - Starts with an uppercase letter (component convention)
+/// - Matches the pattern `use[A-Z0-9]` (hook convention)
+pub fn has_react_like_functions(module: &Module) -> bool {
+    let mut visitor = ReactLikeVisitor {
+        found: false,
+        current_name: None,
+    };
+    visitor.visit_module(module);
+    visitor.found
+}
+
+use react_compiler_hir::environment::is_react_like_name;
+
+struct ReactLikeVisitor {
+    found: bool,
+    current_name: Option<String>,
+}
+
+impl Visit for ReactLikeVisitor {
+    fn visit_var_declarator(&mut self, decl: &VarDeclarator) {
+        if self.found {
+            return;
+        }
+
+        // Extract name from the binding identifier
+        let name = match &decl.name {
+            Pat::Ident(binding_ident) => Some(binding_ident.id.sym.to_string()),
+            _ => None,
+        };
+
+        let prev_name = self.current_name.take();
+        self.current_name = name;
+
+        // Visit the initializer with the name in scope
+        if let Some(init) = &decl.init {
+            self.visit_expr(init);
+        }
+
+        self.current_name = prev_name;
+    }
+
+    fn visit_assign_expr(&mut self, expr: &AssignExpr) {
+        if self.found {
+            return;
+        }
+
+        let name = match &expr.left {
+            AssignTarget::Simple(SimpleAssignTarget::Ident(binding_ident)) => {
+                Some(binding_ident.id.sym.to_string())
+            }
+            _ => None,
+        };
+
+        let prev_name = self.current_name.take();
+        self.current_name = name;
+
+        self.visit_expr(&expr.right);
+
+        self.current_name = prev_name;
+    }
+
+    fn visit_fn_decl(&mut self, decl: &FnDecl) {
+        if self.found {
+            return;
+        }
+
+        if is_react_like_name(&decl.ident.sym) {
+            self.found = true;
+            return;
+        }
+
+        // Don't traverse into the function body
+    }
+
+    fn visit_fn_expr(&mut self, expr: &FnExpr) {
+        if self.found {
+            return;
+        }
+
+        // Check explicit function name
+        if let Some(id) = &expr.ident {
+            if is_react_like_name(&id.sym) {
+                self.found = true;
+                return;
+            }
+        }
+
+        // Check inferred name from parent context
+        if expr.ident.is_none() {
+            if let Some(name) = &self.current_name {
+                if is_react_like_name(name) {
+                    self.found = true;
+                    return;
+                }
+            }
+        }
+
+        // Don't traverse into the function body
+    }
+
+    fn visit_arrow_expr(&mut self, _expr: &ArrowExpr) {
+        if self.found {
+            return;
+        }
+
+        if let Some(name) = &self.current_name {
+            if is_react_like_name(name) {
+                self.found = true;
+                return;
+            }
+        }
+
+        // Don't traverse into the function body
+    }
+
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if self.found {
+            return;
+        }
+
+        // Check if this is memo(fn) / forwardRef(fn) / React.memo(fn) / React.forwardRef(fn)
+        if is_memo_or_forward_ref_call(call) {
+            // If the first arg is a function expression or arrow, mark as found
+            if let Some(first_arg) = call.args.first() {
+                match &*first_arg.expr {
+                    Expr::Fn(_) | Expr::Arrow(_) => {
+                        self.found = true;
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Continue traversal for other call expressions
+        // Visit args to find function expressions inside non-memo/forwardRef calls
+        for arg in &call.args {
+            self.visit_expr(&arg.expr);
+        }
+    }
+
+    fn visit_class(&mut self, _class: &Class) {
+        // Skip class bodies entirely
+    }
+}
+
+fn is_memo_or_forward_ref_call(call: &CallExpr) -> bool {
+    match &call.callee {
+        Callee::Expr(expr) => match &**expr {
+            // Direct calls: memo(...) or forwardRef(...)
+            Expr::Ident(ident) => ident.sym == "memo" || ident.sym == "forwardRef",
+            // Member expression: React.memo(...) or React.forwardRef(...)
+            Expr::Member(member) => {
+                if let Expr::Ident(obj) = &*member.obj {
+                    if obj.sym == "React" {
+                        if let MemberProp::Ident(prop) = &member.prop {
+                            return prop.sym == "memo" || prop.sym == "forwardRef";
+                        }
+                    }
+                }
+                false
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_react_like_name() {
+        assert!(is_react_like_name("Component"));
+        assert!(is_react_like_name("MyComponent"));
+        assert!(is_react_like_name("A"));
+        assert!(is_react_like_name("useState"));
+        assert!(is_react_like_name("useEffect"));
+        assert!(is_react_like_name("use0"));
+
+        assert!(!is_react_like_name("component"));
+        assert!(!is_react_like_name("myFunction"));
+        assert!(!is_react_like_name("use"));
+        assert!(!is_react_like_name("user"));
+        assert!(!is_react_like_name("useful"));
+        assert!(!is_react_like_name(""));
+    }
+}

--- a/turbopack/crates/react_compiler_swc/src/ts_namespace_export_fixup.rs
+++ b/turbopack/crates/react_compiler_swc/src/ts_namespace_export_fixup.rs
@@ -1,0 +1,394 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Workaround for an upstream swc_core::ecma::codegen bug: `TsNamespaceExportDecl`
+//! prints as the `TsExportAssignment` shape.
+//!
+//! In swc_core::ecma::codegen v24 (`crates/swc_core::ecma::codegen/src/typescript.rs`),
+//! `TsNamespaceExportDecl::emit` writes `export`, `=`, then the identifier —
+//! producing `export = Foo` instead of `export as namespace Foo`. The bug is
+//! also present on swc master as of June 2026; no upstream issue has been
+//! filed yet.
+//!
+//! Removal criterion: delete this module and its call site in
+//! `emit_module_to_string` when [`tests::upstream_bug_guard`] fails after an
+//! swc upgrade (a failure means swc now prints `export as namespace`).
+//!
+//! # How the rewrite is anchored
+//!
+//! A genuine `export = Foo` assignment prints the exact same text as the
+//! broken namespace-export print, so the affected lines cannot be identified
+//! from the output text alone. Instead the emit path records a source map
+//! (`Vec<(BytePos, LineCol)>` via `JsWriter`), which attributes output
+//! positions to input spans, and the fixup resolves each top-level
+//! `TsNamespaceExportDecl` to its output line through it.
+//!
+//! Empirically (pinned by [`tests::srcmap_records_id_position_within_span`]),
+//! the v24 emitter records no entry for the declaration's own `span.lo` —
+//! the only position recorded while emitting the node is the identifier's
+//! `span.lo`, which lies inside `[span.lo, span.hi)` and maps to the broken
+//! line. Candidate entries are therefore collected over that whole span
+//! range (exact `span.lo` matches first, then ascending position) and the
+//! first candidate line whose content verifies as `export = {id}` (optional
+//! trailing `;` / whitespace) is rewritten.
+//!
+//! Content verification acts as a candidate *filter*, not a post-hoc
+//! assertion: compiler-generated items receive synthetic spans starting at
+//! `BytePos(1)` (see `transform`), so when the namespace export is the first
+//! source statement its `span.lo` collides with a synthetic span and the
+//! exact-match candidate points at the generated import's line. The id-span
+//! candidate still verifies, so the scan settles on the correct line.
+//!
+//! If no candidate verifies — or the declaration has a dummy span, so the
+//! emitter recorded nothing for it — the fixup panics. A silent fallback
+//! would emit `export = Foo`, which has different semantics (an export
+//! assignment), and this is exactly the silently-wrong path the previous
+//! text-pairing implementation could take when its line matching drifted.
+
+use swc_core::{
+    common::{BytePos, LineCol},
+    ecma::ast::{ModuleDecl, ModuleItem, TsNamespaceExportDecl},
+};
+
+/// Rewrite the output lines of top-level `TsNamespaceExportDecl` items from
+/// the broken `export = {id}` print to `export as namespace {id};`.
+///
+/// `code` must be the raw emitter output (before any other post-emit text
+/// fixups) and `srcmap` the source map recorded while emitting it; line
+/// numbers in the source map index directly into `code`'s lines.
+pub(crate) fn fix_ts_namespace_export_decls(
+    body: &[ModuleItem],
+    code: &str,
+    srcmap: &[(BytePos, LineCol)],
+) -> String {
+    let decls: Vec<&TsNamespaceExportDecl> = body
+        .iter()
+        .filter_map(|item| match item {
+            ModuleItem::ModuleDecl(ModuleDecl::TsNamespaceExport(d)) => Some(d),
+            _ => None,
+        })
+        .collect();
+
+    if decls.is_empty() {
+        return code.to_string();
+    }
+
+    let mut lines: Vec<String> = code.lines().map(str::to_string).collect();
+    for decl in decls {
+        let id = decl.id.sym.to_string();
+        let line_idx = locate_broken_line(decl, &id, &lines, srcmap);
+        lines[line_idx] = format!("export as namespace {id};");
+    }
+
+    let mut output = lines.join("\n");
+    if code.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+/// Find the output line holding the broken `export = {id}` print of `decl`.
+///
+/// Candidates are the source-map entries within `[span.lo, span.hi)`,
+/// ordered exact-`span.lo` matches first and then by ascending position
+/// (stable, so emission order breaks ties). The first candidate line whose
+/// content verifies is returned. Panics — deliberately, see the module docs
+/// — when the declaration cannot be located.
+fn locate_broken_line(
+    decl: &TsNamespaceExportDecl,
+    id: &str,
+    lines: &[String],
+    srcmap: &[(BytePos, LineCol)],
+) -> usize {
+    if decl.span.lo.is_dummy() {
+        panic!(
+            "[react-compiler] internal error: cannot rewrite `export as namespace {id}`: the \
+             declaration has a dummy span, so the emitter recorded no source-map positions for it"
+        );
+    }
+
+    let mut candidates: Vec<(BytePos, LineCol)> = srcmap
+        .iter()
+        .filter(|(pos, _)| decl.span.lo <= *pos && *pos < decl.span.hi)
+        .copied()
+        .collect();
+    candidates.sort_by_key(|(pos, _)| (*pos != decl.span.lo, *pos));
+
+    let mut seen_lines: Vec<usize> = Vec::new();
+    for (_, loc) in &candidates {
+        let line_idx = loc.line as usize;
+        if seen_lines.contains(&line_idx) {
+            continue;
+        }
+        seen_lines.push(line_idx);
+        if let Some(line) = lines.get(line_idx) {
+            if is_broken_namespace_export_line(line, id) {
+                return line_idx;
+            }
+        }
+    }
+
+    let candidate_lines: Vec<&str> = seen_lines
+        .iter()
+        .filter_map(|&idx| lines.get(idx).map(String::as_str))
+        .collect();
+    panic!(
+        "[react-compiler] internal error: cannot rewrite `export as namespace {id}`: no \
+         source-map position within its span ({}..{}) maps to an `export = {id}` output line \
+         (candidate lines: {candidate_lines:?})",
+        decl.span.lo.0, decl.span.hi.0
+    );
+}
+
+/// Whether `line` is the broken namespace-export print for `id`: exactly
+/// `export = {id}`, allowing an optional trailing `;` and trailing
+/// whitespace. (The v24 emitter writes no semicolon after this node, but a
+/// future swc may add one before fixing the print itself.)
+fn is_broken_namespace_export_line(line: &str, id: &str) -> bool {
+    let line = line.trim_end();
+    let line = line.strip_suffix(';').unwrap_or(line);
+    match line.strip_prefix("export = ") {
+        Some(rest) => rest == id,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_core::{
+        common::{
+            BytePos, FileName, LineCol, SourceMap, Spanned, comments::SingleThreadedComments,
+            sync::Lrc,
+        },
+        ecma::{
+            ast::EsVersion,
+            parser::{Syntax, parse_file_as_module},
+        },
+    };
+
+    fn parse(source: &str) -> swc_core::ecma::ast::Module {
+        parse_with_comments(source, None)
+    }
+
+    fn parse_with_comments(
+        source: &str,
+        comments: Option<&SingleThreadedComments>,
+    ) -> swc_core::ecma::ast::Module {
+        let cm = Lrc::new(SourceMap::default());
+        let fm = cm.new_source_file(Lrc::new(FileName::Anon), source.to_string());
+        let mut errors = vec![];
+        parse_file_as_module(
+            &fm,
+            Syntax::Typescript(swc_core::ecma::parser::TsSyntax {
+                tsx: true,
+                ..Default::default()
+            }),
+            EsVersion::latest(),
+            comments.map(|c| c as &dyn swc_core::common::comments::Comments),
+            &mut errors,
+        )
+        .expect("Failed to parse")
+    }
+
+    /// Plain swc_core::ecma::codegen emit, WITHOUT the fixup, collecting the
+    /// source map.
+    fn raw_emit_with_srcmap(
+        module: &swc_core::ecma::ast::Module,
+    ) -> (String, Vec<(BytePos, LineCol)>) {
+        let cm = Lrc::new(SourceMap::default());
+        let mut buf = vec![];
+        let mut srcmap: Vec<(BytePos, LineCol)> = Vec::new();
+        {
+            let wr = swc_core::ecma::codegen::text_writer::JsWriter::new(
+                cm.clone(),
+                "\n",
+                &mut buf,
+                Some(&mut srcmap),
+            );
+            let mut emitter = swc_core::ecma::codegen::Emitter {
+                cfg: swc_core::ecma::codegen::Config::default().with_minify(false),
+                cm,
+                comments: None,
+                wr: Box::new(wr),
+            };
+            swc_core::ecma::codegen::Node::emit_with(module, &mut emitter).unwrap();
+        }
+        (String::from_utf8(buf).unwrap(), srcmap)
+    }
+
+    /// Emit through the crate's fixed emit path (fixup applied).
+    fn fixed_emit(source: &str) -> String {
+        let module = parse(source);
+        crate::emit_module_to_string(&module, None)
+    }
+
+    /// Guard test for the upstream bug. When this test FAILS, swc has fixed
+    /// `TsNamespaceExportDecl::emit`: delete this module and its call site
+    /// in `emit_module_to_string`.
+    #[test]
+    fn upstream_bug_guard() {
+        let module = parse("export as namespace Foo;\n");
+        let (code, _) = raw_emit_with_srcmap(&module);
+        assert!(
+            code.contains("export = "),
+            "expected the upstream TsNamespaceExportDecl bug (`export = `): {code:?}"
+        );
+        assert!(
+            !code.contains("export as namespace"),
+            "swc now prints `export as namespace`: the upstream bug is fixed, delete this module: \
+             {code:?}"
+        );
+    }
+
+    /// Pins the source-map invariant the fixup depends on: emitting a
+    /// `TsNamespaceExportDecl` records at least one position within the
+    /// declaration's span, and that position maps to the broken output
+    /// line. Empirically in v24 the recorded position is the identifier's
+    /// `span.lo` (the declaration's own `span.lo` is never recorded).
+    #[test]
+    fn srcmap_records_id_position_within_span() {
+        let source = "const x = 1;\nexport as namespace Foo;\n";
+        let module = parse(source);
+        let decl_span = module.body[1].span();
+        let id_span = match &module.body[1] {
+            swc_core::ecma::ast::ModuleItem::ModuleDecl(
+                swc_core::ecma::ast::ModuleDecl::TsNamespaceExport(d),
+            ) => d.id.span,
+            other => panic!("expected TsNamespaceExport, got {other:?}"),
+        };
+
+        let (code, srcmap) = raw_emit_with_srcmap(&module);
+        let in_range: Vec<&(BytePos, LineCol)> = srcmap
+            .iter()
+            .filter(|(pos, _)| decl_span.lo <= *pos && *pos < decl_span.hi)
+            .collect();
+
+        assert!(
+            !in_range.is_empty(),
+            "no srcmap position recorded within the decl span; the srcmap-anchored fixup design \
+             no longer works: {srcmap:?}"
+        );
+        // The identifier's lo is the recorded anchor...
+        assert_eq!(in_range[0].0, id_span.lo);
+        // ...and it maps to the broken `export = Foo` line.
+        let line = code.lines().nth(in_range[0].1.line as usize).unwrap();
+        assert_eq!(line, "export = Foo");
+        // The declaration's own span.lo is not recorded by the v24 emitter.
+        assert!(
+            !srcmap.iter().any(|(pos, _)| *pos == decl_span.lo),
+            "v24 unexpectedly records the decl's span.lo; revisit candidate ordering: {srcmap:?}"
+        );
+    }
+
+    /// The emitter prints the genuine assignment as `export = lib` (its
+    /// pending semicolon is dropped before the newline), byte-identical in
+    /// shape to the broken namespace print, so only the srcmap tells them
+    /// apart.
+    #[test]
+    fn umd_pair_rewrites_only_the_namespace_export() {
+        assert_eq!(
+            fixed_emit("export = lib;\nexport as namespace Foo;\n"),
+            "export = lib\nexport as namespace Foo;\n"
+        );
+    }
+
+    #[test]
+    fn two_namespace_exports() {
+        assert_eq!(
+            fixed_emit("export as namespace A;\nexport as namespace B;\n"),
+            "export as namespace A;\nexport as namespace B;\n"
+        );
+    }
+
+    /// The decoy's span lies outside the declaration's span, so it is never
+    /// a rewrite candidate.
+    #[test]
+    fn template_literal_decoy_is_not_rewritten() {
+        let source = "const s = `\nexport = Foo\n`;\nexport as namespace Foo;\n";
+        assert_eq!(
+            fixed_emit(source),
+            "const s = `\nexport = Foo\n`;\nexport as namespace Foo;\n"
+        );
+    }
+
+    /// The expected output keeps `*/ const x = 1;` on one line: the raw
+    /// emitter glues code after a block comment, and the later
+    /// `fix_block_comment_newlines` pass (not under test here) splits it.
+    #[test]
+    fn block_comment_decoy_is_not_rewritten() {
+        let source = "/*\nexport = Foo\n*/\nconst x = 1;\nexport as namespace Foo;\n";
+        let comments = SingleThreadedComments::default();
+        let module = parse_with_comments(source, Some(&comments));
+        let code = crate::emit_module_to_string(&module, Some(&comments));
+        assert_eq!(
+            code,
+            "/*\nexport = Foo\n*/ const x = 1;\nexport as namespace Foo;\n"
+        );
+    }
+
+    #[test]
+    fn parenthesized_export_assignment_is_untouched() {
+        assert_eq!(
+            fixed_emit("export = (Foo);\nexport as namespace Foo;\n"),
+            "export = (Foo)\nexport as namespace Foo;\n"
+        );
+    }
+
+    /// The real-pipeline collision shape: the namespace export is the first
+    /// source statement (span.lo == BytePos(1)) and a compiler-generated
+    /// import carries the synthetic span BytePos(1) (see `transform`). The
+    /// exact-`span.lo` candidate points at the import's line; content
+    /// verification filters it out and the id-span candidate wins.
+    #[test]
+    fn synthetic_span_collision_resolves_to_the_real_line() {
+        let source = "export as namespace Foo;\nfunction f() {}\n";
+        let mut module = parse(source);
+        let synthetic_span = swc_core::common::Span::new(BytePos(1), BytePos(1));
+        module.body.insert(
+            0,
+            swc_core::ecma::ast::ModuleItem::ModuleDecl(swc_core::ecma::ast::ModuleDecl::Import(
+                swc_core::ecma::ast::ImportDecl {
+                    span: synthetic_span,
+                    specifiers: vec![],
+                    src: Box::new(swc_core::ecma::ast::Str {
+                        span: swc_core::common::DUMMY_SP,
+                        value: "react/compiler-runtime".into(),
+                        raw: None,
+                    }),
+                    type_only: false,
+                    with: None,
+                    phase: Default::default(),
+                },
+            )),
+        );
+
+        let code = crate::emit_module_to_string(&module, None);
+        assert_eq!(
+            code,
+            "import \"react/compiler-runtime\";\nexport as namespace Foo;\nfunction f() {}\n"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "[react-compiler] internal error")]
+    fn dummy_span_panics_loudly() {
+        let module = swc_core::ecma::ast::Module {
+            span: swc_core::common::DUMMY_SP,
+            body: vec![swc_core::ecma::ast::ModuleItem::ModuleDecl(
+                swc_core::ecma::ast::ModuleDecl::TsNamespaceExport(
+                    swc_core::ecma::ast::TsNamespaceExportDecl {
+                        span: swc_core::common::DUMMY_SP,
+                        id: swc_core::ecma::ast::Ident::new_no_ctxt(
+                            "Foo".into(),
+                            swc_core::common::DUMMY_SP,
+                        ),
+                    },
+                ),
+            )],
+            shebang: None,
+        };
+        crate::emit_module_to_string(&module, None);
+    }
+}


### PR DESCRIPTION
This vendors react_compiler_swc locally at turbopack/crates/react_compiler_swc, retargeted to swc_core v23 via Cargo [patch].

The only change between this and upstream is `use` imports have been updated to Turbopack's internal `swc_core` crate.