### PR TITLE
[turbopack] Allocate `Effect`s in an arena

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/bump_vec.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/bump_vec.rs
@@ -159,12 +159,6 @@ impl<'a, T> BumpVec<'a, T> {
         }
     }
 
-    /// Move every element out of `other` into `self`, leaving `other` empty. Mirrors
-    /// [`Vec::append`], but takes the `&'a Bump` since growth may reallocate into the arena.
-    pub fn append(&mut self, bump: &'a Bump, other: &mut Self) {
-        self.extend(bump, std::mem::take(other));
-    }
-
     pub fn pop(&mut self) -> Option<T> {
         if self.len == 0 {
             return None;
@@ -517,16 +511,6 @@ mod tests {
 
         let collected: Vec<i32> = v.into_iter().collect();
         assert_eq!(collected, vec![2, 4, 6]);
-    }
-
-    #[test]
-    fn append_moves_and_empties_other() {
-        let bump = Bump::new();
-        let mut a = BumpVec::from_iter_in(&bump, [1, 2]);
-        let mut b = BumpVec::from_iter_in(&bump, [3, 4, 5]);
-        a.append(&bump, &mut b);
-        assert_eq!(&*a, &[1, 2, 3, 4, 5][..]);
-        assert!(b.is_empty());
     }
 
     #[test]

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/bump_vec.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/bump_vec.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use allocator_api2::alloc::Allocator;
-use bumpalo::Bump;
+use bumpalo::{Bump, boxed::Box as BumpBox};
 
 /// A minimal growable vector for the list children of a `JsValue` that grow or are rebuilt after
 /// construction (e.g. `Array.items`, `Object.parts`, `Alternatives.values`, `Add` operands, and the
@@ -43,6 +43,19 @@ unsafe impl<T: Sync> Sync for BumpVec<'_, T> {}
 impl<T> Default for BumpVec<'_, T> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<'a, T> From<BumpBox<'a, [T]>> for BumpVec<'a, T> {
+    fn from(boxed: BumpBox<'a, [T]>) -> Self {
+        let len = boxed.len();
+        let ptr = BumpBox::into_raw(boxed) as *mut T;
+        Self {
+            ptr: NonNull::new(ptr).unwrap_or(NonNull::dangling()),
+            cap: len,
+            len,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -84,6 +97,15 @@ impl<'a, T> BumpVec<'a, T> {
             Self::with_capacity_in(bump, iter.size_hint().1.unwrap_or(iter.size_hint().0));
         vec.extend(bump, iter);
         vec
+    }
+
+    /// Freeze into an arena-allocated boxed slice, handing the existing allocation to the box.
+    pub fn into_boxed_slice(self) -> BumpBox<'a, [T]> {
+        let me = ManuallyDrop::new(self);
+        let slice = ptr::slice_from_raw_parts_mut(me.ptr.as_ptr(), me.len);
+        // SAFETY: `ptr`/`len` describe an initialized arena slice we exclusively own, exactly the
+        // representation `BumpBox<[T]>` expects.
+        unsafe { BumpBox::from_raw(slice) }
     }
 
     /// Reallocate the buffer to `new_cap` elements (`new_cap >= len`), moving the live prefix into

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/bump_vec.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/bump_vec.rs
@@ -159,6 +159,12 @@ impl<'a, T> BumpVec<'a, T> {
         }
     }
 
+    /// Move every element out of `other` into `self`, leaving `other` empty. Mirrors
+    /// [`Vec::append`], but takes the `&'a Bump` since growth may reallocate into the arena.
+    pub fn append(&mut self, bump: &'a Bump, other: &mut Self) {
+        self.extend(bump, std::mem::take(other));
+    }
+
     pub fn pop(&mut self) -> Option<T> {
         if self.len == 0 {
             return None;
@@ -297,6 +303,17 @@ impl<T> Iterator for IntoIter<'_, T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let remaining = self.len - self.idx;
         (remaining, Some(remaining))
+    }
+}
+
+impl<T> DoubleEndedIterator for IntoIter<'_, T> {
+    fn next_back(&mut self) -> Option<T> {
+        if self.idx == self.len {
+            return None;
+        }
+        self.len -= 1;
+        // SAFETY: index `len` (post-decrement) lies in the initialized `[idx, len)` range.
+        Some(unsafe { self.ptr.as_ptr().add(self.len).read() })
     }
 }
 
@@ -500,6 +517,49 @@ mod tests {
 
         let collected: Vec<i32> = v.into_iter().collect();
         assert_eq!(collected, vec![2, 4, 6]);
+    }
+
+    #[test]
+    fn append_moves_and_empties_other() {
+        let bump = Bump::new();
+        let mut a = BumpVec::from_iter_in(&bump, [1, 2]);
+        let mut b = BumpVec::from_iter_in(&bump, [3, 4, 5]);
+        a.append(&bump, &mut b);
+        assert_eq!(&*a, &[1, 2, 3, 4, 5][..]);
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn into_iter_double_ended() {
+        let bump = Bump::new();
+        let v = BumpVec::from_iter_in(&bump, [1, 2, 3, 4]);
+        let reversed: Vec<i32> = v.into_iter().rev().collect();
+        assert_eq!(reversed, vec![4, 3, 2, 1]);
+
+        // Front and back cursors meet without overlap.
+        let v = BumpVec::from_iter_in(&bump, [1, 2, 3]);
+        let mut it = v.into_iter();
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next_back(), Some(3));
+        assert_eq!(it.next(), Some(2));
+        assert_eq!(it.next_back(), None);
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn double_ended_drops_remainder_once() {
+        let bump = Bump::new();
+        let counter = Rc::new(Cell::new(0));
+        let mut v = BumpVec::new();
+        for _ in 0..5 {
+            v.push(&bump, DropCounter(counter.clone()));
+        }
+        let mut it = v.into_iter();
+        drop(it.next()); // front
+        drop(it.next_back()); // back
+        assert_eq!(counter.get(), 2);
+        drop(it); // remaining three drop exactly once
+        assert_eq!(counter.get(), 5);
     }
 
     #[test]

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
@@ -10,7 +10,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct EffectsBlock<'a> {
-    pub effects: BumpVec<'a, Effect<'a>>,
+    pub effects: BumpBox<'a, [Effect<'a>]>,
     pub range: AstPathRange,
 }
 
@@ -34,8 +34,8 @@ pub enum ConditionalKind<'a> {
     /// The blocks of an `if { ... return ... } else { ... } ...` or `if { ... }
     /// else { ... return ... } ...` statement.
     IfElseMultiple {
-        then: Box<[EffectsBlock<'a>]>,
-        r#else: Box<[EffectsBlock<'a>]>,
+        then: BumpBox<'a, [EffectsBlock<'a>]>,
+        r#else: BumpBox<'a, [EffectsBlock<'a>]>,
     },
     /// The expressions on the right side of the `?:` operator.
     Ternary {
@@ -61,28 +61,28 @@ impl<'a> ConditionalKind<'a> {
             | ConditionalKind::And { expr: block, .. }
             | ConditionalKind::Or { expr: block, .. }
             | ConditionalKind::NullishCoalescing { expr: block, .. } => {
-                for effect in &mut block.effects {
+                for effect in block.effects.iter_mut() {
                     effect.normalize(arena);
                 }
             }
             ConditionalKind::IfElse { then, r#else, .. }
             | ConditionalKind::Ternary { then, r#else, .. } => {
-                for effect in &mut then.effects {
+                for effect in then.effects.iter_mut() {
                     effect.normalize(arena);
                 }
-                for effect in &mut r#else.effects {
+                for effect in r#else.effects.iter_mut() {
                     effect.normalize(arena);
                 }
             }
             ConditionalKind::IfElseMultiple { then, r#else, .. } => {
                 for block in then.iter_mut().chain(r#else.iter_mut()) {
-                    for effect in &mut block.effects {
+                    for effect in block.effects.iter_mut() {
                         effect.normalize(arena);
                     }
                 }
             }
             ConditionalKind::Labeled { body } => {
-                for effect in &mut body.effects {
+                for effect in body.effects.iter_mut() {
                     effect.normalize(arena);
                 }
             }
@@ -104,7 +104,7 @@ impl<'a> EffectArg<'a> {
             EffectArg::Value(value) => value.normalize(arena),
             EffectArg::Closure(value, effects) => {
                 value.normalize(arena);
-                for effect in &mut effects.effects {
+                for effect in effects.effects.iter_mut() {
                     effect.normalize(arena);
                 }
             }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
@@ -4,13 +4,13 @@ use turbo_rcstr::RcStr;
 use turbopack_core::resolve::ExportUsage;
 
 use crate::{
-    analyzer::{Bump, JsValue},
+    analyzer::{Bump, BumpVec, JsValue},
     utils::AstPathRange,
 };
 
 #[derive(Debug)]
 pub struct EffectsBlock<'a> {
-    pub effects: Vec<Effect<'a>>,
+    pub effects: BumpVec<'a, Effect<'a>>,
     pub range: AstPathRange,
 }
 
@@ -23,33 +23,35 @@ impl EffectsBlock<'_> {
 #[derive(Debug)]
 pub enum ConditionalKind<'a> {
     /// The blocks of an `if` statement without an `else` block.
-    If { then: Box<EffectsBlock<'a>> },
+    If { then: BumpBox<'a, EffectsBlock<'a>> },
     /// The blocks of an `if ... else` or `if { ... return ... } ...` statement.
     IfElse {
-        then: Box<EffectsBlock<'a>>,
-        r#else: Box<EffectsBlock<'a>>,
+        then: BumpBox<'a, EffectsBlock<'a>>,
+        r#else: BumpBox<'a, EffectsBlock<'a>>,
     },
     /// The blocks of an `if ... else` statement.
-    Else { r#else: Box<EffectsBlock<'a>> },
+    Else {
+        r#else: BumpBox<'a, EffectsBlock<'a>>,
+    },
     /// The blocks of an `if { ... return ... } else { ... } ...` or `if { ... }
     /// else { ... return ... } ...` statement.
     IfElseMultiple {
-        then: Vec<Box<EffectsBlock<'a>>>,
-        r#else: Vec<Box<EffectsBlock<'a>>>,
+        then: Vec<BumpBox<'a, EffectsBlock<'a>>>,
+        r#else: Vec<BumpBox<'a, EffectsBlock<'a>>>,
     },
     /// The expressions on the right side of the `?:` operator.
     Ternary {
-        then: Box<EffectsBlock<'a>>,
-        r#else: Box<EffectsBlock<'a>>,
+        then: BumpBox<'a, EffectsBlock<'a>>,
+        r#else: BumpBox<'a, EffectsBlock<'a>>,
     },
     /// The expression on the right side of the `&&` operator.
-    And { expr: Box<EffectsBlock<'a>> },
+    And { expr: BumpBox<'a, EffectsBlock<'a>> },
     /// The expression on the right side of the `||` operator.
-    Or { expr: Box<EffectsBlock<'a>> },
+    Or { expr: BumpBox<'a, EffectsBlock<'a>> },
     /// The expression on the right side of the `??` operator.
-    NullishCoalescing { expr: Box<EffectsBlock<'a>> },
+    NullishCoalescing { expr: BumpBox<'a, EffectsBlock<'a>> },
     /// The expression on the right side of a labeled statement.
-    Labeled { body: Box<EffectsBlock<'a>> },
+    Labeled { body: BumpBox<'a, EffectsBlock<'a>> },
 }
 
 impl<'a> ConditionalKind<'a> {
@@ -93,7 +95,7 @@ impl<'a> ConditionalKind<'a> {
 #[derive(Debug)]
 pub enum EffectArg<'a> {
     Value(JsValue<'a>),
-    Closure(JsValue<'a>, Box<EffectsBlock<'a>>),
+    Closure(JsValue<'a>, BumpBox<'a, EffectsBlock<'a>>),
     Spread,
 }
 
@@ -120,7 +122,7 @@ pub enum Effect<'a> {
     /// to determine which effects are executed and remove the others.
     Conditional {
         condition: BumpBox<'a, JsValue<'a>>,
-        kind: Box<ConditionalKind<'a>>,
+        kind: BumpBox<'a, ConditionalKind<'a>>,
         /// The ast path to the condition.
         ast_path: Vec<AstParentKind>,
         span: Span,
@@ -128,7 +130,7 @@ pub enum Effect<'a> {
     /// A function call or a new call of a function.
     Call {
         func: BumpBox<'a, JsValue<'a>>,
-        args: Vec<EffectArg<'a>>,
+        args: BumpVec<'a, EffectArg<'a>>,
         ast_path: Vec<AstParentKind>,
         span: Span,
         in_try: bool,
@@ -138,7 +140,7 @@ pub enum Effect<'a> {
     MemberCall {
         obj: BumpBox<'a, JsValue<'a>>,
         prop: BumpBox<'a, JsValue<'a>>,
-        args: Vec<EffectArg<'a>>,
+        args: BumpVec<'a, EffectArg<'a>>,
         ast_path: Vec<AstParentKind>,
         span: Span,
         in_try: bool,
@@ -186,7 +188,7 @@ pub enum Effect<'a> {
     /// - `import(/* webpackExports: ["a"] */ './lib')` (magic comment)
     /// - `import(/* turbopackExports: ["a"] */ './lib')` (magic comment)
     DynamicImport {
-        args: Vec<EffectArg<'a>>,
+        args: BumpVec<'a, EffectArg<'a>>,
         ast_path: Vec<AstParentKind>,
         span: Span,
         in_try: bool,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
@@ -34,8 +34,8 @@ pub enum ConditionalKind<'a> {
     /// The blocks of an `if { ... return ... } else { ... } ...` or `if { ... }
     /// else { ... return ... } ...` statement.
     IfElseMultiple {
-        then: Vec<EffectsBlock<'a>>,
-        r#else: Vec<EffectsBlock<'a>>,
+        then: Box<[EffectsBlock<'a>]>,
+        r#else: Box<[EffectsBlock<'a>]>,
     },
     /// The expressions on the right side of the `?:` operator.
     Ternary {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
@@ -122,14 +122,14 @@ pub enum Effect<'a> {
         condition: BumpBox<'a, JsValue<'a>>,
         kind: BumpBox<'a, ConditionalKind<'a>>,
         /// The ast path to the condition.
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
     },
     /// A function call or a new call of a function.
     Call {
         func: BumpBox<'a, JsValue<'a>>,
         args: BumpVec<'a, EffectArg<'a>>,
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
         in_try: bool,
         new: bool,
@@ -139,7 +139,7 @@ pub enum Effect<'a> {
         obj: BumpBox<'a, JsValue<'a>>,
         prop: BumpBox<'a, JsValue<'a>>,
         args: BumpVec<'a, EffectArg<'a>>,
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
         in_try: bool,
         new: bool,
@@ -148,32 +148,32 @@ pub enum Effect<'a> {
     Member {
         obj: BumpBox<'a, JsValue<'a>>,
         prop: BumpBox<'a, JsValue<'a>>,
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
     },
     /// A reference to an imported binding.
     ImportedBinding {
         esm_reference_index: usize,
         export: Option<RcStr>,
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
     },
     /// A reference to a free var access.
     FreeVar {
         var: Atom,
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
     },
     /// A typeof expression
     TypeOf {
         arg: BumpBox<'a, JsValue<'a>>,
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
     },
     // TODO ImportMeta should be replaced with Member
     /// A reference to `import.meta`.
     ImportMeta {
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
     },
     /// A dynamic import() call, potentially with export usage extracted from
@@ -187,14 +187,16 @@ pub enum Effect<'a> {
     /// - `import(/* turbopackExports: ["a"] */ './lib')` (magic comment)
     DynamicImport {
         args: BumpVec<'a, EffectArg<'a>>,
-        ast_path: Vec<AstParentKind>,
+        ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
         in_try: bool,
         /// The export usage extracted from the usage pattern.
         export_usage: ExportUsage,
     },
     /// Unreachable code, e.g. after a `return` statement.
-    Unreachable { start_ast_path: Vec<AstParentKind> },
+    Unreachable {
+        start_ast_path: BumpBox<'a, [AstParentKind]>,
+    },
 }
 
 impl<'a> Effect<'a> {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/effects.rs
@@ -23,35 +23,33 @@ impl EffectsBlock<'_> {
 #[derive(Debug)]
 pub enum ConditionalKind<'a> {
     /// The blocks of an `if` statement without an `else` block.
-    If { then: BumpBox<'a, EffectsBlock<'a>> },
+    If { then: EffectsBlock<'a> },
     /// The blocks of an `if ... else` or `if { ... return ... } ...` statement.
     IfElse {
-        then: BumpBox<'a, EffectsBlock<'a>>,
-        r#else: BumpBox<'a, EffectsBlock<'a>>,
+        then: EffectsBlock<'a>,
+        r#else: EffectsBlock<'a>,
     },
     /// The blocks of an `if ... else` statement.
-    Else {
-        r#else: BumpBox<'a, EffectsBlock<'a>>,
-    },
+    Else { r#else: EffectsBlock<'a> },
     /// The blocks of an `if { ... return ... } else { ... } ...` or `if { ... }
     /// else { ... return ... } ...` statement.
     IfElseMultiple {
-        then: Vec<BumpBox<'a, EffectsBlock<'a>>>,
-        r#else: Vec<BumpBox<'a, EffectsBlock<'a>>>,
+        then: Vec<EffectsBlock<'a>>,
+        r#else: Vec<EffectsBlock<'a>>,
     },
     /// The expressions on the right side of the `?:` operator.
     Ternary {
-        then: BumpBox<'a, EffectsBlock<'a>>,
-        r#else: BumpBox<'a, EffectsBlock<'a>>,
+        then: EffectsBlock<'a>,
+        r#else: EffectsBlock<'a>,
     },
     /// The expression on the right side of the `&&` operator.
-    And { expr: BumpBox<'a, EffectsBlock<'a>> },
+    And { expr: EffectsBlock<'a> },
     /// The expression on the right side of the `||` operator.
-    Or { expr: BumpBox<'a, EffectsBlock<'a>> },
+    Or { expr: EffectsBlock<'a> },
     /// The expression on the right side of the `??` operator.
-    NullishCoalescing { expr: BumpBox<'a, EffectsBlock<'a>> },
+    NullishCoalescing { expr: EffectsBlock<'a> },
     /// The expression on the right side of a labeled statement.
-    Labeled { body: BumpBox<'a, EffectsBlock<'a>> },
+    Labeled { body: EffectsBlock<'a> },
 }
 
 impl<'a> ConditionalKind<'a> {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/mod.rs
@@ -12,7 +12,7 @@ pub use crate::analyzer::graph::{
 };
 use crate::{
     AnalyzeMode,
-    analyzer::{Bump, JsValue, graph::visitor::Analyzer},
+    analyzer::{Bump, BumpVec, JsValue, graph::visitor::Analyzer},
     code_gen::CodeGen,
 };
 
@@ -30,7 +30,7 @@ pub struct VarGraph<'a> {
     /// non-trivial values.
     pub free_var_ids: FxHashMap<Atom, Id>,
 
-    pub effects: Vec<Effect<'a>>,
+    pub effects: BumpVec<'a, Effect<'a>>,
     // Some unconditional codegens, usually for ESM items.
     pub code_gens: Vec<CodeGen>,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/mod.rs
@@ -12,7 +12,7 @@ pub use crate::analyzer::graph::{
 };
 use crate::{
     AnalyzeMode,
-    analyzer::{Bump, BumpVec, JsValue, graph::visitor::Analyzer},
+    analyzer::{Bump, JsValue, graph::visitor::Analyzer},
     code_gen::CodeGen,
 };
 
@@ -30,7 +30,7 @@ pub struct VarGraph<'a> {
     /// non-trivial values.
     pub free_var_ids: FxHashMap<Atom, Id>,
 
-    pub effects: BumpVec<'a, Effect<'a>>,
+    pub effects: Vec<Effect<'a>>,
     // Some unconditional codegens, usually for ESM items.
     pub code_gens: Vec<CodeGen>,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -32,29 +32,34 @@ use crate::{
 enum EarlyReturn<'a> {
     Always {
         prev_effects: BumpVec<'a, Effect<'a>>,
-        start_ast_path: Vec<AstParentKind>,
+        start_ast_path: BumpBox<'a, [AstParentKind]>,
     },
     Conditional {
         prev_effects: BumpVec<'a, Effect<'a>>,
-        start_ast_path: Vec<AstParentKind>,
+        start_ast_path: BumpBox<'a, [AstParentKind]>,
 
         condition: BumpBox<'a, JsValue<'a>>,
         then: Option<EffectsBlock<'a>>,
         r#else: Option<EffectsBlock<'a>>,
         /// The ast path to the condition.
-        condition_ast_path: Vec<AstParentKind>,
+        condition_ast_path: BumpBox<'a, [AstParentKind]>,
         span: Span,
 
         early_return_condition_value: bool,
     },
 }
 
-pub fn as_parent_path_skip(
+/// Builds an arena-allocated boxed slice of the ast path, skipping the last `skip` entries.
+pub fn as_parent_path_skip_in<'a>(
+    arena: &'a Bump,
     ast_path: &AstNodePath<AstParentNodeRef<'_>>,
     skip: usize,
-) -> Vec<AstParentKind> {
+) -> BumpBox<'a, [AstParentKind]> {
     let kinds = ast_path.kinds();
-    kinds[..kinds.len() - skip].to_vec()
+    let kinds = &kinds[..kinds.len() - skip];
+    let mut path = BumpVec::with_capacity_in(arena, kinds.len());
+    path.extend_from_slice(arena, kinds);
+    path.into_boxed_slice()
 }
 
 pub(super) struct Analyzer<'arena, 'eval> {
@@ -338,7 +343,7 @@ mod analyzer_state {
         ) {
             let early_return = EarlyReturn::Always {
                 prev_effects: take(&mut self.effects),
-                start_ast_path: as_parent_path(ast_path),
+                start_ast_path: as_parent_path_in(self.arena, ast_path),
             };
             self.early_return_stack_mut().push(early_return);
         }
@@ -420,7 +425,7 @@ mod analyzer_state {
                     } => {
                         let block = EffectsBlock {
                             effects: take(&mut self.effects).into_boxed_slice(),
-                            range: AstPathRange::StartAfter(start_ast_path),
+                            range: AstPathRange::StartAfter(start_ast_path.to_vec()),
                         };
                         self.effects = prev_effects;
                         let kind = match (then, r#else, early_return_condition_value) {
@@ -498,6 +503,29 @@ mod analyzer_state {
 
 pub fn as_parent_path(ast_path: &AstNodePath<AstParentNodeRef<'_>>) -> Vec<AstParentKind> {
     ast_path.kinds().to_vec()
+}
+
+/// Like [`as_parent_path`], but freezes the path into an arena-allocated boxed slice.
+pub fn as_parent_path_in<'a>(
+    arena: &'a Bump,
+    ast_path: &AstNodePath<AstParentNodeRef<'_>>,
+) -> BumpBox<'a, [AstParentKind]> {
+    let mut path = BumpVec::with_capacity_in(arena, ast_path.kinds().len());
+    path.extend_from_slice(arena, ast_path.kinds());
+    path.into_boxed_slice()
+}
+
+/// Like [`as_parent_path_with`], but freezes the path into an arena-allocated boxed slice.
+pub fn as_parent_path_with_in<'a>(
+    arena: &'a Bump,
+    ast_path: &AstNodePath<AstParentNodeRef<'_>>,
+    additional: AstParentKind,
+) -> BumpBox<'a, [AstParentKind]> {
+    let kinds = ast_path.kinds();
+    let mut path = BumpVec::with_capacity_in(arena, kinds.len() + 1);
+    path.extend_from_slice(arena, kinds);
+    path.push(arena, additional);
+    path.into_boxed_slice()
 }
 
 /// Extracts export names from usage patterns on a dynamic import.
@@ -994,7 +1022,7 @@ impl<'a> Analyzer<'a, '_> {
                 };
                 self.add_effect(Effect::DynamicImport {
                     args,
-                    ast_path: as_parent_path(ast_path),
+                    ast_path: as_parent_path_in(self.arena, ast_path),
                     span,
                     in_try: self.is_in_try(),
                     export_usage,
@@ -1022,7 +1050,7 @@ impl<'a> Analyzer<'a, '_> {
                         obj: obj_value,
                         prop: prop_value,
                         args,
-                        ast_path: as_parent_path(ast_path),
+                        ast_path: as_parent_path_in(self.arena, ast_path),
                         span,
                         in_try: self.is_in_try(),
                         new,
@@ -1033,7 +1061,7 @@ impl<'a> Analyzer<'a, '_> {
                     self.add_effect(Effect::Call {
                         func: fn_value,
                         args,
-                        ast_path: as_parent_path(ast_path),
+                        ast_path: as_parent_path_in(self.arena, ast_path),
                         span,
                         in_try: self.is_in_try(),
                         new,
@@ -1048,7 +1076,7 @@ impl<'a> Analyzer<'a, '_> {
                     self.arena,
                 ),
                 args,
-                ast_path: as_parent_path(ast_path),
+                ast_path: as_parent_path_in(self.arena, ast_path),
                 span,
                 in_try: self.is_in_try(),
                 new,
@@ -1082,7 +1110,7 @@ impl<'a> Analyzer<'a, '_> {
         self.add_effect(Effect::Member {
             obj: obj_value,
             prop: prop_value,
-            ast_path: as_parent_path(ast_path),
+            ast_path: as_parent_path_in(self.arena, ast_path),
             span: member_expr.span(),
         });
     }
@@ -1807,14 +1835,14 @@ impl VisitAstPath for Analyzer<'_, '_> {
                     esm_reference_index,
                     export: Some(prop_str.into()),
                     // point to the MemberExpression instead
-                    ast_path: as_parent_path_skip(ast_path, 1),
+                    ast_path: as_parent_path_skip_in(self.arena, ast_path, 1),
                     span: member.span(),
                 });
             } else {
                 self.add_effect(Effect::ImportedBinding {
                     esm_reference_index,
                     export: export.map(|e| RcStr::from(e.as_str())),
-                    ast_path: as_parent_path(ast_path),
+                    ast_path: as_parent_path_in(self.arena, ast_path),
                     span: ident.span(),
                 })
             }
@@ -1829,7 +1857,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
             // benefit in an Effect for `window` or `Math`
             self.add_effect(Effect::FreeVar {
                 var,
-                ast_path: as_parent_path(ast_path),
+                ast_path: as_parent_path_in(self.arena, ast_path),
                 span: ident.span(),
             })
         }
@@ -1844,7 +1872,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
             // Otherwise 'this' is free
             self.add_effect(Effect::FreeVar {
                 var: atom!("this"),
-                ast_path: as_parent_path(ast_path),
+                ast_path: as_parent_path_in(self.arena, ast_path),
                 span: node.span(),
             })
         }
@@ -1860,7 +1888,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
             // an effect.
             self.add_effect(Effect::ImportMeta {
                 span: expr.span,
-                ast_path: as_parent_path(ast_path),
+                ast_path: as_parent_path_in(self.arena, ast_path),
             })
         }
     }
@@ -2095,7 +2123,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
 
             self.add_effect(Effect::TypeOf {
                 arg: arg_value,
-                ast_path: as_parent_path(ast_path),
+                ast_path: as_parent_path_in(self.arena, ast_path),
                 span: n.span(),
             });
         }
@@ -2134,7 +2162,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
                     },
                     self.arena,
                 ),
-                ast_path: as_parent_path(ast_path),
+                ast_path: as_parent_path_in(self.arena, ast_path),
                 span: stmt.span,
             },
         );
@@ -2236,11 +2264,15 @@ impl<'a> Analyzer<'a, '_> {
             (true, false) => {
                 let early_return = EarlyReturn::Conditional {
                     prev_effects: take(&mut self.effects),
-                    start_ast_path: as_parent_path(ast_path),
+                    start_ast_path: as_parent_path_in(self.arena, ast_path),
                     condition,
                     then,
                     r#else,
-                    condition_ast_path: as_parent_path_with(ast_path, condition_ast_kind),
+                    condition_ast_path: as_parent_path_with_in(
+                        self.arena,
+                        ast_path,
+                        condition_ast_kind,
+                    ),
                     span,
                     early_return_condition_value: true,
                 };
@@ -2249,11 +2281,15 @@ impl<'a> Analyzer<'a, '_> {
             (false, true) => {
                 let early_return = EarlyReturn::Conditional {
                     prev_effects: take(&mut self.effects),
-                    start_ast_path: as_parent_path(ast_path),
+                    start_ast_path: as_parent_path_in(self.arena, ast_path),
                     condition,
                     then,
                     r#else,
-                    condition_ast_path: as_parent_path_with(ast_path, condition_ast_kind),
+                    condition_ast_path: as_parent_path_with_in(
+                        self.arena,
+                        ast_path,
+                        condition_ast_kind,
+                    ),
                     span,
                     early_return_condition_value: false,
                 };
@@ -2272,13 +2308,13 @@ impl<'a> Analyzer<'a, '_> {
                 self.add_effect(Effect::Conditional {
                     condition,
                     kind: BumpBox::new_in(kind, self.arena),
-                    ast_path: as_parent_path_with(ast_path, condition_ast_kind),
+                    ast_path: as_parent_path_with_in(self.arena, ast_path, condition_ast_kind),
                     span,
                 });
                 if early_return_when_false && early_return_when_true {
                     let early_return = EarlyReturn::Always {
                         prev_effects: take(&mut self.effects),
-                        start_ast_path: as_parent_path(ast_path),
+                        start_ast_path: as_parent_path_in(self.arena, ast_path),
                     };
                     self.early_return_stack_mut().push(early_return);
                 }
@@ -2333,7 +2369,7 @@ impl<'a> Analyzer<'a, '_> {
             self.add_effect(Effect::Conditional {
                 condition,
                 kind: BumpBox::new_in(cond_kind, self.arena),
-                ast_path: as_parent_path_with(ast_path, ast_kind),
+                ast_path: as_parent_path_with_in(self.arena, ast_path, ast_kind),
                 span,
             });
         }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -31,16 +31,16 @@ use crate::{
 
 enum EarlyReturn<'a> {
     Always {
-        prev_effects: Vec<Effect<'a>>,
+        prev_effects: BumpVec<'a, Effect<'a>>,
         start_ast_path: Vec<AstParentKind>,
     },
     Conditional {
-        prev_effects: Vec<Effect<'a>>,
+        prev_effects: BumpVec<'a, Effect<'a>>,
         start_ast_path: Vec<AstParentKind>,
 
         condition: BumpBox<'a, JsValue<'a>>,
-        then: Option<Box<EffectsBlock<'a>>>,
-        r#else: Option<Box<EffectsBlock<'a>>>,
+        then: Option<BumpBox<'a, EffectsBlock<'a>>>,
+        r#else: Option<BumpBox<'a, EffectsBlock<'a>>>,
         /// The ast path to the condition.
         condition_ast_path: Vec<AstParentKind>,
         span: Span,
@@ -65,11 +65,11 @@ pub(super) struct Analyzer<'arena, 'eval> {
     pub(super) data: VarGraph<'arena>,
     pub(super) state: analyzer_state::AnalyzerState<'arena>,
 
-    pub(super) effects: Vec<Effect<'arena>>,
+    pub(super) effects: BumpVec<'arena, Effect<'arena>>,
     /// Effects collected from hoisted declarations. See https://developer.mozilla.org/en-US/docs/Glossary/Hoisting
     /// Tracked separately so we can preserve effects from hoisted declarations even when we don't
     /// collect effects from the declaring context.
-    pub(super) hoisted_effects: Vec<Effect<'arena>>,
+    pub(super) hoisted_effects: BumpVec<'arena, Effect<'arena>>,
 
     // Some unconditional codegens, usually for ESM items.
     pub(super) code_gens: Vec<CodeGen>,
@@ -403,7 +403,8 @@ mod analyzer_state {
                     } => {
                         self.effects = prev_effects;
                         if self.analyze_mode.is_code_gen() {
-                            self.effects.push(Effect::Unreachable { start_ast_path });
+                            self.effects
+                                .push(self.arena, Effect::Unreachable { start_ast_path });
                         }
                         always_returns = true;
                     }
@@ -417,10 +418,13 @@ mod analyzer_state {
                         span,
                         early_return_condition_value,
                     } => {
-                        let block = Box::new(EffectsBlock {
-                            effects: take(&mut self.effects),
-                            range: AstPathRange::StartAfter(start_ast_path),
-                        });
+                        let block = BumpBox::new_in(
+                            EffectsBlock {
+                                effects: take(&mut self.effects),
+                                range: AstPathRange::StartAfter(start_ast_path),
+                            },
+                            self.arena,
+                        );
                         self.effects = prev_effects;
                         let kind = match (then, r#else, early_return_condition_value) {
                             (None, None, false) => ConditionalKind::If { then: block },
@@ -453,12 +457,15 @@ mod analyzer_state {
                                 r#else: vec![r#else, block],
                             },
                         };
-                        self.effects.push(Effect::Conditional {
-                            condition,
-                            kind: Box::new(kind),
-                            ast_path: condition_ast_path,
-                            span,
-                        })
+                        self.effects.push(
+                            self.arena,
+                            Effect::Conditional {
+                                condition,
+                                kind: BumpBox::new_in(kind, self.arena),
+                                ast_path: condition_ast_path,
+                                span,
+                            },
+                        )
                     }
                 }
             }
@@ -652,7 +659,7 @@ impl<'a> Analyzer<'a, '_> {
     }
 
     fn add_effect(&mut self, effect: Effect<'a>) {
-        self.effects.push(effect);
+        self.effects.push(self.arena, effect);
     }
 
     fn check_iife<'ast: 'r, 'r>(
@@ -879,9 +886,9 @@ impl<'a> Analyzer<'a, '_> {
         n: CallOrNewExpr<'ast>,
     ) {
         let new = n.as_new().is_some();
-        let args = args
-            .enumerate()
-            .map(|(i, arg)| {
+        let args = BumpVec::from_iter_in(
+            self.arena,
+            args.enumerate().map(|(i, arg)| {
                 let mut ast_path = ast_path.with_guard(match n {
                     CallOrNewExpr::Call(n) => AstParentNodeRef::CallExpr(n, CallExprField::Args(i)),
                     CallOrNewExpr::New(n) => AstParentNodeRef::NewExpr(n, NewExprField::Args(i)),
@@ -930,10 +937,13 @@ impl<'a> Analyzer<'a, '_> {
                         let effects = replace(&mut self.effects, old_effects);
                         EffectArg::Closure(
                             value,
-                            Box::new(EffectsBlock {
-                                effects,
-                                range: AstPathRange::Exact(path),
-                            }),
+                            BumpBox::new_in(
+                                EffectsBlock {
+                                    effects,
+                                    range: AstPathRange::Exact(path),
+                                },
+                                self.arena,
+                            ),
                         )
                     } else {
                         arg.visit_with_ast_path(self, &mut ast_path);
@@ -943,8 +953,8 @@ impl<'a> Analyzer<'a, '_> {
                     arg.visit_with_ast_path(self, &mut ast_path);
                     EffectArg::Spread
                 }
-            })
-            .collect();
+            }),
+        );
 
         match callee {
             Callee::Import(_) => {
@@ -1278,7 +1288,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
         // This accounts for the fact that even with `if (true) { return f} function f() {} ` `f` is
         // hoisted earlier of the condition. so we still need to process effects for it.
         // TODO(lukesandberg): shouldn't this just be the effects associated with the function.
-        self.hoisted_effects.append(&mut self.effects);
+        self.hoisted_effects.append(self.arena, &mut self.effects);
 
         self.add_value(decl.ident.to_id(), fn_value);
     }
@@ -1841,7 +1851,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
         self.enter_block(LexicalContext::Block, |this| {
             program.visit_children_with_ast_path(this, ast_path);
         });
-        self.effects.append(&mut self.hoisted_effects);
+        self.effects.append(self.arena, &mut self.hoisted_effects);
         self.data.effects = take(&mut self.effects);
         self.data.code_gens = take(&mut self.code_gens);
     }
@@ -1862,19 +1872,25 @@ impl VisitAstPath for Analyzer<'_, '_> {
             let mut ast_path =
                 ast_path.with_guard(AstParentNodeRef::CondExpr(expr, CondExprField::Cons));
             expr.cons.visit_with_ast_path(self, &mut ast_path);
-            Box::new(EffectsBlock {
-                effects: take(&mut self.effects),
-                range: AstPathRange::Exact(as_parent_path(&ast_path)),
-            })
+            BumpBox::new_in(
+                EffectsBlock {
+                    effects: take(&mut self.effects),
+                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
+                },
+                self.arena,
+            )
         };
         let r#else = {
             let mut ast_path =
                 ast_path.with_guard(AstParentNodeRef::CondExpr(expr, CondExprField::Alt));
             expr.alt.visit_with_ast_path(self, &mut ast_path);
-            Box::new(EffectsBlock {
-                effects: take(&mut self.effects),
-                range: AstPathRange::Exact(as_parent_path(&ast_path)),
-            })
+            BumpBox::new_in(
+                EffectsBlock {
+                    effects: take(&mut self.effects),
+                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
+                },
+                self.arena,
+            )
         };
         self.effects = prev_effects;
 
@@ -1908,10 +1924,13 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 })
                 .1;
 
-            Box::new(EffectsBlock {
-                effects: take(&mut self.effects),
-                range: AstPathRange::Exact(as_parent_path(&ast_path)),
-            })
+            BumpBox::new_in(
+                EffectsBlock {
+                    effects: take(&mut self.effects),
+                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
+                },
+                self.arena,
+            )
         };
         let mut else_returning = false;
         let r#else = stmt.alt.as_ref().map(|alt| {
@@ -1923,10 +1942,13 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 })
                 .1;
 
-            Box::new(EffectsBlock {
-                effects: take(&mut self.effects),
-                range: AstPathRange::Exact(as_parent_path(&ast_path)),
-            })
+            BumpBox::new_in(
+                EffectsBlock {
+                    effects: take(&mut self.effects),
+                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
+                },
+                self.arena,
+            )
         });
         self.effects = prev_effects;
         self.add_conditional_if_effect_with_early_return(
@@ -1966,11 +1988,11 @@ impl VisitAstPath for Analyzer<'_, '_> {
             });
             take(&mut self.effects)
         } else {
-            vec![]
+            BumpVec::new()
         };
         self.effects = prev_effects;
-        self.effects.append(&mut block);
-        self.effects.append(&mut handler);
+        self.effects.append(self.arena, &mut block);
+        self.effects.append(self.arena, &mut handler);
         if let Some(finalizer) = stmt.finalizer.as_ref() {
             let finally_returns_unconditionally = {
                 let mut ast_path =
@@ -1998,7 +2020,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
         });
         let mut effects = take(&mut self.effects);
         self.effects = prev_effects;
-        self.effects.append(&mut effects);
+        self.effects.append(self.arena, &mut effects);
     }
 
     fn visit_block_stmt<'ast: 'r, 'r>(
@@ -2021,8 +2043,8 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 if !returns_unconditionally {
                     self.add_return_value(JsValue::Constant(ConstantValue::Undefined));
                 }
-                self.effects.append(&mut self.hoisted_effects);
-                effects.append(&mut self.effects);
+                self.effects.append(self.arena, &mut self.hoisted_effects);
+                effects.append(self.arena, &mut self.effects);
                 self.hoisted_effects = hoisted_effects;
                 self.effects = effects;
             }
@@ -2080,23 +2102,32 @@ impl VisitAstPath for Analyzer<'_, '_> {
 
         let effects = take(&mut self.effects);
 
-        prev_effects.push(Effect::Conditional {
-            condition: BumpBox::new_in(
-                JsValue::unknown_empty(true, rcstr!("labeled statement")),
-                self.arena,
-            ),
-            kind: Box::new(ConditionalKind::Labeled {
-                body: Box::new(EffectsBlock {
-                    effects,
-                    range: AstPathRange::Exact(as_parent_path_with(
-                        ast_path,
-                        AstParentKind::LabeledStmt(LabeledStmtField::Body),
-                    )),
-                }),
-            }),
-            ast_path: as_parent_path(ast_path),
-            span: stmt.span,
-        });
+        prev_effects.push(
+            self.arena,
+            Effect::Conditional {
+                condition: BumpBox::new_in(
+                    JsValue::unknown_empty(true, rcstr!("labeled statement")),
+                    self.arena,
+                ),
+                kind: BumpBox::new_in(
+                    ConditionalKind::Labeled {
+                        body: BumpBox::new_in(
+                            EffectsBlock {
+                                effects,
+                                range: AstPathRange::Exact(as_parent_path_with(
+                                    ast_path,
+                                    AstParentKind::LabeledStmt(LabeledStmtField::Body),
+                                )),
+                            },
+                            self.arena,
+                        ),
+                    },
+                    self.arena,
+                ),
+                ast_path: as_parent_path(ast_path),
+                span: stmt.span,
+            },
+        );
 
         self.effects = prev_effects;
     }
@@ -2171,8 +2202,8 @@ impl<'a> Analyzer<'a, '_> {
         ast_path: &AstNodePath<AstParentNodeRef<'_>>,
         condition_ast_kind: AstParentKind,
         span: Span,
-        then: Option<Box<EffectsBlock<'a>>>,
-        r#else: Option<Box<EffectsBlock<'a>>>,
+        then: Option<BumpBox<'a, EffectsBlock<'a>>>,
+        r#else: Option<BumpBox<'a, EffectsBlock<'a>>>,
         early_return_when_true: bool,
         early_return_when_false: bool,
     ) {
@@ -2183,10 +2214,10 @@ impl<'a> Analyzer<'a, '_> {
         let condition = BumpBox::new_in(self.eval_context.eval(self.arena, test), self.arena);
         if condition.is_unknown() {
             if let Some(mut then) = then {
-                self.effects.append(&mut then.effects);
+                self.effects.append(self.arena, &mut then.effects);
             }
             if let Some(mut r#else) = r#else {
-                self.effects.append(&mut r#else.effects);
+                self.effects.append(self.arena, &mut r#else.effects);
             }
             return;
         }
@@ -2229,7 +2260,7 @@ impl<'a> Analyzer<'a, '_> {
                 };
                 self.add_effect(Effect::Conditional {
                     condition,
-                    kind: Box::new(kind),
+                    kind: BumpBox::new_in(kind, self.arena),
                     ast_path: as_parent_path_with(ast_path, condition_ast_kind),
                     span,
                 });
@@ -2256,37 +2287,37 @@ impl<'a> Analyzer<'a, '_> {
         if condition.is_unknown() {
             match &mut cond_kind {
                 ConditionalKind::If { then } => {
-                    self.effects.append(&mut then.effects);
+                    self.effects.append(self.arena, &mut then.effects);
                 }
                 ConditionalKind::Else { r#else } => {
-                    self.effects.append(&mut r#else.effects);
+                    self.effects.append(self.arena, &mut r#else.effects);
                 }
                 ConditionalKind::IfElse { then, r#else }
                 | ConditionalKind::Ternary { then, r#else } => {
-                    self.effects.append(&mut then.effects);
-                    self.effects.append(&mut r#else.effects);
+                    self.effects.append(self.arena, &mut then.effects);
+                    self.effects.append(self.arena, &mut r#else.effects);
                 }
                 ConditionalKind::IfElseMultiple { then, r#else } => {
                     for block in then {
-                        self.effects.append(&mut block.effects);
+                        self.effects.append(self.arena, &mut block.effects);
                     }
                     for block in r#else {
-                        self.effects.append(&mut block.effects);
+                        self.effects.append(self.arena, &mut block.effects);
                     }
                 }
                 ConditionalKind::And { expr }
                 | ConditionalKind::Or { expr }
                 | ConditionalKind::NullishCoalescing { expr } => {
-                    self.effects.append(&mut expr.effects);
+                    self.effects.append(self.arena, &mut expr.effects);
                 }
                 ConditionalKind::Labeled { body } => {
-                    self.effects.append(&mut body.effects);
+                    self.effects.append(self.arena, &mut body.effects);
                 }
             }
         } else {
             self.add_effect(Effect::Conditional {
                 condition,
-                kind: Box::new(cond_kind),
+                kind: BumpBox::new_in(cond_kind, self.arena),
                 ast_path: as_parent_path_with(ast_path, ast_kind),
                 span,
             });

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -1285,7 +1285,8 @@ impl VisitAstPath for Analyzer<'_, '_> {
         // This accounts for the fact that even with `if (true) { return f} function f() {} ` `f` is
         // hoisted earlier of the condition. so we still need to process effects for it.
         // TODO(lukesandberg): shouldn't this just be the effects associated with the function.
-        self.hoisted_effects.append(self.arena, &mut self.effects);
+        self.hoisted_effects
+            .extend(self.arena, take(&mut self.effects));
 
         self.add_value(decl.ident.to_id(), fn_value);
     }
@@ -1844,12 +1845,13 @@ impl VisitAstPath for Analyzer<'_, '_> {
         program: &'ast Program,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        self.effects = take(&mut self.data.effects);
+        self.effects = BumpVec::from_iter_in(self.arena, take(&mut self.data.effects));
         self.enter_block(LexicalContext::Block, |this| {
             program.visit_children_with_ast_path(this, ast_path);
         });
-        self.effects.append(self.arena, &mut self.hoisted_effects);
-        self.data.effects = take(&mut self.effects);
+        self.effects
+            .extend(self.arena, take(&mut self.hoisted_effects));
+        self.data.effects = take(&mut self.effects).into_iter().collect();
         self.data.code_gens = take(&mut self.code_gens);
     }
 
@@ -1976,8 +1978,8 @@ impl VisitAstPath for Analyzer<'_, '_> {
             BumpVec::new()
         };
         self.effects = prev_effects;
-        self.effects.append(self.arena, &mut block);
-        self.effects.append(self.arena, &mut handler);
+        self.effects.extend(self.arena, take(&mut block));
+        self.effects.extend(self.arena, take(&mut handler));
         if let Some(finalizer) = stmt.finalizer.as_ref() {
             let finally_returns_unconditionally = {
                 let mut ast_path =
@@ -2005,7 +2007,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
         });
         let mut effects = take(&mut self.effects);
         self.effects = prev_effects;
-        self.effects.append(self.arena, &mut effects);
+        self.effects.extend(self.arena, take(&mut effects));
     }
 
     fn visit_block_stmt<'ast: 'r, 'r>(
@@ -2028,8 +2030,9 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 if !returns_unconditionally {
                     self.add_return_value(JsValue::Constant(ConstantValue::Undefined));
                 }
-                self.effects.append(self.arena, &mut self.hoisted_effects);
-                effects.append(self.arena, &mut self.effects);
+                self.effects
+                    .extend(self.arena, take(&mut self.hoisted_effects));
+                effects.extend(self.arena, take(&mut self.effects));
                 self.hoisted_effects = hoisted_effects;
                 self.effects = effects;
             }
@@ -2196,10 +2199,10 @@ impl<'a> Analyzer<'a, '_> {
         let condition = BumpBox::new_in(self.eval_context.eval(self.arena, test), self.arena);
         if condition.is_unknown() {
             if let Some(mut then) = then {
-                self.effects.append(self.arena, &mut then.effects);
+                self.effects.extend(self.arena, take(&mut then.effects));
             }
             if let Some(mut r#else) = r#else {
-                self.effects.append(self.arena, &mut r#else.effects);
+                self.effects.extend(self.arena, take(&mut r#else.effects));
             }
             return;
         }
@@ -2269,31 +2272,31 @@ impl<'a> Analyzer<'a, '_> {
         if condition.is_unknown() {
             match &mut cond_kind {
                 ConditionalKind::If { then } => {
-                    self.effects.append(self.arena, &mut then.effects);
+                    self.effects.extend(self.arena, take(&mut then.effects));
                 }
                 ConditionalKind::Else { r#else } => {
-                    self.effects.append(self.arena, &mut r#else.effects);
+                    self.effects.extend(self.arena, take(&mut r#else.effects));
                 }
                 ConditionalKind::IfElse { then, r#else }
                 | ConditionalKind::Ternary { then, r#else } => {
-                    self.effects.append(self.arena, &mut then.effects);
-                    self.effects.append(self.arena, &mut r#else.effects);
+                    self.effects.extend(self.arena, take(&mut then.effects));
+                    self.effects.extend(self.arena, take(&mut r#else.effects));
                 }
                 ConditionalKind::IfElseMultiple { then, r#else } => {
                     for block in then {
-                        self.effects.append(self.arena, &mut block.effects);
+                        self.effects.extend(self.arena, take(&mut block.effects));
                     }
                     for block in r#else {
-                        self.effects.append(self.arena, &mut block.effects);
+                        self.effects.extend(self.arena, take(&mut block.effects));
                     }
                 }
                 ConditionalKind::And { expr }
                 | ConditionalKind::Or { expr }
                 | ConditionalKind::NullishCoalescing { expr } => {
-                    self.effects.append(self.arena, &mut expr.effects);
+                    self.effects.extend(self.arena, take(&mut expr.effects));
                 }
                 ConditionalKind::Labeled { body } => {
-                    self.effects.append(self.arena, &mut body.effects);
+                    self.effects.extend(self.arena, take(&mut body.effects));
                 }
             }
         } else {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -419,39 +419,64 @@ mod analyzer_state {
                         early_return_condition_value,
                     } => {
                         let block = EffectsBlock {
-                            effects: take(&mut self.effects),
+                            effects: take(&mut self.effects).into_boxed_slice(),
                             range: AstPathRange::StartAfter(start_ast_path),
                         };
                         self.effects = prev_effects;
                         let kind = match (then, r#else, early_return_condition_value) {
                             (None, None, false) => ConditionalKind::If { then: block },
                             (None, None, true) => ConditionalKind::IfElseMultiple {
-                                then: Box::from([block]),
-                                r#else: Box::from([]),
+                                then: bumpalo::collections::Vec::from_iter_in([block], self.arena)
+                                    .into_boxed_slice(),
+                                r#else: bumpalo::collections::Vec::new_in(self.arena)
+                                    .into_boxed_slice(),
                             },
                             (Some(then), None, false) => ConditionalKind::IfElseMultiple {
-                                then: Box::from([then, block]),
-                                r#else: Box::from([]),
+                                then: bumpalo::collections::Vec::from_iter_in(
+                                    [then, block],
+                                    self.arena,
+                                )
+                                .into_boxed_slice(),
+                                r#else: bumpalo::collections::Vec::new_in(self.arena)
+                                    .into_boxed_slice(),
                             },
                             (Some(then), None, true) => ConditionalKind::IfElse {
                                 then,
                                 r#else: block,
                             },
                             (Some(then), Some(r#else), false) => ConditionalKind::IfElseMultiple {
-                                then: Box::from([then, block]),
-                                r#else: Box::from([r#else]),
+                                then: bumpalo::collections::Vec::from_iter_in(
+                                    [then, block],
+                                    self.arena,
+                                )
+                                .into_boxed_slice(),
+                                r#else: bumpalo::collections::Vec::from_iter_in(
+                                    [r#else],
+                                    self.arena,
+                                )
+                                .into_boxed_slice(),
                             },
                             (Some(then), Some(r#else), true) => ConditionalKind::IfElseMultiple {
-                                then: Box::from([then]),
-                                r#else: Box::from([r#else, block]),
+                                then: bumpalo::collections::Vec::from_iter_in([then], self.arena)
+                                    .into_boxed_slice(),
+                                r#else: bumpalo::collections::Vec::from_iter_in(
+                                    [r#else, block],
+                                    self.arena,
+                                )
+                                .into_boxed_slice(),
                             },
                             (None, Some(r#else), false) => ConditionalKind::IfElse {
                                 then: block,
                                 r#else,
                             },
                             (None, Some(r#else), true) => ConditionalKind::IfElseMultiple {
-                                then: Box::from([]),
-                                r#else: Box::from([r#else, block]),
+                                then: bumpalo::collections::Vec::new_in(self.arena)
+                                    .into_boxed_slice(),
+                                r#else: bumpalo::collections::Vec::from_iter_in(
+                                    [r#else, block],
+                                    self.arena,
+                                )
+                                .into_boxed_slice(),
                             },
                         };
                         self.effects.push(
@@ -936,7 +961,7 @@ impl<'a> Analyzer<'a, '_> {
                             value,
                             BumpBox::new_in(
                                 EffectsBlock {
-                                    effects,
+                                    effects: effects.into_boxed_slice(),
                                     range: AstPathRange::Exact(path),
                                 },
                                 self.arena,
@@ -1872,7 +1897,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 ast_path.with_guard(AstParentNodeRef::CondExpr(expr, CondExprField::Cons));
             expr.cons.visit_with_ast_path(self, &mut ast_path);
             EffectsBlock {
-                effects: take(&mut self.effects),
+                effects: take(&mut self.effects).into_boxed_slice(),
                 range: AstPathRange::Exact(as_parent_path(&ast_path)),
             }
         };
@@ -1881,7 +1906,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 ast_path.with_guard(AstParentNodeRef::CondExpr(expr, CondExprField::Alt));
             expr.alt.visit_with_ast_path(self, &mut ast_path);
             EffectsBlock {
-                effects: take(&mut self.effects),
+                effects: take(&mut self.effects).into_boxed_slice(),
                 range: AstPathRange::Exact(as_parent_path(&ast_path)),
             }
         };
@@ -1918,7 +1943,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 .1;
 
             EffectsBlock {
-                effects: take(&mut self.effects),
+                effects: take(&mut self.effects).into_boxed_slice(),
                 range: AstPathRange::Exact(as_parent_path(&ast_path)),
             }
         };
@@ -1933,7 +1958,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 .1;
 
             EffectsBlock {
-                effects: take(&mut self.effects),
+                effects: take(&mut self.effects).into_boxed_slice(),
                 range: AstPathRange::Exact(as_parent_path(&ast_path)),
             }
         });
@@ -2100,7 +2125,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 kind: BumpBox::new_in(
                     ConditionalKind::Labeled {
                         body: EffectsBlock {
-                            effects,
+                            effects: effects.into_boxed_slice(),
                             range: AstPathRange::Exact(as_parent_path_with(
                                 ast_path,
                                 AstParentKind::LabeledStmt(LabeledStmtField::Body),
@@ -2198,11 +2223,12 @@ impl<'a> Analyzer<'a, '_> {
         }
         let condition = BumpBox::new_in(self.eval_context.eval(self.arena, test), self.arena);
         if condition.is_unknown() {
-            if let Some(mut then) = then {
-                self.effects.extend(self.arena, take(&mut then.effects));
+            if let Some(then) = then {
+                self.effects.extend(self.arena, BumpVec::from(then.effects));
             }
-            if let Some(mut r#else) = r#else {
-                self.effects.extend(self.arena, take(&mut r#else.effects));
+            if let Some(r#else) = r#else {
+                self.effects
+                    .extend(self.arena, BumpVec::from(r#else.effects));
             }
             return;
         }
@@ -2266,37 +2292,41 @@ impl<'a> Analyzer<'a, '_> {
         ast_path: &AstNodePath<AstParentNodeRef<'_>>,
         ast_kind: AstParentKind,
         span: Span,
-        mut cond_kind: ConditionalKind<'a>,
+        cond_kind: ConditionalKind<'a>,
     ) {
         let condition = BumpBox::new_in(self.eval_context.eval(self.arena, test), self.arena);
         if condition.is_unknown() {
-            match &mut cond_kind {
+            match cond_kind {
                 ConditionalKind::If { then } => {
-                    self.effects.extend(self.arena, take(&mut then.effects));
+                    self.effects.extend(self.arena, BumpVec::from(then.effects));
                 }
                 ConditionalKind::Else { r#else } => {
-                    self.effects.extend(self.arena, take(&mut r#else.effects));
+                    self.effects
+                        .extend(self.arena, BumpVec::from(r#else.effects));
                 }
                 ConditionalKind::IfElse { then, r#else }
                 | ConditionalKind::Ternary { then, r#else } => {
-                    self.effects.extend(self.arena, take(&mut then.effects));
-                    self.effects.extend(self.arena, take(&mut r#else.effects));
+                    self.effects.extend(self.arena, BumpVec::from(then.effects));
+                    self.effects
+                        .extend(self.arena, BumpVec::from(r#else.effects));
                 }
                 ConditionalKind::IfElseMultiple { then, r#else } => {
-                    for block in then {
-                        self.effects.extend(self.arena, take(&mut block.effects));
+                    for block in BumpVec::from(then) {
+                        self.effects
+                            .extend(self.arena, BumpVec::from(block.effects));
                     }
-                    for block in r#else {
-                        self.effects.extend(self.arena, take(&mut block.effects));
+                    for block in BumpVec::from(r#else) {
+                        self.effects
+                            .extend(self.arena, BumpVec::from(block.effects));
                     }
                 }
                 ConditionalKind::And { expr }
                 | ConditionalKind::Or { expr }
                 | ConditionalKind::NullishCoalescing { expr } => {
-                    self.effects.extend(self.arena, take(&mut expr.effects));
+                    self.effects.extend(self.arena, BumpVec::from(expr.effects));
                 }
                 ConditionalKind::Labeled { body } => {
-                    self.effects.extend(self.arena, take(&mut body.effects));
+                    self.effects.extend(self.arena, BumpVec::from(body.effects));
                 }
             }
         } else {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -426,32 +426,32 @@ mod analyzer_state {
                         let kind = match (then, r#else, early_return_condition_value) {
                             (None, None, false) => ConditionalKind::If { then: block },
                             (None, None, true) => ConditionalKind::IfElseMultiple {
-                                then: vec![block],
-                                r#else: vec![],
+                                then: Box::from([block]),
+                                r#else: Box::from([]),
                             },
                             (Some(then), None, false) => ConditionalKind::IfElseMultiple {
-                                then: vec![then, block],
-                                r#else: vec![],
+                                then: Box::from([then, block]),
+                                r#else: Box::from([]),
                             },
                             (Some(then), None, true) => ConditionalKind::IfElse {
                                 then,
                                 r#else: block,
                             },
                             (Some(then), Some(r#else), false) => ConditionalKind::IfElseMultiple {
-                                then: vec![then, block],
-                                r#else: vec![r#else],
+                                then: Box::from([then, block]),
+                                r#else: Box::from([r#else]),
                             },
                             (Some(then), Some(r#else), true) => ConditionalKind::IfElseMultiple {
-                                then: vec![then],
-                                r#else: vec![r#else, block],
+                                then: Box::from([then]),
+                                r#else: Box::from([r#else, block]),
                             },
                             (None, Some(r#else), false) => ConditionalKind::IfElse {
                                 then: block,
                                 r#else,
                             },
                             (None, Some(r#else), true) => ConditionalKind::IfElseMultiple {
-                                then: vec![],
-                                r#else: vec![r#else, block],
+                                then: Box::from([]),
+                                r#else: Box::from([r#else, block]),
                             },
                         };
                         self.effects.push(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -39,8 +39,8 @@ enum EarlyReturn<'a> {
         start_ast_path: Vec<AstParentKind>,
 
         condition: BumpBox<'a, JsValue<'a>>,
-        then: Option<BumpBox<'a, EffectsBlock<'a>>>,
-        r#else: Option<BumpBox<'a, EffectsBlock<'a>>>,
+        then: Option<EffectsBlock<'a>>,
+        r#else: Option<EffectsBlock<'a>>,
         /// The ast path to the condition.
         condition_ast_path: Vec<AstParentKind>,
         span: Span,
@@ -418,13 +418,10 @@ mod analyzer_state {
                         span,
                         early_return_condition_value,
                     } => {
-                        let block = BumpBox::new_in(
-                            EffectsBlock {
-                                effects: take(&mut self.effects),
-                                range: AstPathRange::StartAfter(start_ast_path),
-                            },
-                            self.arena,
-                        );
+                        let block = EffectsBlock {
+                            effects: take(&mut self.effects),
+                            range: AstPathRange::StartAfter(start_ast_path),
+                        };
                         self.effects = prev_effects;
                         let kind = match (then, r#else, early_return_condition_value) {
                             (None, None, false) => ConditionalKind::If { then: block },
@@ -1872,25 +1869,19 @@ impl VisitAstPath for Analyzer<'_, '_> {
             let mut ast_path =
                 ast_path.with_guard(AstParentNodeRef::CondExpr(expr, CondExprField::Cons));
             expr.cons.visit_with_ast_path(self, &mut ast_path);
-            BumpBox::new_in(
-                EffectsBlock {
-                    effects: take(&mut self.effects),
-                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
-                },
-                self.arena,
-            )
+            EffectsBlock {
+                effects: take(&mut self.effects),
+                range: AstPathRange::Exact(as_parent_path(&ast_path)),
+            }
         };
         let r#else = {
             let mut ast_path =
                 ast_path.with_guard(AstParentNodeRef::CondExpr(expr, CondExprField::Alt));
             expr.alt.visit_with_ast_path(self, &mut ast_path);
-            BumpBox::new_in(
-                EffectsBlock {
-                    effects: take(&mut self.effects),
-                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
-                },
-                self.arena,
-            )
+            EffectsBlock {
+                effects: take(&mut self.effects),
+                range: AstPathRange::Exact(as_parent_path(&ast_path)),
+            }
         };
         self.effects = prev_effects;
 
@@ -1924,13 +1915,10 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 })
                 .1;
 
-            BumpBox::new_in(
-                EffectsBlock {
-                    effects: take(&mut self.effects),
-                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
-                },
-                self.arena,
-            )
+            EffectsBlock {
+                effects: take(&mut self.effects),
+                range: AstPathRange::Exact(as_parent_path(&ast_path)),
+            }
         };
         let mut else_returning = false;
         let r#else = stmt.alt.as_ref().map(|alt| {
@@ -1942,13 +1930,10 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 })
                 .1;
 
-            BumpBox::new_in(
-                EffectsBlock {
-                    effects: take(&mut self.effects),
-                    range: AstPathRange::Exact(as_parent_path(&ast_path)),
-                },
-                self.arena,
-            )
+            EffectsBlock {
+                effects: take(&mut self.effects),
+                range: AstPathRange::Exact(as_parent_path(&ast_path)),
+            }
         });
         self.effects = prev_effects;
         self.add_conditional_if_effect_with_early_return(
@@ -2111,16 +2096,13 @@ impl VisitAstPath for Analyzer<'_, '_> {
                 ),
                 kind: BumpBox::new_in(
                     ConditionalKind::Labeled {
-                        body: BumpBox::new_in(
-                            EffectsBlock {
-                                effects,
-                                range: AstPathRange::Exact(as_parent_path_with(
-                                    ast_path,
-                                    AstParentKind::LabeledStmt(LabeledStmtField::Body),
-                                )),
-                            },
-                            self.arena,
-                        ),
+                        body: EffectsBlock {
+                            effects,
+                            range: AstPathRange::Exact(as_parent_path_with(
+                                ast_path,
+                                AstParentKind::LabeledStmt(LabeledStmtField::Body),
+                            )),
+                        },
                     },
                     self.arena,
                 ),
@@ -2202,8 +2184,8 @@ impl<'a> Analyzer<'a, '_> {
         ast_path: &AstNodePath<AstParentNodeRef<'_>>,
         condition_ast_kind: AstParentKind,
         span: Span,
-        then: Option<BumpBox<'a, EffectsBlock<'a>>>,
-        r#else: Option<BumpBox<'a, EffectsBlock<'a>>>,
+        then: Option<EffectsBlock<'a>>,
+        r#else: Option<EffectsBlock<'a>>,
         early_return_when_true: bool,
         early_return_when_false: bool,
     ) {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -229,6 +229,7 @@ pub mod test_utils {
 mod tests {
     use std::{mem::take, path::PathBuf, sync::Arc, time::Instant};
 
+    use bumpalo::boxed::Box as BumpBox;
     use parking_lot::Mutex;
     use rustc_hash::FxHashMap;
     use swc_core::{
@@ -253,7 +254,7 @@ mod tests {
     };
 
     use super::{
-        JsValue,
+        BumpVec, JsValue,
         graph::{ConditionalKind, Effect, EffectArg, EvalContext, VarGraph, create_graph},
         linker::link,
     };
@@ -468,7 +469,7 @@ mod tests {
                 let start = Instant::now();
                 async fn handle_args<'a>(
                     arena: &'a ThreadLocal<Bump>,
-                    args: Vec<EffectArg<'a>>,
+                    args: BumpVec<'a, EffectArg<'a>>,
                     queue: &mut Vec<(usize, Effect<'a>)>,
                     var_graph: &VarGraph<'a>,
                     var_cache: &Mutex<FxHashMap<Id, JsValue<'a>>>,
@@ -502,7 +503,13 @@ mod tests {
                                     .await
                                     .0,
                                 );
-                                queue.extend(effects.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpBox::into_inner(effects)
+                                        .effects
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                             EffectArg::Spread => {
                                 new_args.push(JsValue::unknown_empty(true, rcstr!("spread")));
@@ -526,31 +533,73 @@ mod tests {
                         )
                         .await;
                         resolved.push((format!("{parent} -> {i} conditional"), condition));
-                        match *kind {
+                        match BumpBox::into_inner(kind) {
                             ConditionalKind::If { then } => {
-                                queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpBox::into_inner(then)
+                                        .effects
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                             ConditionalKind::Else { r#else } => {
-                                queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpBox::into_inner(r#else)
+                                        .effects
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                             ConditionalKind::IfElse { then, r#else }
                             | ConditionalKind::Ternary { then, r#else } => {
-                                queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
-                                queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpBox::into_inner(r#else)
+                                        .effects
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
+                                queue.extend(
+                                    BumpBox::into_inner(then)
+                                        .effects
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                             ConditionalKind::IfElseMultiple { then, r#else } => {
                                 for then in then {
-                                    queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
+                                    queue.extend(
+                                        BumpBox::into_inner(then)
+                                            .effects
+                                            .into_iter()
+                                            .rev()
+                                            .map(|e| (i, e)),
+                                    );
                                 }
                                 for r#else in r#else {
-                                    queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
+                                    queue.extend(
+                                        BumpBox::into_inner(r#else)
+                                            .effects
+                                            .into_iter()
+                                            .rev()
+                                            .map(|e| (i, e)),
+                                    );
                                 }
                             }
                             ConditionalKind::And { expr }
                             | ConditionalKind::Or { expr }
                             | ConditionalKind::NullishCoalescing { expr }
                             | ConditionalKind::Labeled { body: expr } => {
-                                queue.extend(expr.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpBox::into_inner(expr)
+                                        .effects
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                         };
                         steps

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -504,8 +504,7 @@ mod tests {
                                     .0,
                                 );
                                 queue.extend(
-                                    BumpBox::into_inner(effects)
-                                        .effects
+                                    BumpVec::from(BumpBox::into_inner(effects).effects)
                                         .into_iter()
                                         .rev()
                                         .map(|e| (i, e)),
@@ -535,29 +534,64 @@ mod tests {
                         resolved.push((format!("{parent} -> {i} conditional"), condition));
                         match BumpBox::into_inner(kind) {
                             ConditionalKind::If { then } => {
-                                queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpVec::from(then.effects)
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                             ConditionalKind::Else { r#else } => {
-                                queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpVec::from(r#else.effects)
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                             ConditionalKind::IfElse { then, r#else }
                             | ConditionalKind::Ternary { then, r#else } => {
-                                queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
-                                queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpVec::from(r#else.effects)
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
+                                queue.extend(
+                                    BumpVec::from(then.effects)
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                             ConditionalKind::IfElseMultiple { then, r#else } => {
-                                for then in then {
-                                    queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
+                                for then in BumpVec::from(then) {
+                                    queue.extend(
+                                        BumpVec::from(then.effects)
+                                            .into_iter()
+                                            .rev()
+                                            .map(|e| (i, e)),
+                                    );
                                 }
-                                for r#else in r#else {
-                                    queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
+                                for r#else in BumpVec::from(r#else) {
+                                    queue.extend(
+                                        BumpVec::from(r#else.effects)
+                                            .into_iter()
+                                            .rev()
+                                            .map(|e| (i, e)),
+                                    );
                                 }
                             }
                             ConditionalKind::And { expr }
                             | ConditionalKind::Or { expr }
                             | ConditionalKind::NullishCoalescing { expr }
                             | ConditionalKind::Labeled { body: expr } => {
-                                queue.extend(expr.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(
+                                    BumpVec::from(expr.effects)
+                                        .into_iter()
+                                        .rev()
+                                        .map(|e| (i, e)),
+                                );
                             }
                         };
                         steps

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -535,71 +535,29 @@ mod tests {
                         resolved.push((format!("{parent} -> {i} conditional"), condition));
                         match BumpBox::into_inner(kind) {
                             ConditionalKind::If { then } => {
-                                queue.extend(
-                                    BumpBox::into_inner(then)
-                                        .effects
-                                        .into_iter()
-                                        .rev()
-                                        .map(|e| (i, e)),
-                                );
+                                queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
                             }
                             ConditionalKind::Else { r#else } => {
-                                queue.extend(
-                                    BumpBox::into_inner(r#else)
-                                        .effects
-                                        .into_iter()
-                                        .rev()
-                                        .map(|e| (i, e)),
-                                );
+                                queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
                             }
                             ConditionalKind::IfElse { then, r#else }
                             | ConditionalKind::Ternary { then, r#else } => {
-                                queue.extend(
-                                    BumpBox::into_inner(r#else)
-                                        .effects
-                                        .into_iter()
-                                        .rev()
-                                        .map(|e| (i, e)),
-                                );
-                                queue.extend(
-                                    BumpBox::into_inner(then)
-                                        .effects
-                                        .into_iter()
-                                        .rev()
-                                        .map(|e| (i, e)),
-                                );
+                                queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
+                                queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
                             }
                             ConditionalKind::IfElseMultiple { then, r#else } => {
                                 for then in then {
-                                    queue.extend(
-                                        BumpBox::into_inner(then)
-                                            .effects
-                                            .into_iter()
-                                            .rev()
-                                            .map(|e| (i, e)),
-                                    );
+                                    queue.extend(then.effects.into_iter().rev().map(|e| (i, e)));
                                 }
                                 for r#else in r#else {
-                                    queue.extend(
-                                        BumpBox::into_inner(r#else)
-                                            .effects
-                                            .into_iter()
-                                            .rev()
-                                            .map(|e| (i, e)),
-                                    );
+                                    queue.extend(r#else.effects.into_iter().rev().map(|e| (i, e)));
                                 }
                             }
                             ConditionalKind::And { expr }
                             | ConditionalKind::Or { expr }
                             | ConditionalKind::NullishCoalescing { expr }
                             | ConditionalKind::Labeled { body: expr } => {
-                                queue.extend(
-                                    BumpBox::into_inner(expr)
-                                        .effects
-                                        .into_iter()
-                                        .rev()
-                                        .map(|e| (i, e)),
-                                );
+                                queue.extend(expr.effects.into_iter().rev().map(|e| (i, e)));
                             }
                         };
                         steps

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -935,13 +935,9 @@ async fn analyze_ecmascript_module_internal(
                     }
                     macro_rules! active {
                         ($block:ident) => {
-                            queue_stack.get_mut().extend(
-                                BumpBox::into_inner($block)
-                                    .effects
-                                    .into_iter()
-                                    .map(Action::Effect)
-                                    .rev(),
-                            )
+                            queue_stack
+                                .get_mut()
+                                .extend($block.effects.into_iter().map(Action::Effect).rev())
                         };
                     }
                     match BumpBox::into_inner(kind) {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -31,6 +31,7 @@ use std::{
 
 use anyhow::Result;
 use bincode::{Decode, Encode};
+use bumpalo::boxed::Box as BumpBox;
 use constant_condition::{ConstantConditionCodeGen, ConstantConditionValue};
 use constant_value::ConstantValueCodeGen;
 use either::Either;
@@ -885,7 +886,7 @@ async fn analyze_ecmascript_module_internal(
                 Action::Effect(effect) => effect,
             };
 
-            let add_effects = |effects: Vec<_>| {
+            let add_effects = |effects: BumpVec<'_, _>| {
                 queue_stack
                     .lock()
                     .extend(effects.into_iter().map(Action::Effect).rev())
@@ -934,12 +935,16 @@ async fn analyze_ecmascript_module_internal(
                     }
                     macro_rules! active {
                         ($block:ident) => {
-                            queue_stack
-                                .get_mut()
-                                .extend($block.effects.into_iter().map(Action::Effect).rev())
+                            queue_stack.get_mut().extend(
+                                BumpBox::into_inner($block)
+                                    .effects
+                                    .into_iter()
+                                    .map(Action::Effect)
+                                    .rev(),
+                            )
                         };
                     }
-                    match *kind {
+                    match BumpBox::into_inner(kind) {
                         ConditionalKind::If { then } => match condition.is_truthy() {
                             Some(true) => {
                                 condition!(ConstantConditionValue::Truthy);
@@ -1488,11 +1493,11 @@ async fn compile_time_info_for_module_options(
     .cell())
 }
 
-async fn handle_call<'a, G: Fn(Vec<Effect<'a>>) + Send + Sync>(
+async fn handle_call<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>(
     ast_path: &[AstParentKind],
     span: Span,
     func: JsValue<'a>,
-    args: Vec<EffectArg<'a>>,
+    args: BumpVec<'a, EffectArg<'a>>,
     state: &AnalysisState<'a>,
     add_effects: &G,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
@@ -1520,7 +1525,7 @@ async fn handle_call<'a, G: Fn(Vec<Effect<'a>>) + Send + Sync>(
         .map(|effect_arg| match effect_arg {
             EffectArg::Value(value) => value,
             EffectArg::Closure(value, block) => {
-                add_effects(block.effects);
+                add_effects(BumpBox::into_inner(block).effects);
                 value
             }
             EffectArg::Spread => {
@@ -1605,10 +1610,10 @@ async fn handle_call<'a, G: Fn(Vec<Effect<'a>>) + Send + Sync>(
     Ok(())
 }
 
-async fn handle_dynamic_import<'a, G: Fn(Vec<Effect<'a>>) + Send + Sync>(
+async fn handle_dynamic_import<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>(
     ast_path: &[AstParentKind],
     span: Span,
-    args: Vec<EffectArg<'a>>,
+    args: BumpVec<'a, EffectArg<'a>>,
     state: &AnalysisState<'a>,
     add_effects: &G,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
@@ -1644,7 +1649,7 @@ async fn handle_dynamic_import<'a, G: Fn(Vec<Effect<'a>>) + Send + Sync>(
         .map(|effect_arg| match effect_arg {
             EffectArg::Value(value) => value,
             EffectArg::Closure(value, block) => {
-                add_effects(block.effects);
+                add_effects(BumpBox::into_inner(block).effects);
                 value
             }
             EffectArg::Spread => {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -899,8 +899,9 @@ async fn analyze_ecmascript_module_internal(
                         "unexpected Effect::Unreachable in tracing mode"
                     );
 
-                    analysis
-                        .add_code_gen(Unreachable::new(AstPathRange::StartAfter(start_ast_path)));
+                    analysis.add_code_gen(Unreachable::new(AstPathRange::StartAfter(
+                        start_ast_path.to_vec(),
+                    )));
                 }
                 Effect::Conditional {
                     mut condition,
@@ -1210,7 +1211,7 @@ async fn analyze_ecmascript_module_internal(
                     if let Some(placeholder) = worker_placeholder {
                         analysis.add_code_gen(WorkerGlobalsReplacementCodeGen::new(
                             placeholder,
-                            ast_path.into(),
+                            ast_path.to_vec().into(),
                         ));
                         continue;
                     }
@@ -1220,7 +1221,7 @@ async fn analyze_ecmascript_module_internal(
                             analysis_state.first_webpack_exports_info = false;
                             analysis.add_code_gen(ExportsInfoBinding::new());
                         }
-                        analysis.add_code_gen(ExportsInfoRef::new(ast_path.into()));
+                        analysis.add_code_gen(ExportsInfoRef::new(ast_path.to_vec().into()));
                         continue;
                     }
 
@@ -1280,7 +1281,7 @@ async fn analyze_ecmascript_module_internal(
                         let chunking_type = r.await?.chunking_type();
                         analysis.add_reference_code_gen(
                             EsmModuleIdAssetReference::new(*r, chunking_type),
-                            ast_path.into(),
+                            ast_path.to_vec().into(),
                         )
                     } else {
                         if matches!(
@@ -1311,14 +1312,18 @@ async fn analyze_ecmascript_module_internal(
                                 analysis.add_code_gen(EsmBinding::new_keep_this(
                                     named_reference,
                                     Some(export),
-                                    ast_path.into(),
+                                    ast_path.to_vec().into(),
                                 ));
                                 continue;
                             }
                         }
 
                         analysis.add_esm_reference(esm_reference_index);
-                        analysis.add_code_gen(EsmBinding::new(*r, export, ast_path.into()));
+                        analysis.add_code_gen(EsmBinding::new(
+                            *r,
+                            export,
+                            ast_path.to_vec().into(),
+                        ));
                     }
                 }
                 Effect::TypeOf {
@@ -1350,7 +1355,7 @@ async fn analyze_ecmascript_module_internal(
                         ));
                     }
 
-                    analysis.add_code_gen(ImportMetaRef::new(ast_path.into()));
+                    analysis.add_code_gen(ImportMetaRef::new(ast_path.to_vec().into()));
                 }
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -24,7 +24,7 @@ pub mod worker;
 
 use std::{
     future::Future,
-    mem::take,
+    mem::{replace, take},
     ops::Deref,
     sync::{Arc, LazyLock},
 };
@@ -935,9 +935,12 @@ async fn analyze_ecmascript_module_internal(
                     }
                     macro_rules! active {
                         ($block:ident) => {
-                            queue_stack
-                                .get_mut()
-                                .extend($block.effects.into_iter().map(Action::Effect).rev())
+                            queue_stack.get_mut().extend(
+                                BumpVec::from($block.effects)
+                                    .into_iter()
+                                    .map(Action::Effect)
+                                    .rev(),
+                            )
                         };
                     }
                     match BumpBox::into_inner(kind) {
@@ -990,27 +993,27 @@ async fn analyze_ecmascript_module_internal(
                             match condition.is_truthy() {
                                 Some(true) => {
                                     condition!(ConstantConditionValue::Truthy);
-                                    for then in then {
+                                    for then in BumpVec::from(then) {
                                         active!(then);
                                     }
-                                    for r#else in r#else {
+                                    for r#else in BumpVec::from(r#else) {
                                         inactive!(r#else);
                                     }
                                 }
                                 Some(false) => {
                                     condition!(ConstantConditionValue::Falsy);
-                                    for then in then {
+                                    for then in BumpVec::from(then) {
                                         inactive!(then);
                                     }
-                                    for r#else in r#else {
+                                    for r#else in BumpVec::from(r#else) {
                                         active!(r#else);
                                     }
                                 }
                                 None => {
-                                    for then in then {
+                                    for then in BumpVec::from(then) {
                                         active!(then);
                                     }
-                                    for r#else in r#else {
+                                    for r#else in BumpVec::from(r#else) {
                                         active!(r#else);
                                     }
                                 }
@@ -1159,10 +1162,13 @@ async fn analyze_ecmascript_module_internal(
                             );
                             queue_stack.get_mut().push(Action::LeaveScope(*func_ident));
                             queue_stack.get_mut().extend(
-                                take(&mut block.effects)
-                                    .into_iter()
-                                    .map(Action::Effect)
-                                    .rev(),
+                                BumpVec::from(replace(
+                                    &mut block.effects,
+                                    BumpVec::new().into_boxed_slice(),
+                                ))
+                                .into_iter()
+                                .map(Action::Effect)
+                                .rev(),
                             );
                             continue;
                         }
@@ -1521,7 +1527,7 @@ async fn handle_call<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>(
         .map(|effect_arg| match effect_arg {
             EffectArg::Value(value) => value,
             EffectArg::Closure(value, block) => {
-                add_effects(BumpBox::into_inner(block).effects);
+                add_effects(BumpVec::from(BumpBox::into_inner(block).effects));
                 value
             }
             EffectArg::Spread => {
@@ -1645,7 +1651,7 @@ async fn handle_dynamic_import<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>
         .map(|effect_arg| match effect_arg {
             EffectArg::Value(value) => value,
             EffectArg::Closure(value, block) => {
-                add_effects(BumpBox::into_inner(block).effects);
+                add_effects(BumpVec::from(BumpBox::into_inner(block).effects));
                 value
             }
             EffectArg::Spread => {


### PR DESCRIPTION
This is a follow-up PR to https://github.com/vercel/next.js/pull/94297#discussion_r3351215197; also adds an `append()` method to `BumpVec`.