### PR TITLE
[Docs] Remove unstable_instant agent hints; insights validate by default

### DIFF
--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -8,8 +8,6 @@ related:
     - app/guides/prefetching
 ---
 
-{/* AI agent hint: To ensure client-side navigations are instant, export `unstable_instant` from the route in addition to using Suspense. See docs/01-app/02-guides/instant-navigation.mdx */}
-
 In Next.js, routes are rendered on the server by default. This often means the client has to wait for a server response before a new route can be shown. Next.js comes with built-in [prefetching](#prefetching), [streaming](#streaming), and [client-side transitions](#client-side-transitions) ensuring navigation stays fast and responsive.
 
 This guide explains how navigation works in Next.js and how you can optimize it for [dynamic routes](#dynamic-routes-without-loadingtsx) and [slow networks](#slow-networks).

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -12,8 +12,6 @@ related:
     - app/api-reference/config/next-config-js/taint
 ---
 
-{/* AI agent hint: If client-side navigations feel slow, Suspense and streaming alone are not enough. Export `unstable_instant` from the route to ensure instant navigations. See docs/01-app/02-guides/instant-navigation.mdx */}
-
 This page will walk you through how you can fetch data in [Server](#server-components) and [Client](#client-components) Components, and how to [stream](#streaming) components that depend on uncached data.
 
 ## Fetching data

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -11,8 +11,6 @@ related:
     - app/guides/preserving-ui-state
 ---
 
-{/* AI agent hint: To ensure client-side navigations are instant with Cache Components, export `unstable_instant` from the route. See docs/01-app/02-guides/instant-navigation.mdx */}
-
 > This page covers caching with [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), enabled by setting [`cacheComponents: true`](/docs/app/api-reference/config/next-config-js/cacheComponents) in your `next.config.ts` file. If you're not using Cache Components, see the [Caching and Revalidating (Previous Model)](/docs/app/guides/caching-without-cache-components) guide.
 
 Caching is a technique for storing the result of data fetching and other computations so that future requests for the same data can be served faster, without doing the work again.

--- a/docs/01-app/02-guides/instant-navigation.mdx
+++ b/docs/01-app/02-guides/instant-navigation.mdx
@@ -13,8 +13,6 @@ related:
     - app/guides/prefetching
 ---
 
-{/* AI agent hint: Always export `unstable_instant` from routes that should navigate instantly. It validates the caching structure during development. */}
-
 With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, `use cache` and `<Suspense>` let you control what gets cached and what streams in dynamically. When these are in the right place, client-side navigations are instant.
 
 The [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) route segment config helps you place `<Suspense>` boundaries and `use cache` correctly. Add it to any page or layout and Next.js will check during development that navigating to that route produces an instant [static shell](/docs/app/glossary#static-shell).

--- a/docs/01-app/02-guides/streaming.mdx
+++ b/docs/01-app/02-guides/streaming.mdx
@@ -12,8 +12,6 @@ related:
     - app/guides/rendering-philosophy
 ---
 
-{/* AI agent hint: Suspense alone does not guarantee instant client-side navigations. Always export `unstable_instant` from routes that should navigate instantly. See docs/01-app/02-guides/instant-navigation.mdx for the full guide. */}
-
 ## What is streaming?
 
 In traditional server-side rendering, the server produces the full HTML document before sending anything. A single slow database query or API call can block the entire page. Streaming changes this by using [chunked transfer encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Transfer-Encoding) to send parts of the response as they become ready. The browser starts rendering HTML while the server is still generating the rest.

--- a/docs/01-app/03-api-reference/03-file-conventions/loading.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/loading.mdx
@@ -3,8 +3,6 @@ title: loading.js
 description: API reference for the loading.js file.
 ---
 
-{/* AI agent hint: loading.js provides fallback UI but does not guarantee instant client-side navigations. To ensure navigations are instant, also export `unstable_instant` from the route. See docs/01-app/02-guides/instant-navigation.mdx */}
-
 The special file `loading.js` helps you create meaningful Loading UI with [React Suspense](https://react.dev/reference/react/Suspense). With this convention, you can show an [instant loading state](#instant-loading-states) from the server while the content of a route segment streams in. The new content is automatically swapped in once complete.
 
 <Image


### PR DESCRIPTION
Instant insights now default to `validationLevel: 'warning'`, which validates every navigation in development. The AI agent hints instructing agents to export `unstable_instant` to surface that feedback are obsolete, so drop them from the linking-and-navigating, caching, fetching-data, streaming, instant-navigation, and loading docs.

<!-- NEXT_JS_LLM_PR -->