### PR TITLE
docs: Partial Prefetching adoption guide + cross-links

### DIFF
--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -105,6 +105,19 @@ export default function Page() {
 
 Use this for content-heavy routes where the per-link cost of a full prefetch is acceptable and the value of having the rendered page ready is high — for example, a blog index where most users click through to read.
 
+## Choosing a strategy
+
+| You want                                                         | Set                                        | Where                   |
+| ---------------------------------------------------------------- | ------------------------------------------ | ----------------------- |
+| App-wide shell-only default                                      | `partialPrefetching: true`                 | `next.config.ts`        |
+| Shell-only for this route only                                   | `export const prefetch = 'partial'`        | `page.tsx`/`layout.tsx` |
+| This particular link to also prefetch page content               | `<Link prefetch>`                          | call site               |
+| This route's visible links to always prefetch page content       | `export const prefetch = 'unstable_eager'` | `page.tsx`/`layout.tsx` |
+| To opt this route out of prefetching entirely                    | `export const prefetch = 'force-disabled'` | `page.tsx`/`layout.tsx` |
+| To prefetch this route's runtime data (cookies, headers, search) | `export const prefetch = 'allow-runtime'`  | `page.tsx`/`layout.tsx` |
+
+A route with `unstable_instant = true` is implicitly partial-prefetched — you don't need both exports.
+
 ## Next steps
 
 - [Runtime prefetching](/docs/app/guides/runtime-prefetching) for per-link runtime prefetches and App Shells in depth.

--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -77,9 +77,9 @@ export default function Page() {
 }
 ```
 
-Every link that points at a route with `prefetch = 'partial'` prefetches the App Shell only, even while the global flag is still off. The [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) export implicitly opts the route into Partial Prefetching, so routes you've already added instant validation to don't need a separate `prefetch` export.
+Every link that points at a route with `prefetch = 'partial'` prefetches the App Shell only, even while the global flag is still off.
 
-Once every route in scope has either `prefetch = 'partial'` or `unstable_instant`, flip the global default and remove the per-route exports:
+Once every route in scope has `prefetch = 'partial'`, flip the global default and remove the per-route exports:
 
 ```ts filename="next.config.ts" highlight={5}
 import type { NextConfig } from 'next'
@@ -116,8 +116,6 @@ Use this for content-heavy routes where the per-link cost of a full prefetch is 
 | This route's visible links to always prefetch page content       | `export const prefetch = 'unstable_eager'` | `page.tsx`/`layout.tsx` |
 | To opt this route out of prefetching entirely                    | `export const prefetch = 'force-disabled'` | `page.tsx`/`layout.tsx` |
 | To prefetch this route's runtime data (cookies, headers, search) | `export const prefetch = 'allow-runtime'`  | `page.tsx`/`layout.tsx` |
-
-A route with `unstable_instant = true` is implicitly partial-prefetched — you don't need both exports.
 
 ## Next steps
 

--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -13,23 +13,23 @@ related:
     - app/api-reference/config/next-config-js/partialPrefetching
 ---
 
-Partial Prefetching changes how `<Link>` decides what to download. Instead of trying to prefetch the entire page for every visible link, it prefetches a reusable [**App Shell**](/docs/app/glossary#app-shell) per route by default, and per-link page content only when you explicitly opt in.
+Partial Prefetching changes how `<Link>` decides what to download. Instead of prefetching the entire page for every visible link, it prefetches a reusable [**App Shell**](/docs/app/glossary#app-shell) per route by default. Page content is prefetched per link only when you opt in.
 
-This guide covers the behavior change and the recommended path for adopting it, including the incremental adoption path for existing apps.
+This guide covers the behavior change, the recommended path for new apps, and the incremental adoption path for existing apps.
 
 > **Good to know**: Partial Prefetching only works when [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled.
 
 ## What changes for `<Link>`
 
-When Partial Prefetching is enabled, the default cost of rendering a `<Link>` drops to "effectively free": each visible link only contributes a reusable App Shell prefetch, not a per-link page render. The shell is downloaded once per filesystem route and reused for every link that points at that route, even if the dynamic params differ.
+When Partial Prefetching is enabled, the default cost of rendering a `<Link>` drops to "effectively free". Each visible link contributes a reusable App Shell prefetch, not a per-link page render. The shell is downloaded once per filesystem route and reused for every link that points at that route, even if the dynamic params differ.
 
 | `<Link>` prop                       | Before (Cache Components default)                                   | After Partial Prefetching                          |
 | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------- |
 | `<Link href="/x">`                  | Static route: prefetched the full route. Dynamic route: shell only. | Prefetches the App Shell for `/x` only.            |
 | `<Link href="/x" prefetch>`         | Prefetched the full route (data + UI).                              | Prefetches the App Shell **and** the page content. |
-| `<Link href="/x" prefetch={false}>` | Disabled all prefetching for this link.                             | Unchanged — still disabled.                        |
+| `<Link href="/x" prefetch={false}>` | Disabled all prefetching for this link.                             | Unchanged. Still disabled.                         |
 
-For fully static pages this is the biggest change. Before Partial Prefetching, every `<Link>` to a static page would prefetch the whole rendered HTML; after, only links with `prefetch={true}` do.
+For fully static pages this is the biggest change. Before Partial Prefetching, every `<Link>` to a static page prefetched the whole rendered HTML. After, only links with `prefetch={true}` do.
 
 ## Adopting in a new project
 
@@ -77,7 +77,7 @@ export default function Page() {
 }
 ```
 
-Every link that points at a route with `prefetch = 'partial'` prefetches the App Shell only, even while the global flag is still off.
+Every link that points at a route with `prefetch = 'partial'` prefetches the App Shell only, even when the global flag is off.
 
 Once every route in scope has `prefetch = 'partial'`, flip the global default and remove the per-route exports:
 
@@ -104,7 +104,7 @@ export default function Page() {
 }
 ```
 
-Use this for content-heavy routes where the per-link cost of a full prefetch is acceptable and the value of having the rendered page ready is high — for example, a blog index where most users click through to read.
+Use this for content-heavy routes where the per-link cost of a full prefetch is acceptable and the value of having the rendered page ready is high. A blog index where most users click through to read is a typical case.
 
 ## Choosing a strategy
 

--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -121,6 +121,6 @@ Use this for content-heavy routes where the per-link cost of a full prefetch is 
 
 - [Runtime prefetching](/docs/app/guides/runtime-prefetching) for per-link runtime prefetches and App Shells in depth.
 - [`partialPrefetching` API reference](/docs/app/api-reference/config/next-config-js/partialPrefetching) for the global config flag.
-- [`prefetch` API reference](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for all segment-level prefetch modes.
+- [`prefetch` API reference](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for the per-segment prefetch config.
 - [`<Link>` API reference](/docs/app/api-reference/components/link#prefetch) for the per-link `prefetch` prop.
 - [Instant navigation](/docs/app/guides/instant-navigation) to validate that the routes you've marked actually navigate instantly.

--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -10,6 +10,7 @@ related:
     - app/guides/instant-navigation
     - app/guides/runtime-prefetching
     - app/api-reference/components/link
+    - app/api-reference/config/next-config-js/partialPrefetching
 ---
 
 Partial Prefetching changes how `<Link>` decides what to download. Instead of trying to prefetch the entire page for every visible link, it prefetches a reusable [**App Shell**](/docs/app/glossary#app-shell) per route by default, and per-link page content only when you explicitly opt in.
@@ -32,7 +33,7 @@ For fully static pages this is the biggest change. Before Partial Prefetching, e
 
 ## Adopting in a new project
 
-Enable Partial Prefetching in `next.config.ts` alongside Cache Components:
+Enable [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) in `next.config.ts` alongside Cache Components:
 
 ```ts filename="next.config.ts" highlight={5}
 import type { NextConfig } from 'next'
@@ -121,6 +122,7 @@ A route with `unstable_instant = true` is implicitly partial-prefetched — you 
 ## Next steps
 
 - [Runtime prefetching](/docs/app/guides/runtime-prefetching) for per-link runtime prefetches and App Shells in depth.
+- [`partialPrefetching` API reference](/docs/app/api-reference/config/next-config-js/partialPrefetching) for the global config flag.
 - [`prefetch` API reference](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for all segment-level prefetch modes.
 - [`<Link>` API reference](/docs/app/api-reference/components/link#prefetch) for the per-link `prefetch` prop.
 - [Instant navigation](/docs/app/guides/instant-navigation) to validate that the routes you've marked actually navigate instantly.

--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -12,7 +12,7 @@ related:
     - app/api-reference/components/link
 ---
 
-Partial Prefetching changes how `<Link>` decides what to download. Instead of trying to prefetch the entire page for every visible link, it prefetches a reusable **App Shell** per route by default, and per-link page content only when you explicitly opt in.
+Partial Prefetching changes how `<Link>` decides what to download. Instead of trying to prefetch the entire page for every visible link, it prefetches a reusable [**App Shell**](/docs/app/glossary#app-shell) per route by default, and per-link page content only when you explicitly opt in.
 
 This guide covers the behavior change and the recommended path for adopting it, including the incremental adoption path for existing apps.
 

--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -1,0 +1,113 @@
+---
+title: Adopting Partial Prefetching
+nav_title: Adopting Partial Prefetching
+description: Learn how to enable Partial Prefetching and what changes for `<Link>`.
+version: draft
+related:
+  title: Next Steps
+  description: Learn more about prefetching and instant navigations.
+  links:
+    - app/guides/instant-navigation
+    - app/guides/runtime-prefetching
+    - app/api-reference/components/link
+---
+
+Partial Prefetching changes how `<Link>` decides what to download. Instead of trying to prefetch the entire page for every visible link, it prefetches a reusable **App Shell** per route by default, and per-link page content only when you explicitly opt in.
+
+This guide covers the behavior change and the recommended path for adopting it, including the incremental adoption path for existing apps.
+
+> **Good to know**: Partial Prefetching only works when [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled.
+
+## What changes for `<Link>`
+
+When Partial Prefetching is enabled, the default cost of rendering a `<Link>` drops to "effectively free": each visible link only contributes a reusable App Shell prefetch, not a per-link page render. The shell is downloaded once per filesystem route and reused for every link that points at that route, even if the dynamic params differ.
+
+| `<Link>` prop                       | Before (Cache Components default)                                   | After Partial Prefetching                          |
+| ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------- |
+| `<Link href="/x">`                  | Static route: prefetched the full route. Dynamic route: shell only. | Prefetches the App Shell for `/x` only.            |
+| `<Link href="/x" prefetch>`         | Prefetched the full route (data + UI).                              | Prefetches the App Shell **and** the page content. |
+| `<Link href="/x" prefetch={false}>` | Disabled all prefetching for this link.                             | Unchanged — still disabled.                        |
+
+For fully static pages this is the biggest change. Before Partial Prefetching, every `<Link>` to a static page would prefetch the whole rendered HTML; after, only links with `prefetch={true}` do.
+
+## Adopting in a new project
+
+Enable Partial Prefetching in `next.config.ts` alongside Cache Components:
+
+```ts filename="next.config.ts" highlight={5}
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+export default nextConfig
+```
+
+Then opt in per link where the page content is worth prefetching alongside the App Shell:
+
+```tsx filename="app/page.tsx"
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <nav>
+      <Link href="/products">Products</Link>
+      <Link href="/checkout" prefetch>
+        Checkout
+      </Link>
+    </nav>
+  )
+}
+```
+
+Pair this with [App Shells](/docs/app/guides/runtime-prefetching#app-shells) so every route has an instant floor.
+
+## Adopting incrementally in an existing project
+
+If the app already ships static prefetching and you can't flip the global flag at once, opt routes in one at a time with the [`prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) route segment config:
+
+```tsx filename="app/products/[slug]/page.tsx"
+export const prefetch = 'partial'
+
+export default function Page() {
+  return <div>...</div>
+}
+```
+
+Every link that points at a route with `prefetch = 'partial'` prefetches the App Shell only, even while the global flag is still off. The [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) export implicitly opts the route into Partial Prefetching, so routes you've already added instant validation to don't need a separate `prefetch` export.
+
+Once every route in scope has either `prefetch = 'partial'` or `unstable_instant`, flip the global default and remove the per-route exports:
+
+```ts filename="next.config.ts" highlight={5}
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+export default nextConfig
+```
+
+## Per-route eager prefetching
+
+If you need a specific route to keep the pre-Partial-Prefetching behavior (every visible link to it prefetches page content), set the segment config:
+
+```tsx filename="app/blog/[slug]/page.tsx"
+export const prefetch = 'unstable_eager'
+
+export default function Page() {
+  return <article>...</article>
+}
+```
+
+Use this for content-heavy routes where the per-link cost of a full prefetch is acceptable and the value of having the rendered page ready is high — for example, a blog index where most users click through to read.
+
+## Next steps
+
+- [Runtime prefetching](/docs/app/guides/runtime-prefetching) for per-link runtime prefetches and App Shells in depth.
+- [`prefetch` API reference](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for all segment-level prefetch modes.
+- [`<Link>` API reference](/docs/app/api-reference/components/link#prefetch) for the per-link `prefetch` prop.
+- [Instant navigation](/docs/app/guides/instant-navigation) to validate that the routes you've marked actually navigate instantly.

--- a/docs/01-app/02-guides/instant-navigation.mdx
+++ b/docs/01-app/02-guides/instant-navigation.mdx
@@ -50,7 +50,7 @@ With Cache Components, **caching directives** (`"use cache"` and its variants) a
 
 > **Good to know:** A fallback may access `cookies()`, `headers()`, or the full URL. At build time, the fallback itself suspends, and a `<Suspense>` boundary further up the tree is needed. With [runtime prefetching](/docs/app/guides/runtime-prefetching), the information is available and such a fallback becomes part of the instant UI. Cached values like timestamps or data fetches can sit directly inside the fallback.
 
-Next.js can also generate an **App Shell** per route: a fallback that renders instantly during client navigations when nothing else is ready. See [App Shells](/docs/app/guides/runtime-prefetching#app-shells) for how to enable them and how they pair with runtime prefetching.
+Next.js can also generate an [**App Shell**](/docs/app/glossary#app-shell) per route: a fallback that renders instantly during client navigations when nothing else is ready. See [App Shells](/docs/app/guides/runtime-prefetching#app-shells) for how to enable them and how they pair with runtime prefetching.
 
 ### Tune what `<Link>` prefetches
 

--- a/docs/01-app/02-guides/instant-navigation.mdx
+++ b/docs/01-app/02-guides/instant-navigation.mdx
@@ -52,6 +52,20 @@ With Cache Components, **caching directives** (`"use cache"` and its variants) a
 
 Next.js can also generate an **App Shell** per route: a fallback that renders instantly during client navigations when nothing else is ready. See [App Shells](/docs/app/guides/runtime-prefetching#app-shells) for how to enable them and how they pair with runtime prefetching.
 
+### Tune what `<Link>` prefetches
+
+Under [Partial Prefetching](/docs/app/guides/adopting-partial-prefetching), each visible `<Link>` prefetches the destination's App Shell by default. The shell is shared across every link to the same route, so rendering a `<Link>` is effectively free.
+
+To prefetch the page content alongside the shell for a specific link, set [`prefetch={true}`](/docs/app/api-reference/components/link#prefetch):
+
+```tsx
+<Link href="/checkout" prefetch>
+  Checkout
+</Link>
+```
+
+To prefetch with the user's session (cookies, headers, the full URL), opt the destination segment into [runtime prefetching](/docs/app/guides/runtime-prefetching) with `export const prefetch = 'allow-runtime'`.
+
 ### Validate instant navigation
 
 By **default** Cache Components apps validate every navigation in development, giving you insight into what would keep it from being instant: which navigations would block, where a `<Suspense>` boundary is missing, and which data is reaching the user uncached.
@@ -436,18 +450,11 @@ export const unstable_instant = false
 
 With `false` on `/dashboard/layout.tsx`, validation no longer flags navigations into `/dashboard` from outside; navigations between `/dashboard/a` and `/dashboard/b` are still checked.
 
-**Layout and its children.** To disable validation for the layout and every segment below it, use:
-
-```tsx filename="app/admin/layout.tsx"
-export const unstable_instant = { unstable_disableValidation: true }
-```
-
-Useful when an entire section of the app shouldn't be validated.
-
 For opted-out segments, the navigation blocks on the server. If the content depends on cookies or headers but has a known cache lifetime, [runtime prefetching](/docs/app/guides/runtime-prefetching) can prerender it ahead of click instead of opting out.
 
 ## Next steps
 
+- [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for the recommended `<Link>` defaults and the migration path off `unstable_eager`
 - [`unstable_instant` API reference](/docs/app/api-reference/file-conventions/route-segment-config/instant) for the full configuration
 - [Runtime prefetching](/docs/app/guides/runtime-prefetching) when parts of your route depend on cookies or headers and you want those in the shell
 - [Caching](/docs/app/getting-started/caching) for background on `use cache`, Suspense, and Partial Prerendering

--- a/docs/01-app/02-guides/prefetching.mdx
+++ b/docs/01-app/02-guides/prefetching.mdx
@@ -13,7 +13,7 @@ This guide will explain how prefetching works and show common implementation pat
 - [Extending or ejecting link](#extending-or-ejecting-link)
 - [Disabled prefetch](#disabled-prefetch)
 
-> **Using Cache Components?** With [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, `<Link>` defaults to prefetching a per-route [App Shell](/docs/app/guides/runtime-prefetching#app-shells) rather than the full page. Set `prefetch={true}` on a `<Link>` to also prefetch the destination page's content. See [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for the behavior change and the recommended adoption path.
+> **Using Cache Components?** With [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, `<Link>` defaults to prefetching a per-route [App Shell](/docs/app/glossary#app-shell) rather than the full page. Set `prefetch={true}` on a `<Link>` to also prefetch the destination page's content. See [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for the behavior change and the recommended adoption path.
 
 ## How does prefetching work?
 

--- a/docs/01-app/02-guides/prefetching.mdx
+++ b/docs/01-app/02-guides/prefetching.mdx
@@ -13,6 +13,8 @@ This guide will explain how prefetching works and show common implementation pat
 - [Extending or ejecting link](#extending-or-ejecting-link)
 - [Disabled prefetch](#disabled-prefetch)
 
+> **Using Cache Components?** With [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, `<Link>` defaults to prefetching a per-route [App Shell](/docs/app/guides/runtime-prefetching#app-shells) rather than the full page. Set `prefetch={true}` on a `<Link>` to also prefetch the destination page's content. See [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for the behavior change and the recommended adoption path.
+
 ## How does prefetching work?
 
 When navigating between routes, the browser requests assets for the page like HTML and JavaScript files. Prefetching is the process of fetching these resources _ahead_ of time, before you navigate to a new route.

--- a/docs/01-app/02-guides/runtime-prefetching.mdx
+++ b/docs/01-app/02-guides/runtime-prefetching.mdx
@@ -204,6 +204,7 @@ Compared with per-link runtime prefetching:
 
 ## Next steps
 
+- [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for how `<Link>` behaves under the new model and how to migrate existing apps.
 - [`prefetch` API reference](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for all prefetch modes.
 - [`use cache: private` reference](/docs/app/api-reference/directives/use-cache-private) for per-user caching specifics.
 - [Instant navigation guide](/docs/app/guides/instant-navigation) for validating the route's caching structure.

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -303,7 +303,7 @@ The following values can be passed to the `prefetch` prop:
 - `true`: The full route will be prefetched for both static and dynamic routes.
 - `false`: Prefetching will never happen both on entering the viewport and on hover.
 
-> **With Partial Prefetching enabled** ([`partialPrefetching: true`](/docs/app/api-reference/config/next-config-js/partialPrefetching)): the default changes. `auto` prefetches only the per-route [App Shell](/docs/app/guides/runtime-prefetching#app-shells), not the page content. Set `prefetch={true}` to also prefetch the destination page's content. See [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for the full behavior change.
+> **With Partial Prefetching enabled** ([`partialPrefetching: true`](/docs/app/api-reference/config/next-config-js/partialPrefetching)): the default changes. `auto` prefetches only the per-route [App Shell](/docs/app/glossary#app-shell), not the page content. Set `prefetch={true}` to also prefetch the destination page's content. See [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for the full behavior change.
 
 ```tsx filename="app/page.tsx" switcher
 import Link from 'next/link'

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -303,6 +303,8 @@ The following values can be passed to the `prefetch` prop:
 - `true`: The full route will be prefetched for both static and dynamic routes.
 - `false`: Prefetching will never happen both on entering the viewport and on hover.
 
+> **With Partial Prefetching enabled** ([`partialPrefetching: true`](/docs/app/api-reference/config/next-config-js/partialPrefetching)): the default changes. `auto` prefetches only the per-route [App Shell](/docs/app/guides/runtime-prefetching#app-shells), not the page content. Set `prefetch={true}` to also prefetch the destination page's content. See [Adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) for the full behavior change.
+
 ```tsx filename="app/page.tsx" switcher
 import Link from 'next/link'
 


### PR DESCRIPTION
### What?

Adoption guide for Partial Prefetching: what changes for `<Link>`, the recommended path for new apps, and the incremental migration path for existing apps.

### How?

New file: [`docs/01-app/02-guides/adopting-partial-prefetching.mdx`](./docs/01-app/02-guides/adopting-partial-prefetching.mdx).

Cross-links from `instant-navigation.mdx`, `prefetching.mdx`, `runtime-prefetching.mdx`, and the `<Link>` API page so readers find the new guide from wherever the change is relevant.

### Base branch

Targets [`instant-spa-navs`](https://github.com/vercel/next.js/pull/93204), not `canary`. Rebase onto canary once #93204 merges.

<!-- NEXT_JS_LLM_PR -->
