### PR TITLE
[turbopack] add an extension to trace files

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -465,7 +465,8 @@ pub fn project_new(
             PathBuf::from(&options.root_path)
                 .join(&options.project_path)
                 .join(DIST_PROFILES_DIR_NAME)
-                .join("trace-turbopack")
+                // use a generic binary extension to hint to random tools not to read it.
+                .join("trace-turbopack.bin")
         };
         let trace_dir = trace_file
             .parent()

--- a/packages/next/src/cli/internal/upload-trace.ts
+++ b/packages/next/src/cli/internal/upload-trace.ts
@@ -99,7 +99,7 @@ export async function uploadTraceToBlob(
   }
 
   const uploadableFiles = entries.filter(
-    (f) => f.endsWith('.cpuprofile') || f.endsWith('trace-turbopack')
+    (f) => f.endsWith('.cpuprofile') || f.endsWith('trace-turbopack.bin')
   )
 
   if (uploadableFiles.length === 0) {
@@ -135,7 +135,7 @@ export async function uploadTraceToBlob(
 
     if (file.endsWith('.cpuprofile')) {
       validateCpuProfile(headerBuf, file)
-    } else if (file.endsWith('trace-turbopack')) {
+    } else if (file.endsWith('trace-turbopack.bin')) {
       validateTurbopackTrace(headerBuf, file)
     }
 

--- a/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
+++ b/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
@@ -161,7 +161,7 @@ describe('turbopack-trace-server', () => {
     const traceFileNewPath = path.join(
       next.testDir,
       '.next-profiles',
-      'trace-turbopack'
+      'trace-turbopack.bin'
     )
     const traceFileOldPath = path.join(
       next.testDir,

--- a/test/production/app-dir/upload-trace/upload-trace.test.ts
+++ b/test/production/app-dir/upload-trace/upload-trace.test.ts
@@ -32,11 +32,11 @@ describe('upload-trace', () => {
     expect(cpuProfiles.length).toBeGreaterThan(0)
 
     if (isTurbopack) {
-      expect(allFiles).toContain('trace-turbopack')
+      expect(allFiles).toContain('trace-turbopack.bin')
     }
 
     const uploadableFiles = allFiles.filter(
-      (f: string) => f.endsWith('.cpuprofile') || f === 'trace-turbopack'
+      (f: string) => f.endsWith('.cpuprofile') || f === 'trace-turbopack.bin'
     )
     const expectedUploadCount = uploadableFiles.length
 


### PR DESCRIPTION
Add `.bin` extension to trace files

This will hint to tools like tailwind that scan for content not to open these.