### PR TITLE
[cd] Publish preview release with `@preview` NPM dist-tag

### DIFF
--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -2,16 +2,81 @@
 
 const path = require('path')
 const execa = require('execa')
+const semver = require('semver')
 const { Sema } = require('async-sema')
+const { execSync } = require('child_process')
+const fs = require('fs')
 const { readFile, readdir, writeFile, cp } = require('fs/promises')
 
 const cwd = process.cwd()
 
 ;(async function () {
+  let isCanary = true
+  let isReleaseCandidate = false
+  let isBeta = false
+  let isPreview = false
+
+  try {
+    const tagOutput = execSync(
+      `node ${path.join(__dirname, 'check-is-release.js')}`
+    ).toString()
+    console.log(tagOutput)
+
+    if (tagOutput.trim().startsWith('v')) {
+      isCanary = tagOutput.includes('-canary')
+    }
+    isReleaseCandidate = tagOutput.includes('-rc')
+    isBeta = tagOutput.includes('-beta')
+    isPreview = tagOutput.includes('-preview')
+  } catch (err) {
+    console.log(err)
+
+    if (err.message && err.message.includes('no tag exactly matches')) {
+      console.log('Nothing to publish, exiting...')
+      return
+    }
+    throw err
+  }
+
   try {
     const publishSema = new Sema(2)
 
     let version = require('@next/swc/package.json').version
+
+    let tag = isCanary
+      ? 'canary'
+      : isReleaseCandidate
+        ? 'rc'
+        : isBeta
+          ? 'beta'
+          : isPreview
+            ? 'preview'
+            : 'latest'
+
+    try {
+      if (!isCanary && !isReleaseCandidate && !isBeta && !isPreview) {
+        const version = JSON.parse(
+          await fs.promises.readFile(path.join(cwd, 'lerna.json'), 'utf-8')
+        ).version
+
+        const res = await fetch(
+          `https://registry.npmjs.org/-/package/next/dist-tags`
+        )
+        const tags = await res.json()
+
+        if (semver.lt(version, tags.latest)) {
+          // If the current version is less than the latest, it means this
+          // is a backport release. Since NPM sets the 'latest' tag by default
+          // during publishing, when users install `next@latest`, they might
+          // get the backported version instead of the actual "latest" version.
+          // Therefore, we explicitly set the tag as 'backport' for backports.
+          tag = 'backport'
+        }
+      }
+    } catch (error) {
+      console.log('Failed to fetch Next.js dist tags from the NPM registry.')
+      throw error
+    }
 
     // Copy binaries to package folders, update version, and publish
     let nativePackagesDir = path.join(cwd, 'crates/next-napi-bindings/npm')
@@ -47,7 +112,8 @@ const cwd = process.cwd()
               `${path.join(nativePackagesDir, platform)}`,
               `--access`,
               `public`,
-              ...(version.includes('canary') ? ['--tag', 'canary'] : []),
+              '--tag',
+              tag,
             ],
             { stdio: 'inherit' }
           )

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -18,6 +18,7 @@ const cwd = process.cwd()
   let isCanary = true
   let isReleaseCandidate = false
   let isBeta = false
+  let isPreview = false
 
   try {
     const tagOutput = execSync(
@@ -30,6 +31,7 @@ const cwd = process.cwd()
     }
     isReleaseCandidate = tagOutput.includes('-rc')
     isBeta = tagOutput.includes('-beta')
+    isPreview = tagOutput.includes('-preview')
   } catch (err) {
     console.log(err)
 
@@ -46,10 +48,12 @@ const cwd = process.cwd()
       ? 'rc'
       : isBeta
         ? 'beta'
-        : 'latest'
+        : isPreview
+          ? 'preview'
+          : 'latest'
 
   try {
-    if (!isCanary && !isReleaseCandidate && !isBeta) {
+    if (!isCanary && !isReleaseCandidate && !isBeta && !isPreview) {
       const version = JSON.parse(
         await fs.promises.readFile(path.join(cwd, 'lerna.json'), 'utf-8')
       ).version


### PR DESCRIPTION
I don't know why the publish native script drifted so much. But at a glance, it seemed like it only handled publish `@latest` and `@canary` i.e. a preview release would've published native binaries `@latest`.

Forgot https://github.com/vercel/next.js/pull/84725

## test plan

```console
$ git commit --allow-empty -m 'v16.3.0-preview.1'
$ node scripts/publish-release.js
Publishing as "preview" dist tag...
```