### PR TITLE
recognize root not-found inside route groups

### DIFF
--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -7,6 +7,7 @@ import { warn } from '../../build/output/log'
 import { cyan } from '../../lib/picocolors'
 import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
 import { escapeStringRegexp } from '../../shared/lib/escape-regexp'
+import { isGroupSegment } from '../../shared/lib/segment'
 import type { PageExtensions } from '../../build/page-extensions-type'
 
 async function isTrueCasePagePath(pagePath: string, pagesDir: string) {
@@ -159,7 +160,16 @@ export function createValidFileMatcher(
       return false
     }
     const rest = filePath.slice(appDirPath.length + 1)
-    return rootNotFoundFileRegex.test(rest)
+    const parts = rest.split(sep)
+    // Strip leading route-group segments — they are URL-transparent and a
+    // not-found.tsx nested only inside route groups is still a root not-found.
+    // e.g. app/(app)/not-found.tsx should behave identically to app/not-found.tsx
+    const nonGroupParts = parts.filter(
+      (seg, i) => i === parts.length - 1 || !isGroupSegment(seg)
+    )
+    return (
+      nonGroupParts.length === 1 && rootNotFoundFileRegex.test(nonGroupParts[0])
+    )
   }
 
   return {

--- a/test/e2e/app-dir/not-found-default/app/(with-not-found)/not-found.js
+++ b/test/e2e/app-dir/not-found-default/app/(with-not-found)/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1 id="group-custom-not-found">Custom Not Found in Route Group</h1>
+}

--- a/test/e2e/app-dir/not-found-default/app/(with-not-found)/with-not-found-route/[id]/page.js
+++ b/test/e2e/app-dir/not-found-default/app/(with-not-found)/with-not-found-route/[id]/page.js
@@ -1,0 +1,9 @@
+import { notFound } from 'next/navigation'
+
+export default async function Page(props) {
+  const params = await props.params
+  if (params.id === 'missing') {
+    notFound()
+  }
+  return <p id="with-not-found-page">{`with-not-found-route [id]`}</p>
+}

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -87,6 +87,14 @@ describe('app dir - not found with default 404 page', () => {
     )
   })
 
+  it('should render custom not-found inside route group for non-existent page', async () => {
+    const browser = await next.browser('/with-not-found-route/missing')
+    await browser.waitForElementByCss('#group-custom-not-found')
+    expect(await browser.elementByCss('#group-custom-not-found').text()).toBe(
+      'Custom Not Found in Route Group'
+    )
+  })
+
   it('should render default not found for group routes if not found is not defined', async () => {
     const browser = await next.browser('/group-dynamic/123')
     expect(await browser.elementByCss('#page').text()).toBe(


### PR DESCRIPTION
fixes #73380.

**problem:** `isRootNotFound` in `find-page-file.ts` used a regex anchored to the start (`^`) after slicing off the app dir prefix. for `app/(group)/not-found.tsx`, the rest is `(group)/not-found.tsx` — the leading route-group segment causes the regex to fail, so the file is never recognized as a root not-found page, and the default 404 is shown instead of the custom one.

**fix:** strip leading route-group segments (which are URL-transparent) before testing against the regex. `app/(group)/not-found.tsx` and `app/not-found.tsx` now behave identically.

regression test: `should render custom not-found inside route group for non-existent page` — navigates to a route that calls `notFound()` inside `app/(with-not-found)/`, confirms the custom not-found renders.

<!-- NEXT_JS_LLM_PR -->
