### PR TITLE
docs: include node_modules/@img in sharp outputFileTracingIncludes example

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
@@ -152,7 +152,13 @@ Common include patterns for native/runtime assets:
 ```js filename="next.config.js"
 module.exports = {
   outputFileTracingIncludes: {
-    '/*': ['node_modules/sharp/**/*', 'node_modules/aws-crt/dist/bin/**/*'],
+    '/*': [
+      'node_modules/sharp/**/*',
+      'node_modules/@img/**/*',
+      'node_modules/aws-crt/dist/bin/**/*',
+    ],
   },
 }
 ```
+
+> **Good to know**: As of `sharp@0.33`, the prebuilt native binaries live in separate `@img/*` packages (hoisted as siblings of `sharp` in `node_modules`), so `node_modules/@img/**/*` must be included alongside `node_modules/sharp/**/*` — otherwise the trace omits the native binary and the function fails at runtime with `Could not load the "sharp" module`. These globs supplement static tracing: when a package is statically imported, `@vercel/nft` already pulls in its pure-JS dependencies automatically.


### PR DESCRIPTION
### What

Updates the **"Common include patterns for native/runtime assets"** example under [`outputFileTracingIncludes`](https://nextjs.org/docs/app/api-reference/config/next-config-js/output) to include `node_modules/@img/**/*` alongside `node_modules/sharp/**/*`, and adds a short note explaining why.

### Why

As of **`sharp@0.33`**, the prebuilt native libvips binaries were moved **out** of `node_modules/sharp/` into separate `@img/*` packages (`@img/sharp-<platform>`, `@img/sharp-libvips-<platform>`), which npm hoists as **siblings** of `sharp` in `node_modules`, not children.

Verified on a clean `sharp@0.33.5` install:

- `find node_modules/sharp -name '*.node'` → **0 files** — no native binary remains under `sharp/`.
- The binary loaded at runtime lives at `node_modules/@img/sharp-<platform>/` and `node_modules/@img/sharp-libvips-<platform>/`.

So the existing `node_modules/sharp/**/*` glob no longer captures the native binary, and a function traced with only that pattern fails at the first `require('sharp')`:

```
Could not load the "sharp" module using the <platform> runtime
```

The added `node_modules/@img/**/*` is self-narrowing in practice: `@img/sharp-*` are `optionalDependencies` gated by `os`/`cpu`, so only the build platform's binaries are installed and traced.

### Notes

These globs supplement static tracing — when a package is statically imported, `@vercel/nft` already pulls in its pure-JS dependencies (e.g. `color`, `detect-libc`, `semver`) automatically; the explicit globs are only needed for native files nft can't follow.

Reported in #94589 (auto-closed by the repro-link bot as it's a docs fix with no runtime reproduction).