### PR TITLE
Revert "Stabilize catchError and retry by removing unstable_ prefix"

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -671,7 +671,7 @@ impl ReactServerComponentValidator {
                         "useFormState",
                     ],
                 ),
-                (atom!("next/error").into(), vec!["catchError"]),
+                (atom!("next/error").into(), vec!["unstable_catchError"]),
                 (
                     atom!("next/navigation").into(),
                     vec![

--- a/docs/01-app/01-getting-started/10-error-handling.mdx
+++ b/docs/01-app/01-getting-started/10-error-handling.mdx
@@ -215,10 +215,10 @@ import { useEffect } from 'react'
 
 export default function ErrorPage({
   error,
-  retry,
+  unstable_retry,
 }: {
   error: Error & { digest?: string }
-  retry: () => void
+  unstable_retry: () => void
 }) {
   useEffect(() => {
     // Log the error to an error reporting service
@@ -231,7 +231,7 @@ export default function ErrorPage({
       <button
         onClick={
           // Attempt to recover by re-fetching and re-rendering the segment
-          () => retry()
+          () => unstable_retry()
         }
       >
         Try again
@@ -246,7 +246,7 @@ export default function ErrorPage({
 
 import { useEffect } from 'react'
 
-export default function ErrorPage({ error, retry }) {
+export default function ErrorPage({ error, unstable_retry }) {
   useEffect(() => {
     // Log the error to an error reporting service
     console.error(error)
@@ -258,7 +258,7 @@ export default function ErrorPage({ error, retry }) {
       <button
         onClick={
           // Attempt to recover by re-fetching and re-rendering the segment
-          () => retry()
+          () => unstable_retry()
         }
       >
         Try again
@@ -278,19 +278,22 @@ Errors will bubble up to the nearest parent error boundary. This allows for gran
   height="687"
 />
 
-For component-level error recovery, the [`catchError`](/docs/app/api-reference/functions/catchError) function lets you create error boundaries that can wrap any part of your component tree:
+For component-level error recovery, the [`unstable_catchError`](/docs/app/api-reference/functions/catchError) function lets you create error boundaries that can wrap any part of your component tree:
 
 ```tsx filename="app/custom-error-boundary.tsx" switcher
 'use client'
 
-import { catchError, type ErrorInfo } from 'next/error'
+import { unstable_catchError as catchError, type ErrorInfo } from 'next/error'
 
-function ErrorFallback(props: { title: string }, { error, retry }: ErrorInfo) {
+function ErrorFallback(
+  props: { title: string },
+  { error, unstable_retry }: ErrorInfo
+) {
   return (
     <div>
       <h2>{props.title}</h2>
       <p>{error.message}</p>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
     </div>
   )
 }
@@ -301,14 +304,14 @@ export default catchError(ErrorFallback)
 ```jsx filename="app/custom-error-boundary.js" switcher
 'use client'
 
-import { catchError } from 'next/error'
+import { unstable_catchError as catchError } from 'next/error'
 
-function ErrorFallback(props, { error, retry }) {
+function ErrorFallback(props, { error, unstable_retry }) {
   return (
     <div>
       <h2>{props.title}</h2>
       <p>{error.message}</p>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
     </div>
   )
 }
@@ -401,17 +404,17 @@ While less common, you can handle errors in the root layout using the [`global-e
 
 export default function GlobalError({
   error,
-  retry,
+  unstable_retry,
 }: {
   error: Error & { digest?: string }
-  retry: () => void
+  unstable_retry: () => void
 }) {
   return (
     // global-error must include html and body tags
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => retry()}>Try again</button>
+        <button onClick={() => unstable_retry()}>Try again</button>
       </body>
     </html>
   )
@@ -421,13 +424,13 @@ export default function GlobalError({
 ```jsx filename="app/global-error.js" switcher
 'use client' // Error boundaries must be Client Components
 
-export default function GlobalError({ error, retry }) {
+export default function GlobalError({ error, unstable_retry }) {
   return (
     // global-error must include html and body tags
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => retry()}>Try again</button>
+        <button onClick={() => unstable_retry()}>Try again</button>
       </body>
     </html>
   )

--- a/docs/01-app/03-api-reference/03-file-conventions/error.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/error.mdx
@@ -24,10 +24,10 @@ import { useEffect } from 'react'
 
 export default function Error({
   error,
-  retry,
+  unstable_retry,
 }: {
   error: Error & { digest?: string }
-  retry: () => void
+  unstable_retry: () => void
 }) {
   useEffect(() => {
     // Log the error to an error reporting service
@@ -40,7 +40,7 @@ export default function Error({
       <button
         onClick={
           // Attempt to recover by re-fetching and re-rendering the segment
-          () => retry()
+          () => unstable_retry()
         }
       >
         Try again
@@ -55,7 +55,7 @@ export default function Error({
 
 import { useEffect } from 'react'
 
-export default function Error({ error, retry }) {
+export default function Error({ error, unstable_retry }) {
   useEffect(() => {
     // Log the error to an error reporting service
     console.error(error)
@@ -67,7 +67,7 @@ export default function Error({ error, retry }) {
       <button
         onClick={
           // Attempt to recover by re-fetching and re-rendering the segment
-          () => retry()
+          () => unstable_retry()
         }
       >
         Try again
@@ -91,7 +91,7 @@ export default function Error({ error, retry }) {
 >
 > - The [React DevTools](https://react.dev/learn/react-developer-tools) allow you to toggle error boundaries to test error states.
 > - If you want errors to bubble up to the parent error boundary, you can `throw` when rendering the `error` component.
-> - For component-level error recovery that aren't tied to route segments like [`error.js`](/docs/app/api-reference/file-conventions/error), use the [`catchError`](/docs/app/api-reference/functions/catchError) function.
+> - For component-level error recovery that aren't tied to route segments like [`error.js`](/docs/app/api-reference/file-conventions/error), use the [`unstable_catchError`](/docs/app/api-reference/functions/catchError) function.
 
 In the [component hierarchy](/docs/app/getting-started/project-structure#component-hierarchy), `error.js` wraps `loading.js`, `not-found.js`, `page.js`, and nested `layout.js` files in a React error boundary. It does **not** wrap the `layout.js` or `template.js` above it in the same segment. To handle errors in the root layout, use [`global-error.js`](/docs/app/api-reference/file-conventions/error#global-error).
 
@@ -114,26 +114,26 @@ An instance of an [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Re
 
 An automatically generated hash of the error thrown. It can be used to match the corresponding error in server-side logs.
 
-#### `retry`
+#### `unstable_retry`
 
 The cause of an error can sometimes be temporary. In these cases, trying again might resolve the issue.
 
-An error component can use the `retry()` function to prompt the user to attempt to recover from the error. When executed, the function will try to re-fetch and re-render the error boundary's children. If successful, the fallback error component is replaced with the result of the re-render.
+An error component can use the `unstable_retry()` function to prompt the user to attempt to recover from the error. When executed, the function will try to re-fetch and re-render the error boundary's children. If successful, the fallback error component is replaced with the result of the re-render.
 
 ```tsx filename="app/dashboard/error.tsx" switcher
 'use client' // Error boundaries must be Client Components
 
 export default function Error({
   error,
-  retry,
+  unstable_retry,
 }: {
   error: Error & { digest?: string }
-  retry: () => void
+  unstable_retry: () => void
 }) {
   return (
     <div>
       <h2>Something went wrong!</h2>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
     </div>
   )
 }
@@ -142,11 +142,11 @@ export default function Error({
 ```jsx filename="app/dashboard/error.js" switcher
 'use client' // Error boundaries must be Client Components
 
-export default function Error({ error, retry }) {
+export default function Error({ error, unstable_retry }) {
   return (
     <div>
       <h2>Something went wrong!</h2>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
     </div>
   )
 }
@@ -154,7 +154,7 @@ export default function Error({ error, retry }) {
 
 #### `reset`
 
-In most cases, you should use [`retry()`](#retry) instead. However, if you have a specific reason to clear the error state and re-render the error boundary's children without re-fetching the contents, you can use the `reset()` function.
+In most cases, you should use [`unstable_retry()`](#unstable_retry) instead. However, if you have a specific reason to clear the error state and re-render the error boundary's children without re-fetching the contents, you can use the `reset()` function.
 
 ## Examples
 
@@ -169,17 +169,17 @@ While less common, you can handle errors in the root layout or template using `g
 
 export default function GlobalError({
   error,
-  retry,
+  unstable_retry,
 }: {
   error: Error & { digest?: string }
-  retry: () => void
+  unstable_retry: () => void
 }) {
   return (
     // global-error must include html and body tags
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => retry()}>Try again</button>
+        <button onClick={() => unstable_retry()}>Try again</button>
       </body>
     </html>
   )
@@ -189,13 +189,13 @@ export default function GlobalError({
 ```jsx filename="app/global-error.js" switcher
 'use client' // Error boundaries must be Client Components
 
-export default function GlobalError({ error, retry }) {
+export default function GlobalError({ error, unstable_retry }) {
   return (
     // global-error must include html and body tags
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => retry()}>Try again</button>
+        <button onClick={() => unstable_retry()}>Try again</button>
       </body>
     </html>
   )
@@ -326,7 +326,6 @@ export default GracefullyDegradingErrorBoundary
 
 | Version   | Changes                                     |
 | --------- | ------------------------------------------- |
-| `v16.3.0` | `retry` prop became stable.                 |
 | `v16.2.0` | `unstable_retry` prop added.                |
 | `v15.2.0` | Also display `global-error` in development. |
 | `v13.1.0` | `global-error` introduced.                  |

--- a/docs/01-app/03-api-reference/04-functions/catchError.mdx
+++ b/docs/01-app/03-api-reference/04-functions/catchError.mdx
@@ -1,6 +1,6 @@
 ---
-title: catchError
-description: API Reference for the catchError function.
+title: unstable_catchError
+description: API Reference for the unstable_catchError function.
 related:
   title: Learn more about error handling
   links:
@@ -8,60 +8,63 @@ related:
     - app/api-reference/file-conventions/error
 ---
 
-The `catchError` function creates a component that wraps its children in an error boundary. It provides a programmatic alternative to the [`error.js`](/docs/app/api-reference/file-conventions/error) file convention, enabling component-level error recovery anywhere in your component tree.
+The `unstable_catchError` function creates a component that wraps its children in an error boundary. It provides a programmatic alternative to the [`error.js`](/docs/app/api-reference/file-conventions/error) file convention, enabling component-level error recovery anywhere in your component tree.
 
-Compared to a custom React error boundary, `catchError` is designed to work with Next.js out of the box:
+Compared to a custom React error boundary, `unstable_catchError` is designed to work with Next.js out of the box:
 
-- **Built-in error recovery** — [`retry()`](/docs/app/api-reference/file-conventions/error#retry) re-renders the page inside a [Transition](https://react.dev/reference/react/startTransition), preserving Client Components state outside of the error boundary.
-- **Framework-aware integration** — APIs like `redirect()` and `notFound()` work by throwing special errors under the hood. `catchError` handles these seamlessly, so they're not accidentally caught by your error boundary.
+- **Built-in error recovery** — [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) re-renders the page inside a [Transition](https://react.dev/reference/react/startTransition), preserving Client Components state outside of the error boundary.
+- **Framework-aware integration** — APIs like `redirect()` and `notFound()` work by throwing special errors under the hood. `unstable_catchError` handles these seamlessly, so they're not accidentally caught by your error boundary.
 - **Client navigation handling** — The error state automatically clears when you do a client navigation to a different route.
 
-`catchError` can be called from [Client Components](/docs/app/getting-started/server-and-client-components).
+`unstable_catchError` can be called from [Client Components](/docs/app/getting-started/server-and-client-components).
 
 ```tsx filename="app/custom-error-boundary.tsx" switcher
 'use client'
 
-import { catchError, type ErrorInfo } from 'next/error'
+import { unstable_catchError, type ErrorInfo } from 'next/error'
 
-function ErrorFallback(props: { title: string }, { error, retry }: ErrorInfo) {
+function ErrorFallback(
+  props: { title: string },
+  { error, unstable_retry }: ErrorInfo
+) {
   return (
     <div>
       <h2>{props.title}</h2>
       <p>{error.message}</p>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
     </div>
   )
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)
 ```
 
 ```jsx filename="app/custom-error-boundary.js" switcher
 'use client'
 
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
-function ErrorFallback(props, { error, retry }) {
+function ErrorFallback(props, { error, unstable_retry }) {
   return (
     <div>
       <h2>{props.title}</h2>
       <p>{error.message}</p>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
     </div>
   )
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)
 ```
 
 ## Reference
 
 ### Parameters
 
-`catchError` accepts a single argument:
+`unstable_catchError` accepts a single argument:
 
 ```ts
-const ErrorWrapper = catchError(fallback)
+const ErrorWrapper = unstable_catchError(fallback)
 ```
 
 #### `fallback`
@@ -71,17 +74,17 @@ A function that renders the error UI when an error is caught. It receives two ar
 - `props` — The props passed to the wrapper component (excluding `children`).
 - `errorInfo` — An object containing information about the error:
 
-| Property | Type                                                                                        | Description                                                                                                                                     |
-| -------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `error`  | [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error) | The error instance that was caught.                                                                                                             |
-| `retry`  | `() => void`                                                                                | Re-fetches and re-renders the error boundary's children. If successful, the fallback is replaced with the re-rendered result.                   |
-| `reset`  | `() => void`                                                                                | Resets the error state and re-renders without re-fetching. Use [`retry()`](/docs/app/api-reference/file-conventions/error#retry) in most cases. |
+| Property         | Type                                                                                        | Description                                                                                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `error`          | [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error) | The error instance that was caught.                                                                                                                               |
+| `unstable_retry` | `() => void`                                                                                | Re-fetches and re-renders the error boundary's children. If successful, the fallback is replaced with the re-rendered result.                                     |
+| `reset`          | `() => void`                                                                                | Resets the error state and re-renders without re-fetching. Use [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) in most cases. |
 
 The `fallback` function must be a Client Component (or defined in a `'use client'` module).
 
 ### Returns
 
-`catchError` returns a React component that:
+`unstable_catchError` returns a React component that:
 
 - Accepts the same props as your fallback's first argument, plus `children`.
 - Wraps `children` in an error boundary.
@@ -111,44 +114,44 @@ export default function Component({ children }) {
 
 ### Recovering from errors
 
-Use `retry()` to prompt the user to recover from the error. When called, the function re-fetches and re-renders the error boundary's children. If successful, the fallback is replaced with the re-rendered result.
+Use `unstable_retry()` to prompt the user to recover from the error. When called, the function re-fetches and re-renders the error boundary's children. If successful, the fallback is replaced with the re-rendered result.
 
-In most cases, use `retry()` instead of `reset()`. The `reset()` function only clears the error state and re-renders without re-fetching, which means it won't recover from Server Component errors.
+In most cases, use `unstable_retry()` instead of `reset()`. The `reset()` function only clears the error state and re-renders without re-fetching, which means it won't recover from Server Component errors.
 
 ```tsx filename="app/custom-error-boundary.tsx" switcher
 'use client'
 
-import { catchError, type ErrorInfo } from 'next/error'
+import { unstable_catchError, type ErrorInfo } from 'next/error'
 
-function ErrorFallback(props: {}, { error, retry, reset }: ErrorInfo) {
+function ErrorFallback(props: {}, { error, unstable_retry, reset }: ErrorInfo) {
   return (
     <div>
       <p>{error.message}</p>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
       <button onClick={() => reset()}>Reset</button>
     </div>
   )
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)
 ```
 
 ```jsx filename="app/custom-error-boundary.js" switcher
 'use client'
 
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
-function ErrorFallback(props, { error, retry, reset }) {
+function ErrorFallback(props, { error, unstable_retry, reset }) {
   return (
     <div>
       <p>{error.message}</p>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
       <button onClick={() => reset()}>Reset</button>
     </div>
   )
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)
 ```
 
 ### Server-rendered error fallback
@@ -160,7 +163,7 @@ You can pass server-rendered content as a prop to display data-driven fallback U
 ```tsx filename="app/error-boundary.tsx" switcher
 'use client'
 
-import { catchError, type ErrorInfo } from 'next/error'
+import { unstable_catchError, type ErrorInfo } from 'next/error'
 
 function ErrorFallback(
   props: { fallback: React.ReactNode },
@@ -169,19 +172,19 @@ function ErrorFallback(
   return props.fallback
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)
 ```
 
 ```jsx filename="app/error-boundary.js" switcher
 'use client'
 
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
 function ErrorFallback(props, errorInfo) {
   return props.fallback
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)
 ```
 
 ```tsx filename="app/some-component.tsx" switcher
@@ -212,13 +215,12 @@ export default function Component({ children }) {
 
 > **Good to know**:
 >
-> - Unlike the `error.js` file convention which is scoped to route segments, `catchError` can be used to wrap any part of your component tree for component-level error recovery.
+> - Unlike the `error.js` file convention which is scoped to route segments, `unstable_catchError` can be used to wrap any part of your component tree for component-level error recovery.
 > - Props passed to the wrapper component are forwarded to the fallback function, making it easy to create reusable error UIs with different configurations.
-> - You don't need to wrap `error.js` default exports with `catchError`. The [`error.js`](/docs/app/api-reference/file-conventions/error) file convention already renders inside a built-in error boundary provided by Next.js.
+> - You don't need to wrap `error.js` default exports with `unstable_catchError`. The [`error.js`](/docs/app/api-reference/file-conventions/error) file convention already renders inside a built-in error boundary provided by Next.js.
 
 ## Version History
 
 | Version   | Changes                           |
 | --------- | --------------------------------- |
-| `v16.3.0` | `catchError` became stable.       |
 | `v16.2.0` | `unstable_catchError` introduced. |

--- a/packages/next/error.d.ts
+++ b/packages/next/error.d.ts
@@ -3,5 +3,5 @@ import Error from './dist/api/error'
 export * from './dist/api/error'
 export default Error
 
-export { catchError } from './dist/api/error'
+export { unstable_catchError } from './dist/api/error'
 export type { ErrorInfo } from './dist/api/error'

--- a/packages/next/error.js
+++ b/packages/next/error.js
@@ -1,9 +1,9 @@
 module.exports = require('./dist/pages/_error')
 
 // Keep the catch-error graph lazy so default Error consumers do not load it.
-Object.defineProperty(module.exports, 'catchError', {
+Object.defineProperty(module.exports, 'unstable_catchError', {
   enumerable: true,
   get() {
-    return require('./dist/client/components/catch-error').catchError
+    return require('./dist/client/components/catch-error').unstable_catchError
   },
 })

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1321,7 +1321,5 @@
   "1320": "Route \"%s\": Next.js encountered runtime data during prerendering.\\n\\n\\`cookies()\\`, \\`headers()\\`, \\`params\\`, or \\`searchParams\\` accessed outside of \\`<Suspense>\\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.\\n\\nWays to fix this:\\n  - [stream] Provide a placeholder with \\`<Suspense fallback={...}>\\` around the data access\\n    https://nextjs.org/docs/messages/blocking-prerender-runtime#wrap-in-or-move-into-suspense\\n  - [cache] For \\`params\\`: if the params are known, prerender them with \\`generateStaticParams\\`\\n    https://nextjs.org/docs/messages/blocking-prerender-runtime#for-known-params-prerender\\n  - [block] Set \\`export const unstable_instant = false\\` to silence this warning and allow a blocking route\\n    https://nextjs.org/docs/messages/blocking-prerender-runtime#allow-blocking-route",
   "1321": "\\`partialPrefetching\\` requires \\`cacheComponents\\` to be enabled. Please update your %s accordingly.",
   "1322": "Route \"%s\" cannot use \\`export const prefetch = ...\\` without enabling \\`cacheComponents\\`.",
-  "1323": "\"prefetch\" is a route segment config and can only be used when the segment is a Server Component module. Remove the \"use client\" directive from \"%s\" to use this API.",
-  "1324": "`retry()` can only be used in the App Router. Use `reset()` in the Pages Router.",
-  "1325": "`catchError` can only be used in Client Components."
+  "1323": "\"prefetch\" is a route segment config and can only be used when the segment is a Server Component module. Remove the \"use client\" directive from \"%s\" to use this API."
 }

--- a/packages/next/src/api/error.react-server.ts
+++ b/packages/next/src/api/error.react-server.ts
@@ -1,5 +1,7 @@
-export function catchError(): never {
-  throw new Error('`catchError` can only be used in Client Components.')
+export function unstable_catchError(): never {
+  throw new Error(
+    '`unstable_catchError` can only be used in Client Components.'
+  )
 }
 
 export type { ErrorInfo } from '../client/components/error-boundary'

--- a/packages/next/src/api/error.ts
+++ b/packages/next/src/api/error.ts
@@ -2,5 +2,5 @@
 export { default } from '../pages/_error'
 export * from '../pages/_error'
 
-export { catchError } from '../client/components/catch-error'
+export { unstable_catchError } from '../client/components/catch-error'
 export type { ErrorInfo } from '../client/components/error-boundary'

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -7,7 +7,7 @@ import { errorStyles, errorThemeCss, WarningIcon } from './error-styles'
 export type GlobalErrorComponent = React.ComponentType<{
   error: any
   reset: () => void
-  retry: () => void
+  unstable_retry: () => void
 }>
 
 function DefaultGlobalError({ error }: { error: any }) {

--- a/packages/next/src/client/components/catch-error.tsx
+++ b/packages/next/src/client/components/catch-error.tsx
@@ -42,9 +42,9 @@ class CatchError<P extends UserProps> extends React.Component<
 > {
   declare context: AppRouterInstance | null
   static contextType = AppRouterContext
-  // `catchError()` is parsed as an HOC-style name and displays as
-  // a label (<name> [catchError]) in DevTools.
-  static displayName = 'catchError(Next.CatchError)'
+  // `unstable_catchError()` is parsed as an HOC-style name and displays as
+  // a label (<name> [unstable_catchError]) in DevTools.
+  static displayName = 'unstable_catchError(Next.CatchError)'
 
   constructor(props: CatchErrorProps<P>) {
     super(props)
@@ -108,10 +108,10 @@ class CatchError<P extends UserProps> extends React.Component<
     this.setState({ error: null })
   }
 
-  retry = () => {
+  unstable_retry = () => {
     if (this.props.isPagesRouter) {
       throw new Error(
-        '`retry()` can only be used in the App Router. Use `reset()` in the Pages Router.'
+        '`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.'
       )
     }
 
@@ -136,7 +136,7 @@ class CatchError<P extends UserProps> extends React.Component<
             // TODO(NAR-804): Docs say this is an Error object, but we don't guarantee that
             error: thrownValue,
             reset: this.reset,
-            retry: this.retry,
+            unstable_retry: this.unstable_retry,
           }}
         />
       )
@@ -147,9 +147,9 @@ class CatchError<P extends UserProps> extends React.Component<
 }
 
 /**
- * `catchError` is a counterpart to `error.js` that provides a granular
+ * `unstable_catchError` is a counterpart to `error.js` that provides a granular
  * control of error boundaries at the component level. It provides the `ErrorInfo`
- * including `retry` for error recovery.
+ * including `unstable_retry` for error recovery.
  *
  * Pass a Component-like fallback function that receives the props and `ErrorInfo`.
  * The props omit `children` intentionally as it is the "fallback" of the error and
@@ -162,13 +162,13 @@ class CatchError<P extends UserProps> extends React.Component<
  * ```tsx
  * // CustomErrorBoundary.tsx
  * 'use client'
- * import { catchError, type ErrorInfo } from 'next/error'
+ * import { unstable_catchError, type ErrorInfo } from 'next/error'
  *
  * function CustomErrorBoundary(props: Props, errorInfo: ErrorInfo) {
  *   return ...
  * }
  *
- * export default catchError(CustomErrorBoundary)
+ * export default unstable_catchError(CustomErrorBoundary)
  *
  * // page.tsx
  * 'use client'
@@ -183,7 +183,7 @@ class CatchError<P extends UserProps> extends React.Component<
  * }
  * ```
  */
-export function catchError<P extends UserProps>(
+export function unstable_catchError<P extends UserProps>(
   fallback: (
     // children is omitted by design as the error fallback component is the "fallback"
     // for the children when an error occurs.
@@ -191,7 +191,7 @@ export function catchError<P extends UserProps>(
     errorInfo: ErrorInfo
   ) => React.ReactNode
 ): React.ComponentType<P & { children?: React.ReactNode }> {
-  // Create Fallback component from the closure of `catchError`.
+  // Create Fallback component from the closure of `unstable_catchError`.
   const Fallback = ({ props, errorInfo }: { props: P; errorInfo: ErrorInfo }) =>
     fallback(props, errorInfo)
 

--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -17,7 +17,7 @@ const isBotUserAgent =
 export type ErrorInfo = {
   error: unknown
   reset: () => void
-  retry: () => void
+  unstable_retry: () => void
 }
 
 export type ErrorComponent = React.ComponentType<ErrorInfo>
@@ -108,7 +108,7 @@ export class ErrorBoundaryHandler extends React.Component<
     this.setState({ error: null })
   }
 
-  retry = () => {
+  unstable_retry = () => {
     startTransition(() => {
       this.context?.refresh()
       this.reset()
@@ -131,7 +131,7 @@ export class ErrorBoundaryHandler extends React.Component<
             // TODO(NAR-804): Docs say this is an Error object, but we don't guarantee that
             error={thrownValue}
             reset={this.reset}
-            retry={this.retry}
+            unstable_retry={this.unstable_retry}
           />
         </>
       )

--- a/packages/next/src/next-devtools/userspace/app/app-dev-overlay-error-boundary.tsx
+++ b/packages/next/src/next-devtools/userspace/app/app-dev-overlay-error-boundary.tsx
@@ -24,17 +24,21 @@ function ErroredHtml({
   globalError: [GlobalError, globalErrorStyles],
   thrownValue,
   reset,
-  retry,
+  unstable_retry,
 }: {
   globalError: GlobalErrorState
   thrownValue: unknown
   reset: () => void
-  retry: () => void
+  unstable_retry: () => void
 }) {
   return (
     <ErrorBoundary errorComponent={DefaultGlobalError}>
       {globalErrorStyles}
-      <GlobalError error={thrownValue} reset={reset} retry={retry} />
+      <GlobalError
+        error={thrownValue}
+        reset={reset}
+        unstable_retry={unstable_retry}
+      />
     </ErrorBoundary>
   )
 }
@@ -71,7 +75,7 @@ export class AppDevOverlayErrorBoundary extends PureComponent<
     dispatcher.openErrorOverlay()
   }
 
-  retry = () => {
+  unstable_retry = () => {
     startTransition(() => {
       this.context?.refresh()
       this.reset()
@@ -93,7 +97,7 @@ export class AppDevOverlayErrorBoundary extends PureComponent<
           globalError={globalError}
           thrownValue={thrownValue}
           reset={this.reset}
-          retry={this.retry}
+          unstable_retry={this.unstable_retry}
         />
       )
     }

--- a/packages/next/src/server/typescript/rules/client-boundary.ts
+++ b/packages/next/src/server/typescript/rules/client-boundary.ts
@@ -76,14 +76,14 @@ const clientBoundary = {
                     propName === 'action' || /.+Action$/.test(propName)
 
                   // There's a special case for error files where the
-                  // framework-injected `reset` and `retry` props are
+                  // framework-injected `reset` and `unstable_retry` props are
                   // allowed to be functions. Next.js provides these props, the
                   // user doesn't pass them, so they don't need to be
                   // serializable.
                   // https://github.com/vercel/next.js/issues/46573
                   const isErrorBoundaryFunctionProp =
                     (isErrorFile || isGlobalErrorFile) &&
-                    (propName === 'reset' || propName === 'retry')
+                    (propName === 'reset' || propName === 'unstable_retry')
 
                   if (!maybeServerAction && !isErrorBoundaryFunctionProp) {
                     diagnostics.push({

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -256,14 +256,14 @@ describe('Error overlay - RSC build errors', () => {
     })
   }
 
-  it('should error when catchError from next/error is used in a server component', async () => {
+  it('should error when unstable_catchError from next/error is used in a server component', async () => {
     await using sandbox = await createSandbox(
       next,
       new Map([
         [
           'app/page.js',
           outdent`
-            import { catchError } from 'next/error'
+            import { unstable_catchError } from 'next/error'
 
             export default function Page() {
               return 'Hello world'
@@ -276,7 +276,7 @@ describe('Error overlay - RSC build errors', () => {
     const { session } = sandbox
     await session.waitForRedbox()
     expect(await session.getRedboxSource()).toInclude(
-      'You\'re importing a module that depends on `catchError` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the `"use client"` directive.'
+      'You\'re importing a module that depends on `unstable_catchError` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the `"use client"` directive.'
     )
   })
 
@@ -285,7 +285,7 @@ describe('Error overlay - RSC build errors', () => {
     ['proxy.js', 'export function proxy() {}'],
     ['instrumentation.js', 'export function register() {}'],
   ])(
-    'should error when catchError from next/error is imported in %s',
+    'should error when unstable_catchError from next/error is imported in %s',
     async (entryFile, exportCode) => {
       await using sandbox = await createSandbox(
         next,
@@ -301,7 +301,7 @@ describe('Error overlay - RSC build errors', () => {
           [
             entryFile,
             outdent`
-              import { catchError } from 'next/error'
+              import { unstable_catchError } from 'next/error'
               ${exportCode}
             `,
           ],
@@ -311,7 +311,7 @@ describe('Error overlay - RSC build errors', () => {
       const { session } = sandbox
       await session.waitForRedbox()
       expect(await session.getRedboxSource()).toInclude(
-        'You\'re importing a module that depends on `catchError` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the `"use client"` directive.'
+        'You\'re importing a module that depends on `unstable_catchError` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the `"use client"` directive.'
       )
     }
   )

--- a/test/development/typescript-plugin/README.md
+++ b/test/development/typescript-plugin/README.md
@@ -17,7 +17,7 @@ The plugin only applies to VSCode so manual testing in VSCode is required.
 Ensure the current comments still describe the observed behavior.
 
 `app/error.tsx#Error` and `app/global-error.tsx#GlobalError` have `reset` and
-`retry` props that should be excluded from the serialization check.
+`unstable_retry` props that should be excluded from the serialization check.
 
 ### Client Boundary
 

--- a/test/development/typescript-plugin/app/error.tsx
+++ b/test/development/typescript-plugin/app/error.tsx
@@ -5,13 +5,13 @@ import { useEffect } from 'react'
 export default function Error({
   error,
   reset,
-  retry,
-  //^^^ `reset` and `retry` are fine because they are the special
+  unstable_retry,
+  //^^^ `reset` and `unstable_retry` are fine because they are the special
   // framework-injected function props in an error file
 }: {
   error: Error & { digest?: string }
   reset: () => void
-  retry: () => void
+  unstable_retry: () => void
 }) {
   useEffect(() => {
     console.error(error)
@@ -21,7 +21,7 @@ export default function Error({
     <div>
       <h2>Something went wrong!</h2>
       <button onClick={() => reset()}>Try again</button>
-      <button onClick={() => retry()}>Retry</button>
+      <button onClick={() => unstable_retry()}>Retry</button>
     </div>
   )
 }

--- a/test/development/typescript-plugin/app/global-error.tsx
+++ b/test/development/typescript-plugin/app/global-error.tsx
@@ -3,20 +3,20 @@
 export default function GlobalError({
   error,
   reset,
-  retry,
-  //^^^ `reset` and `retry` are fine because they are the special
+  unstable_retry,
+  //^^^ `reset` and `unstable_retry` are fine because they are the special
   // framework-injected function props in a global-error file
 }: {
   error: Error & { digest?: string }
   reset: () => void
-  retry: () => void
+  unstable_retry: () => void
 }) {
   return (
     <html>
       <body>
         <h2>Something went wrong!</h2>
         <button onClick={() => reset()}>Try again</button>
-        <button onClick={() => retry()}>Retry</button>
+        <button onClick={() => unstable_retry()}>Retry</button>
       </body>
     </html>
   )

--- a/test/development/typescript-plugin/client-boundary/app/error.tsx
+++ b/test/development/typescript-plugin/client-boundary/app/error.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-// Error boundaries receive `error`, `reset`, and `retry` from the
-// framework. `reset` and `retry` are functions, but they are injected
+// Error boundaries receive `error`, `reset`, and `unstable_retry` from the
+// framework. `reset` and `unstable_retry` are functions, but they are injected
 // by Next.js rather than passed by the user, so the client-entry serialization
 // rule must not flag them. `_notExempt` is an ordinary function prop and
 // must still be flagged, proving the exemption stays scoped to error-boundary
@@ -9,12 +9,12 @@
 export default function Error({
   error,
   reset,
-  retry,
+  unstable_retry,
   _notExempt,
 }: {
   error: Error & { digest?: string }
   reset: () => void
-  retry: () => void
+  unstable_retry: () => void
   _notExempt: () => void
 }) {
   return (
@@ -22,7 +22,7 @@ export default function Error({
       <h2>Something went wrong!</h2>
       <p>{error.message}</p>
       <button onClick={() => reset()}>Reset</button>
-      <button onClick={() => retry()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Try again</button>
       <button onClick={() => _notExempt()}>Nope</button>
     </div>
   )

--- a/test/development/typescript-plugin/client-boundary/app/global-error.tsx
+++ b/test/development/typescript-plugin/client-boundary/app/global-error.tsx
@@ -1,19 +1,19 @@
 'use client'
 
 // `global-error.tsx` receives the same framework-injected props as `error.tsx`.
-// Its function props (`reset`, `retry`) are provided by Next.js and
+// Its function props (`reset`, `unstable_retry`) are provided by Next.js and
 // must not be flagged as non-serializable. `_notExempt` is an ordinary function
 // prop and must still be flagged, proving the exemption stays scoped to known
 // error-boundary props.
 export default function GlobalError({
   error,
   reset,
-  retry,
+  unstable_retry,
   _notExempt,
 }: {
   error: Error & { digest?: string }
   reset: () => void
-  retry: () => void
+  unstable_retry: () => void
   _notExempt: () => void
 }) {
   return (
@@ -22,7 +22,7 @@ export default function GlobalError({
         <h2>Something went wrong!</h2>
         <p>{error.message}</p>
         <button onClick={() => reset()}>Reset</button>
-        <button onClick={() => retry()}>Try again</button>
+        <button onClick={() => unstable_retry()}>Try again</button>
         <button onClick={() => _notExempt()}>Nope</button>
       </body>
     </html>

--- a/test/development/typescript-plugin/client-boundary/client-boundary.test.ts
+++ b/test/development/typescript-plugin/client-boundary/client-boundary.test.ts
@@ -130,10 +130,10 @@ describe('typescript-plugin - client-boundary', () => {
       )
       .map((diagnostic) => String(diagnostic.messageText))
 
-    // `reset` and `retry` are injected by Next.js into error
+    // `reset` and `unstable_retry` are injected by Next.js into error
     // boundaries, so they must not be flagged as non-serializable props.
     expect(flaggedProps.some((m) => m.includes('"reset"'))).toBe(false)
-    expect(flaggedProps.some((m) => m.includes('"retry"'))).toBe(false)
+    expect(flaggedProps.some((m) => m.includes('"unstable_retry"'))).toBe(false)
     // The exemption stays scoped to known error-boundary props: an ordinary
     // function prop in an error file is still flagged.
     expect(flaggedProps.some((m) => m.includes('"_notExempt"'))).toBe(true)
@@ -151,10 +151,10 @@ describe('typescript-plugin - client-boundary', () => {
       )
       .map((diagnostic) => String(diagnostic.messageText))
 
-    // `reset` and `retry` are injected by Next.js into global-error
+    // `reset` and `unstable_retry` are injected by Next.js into global-error
     // boundaries, so they must not be flagged as non-serializable props.
     expect(flaggedProps.some((m) => m.includes('"reset"'))).toBe(false)
-    expect(flaggedProps.some((m) => m.includes('"retry"'))).toBe(false)
+    expect(flaggedProps.some((m) => m.includes('"unstable_retry"'))).toBe(false)
     // The exemption stays scoped to known error-boundary props: an ordinary
     // function prop in a global-error file is still flagged.
     expect(flaggedProps.some((m) => m.includes('"_notExempt"'))).toBe(true)

--- a/test/e2e/app-dir/catch-error/app/client-component/catch-error-wrapper.tsx
+++ b/test/e2e/app-dir/catch-error/app/client-component/catch-error-wrapper.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import type { ErrorInfo } from 'next/error'
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
 export function ErrorFallback(
   props: { title: string },
-  { error, reset, retry }: ErrorInfo
+  { error, reset, unstable_retry }: ErrorInfo
 ) {
   return (
     <>
@@ -14,11 +14,11 @@ export function ErrorFallback(
       <button id="reset" onClick={() => reset()}>
         Reset
       </button>
-      <button id="retry" onClick={() => retry()}>
+      <button id="retry" onClick={() => unstable_retry()}>
         Retry
       </button>
     </>
   )
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)

--- a/test/e2e/app-dir/catch-error/app/client-component/throw-null/page.tsx
+++ b/test/e2e/app-dir/catch-error/app/client-component/throw-null/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import type { ErrorInfo } from 'next/error'
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
 function Inner() {
   const [clicked, setClicked] = useState(false)
@@ -26,7 +26,7 @@ function ErrorFallback(_props: {}, { error }: ErrorInfo) {
   return <p id="error-boundary-message">{`An error occurred: ${error}`}</p>
 }
 
-const Wrapped = catchError(ErrorFallback)
+const Wrapped = unstable_catchError(ErrorFallback)
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/catch-error/app/client-component/throw-undefined/page.tsx
+++ b/test/e2e/app-dir/catch-error/app/client-component/throw-undefined/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import type { ErrorInfo } from 'next/error'
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
 function Inner() {
   const [clicked, setClicked] = useState(false)
@@ -26,7 +26,7 @@ function ErrorFallback(_props: {}, { error }: ErrorInfo) {
   return <p id="error-boundary-message">{`An error occurred: ${error}`}</p>
 }
 
-const Wrapped = catchError(ErrorFallback)
+const Wrapped = unstable_catchError(ErrorFallback)
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/catch-error/app/server-component/catch-error-wrapper.tsx
+++ b/test/e2e/app-dir/catch-error/app/server-component/catch-error-wrapper.tsx
@@ -1,10 +1,10 @@
 'use client'
 import type { ErrorInfo } from 'next/error'
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
 export function ErrorFallback(
   props: { title: string },
-  { error, reset, retry }: ErrorInfo
+  { error, reset, unstable_retry }: ErrorInfo
 ) {
   return (
     <>
@@ -13,11 +13,11 @@ export function ErrorFallback(
       <button id="reset" onClick={() => reset()}>
         Reset
       </button>
-      <button id="retry" onClick={() => retry()}>
+      <button id="retry" onClick={() => unstable_retry()}>
         Retry
       </button>
     </>
   )
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)

--- a/test/e2e/app-dir/catch-error/app/server-component/throw-null/error-wrapper.tsx
+++ b/test/e2e/app-dir/catch-error/app/server-component/throw-null/error-wrapper.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import type { ErrorInfo } from 'next/error'
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
 function ErrorFallback(_props: {}, { error }: ErrorInfo) {
   return <p id="error-boundary-message">{`An error occurred: ${error}`}</p>
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)

--- a/test/e2e/app-dir/catch-error/app/server-component/throw-undefined/error-wrapper.tsx
+++ b/test/e2e/app-dir/catch-error/app/server-component/throw-undefined/error-wrapper.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import type { ErrorInfo } from 'next/error'
-import { catchError } from 'next/error'
+import { unstable_catchError } from 'next/error'
 
 function ErrorFallback(_props: {}, { error }: ErrorInfo) {
   return <p id="error-boundary-message">{`An error occurred: ${error}`}</p>
 }
 
-export default catchError(ErrorFallback)
+export default unstable_catchError(ErrorFallback)

--- a/test/e2e/app-dir/catch-error/catch-error-react-compiler.test.ts
+++ b/test/e2e/app-dir/catch-error/catch-error-react-compiler.test.ts
@@ -5,7 +5,7 @@ import { isReact18, nextTestSetup } from 'e2e-utils'
 // _describe for cleaner git history.
 const _describe = isReact18 ? describe.skip : describe
 
-_describe('app-dir - catchError with react compiler', () => {
+_describe('app-dir - unstable_catchError with react compiler', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     nextConfig: {
@@ -41,7 +41,7 @@ _describe('app-dir - catchError with react compiler', () => {
     }
   })
 
-  it('should recover Client Component error after retry', async () => {
+  it('should recover Client Component error after unstable_retry', async () => {
     const browser = await next.browser('/client-component')
 
     // Try triggering and retrying a few times in a row
@@ -66,7 +66,7 @@ _describe('app-dir - catchError with react compiler', () => {
     }
   })
 
-  it('should recover Server Component error after retry', async () => {
+  it('should recover Server Component error after unstable_retry', async () => {
     const browser = await next.browser('/server-component')
 
     expect(await browser.elementByCss('#error-boundary-message').text()).toBe(
@@ -100,7 +100,7 @@ _describe('app-dir - catchError with react compiler', () => {
     )
   })
 
-  it('should throw when retry is called on Pages Router', async () => {
+  it('should throw when unstable_retry is called on Pages Router', async () => {
     const browser = await next.browser('/pages-router')
 
     await browser
@@ -112,7 +112,7 @@ _describe('app-dir - catchError with react compiler', () => {
     await browser.waitForElementByCss('#pages-retry-error')
 
     expect(await browser.elementByCss('#pages-retry-error').text()).toBe(
-      '`retry()` can only be used in the App Router. Use `reset()` in the Pages Router.'
+      '`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.'
     )
   })
 })

--- a/test/e2e/app-dir/catch-error/catch-error.test.ts
+++ b/test/e2e/app-dir/catch-error/catch-error.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('app-dir - catchError', () => {
+describe('app-dir - unstable_catchError', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
@@ -30,7 +30,7 @@ describe('app-dir - catchError', () => {
     }
   })
 
-  it('should recover Client Component error after retry', async () => {
+  it('should recover Client Component error after unstable_retry', async () => {
     const browser = await next.browser('/client-component')
 
     // Try triggering and retrying a few times in a row
@@ -55,7 +55,7 @@ describe('app-dir - catchError', () => {
     }
   })
 
-  it('should recover Server Component error after retry', async () => {
+  it('should recover Server Component error after unstable_retry', async () => {
     const browser = await next.browser('/server-component')
 
     expect(await browser.elementByCss('#error-boundary-message').text()).toBe(
@@ -131,7 +131,7 @@ describe('app-dir - catchError', () => {
     )
   })
 
-  it('should throw when retry is called on Pages Router', async () => {
+  it('should throw when unstable_retry is called on Pages Router', async () => {
     const browser = await next.browser('/pages-router')
 
     await browser
@@ -143,7 +143,7 @@ describe('app-dir - catchError', () => {
     await browser.waitForElementByCss('#pages-retry-error')
 
     expect(await browser.elementByCss('#pages-retry-error').text()).toBe(
-      '`retry()` can only be used in the App Router. Use `reset()` in the Pages Router.'
+      '`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.'
     )
   })
 })

--- a/test/e2e/app-dir/catch-error/pages/pages-router.tsx
+++ b/test/e2e/app-dir/catch-error/pages/pages-router.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
-import { catchError, type ErrorInfo } from 'next/error'
+import { unstable_catchError, type ErrorInfo } from 'next/error'
 
 function ErrorFallback(
   { clearError }: { clearError: () => void },
-  { error, reset, retry }: ErrorInfo
+  { error, reset, unstable_retry }: ErrorInfo
 ) {
   const [retryError, setRetryError] = useState<string | null>(null)
 
@@ -23,7 +23,7 @@ function ErrorFallback(
         id="pages-retry"
         onClick={() => {
           try {
-            retry()
+            unstable_retry()
           } catch (error) {
             setRetryError((error as Error).message)
           }
@@ -36,7 +36,7 @@ function ErrorFallback(
   )
 }
 
-const ErrorBoundary = catchError(ErrorFallback)
+const ErrorBoundary = unstable_catchError(ErrorFallback)
 
 function ErrorThrower({ shouldThrow }: { shouldThrow: boolean }) {
   if (shouldThrow) {

--- a/test/e2e/app-dir/errors/app/client-component/error.js
+++ b/test/e2e/app-dir/errors/app/client-component/error.js
@@ -2,14 +2,18 @@
 
 import styles from './style.module.css'
 
-export default function ErrorBoundary({ error, reset, retry }) {
+export default function ErrorBoundary({ error, reset, unstable_retry }) {
   return (
     <>
       <p id="error-boundary-message">An error occurred: {error.message}</p>
       <button id="reset" onClick={() => reset()} className={styles.button}>
         Try again
       </button>
-      <button id="retry" onClick={() => retry()} className={styles.button}>
+      <button
+        id="retry"
+        onClick={() => unstable_retry()}
+        className={styles.button}
+      >
         Retry
       </button>
     </>

--- a/test/e2e/app-dir/errors/app/server-component/error.js
+++ b/test/e2e/app-dir/errors/app/server-component/error.js
@@ -1,6 +1,6 @@
 'use client'
 
-export default function ErrorBoundary({ error, reset, retry }) {
+export default function ErrorBoundary({ error, reset, unstable_retry }) {
   return (
     <>
       <p id="error-boundary-message">{error.message}</p>
@@ -8,7 +8,7 @@ export default function ErrorBoundary({ error, reset, retry }) {
       <button id="reset" onClick={() => reset()}>
         Try again
       </button>
-      <button id="retry" onClick={() => retry()}>
+      <button id="retry" onClick={() => unstable_retry()}>
         Retry
       </button>
     </>

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -401,13 +401,13 @@ describe('app-dir - errors', () => {
       })
     }
 
-    describe('retry', () => {
+    describe('unstable_retry', () => {
       afterEach(async () => {
         // Always restore __nextTestRecover so it doesn't leak between tests
         await next.fetch('/server-component/recover/set-recover?enabled=false')
       })
 
-      it('should recover Server Component error after retry', async () => {
+      it('should recover Server Component error after unstable_retry', async () => {
         const browser = await next.browser('/server-component/recover')
 
         expect(
@@ -429,7 +429,7 @@ describe('app-dir - errors', () => {
         expect(await browser.elementByCss('#recover').text()).toBe('Recovered')
       })
 
-      it('should recover Client Component error after retry', async () => {
+      it('should recover Client Component error after unstable_retry', async () => {
         const browser = await next.browser('/client-component')
 
         // Try triggering and retrying a few times in a row

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -2353,11 +2353,11 @@
   },
   "test/e2e/app-dir/catch-error/catch-error-react-compiler.test.ts": {
     "passed": [
-      "app-dir - catchError with react compiler should recover Client Component error after reset",
-      "app-dir - catchError with react compiler should recover Client Component error after retry",
-      "app-dir - catchError with react compiler should recover Server Component error after retry",
-      "app-dir - catchError with react compiler should recover after reset on Pages Router",
-      "app-dir - catchError with react compiler should throw when retry is called on Pages Router"
+      "app-dir - unstable_catchError with react compiler should recover Client Component error after reset",
+      "app-dir - unstable_catchError with react compiler should recover Client Component error after unstable_retry",
+      "app-dir - unstable_catchError with react compiler should recover Server Component error after unstable_retry",
+      "app-dir - unstable_catchError with react compiler should recover after reset on Pages Router",
+      "app-dir - unstable_catchError with react compiler should throw when unstable_retry is called on Pages Router"
     ],
     "failed": [],
     "pending": [],
@@ -2366,11 +2366,11 @@
   },
   "test/e2e/app-dir/catch-error/catch-error.test.ts": {
     "passed": [
-      "app-dir - catchError should recover Client Component error after reset",
-      "app-dir - catchError should recover Client Component error after retry",
-      "app-dir - catchError should recover Server Component error after retry",
-      "app-dir - catchError should recover after reset on Pages Router",
-      "app-dir - catchError should throw when retry is called on Pages Router"
+      "app-dir - unstable_catchError should recover Client Component error after reset",
+      "app-dir - unstable_catchError should recover Client Component error after unstable_retry",
+      "app-dir - unstable_catchError should recover Server Component error after unstable_retry",
+      "app-dir - unstable_catchError should recover after reset on Pages Router",
+      "app-dir - unstable_catchError should throw when unstable_retry is called on Pages Router"
     ],
     "failed": [],
     "pending": [],
@@ -3118,8 +3118,8 @@
       "app-dir - errors error component should trigger error component when null is thrown during server components rendering",
       "app-dir - errors error component should trigger error component when undefined is thrown during server components rendering",
       "app-dir - errors error component should use default error boundary for prod and overlay for dev when no error component specified",
-      "app-dir - errors error component retry should recover Client Component error after retry",
-      "app-dir - errors error component retry should recover Server Component error after retry"
+      "app-dir - errors error component unstable_retry should recover Client Component error after unstable_retry",
+      "app-dir - errors error component unstable_retry should recover Server Component error after unstable_retry"
     ],
     "failed": [],
     "pending": [],

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -235,10 +235,10 @@
       "Error overlay - RSC build errors should error when createFactory from react is used in server component",
       "Error overlay - RSC build errors should error when flushSync from react-dom is used in server component",
       "Error overlay - RSC build errors should error when unstable_batchedUpdates from react-dom is used in server component",
-      "Error overlay - RSC build errors should error when catchError from next/error is imported in instrumentation.js",
-      "Error overlay - RSC build errors should error when catchError from next/error is imported in middleware.js",
-      "Error overlay - RSC build errors should error when catchError from next/error is imported in proxy.js",
-      "Error overlay - RSC build errors should error when catchError from next/error is used in a server component",
+      "Error overlay - RSC build errors should error when unstable_catchError from next/error is imported in instrumentation.js",
+      "Error overlay - RSC build errors should error when unstable_catchError from next/error is imported in middleware.js",
+      "Error overlay - RSC build errors should error when unstable_catchError from next/error is imported in proxy.js",
+      "Error overlay - RSC build errors should error when unstable_catchError from next/error is used in a server component",
       "Error overlay - RSC build errors should error when useActionState from react is used in server component",
       "Error overlay - RSC build errors should error when useDeferredValue from react is used in server component",
       "Error overlay - RSC build errors should error when useEffect from react is used in server component",
@@ -4901,11 +4901,11 @@
   },
   "test/e2e/app-dir/catch-error/catch-error-react-compiler.test.ts": {
     "passed": [
-      "app-dir - catchError with react compiler should recover Client Component error after reset",
-      "app-dir - catchError with react compiler should recover Client Component error after retry",
-      "app-dir - catchError with react compiler should recover Server Component error after retry",
-      "app-dir - catchError with react compiler should recover after reset on Pages Router",
-      "app-dir - catchError with react compiler should throw when retry is called on Pages Router"
+      "app-dir - unstable_catchError with react compiler should recover Client Component error after reset",
+      "app-dir - unstable_catchError with react compiler should recover Client Component error after unstable_retry",
+      "app-dir - unstable_catchError with react compiler should recover Server Component error after unstable_retry",
+      "app-dir - unstable_catchError with react compiler should recover after reset on Pages Router",
+      "app-dir - unstable_catchError with react compiler should throw when unstable_retry is called on Pages Router"
     ],
     "failed": [],
     "pending": [],
@@ -4914,11 +4914,11 @@
   },
   "test/e2e/app-dir/catch-error/catch-error.test.ts": {
     "passed": [
-      "app-dir - catchError should recover Client Component error after reset",
-      "app-dir - catchError should recover Client Component error after retry",
-      "app-dir - catchError should recover Server Component error after retry",
-      "app-dir - catchError should recover after reset on Pages Router",
-      "app-dir - catchError should throw when retry is called on Pages Router"
+      "app-dir - unstable_catchError should recover Client Component error after reset",
+      "app-dir - unstable_catchError should recover Client Component error after unstable_retry",
+      "app-dir - unstable_catchError should recover Server Component error after unstable_retry",
+      "app-dir - unstable_catchError should recover after reset on Pages Router",
+      "app-dir - unstable_catchError should throw when unstable_retry is called on Pages Router"
     ],
     "failed": [],
     "pending": [],
@@ -5661,8 +5661,8 @@
       "app-dir - errors error component should trigger error component when null is thrown during server components rendering",
       "app-dir - errors error component should trigger error component when undefined is thrown during server components rendering",
       "app-dir - errors error component should use default error boundary for prod and overlay for dev when no error component specified",
-      "app-dir - errors error component retry should recover Client Component error after retry",
-      "app-dir - errors error component retry should recover Server Component error after retry"
+      "app-dir - errors error component unstable_retry should recover Client Component error after unstable_retry",
+      "app-dir - errors error component unstable_retry should recover Server Component error after unstable_retry"
     ],
     "failed": [],
     "pending": [],


### PR DESCRIPTION
Reverts vercel/next.js#94610

Unblock https://github.com/vercel/next.js/pull/94578