### PR TITLE
Stage short-lived `'use cache'` entries correctly in dev

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4339,6 +4339,7 @@ function runDevValidationInBackground(
   ctx: AppRenderContext,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
+  shellStage: RenderStage.Static | RenderStage.Runtime,
   getDevRenderDidError: () => boolean,
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
@@ -4393,7 +4394,8 @@ function runDevValidationInBackground(
             createRequestStore,
             getPayload,
             onError,
-            prerenderResumeDataCache
+            prerenderResumeDataCache,
+            shellStage
           )
 
           // Unlike the cold streamed render, which fills the caches, the warm
@@ -4440,7 +4442,8 @@ interface StagedDevRenderSetup {
  * the request store.
  */
 function setUpStagedDevRender(
-  requestStore: RequestStore
+  requestStore: RequestStore,
+  shellStage: RenderStage.Static | RenderStage.Runtime
 ): StagedDevRenderSetup {
   const cacheSignal = new CacheSignal()
   trackPendingModules(cacheSignal)
@@ -4460,6 +4463,7 @@ function setUpStagedDevRender(
     requestStore.headers
   )
   requestStore.cacheSignal = cacheSignal
+  requestStore.shellStage = shellStage
 
   const environmentName = () =>
     getEnvironmentNameForStage(stageController.currentStage)
@@ -4715,7 +4719,8 @@ async function renderWithWarmCachesForValidationInDev(
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>
+  prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
+  shellStage: RenderStage.Static | RenderStage.Runtime
 ): Promise<DevValidationInputs> {
   const { ComponentMod, setReactDebugChannel } = ctx.renderOpts
   const { clientModules } = getClientReferenceManifest()
@@ -4728,6 +4733,7 @@ async function renderWithWarmCachesForValidationInDev(
   })
 
   const requestStore = createRequestStore()
+  requestStore.shellStage = shellStage
   requestStore.resumeDataCache = createRenderResumeDataCache(
     prerenderResumeDataCache
   )
@@ -4830,7 +4836,7 @@ async function stagedRenderWithCachesInDev(
     prerenderResumeDataCache,
     stageController,
     environmentName,
-  } = setUpStagedDevRender(requestStore)
+  } = setUpStagedDevRender(requestStore, shellStage)
 
   let validationDebugChannel: AnyStream | undefined
   const debugChannel = setReactDebugChannel && createNodeDebugChannel()
@@ -4867,6 +4873,7 @@ async function stagedRenderWithCachesInDev(
       ctx,
       fallbackRouteParams,
       prerenderResumeDataCache,
+      shellStage,
       getDevRenderDidError,
       createRequestStore,
       getPayload,

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -90,6 +90,13 @@ export interface RequestStore extends CommonWorkUnitStore {
 
   // DEV-only
   usedDynamic?: boolean
+  /**
+   * Which shell this dev render produces: `Static` for an initial HTML load, a
+   * plain client navigation, or an HMR refresh; `Runtime` for a client
+   * navigation into a runtime-prefetch route, where the runtime-prefetchable
+   * content has already settled on the client.
+   */
+  shellStage?: RenderStage.Static | RenderStage.Runtime
 }
 
 export type InstantValidationSamples = {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2861,6 +2861,17 @@ export async function cache(
             }
           }
 
+          if (cacheSignal && cacheSignalReadEnded) {
+            // A short-lived deferral above (a `revalidate` of zero or a short
+            // expire, or a short stale time) already ended this read. We're now
+            // regenerating the entry rather than serving it, and the generation
+            // ends the read again once its entry is collected. Re-begin the
+            // read here so the trailing `endRead` stays balanced instead of
+            // over-decrementing the cache signal.
+            cacheSignal.beginRead()
+            cacheSignalReadEnded = false
+          }
+
           const result = await generateCacheEntry(
             workStore,
             cacheContext,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2023,6 +2023,12 @@ export async function cache(
 
   let stream: undefined | ReadableStream = undefined
 
+  // Set when a short-lived warm hit ends its cache read up front (dev only) so
+  // the static-shell boundary doesn't count it as a phantom miss. Once set, the
+  // cache signal read is balanced, so serving must use a plain stream and skip
+  // any trailing cacheSignal.endRead() call.
+  let cacheSignalReadEnded = false
+
   const resumeDataCache = getResumeDataCache(workUnitStore)
 
   const implicitTags = workUnitStore.implicitTags?.tags ?? []
@@ -2165,19 +2171,20 @@ export async function cache(
                     })
                   )
                 }
-                // We delay the cache here so that it doesn't resolve in the static task --
-                // in a regular static prerender, it'd be a hanging promise, and we need to reflect that,
-                // so it has to resolve later.
-                // TODO(restart-on-cache-miss): Optimize away this phantom miss.
-                // We don't end the cache read here, so it always appears as a
-                // cache miss in the static stage even when all caches are
-                // filled, which now routes validation through the background
-                // warm render rather than restarting the streamed response.
+                // A short-lived entry is a dynamic hole, excluded from the
+                // static shell, so we end the cache signal read here (the
+                // prerender case does the same) to avoid this cache hit being
+                // considered a cache miss when checking for pending cache reads
+                // at staged rendering task boundaries. The value is deferred to
+                // the runtime stage.
+                if (cacheSignal && !cacheSignalReadEnded) {
+                  cacheSignal.endRead()
+                  cacheSignalReadEnded = true
+                }
 
                 const stagedRendering = workUnitStore.stagedRendering
                 const stage = stagedRendering
-                  ? // TODO(app-shells): exclude caches with a short staletime
-                    getSessionDataStage(stagedRendering)
+                  ? getSessionDataStage(stagedRendering)
                   : RenderStage.Runtime
                 await makeDevtoolsIOAwarePromise(
                   undefined,
@@ -2221,15 +2228,25 @@ export async function cache(
                 'dynamic "use cache"'
               )
             case 'request': {
-              if (process.env.NODE_ENV === 'development') {
-                // We delay the cache here so that it doesn't resolve in the runtime phase --
-                // in a regular runtime prerender, it'd be a hanging promise, and we need to reflect that,
-                // so it has to resolve later.
-                // TODO(restart-on-cache-miss): Optimize away this phantom miss.
-                // We don't end the cache read here, so it always appears as a
-                // cache miss in the runtime stage even when all caches are
-                // filled, which now routes validation through the background
-                // warm render rather than restarting the streamed response.
+              // A short stale time excludes the entry from the runtime prefetch
+              // shell, but not from the static shell. We only replicate that
+              // exclusion (the `prerender-runtime` behavior) when this render
+              // produces the runtime prefetch shell: a client navigation into a
+              // runtime-prefetch route. An initial load, a plain navigation,
+              // and an HMR refresh produce the static shell, where the entry
+              // stays and resolves like the static prerender.
+              if (
+                process.env.NODE_ENV === 'development' &&
+                workUnitStore.shellStage === RenderStage.Runtime
+              ) {
+                // End the cache signal read (once, in case the expire block
+                // above already did) so the deferred value isn't counted as a
+                // pending read at a staged rendering boundary, then defer it to
+                // the dynamic stage.
+                if (cacheSignal && !cacheSignalReadEnded) {
+                  cacheSignal.endRead()
+                  cacheSignalReadEnded = true
+                }
                 await makeDevtoolsIOAwarePromise(
                   undefined,
                   workUnitStore,
@@ -2325,11 +2342,13 @@ export async function cache(
         const [streamA, streamB] = rdcResult.entry.value.tee()
         rdcResult.entry.value = streamB
 
-        if (cacheSignal) {
+        if (cacheSignal && !cacheSignalReadEnded) {
           // When we have a cacheSignal we need to block on reading the cache
           // entry before ending the read.
           stream = createTrackedReadableStream(streamA, cacheSignal)
         } else {
+          // The cache signal read was already ended for a short-lived deferral
+          // (or there is no cacheSignal), so serve a plain stream.
           stream = streamA
         }
       } else {
@@ -2722,21 +2741,20 @@ export async function cache(
               return hangingPromise
             case 'request': {
               if (process.env.NODE_ENV === 'development') {
-                // We delay the cache here so that it doesn't resolve in the
-                // static task -- in a regular static prerender, it'd be a
-                // hanging promise, and we need to reflect that, so it has to
-                // resolve later.
-                // TODO(restart-on-cache-miss): Optimize away this phantom miss.
-                // We don't end the cache read here, so on a warm handler hit it
-                // still appears as a cache miss in the static stage even when
-                // all caches are filled, which now routes validation through the
-                // background warm render rather than restarting the streamed
-                // response.
+                // A short-lived entry is a dynamic hole, excluded from the
+                // static shell, so we end the cache signal read here (the
+                // prerender case does the same) to avoid this cache hit being
+                // considered a cache miss when checking for pending cache reads
+                // at staged rendering task boundaries. The value is deferred to
+                // the runtime stage.
+                if (cacheSignal && !cacheSignalReadEnded) {
+                  cacheSignal.endRead()
+                  cacheSignalReadEnded = true
+                }
 
                 const stagedRendering = workUnitStore.stagedRendering
                 const stage = stagedRendering
-                  ? // TODO(app-shells): exclude caches with a short staletime
-                    getSessionDataStage(stagedRendering)
+                  ? getSessionDataStage(stagedRendering)
                   : RenderStage.Runtime
                 await makeDevtoolsIOAwarePromise(
                   undefined,
@@ -2753,6 +2771,56 @@ export async function cache(
             case 'private-cache':
             case 'unstable-cache':
             case 'generate-static-params':
+              break
+            default:
+              workUnitStore satisfies never
+          }
+        }
+
+        if (
+          entry !== undefined &&
+          entry.stale < RUNTIME_PREFETCH_DYNAMIC_STALE
+        ) {
+          switch (workUnitStore.type) {
+            case 'request': {
+              // A short stale time excludes the entry from the runtime prefetch
+              // shell, but not from the static shell. We only replicate that
+              // exclusion (the `prerender-runtime` behavior) when this render
+              // produces the runtime prefetch shell: a client navigation into a
+              // runtime-prefetch route. An initial load, a plain navigation,
+              // and an HMR refresh produce the static shell, where the entry
+              // stays and resolves like the static prerender.
+              if (
+                process.env.NODE_ENV === 'development' &&
+                workUnitStore.shellStage === RenderStage.Runtime
+              ) {
+                // End the cache signal read (once, in case the expire block
+                // above already did) so the deferred value isn't counted as a
+                // pending read at a staged rendering boundary, then defer it to
+                // the dynamic stage.
+                if (cacheSignal && !cacheSignalReadEnded) {
+                  cacheSignal.endRead()
+                  cacheSignalReadEnded = true
+                }
+                await makeDevtoolsIOAwarePromise(
+                  undefined,
+                  workUnitStore,
+                  RenderStage.Dynamic
+                )
+              }
+              break
+            }
+            case 'prerender':
+            case 'prerender-runtime':
+            case 'prerender-ppr':
+            case 'prerender-legacy':
+            case 'cache':
+            case 'private-cache':
+            case 'unstable-cache':
+            case 'generate-static-params':
+              // A handler read in a prerender context is a cache-filling read.
+              // The stale exclusion for those is applied when the RDC is read
+              // in the final prerender, so there's nothing to do here.
               break
             default:
               workUnitStore satisfies never
@@ -2898,9 +2966,11 @@ export async function cache(
           // and add it to the resume data cache.
           if (resumeDataCache?.mutable) {
             const [entryLeft, entryRight] = cloneCacheEntry(entry)
-            if (cacheSignal) {
+            if (cacheSignal && !cacheSignalReadEnded) {
               stream = createTrackedReadableStream(entryLeft.value, cacheSignal)
             } else {
+              // The read was already ended for a short-lived deferral (or there
+              // is no cacheSignal), so serve a plain stream.
               stream = entryLeft.value
             }
 
@@ -2916,10 +2986,11 @@ export async function cache(
                 dynamicNestedCacheError: entryMetadata.dynamicNestedCacheError,
               })
             )
-          } else {
+          } else if (!cacheSignalReadEnded) {
             // If we're not regenerating we need to signal that we've finished
             // putting the entry into the cache scope at this point. Otherwise
-            // we do that inside generateCacheEntry.
+            // we do that inside generateCacheEntry. (Skipped when the read was
+            // already ended for a short-lived deferral.)
             cacheSignal?.endRead()
           }
 

--- a/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
@@ -276,12 +276,7 @@ describe.each([
           }
         })
 
-        // TODO: Skipped until the cache read is ended for short-lived handler
-        // hits. Today a warm reload defers the value without ending the read,
-        // so it triggers as a phantom cache miss whose phase the streaming dev
-        // render doesn't pin down. Re-enable once the read is ended, after
-        // which a warm reload should resolve in the runtime stage.
-        it.skip('cached data + short-lived cached data', async () => {
+        it('cached data + short-lived cached data', async () => {
           const path = '/short-lived-cache'
 
           const assertLogs = async (browser: Playwright) => {
@@ -296,6 +291,47 @@ describe.each([
               logs,
               'after short-lived cache read - layout',
               RUNTIME_ENV
+            )
+
+            assertLog(logs, 'after uncached fetch - layout', 'Server')
+            assertLog(logs, 'after uncached fetch - page', 'Server')
+          }
+
+          if (isInitialLoad) {
+            await testInitialLoad(path, assertLogs)
+          } else {
+            await testNavigation(path, assertLogs)
+          }
+        })
+
+        it('cached data + short-stale cached data', async () => {
+          const path = '/short-stale-cache'
+
+          // A short stale time excludes the entry from the runtime prefetch
+          // shell, but not from the static shell. So an initial load resolves
+          // it in the static stage (Prerender), and so does a navigation into a
+          // route without runtime prefetch. Only a navigation into a
+          // runtime-prefetch route excludes it, resolving it in the dynamic
+          // stage (Server). This asymmetry mirrors the build-time behavior,
+          // where a short stale time is omitted from the runtime prefetch but
+          // not from the static shell.
+          const shortStaleEnv =
+            !isInitialLoad && hasRuntimePrefetch ? 'Server' : 'Prerender'
+
+          const assertLogs = async (browser: Playwright) => {
+            const logs = await browser.log()
+            assertLog(logs, 'after cache read - layout', 'Prerender')
+            assertLog(logs, 'after cache read - page', 'Prerender')
+
+            assertLog(
+              logs,
+              'after short-stale cache read - page',
+              shortStaleEnv
+            )
+            assertLog(
+              logs,
+              'after short-stale cache read - layout',
+              shortStaleEnv
             )
 
             assertLog(logs, 'after uncached fetch - layout', 'Server')

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/page.tsx
@@ -15,6 +15,9 @@ export default function Page() {
           <Link href="/short-lived-cache">/short-lived-cache</Link>
         </li>
         <li>
+          <Link href="/short-stale-cache">/short-stale-cache</Link>
+        </li>
+        <li>
           <Link href="/successive-caches">/successive-caches</Link>
         </li>
         <li>

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/data-fetching.tsx
@@ -19,7 +19,16 @@ export async function ShortLivedCache({
 
 async function getShortLivedCachedData(_key: string) {
   'use cache'
-  cacheLife('seconds')
+  // TODO(make-dev-fast): This should be able to use `cacheLife('seconds')`. We
+  // use a long `revalidate` instead so the entry stays a fresh hit for the
+  // duration of the test, isolating it from the in-memory handler dropping the
+  // entry at `revalidate` (and thus from dev SWR). `expire` stays under 5
+  // minutes so the entry is still short-lived (excluded from the static shell,
+  // deferred to the runtime stage), and `stale` stays at the runtime-prefetch
+  // threshold so it is not also excluded from the runtime prefetch shell. Once
+  // the dev in-memory handler serves stale entries (SWR), flip this back to
+  // `cacheLife('seconds')`.
+  cacheLife({ stale: 30, revalidate: 120, expire: 240 })
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/data-fetching.tsx
@@ -1,0 +1,36 @@
+import { cacheLife } from 'next/cache'
+
+export async function ShortStaleCache({
+  label,
+  cacheKey,
+}: {
+  label: string
+  cacheKey: string
+}) {
+  const data = await getShortStaleCachedData(cacheKey)
+  console.log(`after short-stale cache read - ${label}`)
+  return (
+    <dl>
+      <dt>Short-stale Cached Data</dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function getShortStaleCachedData(_key: string) {
+  'use cache'
+  // A short stale time (below the runtime-prefetch threshold) paired with a
+  // long expire time. The long expire keeps the entry in the static shell, so
+  // an initial load, and a navigation into a route without runtime prefetch,
+  // resolves it during the static stage. The short stale time excludes it from
+  // the runtime prefetch shell, so a navigation into a runtime-prefetch route
+  // resolves it dynamically instead. The long revalidate keeps the entry a
+  // fresh hit for the duration of the test, isolating it from the in-memory
+  // handler dropping the entry at `revalidate` (and thus from dev
+  // stale-while-revalidate).
+  // TODO(make-dev-fast): Once the dev in-memory handler serves stale entries
+  // (SWR), the long revalidate can be dropped.
+  cacheLife({ stale: 10, revalidate: 120, expire: 3600 })
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/layout.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+import { UncachedFetch, CachedData } from '../data-fetching'
+import { ShortStaleCache } from './data-fetching'
+
+export const prefetch = 'allow-runtime'
+
+const CACHE_KEY = __dirname + '/__LAYOUT__'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <section>
+        <h1>Layout</h1>
+        <p>This data is from a layout</p>
+
+        <CachedData label="layout" cacheKey={CACHE_KEY} />
+
+        <Suspense fallback="Loading short-stale cache...">
+          <ShortStaleCache label="layout" cacheKey={CACHE_KEY} />
+        </Suspense>
+
+        <Suspense fallback="Loading uncached fetch...">
+          <UncachedFetch label="layout" cacheKey={CACHE_KEY} />
+        </Suspense>
+      </section>
+    </>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { CachedData, UncachedFetch } from '../data-fetching'
+import { ShortStaleCache } from './data-fetching'
+
+const CACHE_KEY = __dirname + '/__PAGE__'
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Warmup Dev Renders - short stale cache</h1>
+
+      <CachedData label="page" cacheKey={CACHE_KEY} />
+
+      <Suspense fallback="Loading short-stale cache...">
+        <ShortStaleCache label="page" cacheKey={CACHE_KEY} />
+      </Suspense>
+
+      <Suspense fallback="Loading uncached fetch...">
+        <UncachedFetch label="page" cacheKey={CACHE_KEY} />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/page.tsx
@@ -15,6 +15,9 @@ export default function Page() {
           <Link href="/short-lived-cache">/short-lived-cache</Link>
         </li>
         <li>
+          <Link href="/short-stale-cache">/short-stale-cache</Link>
+        </li>
+        <li>
           <Link href="/successive-caches">/successive-caches</Link>
         </li>
         <li>

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/data-fetching.tsx
@@ -19,7 +19,16 @@ export async function ShortLivedCache({
 
 async function getShortLivedCachedData(_key: string) {
   'use cache'
-  cacheLife('seconds')
+  // TODO(make-dev-fast): This should be able to use `cacheLife('seconds')`. We
+  // use a long `revalidate` instead so the entry stays a fresh hit for the
+  // duration of the test, isolating it from the in-memory handler dropping the
+  // entry at `revalidate` (and thus from dev SWR). `expire` stays under 5
+  // minutes so the entry is still short-lived (excluded from the static shell,
+  // deferred to the runtime stage), and `stale` stays at the runtime-prefetch
+  // threshold so it is not also excluded from the runtime prefetch shell. Once
+  // the dev in-memory handler serves stale entries (SWR), flip this back to
+  // `cacheLife('seconds')`.
+  cacheLife({ stale: 30, revalidate: 120, expire: 240 })
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/data-fetching.tsx
@@ -1,0 +1,36 @@
+import { cacheLife } from 'next/cache'
+
+export async function ShortStaleCache({
+  label,
+  cacheKey,
+}: {
+  label: string
+  cacheKey: string
+}) {
+  const data = await getShortStaleCachedData(cacheKey)
+  console.log(`after short-stale cache read - ${label}`)
+  return (
+    <dl>
+      <dt>Short-stale Cached Data</dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function getShortStaleCachedData(_key: string) {
+  'use cache'
+  // A short stale time (below the runtime-prefetch threshold) paired with a
+  // long expire time. The long expire keeps the entry in the static shell, so
+  // an initial load, and a navigation into a route without runtime prefetch,
+  // resolves it during the static stage. The short stale time excludes it from
+  // the runtime prefetch shell, so a navigation into a runtime-prefetch route
+  // resolves it dynamically instead. The long revalidate keeps the entry a
+  // fresh hit for the duration of the test, isolating it from the in-memory
+  // handler dropping the entry at `revalidate` (and thus from dev
+  // stale-while-revalidate).
+  // TODO(make-dev-fast): Once the dev in-memory handler serves stale entries
+  // (SWR), the long revalidate can be dropped.
+  cacheLife({ stale: 10, revalidate: 120, expire: 3600 })
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/layout.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { UncachedFetch, CachedData } from '../data-fetching'
+import { ShortStaleCache } from './data-fetching'
+
+const CACHE_KEY = __dirname + '/__LAYOUT__'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <section>
+        <h1>Layout</h1>
+        <p>This data is from a layout</p>
+
+        <CachedData label="layout" cacheKey={CACHE_KEY} />
+
+        <Suspense fallback="Loading short-stale cache...">
+          <ShortStaleCache label="layout" cacheKey={CACHE_KEY} />
+        </Suspense>
+
+        <Suspense fallback="Loading uncached fetch...">
+          <UncachedFetch label="layout" cacheKey={CACHE_KEY} />
+        </Suspense>
+      </section>
+    </>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { CachedData, UncachedFetch } from '../data-fetching'
+import { ShortStaleCache } from './data-fetching'
+
+const CACHE_KEY = __dirname + '/__PAGE__'
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Warmup Dev Renders - short stale cache</h1>
+
+      <CachedData label="page" cacheKey={CACHE_KEY} />
+
+      <Suspense fallback="Loading short-stale cache...">
+        <ShortStaleCache label="page" cacheKey={CACHE_KEY} />
+      </Suspense>
+
+      <Suspense fallback="Loading uncached fetch...">
+        <UncachedFetch label="page" cacheKey={CACHE_KEY} />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-indicator/app/short-lived/page.tsx
+++ b/test/development/app-dir/cache-indicator/app/short-lived/page.tsx
@@ -3,7 +3,14 @@ import { Suspense } from 'react'
 
 async function ShortLivedData() {
   'use cache'
-  cacheLife('seconds')
+  // TODO(make-dev-fast): This should be able to use `cacheLife('seconds')`. We
+  // use a long `revalidate` instead so the entry stays a fresh hit on the warm
+  // reload of the page, isolating this test from the in-memory handler dropping
+  // the entry at `revalidate` (and thus from dev SWR). `expire` stays under 5
+  // minutes so it is still short-lived (deferred, out of the static shell).
+  // Once the dev in-memory handler serves stale entries (SWR), flip this back
+  // to `cacheLife('seconds')`.
+  cacheLife({ stale: 30, revalidate: 120, expire: 240 })
   await new Promise((resolve) => setTimeout(resolve, 100))
   return <p id="short-lived">{Math.random()}</p>
 }

--- a/test/development/app-dir/cache-indicator/cache-indicator.test.ts
+++ b/test/development/app-dir/cache-indicator/cache-indicator.test.ts
@@ -246,27 +246,29 @@ describe('cache-indicator', () => {
       ])
     })
 
-    // TODO: short-lived `'use cache'` entries are deferred to a later stage
-    // without ending the cache read, so they register as a cache miss on every
-    // load. Until that's fixed, the Cold cache badge shows even on subsequent
-    // reloads. After this is fixed, flip the warm-reload assertion below to
-    // expect no badge.
-    it('shows the Cold cache badge on every load for a short-lived cache (current limitation)', async () => {
+    it('shows the Cold cache badge on an initial cold load and not on a warm reload for a short-lived cache', async () => {
       const browser = await next.browser('/short-lived')
 
-      await retry(async () => {
-        expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
-          true
-        )
-      })
-
-      await browser.refresh()
+      // Cold load: the short-lived cache misses and fills while streaming, so
+      // the cold verdict is replayed after load.
       await browser.elementById('short-lived')
       await retry(async () => {
         expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
           true
         )
       })
+
+      // Warm reload: the short-lived entry is a hit. It is deferred to a later
+      // stage (it stays out of the static shell), but its cache read is ended up
+      // front, so it does not register as a phantom cache miss and no badge
+      // appears. An absence can't be retried on, so wait out the
+      // replay-on-connect window and then assert it never showed.
+      await browser.refresh()
+      await browser.elementById('short-lived')
+      await waitFor(500)
+      expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
+        false
+      )
     })
 
     // TODO: private `'use cache'` entries aren't persisted in dev yet, so they


### PR DESCRIPTION
When the streaming dev render defers a short-lived `'use cache'` entry to a later stage (a `revalidate` of zero or a short `expire` excludes it from the static shell, a short `stale` time excludes it from the runtime prefetch shell), it previously left the cache signal read open. At a staged rendering task boundary that open read looked like a pending cache read, so even a warm handler hit was counted as a cache miss, lighting the cold-cache indicator and routing validation through the background warm render. We now end the cache signal read as soon as such an entry is deferred, the same as the prerender path already does, and serve the buffered value through a plain stream instead of one tracked by the cache signal, so a warm short-lived hit is no longer mistaken for a miss. A deferred entry can still turn out to be stale and need regenerating (for instance, a cache handler may return a past-`expire` entry), so the regenerate path re-begins the read before generating, keeping the signal balanced against the regeneration's own end of the read rather than over-decrementing it.

The runtime-prefetch exclusion for a short stale time must only apply when the render actually produces the runtime prefetch shell, which is a property of the request rather than the cache entry. An initial HTML load, a plain client navigation, and an HMR refresh all produce the static shell, where a short-stale entry stays, mirroring the static prerender. A client navigation into a runtime-prefetch route produces the runtime prefetch shell, where it is excluded, mirroring the `prerender-runtime` prerender. We thread the render's shell stage onto the request store, and onto the warm validation render that mirrors it, and gate the stale-based deferral on `shellStage === Runtime`. This preserves the build-time asymmetry where a short stale time is omitted from the runtime prefetch but not from the static shell.

A new `short-stale-cache` fixture and warmup test exercise this asymmetry directly: a `'use cache'` entry with a short stale time but a long expire resolves in the static stage on an initial load and on a navigation without runtime prefetch, and only resolves dynamically on a navigation into a runtime-prefetch route. The previously skipped short-lived warmup case is re-enabled, and the cache-indicator short-lived case now asserts the cold-cache badge on a cold load but not on a warm reload. Those fixtures use a long `revalidate` so the entry stays a fresh hit for the duration of the test, isolating them from the in-memory handler dropping the entry at `revalidate`; that workaround can be dropped once the cache handler serves stale entries in dev.