### PR TITLE
fix(next-start): report export dir for output export

### DIFF
--- a/packages/next/src/server/lib/output-error.ts
+++ b/packages/next/src/server/lib/output-error.ts
@@ -1,0 +1,9 @@
+import type { NextConfigComplete } from '../config-shared'
+
+export function getOutputExportStartError(
+  config: Pick<NextConfigComplete, 'distDir'>
+) {
+  const exportDir = config.distDir === '.next' ? 'out' : config.distDir
+
+  return `"next start" does not work with "output: export" configuration. Use "npx serve@latest ${exportDir}" instead.`
+}

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -51,6 +51,7 @@ import { filterInternalHeaders } from './server-ipc/utils'
 import { blockCrossSiteDEV } from './router-utils/block-cross-site-dev'
 import { traceGlobals } from '../../trace/shared'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
+import { getOutputExportStartError } from './output-error'
 import {
   RouterServerContextSymbol,
   routerServerGlobal,
@@ -112,6 +113,10 @@ export async function initialize(opts: {
       },
     }
   )
+
+  if (!opts.dev && config.output === 'export') {
+    throw new Error(getOutputExportStartError(config))
+  }
 
   let compress: ReturnType<typeof setupCompression> | undefined
 

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -22,6 +22,7 @@ import {
 import { PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 import { getTracer } from './lib/trace/tracer'
 import { NextServerSpan } from './lib/trace/constants'
+import { getOutputExportStartError } from './lib/output-error'
 import { formatUrl } from '../shared/lib/router/utils/format-url'
 import type { ServerFields } from './lib/router-utils/setup-dev-bundler'
 import type { ServerInitResult } from './lib/render-server'
@@ -385,9 +386,7 @@ export class NextServer implements NextWrapperServer {
               )
             }
           } else if (conf.output === 'export') {
-            throw new Error(
-              `"next start" does not work with "output: export" configuration. Use "npx serve@latest out" instead.`
-            )
+            throw new Error(getOutputExportStartError(conf))
           }
         }
 

--- a/test/e2e/app-dir-export/test/start.test.ts
+++ b/test/e2e/app-dir-export/test/start.test.ts
@@ -24,6 +24,30 @@ describe('app dir - with output export (next start)', () => {
       })
     })
 
+    it('should error during next start with output export and custom distDir', async () => {
+      await next.patchFile(
+        'next.config.js',
+        (content) => content.replace('// distDir', 'distDir'),
+        async () => {
+          const { exitCode } = await next.build()
+          expect(exitCode).toBe(0)
+
+          try {
+            await next.start({ skipBuild: true })
+          } catch (e) {}
+
+          await retry(() => {
+            expect(next.cliOutput).toContain(
+              `"next start" does not work with "output: export" configuration. Use "npx serve@latest .next-custom" instead.`
+            )
+            expect(next.cliOutput).not.toContain(
+              'Could not find a production build'
+            )
+          })
+        }
+      )
+    })
+
     it('should warn during next start with output standalone', async () => {
       await next.patchFile(
         'next.config.js',


### PR DESCRIPTION
### What?

Share the `next start` error for `output: 'export'` and make it report the directory that should be served.

### Why?

When `output: 'export'` is used with a custom `distDir`, `next build` writes the static export to that configured directory while the internal build artifacts still live in `.next`. `next start` could fail while looking for `BUILD_ID` in the export directory and show the generic "Could not find a production build" error instead of the existing static-export guidance.

### How?

- Added a shared helper for the `output: 'export'` `next start` error.
- Check `config.output === 'export'` in `router-server` before filesystem initialization tries to read `BUILD_ID`.
- Keep the default guidance as `npx serve@latest out`, and use the configured export directory when `distDir` is customized.
- Added an e2e regression test for `output: 'export'` with a custom `distDir`.

Fixes #73051

### Tests

- `pnpm exec prettier --check packages/next/src/server/lib/output-error.ts packages/next/src/server/next.ts packages/next/src/server/lib/router-server.ts test/e2e/app-dir-export/test/start.test.ts`
- `NEXT_TEST_MODE=start IS_WEBPACK_TEST=1 HEADLESS=true pnpm exec jest --runInBand test/e2e/app-dir-export/test/start.test.ts`
