### PR TITLE
[cd] Ensure wasm binaries get tagged properly

### DIFF
--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -171,7 +171,8 @@ const cwd = process.cwd()
               `${path.join(wasmDir, `pkg-${wasmTarget}`)}`,
               '--access',
               'public',
-              ...(version.includes('canary') ? ['--tag', 'canary'] : []),
+              '--tag',
+              tag,
             ],
             { stdio: 'inherit' }
           )


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/94619