### PR TITLE
[15.5.x][cd] Ensure release can be triggered on old branches

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -61,6 +61,10 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          # Even though this permission may seem optional, it's required for
+          # creating refs on branches that have diverged a lot from the default
+          # branch. This is not documented but was confirmed by GitHub support.
+          permission-workflows: write
 
       - name: Get GitHub App user ID
         id: release-app-user


### PR DESCRIPTION
Backports https://github.com/vercel/next.js/pull/94596