### PR TITLE
Fix(deployment-id): prevent exception on old webkit

### DIFF
--- a/packages/next/src/shared/lib/deployment-id.ts
+++ b/packages/next/src/shared/lib/deployment-id.ts
@@ -4,7 +4,7 @@ if (typeof window !== 'undefined') {
   deploymentId = document.documentElement.dataset.dplId
   // Immediately remove the attribute to prevent hydration errors (the dplId was inserted into the
   // HTML only), React isn't aware of it at all.
-  delete document.documentElement.dataset.dplId
+  document.documentElement.removeAttribute('data-dpl-id')
 } else {
   // Client side: replaced with globalThis.NEXT_DEPLOYMENT_ID
   // Server side: left as is or replaced with a string or replaced with false


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #
https://github.com/vercel/next.js/issues/94601
-->

### What?

Start a next application after 16.2.0 in a safari 9 which is used in playstation 4.
The application will error with this message
```TypeError:  Unable to delete property```

### Why?

We narrow down the problem to this line

```delete document.documentElement.dataset.dplId ```
in
 ```packages/next/src/shared/lib/deployment-id.ts ```

It seems to be related of how webkit implemented dataset, as discussed in this [thread](https://stackoverflow.com/questions/28973603/unable-to-delete-property-on-safari-when-trying-to-delete-dataset-attribute-in)

### How?
replace 
this line 

```   delete document.documentElement.dataset.dplId; ```
with
```   document.documentElement.removeAttribute('data-dpl-id');```

if data cannot be deleted , we can remove the attribute.
It should achieve the same with a different syntax

Fixes #94601