### PR TITLE
Split server render config from request state

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -62,6 +62,7 @@ import {
 import { getSortedRoutes, isDynamicRoute } from '../shared/lib/router/utils'
 import { execOnce } from '../shared/lib/utils'
 import { isBlockedPage } from './utils'
+import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import RenderResult from './render-result'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -63,6 +63,7 @@ import {
 import { getSortedRoutes, isDynamicRoute } from '../shared/lib/router/utils'
 import { execOnce } from '../shared/lib/utils'
 import { isBlockedPage } from './utils'
+import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import RenderResult from './render-result'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -6,7 +6,6 @@ import type {
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 import type { Params } from './request/params'
 import type { NextConfig, NextConfigRuntime } from './config-shared'
-import { parseMaxPostponedStateSize } from './config-shared'
 import type {
   NextParsedUrlQuery,
   NextUrlWithParsedQuery,
@@ -57,7 +56,6 @@ import { formatHostname } from './lib/format-hostname'
 import { isRSCRequestHeader } from './lib/is-rsc-request'
 import { isNonHtmlSecFetchDest } from './lib/is-non-html-sec-fetch-dest'
 import {
-  NEXT_BUILTIN_DOCUMENT,
   STATIC_STATUS_PAGES,
   UNDERSCORE_NOT_FOUND_ROUTE,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
@@ -65,8 +63,6 @@ import {
 import { getSortedRoutes, isDynamicRoute } from '../shared/lib/router/utils'
 import { execOnce } from '../shared/lib/utils'
 import { isBlockedPage } from './utils'
-import { getBotType, isBot } from '../shared/lib/router/utils/is-bot'
-import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import RenderResult from './render-result'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
@@ -152,7 +148,6 @@ import { NextRequestHint } from './web/adapter'
 import type { RouteModule } from './route-modules/route-module'
 import { type FallbackMode, parseFallbackField } from '../lib/fallback'
 import { SegmentPrefixRSCPathnameNormalizer } from './normalizers/request/segment-prefix-rsc'
-import { shouldServeStreamingMetadata } from './lib/streaming-metadata'
 import { decodeQueryPathParameter } from './lib/decode-query-path-parameter'
 import { NoFallbackError } from '../shared/lib/no-fallback-error.external'
 import { fixMojibake } from './lib/fix-mojibake'
@@ -276,11 +271,19 @@ export type RequestLifecycleOpts = {
   onAfterTaskError: ((error: unknown) => void) | undefined
 }
 
-type BaseRenderOpts = RenderOpts & {
+type ServerRenderConfig = Readonly<{
   poweredByHeader: boolean
   generateEtags: boolean
   previewProps: __ApiPreviewProps
-}
+  optimizeCss: NextConfigRuntime['experimental']['optimizeCss']
+  nextScriptWorkers: NextConfigRuntime['experimental']['nextScriptWorkers']
+  isExperimentalCompile: boolean | undefined
+}>
+
+type RequestRenderState = Readonly<{
+  params?: Params
+  error?: Error | null
+}>
 
 /**
  * The public interface for rendering with the server programmatically. This
@@ -309,7 +312,7 @@ export type RequestContext<
   res: ServerResponse
   pathname: string
   query: NextParsedUrlQuery
-  renderOpts: RenderOpts
+  renderState: RequestRenderState
 }
 
 // Internal wrapper around build errors at development
@@ -353,7 +356,7 @@ export default abstract class Server<
   protected readonly deploymentId: string
   protected readonly dev: boolean
   protected readonly minimalMode: boolean
-  protected readonly renderOpts: BaseRenderOpts
+  protected readonly serverRenderConfig: ServerRenderConfig
   protected readonly serverOptions: Readonly<ServerOptions>
   protected appPathRoutes?: Record<string, string[]>
   protected readonly clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>
@@ -575,78 +578,13 @@ export default abstract class Server<
 
     this.nextFontManifest = this.getNextFontManifest()
 
-    this.renderOpts = {
-      dir: this.dir,
-      supportsDynamicResponse: true,
-      trailingSlash: this.nextConfig.trailingSlash,
+    this.serverRenderConfig = {
       poweredByHeader: this.nextConfig.poweredByHeader,
       generateEtags,
       previewProps: this.getPreviewProps(),
-      basePath: this.nextConfig.basePath,
-      images: this.nextConfig.images,
       optimizeCss: this.nextConfig.experimental.optimizeCss,
-      nextConfigOutput: this.nextConfig.output,
       nextScriptWorkers: this.nextConfig.experimental.nextScriptWorkers,
-      disableOptimizedLoading:
-        this.nextConfig.experimental.disableOptimizedLoading,
-      domainLocales: this.nextConfig.i18n?.domains,
-      distDir: this.distDir,
-      serverComponents: this.enabledDirectories.app,
-      cacheLifeProfiles: this.nextConfig.cacheLife,
-      staticPageGenerationTimeout: this.nextConfig.staticPageGenerationTimeout,
-      enableTainting: this.nextConfig.experimental.taint,
-      crossOrigin: this.nextConfig.crossOrigin
-        ? this.nextConfig.crossOrigin
-        : undefined,
-      largePageDataBytes: this.nextConfig.experimental.largePageDataBytes,
-
       isExperimentalCompile: this.nextConfig.experimental.isExperimentalCompile,
-      cacheComponents: this.nextConfig.cacheComponents ?? false,
-      partialPrefetching: this.nextConfig.partialPrefetching,
-      validationLevel:
-        this.nextConfig.experimental.instantInsights.validationLevel,
-      experimental: {
-        expireTime: this.nextConfig.expireTime,
-        staleTimes: this.nextConfig.experimental.staleTimes,
-        clientTraceMetadata: this.nextConfig.experimental.clientTraceMetadata,
-        clientParamParsingOrigins:
-          this.nextConfig.experimental.clientParamParsingOrigins,
-        dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,
-        optimisticRouting:
-          this.nextConfig.experimental.optimisticRouting ?? false,
-        inlineCss: this.nextConfig.experimental.inlineCss ?? false,
-        prefetchInlining:
-          this.nextConfig.experimental.prefetchInlining ?? false,
-        authInterrupts: !!this.nextConfig.experimental.authInterrupts,
-        reactBrowserBailout:
-          this.nextConfig.experimental.reactBrowserBailout ?? false,
-        serverComponentsHmrCancellation:
-          this.nextConfig.experimental.serverComponentsHmrCancellation,
-        useCacheTimeout: this.nextConfig.experimental.useCacheTimeout,
-        durableUseCacheEntries: Boolean(
-          this.nextConfig.experimental.durableUseCacheEntries
-        ),
-        cachedNavigations:
-          this.nextConfig.experimental.cachedNavigations ?? false,
-        maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
-          this.nextConfig.experimental.maxPostponedStateSize
-        ),
-        disableResumeDataCacheCompression:
-          this.nextConfig.experimental.disableResumeDataCacheCompression ??
-          false,
-        exposeTestingApi:
-          this.nextConfig.cacheComponents === true &&
-          (this.dev === true ||
-            this.nextConfig.experimental.exposeTestingApiInProductionBuild ===
-              true),
-      },
-      onInstrumentationRequestError:
-        this.instrumentationOnRequestError.bind(this),
-      prefetchHints: {},
-      reactMaxHeadersLength: this.nextConfig.reactMaxHeadersLength,
-      logServerFunctions:
-        typeof this.nextConfig.logging === 'object' &&
-        Boolean(this.nextConfig.logging.serverFunctions),
     }
 
     this.pagesManifest = this.getPagesManifest()
@@ -2112,7 +2050,7 @@ export default abstract class Server<
     ) => Promise<ResponsePayload | null>,
     partialContext: Omit<
       RequestContext<ServerRequest, ServerResponse>,
-      'renderOpts'
+      'renderState'
     >
   ): Promise<void> {
     return getTracer().trace(BaseServerSpan.pipe, async () =>
@@ -2126,22 +2064,12 @@ export default abstract class Server<
     ) => Promise<ResponsePayload | null>,
     partialContext: Omit<
       RequestContext<ServerRequest, ServerResponse>,
-      'renderOpts'
+      'renderState'
     >
   ): Promise<void> {
-    const ua = partialContext.req.headers['user-agent'] || ''
-
     const ctx: RequestContext<ServerRequest, ServerResponse> = {
       ...partialContext,
-      renderOpts: {
-        ...this.renderOpts,
-        // `renderOpts.botType` is accumulated in `this.renderImpl()`
-        supportsDynamicResponse: !this.renderOpts.botType,
-        serveStreamingMetadata: shouldServeStreamingMetadata(
-          ua,
-          this.nextConfig.htmlLimitedBots
-        ),
-      },
+      renderState: {},
     }
 
     const payload = await fn(ctx)
@@ -2153,7 +2081,7 @@ export default abstract class Server<
     const { body } = payload
     let { cacheControl } = payload
     if (!res.sent) {
-      const { generateEtags, poweredByHeader } = this.renderOpts
+      const { generateEtags, poweredByHeader } = this.serverRenderConfig
 
       // Documents and data responses must not be stored in development.
       // Browsers reuse a stored response for a history navigation without
@@ -2186,15 +2114,12 @@ export default abstract class Server<
     ) => Promise<ResponsePayload | null>,
     partialContext: Omit<
       RequestContext<ServerRequest, ServerResponse>,
-      'renderOpts'
+      'renderState'
     >
   ): Promise<string | null> {
     const ctx: RequestContext<ServerRequest, ServerResponse> = {
       ...partialContext,
-      renderOpts: {
-        ...this.renderOpts,
-        supportsDynamicResponse: false,
-      },
+      renderState: {},
     }
     const payload = await fn(ctx)
     if (payload === null) {
@@ -2270,9 +2195,6 @@ export default abstract class Server<
       // (see custom-server integration tests)
       pathname = '/'
     }
-
-    const ua = req.headers['user-agent'] || ''
-    this.renderOpts.botType = getBotType(ua)
 
     // we allow custom servers to call render for all URLs
     // so check if we need to serve a static _next file or not.
@@ -2382,7 +2304,7 @@ export default abstract class Server<
       req,
       res,
       pathname,
-      renderOpts: opts,
+      renderState,
     }: RequestContext<ServerRequest, ServerResponse>,
     { components, query }: FindComponentsResult
   ): Promise<ResponsePayload | null> {
@@ -2676,28 +2598,6 @@ export default abstract class Server<
       }
     }
 
-    if (opts.supportsDynamicResponse === true) {
-      const ua = req.headers['user-agent'] || ''
-      const isBotRequest = isBot(ua)
-      const isSupportedDocument =
-        typeof components.Document?.getInitialProps !== 'function' ||
-        // The built-in `Document` component also supports dynamic HTML for concurrent mode.
-        NEXT_BUILTIN_DOCUMENT in components.Document
-
-      // Disable dynamic HTML in cases that we know it won't be generated,
-      // so that we can continue generating a cache key when possible.
-      // TODO-APP: should the first render for a dynamic app path
-      // be static so we can collect revalidate and populate the
-      // cache if there are no dynamic data requirements
-      opts.supportsDynamicResponse =
-        !isSSG && !isBotRequest && isSupportedDocument
-    }
-
-    // In development, we always want to generate dynamic HTML.
-    if (!isNextDataRequest && isAppPath && this.dev) {
-      opts.supportsDynamicResponse = true
-    }
-
     if (isSSG && this.minimalMode && req.headers[MATCHED_PATH_HEADER]) {
       // the url value is already correct when the matched-path header is set
       resolvedUrlPathname = urlPathname
@@ -2833,11 +2733,11 @@ export default abstract class Server<
     setRequestMeta(request, getRequestMeta(req))
     addRequestMeta(request, 'distDir', this.distDir)
     addRequestMeta(request, 'query', query)
-    addRequestMeta(request, 'params', opts.params)
+    addRequestMeta(request, 'params', renderState.params)
     addRequestMeta(request, 'minimalMode', this.minimalMode)
 
-    if (opts.err) {
-      addRequestMeta(request, 'invokeError', opts.err)
+    if (renderState.error) {
+      addRequestMeta(request, 'invokeError', renderState.error)
     }
 
     const maybeDevRequest: ServerRequest | IncomingMessage =
@@ -2935,7 +2835,7 @@ export default abstract class Server<
       locale: getRequestMeta(ctx.req, 'locale'),
       page,
       query,
-      params: ctx.renderOpts.params || {},
+      params: ctx.renderState.params || {},
       isAppPath,
       sriEnabled: !!this.nextConfig.experimental.sri?.algorithm,
       appPaths,
@@ -3031,8 +2931,8 @@ export default abstract class Server<
             {
               ...ctx,
               pathname: existingMatch.definition.pathname,
-              renderOpts: {
-                ...ctx.renderOpts,
+              renderState: {
+                ...ctx.renderState,
                 params: existingMatch.params,
               },
             },
@@ -3374,9 +3274,9 @@ export default abstract class Server<
           {
             ...ctx,
             pathname: statusPage,
-            renderOpts: {
-              ...ctx.renderOpts,
-              err,
+            renderState: {
+              ...ctx.renderState,
+              error: err,
             },
           },
           result
@@ -3410,11 +3310,11 @@ export default abstract class Server<
           {
             ...ctx,
             pathname: '/_error',
-            renderOpts: {
-              ...ctx.renderOpts,
+            renderState: {
+              ...ctx.renderState,
               // We render `renderToHtmlError` here because `err` is
               // already captured in the stacktrace.
-              err: isWrappedError
+              error: isWrappedError
                 ? renderToHtmlError.innerError
                 : renderToHtmlError,
             },

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -6,7 +6,6 @@ import type {
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 import type { Params } from './request/params'
 import type { NextConfig, NextConfigRuntime } from './config-shared'
-import { parseMaxPostponedStateSize } from './config-shared'
 import type {
   NextParsedUrlQuery,
   NextUrlWithParsedQuery,
@@ -56,7 +55,6 @@ import { formatHostname } from './lib/format-hostname'
 import { isRSCRequestHeader } from './lib/is-rsc-request'
 import { isNonHtmlSecFetchDest } from './lib/is-non-html-sec-fetch-dest'
 import {
-  NEXT_BUILTIN_DOCUMENT,
   STATIC_STATUS_PAGES,
   UNDERSCORE_NOT_FOUND_ROUTE,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
@@ -64,8 +62,6 @@ import {
 import { getSortedRoutes, isDynamicRoute } from '../shared/lib/router/utils'
 import { execOnce } from '../shared/lib/utils'
 import { isBlockedPage } from './utils'
-import { getBotType, isBot } from '../shared/lib/router/utils/is-bot'
-import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import RenderResult from './render-result'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
@@ -153,7 +149,6 @@ import { NextRequestHint } from './web/adapter'
 import type { RouteModule } from './route-modules/route-module'
 import { type FallbackMode, parseFallbackField } from '../lib/fallback'
 import { SegmentPrefixRSCPathnameNormalizer } from './normalizers/request/segment-prefix-rsc'
-import { shouldServeStreamingMetadata } from './lib/streaming-metadata'
 import { decodeQueryPathParameter } from './lib/decode-query-path-parameter'
 import { NoFallbackError } from '../shared/lib/no-fallback-error.external'
 import { fixMojibake } from './lib/fix-mojibake'
@@ -277,11 +272,19 @@ export type RequestLifecycleOpts = {
   onAfterTaskError: ((error: unknown) => void) | undefined
 }
 
-type BaseRenderOpts = RenderOpts & {
+type ServerRenderConfig = Readonly<{
   poweredByHeader: boolean
   generateEtags: boolean
   previewProps: __ApiPreviewProps
-}
+  optimizeCss: NextConfigRuntime['experimental']['optimizeCss']
+  nextScriptWorkers: NextConfigRuntime['experimental']['nextScriptWorkers']
+  isExperimentalCompile: boolean | undefined
+}>
+
+type RequestRenderState = Readonly<{
+  params?: Params
+  error?: Error | null
+}>
 
 /**
  * The public interface for rendering with the server programmatically. This
@@ -310,7 +313,7 @@ export type RequestContext<
   res: ServerResponse
   pathname: string
   query: NextParsedUrlQuery
-  renderOpts: RenderOpts
+  renderState: RequestRenderState
 }
 
 // Internal wrapper around build errors at development
@@ -354,7 +357,7 @@ export default abstract class Server<
   protected readonly deploymentId: string
   protected readonly dev: boolean
   protected readonly minimalMode: boolean
-  protected readonly renderOpts: BaseRenderOpts
+  protected readonly serverRenderConfig: ServerRenderConfig
   protected readonly serverOptions: Readonly<ServerOptions>
   protected appPathRoutes?: Record<string, string[]>
   protected readonly clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>
@@ -576,71 +579,13 @@ export default abstract class Server<
 
     this.nextFontManifest = this.getNextFontManifest()
 
-    this.renderOpts = {
-      dir: this.dir,
-      supportsDynamicResponse: true,
-      trailingSlash: this.nextConfig.trailingSlash,
+    this.serverRenderConfig = {
       poweredByHeader: this.nextConfig.poweredByHeader,
       generateEtags,
       previewProps: this.getPrerenderManifest().preview,
-      basePath: this.nextConfig.basePath,
-      images: this.nextConfig.images,
       optimizeCss: this.nextConfig.experimental.optimizeCss,
-      nextConfigOutput: this.nextConfig.output,
       nextScriptWorkers: this.nextConfig.experimental.nextScriptWorkers,
-      disableOptimizedLoading:
-        this.nextConfig.experimental.disableOptimizedLoading,
-      domainLocales: this.nextConfig.i18n?.domains,
-      distDir: this.distDir,
-      serverComponents: this.enabledDirectories.app,
-      cacheLifeProfiles: this.nextConfig.cacheLife,
-      staticPageGenerationTimeout: this.nextConfig.staticPageGenerationTimeout,
-      enableTainting: this.nextConfig.experimental.taint,
-      crossOrigin: this.nextConfig.crossOrigin
-        ? this.nextConfig.crossOrigin
-        : undefined,
-      largePageDataBytes: this.nextConfig.experimental.largePageDataBytes,
-
       isExperimentalCompile: this.nextConfig.experimental.isExperimentalCompile,
-      // `htmlLimitedBots` is passed to server as serialized config in string format
-      htmlLimitedBots: this.nextConfig.htmlLimitedBots,
-      cacheComponents: this.nextConfig.cacheComponents ?? false,
-      partialPrefetching: this.nextConfig.partialPrefetching,
-      validationLevel:
-        this.nextConfig.experimental.instantInsights.validationLevel,
-      experimental: {
-        expireTime: this.nextConfig.expireTime,
-        staleTimes: this.nextConfig.experimental.staleTimes,
-        clientTraceMetadata: this.nextConfig.experimental.clientTraceMetadata,
-        clientParamParsingOrigins:
-          this.nextConfig.experimental.clientParamParsingOrigins,
-        dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,
-        optimisticRouting:
-          this.nextConfig.experimental.optimisticRouting ?? false,
-        inlineCss: this.nextConfig.experimental.inlineCss ?? false,
-        prefetchInlining:
-          this.nextConfig.experimental.prefetchInlining ?? false,
-        authInterrupts: !!this.nextConfig.experimental.authInterrupts,
-        serverComponentsHmrCancellation:
-          this.nextConfig.experimental.serverComponentsHmrCancellation,
-        useCacheTimeout: this.nextConfig.experimental.useCacheTimeout,
-        cachedNavigations:
-          this.nextConfig.experimental.cachedNavigations ?? false,
-        maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
-          this.nextConfig.experimental.maxPostponedStateSize
-        ),
-        exposeTestingApi:
-          this.dev === true ||
-          this.nextConfig.experimental.exposeTestingApiInProductionBuild ===
-            true,
-      },
-      onInstrumentationRequestError:
-        this.instrumentationOnRequestError.bind(this),
-      prefetchHints: {},
-      reactMaxHeadersLength: this.nextConfig.reactMaxHeadersLength,
-      logServerFunctions:
-        typeof this.nextConfig.logging === 'object' &&
-        Boolean(this.nextConfig.logging.serverFunctions),
     }
 
     this.pagesManifest = this.getPagesManifest()
@@ -2106,7 +2051,7 @@ export default abstract class Server<
     ) => Promise<ResponsePayload | null>,
     partialContext: Omit<
       RequestContext<ServerRequest, ServerResponse>,
-      'renderOpts'
+      'renderState'
     >
   ): Promise<void> {
     return getTracer().trace(BaseServerSpan.pipe, async () =>
@@ -2120,22 +2065,12 @@ export default abstract class Server<
     ) => Promise<ResponsePayload | null>,
     partialContext: Omit<
       RequestContext<ServerRequest, ServerResponse>,
-      'renderOpts'
+      'renderState'
     >
   ): Promise<void> {
-    const ua = partialContext.req.headers['user-agent'] || ''
-
     const ctx: RequestContext<ServerRequest, ServerResponse> = {
       ...partialContext,
-      renderOpts: {
-        ...this.renderOpts,
-        // `renderOpts.botType` is accumulated in `this.renderImpl()`
-        supportsDynamicResponse: !this.renderOpts.botType,
-        serveStreamingMetadata: shouldServeStreamingMetadata(
-          ua,
-          this.nextConfig.htmlLimitedBots
-        ),
-      },
+      renderState: {},
     }
 
     const payload = await fn(ctx)
@@ -2147,7 +2082,7 @@ export default abstract class Server<
     const { body } = payload
     let { cacheControl } = payload
     if (!res.sent) {
-      const { generateEtags, poweredByHeader } = this.renderOpts
+      const { generateEtags, poweredByHeader } = this.serverRenderConfig
 
       // Dev responses use `no-cache` so the browser can restore them from the
       // HTTP cache on back/forward instead of reloading. HMR refresh responses
@@ -2187,15 +2122,12 @@ export default abstract class Server<
     ) => Promise<ResponsePayload | null>,
     partialContext: Omit<
       RequestContext<ServerRequest, ServerResponse>,
-      'renderOpts'
+      'renderState'
     >
   ): Promise<string | null> {
     const ctx: RequestContext<ServerRequest, ServerResponse> = {
       ...partialContext,
-      renderOpts: {
-        ...this.renderOpts,
-        supportsDynamicResponse: false,
-      },
+      renderState: {},
     }
     const payload = await fn(ctx)
     if (payload === null) {
@@ -2271,9 +2203,6 @@ export default abstract class Server<
       // (see custom-server integration tests)
       pathname = '/'
     }
-
-    const ua = req.headers['user-agent'] || ''
-    this.renderOpts.botType = getBotType(ua)
 
     // we allow custom servers to call render for all URLs
     // so check if we need to serve a static _next file or not.
@@ -2383,7 +2312,7 @@ export default abstract class Server<
       req,
       res,
       pathname,
-      renderOpts: opts,
+      renderState,
     }: RequestContext<ServerRequest, ServerResponse>,
     { components, query }: FindComponentsResult
   ): Promise<ResponsePayload | null> {
@@ -2677,28 +2606,6 @@ export default abstract class Server<
       }
     }
 
-    if (opts.supportsDynamicResponse === true) {
-      const ua = req.headers['user-agent'] || ''
-      const isBotRequest = isBot(ua)
-      const isSupportedDocument =
-        typeof components.Document?.getInitialProps !== 'function' ||
-        // The built-in `Document` component also supports dynamic HTML for concurrent mode.
-        NEXT_BUILTIN_DOCUMENT in components.Document
-
-      // Disable dynamic HTML in cases that we know it won't be generated,
-      // so that we can continue generating a cache key when possible.
-      // TODO-APP: should the first render for a dynamic app path
-      // be static so we can collect revalidate and populate the
-      // cache if there are no dynamic data requirements
-      opts.supportsDynamicResponse =
-        !isSSG && !isBotRequest && isSupportedDocument
-    }
-
-    // In development, we always want to generate dynamic HTML.
-    if (!isNextDataRequest && isAppPath && this.dev) {
-      opts.supportsDynamicResponse = true
-    }
-
     if (isSSG && this.minimalMode && req.headers[MATCHED_PATH_HEADER]) {
       // the url value is already correct when the matched-path header is set
       resolvedUrlPathname = urlPathname
@@ -2834,11 +2741,11 @@ export default abstract class Server<
     setRequestMeta(request, getRequestMeta(req))
     addRequestMeta(request, 'distDir', this.distDir)
     addRequestMeta(request, 'query', query)
-    addRequestMeta(request, 'params', opts.params)
+    addRequestMeta(request, 'params', renderState.params)
     addRequestMeta(request, 'minimalMode', this.minimalMode)
 
-    if (opts.err) {
-      addRequestMeta(request, 'invokeError', opts.err)
+    if (renderState.error) {
+      addRequestMeta(request, 'invokeError', renderState.error)
     }
 
     const maybeDevRequest: ServerRequest | IncomingMessage =
@@ -2936,7 +2843,7 @@ export default abstract class Server<
       locale: getRequestMeta(ctx.req, 'locale'),
       page,
       query,
-      params: ctx.renderOpts.params || {},
+      params: ctx.renderState.params || {},
       isAppPath,
       sriEnabled: !!this.nextConfig.experimental.sri?.algorithm,
       appPaths,
@@ -3032,8 +2939,8 @@ export default abstract class Server<
             {
               ...ctx,
               pathname: existingMatch.definition.pathname,
-              renderOpts: {
-                ...ctx.renderOpts,
+              renderState: {
+                ...ctx.renderState,
                 params: existingMatch.params,
               },
             },
@@ -3375,9 +3282,9 @@ export default abstract class Server<
           {
             ...ctx,
             pathname: statusPage,
-            renderOpts: {
-              ...ctx.renderOpts,
-              err,
+            renderState: {
+              ...ctx.renderState,
+              error: err,
             },
           },
           result
@@ -3411,11 +3318,11 @@ export default abstract class Server<
           {
             ...ctx,
             pathname: '/_error',
-            renderOpts: {
-              ...ctx.renderOpts,
+            renderState: {
+              ...ctx.renderState,
               // We render `renderToHtmlError` here because `err` is
               // already captured in the stacktrace.
-              err: isWrappedError
+              error: isWrappedError
                 ? renderToHtmlError.innerError
                 : renderToHtmlError,
             },

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -129,6 +129,7 @@ export interface Options extends ServerOptions {
 export default class DevServer extends Server {
   // Override type to make the full config available instead of only NextConfigRuntime
   protected readonly nextConfig: NextConfigComplete
+  private readonly pagesErrorDebug = ReactDevOverlay
 
   /**
    * The promise that resolves when the server is ready. When this is unset
@@ -193,7 +194,6 @@ export default class DevServer extends Server {
     this.bundlerService = options.bundlerService
     this.startServerSpan =
       options.startServerSpan ?? trace('start-next-dev-server')
-    this.renderOpts.ErrorDebug = ReactDevOverlay
     this.staticPathsCache = new LRUCache(
       // 5MB
       5 * 1024 * 1024,
@@ -547,7 +547,7 @@ export default class DevServer extends Server {
     const span = trace('handle-request', undefined, { url: req.url })
     const result = await span.traceAsyncFn(async () => {
       await this.ready?.promise
-      addRequestMeta(req, 'PagesErrorDebug', this.renderOpts.ErrorDebug)
+      addRequestMeta(req, 'PagesErrorDebug', this.pagesErrorDebug)
       return await super.handleRequest(req, res, parsedUrl)
     })
     const memoryUsage = process.memoryUsage()

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -129,6 +129,7 @@ export interface Options extends ServerOptions {
 export default class DevServer extends Server {
   // Override type to make the full config available instead of only NextConfigRuntime
   protected readonly nextConfig: NextConfigComplete
+  private readonly pagesErrorDebug = ReactDevOverlay
 
   /**
    * The promise that resolves when the server is ready. When this is unset
@@ -193,7 +194,6 @@ export default class DevServer extends Server {
     this.bundlerService = options.bundlerService
     this.startServerSpan =
       options.startServerSpan ?? trace('start-next-dev-server')
-    this.renderOpts.ErrorDebug = ReactDevOverlay
     this.staticPathsCache = new LRUCache(
       // 5MB
       5 * 1024 * 1024,
@@ -546,7 +546,7 @@ export default class DevServer extends Server {
     const span = trace('handle-request', undefined, { url: req.url })
     const result = await span.traceAsyncFn(async () => {
       await this.ready?.promise
-      addRequestMeta(req, 'PagesErrorDebug', this.renderOpts.ErrorDebug)
+      addRequestMeta(req, 'PagesErrorDebug', this.pagesErrorDebug)
       return await super.handleRequest(req, res, parsedUrl)
     })
     const memoryUsage = process.memoryUsage()

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -44,7 +44,6 @@ import {
   PAGES_MANIFEST,
   BUILD_ID_FILE,
   MIDDLEWARE_MANIFEST,
-  PREFETCH_HINTS,
   PRERENDER_MANIFEST,
   ROUTES_MANIFEST,
   CLIENT_PUBLIC_FILES_PATH,
@@ -121,7 +120,6 @@ import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 import { isInterceptionRouteRewrite } from '../lib/is-interception-route-rewrite'
 import type { ServerOnInstrumentationRequestError } from './app-render/types'
-import type { PrefetchHints } from '../shared/lib/app-router-types'
 import { RouteKind } from './route-kind'
 import { InvariantError } from '../shared/lib/invariant-error'
 import { AwaiterOnce } from './after/awaiter'
@@ -212,10 +210,6 @@ export default class NextNodeServer extends BaseServer<
     this.routerServerHandler = options.routerServerHandler
     installGlobalBehaviors(this.nextConfig)
 
-    // Load prefetch hints from the build output. This must happen before
-    // any render to ensure segment inlining decisions are available.
-    this.renderOpts.prefetchHints = this.getPrefetchHints()
-
     const isDev = options.dev ?? false
     this.isDev = isDev
     this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
@@ -225,10 +219,10 @@ export default class NextNodeServer extends BaseServer<
      * Using this from process.env allows targeting SSR by calling
      * `process.env.__NEXT_OPTIMIZE_CSS`.
      */
-    if (this.renderOpts.optimizeCss) {
+    if (this.serverRenderConfig.optimizeCss) {
       process.env.__NEXT_OPTIMIZE_CSS = JSON.stringify(true)
     }
-    if (this.renderOpts.nextScriptWorkers) {
+    if (this.serverRenderConfig.nextScriptWorkers) {
       process.env.__NEXT_SCRIPT_WORKERS = JSON.stringify(true)
     }
     if (
@@ -296,7 +290,7 @@ export default class NextNodeServer extends BaseServer<
 
     // when using compile mode static env isn't inlined so we
     // need to populate in normal runtime env
-    if (this.renderOpts.isExperimentalCompile) {
+    if (this.serverRenderConfig.isExperimentalCompile) {
       // supportsImmutableAssets only works with Turbopack, and `isExperimentalCompile` isn't supported
       // with that anyway, so we can assign just use deploymentId here
       populateStaticEnv(this.nextConfig, this.deploymentId || '')
@@ -831,7 +825,7 @@ export default class NextNodeServer extends BaseServer<
             req: ctx.req,
             res: ctx.res,
             query: ctx.query,
-            params: ctx.renderOpts.params,
+            params: ctx.renderState.params,
             page,
             appPaths,
           })
@@ -931,7 +925,7 @@ export default class NextNodeServer extends BaseServer<
         return {
           components,
           query: {
-            ...(!this.renderOpts.isExperimentalCompile &&
+            ...(!this.serverRenderConfig.isExperimentalCompile &&
             components.getStaticProps
               ? {}
               : query),
@@ -1735,7 +1729,7 @@ export default class NextNodeServer extends BaseServer<
     if (
       checkIsOnDemandRevalidate(
         params.request.headers,
-        this.renderOpts.previewProps
+        this.serverRenderConfig.previewProps
       ).isOnDemandRevalidate
     ) {
       return {
@@ -2043,28 +2037,6 @@ export default class NextNodeServer extends BaseServer<
     ) as PreviewPropsManifest
 
     return this._cachedPreviewPropsManifest
-  }
-
-  private _cachedPrefetchHints: Record<string, PrefetchHints> | undefined
-  protected getPrefetchHints(): Record<string, PrefetchHints> {
-    if (this._cachedPrefetchHints) {
-      return this._cachedPrefetchHints
-    }
-
-    this._cachedPrefetchHints =
-      loadManifest<Record<string, PrefetchHints>>(
-        join(
-          /* turbopackIgnore: true */ this.distDir,
-          SERVER_DIRECTORY,
-          PREFETCH_HINTS
-        ),
-        true,
-        undefined,
-        false,
-        true // handleMissing: don't crash if the file doesn't exist
-      ) ?? {}
-
-    return this._cachedPrefetchHints
   }
 
   protected getRoutesManifest(): NormalizedRouteManifest | undefined {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -40,7 +40,6 @@ import {
   PAGES_MANIFEST,
   BUILD_ID_FILE,
   MIDDLEWARE_MANIFEST,
-  PREFETCH_HINTS,
   PRERENDER_MANIFEST,
   ROUTES_MANIFEST,
   CLIENT_PUBLIC_FILES_PATH,
@@ -113,7 +112,6 @@ import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 import { isInterceptionRouteRewrite } from '../lib/is-interception-route-rewrite'
 import type { ServerOnInstrumentationRequestError } from './app-render/types'
-import type { PrefetchHints } from '../shared/lib/app-router-types'
 import { RouteKind } from './route-kind'
 import { InvariantError } from '../shared/lib/invariant-error'
 import { AwaiterOnce } from './after/awaiter'
@@ -203,10 +201,6 @@ export default class NextNodeServer extends BaseServer<
     this.routerServerHandler = options.routerServerHandler
     installGlobalBehaviors(this.nextConfig)
 
-    // Load prefetch hints from the build output. This must happen before
-    // any render to ensure segment inlining decisions are available.
-    this.renderOpts.prefetchHints = this.getPrefetchHints()
-
     const isDev = options.dev ?? false
     this.isDev = isDev
     this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
@@ -216,10 +210,10 @@ export default class NextNodeServer extends BaseServer<
      * Using this from process.env allows targeting SSR by calling
      * `process.env.__NEXT_OPTIMIZE_CSS`.
      */
-    if (this.renderOpts.optimizeCss) {
+    if (this.serverRenderConfig.optimizeCss) {
       process.env.__NEXT_OPTIMIZE_CSS = JSON.stringify(true)
     }
-    if (this.renderOpts.nextScriptWorkers) {
+    if (this.serverRenderConfig.nextScriptWorkers) {
       process.env.__NEXT_SCRIPT_WORKERS = JSON.stringify(true)
     }
     if (
@@ -287,7 +281,7 @@ export default class NextNodeServer extends BaseServer<
 
     // when using compile mode static env isn't inlined so we
     // need to populate in normal runtime env
-    if (this.renderOpts.isExperimentalCompile) {
+    if (this.serverRenderConfig.isExperimentalCompile) {
       // supportsImmutableAssets only works with Turbopack, and `isExperimentalCompile` isn't supported
       // with that anyway, so we can assign just use deploymentId here
       populateStaticEnv(this.nextConfig, this.deploymentId || '')
@@ -814,7 +808,7 @@ export default class NextNodeServer extends BaseServer<
             req: ctx.req,
             res: ctx.res,
             query: ctx.query,
-            params: ctx.renderOpts.params,
+            params: ctx.renderState.params,
             page,
             appPaths,
           })
@@ -914,7 +908,7 @@ export default class NextNodeServer extends BaseServer<
         return {
           components,
           query: {
-            ...(!this.renderOpts.isExperimentalCompile &&
+            ...(!this.serverRenderConfig.isExperimentalCompile &&
             components.getStaticProps
               ? {}
               : query),
@@ -1718,7 +1712,7 @@ export default class NextNodeServer extends BaseServer<
     if (
       checkIsOnDemandRevalidate(
         params.request.headers,
-        this.renderOpts.previewProps
+        this.serverRenderConfig.previewProps
       ).isOnDemandRevalidate
     ) {
       return {
@@ -2009,28 +2003,6 @@ export default class NextNodeServer extends BaseServer<
     ) as PrerenderManifest
 
     return this._cachedPreviewManifest
-  }
-
-  private _cachedPrefetchHints: Record<string, PrefetchHints> | undefined
-  protected getPrefetchHints(): Record<string, PrefetchHints> {
-    if (this._cachedPrefetchHints) {
-      return this._cachedPrefetchHints
-    }
-
-    this._cachedPrefetchHints =
-      (loadManifest(
-        join(
-          /* turbopackIgnore: true */ this.distDir,
-          SERVER_DIRECTORY,
-          PREFETCH_HINTS
-        ),
-        true,
-        undefined,
-        false,
-        true // handleMissing: don't crash if the file doesn't exist
-      ) as Record<string, PrefetchHints>) ?? {}
-
-    return this._cachedPrefetchHints
   }
 
   protected getRoutesManifest(): NormalizedRouteManifest | undefined {

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -66,6 +66,22 @@ describe('app-dir - metadata-streaming', () => {
     expect(await $('title').text()).toBe('index page')
   })
 
+  it('should isolate metadata rendering between concurrent requests', async () => {
+    const [bot$, user$] = await Promise.all([
+      next.render$('/', undefined, {
+        headers: {
+          'user-agent': 'Twitterbot',
+        },
+      }),
+      next.render$('/'),
+    ])
+
+    expect(bot$('head title').text()).toBe('index page')
+    expect(bot$('body title').length).toBe(0)
+    expect(user$('head title').length).toBe(0)
+    expect(user$('body title').text()).toBe('index page')
+  })
+
   it('should send streaming response for headless browser bots', async () => {
     const browser = await next.browser('/')
     await retry(async () => {


### PR DESCRIPTION
### What?

Split BaseServer server-lifetime render configuration from per-request render state. The request context now carries only params and errors, while stable server settings live in a narrow readonly configuration object.

This also removes the shared bot type mutation, dead BaseServer streaming decisions, unused prefetch-hints plumbing, and shared dev overlay mutation.

### Why?

The previous renderOpts object mixed static configuration with request-derived values and was mutated during rendering. Because the object lived on the server instance, values such as bot type could leak between concurrent requests.

### How?

- Add a readonly ServerRenderConfig for the stable values consumed by BaseServer and NextServer.
- Create a fresh RequestRenderState for every request and replace it when propagating params or errors.
- Keep bot, streaming metadata, and dynamic response decisions in the route templates that derive them from the current request.
- Add concurrent bot and user metadata rendering coverage.

### Verification

- `pnpm --filter=next types`
- `pnpm --filter=next build`
- `npx eslint --config eslint.config.mjs --fix packages/next/src/server/base-server.ts packages/next/src/server/next-server.ts packages/next/src/server/dev/next-dev-server.ts test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts`
- `pnpm test-dev-turbo test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts`
- `pnpm test-dev-turbo test/e2e/custom-server/custom-server.test.ts`
- `pnpm test-start-turbo test/production/app-dir/graceful-degrade/graceful-degrade.test.ts test/production/app-dir/graceful-degrade/graceful-degrade-non-bot.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/cache-components-bot-ua/cache-components-bot-ua.test.ts test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/edge-route-catchall/edge-route-catchall.test.ts test/e2e/app-dir/edge-route-rewrite/edge-route-rewrite.test.ts`

<!-- NEXT_JS_LLM_PR -->