### PR TITLE
Fix PPR resume metadata tree mismatch for bot user agents

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -330,6 +330,31 @@ import { RENDER_STAGES_BY_DATA_KIND } from '../dynamic-rendering-utils'
 import type { ValidationPrefetchKind } from './instant-validation/instant-validation'
 import { hasNonRootStaticParams } from '../lib/params-utils'
 
+/**
+ * Determines whether streaming metadata should be served for this render.
+ *
+ * The metadata component tree has a different shape depending on whether
+ * streaming metadata is enabled (see `createMetadataComponents`). Prerenders
+ * always render with streaming metadata enabled (`serveStreamingMetadata` is
+ * set to `true` during build/export), so a render that resumes a postponed
+ * prerender must also render with it enabled — regardless of the requesting
+ * user agent — or React will detect a tree mismatch ("Expected the resume to
+ * render <div> in this slot but instead it rendered
+ * <__next_metadata_boundary__>") and fall back to client rendering.
+ *
+ * The user-agent based opt-out (HTML-limited bots receive blocking metadata)
+ * only applies to renders that produce the whole document in a single pass.
+ */
+function getServeStreamingMetadata(
+  renderOpts: Pick<RenderOpts, 'serveStreamingMetadata' | 'postponed'>
+): boolean {
+  if (typeof renderOpts.postponed === 'string') {
+    return true
+  }
+
+  return !!renderOpts.serveStreamingMetadata
+}
+
 export type GetDynamicParamFromSegment = (
   // The LoaderTree to extract the dynamic param from
   loaderTree: LoaderTree
@@ -685,7 +710,7 @@ async function generateDynamicRSCPayload(
     url,
   } = ctx
 
-  const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
+  const serveStreamingMetadata = getServeStreamingMetadata(ctx.renderOpts)
 
   if (!options?.skipPageRendering) {
     const preloadCallbacks: PreloadCallbacks = []
@@ -2096,7 +2121,7 @@ async function getRSCPayload(
     getDynamicParamFromSegment,
     query
   )
-  const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
+  const serveStreamingMetadata = getServeStreamingMetadata(ctx.renderOpts)
   const hasGlobalNotFound = !!tree[2]['global-not-found']
 
   const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
@@ -2249,7 +2274,7 @@ async function getErrorRSCPayload(
   let Viewport: ComponentType | null = null
   let Metadata: ComponentType | null = null
   if (shouldRenderMetadataAndViewport) {
-    const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
+    const serveStreamingMetadata = getServeStreamingMetadata(ctx.renderOpts)
     const metadataComponents = createMetadataComponents({
       tree,
       parsedQuery: query,

--- a/test/production/standalone-mode/ppr-resume-bot-metadata/app/dynamic/loading.js
+++ b/test/production/standalone-mode/ppr-resume-bot-metadata/app/dynamic/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>loading...</p>
+}

--- a/test/production/standalone-mode/ppr-resume-bot-metadata/app/dynamic/page.js
+++ b/test/production/standalone-mode/ppr-resume-bot-metadata/app/dynamic/page.js
@@ -1,0 +1,24 @@
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  // Dynamic metadata: resolved during the resume, not the prerender.
+  await connection()
+
+  return {
+    title: 'dynamic-metadata-title',
+  }
+}
+
+export default async function Page() {
+  // Dynamic at the top level of the page (no Suspense boundary): the whole
+  // segment, including the metadata slot rendered adjacent to it, is part of
+  // the postponed hole instead of the static shell.
+  const store = await cookies()
+
+  return (
+    <main>
+      <p id="content">dynamic content {store.size}</p>
+    </main>
+  )
+}

--- a/test/production/standalone-mode/ppr-resume-bot-metadata/app/layout.js
+++ b/test/production/standalone-mode/ppr-resume-bot-metadata/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/standalone-mode/ppr-resume-bot-metadata/ppr-resume-bot-metadata.test.ts
+++ b/test/production/standalone-mode/ppr-resume-bot-metadata/ppr-resume-bot-metadata.test.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs/promises'
+import { join } from 'node:path'
+import { ChildProcess } from 'node:child_process'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import {
+  fetchViaHTTP,
+  findPort,
+  initNextServerScript,
+  killApp,
+  withInvocationId,
+} from 'next-test-utils'
+
+const GOOGLEBOT_UA =
+  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+
+const TWITTERBOT_UA = 'Twitterbot/1.0'
+
+// Regression test for the PPR resume metadata tree mismatch: a resume must
+// render the same metadata tree shape as the prerender that postponed it,
+// regardless of the requesting user agent. Previously, bot user agents forced
+// `serveStreamingMetadata` to `false` during the resume while the prerender
+// rendered with it enabled, causing:
+//   "Expected the resume to render <div> in this slot but instead it
+//    rendered <__next_metadata_boundary__>."
+// and a fallback to client rendering.
+describe('ppr-resume-bot-metadata', () => {
+  let server: ChildProcess
+  let appPort: number | string
+  let dynamicPostpone: string
+  let cliOutput = ''
+
+  beforeAll(() => {
+    process.env.NOW_BUILDER = '1'
+    process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
+  })
+
+  const { next } = nextTestSetup({
+    files: {
+      app: new FileRef(join(__dirname, 'app')),
+    },
+    nextConfig: {
+      cacheComponents: true,
+      output: 'standalone',
+    },
+  })
+
+  beforeAll(async () => {
+    // Stop the server, we're going to restart it using the standalone server
+    // in minimal mode below.
+    await next.stop()
+
+    // Read the postponed state that was generated at build time.
+    dynamicPostpone = (await next.readJSON('.next/server/app/dynamic.meta'))
+      .postponed
+
+    if (typeof dynamicPostpone !== 'string') {
+      throw new Error(
+        'invariant: expected the build to generate postponed state for /dynamic'
+      )
+    }
+
+    await fs.rename(
+      join(next.testDir, '.next/standalone'),
+      join(next.testDir, 'standalone')
+    )
+
+    const serverFilePath = join(next.testDir, 'standalone/server.js')
+
+    // We're going to use the minimal mode for the server, which is how the
+    // server runs when deployed: the platform serves the static shell from
+    // its cache and invokes the server only to resume the postponed state.
+    await fs.writeFile(
+      serverFilePath,
+      (await fs.readFile(serverFilePath, 'utf8')).replace(
+        'port:',
+        `minimalMode: true, port:`
+      )
+    )
+
+    appPort = await findPort()
+
+    server = await initNextServerScript(
+      serverFilePath,
+      /- Local:/,
+      {
+        ...process.env,
+        ...next.env,
+        __NEXT_TEST_MODE: 'e2e',
+        PORT: `${appPort}`,
+      },
+      undefined,
+      {
+        cwd: next.testDir,
+        onStderr(data) {
+          cliOutput += data
+        },
+        onStdout(data) {
+          cliOutput += data
+        },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    delete process.env.NOW_BUILDER
+    delete process.env.NEXT_PRIVATE_TEST_HEADERS
+    if (server) await killApp(server)
+  })
+
+  it.each([
+    ['a browser', undefined],
+    // DOM bots (resolves `getBotType()` to 'dom').
+    ['Googlebot', GOOGLEBOT_UA],
+    // HTML-limited bots (resolves `getBotType()` to 'html').
+    ['Twitterbot', TWITTERBOT_UA],
+  ])(
+    'should resume without a metadata tree mismatch for %s',
+    async (_label, userAgent) => {
+      const before = cliOutput.length
+
+      const res = await fetchViaHTTP(
+        appPort,
+        '/dynamic',
+        undefined,
+        withInvocationId({
+          headers: {
+            'x-matched-path': '/dynamic',
+            'next-resume': '1',
+            ...(userAgent ? { 'user-agent': userAgent } : {}),
+          },
+          method: 'POST',
+          body: dynamicPostpone,
+        })
+      )
+
+      expect(res.status).toBe(200)
+
+      const html = await res.text()
+
+      // The dynamic content must be rendered into the resumed HTML rather
+      // than deferred to client rendering.
+      expect(html).toContain('dynamic content')
+      expect(html).toContain('dynamic-metadata-title')
+
+      // React must not have bailed out of the resume.
+      expect(cliOutput.slice(before)).not.toContain(
+        'Expected the resume to render'
+      )
+    }
+  )
+})


### PR DESCRIPTION
### Fixing a bug

- Related issues: fixes #93401, fixes #93370
- Tests added: `test/production/standalone-mode/ppr-resume-bot-metadata`

## What

Requests from bot user agents to PPR-enabled routes fail to resume the postponed state and fall back to client rendering:

```
Error: Expected the resume to render <div> in this slot but instead it rendered <__next_metadata_boundary__>. The tree doesn't match so React will fallback to client rendering.
```

This happens in production (minimal mode) with the **default config** — no `htmlLimitedBots` override needed — for any recognized bot (Googlebot as a DOM bot, Twitterbot/Bingbot/etc. as HTML-limited bots). The result is that the dynamic content is deferred to client rendering for exactly the requests that need server-rendered HTML the most (crawlers), while regular browser requests are unaffected.

## Why

A resume must produce the exact tree shape that the prerender postponed. Prerenders always render with streaming metadata enabled (`serveStreamingMetadata` is set to `true` during build/export), and the metadata component tree has a different shape depending on that flag — the streaming variant wraps the metadata boundary in a `<div hidden>` (`createMetadataComponents`).

The route handler however forces the flag to `false` for any bot user agent on a PPR-enabled route:

```js
// packages/next/src/build/templates/app-page.ts
const serveStreamingMetadata =
  botType && isRoutePPREnabled
    ? false
    : ...
```

The intended behavior for bots on PPR routes is a single-pass blocking render (`shouldWaitOnAllReady`), which works when the server controls the whole response. In minimal mode however the platform serves the prerendered shell from its cache and only invokes the server to resume the postponed state — so the bot opt-out is applied to one half of a render whose other half was produced with streaming metadata enabled. When the page is dynamic at the segment level, the metadata slot is part of the postponed hole, and the resume renders `<MetadataBoundary>` where the postponed state expects the `<div>`.

The same mismatch is reproducible with a custom `htmlLimitedBots` config that matches browser user agents (#93401, #93370) — that path is also covered by this fix for resumes.

## How

When `renderOpts.postponed` is present (i.e. the render is a resume), always render with streaming metadata enabled, matching the prerender that produced the postponed state. The user-agent based opt-out still applies to single-pass renders.

The added test builds a `cacheComponents` app with a dynamic page and dynamic `generateMetadata`, runs the standalone server in minimal mode, and replays the build-time postponed state with `Next-Resume`. Before the fix, the Googlebot and Twitterbot cases fail with the tree mismatch above; the browser case passes:

```
✓ should resume without a metadata tree mismatch for a browser
✕ should resume without a metadata tree mismatch for Googlebot
✕ should resume without a metadata tree mismatch for Twitterbot
```

After the fix all three pass.