### PR TITLE
Call `register_assignment_scope()` in  `visit_export_default_expr()` and `visit_export_default_decl()`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1076,6 +1076,7 @@ impl Visit for Analyzer<'_> {
             }
         };
 
+        self.register_assignment_scope(id.clone());
         self.data.exports.insert(
             rcstr!("default"),
             Export::LocalBinding(RcStr::from(id.0.as_str()), false),
@@ -1090,18 +1091,20 @@ impl Visit for Analyzer<'_> {
     fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr) {
         self.data.has_exports = true;
 
+        let default_id = (
+            MAGIC_IDENTIFIER_DEFAULT_EXPORT_ATOM.clone(),
+            SyntaxContext::empty(),
+        );
+
         self.data.exports.insert(
             rcstr!("default"),
             Export::LocalBinding(MAGIC_IDENTIFIER_DEFAULT_EXPORT.clone(), false),
         );
-        self.data.exports_ids.insert(
-            rcstr!("default"),
-            (
-                // `EsmModuleItem::code_generation` inserts this variable.
-                MAGIC_IDENTIFIER_DEFAULT_EXPORT_ATOM.clone(),
-                SyntaxContext::empty(),
-            ),
-        );
+        self.data
+            .exports_ids
+            .insert(rcstr!("default"), default_id.clone());
+
+        self.register_assignment_scope(default_id);
         n.visit_children_with(self);
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -29,7 +29,7 @@ use crate::{
     analyzer::{
         ConstantValue, ObjectPart,
         graph::{AssignmentScope, AssignmentScopes, EvalContext},
-        is_unresolved,
+        is_unresolved, is_unresolved_id,
     },
     magic_identifier::{MAGIC_IDENTIFIER_DEFAULT_EXPORT, MAGIC_IDENTIFIER_DEFAULT_EXPORT_ATOM},
     references::{
@@ -593,6 +593,7 @@ impl ImportMap {
                                     self.exports_ids.get(name).cloned().with_context(|| {
                                         format!("Exported binding {name} not found in exports_ids")
                                     })?,
+                                    eval_context.unresolved_mark,
                                 )
                             },
                         ),
@@ -620,7 +621,7 @@ impl ImportMap {
 
     /// Returns the liveness of a given export identifier. An export is live if it might change
     /// values after module evaluation.
-    pub fn get_export_ident_liveness(&self, id: Id) -> Liveness {
+    pub fn get_export_ident_liveness(&self, id: Id, unresolved_mark: Mark) -> Liveness {
         if let Some(assignment_scopes) = self.assignment_scopes.get(&id) {
             // If all assignments are in module scope, the export is not live.
             if *assignment_scopes != AssignmentScopes::AllInModuleEvalScope {
@@ -633,6 +634,14 @@ impl ImportMap {
             // - A free variable or
             // - an imported variable
             // In those cases, we just assume that the value is live since we don't know anything
+            debug_assert!(
+                is_unresolved_id(&id, unresolved_mark)
+                    || self.imports.contains_key(&id)
+                    || self.namespace_imports.contains_key(&id),
+                "export ident {id:?} without an assignment scope should be a free variable or an \
+                 imported variable"
+            );
+
             Liveness::Live
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_core::{
     atoms::Wtf8Atom,
-    common::{BytePos, Mark, Span, Spanned, SyntaxContext, comments::Comments},
+    common::{BytePos, GLOBALS, Mark, Span, Spanned, SyntaxContext, comments::Comments},
     ecma::{
         ast::*,
         atoms::{Atom, atom},
@@ -635,9 +635,10 @@ impl ImportMap {
             // - an imported variable
             // In those cases, we just assume that the value is live since we don't know anything
             debug_assert!(
-                is_unresolved_id(&id, unresolved_mark)
-                    || self.imports.contains_key(&id)
-                    || self.namespace_imports.contains_key(&id),
+                self.imports.contains_key(&id)
+                    || self.namespace_imports.contains_key(&id)
+                    || !GLOBALS.is_set()
+                    || is_unresolved_id(&id, unresolved_mark),
                 "export ident {id:?} without an assignment scope should be a free variable or an \
                  imported variable"
             );

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/index.js
@@ -1,0 +1,3 @@
+import value from 'lib'
+
+console.log(value)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/node_modules/lib/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/node_modules/lib/index.js
@@ -1,0 +1,4 @@
+const a = 1
+const b = 2
+
+export default a + b

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/options.json
@@ -1,0 +1,3 @@
+{
+  "removeUnusedExports": true
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_1k9-ja7._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_1k9-ja7._.js
@@ -1,0 +1,24 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_1k9-ja7._.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2f$export$2d$default$2f$input$2f$node_modules$2f$lib$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/node_modules/lib/index.js [test] (ecmascript)");
+;
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2f$export$2d$default$2f$input$2f$node_modules$2f$lib$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__["default"]);
+__turbopack_context__.s([]);
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/node_modules/lib/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const a = 1;
+const b = 2;
+const __TURBOPACK__default__export__ = a + b;
+__turbopack_context__.s([
+    "default",
+    0,
+    __TURBOPACK__default__export__
+]);
+}),
+]);
+
+//# sourceMappingURL=1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_1k9-ja7._.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_1k9-ja7._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_1k9-ja7._.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/index.js"],"sourcesContent":["import value from 'lib'\n\nconsole.log(value)\n"],"names":["console","log"],"mappings":"AAAA;;AAEAA,QAAQC,GAAG,CAAC,0OAAK"}},
+    {"offset": {"line": 12, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/node_modules/lib/index.js"],"sourcesContent":["const a = 1\nconst b = 2\n\nexport default a + b\n"],"names":["a","b"],"mappings":"AAAA,MAAMA,IAAI;AACV,MAAMC,IAAI;uCAEKD,IAAIC","ignoreList":[0]}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_index_0va0_sb.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_index_0va0_sb.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1i9t_crates_turbopack-tests_tests_snapshot_basic_export-default_input_index_0va0_sb.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/output/1i9t_crates_turbopack-tests_tests_snapshot_basic_export-default_input_index_0va0_sb.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/1i9t_crates_turbopack-tests_tests_snapshot_basic_export-default_input_index_0va0_sb.js",
+    {"otherChunks":["output/1do3_crates_turbopack-tests_tests_snapshot_basic_export-default_input_1k9-ja7._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/export-default/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION
Talked IRL, we found that calling this in `visit_export_default_expr()` cut down the `module-cost` benchmark on ESM execution by about 10ms (approx. 35%).

Doing this unlocks a codegen optimization to avoid arrow functions, this special case was needed to support `export default ...` which is a kind of declaration all on its own.