### PR TITLE
[cd] Allow tagging semver-lower releases as `@latest` if `@latest` points at a prerelease

### DIFF
--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -65,7 +65,10 @@ const cwd = process.cwd()
         // during publishing, when users install `next@latest`, they might
         // get the backported version instead of the actual "latest" version.
         // Therefore, we explicitly set the tag as 'backport' for backports.
-        tag = 'backport'
+        // But force @latest tag if we accidentally tagged a prerelase as latest
+        if (!semver.prerelease(tags.latest)) {
+          tag = 'backport'
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
`@latest` pointing at a prerelease is always a mistake so subsequent stable release should automatically get `@latest`.

`publish-native` already overwrites (which will be fixed in https://github.com/vercel/next.js/pull/94319)

## test plan

```
$ git commit --allow-empty -m 'v16.2.9'
$ node scripts/publish-release.js
v16.2.9

Publishing as "latest" dist tag...
```