### PR TITLE
Replace server fields with typed dev state

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1467,5 +1467,7 @@
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1468": "Invariant: no direct app page entry found for %s",
-  "1469": "Invariant: dev virtual filesystem item was not handled by the development bundler"
+  "1469": "Invariant: dev virtual filesystem item was not handled by the development bundler",
+  "1470": "Invariant: dev server state can only be updated in dev",
+  "1471": "Invariant: no app initialized"
 }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -253,6 +253,15 @@ export interface Options {
    * The HTTP Server that Next.js is running behind
    */
   httpServer?: HTTPServer
+  /**
+   * The router server handler used for internal requests.
+   *
+   * @internal
+   */
+  routerServerHandler?: (
+    req: IncomingMessage,
+    res: HTTPServerResponse
+  ) => Promise<void> | void
 }
 
 export type RenderOpts = PagesRenderOptsPartial & AppRenderOptsPartial
@@ -346,7 +355,7 @@ export default abstract class Server<
   protected readonly minimalMode: boolean
   protected readonly renderOpts: BaseRenderOpts
   protected readonly serverOptions: Readonly<ServerOptions>
-  protected readonly appPathRoutes?: Record<string, string[]>
+  protected appPathRoutes?: Record<string, string[]>
   protected readonly clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>
   protected interceptionRoutePatterns: RegExp[]
   protected nextFontManifest?: DeepReadonly<NextFontManifest>

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -254,6 +254,15 @@ export interface Options {
    * The HTTP Server that Next.js is running behind
    */
   httpServer?: HTTPServer
+  /**
+   * The router server handler used for internal requests.
+   *
+   * @internal
+   */
+  routerServerHandler?: (
+    req: IncomingMessage,
+    res: HTTPServerResponse
+  ) => Promise<void> | void
 }
 
 export type RenderOpts = PagesRenderOptsPartial & AppRenderOptsPartial
@@ -347,7 +356,7 @@ export default abstract class Server<
   protected readonly minimalMode: boolean
   protected readonly renderOpts: BaseRenderOpts
   protected readonly serverOptions: Readonly<ServerOptions>
-  protected readonly appPathRoutes?: Record<string, string[]>
+  protected appPathRoutes?: Record<string, string[]>
   protected readonly clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>
   protected interceptionRoutePatterns: RegExp[]
   protected nextFontManifest?: DeepReadonly<NextFontManifest>

--- a/packages/next/src/server/dev/dev-server-state.ts
+++ b/packages/next/src/server/dev/dev-server-state.ts
@@ -1,0 +1,13 @@
+import type { ProxyMatcher } from '../../build/analysis/get-page-static-info'
+
+export type DevServerState = {
+  actualMiddlewareFile?: string
+  actualInstrumentationHookFile?: string
+  appPathRoutes?: Record<string, string[]>
+  middleware?: {
+    page: string
+    matchers?: ProxyMatcher[]
+  }
+}
+
+export type DevServerStateUpdate = Partial<DevServerState>

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -69,10 +69,10 @@ import {
   type StartChangeSubscription,
 } from './turbopack-utils'
 import {
-  propagateServerField,
-  type ServerFields,
   type SetupOpts,
+  updateDevServerState,
 } from '../lib/router-utils/setup-dev-bundler'
+import type { DevServerState } from './dev-server-state'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import { findPagePathData } from './on-demand-entry-handler'
 import type { RouteDefinition } from '../route-definitions/route-definition'
@@ -395,7 +395,7 @@ function getSourceMapURLFromTurbopack(
 
 export async function createHotReloaderTurbopack(
   opts: SetupOpts & { isSrcDir: boolean },
-  serverFields: ServerFields,
+  devServerState: DevServerState,
   distDir: string,
   resetFetch: () => void,
   lockfile: Lockfile | undefined,
@@ -1152,14 +1152,17 @@ export async function createHotReloaderTurbopack(
             ...clientsByHtmlRequestId.values(),
           ],
           clientStates,
-          serverFields,
 
           hooks: {
             handleWrittenEndpoint: (id, result, forceDeleteCache) => {
               currentWrittenEntrypoints.set(id, result)
               return clearRequireCache(id, result, { force: forceDeleteCache })
             },
-            propagateServerField: propagateServerField.bind(null, opts),
+            updateDevServerState: updateDevServerState.bind(
+              null,
+              opts,
+              devServerState
+            ),
             sendHmr,
             startBuilding,
             subscribeToChanges: subscribeToClientChanges,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -64,10 +64,10 @@ import {
   type StartChangeSubscription,
 } from './turbopack-utils'
 import {
-  propagateServerField,
-  type ServerFields,
   type SetupOpts,
+  updateDevServerState,
 } from '../lib/router-utils/setup-dev-bundler'
+import type { DevServerState } from './dev-server-state'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import { findPagePathData } from './on-demand-entry-handler'
 import type { RouteDefinition } from '../route-definitions/route-definition'
@@ -360,7 +360,7 @@ function getSourceMapURLFromTurbopack(
 
 export async function createHotReloaderTurbopack(
   opts: SetupOpts & { isSrcDir: boolean },
-  serverFields: ServerFields,
+  devServerState: DevServerState,
   distDir: string,
   resetFetch: () => void,
   lockfile: Lockfile | undefined,
@@ -1073,14 +1073,17 @@ export async function createHotReloaderTurbopack(
             ...clientsByHtmlRequestId.values(),
           ],
           clientStates,
-          serverFields,
 
           hooks: {
             handleWrittenEndpoint: (id, result, forceDeleteCache) => {
               currentWrittenEntrypoints.set(id, result)
               return clearRequireCache(id, result, { force: forceDeleteCache })
             },
-            propagateServerField: propagateServerField.bind(null, opts),
+            updateDevServerState: updateDevServerState.bind(
+              null,
+              opts,
+              devServerState
+            ),
             sendHmr,
             startBuilding,
             subscribeToChanges: subscribeToClientChanges,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -84,6 +84,7 @@ import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import type { PrerenderedRoute } from '../../build/static-paths/types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import { registerLocalSpanRecorder } from '../lib/trace/local-span-recorder'
+import type { DevServerStateUpdate } from './dev-server-state'
 
 registerLocalSpanRecorder()
 
@@ -261,6 +262,27 @@ export default class DevServer extends Server {
 
   protected override getServerComponentsHmrRefreshHash(): string | undefined {
     return this.bundlerService.getServerComponentsHmrRefreshHash()
+  }
+
+  public override updateDevServerState(update: DevServerStateUpdate): void {
+    if ('actualMiddlewareFile' in update) {
+      this.actualMiddlewareFile = update.actualMiddlewareFile
+    }
+    if ('actualInstrumentationHookFile' in update) {
+      this.actualInstrumentationHookFile = update.actualInstrumentationHookFile
+    }
+    if ('middleware' in update) {
+      this.middleware = update.middleware
+        ? {
+            ...update.middleware,
+            match: getMiddlewareRouteMatcher(update.middleware.matchers || []),
+          }
+        : undefined
+    }
+    if ('appPathRoutes' in update) {
+      this.appPathRoutes = update.appPathRoutes
+      this.interceptionRoutePatterns = this.getinterceptionRoutePatterns()
+    }
   }
 
   protected getBuildId(): string {
@@ -631,13 +653,6 @@ export default class DevServer extends Server {
   }
 
   protected async getMiddleware() {
-    // We need to populate the match
-    // field as it isn't serializable
-    if (this.middleware?.match === null) {
-      this.middleware.match = getMiddlewareRouteMatcher(
-        this.middleware.matchers || []
-      )
-    }
     return this.middleware
   }
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -84,6 +84,7 @@ import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import type { PrerenderedRoute } from '../../build/static-paths/types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import { registerLocalSpanRecorder } from '../lib/trace/local-span-recorder'
+import type { DevServerStateUpdate } from './dev-server-state'
 
 registerLocalSpanRecorder()
 
@@ -261,6 +262,27 @@ export default class DevServer extends Server {
 
   protected override getServerComponentsHmrRefreshHash(): string | undefined {
     return this.bundlerService.getServerComponentsHmrRefreshHash()
+  }
+
+  public override updateDevServerState(update: DevServerStateUpdate): void {
+    if ('actualMiddlewareFile' in update) {
+      this.actualMiddlewareFile = update.actualMiddlewareFile
+    }
+    if ('actualInstrumentationHookFile' in update) {
+      this.actualInstrumentationHookFile = update.actualInstrumentationHookFile
+    }
+    if ('middleware' in update) {
+      this.middleware = update.middleware
+        ? {
+            ...update.middleware,
+            match: getMiddlewareRouteMatcher(update.middleware.matchers || []),
+          }
+        : undefined
+    }
+    if ('appPathRoutes' in update) {
+      this.appPathRoutes = update.appPathRoutes
+      this.interceptionRoutePatterns = this.getinterceptionRoutePatterns()
+    }
   }
 
   protected getBuildId(): string {
@@ -630,13 +652,6 @@ export default class DevServer extends Server {
   }
 
   protected async getMiddleware() {
-    // We need to populate the match
-    // field as it isn't serializable
-    if (this.middleware?.match === null) {
-      this.middleware.match = getMiddlewareRouteMatcher(
-        this.middleware.matchers || []
-      )
-    }
     return this.middleware
   }
 

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -1,7 +1,5 @@
-import type {
-  ServerFields,
-  SetupOpts,
-} from '../lib/router-utils/setup-dev-bundler'
+import type { SetupOpts } from '../lib/router-utils/setup-dev-bundler'
+import type { DevServerStateUpdate } from './dev-server-state'
 import type {
   Issue,
   TurbopackResult,
@@ -16,7 +14,6 @@ import {
 } from './hot-reloader-types'
 import * as Log from '../../build/output/log'
 import { warnAboutEdgeRuntime } from '../../build/warn-about-edge-runtime'
-import type { PropagateToWorkersField } from '../lib/router-utils/types'
 import type { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import type { AppRoute, Entrypoints, PageRoute } from '../../build/swc/types'
 import {
@@ -596,10 +593,7 @@ export function hasEntrypointForKey(
 // hooks only used by the dev server.
 type HandleEntrypointsHooks = {
   handleWrittenEndpoint: HandleWrittenEndpoint
-  propagateServerField: (
-    field: PropagateToWorkersField,
-    args: any
-  ) => Promise<void>
+  updateDevServerState: (update: DevServerStateUpdate) => Promise<void>
   sendHmr: SendHmr
   startBuilding: StartBuilding
   subscribeToChanges: StartChangeSubscription
@@ -612,7 +606,6 @@ type HandleEntrypointsDevOpts = {
   changeSubscriptions: ChangeSubscriptions
   clients: Array<ws>
   clientStates: ClientStateMap
-  serverFields: ServerFields
 
   hooks: HandleEntrypointsHooks
 }
@@ -740,17 +733,13 @@ export async function handleEntrypoints({
       entrypoints: currentEntrypoints,
     })
 
-    dev.serverFields.actualInstrumentationHookFile = '/instrumentation'
-    await dev.hooks.propagateServerField(
-      'actualInstrumentationHookFile',
-      dev.serverFields.actualInstrumentationHookFile
-    )
+    await dev.hooks.updateDevServerState({
+      actualInstrumentationHookFile: '/instrumentation',
+    })
   } else {
-    dev.serverFields.actualInstrumentationHookFile = undefined
-    await dev.hooks.propagateServerField(
-      'actualInstrumentationHookFile',
-      dev.serverFields.actualInstrumentationHookFile
-    )
+    await dev.hooks.updateDevServerState({
+      actualInstrumentationHookFile: undefined,
+    })
   }
 
   if (middleware) {
@@ -775,11 +764,12 @@ export async function handleEntrypoints({
         manifestLoader.getMiddlewareManifest(key)?.middleware['/']
 
       if (dev && middlewareConfig) {
-        dev.serverFields.middleware = {
-          match: null as any,
-          page: '/',
-          matchers: middlewareConfig.matchers,
-        }
+        await dev.hooks.updateDevServerState({
+          middleware: {
+            page: '/',
+            matchers: middlewareConfig.matchers,
+          },
+        })
       }
       finishBuilding()
     }
@@ -797,14 +787,6 @@ export async function handleEntrypoints({
             true
           )
           await processMiddleware()
-          await dev.hooks.propagateServerField(
-            'actualMiddlewareFile',
-            dev.serverFields.actualMiddlewareFile
-          )
-          await dev.hooks.propagateServerField(
-            'middleware',
-            dev.serverFields.middleware
-          )
           manifestLoader.writeManifests({
             devRewrites,
             productionRewrites: undefined,
@@ -827,18 +809,11 @@ export async function handleEntrypoints({
     manifestLoader.deleteMiddlewareManifest(
       getEntryKey('root', 'server', 'middleware')
     )
-    dev.serverFields.actualMiddlewareFile = undefined
-    dev.serverFields.middleware = undefined
+    await dev.hooks.updateDevServerState({
+      actualMiddlewareFile: undefined,
+      middleware: undefined,
+    })
   }
-
-  await dev.hooks.propagateServerField(
-    'actualMiddlewareFile',
-    dev.serverFields.actualMiddlewareFile
-  )
-  await dev.hooks.propagateServerField(
-    'middleware',
-    dev.serverFields.middleware
-  )
 }
 
 async function handleEntrypointsDevCleanup({

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -1,7 +1,5 @@
-import type {
-  ServerFields,
-  SetupOpts,
-} from '../lib/router-utils/setup-dev-bundler'
+import type { SetupOpts } from '../lib/router-utils/setup-dev-bundler'
+import type { DevServerStateUpdate } from './dev-server-state'
 import type {
   Issue,
   TurbopackResult,
@@ -16,7 +14,6 @@ import {
 } from './hot-reloader-types'
 import * as Log from '../../build/output/log'
 import { warnAboutEdgeRuntime } from '../../build/warn-about-edge-runtime'
-import type { PropagateToWorkersField } from '../lib/router-utils/types'
 import type { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import type { AppRoute, Entrypoints, PageRoute } from '../../build/swc/types'
 import {
@@ -576,10 +573,7 @@ export function hasEntrypointForKey(
 // hooks only used by the dev server.
 type HandleEntrypointsHooks = {
   handleWrittenEndpoint: HandleWrittenEndpoint
-  propagateServerField: (
-    field: PropagateToWorkersField,
-    args: any
-  ) => Promise<void>
+  updateDevServerState: (update: DevServerStateUpdate) => Promise<void>
   sendHmr: SendHmr
   startBuilding: StartBuilding
   subscribeToChanges: StartChangeSubscription
@@ -592,7 +586,6 @@ type HandleEntrypointsDevOpts = {
   changeSubscriptions: ChangeSubscriptions
   clients: Array<ws>
   clientStates: ClientStateMap
-  serverFields: ServerFields
 
   hooks: HandleEntrypointsHooks
 }
@@ -721,17 +714,13 @@ export async function handleEntrypoints({
       entrypoints: currentEntrypoints,
     })
 
-    dev.serverFields.actualInstrumentationHookFile = '/instrumentation'
-    await dev.hooks.propagateServerField(
-      'actualInstrumentationHookFile',
-      dev.serverFields.actualInstrumentationHookFile
-    )
+    await dev.hooks.updateDevServerState({
+      actualInstrumentationHookFile: '/instrumentation',
+    })
   } else {
-    dev.serverFields.actualInstrumentationHookFile = undefined
-    await dev.hooks.propagateServerField(
-      'actualInstrumentationHookFile',
-      dev.serverFields.actualInstrumentationHookFile
-    )
+    await dev.hooks.updateDevServerState({
+      actualInstrumentationHookFile: undefined,
+    })
   }
 
   if (middleware) {
@@ -756,11 +745,12 @@ export async function handleEntrypoints({
         manifestLoader.getMiddlewareManifest(key)?.middleware['/']
 
       if (dev && middlewareConfig) {
-        dev.serverFields.middleware = {
-          match: null as any,
-          page: '/',
-          matchers: middlewareConfig.matchers,
-        }
+        await dev.hooks.updateDevServerState({
+          middleware: {
+            page: '/',
+            matchers: middlewareConfig.matchers,
+          },
+        })
       }
       finishBuilding()
     }
@@ -778,14 +768,6 @@ export async function handleEntrypoints({
             true
           )
           await processMiddleware()
-          await dev.hooks.propagateServerField(
-            'actualMiddlewareFile',
-            dev.serverFields.actualMiddlewareFile
-          )
-          await dev.hooks.propagateServerField(
-            'middleware',
-            dev.serverFields.middleware
-          )
           manifestLoader.writeManifests({
             devRewrites,
             productionRewrites: undefined,
@@ -808,18 +790,11 @@ export async function handleEntrypoints({
     manifestLoader.deleteMiddlewareManifest(
       getEntryKey('root', 'server', 'middleware')
     )
-    dev.serverFields.actualMiddlewareFile = undefined
-    dev.serverFields.middleware = undefined
+    await dev.hooks.updateDevServerState({
+      actualMiddlewareFile: undefined,
+      middleware: undefined,
+    })
   }
-
-  await dev.hooks.propagateServerField(
-    'actualMiddlewareFile',
-    dev.serverFields.actualMiddlewareFile
-  )
-  await dev.hooks.propagateServerField(
-    'middleware',
-    dev.serverFields.middleware
-  )
 }
 
 async function handleEntrypointsDevCleanup({

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -1,6 +1,10 @@
 import type { NextServer, RequestHandler, UpgradeHandler } from '../next'
 import type { DevBundlerService } from './dev-bundler-service'
-import type { PropagateToWorkersField } from './router-utils/types'
+import type {
+  DevServerState,
+  DevServerStateUpdate,
+} from '../dev/dev-server-state'
+import type { WorkerRequestHandler } from './types'
 
 import next from '../next'
 import type { Span } from '../../trace'
@@ -47,44 +51,27 @@ export function clearModuleContext(target: string) {
   return sandboxContext?.clearModuleContext(target)
 }
 
-export async function getServerField(
-  dir: string,
-  field: PropagateToWorkersField
-) {
+async function getInitialization(dir: string) {
   const initialization = await initializations[dir]
   if (!initialization) {
-    throw new Error('Invariant cant propagate server field, no app initialized')
+    throw new Error('Invariant: no app initialized')
   }
-  const { server } = initialization
-  let wrappedServer = server['server']! // NextServer.server is private
-  return wrappedServer[field as keyof typeof wrappedServer]
+  return initialization
 }
 
-export async function propagateServerField(
+export async function updateDevServerState(
   dir: string,
-  field: PropagateToWorkersField,
-  value: any
+  update: DevServerStateUpdate
 ) {
-  const initialization = await initializations[dir]
-  if (!initialization) {
-    throw new Error('Invariant cant propagate server field, no app initialized')
-  }
+  const initialization = await getInitialization(dir)
   const { server } = initialization
-  let wrappedServer = server['server']
-  const _field = field as keyof NonNullable<typeof wrappedServer>
+  await server.updateDevServerState(update)
+}
 
-  if (wrappedServer) {
-    if (typeof wrappedServer[_field] === 'function') {
-      // @ts-expect-error
-      await wrappedServer[_field].apply(
-        wrappedServer,
-        Array.isArray(value) ? value : []
-      )
-    } else {
-      // @ts-expect-error
-      wrappedServer[_field] = value
-    }
-  }
+export async function reloadEnv(dir: string) {
+  const initialization = await getInitialization(dir)
+  const { server } = initialization
+  await server.reloadEnv()
 }
 
 async function initializeImpl(opts: {
@@ -94,7 +81,8 @@ async function initializeImpl(opts: {
   minimalMode?: boolean
   hostname?: string
   keepAliveTimeout?: number
-  serverFields?: any
+  devServerState?: DevServerState
+  routerServerHandler?: WorkerRequestHandler
   server?: any
   experimentalTestProxy: boolean
   experimentalHttpsServer: boolean
@@ -118,8 +106,9 @@ async function initializeImpl(opts: {
   let requestHandler: RequestHandler
   let upgradeHandler: UpgradeHandler
 
+  const { devServerState, ...serverOptions } = opts
   const server = next({
-    ...opts,
+    ...serverOptions,
     hostname: opts.hostname || 'localhost',
     customServer: false,
     httpServer: opts.server,
@@ -175,7 +164,10 @@ async function initializeImpl(opts: {
     upgradeHandler = server.getUpgradeHandler()
   }
 
-  await server.prepare(opts.serverFields)
+  if (devServerState) {
+    await server.updateDevServerState(devServerState)
+  }
+  await server.prepare()
 
   return {
     requestHandler,

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -1,6 +1,6 @@
 // this must come first as it includes require hooks
 import type { WorkerRequestHandler, WorkerUpgradeHandler } from './types'
-import type { DevBundler, ServerFields } from './router-utils/setup-dev-bundler'
+import type { DevBundler } from './router-utils/setup-dev-bundler'
 import type { NextUrlWithParsedQuery, RequestMeta } from '../request-meta'
 
 // This is required before other imports to ensure the require hook is setup.
@@ -115,10 +115,7 @@ function getErrorMessage(error: unknown): string {
 
 export type RenderServer = Pick<
   typeof import('./render-server'),
-  | 'initialize'
-  | 'clearModuleContext'
-  | 'propagateServerField'
-  | 'getServerField'
+  'initialize' | 'clearModuleContext' | 'updateDevServerState' | 'reloadEnv'
 >
 
 export interface LazyRenderServerInstance {
@@ -849,7 +846,7 @@ export async function initialize(opts: {
       }
 
       const appNotFound = opts.dev
-        ? development?.bundler?.serverFields.hasAppNotFound
+        ? development?.bundler?.hasAppNotFound
         : await fsChecker.getItem(UNDERSCORE_NOT_FOUND_ROUTE)
 
       res.statusCode = 404
@@ -919,12 +916,8 @@ export async function initialize(opts: {
     minimalMode: opts.minimalMode,
     dev: !!opts.dev,
     server: opts.server,
-    serverFields: {
-      ...(development?.bundler?.serverFields || {}),
-      setIsrStatus: development?.service?.setIsrStatus.bind(
-        development?.service
-      ),
-    } satisfies ServerFields,
+    devServerState: development?.bundler.devServerState,
+    routerServerHandler: requestHandlerImpl,
     experimentalTestProxy: !!config.experimental.testProxy,
     experimentalHttpsServer: !!opts.experimentalHttpsServer,
     bundlerService: development?.service,
@@ -937,8 +930,6 @@ export async function initialize(opts: {
     partialPrefetching: config.partialPrefetching,
     devMemoryThresholdRestart,
   }
-  renderServerOpts.serverFields.routerServerHandler = requestHandlerImpl
-
   // pre-initialize workers
   const handlers = await renderServer.instance.initialize(renderServerOpts)
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -1,6 +1,6 @@
 // this must come first as it includes require hooks
 import type { WorkerRequestHandler, WorkerUpgradeHandler } from './types'
-import type { DevBundler, ServerFields } from './router-utils/setup-dev-bundler'
+import type { DevBundler } from './router-utils/setup-dev-bundler'
 import type { NextUrlWithParsedQuery, RequestMeta } from '../request-meta'
 
 // This is required before other imports to ensure the require hook is setup.
@@ -116,10 +116,7 @@ function getErrorMessage(error: unknown): string {
 
 export type RenderServer = Pick<
   typeof import('./render-server'),
-  | 'initialize'
-  | 'clearModuleContext'
-  | 'propagateServerField'
-  | 'getServerField'
+  'initialize' | 'clearModuleContext' | 'updateDevServerState' | 'reloadEnv'
 >
 
 export interface LazyRenderServerInstance {
@@ -846,7 +843,7 @@ export async function initialize(opts: {
       }
 
       const appNotFound = opts.dev
-        ? development?.bundler?.serverFields.hasAppNotFound
+        ? development?.bundler?.hasAppNotFound
         : await fsChecker.getItem(UNDERSCORE_NOT_FOUND_ROUTE)
 
       res.statusCode = 404
@@ -916,12 +913,8 @@ export async function initialize(opts: {
     minimalMode: opts.minimalMode,
     dev: !!opts.dev,
     server: opts.server,
-    serverFields: {
-      ...(development?.bundler?.serverFields || {}),
-      setIsrStatus: development?.service?.setIsrStatus.bind(
-        development?.service
-      ),
-    } satisfies ServerFields,
+    devServerState: development?.bundler.devServerState,
+    routerServerHandler: requestHandlerImpl,
     experimentalTestProxy: !!config.experimental.testProxy,
     experimentalHttpsServer: !!opts.experimentalHttpsServer,
     bundlerService: development?.service,
@@ -934,8 +927,6 @@ export async function initialize(opts: {
     partialPrefetching: config.partialPrefetching,
     devMemoryThresholdRestart,
   }
-  renderServerOpts.serverFields.routerServerHandler = requestHandlerImpl
-
   // pre-initialize workers
   const handlers = await renderServer.instance.initialize(renderServerOpts)
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -3,12 +3,14 @@ import type { FilesystemDynamicRoute } from './filesystem'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
 import type { ProxyMatcher } from '../../../build/analysis/get-page-static-info'
 import type { RoutesManifest } from '../../../build'
-import type { MiddlewareRouteMatch } from '../../../shared/lib/router/utils/middleware-route-matcher'
-import type { PropagateToWorkersField } from './types'
 import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
 import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
 import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
 import type { LocaleRouteDefinition } from '../../route-definitions/locale-route-definition'
+import type {
+  DevServerState,
+  DevServerStateUpdate,
+} from '../../dev/dev-server-state'
 
 import { createDefineEnv } from '../../../build/swc'
 import { installBindings } from '../../../build/swc/install-bindings'
@@ -145,25 +147,6 @@ export interface DevRoutesManifest {
   skipProxyUrlNormalize: RoutesManifest['skipProxyUrlNormalize']
 }
 
-export type ServerFields = {
-  actualMiddlewareFile?: string | undefined
-  actualInstrumentationHookFile?: string | undefined
-  appPathRoutes?: Record<string, string | string[]>
-  middleware?:
-    | {
-        page: string
-        match: MiddlewareRouteMatch
-        matchers?: ProxyMatcher[]
-      }
-    | undefined
-  hasAppNotFound?: boolean
-  interceptionRoutes?: ReturnType<
-    typeof import('./filesystem').buildCustomRoute
-  >[]
-  setIsrStatus?: (key: string, value: boolean | undefined) => void
-  resetFetch?: () => void
-}
-
 async function verifyTypeScript(opts: SetupOpts) {
   const verifyResult = await verifyAndRunTypeScript({
     dir: opts.dir,
@@ -186,12 +169,13 @@ async function verifyTypeScript(opts: SetupOpts) {
   return false
 }
 
-export async function propagateServerField(
+export async function updateDevServerState(
   opts: SetupOpts,
-  field: PropagateToWorkersField,
-  args: any
+  state: DevServerState,
+  update: DevServerStateUpdate
 ) {
-  await opts.renderServer?.instance?.propagateServerField(opts.dir, field, args)
+  Object.assign(state, update)
+  await opts.renderServer.instance?.updateDevServerState(opts.dir, update)
 }
 
 async function startWatcher(
@@ -238,7 +222,7 @@ async function startWatcher(
     appDir
   )
 
-  const serverFields: ServerFields = {}
+  const devServerState: DevServerState = {}
 
   // Update logging state once based on next.config.js when initializing
   consoleStore.setState({
@@ -252,7 +236,7 @@ async function startWatcher(
         ).createHotReloaderTurbopack
         return await createHotReloaderTurbopack(
           opts,
-          serverFields,
+          devServerState,
           distDir,
           resetFetch,
           lockfile,
@@ -365,6 +349,7 @@ async function startWatcher(
 
   let resolved = false
   let prevSortedRoutes: string[] = []
+  let hasAppNotFound = false
 
   await new Promise<void>(async (resolve, reject) => {
     if (pagesDir) {
@@ -440,6 +425,8 @@ async function startWatcher(
       let writeEnvDefinitions = false
       let typescriptStatusFromLastAggregation = enabledTypeScript
       let middlewareMatchers: ProxyMatcher[] | undefined
+      let actualMiddlewareFile: string | undefined
+      let actualInstrumentationHookFile: string | undefined
       const routedPages: string[] = []
       const knownFiles = wp.getTimeInfoEntries()
       const appPaths: Record<string, string[]> = {}
@@ -600,25 +587,14 @@ async function startWatcher(
             )
             continue
           }
-          serverFields.actualMiddlewareFile = rootFile
-
-          await propagateServerField(
-            opts,
-            'actualMiddlewareFile',
-            serverFields.actualMiddlewareFile
-          )
+          actualMiddlewareFile = rootFile
           middlewareMatchers = staticInfo.middleware?.matchers || [
             { regexp: '^/.*$', originalSource: '/:path*' },
           ]
           continue
         }
         if (isInstrumentationHookFile(rootFile)) {
-          serverFields.actualInstrumentationHookFile = rootFile
-          await propagateServerField(
-            opts,
-            'actualInstrumentationHookFile',
-            serverFields.actualInstrumentationHookFile
-          )
+          actualInstrumentationHookFile = rootFile
           continue
         }
 
@@ -811,6 +787,11 @@ async function startWatcher(
         routedPages.push(pageName)
       }
 
+      await updateDevServerState(opts, devServerState, {
+        actualMiddlewareFile,
+        actualInstrumentationHookFile,
+      })
+
       const numConflicting = conflictingAppPagePaths.size
       conflictingPageChange = numConflicting - previousConflictingPagePaths.size
 
@@ -860,9 +841,7 @@ async function startWatcher(
         if (envChange) {
           writeEnvDefinitions = true
 
-          await propagateServerField(opts, 'loadEnvConfig', [
-            { dev: true, forceReload: true },
-          ])
+          await opts.renderServer.instance?.reloadEnv(opts.dir)
         }
 
         if (hotReloader.turbopackProject) {
@@ -1018,14 +997,10 @@ async function startWatcher(
       normalizeCatchAllRoutes(appPaths)
 
       // Make sure to sort parallel routes to make the result deterministic.
-      serverFields.appPathRoutes = Object.fromEntries(
+      const appPathRoutes = Object.fromEntries(
         Object.entries(appPaths).map(([k, v]) => [k, v.sort(compareAppPaths)])
       )
-      await propagateServerField(
-        opts,
-        'appPathRoutes',
-        serverFields.appPathRoutes
-      )
+      await updateDevServerState(opts, devServerState, { appPathRoutes })
 
       // fsChecker replaces the removed dev matcher providers. Refresh its
       // definitions on every watcher pass so newly added routes can be ensured
@@ -1086,19 +1061,18 @@ async function startWatcher(
       opts.fsChecker.setRouteDefinitions('appFile', appRouteDefinitions)
 
       // TODO: pass this to fsChecker/next-dev-server?
-      serverFields.middleware = middlewareMatchers
+      const middleware = middlewareMatchers
         ? {
-            match: null as any,
             page: '/',
             matchers: middlewareMatchers,
           }
         : undefined
 
-      await propagateServerField(opts, 'middleware', serverFields.middleware)
-      serverFields.hasAppNotFound = hasRootAppNotFound
+      await updateDevServerState(opts, devServerState, { middleware })
+      hasAppNotFound = hasRootAppNotFound
 
-      opts.fsChecker.middlewareMatcher = serverFields.middleware?.matchers
-        ? getMiddlewareRouteMatcher(serverFields.middleware?.matchers)
+      opts.fsChecker.middlewareMatcher = middleware?.matchers
+        ? getMiddlewareRouteMatcher(middleware.matchers)
         : undefined
 
       const interceptionRoutes = generateInterceptionRoutesRewrites(
@@ -1253,7 +1227,7 @@ async function startWatcher(
           }
 
           if (writeEnvDefinitions && nextConfig.experimental?.typedEnv) {
-            // TODO: The call to propagateServerField 'loadEnvConfig' causes the env to be loaded twice on env file changes.
+            // TODO: Calling reloadEnv causes the env to be loaded twice on env file changes.
             const loadEnvConfig = (
               require('@next/env') as typeof import('@next/env')
             ).loadEnvConfig
@@ -1367,7 +1341,7 @@ async function startWatcher(
     ) {
       res.statusCode = 200
       res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
-      res.end(JSON.stringify(serverFields.middleware?.matchers || []))
+      res.end(JSON.stringify(devServerState.middleware?.matchers || []))
       return { finished: true }
     }
     return { finished: false }
@@ -1398,15 +1372,18 @@ async function startWatcher(
   }
 
   return {
-    serverFields,
+    devServerState,
+    get hasAppNotFound() {
+      return hasAppNotFound
+    },
     hotReloader,
     requestHandler,
     logErrorWithOriginalStack,
 
     async ensureMiddleware(requestUrl?: string) {
-      if (!serverFields.actualMiddlewareFile) return
+      if (!devServerState.actualMiddlewareFile) return
       return hotReloader.ensurePage({
-        page: serverFields.actualMiddlewareFile,
+        page: devServerState.actualMiddlewareFile,
         clientOnly: false,
         definition: undefined,
         url: requestUrl,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -3,12 +3,14 @@ import type { FilesystemDynamicRoute } from './filesystem'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
 import type { ProxyMatcher } from '../../../build/analysis/get-page-static-info'
 import type { RoutesManifest } from '../../../build'
-import type { MiddlewareRouteMatch } from '../../../shared/lib/router/utils/middleware-route-matcher'
-import type { PropagateToWorkersField } from './types'
 import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
 import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
 import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
 import type { LocaleRouteDefinition } from '../../route-definitions/locale-route-definition'
+import type {
+  DevServerState,
+  DevServerStateUpdate,
+} from '../../dev/dev-server-state'
 
 import { createDefineEnv } from '../../../build/swc'
 import { installBindings } from '../../../build/swc/install-bindings'
@@ -149,25 +151,6 @@ export interface DevRoutesManifest {
   skipProxyUrlNormalize: RoutesManifest['skipProxyUrlNormalize']
 }
 
-export type ServerFields = {
-  actualMiddlewareFile?: string | undefined
-  actualInstrumentationHookFile?: string | undefined
-  appPathRoutes?: Record<string, string | string[]>
-  middleware?:
-    | {
-        page: string
-        match: MiddlewareRouteMatch
-        matchers?: ProxyMatcher[]
-      }
-    | undefined
-  hasAppNotFound?: boolean
-  interceptionRoutes?: ReturnType<
-    typeof import('./filesystem').buildCustomRoute
-  >[]
-  setIsrStatus?: (key: string, value: boolean | undefined) => void
-  resetFetch?: () => void
-}
-
 async function verifyTypeScript(opts: SetupOpts) {
   const verifyResult = await verifyAndRunTypeScript({
     dir: opts.dir,
@@ -190,12 +173,13 @@ async function verifyTypeScript(opts: SetupOpts) {
   return false
 }
 
-export async function propagateServerField(
+export async function updateDevServerState(
   opts: SetupOpts,
-  field: PropagateToWorkersField,
-  args: any
+  state: DevServerState,
+  update: DevServerStateUpdate
 ) {
-  await opts.renderServer?.instance?.propagateServerField(opts.dir, field, args)
+  Object.assign(state, update)
+  await opts.renderServer.instance?.updateDevServerState(opts.dir, update)
 }
 
 async function startWatcher(
@@ -242,7 +226,7 @@ async function startWatcher(
     appDir
   )
 
-  const serverFields: ServerFields = {}
+  const devServerState: DevServerState = {}
 
   // Update logging state once based on next.config.js when initializing
   consoleStore.setState({
@@ -256,7 +240,7 @@ async function startWatcher(
         ).createHotReloaderTurbopack
         return await createHotReloaderTurbopack(
           opts,
-          serverFields,
+          devServerState,
           distDir,
           resetFetch,
           lockfile,
@@ -383,6 +367,7 @@ async function startWatcher(
   let resolved = false
   let prevSortedRoutes: string[] = []
   let hasComputedSortedRoutes = false
+  let hasAppNotFound = false
 
   await new Promise<void>(async (resolve, reject) => {
     if (pagesDir) {
@@ -461,6 +446,8 @@ async function startWatcher(
       let writeEnvDefinitions = false
       let typescriptStatusFromLastAggregation = enabledTypeScript
       let middlewareMatchers: ProxyMatcher[] | undefined
+      let actualMiddlewareFile: string | undefined
+      let actualInstrumentationHookFile: string | undefined
       const routedPages: string[] = []
       const knownFiles = wp.getTimeInfoEntries()
       const appPaths: Record<string, string[]> = {}
@@ -623,25 +610,14 @@ async function startWatcher(
             )
             continue
           }
-          serverFields.actualMiddlewareFile = rootFile
-
-          await propagateServerField(
-            opts,
-            'actualMiddlewareFile',
-            serverFields.actualMiddlewareFile
-          )
+          actualMiddlewareFile = rootFile
           middlewareMatchers = staticInfo.middleware?.matchers || [
             { regexp: '^/.*$', originalSource: '/:path*' },
           ]
           continue
         }
         if (isInstrumentationHookFile(rootFile)) {
-          serverFields.actualInstrumentationHookFile = rootFile
-          await propagateServerField(
-            opts,
-            'actualInstrumentationHookFile',
-            serverFields.actualInstrumentationHookFile
-          )
+          actualInstrumentationHookFile = rootFile
           continue
         }
 
@@ -833,6 +809,11 @@ async function startWatcher(
         routedPages.push(pageName)
       }
 
+      await updateDevServerState(opts, devServerState, {
+        actualMiddlewareFile,
+        actualInstrumentationHookFile,
+      })
+
       const numConflicting = conflictingAppPagePaths.size
       conflictingPageChange = numConflicting - previousConflictingPagePaths.size
 
@@ -886,9 +867,7 @@ async function startWatcher(
 
       if (envFileChange || clientRouterFiltersChange || tsconfigChange) {
         if (envFileChange) {
-          await propagateServerField(opts, 'loadEnvConfig', [
-            { dev: true, forceReload: true },
-          ])
+          await opts.renderServer.instance?.reloadEnv(opts.dir)
         }
 
         if (hotReloader.turbopackProject) {
@@ -1066,14 +1045,10 @@ async function startWatcher(
       normalizeCatchAllRoutes(appPaths)
 
       // Make sure to sort parallel routes to make the result deterministic.
-      serverFields.appPathRoutes = Object.fromEntries(
+      const appPathRoutes = Object.fromEntries(
         Object.entries(appPaths).map(([k, v]) => [k, v.sort(compareAppPaths)])
       )
-      await propagateServerField(
-        opts,
-        'appPathRoutes',
-        serverFields.appPathRoutes
-      )
+      await updateDevServerState(opts, devServerState, { appPathRoutes })
 
       // fsChecker replaces the removed dev matcher providers. Refresh its
       // definitions on every watcher pass so newly added routes can be ensured
@@ -1133,19 +1108,18 @@ async function startWatcher(
       opts.fsChecker.setRouteDefinitions('appFile', appRouteDefinitions)
 
       // TODO: pass this to fsChecker/next-dev-server?
-      serverFields.middleware = middlewareMatchers
+      const middleware = middlewareMatchers
         ? {
-            match: null as any,
             page: '/',
             matchers: middlewareMatchers,
           }
         : undefined
 
-      await propagateServerField(opts, 'middleware', serverFields.middleware)
-      serverFields.hasAppNotFound = hasRootAppNotFound
+      await updateDevServerState(opts, devServerState, { middleware })
+      hasAppNotFound = hasRootAppNotFound
 
-      opts.fsChecker.middlewareMatcher = serverFields.middleware?.matchers
-        ? getMiddlewareRouteMatcher(serverFields.middleware?.matchers)
+      opts.fsChecker.middlewareMatcher = middleware?.matchers
+        ? getMiddlewareRouteMatcher(middleware.matchers)
         : undefined
 
       const interceptionRoutes = generateInterceptionRoutesRewrites(
@@ -1305,7 +1279,7 @@ async function startWatcher(
           }
 
           if (writeEnvDefinitions && nextConfig.experimental?.typedEnv) {
-            // TODO: The call to propagateServerField 'loadEnvConfig' causes the env to be loaded twice on env file changes.
+            // TODO: Calling reloadEnv causes the env to be loaded twice on env file changes.
             const loadEnvConfig = (
               require('@next/env') as typeof import('@next/env')
             ).loadEnvConfig
@@ -1419,7 +1393,7 @@ async function startWatcher(
     ) {
       res.statusCode = 200
       res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
-      res.end(JSON.stringify(serverFields.middleware?.matchers || []))
+      res.end(JSON.stringify(devServerState.middleware?.matchers || []))
       return { finished: true }
     }
     return { finished: false }
@@ -1450,15 +1424,18 @@ async function startWatcher(
   }
 
   return {
-    serverFields,
+    devServerState,
+    get hasAppNotFound() {
+      return hasAppNotFound
+    },
     hotReloader,
     requestHandler,
     logErrorWithOriginalStack,
 
     async ensureMiddleware(requestUrl?: string) {
-      if (!serverFields.actualMiddlewareFile) return
+      if (!devServerState.actualMiddlewareFile) return
       return hotReloader.ensurePage({
-        page: serverFields.actualMiddlewareFile,
+        page: devServerState.actualMiddlewareFile,
         clientOnly: false,
         definition: undefined,
         url: requestUrl,

--- a/packages/next/src/server/lib/router-utils/types.ts
+++ b/packages/next/src/server/lib/router-utils/types.ts
@@ -1,7 +1,0 @@
-export type PropagateToWorkersField =
-  | 'actualMiddlewareFile'
-  | 'actualInstrumentationHookFile'
-  | 'loadEnvConfig'
-  | 'appPathRoutes'
-  | 'middleware'
-  | 'renderOpts'

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -142,6 +142,7 @@ import {
 import { installGlobalBehaviors } from './node-environment-extensions/global-behaviors'
 import { installProcessErrorHandlers } from './node-environment-extensions/process-error-handlers'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
+import type { DevServerStateUpdate } from './dev/dev-server-state'
 
 export * from './base-server'
 
@@ -197,10 +198,7 @@ export default class NextNodeServer extends BaseServer<
     page: string
     re: RegExp
   }[]
-  private routerServerHandler?: (
-    req: IncomingMessage,
-    res: ServerResponse
-  ) => void
+  private routerServerHandler: Options['routerServerHandler']
 
   protected cleanupListeners = new AsyncCallbackSet()
   protected internalWaitUntil: WaitUntil | undefined
@@ -211,6 +209,7 @@ export default class NextNodeServer extends BaseServer<
     // Initialize super class
     super(options)
 
+    this.routerServerHandler = options.routerServerHandler
     installGlobalBehaviors(this.nextConfig)
 
     // Load prefetch hints from the build output. This must happen before
@@ -353,6 +352,16 @@ export default class NextNodeServer extends BaseServer<
         // Intentionally ignored because this is a preload step.
       }
     }
+  }
+
+  /** @internal */
+  public updateDevServerState(_update: DevServerStateUpdate): void {
+    throw new Error('Invariant: dev server state can only be updated in dev')
+  }
+
+  /** @internal */
+  public reloadEnv(): void {
+    this.loadEnvConfig({ dev: true, forceReload: true })
   }
 
   protected async handleUpgrade(): Promise<void> {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -133,6 +133,7 @@ import {
 } from './lib/router-utils/router-server-context'
 import { installGlobalBehaviors } from './node-environment-extensions/global-behaviors'
 import { installProcessErrorHandlers } from './node-environment-extensions/process-error-handlers'
+import type { DevServerStateUpdate } from './dev/dev-server-state'
 
 export * from './base-server'
 
@@ -188,10 +189,7 @@ export default class NextNodeServer extends BaseServer<
     page: string
     re: RegExp
   }[]
-  private routerServerHandler?: (
-    req: IncomingMessage,
-    res: ServerResponse
-  ) => void
+  private routerServerHandler: Options['routerServerHandler']
 
   protected cleanupListeners = new AsyncCallbackSet()
   protected internalWaitUntil: WaitUntil | undefined
@@ -202,6 +200,7 @@ export default class NextNodeServer extends BaseServer<
     // Initialize super class
     super(options)
 
+    this.routerServerHandler = options.routerServerHandler
     installGlobalBehaviors(this.nextConfig)
 
     // Load prefetch hints from the build output. This must happen before
@@ -344,6 +343,16 @@ export default class NextNodeServer extends BaseServer<
         // Intentionally ignored because this is a preload step.
       }
     }
+  }
+
+  /** @internal */
+  public updateDevServerState(_update: DevServerStateUpdate): void {
+    throw new Error('Invariant: dev server state can only be updated in dev')
+  }
+
+  /** @internal */
+  public reloadEnv(): void {
+    this.loadEnvConfig({ dev: true, forceReload: true })
   }
 
   protected async handleUpgrade(): Promise<void> {

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -23,7 +23,7 @@ import { PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 import { getTracer } from './lib/trace/tracer'
 import { NextServerSpan } from './lib/trace/constants'
 import { formatUrl } from '../shared/lib/router/utils/format-url'
-import type { ServerFields } from './lib/router-utils/setup-dev-bundler'
+import type { DevServerStateUpdate } from './dev/dev-server-state'
 import type { ServerInitResult } from './lib/render-server'
 import { AsyncCallbackSet } from './lib/async-callback-set'
 import {
@@ -122,7 +122,7 @@ interface NextWrapperServer {
   port: number | undefined
 
   getRequestHandler(): RequestHandler
-  prepare(serverFields?: ServerFields): Promise<void>
+  prepare(): Promise<void>
   /** @deprecated Configure `assetPrefix` in `next.config.js` instead. */
   setAssetPrefix(assetPrefix: string): void
   close(): Promise<void>
@@ -301,17 +301,26 @@ export class NextServer implements NextWrapperServer {
     return server.render404(...args)
   }
 
-  async prepare(serverFields?: ServerFields) {
+  async prepare() {
     const server = await this.getServer()
 
-    if (serverFields) {
-      Object.assign(server, serverFields)
-    }
     // We shouldn't prepare the server in production,
     // because this code won't be executed when deployed
     if (this.options.dev) {
       await server.prepare()
     }
+  }
+
+  /** @internal */
+  async updateDevServerState(update: DevServerStateUpdate) {
+    const server = await this.getServer()
+    server.updateDevServerState(update)
+  }
+
+  /** @internal */
+  async reloadEnv() {
+    const server = await this.getServer()
+    server.reloadEnv()
   }
 
   async close() {


### PR DESCRIPTION
### What?

Replace the generic `serverFields` bag with typed development server state and explicit render-server commands.

### Why?

The string-keyed mutation API mixed serializable state, commands, router-local values, and startup dependencies. This made the render-server boundary difficult to reason about and allowed stale or unrelated fields to accumulate.

### How?

Add `DevServerState` and typed incremental updates, construct middleware matchers inside the render server, pass the router handler as an explicit server option, keep root not-found state in the dev bundler, and replace env propagation with `reloadEnv()`.

### Verification

- `pnpm --filter=next types`
- `pnpm test-dev-turbo test/development/middleware-dev-update/middleware-dev-update.test.ts`
- `pnpm test-dev-webpack test/development/middleware-dev-update/middleware-dev-update.test.ts`
- `pnpm test-dev-turbo test/e2e/env-config/env-config.test.ts -t "with hot reload"`
- `pnpm test-dev-webpack test/e2e/env-config/env-config.test.ts -t "with hot reload"`
- `pnpm test-dev-turbo test/development/app-dir/hmr-intercept-routes/hmr-intercept-routes.test.ts`
- `pnpm test-dev-turbo test/e2e/app-dir/not-found/basic/index.test.ts -t "should use the not-found page for non-matching routes|should render the 404 page when the file is removed"`
- `pnpm test-dev-turbo test/e2e/instrumentation-hook/instrumentation-hook.test.ts -t "with-node-page should run the instrumentation hook"`
- `pnpm test-dev-turbo test/e2e/next-image-new/app-dir/app-dir.test.ts -t "should load the images"`

<!-- NEXT_JS_LLM_PR -->