### PR TITLE
[16.3.x-preview] Setup release branch

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -93,7 +93,7 @@ jobs:
               exit 1
             fi
             echo "release_environment=$RELEASE_ENVIRONMENT" >> $GITHUB_OUTPUT
-          elif [ ''"${GIT_REF}"'' == 'refs/heads/canary' ]
+          elif [ ''"${GIT_REF}"'' == 'refs/heads/next-16-3-beta' ]
           then
             echo "value=staging" >> $GITHUB_OUTPUT
           elif [ '${{ github.event_name }}' == 'workflow_dispatch' ]

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -80,6 +80,9 @@ jobs:
             elif [[ "$RELEASE_VERSION" == *-beta.* ]];
             then
               RELEASE_ENVIRONMENT="release-beta"
+            elif [[ "$RELEASE_VERSION" == *-preview.* ]];
+            then
+              RELEASE_ENVIRONMENT="release-preview"
             elif [[ "$RELEASE_VERSION" == *-rc.* ]];
             then
               RELEASE_ENVIRONMENT="release-release-candidate"
@@ -93,7 +96,7 @@ jobs:
               exit 1
             fi
             echo "release_environment=$RELEASE_ENVIRONMENT" >> $GITHUB_OUTPUT
-          elif [ ''"${GIT_REF}"'' == 'refs/heads/next-16-3-beta' ]
+          elif [ ''"${GIT_REF}"'' == 'refs/heads/next-16-3-preview' ]
           then
             echo "value=staging" >> $GITHUB_OUTPUT
           elif [ '${{ github.event_name }}' == 'workflow_dispatch' ]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: build-and-test
 
 on:
   push:
-    branches: ['canary']
+    branches: ['next-16-3-beta']
   pull_request:
     types: [opened, synchronize]
 
@@ -659,7 +659,7 @@ jobs:
     name: Test new and changed tests for flakes (dev)
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: false
     # test-new-tests-end-if
 
     strategy:
@@ -685,7 +685,7 @@ jobs:
     name: Test new and changed tests for flakes (prod)
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: false
     # test-new-tests-end-if
 
     strategy:
@@ -711,7 +711,7 @@ jobs:
     needs:
       ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
+    if: false
     # test-new-tests-end-if
 
     strategy:
@@ -744,7 +744,7 @@ jobs:
         'test-new-tests-start',
       ]
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
+    if: false
     # test-new-tests-end-if
 
     strategy:
@@ -1042,10 +1042,6 @@ jobs:
         'rustdoc-check',
         'test-next-swc-wasm',
         'test-turbopack-dev',
-        'test-new-tests-dev',
-        'test-new-tests-start',
-        'test-new-tests-deploy',
-        'test-new-tests-deploy-cache-components',
         'test-turbopack-production',
         'test-unit-windows',
         'test-dev-windows',

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: build-and-test
 
 on:
   push:
-    branches: ['next-16-3-beta']
+    branches: ['next-16-3-preview']
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: stable, canary, beta, or release candidate?
+        description: stable, canary, beta, preview, or release candidate?
         required: true
         type: choice
         options:
@@ -14,6 +14,7 @@ on:
           - stable
           - release-candidate
           - beta
+          - preview
 
       semverType:
         description: semver type?

--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
       "npmClient": "npm",
       "allowBranch": [
         "canary",
-        "next-16-3-beta"
+        "next-16-3-preview"
       ],
       "registry": "https://registry.npmjs.org/"
     }

--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,8 @@
     "publish": {
       "npmClient": "npm",
       "allowBranch": [
-        "canary"
+        "canary",
+        "next-16-3-beta"
       ],
       "registry": "https://registry.npmjs.org/"
     }

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -19,15 +19,17 @@ async function main() {
   const isCanary = releaseType === 'canary'
   const isReleaseCandidate = releaseType === 'release-candidate'
   const isBeta = releaseType === 'beta'
+  const isPreview = releaseType === 'preview'
 
   if (
     releaseType !== 'stable' &&
     releaseType !== 'canary' &&
     releaseType !== 'release-candidate' &&
-    releaseType !== 'beta'
+    releaseType !== 'beta' &&
+    releaseType !== 'preview'
   ) {
     console.log(
-      `Invalid release type ${releaseType}, must be stable, canary, release-candidate, or beta`
+      `Invalid release type ${releaseType}, must be stable, canary, release-candidate, beta, or preview`
     )
     return
   }
@@ -74,7 +76,9 @@ async function main() {
   const lernaArgs = [
     'lerna',
     'version',
-    isCanary || isReleaseCandidate || isBeta ? preleaseType : semverType,
+    isCanary || isReleaseCandidate || isBeta || isPreview
+      ? preleaseType
+      : semverType,
   ]
 
   if (isCanary) {
@@ -83,6 +87,8 @@ async function main() {
     lernaArgs.push('--preid', 'rc')
   } else if (isBeta) {
     lernaArgs.push('--preid', 'beta')
+  } else if (isPreview) {
+    lernaArgs.push('--preid', 'preview')
   }
 
   lernaArgs.push('--force-publish', '-y', '--no-push')
@@ -95,7 +101,7 @@ async function main() {
 
   await createGitHubReleaseCommit(githubToken)
 
-  if (isCanary || isReleaseCandidate || isBeta) {
+  if (isCanary || isReleaseCandidate || isBeta || isPreview) {
     const releaseChild = execa(
       'pnpm',
       ['release', '--pre', '--skip-questions', '--show-url'],


### PR DESCRIPTION
Same as 1c772d760be108a5667da183d234e6cb38a4a605 and https://github.com/vercel/next.js/pull/84713 but for `preview` releases in `next-16-3-preview`

## test plan

<details>
<summary>with auth disabled</summary>


```diff
diff --git a/lerna.json b/lerna.json
index b35d16256b..07d1edb326 100644
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
       "npmClient": "npm",
       "allowBranch": [
         "canary",
-        "next-16-3-preview"
+        "sebbie/setup-beta-release"
       ],
       "registry": "https://registry.npmjs.org/"
     }
diff --git a/scripts/start-release.js b/scripts/start-release.js
index 12f344e097..ba19218eaf 100644
--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -58,12 +58,12 @@ async function main() {
   const config = new ConfigStore('release')
   config.set('token', githubToken)
 
-  await configureGitHubAuth(githubToken)
-  await verifyGitHubApiAccess(
-    githubToken,
-    '/repos/vercel/next.js/releases?per_page=1',
-    'release lookup'
-  )
+  // await configureGitHubAuth(githubToken)
+  // await verifyGitHubApiAccess(
+  //   githubToken,
+  //   '/repos/vercel/next.js/releases?per_page=1',
+  //   'release lookup'
+  // )
 
   console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
```

</details>

```console
$ RELEASE_GITHUB_TOKEN=1 node ./scripts/start-release.js --release-type preview --semver-type patch
```

commits `16.3.0-preview.0` as the version.

build and deploy environment works (approval/branch protected): https://github.com/vercel/next.js/actions/runs/27224686986/job/80395672877