### PR TITLE
[cd] Ensure release can be triggered on old branches

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -62,6 +62,10 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          # Even though this permission may seem optional, it's required for
+          # creating refs on branches that have diverged a lot from the default
+          # branch. This is not documented but was confirmed by GitHub support.
+          permission-workflows: write
 
       - name: Get GitHub App user ID
         id: release-app-user


### PR DESCRIPTION
Creating a ref requires `contents: write` or `contents: write` and `workflows: write`. The API didn't make it clear when we need `workflows: write`. Turns out `workflows: write` is needed when running on commits that are far removed from the default branch according to GitHub support. Adding `workflows: write` fixed permission issues when creating refs on old, diverged commits so this seems to have been the issue indeed.

IT already updated the application to have `workflows: write`. Now we need to update the requested token.

Needs to be backported to be effective.

## test plan

- [x] ref creation works on old (`next-15-5`) branches: https://github.com/vercel/next.js/actions/runs/27212237311