### PR TITLE
instant: build fix-card Copy AI prompt dynamically from title + link

### DIFF
--- a/.agents/skills/insight-error-page/SKILL.md
+++ b/.agents/skills/insight-error-page/SKILL.md
@@ -95,8 +95,8 @@ kind: insight
 - `title` = card title from framework, **verbatim**. If it reads awkward as a heading, change the framework first — never the docs.
 - `href` = `#` + the auto-slug of the title (e.g. "Generate on every request" → `#generate-on-every-request`). This must match what the heading auto-generates.
 - `group` = card group from framework (`dynamic`, `cache`, `client`, `stream`, `defer`, `measure`, `block`, `render`, `silence`).
-- `prompt` = AI-agent prompt. Single line, no rendered markdown. The user copies this to the clipboard via the Copy AI prompt button to paste into their agent. It is read by an agent acting on the user's behalf, so guardrail phrasing like `Confirm with the user that ...` is fine here — it tells the agent to verify intent before applying an irreversible or surprising change. Keep prompts directive and specific ("Add X. Do not do Y."). Do not add cross-fix comparisons ("If the user wants X, choose Y instead") — by the time the agent reads the prompt the user has already clicked this card.
 - Children = one-sentence plain-prose summary. **No inline code**, no API names in backticks, no snippets. Save technical detail for the section body.
+- **No `prompt` prop.** The "Copy AI prompt" button builds the prompt dynamically at click time from the page URL and the card's `title` + `href`. The agent receives a prompt that points at the rule docs and names the fix — it then reads the docs page (the same one the user is on) for every constraint and code shape. That is why this skill exists: the docs page itself **is** the prompt's source of truth.
 
 ### `## <Fix>` sections
 
@@ -142,7 +142,7 @@ kind: insight
 
 When the framework card set includes `instant = false` (group `block`), use the canonical `## Allow blocking route` section shape. All pages with this fix must match. Cross-page consistency matters — diverging from this shape produces a page that reads like an outlier.
 
-**Intro**: One paragraph explaining what setting `instant` to `false` does and what the trade-off is. Optional second paragraph noting when this is _rarely_ the right answer (for example, on client-hook or cache fixes where a Suspense boundary is almost always feasible). Phrase the rarity directly. Do not write `Confirm with the user` in body prose — that phrasing belongs in `prompt={...}` agent strings, not in the page the user reads.
+**Intro**: One paragraph explaining what setting `instant` to `false` does and what the trade-off is. Optional second paragraph noting when this is _rarely_ the right answer (for example, on client-hook or cache fixes where a Suspense boundary is almost always feasible). Phrase the rarity directly.
 
 **Patterns**: For page-body errors (runtime data, uncached data, client hooks), use both `#### Opt the page out` and `#### Opt the layout out`. For viewport errors, use only `#### Opt the layout out` (viewport always lives on a layout). Each pattern has:
 
@@ -160,7 +160,7 @@ After the pattern snippets, include a "Use either pattern when:" bulleted list (
 - This export does not disable prerendering. The route still prerenders if it can. It only silences the instant-navigation validation error.
 - Page-specific gotchas (for example, viewport pages add framework-synthesized routes gotcha) come after the two canonical bullets.
 
-**Never** add a gotcha that says `Confirm with the user that ...` in user-facing body prose. That phrasing is agent-prompt voice and belongs in `prompt={...}` strings, not in gotchas or trade-offs the user reads on the page.
+**Never** add a gotcha that says `Confirm with the user that ...` in user-facing body prose. The page is what the user reads — write for them, not for the agent. Guardrails the agent should apply belong in the actual code-shape guidance under the `### Patterns` heading (which the agent reads via the docs link in the copied prompt).
 
 ### Don't want this validation?
 
@@ -199,12 +199,12 @@ When auditing an existing page, check every item:
 - [ ] Every `<FixOption>` `title` = card title verbatim
 - [ ] Every `<FixOption>` `href` = auto-slug of the heading
 - [ ] Every `<FixOption>` `group` matches framework card group
-- [ ] Every `<FixOption>` has a `prompt` prop (AI-agent prompt, single line)
+- [ ] No `prompt` prop on any `<FixOption>` — the copy button generates the prompt from `title` + `href` + the page URL
 - [ ] `<FixOption>` children: plain prose, no backticks, no inline code
 - [ ] Every `## <Fix>` heading = card title verbatim
 - [ ] Every fix section has `### Patterns`, `### Trade-off`, `### Gotchas`
 - [ ] No "Default." labels on patterns
-- [ ] No `Confirm with the user ...` phrasing in user-facing body prose (intro paragraphs, Trade-off, Gotchas). It belongs in `prompt={...}` agent strings, not on the page the reader sees.
+- [ ] No `Confirm with the user ...` phrasing anywhere in the page. The page is for the user; the agent reads the same page via the docs link in the copied prompt.
 - [ ] If the page has `## Allow blocking route`, it matches the canonical shape: patterns (page-body errors use both Opt the page out + Opt the layout out; viewport errors use Opt the layout out only), "Use either pattern when" list, "Don't use this to dismiss the error" closer, canonical 2-bullet Gotchas
 - [ ] Code snippets are valid React (no inline `Math.random()` during render in Client Components)
 - [ ] `useState(() => Math.random())` warned against in Gotchas

--- a/errors/blocking-prerender-client-hook.mdx
+++ b/errors/blocking-prerender-client-hook.mdx
@@ -16,7 +16,6 @@ Server-side request-bound reads ([`cookies()`](/docs/app/api-reference/functions
 <FixOption
   group="stream"
   href="#wrap-in-or-move-into-suspense"
-  prompt={`Wrap the component that calls the navigation hook in <Suspense>. The fallback prop must render synchronous, deterministic JSX (no fetch, no awaiting, no Math.random or Date.now) that approximates the final layout. Import Suspense from "react". Do not change the hook call itself. Place the Suspense boundary as close to the hook call as possible so the rest of the route stays in the prerendered static shell.`}
   title="Wrap in or move into Suspense"
 >
   Wrap the component that calls the hook in a Suspense boundary so Next.js can
@@ -26,7 +25,6 @@ Server-side request-bound reads ([`cookies()`](/docs/app/api-reference/functions
 <FixOption
   group="cache"
   href="#for-known-params-prerender"
-  prompt={`Add a generateStaticParams() export to the page or layout that defines the dynamic segment. Return an array of param objects whose keys match the segment's [param] names. On the generated paths, useParams resolves to a build-time constant, and usePathname and useSelectedLayoutSegment(s) (which derive from the URL path) also resolve without needing a Suspense boundary. Does not help useSearchParams, since search params come from the request URL's query string and are not part of segment params. Do not introduce new imports beyond Next.js types. If you can't return at least one known param at build time, use "Wrap in or move into Suspense" instead.`}
   title="For known params, prerender"
 >
   Tell Next.js the full set of valid params ahead of time. Each one becomes a
@@ -36,7 +34,6 @@ Server-side request-bound reads ([`cookies()`](/docs/app/api-reference/functions
 <FixOption
   group="block"
   href="#allow-blocking-route"
-  prompt={`Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally request-time before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request, so navigations to it block until the render completes.`}
   title="Allow blocking route"
 >
   Opt the segment out of instant-navigation validation. The route renders on

--- a/errors/blocking-prerender-crypto-client.mdx
+++ b/errors/blocking-prerender-crypto-client.mdx
@@ -14,7 +14,6 @@ The Server Component case is handled at [Crypto APIs during prerendering](/docs/
 <FixOption
   group="stream"
   href="#wrap-in-or-move-into-suspense"
-  prompt={`Wrap the Client Component that calls the crypto API in <Suspense> in its parent. The fallback prop must render synchronous, deterministic JSX that approximates the final layout. Import Suspense from "react". Do not change the crypto call.`}
   title="Wrap in or move into Suspense"
 >
   Wrap the component in a Suspense boundary so the shell ships instantly and the
@@ -24,7 +23,6 @@ The Server Component case is handled at [Crypto APIs during prerendering](/docs/
 <FixOption
   group="defer"
   href="#move-into-effect-or-event-handler"
-  prompt={`Move the crypto call out of the inline render path and into useEffect (for first-paint values) or an event handler (for interaction values). Initialize state to a deterministic value so SSR and the first hydrated render agree. Do not introduce new imports beyond "react".`}
   title="Move into effect or event handler"
 >
   Defer the crypto call until after hydration so SSR and the browser agree on

--- a/errors/blocking-prerender-crypto.mdx
+++ b/errors/blocking-prerender-crypto.mdx
@@ -14,7 +14,6 @@ Other unpredictable APIs ([`Math.random()`](https://developer.mozilla.org/en-US/
 <FixOption
   group="dynamic"
   href="#generate-on-every-request"
-  prompt={`Add "await connection()" from "next/server" immediately before the crypto call. This marks the component as request-time, so Next.js excludes it from the prerendered HTML and streams it in from the nearest <Suspense> boundary on each request. Do not change the crypto call itself. Only change the call site once you've confirmed with the user that a fresh value on every request is the intent.`}
   title="Generate on every request"
 >
   Mark the component as request-time so a fresh token is produced for each
@@ -24,7 +23,6 @@ Other unpredictable APIs ([`Math.random()`](https://developer.mozilla.org/en-US/
 <FixOption
   group="cache"
   href="#cache-the-generated-value"
-  prompt={`Move the crypto call into its own function and add "use cache" as the first statement. Useful when the same generated value is reused as a key for another cached operation (talking to a database, signing a payload). Do not introduce new imports beyond "next/cache".`}
   title="Cache the generated value"
 >
   Generate one value at build time and reuse it. Useful when the value is a key
@@ -34,7 +32,6 @@ Other unpredictable APIs ([`Math.random()`](https://developer.mozilla.org/en-US/
 <FixOption
   group="client"
   href="#render-on-the-client"
-  prompt={`Move the component that calls the crypto API into a Client Component by adding "use client" at the top of the file. The browser produces the value, so the server never has to. If the value needs to be hydration-stable, compute it inside useEffect instead of inline during render.`}
   title="Render on the client"
 >
   Move the call into a Client Component. The browser produces the random value.

--- a/errors/blocking-prerender-current-time-client.mdx
+++ b/errors/blocking-prerender-current-time-client.mdx
@@ -14,7 +14,6 @@ The Server Component case is handled at [`Date.now()` during prerendering](/docs
 <FixOption
   group="stream"
   href="#wrap-in-or-move-into-suspense"
-  prompt={`Wrap the Client Component that calls Date.now() in <Suspense> in its parent. The fallback prop must render synchronous, deterministic JSX (no Date.now or Math.random) that approximates the final layout. Import Suspense from "react". Do not change the Date.now() call.`}
   title="Wrap in or move into Suspense"
 >
   Wrap the component in a Suspense boundary so the shell ships instantly and the
@@ -24,7 +23,6 @@ The Server Component case is handled at [`Date.now()` during prerendering](/docs
 <FixOption
   group="defer"
   href="#move-into-effect-or-event-handler"
-  prompt={`Move the Date.now() call out of the inline render path and into useEffect (for first-paint values) or an event handler (for interaction values). Initialize state to a deterministic value so SSR and the first hydrated render agree. Do not introduce new imports beyond "react".`}
   title="Move into effect or event handler"
 >
   Defer the timestamp read until after hydration so SSR and the browser agree on
@@ -34,7 +32,6 @@ The Server Component case is handled at [`Date.now()` during prerendering](/docs
 <FixOption
   group="measure"
   href="#for-telemetry-use-a-timing-api"
-  prompt={`Replace Date.now() with performance.now() if the value is used for elapsed-time measurement, instrumentation, or telemetry. performance.now() returns a high-resolution monotonic timestamp and does not interfere with prerendering. Do not change the call if the value is rendered into the UI.`}
   title="For telemetry, use a timing API"
 >
   When the timestamp is only used for measuring durations, switch to

--- a/errors/blocking-prerender-current-time.mdx
+++ b/errors/blocking-prerender-current-time.mdx
@@ -14,7 +14,6 @@ Other unpredictable APIs ([`Math.random()`](https://developer.mozilla.org/en-US/
 <FixOption
   group="dynamic"
   href="#generate-on-every-request"
-  prompt={`Add "await connection()" from "next/server" immediately before the Date.now() call. This marks the component as request-time, so Next.js excludes it from the prerendered HTML and streams it in from the nearest <Suspense> boundary on each request. Do not change the call site of Date.now() itself. Only change the call site once you've confirmed with the user that a fresh value on every request is the intent.`}
   title="Generate on every request"
 >
   Mark the component as request-time so the timestamp is recomputed each time
@@ -24,7 +23,6 @@ Other unpredictable APIs ([`Math.random()`](https://developer.mozilla.org/en-US/
 <FixOption
   group="cache"
   href="#cache-the-timestamp"
-  prompt={`Move the Date.now() call into its own function and add "use cache" as the first statement. Optionally call cacheLife(profile) to control how often the timestamp is regenerated. Do not introduce new imports beyond "next/cache".`}
   title="Cache the timestamp"
 >
   Capture one timestamp per cache window and reuse it. The route stays
@@ -34,7 +32,6 @@ Other unpredictable APIs ([`Math.random()`](https://developer.mozilla.org/en-US/
 <FixOption
   group="client"
   href="#render-on-the-client"
-  prompt={`Move the component that calls Date.now() into a Client Component by adding "use client" at the top of the file. If the value needs to be hydration-stable, compute it inside useEffect instead of inline during render.`}
   title="Render on the client"
 >
   Move the call into a Client Component. The browser produces the timestamp on
@@ -44,7 +41,6 @@ Other unpredictable APIs ([`Math.random()`](https://developer.mozilla.org/en-US/
 <FixOption
   group="measure"
   href="#for-telemetry-use-a-timing-api"
-  prompt={`Replace Date.now() with performance.now() if the value is used for elapsed-time measurement, instrumentation, or telemetry. performance.now() returns a high-resolution monotonic timestamp and does not interfere with prerendering. Do not change the call if the value is rendered into the UI.`}
   title="For telemetry, use a timing API"
 >
   When the timestamp is only used for measuring durations, switch to

--- a/errors/blocking-prerender-dynamic.mdx
+++ b/errors/blocking-prerender-dynamic.mdx
@@ -16,7 +16,6 @@ This error can also appear during a client-side navigation when the data access 
 <FixOption
   group="cache"
   href="#cache-the-component-or-data"
-  prompt={`Convert the highlighted data access into a cached function. Put "use cache" as the first statement of the function body. If the value depends on input that changes between calls, accept the input as a function argument so it becomes part of the cache key. Optionally call cacheTag(tag) so the entry can be invalidated on-demand from a Server Action via updateTag(tag), or from a Route Handler via revalidateTag(tag, "max") for stale-while-revalidate semantics. Optionally call cacheLife(profile) to control how long the cache lives before background revalidation or full expiration. Do not move the call site. Do not introduce new imports beyond "next/cache".`}
   title="Cache the component or data"
 >
   Move the data access into a cached function so the result is reused and the
@@ -26,7 +25,6 @@ This error can also appear during a client-side navigation when the data access 
 <FixOption
   group="stream"
   href="#wrap-in-or-move-into-suspense"
-  prompt={`Wrap the component that performs the failing data access in <Suspense>. The fallback prop must render synchronous, deterministic JSX (no fetch, no awaiting, no Math.random or Date.now) that approximates the final layout (skeleton, spinner, or stable placeholder text). Import Suspense from "react". Do not change the data fetching logic. If the surrounding parent component already has cached content, place the Suspense boundary as close to the data access as possible so the cached content remains in the static shell.`}
   title="Wrap in or move into Suspense"
 >
   Wrap the data-accessing component in a Suspense boundary. The shell ships
@@ -36,7 +34,6 @@ This error can also appear during a client-side navigation when the data access 
 <FixOption
   group="block"
   href="#allow-blocking-route"
-  prompt={`Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally request-time before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request, so navigations to it block until the render completes.`}
   title="Allow blocking route"
 >
   Opt this segment out of instant navigation. The route has no static shell and

--- a/errors/blocking-prerender-metadata-dynamic.mdx
+++ b/errors/blocking-prerender-metadata-dynamic.mdx
@@ -15,12 +15,7 @@ For errors in the page body rather than metadata, see [Next.js encountered uncac
 
 ## Ways to fix this
 
-<FixOption
-  group="cache"
-  href="#cache-the-metadata"
-  prompt={`Add "use cache" as the first statement inside generateMetadata(). This caches the metadata so it can be included in the prerender. Optionally call cacheTag(tag) so the entry can be invalidated on-demand from a Server Action via updateTag(tag), or from a Route Handler via revalidateTag(tag, "max") for stale-while-revalidate semantics. Optionally call cacheLife(profile) to control how long the cache lives before background revalidation or full expiration. Do not introduce new imports beyond "next/cache".`}
-  title="Cache the metadata"
->
+<FixOption group="cache" href="#cache-the-metadata" title="Cache the metadata">
   Cache the metadata function so the result is reused and the route stays
   prerenderable.
 </FixOption>
@@ -28,7 +23,6 @@ For errors in the page body rather than metadata, see [Next.js encountered uncac
 <FixOption
   group="dynamic"
   href="#mark-the-route-as-dynamic"
-  prompt={`Add "await connection()" from "next/server" inside a component rendered by the page, wrapped in <Suspense>. The component can render null. This creates a dynamic hole inside Suspense so the rest of the page can still prerender, while signalling to Next.js that the dynamic metadata is intentional. Use this fix when the page would otherwise have no dynamic content other than the metadata.`}
   title="Mark the route as dynamic"
 >
   Tell Next.js the page itself has dynamic content, so the dynamic metadata is

--- a/errors/blocking-prerender-metadata-runtime.mdx
+++ b/errors/blocking-prerender-metadata-runtime.mdx
@@ -18,7 +18,6 @@ For errors in the page body rather than metadata, see [Next.js encountered runti
 <FixOption
   group="static"
   href="#use-static-metadata"
-  prompt={`Replace the generateMetadata() function with a static metadata export. Convert all dynamic values to static strings. If the metadata depends on params, use generateStaticParams instead to prerender each variant. Do not introduce new imports.`}
   title="Use static metadata"
 >
   Replace the dynamic function with a static export so the metadata is known at
@@ -28,7 +27,6 @@ For errors in the page body rather than metadata, see [Next.js encountered runti
 <FixOption
   group="dynamic"
   href="#mark-the-route-as-dynamic"
-  prompt={`Add "await connection()" from "next/server" inside a component rendered by the page, wrapped in <Suspense>. The component can render null. This creates a dynamic hole inside Suspense so the rest of the page can still prerender, while signalling to Next.js that the dynamic metadata is intentional. Use this fix when the page would otherwise have no dynamic content other than the metadata.`}
   title="Mark the route as dynamic"
 >
   Tell Next.js the page itself has dynamic content, so the dynamic metadata is

--- a/errors/blocking-prerender-random-client.mdx
+++ b/errors/blocking-prerender-random-client.mdx
@@ -14,7 +14,6 @@ The Server Component case is handled at [`Math.random()` during prerendering](/d
 <FixOption
   group="stream"
   href="#wrap-in-or-move-into-suspense"
-  prompt={`Wrap the Client Component that calls Math.random() in <Suspense> in its parent. The fallback prop must render synchronous, deterministic JSX (no Math.random or Date.now) that approximates the final layout (skeleton, spinner, or stable placeholder text). Import Suspense from "react". Do not change the Math.random() call.`}
   title="Wrap in or move into Suspense"
 >
   Wrap the component in a Suspense boundary so the shell ships instantly and the
@@ -24,7 +23,6 @@ The Server Component case is handled at [`Math.random()` during prerendering](/d
 <FixOption
   group="defer"
   href="#move-into-effect-or-event-handler"
-  prompt={`Move the Math.random() call out of the inline render path and into useEffect (for first-paint values) or an event handler (for interaction values). Initialize state to a deterministic value so SSR and the first hydrated render agree. Do not introduce new imports beyond "react".`}
   title="Move into effect or event handler"
 >
   Defer the random read until after hydration so SSR and the browser agree on

--- a/errors/blocking-prerender-random.mdx
+++ b/errors/blocking-prerender-random.mdx
@@ -14,7 +14,6 @@ Other unpredictable APIs ([`Date.now()`](https://developer.mozilla.org/en-US/doc
 <FixOption
   group="dynamic"
   href="#generate-on-every-request"
-  prompt={`Add "await connection()" from "next/server" immediately before the Math.random() call. This marks the component as request-time, so Next.js excludes it from the prerendered HTML and streams it in from the nearest <Suspense> boundary on each request. Do not change the call site of Math.random() itself. Only change the call site once you've confirmed with the user that a fresh value on every request is the intent.`}
   title="Generate on every request"
 >
   Mark the component as request-time so the random value is generated each time
@@ -24,7 +23,6 @@ Other unpredictable APIs ([`Date.now()`](https://developer.mozilla.org/en-US/doc
 <FixOption
   group="cache"
   href="#cache-the-random-value"
-  prompt={`Move the Math.random() call into its own function or component and add "use cache" as the first statement of the body. Optionally call cacheLife(profile) to control how long the same random value is reused before regeneration. Do not introduce new imports beyond "next/cache".`}
   title="Cache the random value"
 >
   Generate one random value at build time and reuse it. The route stays
@@ -34,7 +32,6 @@ Other unpredictable APIs ([`Date.now()`](https://developer.mozilla.org/en-US/doc
 <FixOption
   group="client"
   href="#render-on-the-client"
-  prompt={`Move the component that calls Math.random() into a Client Component by adding "use client" at the top of the file. The browser produces a fresh value on each visit. If the value needs to be hydration-stable, compute it inside a useEffect or event handler instead of inline during render.`}
   title="Render on the client"
 >
   Move the call into a Client Component. The browser produces the random value,

--- a/errors/blocking-prerender-runtime.mdx
+++ b/errors/blocking-prerender-runtime.mdx
@@ -16,7 +16,6 @@ This error can also appear during a client-side navigation when the data access 
 <FixOption
   group="stream"
   href="#wrap-in-or-move-into-suspense"
-  prompt={`Wrap the component that reads cookies(), headers(), params, or searchParams in <Suspense>. The fallback prop must render synchronous, deterministic JSX (no fetch, no awaiting, no Math.random or Date.now) that approximates the final layout (skeleton, spinner, or stable placeholder text). Import Suspense from "react". Do not change the data access call. Place the Suspense boundary as close to the access as possible so the cached content above remains in the static shell. If the access is deep in a tree and used for a small piece of UI, prefer to push the access down to the leaf component that needs it instead of awaiting it at the top and forwarding the value.`}
   title="Wrap in or move into Suspense"
 >
   Wrap the component that reads the request-time value in a Suspense boundary,
@@ -26,7 +25,6 @@ This error can also appear during a client-side navigation when the data access 
 <FixOption
   group="cache"
   href="#for-known-params-prerender"
-  prompt={`Add a generateStaticParams() export to the dynamic segment. Return an array of param objects whose keys match the segment's [param] names. Each entry is prerendered into static HTML at build time. With Cache Components, requests for params not in the list are served a fallback shell and the route is upgraded in the background. Return a subset of known params for common routes (popular categories, top locales, recent slugs); rare or open-ended params will fall back at runtime. Do not introduce new imports beyond Next.js types. If you can't return at least one known param at build time, use "Wrap in or move into Suspense" instead.`}
   title="For known params, prerender"
 >
   Tell Next.js the full set of valid params ahead of time. Each one becomes a
@@ -36,7 +34,6 @@ This error can also appear during a client-side navigation when the data access 
 <FixOption
   group="block"
   href="#allow-blocking-route"
-  prompt={`Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally request-time before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request, so navigations to it block until the render completes.`}
   title="Allow blocking route"
 >
   Opt this segment out of instant navigation. The route has no static shell and

--- a/errors/blocking-prerender-viewport-dynamic.mdx
+++ b/errors/blocking-prerender-viewport-dynamic.mdx
@@ -14,7 +14,6 @@ Request-bound reads ([`cookies()`](/docs/app/api-reference/functions/cookies), [
 <FixOption
   group="cache"
   href="#cache-the-viewport-data"
-  prompt={`Add "use cache" as the first statement inside generateViewport(). This caches the viewport so Next.js can include it in the prerender. Optionally call cacheLife(profile) to set automatic expiration. Do not introduce new imports beyond "next/cache".`}
   title="Cache the viewport data"
 >
   Cache the viewport function so the result is reused and the route stays
@@ -24,7 +23,6 @@ Request-bound reads ([`cookies()`](/docs/app/api-reference/functions/cookies), [
 <FixOption
   group="block"
   href="#allow-blocking-route"
-  prompt={`Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally fully dynamic before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request.`}
   title="Allow blocking route"
 >
   Opt this segment out of instant navigation. The route renders on every request

--- a/errors/blocking-prerender-viewport-runtime.mdx
+++ b/errors/blocking-prerender-viewport-runtime.mdx
@@ -14,7 +14,6 @@ Uncached data accesses ([`fetch()`](https://developer.mozilla.org/en-US/docs/Web
 <FixOption
   group="static"
   href="#use-static-viewport"
-  prompt={`Replace the generateViewport() function with a static viewport export. Convert all dynamic values to static ones. Do not introduce new imports.`}
   title="Use static viewport"
 >
   Replace the dynamic function with a static export so the viewport is known at
@@ -24,7 +23,6 @@ Uncached data accesses ([`fetch()`](https://developer.mozilla.org/en-US/docs/Web
 <FixOption
   group="block"
   href="#allow-blocking-route"
-  prompt={`Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally fully dynamic before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request.`}
   title="Allow blocking route"
 >
   Opt this segment out of instant navigation. The route renders on every request

--- a/errors/instant-unrendered-segment.mdx
+++ b/errors/instant-unrendered-segment.mdx
@@ -14,7 +14,6 @@ This typically happens when a layout conditionally omits `{children}`, a paralle
 <FixOption
   group="render"
   href="#render-the-dropped-segment"
-  prompt={`Ensure the layout renders {children} so the dropped segment is included in the render tree. If the layout conditionally omits {children} (e.g. showing a login page instead), restructure so both branches render {children} and use a Suspense boundary or conditional content inside the child segment instead. If the segment is a parallel route slot, ensure the layout renders the slot prop.`}
   title="Render the dropped segment"
 >
   Include the segment in the render tree so Next.js can validate it for instant
@@ -24,7 +23,6 @@ This typically happens when a layout conditionally omits `{children}`, a paralle
 <FixOption
   group="ignore"
   href="#skip-validation-on-the-segment"
-  prompt={`Add "export const instant = false" as a top-level export in the dropped segment's page or layout file. This silences the warning for the dropped segment and tells Next.js the segment does not need instant-navigation validation. Confirm with the user that skipping validation is intentional before applying this change.`}
   title="Skip validation on the segment"
 >
   Opt the dropped segment out of instant-navigation validation.

--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance-data.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance-data.ts
@@ -48,11 +48,8 @@ export type FixCard = {
   /** Docs URL the card links to, or `null` for no link. */
   link: string | null
   snippets: Snippet[]
-  /**
-   * AI-agent prompt copied when the user presses the "Copy AI prompt" button on
-   * the card. Phrased as an instruction the agent can act on directly.
-   */
-  prompt?: string
+  /** Whether to render the "Copy AI prompt" button on this card. */
+  copyable?: boolean
 }
 
 export type SnippetPart = {
@@ -82,8 +79,7 @@ const runtimeCards: FixCard[] = [
       { text: '  <DataChild />' },
       { text: '</Suspense>', highlight: true },
     ],
-    prompt:
-      'Wrap the component that reads cookies(), headers(), params, or searchParams in <Suspense>. The fallback prop must render synchronous, deterministic JSX (no fetch, no awaiting, no Math.random or Date.now) that approximates the final layout (skeleton, spinner, or stable placeholder text). Import Suspense from "react". Do not change the data access call. Place the Suspense boundary as close to the access as possible so the cached content above remains in the static shell. If the access is deep in a tree and used for a small piece of UI, prefer to push the access down to the leaf component that needs it instead of awaiting it at the top and forwarding the value.',
+    copyable: true,
   },
   {
     id: 'for-known-params-prerender',
@@ -108,8 +104,7 @@ const runtimeCards: FixCard[] = [
       },
       { text: '}' },
     ],
-    prompt:
-      'Add a generateStaticParams() export to the dynamic segment. Return an array of param objects whose keys match the segment\'s [param] names. Each entry is prerendered into static HTML at build time. With Cache Components, requests for params not in the list are served a fallback shell and the route is upgraded in the background. Return a subset of known params for common routes (popular categories, top locales, recent slugs); rare or open-ended params will fall back at runtime. Do not introduce new imports beyond Next.js types. If you can\'t return at least one known param at build time, use "Wrap in or move into Suspense" instead.',
+    copyable: true,
   },
   {
     id: 'allow-blocking-route',
@@ -120,8 +115,7 @@ const runtimeCards: FixCard[] = [
       { text: '// page.tsx or layout.tsx' },
       { text: 'export const instant = false', highlight: true },
     ],
-    prompt:
-      'Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally request-time before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request, so navigations to it block until the render completes.',
+    copyable: true,
   },
 ]
 
@@ -135,8 +129,7 @@ const clientHookSuspenseCard: FixCard = {
     { text: '  <SidebarNav />' },
     { text: '</Suspense>', highlight: true },
   ],
-  prompt:
-    'Wrap the component that calls the navigation hook in <Suspense>. The fallback prop must render synchronous, deterministic JSX (no fetch, no awaiting, no Math.random or Date.now) that approximates the final layout. Import Suspense from "react". Do not change the hook call itself. Place the Suspense boundary as close to the hook call as possible so the rest of the route stays in the prerendered static shell.',
+  copyable: true,
 }
 
 const clientHookBlockCard: FixCard = {
@@ -148,8 +141,7 @@ const clientHookBlockCard: FixCard = {
     { text: '// page.tsx or layout.tsx' },
     { text: 'export const instant = false', highlight: true },
   ],
-  prompt:
-    'Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally request-time before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request, so navigations to it block until the render completes.',
+  copyable: true,
 }
 
 const clientHookGspCard: FixCard = {
@@ -175,8 +167,7 @@ const clientHookGspCard: FixCard = {
     },
     { text: '}' },
   ],
-  prompt:
-    "Add a generateStaticParams() export to the page or layout that defines the dynamic segment. Return an array of param objects whose keys match the segment's [param] names. On the generated paths, useParams resolves to a build-time constant, and usePathname and useSelectedLayoutSegment(s) (which derive from the URL path) also resolve without needing a Suspense boundary. Does not help useSearchParams, since search params come from the request URL's query string and are not part of segment params. Do not introduce new imports beyond Next.js types. If you can't return at least one known param at build time, use \"Wrap in or move into Suspense\" instead.",
+  copyable: true,
 }
 
 /** useSearchParams: Stream + Block (GSP doesn't apply — search params come from request). */
@@ -209,8 +200,7 @@ const dynamicCards: FixCard[] = [
       { text: '  "use cache"', highlight: true },
       { text: '  return <List items={…} />' },
     ],
-    prompt:
-      'Convert the highlighted data access into a cached function. Put "use cache" as the first statement of the function body. If the value depends on input that changes between calls, accept the input as a function argument so it becomes part of the cache key. Optionally call cacheTag(tag) to allow invalidation via revalidateTag(tag), and cacheLife(profile) to set automatic expiration. Do not move the call site. Do not introduce new imports beyond "next/cache".',
+    copyable: true,
   },
   {
     id: 'wrap-in-or-move-into-suspense',
@@ -222,8 +212,7 @@ const dynamicCards: FixCard[] = [
       { text: '  <DataChild />' },
       { text: '</Suspense>', highlight: true },
     ],
-    prompt:
-      'Wrap the component that performs the failing data access in <Suspense>. The fallback prop must render synchronous, deterministic JSX (no fetch, no awaiting, no Math.random or Date.now) that approximates the final layout (skeleton, spinner, or stable placeholder text). Import Suspense from "react". Do not change the data fetching logic. If the surrounding parent component already has cached content, place the Suspense boundary as close to the data access as possible so the cached content remains in the static shell.',
+    copyable: true,
   },
   {
     id: 'allow-blocking-route',
@@ -234,8 +223,7 @@ const dynamicCards: FixCard[] = [
       { text: '// page.tsx or layout.tsx' },
       { text: 'export const instant = false', highlight: true },
     ],
-    prompt:
-      'Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally request-time before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request, so navigations to it block until the render completes.',
+    copyable: true,
   },
 ]
 
@@ -266,8 +254,7 @@ const unrenderedSegmentCards: FixCard[] = [
       },
       { text: '}' },
     ],
-    prompt:
-      'Ensure the layout renders {children} so the dropped segment is included in the render tree. If the layout conditionally omits {children} (e.g. showing a login page instead), restructure so both branches render {children} and use a Suspense boundary or conditional content inside the child segment instead. If the segment is a parallel route slot, ensure the layout renders the slot prop.',
+    copyable: true,
   },
   {
     id: 'skip-validation-on-the-segment',
@@ -279,8 +266,7 @@ const unrenderedSegmentCards: FixCard[] = [
       { text: '' },
       { text: 'export const instant = false', highlight: true },
     ],
-    prompt:
-      'Add "export const instant = false" as a top-level export in the dropped segment\'s page or layout file. This silences the warning for the dropped segment and tells Next.js the segment does not need instant-navigation validation. Confirm with the user that skipping validation is intentional before applying this change.',
+    copyable: true,
   },
 ]
 
@@ -297,8 +283,7 @@ const metadataRuntimeCards: FixCard[] = [
       { text: '  title: "My Page"' },
       { text: '}' },
     ],
-    prompt:
-      'Replace the generateMetadata() function with a static metadata export. Convert all dynamic values to static strings. If the metadata depends on params, use generateStaticParams instead to prerender each variant. Do not introduce new imports.',
+    copyable: true,
   },
   {
     id: 'render-page-at-request-time',
@@ -309,8 +294,7 @@ const metadataRuntimeCards: FixCard[] = [
       { text: '// page.tsx or layout.tsx' },
       { text: 'await connection()', highlight: true },
     ],
-    prompt:
-      'Add "await connection()" from "next/server" inside a component rendered by the page, wrapped in <Suspense>. The component can render null. This creates a dynamic hole inside Suspense so the rest of the page can still prerender, while signalling to Next.js that the dynamic metadata is intentional. Use this fix when the page would otherwise have no dynamic content other than the metadata.',
+    copyable: true,
   },
 ]
 
@@ -325,8 +309,7 @@ const metadataDynamicCards: FixCard[] = [
       { text: '  "use cache"', highlight: true },
       { text: '  return await cms.getMeta(…)' },
     ],
-    prompt:
-      'Add "use cache" as the first statement inside generateMetadata(). This caches the metadata so it can be included in the prerender. Optionally call cacheTag(tag) so the entry can be invalidated on-demand from a Server Action via updateTag(tag), or from a Route Handler via revalidateTag(tag, "max") for stale-while-revalidate semantics. Optionally call cacheLife(profile) to control how long the cache lives before background revalidation or full expiration. Do not introduce new imports beyond "next/cache".',
+    copyable: true,
   },
   {
     id: 'render-page-at-request-time',
@@ -337,8 +320,7 @@ const metadataDynamicCards: FixCard[] = [
       { text: '// page.tsx or layout.tsx' },
       { text: 'await connection()', highlight: true },
     ],
-    prompt:
-      'Add "await connection()" from "next/server" inside a component rendered by the page, wrapped in <Suspense>. The component can render null. This creates a dynamic hole inside Suspense so the rest of the page can still prerender, while signalling to Next.js that the dynamic metadata is intentional. Use this fix when the page would otherwise have no dynamic content other than the metadata.',
+    copyable: true,
   },
 ]
 
@@ -355,8 +337,7 @@ const viewportRuntimeCards: FixCard[] = [
       { text: '  themeColor: "#000"' },
       { text: '}' },
     ],
-    prompt:
-      'Replace the generateViewport() function with a static viewport export. Convert all dynamic values to static ones. Do not introduce new imports.',
+    copyable: true,
   },
   {
     id: 'allow-blocking-route',
@@ -367,8 +348,7 @@ const viewportRuntimeCards: FixCard[] = [
       { text: '// page.tsx or layout.tsx' },
       { text: 'export const instant = false', highlight: true },
     ],
-    prompt:
-      'Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally fully dynamic before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request.',
+    copyable: true,
   },
 ]
 
@@ -383,8 +363,7 @@ const viewportDynamicCards: FixCard[] = [
       { text: '  "use cache"', highlight: true },
       { text: '  return await db.getViewport(…)' },
     ],
-    prompt:
-      'Add "use cache" as the first statement inside generateViewport(). This caches the viewport so Next.js can include it in the prerender. Optionally call cacheLife(profile) to set automatic expiration. Do not introduce new imports beyond "next/cache".',
+    copyable: true,
   },
   {
     id: 'allow-blocking-route',
@@ -395,8 +374,7 @@ const viewportDynamicCards: FixCard[] = [
       { text: '// page.tsx or layout.tsx' },
       { text: 'export const instant = false', highlight: true },
     ],
-    prompt:
-      'Add "export const instant = false" as a top-level export in the page or layout file. This silences the warning for this segment. Confirm with the user that the route is intentionally fully dynamic before applying this change: the export exempts the segment from instant-navigation validation, and the route renders on every request.',
+    copyable: true,
   },
 ]
 
@@ -413,8 +391,7 @@ const syncMathCards: FixCard[] = [
       { text: 'const id = Math.random()' },
       { text: 'return <Item id={id} />' },
     ],
-    prompt:
-      'Add "await connection()" from "next/server" immediately before the Math.random() call. This marks the component as request-time, so Next.js excludes it from the prerendered HTML and streams it in from the nearest <Suspense> boundary on each request. Do not change the call site of Math.random() itself. Only change the call site once you\'ve confirmed with the user that a fresh value on every request is the intent.',
+    copyable: true,
   },
   {
     id: 'cache-the-random-value',
@@ -426,8 +403,7 @@ const syncMathCards: FixCard[] = [
       { text: '  "use cache"', highlight: true },
       { text: '  return String(Math.random())' },
     ],
-    prompt:
-      'Move the Math.random() call into its own function or component and add "use cache" as the first statement of the body. Optionally call cacheLife(profile) to control how long the same random value is reused before regeneration. Do not introduce new imports beyond "next/cache".',
+    copyable: true,
   },
   {
     id: 'render-on-the-client',
@@ -439,8 +415,7 @@ const syncMathCards: FixCard[] = [
       { text: '// runs in the browser' },
       { text: 'const id = Math.random()' },
     ],
-    prompt:
-      'Move the component that calls Math.random() into a Client Component by adding "use client" at the top of the file. The browser produces a fresh value on each visit. If the value needs to be hydration-stable, compute it inside a useEffect or event handler instead of inline during render.',
+    copyable: true,
   },
 ]
 
@@ -455,8 +430,7 @@ const syncDateCards: FixCard[] = [
       { text: 'const t = Date.now()' },
       { text: 'return <Banner time={t} />' },
     ],
-    prompt:
-      'Add "await connection()" from "next/server" immediately before the Date.now() call. This marks the component as request-time, so Next.js excludes it from the prerendered HTML and streams it in from the nearest <Suspense> boundary on each request. Do not change the call site of Date.now() itself. Only change the call site once you\'ve confirmed with the user that a fresh value on every request is the intent.',
+    copyable: true,
   },
   {
     id: 'cache-the-timestamp',
@@ -468,8 +442,7 @@ const syncDateCards: FixCard[] = [
       { text: '  "use cache"', highlight: true },
       { text: '  return <time>{Date.now()}</time>' },
     ],
-    prompt:
-      'Move the Date.now() call into its own function and add "use cache" as the first statement. Optionally call cacheLife(profile) to control how often the timestamp is regenerated. Do not introduce new imports beyond "next/cache".',
+    copyable: true,
   },
   {
     id: 'render-on-the-client',
@@ -481,8 +454,7 @@ const syncDateCards: FixCard[] = [
       { text: '// runs in the browser' },
       { text: 'const t = Date.now()' },
     ],
-    prompt:
-      'Move the component that calls Date.now() into a Client Component by adding "use client" at the top of the file. If the value needs to be hydration-stable, compute it inside useEffect instead of inline during render.',
+    copyable: true,
   },
   {
     id: 'measure-elapsed-time',
@@ -494,8 +466,7 @@ const syncDateCards: FixCard[] = [
       { text: 'doWork()' },
       { text: 'const ms = performance.now() - start' },
     ],
-    prompt:
-      'Replace Date.now() with performance.now() if the value is used for elapsed-time measurement, instrumentation, or telemetry. performance.now() returns a high-resolution monotonic timestamp and does not interfere with prerendering. Do not change the call if the value is rendered into the UI.',
+    copyable: true,
   },
 ]
 
@@ -510,8 +481,7 @@ const syncCryptoCards: FixCard[] = [
       { text: 'const id = crypto.randomUUID()' },
       { text: 'return <Token id={id} />' },
     ],
-    prompt:
-      'Add "await connection()" from "next/server" immediately before the crypto call. This marks the component as request-time, so Next.js excludes it from the prerendered HTML and streams it in from the nearest <Suspense> boundary on each request. Do not change the crypto call itself. Only change the call site once you\'ve confirmed with the user that a fresh value on every request is the intent.',
+    copyable: true,
   },
   {
     id: 'cache-the-generated-value',
@@ -523,8 +493,7 @@ const syncCryptoCards: FixCard[] = [
       { text: '  "use cache"', highlight: true },
       { text: '  return crypto.randomUUID()' },
     ],
-    prompt:
-      'Move the crypto call into its own function and add "use cache" as the first statement. Useful when the same generated value is reused as a key for another cached operation (talking to a database, signing a payload). Do not introduce new imports beyond "next/cache".',
+    copyable: true,
   },
   {
     id: 'render-on-the-client',
@@ -536,8 +505,7 @@ const syncCryptoCards: FixCard[] = [
       { text: '// runs in the browser' },
       { text: 'const id = crypto.randomUUID()' },
     ],
-    prompt:
-      'Move the component that calls the crypto API into a Client Component by adding "use client" at the top of the file. The browser produces the value, so the server never has to. If the value needs to be hydration-stable, compute it inside useEffect instead of inline during render.',
+    copyable: true,
   },
 ]
 
@@ -554,8 +522,7 @@ const syncClientDateCards: FixCard[] = [
       { text: '  <DateDisplay />' },
       { text: '</Suspense>', highlight: true },
     ],
-    prompt:
-      'Wrap the Client Component that calls Date.now() in <Suspense> in its parent. The fallback prop must render synchronous, deterministic JSX (no Date.now or Math.random) that approximates the final layout. Import Suspense from "react". Do not change the Date.now() call.',
+    copyable: true,
   },
   {
     id: 'move-into-effect-or-event-handler',
@@ -567,8 +534,7 @@ const syncClientDateCards: FixCard[] = [
       { text: '  setT(Date.now())' },
       { text: '}} />' },
     ],
-    prompt:
-      'Move the Date.now() call out of the inline render path and into useEffect (for mount-time values) or an event handler (for interaction values). Initialize state to a deterministic value so SSR and the first hydrated render agree. Do not introduce new imports beyond "react".',
+    copyable: true,
   },
   {
     id: 'measure-elapsed-time',
@@ -580,8 +546,7 @@ const syncClientDateCards: FixCard[] = [
       { text: 'doWork()' },
       { text: 'const ms = performance.now() - start' },
     ],
-    prompt:
-      'Replace Date.now() with performance.now() if the value is used for elapsed-time measurement, instrumentation, or telemetry. performance.now() returns a high-resolution monotonic timestamp and does not interfere with prerendering. Do not change the call if the value is rendered into the UI.',
+    copyable: true,
   },
 ]
 
@@ -596,8 +561,7 @@ const syncClientMathCards: FixCard[] = [
       { text: '  <RandomId />' },
       { text: '</Suspense>', highlight: true },
     ],
-    prompt:
-      'Wrap the Client Component that calls Math.random() in <Suspense> in its parent. The fallback prop must render synchronous, deterministic JSX (no Math.random or Date.now) that approximates the final layout (skeleton, spinner, or stable placeholder text). Import Suspense from "react". Do not change the Math.random() call.',
+    copyable: true,
   },
   {
     id: 'move-into-effect-or-event-handler',
@@ -609,8 +573,7 @@ const syncClientMathCards: FixCard[] = [
       { text: '  setId(Math.random())' },
       { text: '}} />' },
     ],
-    prompt:
-      'Move the Math.random() call out of the inline render path and into useEffect (for mount-time values) or an event handler (for interaction values). Initialize state to a deterministic value so SSR and the first hydrated render agree. Do not introduce new imports beyond "react".',
+    copyable: true,
   },
 ]
 
@@ -625,8 +588,7 @@ const syncClientCryptoCards: FixCard[] = [
       { text: '  <TokenId />' },
       { text: '</Suspense>', highlight: true },
     ],
-    prompt:
-      'Wrap the Client Component that calls the crypto API in <Suspense> in its parent. The fallback prop must render synchronous, deterministic JSX that approximates the final layout. Import Suspense from "react". Do not change the crypto call.',
+    copyable: true,
   },
   {
     id: 'move-into-effect-or-event-handler',
@@ -638,8 +600,7 @@ const syncClientCryptoCards: FixCard[] = [
       { text: '  setId(crypto.randomUUID())' },
       { text: '}} />' },
     ],
-    prompt:
-      'Move the crypto call out of the inline render path and into useEffect (for mount-time values) or an event handler (for interaction values). Initialize state to a deterministic value so SSR and the first hydrated render agree. Do not introduce new imports beyond "react".',
+    copyable: true,
   },
 ]
 

--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
@@ -21,6 +21,7 @@ import {
   SYNC_IO_DOCS,
   getCards,
   type FixCard,
+  type FixCardGroup,
   type FixCardIcon,
   type GuidanceKind,
   type GuidanceVariant,
@@ -57,22 +58,45 @@ function getCardIcon(icon: FixCardIcon) {
   }
 }
 
-function CopyPromptButton({ title, link }: { title: string; link: string }) {
+function CopyPromptButton({
+  title,
+  group,
+  link,
+  generateErrorInfo,
+}: {
+  title: string
+  group: FixCardGroup
+  link: string
+  generateErrorInfo?: () => Promise<string>
+}) {
+  const groupLabel = FIX_CARD_GROUPS[group].label
   const hashIndex = link.indexOf('#')
   const rulePage = hashIndex === -1 ? link : link.slice(0, hashIndex)
-  const prompt = [
-    'Before applying this fix:',
+  const fixHeader = [
+    `Apply the [${groupLabel}] "${title}" fix to the Next.js Insight raised in this project.`,
     '',
-    "1. Read the actual Next.js error in the dev overlay (or browser/terminal console) to identify the failing file, line, and component. Match the fix to that component — don't patch unrelated files.",
+    'Steps:',
     '',
-    `2. Read the full context for this rule at ${rulePage}, then read the specific fix section at ${link}. The fix section names the exact code shape, every constraint, and the imports allowed. Follow it exactly — don't improvise.`,
+    "1. The failing code is in the error block below — it may be a data-access call, a hook call, a metadata or viewport export, or a component. The fix applies to that exact code; don't touch unrelated files.",
     '',
-    `Apply the "${title}" fix.`,
+    `2. Read the rule docs at ${rulePage} for the full Insight explanation, then read the fix section at ${link}. Pick the pattern under "### Patterns" that matches the failing code, then read "### Gotchas" before editing — they list constraints that are easy to miss. Use the canonical imports and code shape from the page; don't improvise variations.`,
+    '',
+    `3. Apply the chosen pattern to the code identified in step 1.`,
   ].join('\n')
 
-  return (
+  return generateErrorInfo ? (
     <CopyButton
-      content={prompt}
+      getContent={async () => {
+        const info = await generateErrorInfo()
+        return info ? `${fixHeader}\n\n${info}` : fixHeader
+      }}
+      actionLabel="Copy AI prompt"
+      successLabel="Prompt copied"
+      data-nextjs-fix-card-copy-button
+    />
+  ) : (
+    <CopyButton
+      content={fixHeader}
       actionLabel="Copy AI prompt"
       successLabel="Prompt copied"
       data-nextjs-fix-card-copy-button
@@ -80,7 +104,13 @@ function CopyPromptButton({ title, link }: { title: string; link: string }) {
   )
 }
 
-function CardGrid({ cards }: { cards: FixCard[] }) {
+function CardGrid({
+  cards,
+  generateErrorInfo,
+}: {
+  cards: FixCard[]
+  generateErrorInfo?: () => Promise<string>
+}) {
   return (
     <div data-nextjs-card-grid>
       {cards.map((card) => {
@@ -158,7 +188,12 @@ function CardGrid({ cards }: { cards: FixCard[] }) {
         return card.copyable && card.link ? (
           <div data-nextjs-fix-card-wrapper key={card.id}>
             {cardElement}
-            <CopyPromptButton title={card.title} link={card.link} />
+            <CopyPromptButton
+              title={card.title}
+              group={card.group}
+              link={card.link}
+              generateErrorInfo={generateErrorInfo}
+            />
           </div>
         ) : (
           <div data-nextjs-fix-card-wrapper key={card.id}>
@@ -176,12 +211,14 @@ export function InstantGuidance({
   explanation,
   cause,
   showExplanation = true,
+  generateErrorInfo,
 }: {
   variant: GuidanceVariant
   kind?: GuidanceKind
   explanation?: string
   cause?: string
   showExplanation?: boolean
+  generateErrorInfo?: () => Promise<string>
 }) {
   const cards = getCards(kind, variant, cause)
   let docsUrl: string
@@ -229,7 +266,7 @@ export function InstantGuidance({
         Ways to fix this:
       </div>
 
-      <CardGrid cards={cards} />
+      <CardGrid cards={cards} generateErrorInfo={generateErrorInfo} />
     </div>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
@@ -57,7 +57,19 @@ function getCardIcon(icon: FixCardIcon) {
   }
 }
 
-function CopyPromptButton({ prompt }: { prompt: string }) {
+function CopyPromptButton({ title, link }: { title: string; link: string }) {
+  const hashIndex = link.indexOf('#')
+  const rulePage = hashIndex === -1 ? link : link.slice(0, hashIndex)
+  const prompt = [
+    'Before applying this fix:',
+    '',
+    "1. Read the actual Next.js error in the dev overlay (or browser/terminal console) to identify the failing file, line, and component. Match the fix to that component — don't patch unrelated files.",
+    '',
+    `2. Read the full context for this rule at ${rulePage}, then read the specific fix section at ${link}. The fix section names the exact code shape, every constraint, and the imports allowed. Follow it exactly — don't improvise.`,
+    '',
+    `Apply the "${title}" fix.`,
+  ].join('\n')
+
   return (
     <CopyButton
       content={prompt}
@@ -75,7 +87,7 @@ function CardGrid({ cards }: { cards: FixCard[] }) {
         const groupMeta = FIX_CARD_GROUPS[card.group]
         const inner = (
           <>
-            {card.link && !card.prompt ? (
+            {card.link && !card.copyable ? (
               <span data-nextjs-fix-card-link-icon aria-hidden="true">
                 <ExternalIcon width={16} height={16} />
               </span>
@@ -85,7 +97,7 @@ function CardGrid({ cards }: { cards: FixCard[] }) {
               <div data-nextjs-fix-card-header-text>
                 <div data-nextjs-fix-card-title-row>
                   <span data-nextjs-fix-card-title>{groupMeta.label}</span>
-                  {card.prompt && card.link ? (
+                  {card.copyable && card.link ? (
                     <span
                       data-nextjs-fix-card-title-link-icon
                       aria-hidden="true"
@@ -143,10 +155,10 @@ function CardGrid({ cards }: { cards: FixCard[] }) {
         // Render the copy button as a sibling of the card so the <button>
         // isn't nested inside the card's <a>, which would be invalid HTML
         // and break keyboard / focus behavior.
-        return card.prompt ? (
+        return card.copyable && card.link ? (
           <div data-nextjs-fix-card-wrapper key={card.id}>
             {cardElement}
-            <CopyPromptButton prompt={card.prompt} />
+            <CopyPromptButton title={card.title} link={card.link} />
           </div>
         ) : (
           <div data-nextjs-fix-card-wrapper key={card.id}>

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -25,8 +25,7 @@ import type { ReadyRuntimeError } from '../utils/get-error-by-type'
 import type { ErrorBaseProps } from '../components/errors/error-overlay/error-overlay'
 import type { HydrationErrorState } from '../../shared/hydration-error'
 import { useActiveRuntimeError } from '../hooks/use-active-runtime-error'
-import { formatCodeFrame } from '../components/code-frame/parse-code-frame'
-import stripAnsi from 'next/dist/compiled/strip-ansi'
+import { generateErrorInfo as generateErrorInfoHelper } from '../utils/generate-error-info'
 import {
   InstantHeaderExplanation,
   InstantGuidance,
@@ -257,6 +256,7 @@ function InstantRuntimeError({
   cause,
   showExplanation = true,
   dialogResizerRef,
+  generateErrorInfo,
 }: {
   error: ReadyRuntimeError
   variant: GuidanceVariant
@@ -265,6 +265,7 @@ function InstantRuntimeError({
   cause?: string
   showExplanation?: boolean
   dialogResizerRef: React.RefObject<HTMLDivElement | null>
+  generateErrorInfo: () => Promise<string>
 }) {
   const frames = useFrames(error)
 
@@ -292,6 +293,7 @@ function InstantRuntimeError({
         explanation={explanation}
         cause={cause}
         showExplanation={showExplanation}
+        generateErrorInfo={generateErrorInfo}
       />
       {frames.length > 0 && (
         <ErrorOverlayCallStack
@@ -623,89 +625,16 @@ export function Errors({
     },
   })
 
-  const generateErrorInfo = useCallback(async () => {
-    if (!activeError) return ''
-
-    const parts: string[] = []
-
-    // 1. Error Type
-    if (errorType) {
-      parts.push(`## Error Type\n${errorType}`)
-    }
-
-    // 2. Error Message
-    const error = activeError.error
-    let message = error.message
-    if ('environmentName' in error && error.environmentName) {
-      const envPrefix = `[ ${error.environmentName} ] `
-      if (message.startsWith(envPrefix)) {
-        message = message.slice(envPrefix.length)
-      }
-    }
-    if (message) {
-      parts.push(`## Error Message\n${message}`)
-    }
-
-    const frames = await Promise.race([
-      activeError.frames(),
-      new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
-    ])
-
-    // Append call stack
-    if (frames === null) {
-      parts.push(
-        'Unable to retrieve stack frames for this error. Falling back to unsourcemapped stack\n\n' +
-          error.stack
-      )
-    } else {
-      if (frames.length > 0) {
-        const visibleFrames = frames.filter((frame) => !frame.ignored)
-        if (visibleFrames.length > 0) {
-          const stackLines = visibleFrames
-            .map((frame) => {
-              if (frame.originalStackFrame) {
-                const { methodName, file, line1, column1 } =
-                  frame.originalStackFrame
-                return `    at ${methodName} (${file}:${line1}:${column1})`
-              } else if (frame.sourceStackFrame) {
-                const { methodName, file, line1, column1 } =
-                  frame.sourceStackFrame
-                return `    at ${methodName} (${file}:${line1}:${column1})`
-              }
-              return ''
-            })
-            .filter(Boolean)
-
-          if (stackLines.length > 0) {
-            parts.push(`\n${stackLines.join('\n')}`)
-          }
-        }
-      }
-
-      // 3. Code Frame (decoded)
-      const firstFirstPartyFrameIndex = frames.findIndex(
-        (entry) =>
-          !entry.ignored &&
-          Boolean(entry.originalCodeFrame) &&
-          Boolean(entry.originalStackFrame)
-      )
-
-      const firstFrame = frames[firstFirstPartyFrameIndex] ?? null
-      if (firstFrame?.originalCodeFrame) {
-        const decodedCodeFrame = stripAnsi(
-          formatCodeFrame(firstFrame.originalCodeFrame)
-        )
-        parts.push(`## Code Frame\n${decodedCodeFrame}`)
-      }
-    }
-
-    // Format as markdown error info
-    const errorInfo = `${parts.join('\n\n')}
-
-Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\n`
-
-    return errorInfo
-  }, [activeError, errorType, props.versionInfo])
+  const generateErrorInfo = useCallback(
+    () =>
+      generateErrorInfoHelper({
+        activeError,
+        errorType,
+        versionInfo: props.versionInfo.installed,
+        bundler: process.env.__NEXT_BUNDLER as string,
+      }),
+    [activeError, errorType, props.versionInfo]
+  )
 
   if (isLoading) {
     // TODO: better loading state
@@ -908,6 +837,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               variant={errorDetails.variant}
               showExplanation={false}
               dialogResizerRef={dialogResizerRef}
+              generateErrorInfo={generateErrorInfo}
             />
           </Suspense>
         </ErrorOverlayLayout>
@@ -949,6 +879,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               cause={errorDetails.expression}
               showExplanation={false}
               dialogResizerRef={dialogResizerRef}
+              generateErrorInfo={generateErrorInfo}
             />
           </Suspense>
         </ErrorOverlayLayout>
@@ -1000,6 +931,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               kind="metadata"
               showExplanation={false}
               dialogResizerRef={dialogResizerRef}
+              generateErrorInfo={generateErrorInfo}
             />
           </Suspense>
         </ErrorOverlayLayout>
@@ -1051,6 +983,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               kind="viewport"
               showExplanation={false}
               dialogResizerRef={dialogResizerRef}
+              generateErrorInfo={generateErrorInfo}
             />
           </Suspense>
         </ErrorOverlayLayout>
@@ -1096,6 +1029,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               cause={errorDetails.cause}
               showExplanation={false}
               dialogResizerRef={dialogResizerRef}
+              generateErrorInfo={generateErrorInfo}
             />
           </Suspense>
         </ErrorOverlayLayout>
@@ -1141,6 +1075,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
               cause={errorDetails.cause}
               showExplanation={false}
               dialogResizerRef={dialogResizerRef}
+              generateErrorInfo={generateErrorInfo}
             />
           </Suspense>
         </ErrorOverlayLayout>

--- a/packages/next/src/next-devtools/dev-overlay/utils/generate-error-info.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/generate-error-info.ts
@@ -1,0 +1,90 @@
+import { formatCodeFrame } from '../components/code-frame/parse-code-frame'
+import stripAnsi from 'next/dist/compiled/strip-ansi'
+import type { ReadyRuntimeError } from './get-error-by-type'
+
+export async function generateErrorInfo({
+  activeError,
+  errorType,
+  versionInfo,
+  bundler,
+}: {
+  activeError: ReadyRuntimeError | null
+  errorType: string | null
+  versionInfo: string
+  bundler: string
+}): Promise<string> {
+  if (!activeError) return ''
+
+  const parts: string[] = []
+
+  if (errorType) {
+    parts.push(`## Error Type\n${errorType}`)
+  }
+
+  const error = activeError.error
+  let message = error.message
+  if ('environmentName' in error && error.environmentName) {
+    const envPrefix = `[ ${error.environmentName} ] `
+    if (message.startsWith(envPrefix)) {
+      message = message.slice(envPrefix.length)
+    }
+  }
+  if (message) {
+    parts.push(`## Error Message\n${message}`)
+  }
+
+  const frames = await Promise.race([
+    activeError.frames(),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+  ])
+
+  if (frames === null) {
+    parts.push(
+      'Unable to retrieve stack frames for this error. Falling back to unsourcemapped stack\n\n' +
+        error.stack
+    )
+  } else {
+    if (frames.length > 0) {
+      const visibleFrames = frames.filter((frame) => !frame.ignored)
+      if (visibleFrames.length > 0) {
+        const stackLines = visibleFrames
+          .map((frame) => {
+            if (frame.originalStackFrame) {
+              const { methodName, file, line1, column1 } =
+                frame.originalStackFrame
+              return `    at ${methodName} (${file}:${line1}:${column1})`
+            } else if (frame.sourceStackFrame) {
+              const { methodName, file, line1, column1 } =
+                frame.sourceStackFrame
+              return `    at ${methodName} (${file}:${line1}:${column1})`
+            }
+            return ''
+          })
+          .filter(Boolean)
+
+        if (stackLines.length > 0) {
+          parts.push(`\n${stackLines.join('\n')}`)
+        }
+      }
+    }
+
+    const firstFirstPartyFrameIndex = frames.findIndex(
+      (entry) =>
+        !entry.ignored &&
+        Boolean(entry.originalCodeFrame) &&
+        Boolean(entry.originalStackFrame)
+    )
+
+    const firstFrame = frames[firstFirstPartyFrameIndex] ?? null
+    if (firstFrame?.originalCodeFrame) {
+      const decodedCodeFrame = stripAnsi(
+        formatCodeFrame(firstFrame.originalCodeFrame)
+      )
+      parts.push(`## Code Frame\n${decodedCodeFrame}`)
+    }
+  }
+
+  return `${parts.join('\n\n')}
+
+Next.js version: ${versionInfo} (${bundler})\n`
+}


### PR DESCRIPTION
### What

The dev-overlay fix cards' `Copy AI prompt` button used to copy a multi-paragraph instruction string baked into each card (71 prompts across docs + runtime). This PR replaces that with a dynamic template the button builds at click time:

```
Apply the [Stream] "Wrap in or move into Suspense" fix to the Next.js Insight raised in this project.

Steps:

1. The failing code is in the error block below — it may be a data-access call, a hook call, a metadata or viewport export, or a component. The fix applies to that exact code; don't touch unrelated files.

2. Read the rule docs at <rule-url> for the full Insight explanation, then read the fix section at <fix-url>. Pick the pattern under "### Patterns" that matches the failing code, then read "### Gotchas" before editing — they list constraints that are easy to miss. Use the canonical imports and code shape from the page; don't improvise variations.

3. Apply the chosen pattern to the code identified in step 1.

## Error Type
Blocking Route

## Error Message
Route "/01-cookies-body": ...
    at Page (app/01-cookies-body/page.tsx:4:26)

## Code Frame
> 4 |   const c = await cookies();
    |                          ^
...

Next.js version: 16.3.0-canary.47 (Turbopack)
```

### Why

Old verbatim prompts repeated what the docs already say and never anchored the fix to the actual error. The new template:

- Names the chosen fix (group badge + title) so the agent picks the right pattern.
- Points at the rule docs AND the specific fix anchor, with explicit instructions to read `### Patterns` and `### Gotchas`.
- Prepends the live error block (same shape the existing 'Copy error info' button emits) so the agent has the failing file, line, code frame, and stack inline — no need to re-fetch the dev overlay.

### Changes

- `FixCard` type: `prompt?: string` → `copyable?: boolean`
- `CopyPromptButton`: takes `title + group + link + generateErrorInfo`, builds the prompt
- Refactored `generateErrorInfo` from `errors.tsx` into a shared `utils/generate-error-info.ts` so the existing 'Copy error info' button and the fix-card 'Copy AI prompt' button format the error block identically
- 14 error MDX pages: every `prompt={...}` removed (36 strings)
- `instant-guidance-data.ts`: every `prompt: '...'` → `copyable: true` (35 strings)
- Skill (`.agents/skills/insight-error-page/SKILL.md`): updated

### Pairs with

vercel/front#73087 — same template in the docs-site `<FixOption>` (without the error block, since there's no live error on a docs page).

<!-- NEXT_JS_LLM_PR -->