### PR TITLE
docs: expand the Cache Components migration guide

### DIFF
--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -623,7 +623,7 @@ async function Dashboard() {
 }
 ```
 
-Your page receives `params` and `searchParams` as props, and both are promises. Apply the same pattern: pass the promise straight through to the `<Suspense>`-wrapped component as a prop and `await` it there, rather than at the top of the page. You can also unwrap the promise inline with `.then()` and pass a plain value down; see [Streaming](/docs/app/guides/streaming) for the full pattern.
+Your page receives `params` and `searchParams` as props, and both are promises. Apply the same pattern: pass the promise straight through to the `<Suspense>`-wrapped component as a prop and `await` it there, rather than at the top of the page. You can also unwrap the promise inline with `.then()` and pass a plain value down; see [Streaming](/docs/app/guides/streaming#push-dynamic-access-down) for a similar pattern.
 
 ```tsx filename="app/page.tsx" switcher
 import { Suspense } from 'react'
@@ -717,7 +717,7 @@ async function getProducts() {
 }
 ```
 
-> **Good to know:** Reading uncached or runtime data in a `GET` handler bails out of prerendering by **throwing**. A `try/catch` you already have around other operations will catch that bail-out. This is harmless (prerendering has already stopped and the value isn't used), but a `catch` that logs the error produces noisy build-time logs. To quiet them, set `experimental.hideLogsAfterAbort: true` to hide logs emitted after a bail-out.
+> **Good to know:** Reading uncached or runtime data in a `GET` handler bails out of prerendering by **throwing**. A `try/catch` you already have around other operations will catch that bail-out. If the `catch` block logs the error, it adds noise to the build output. Set `experimental.hideLogsAfterAbort: true` to hide logs emitted after a bail-out.
 
 ## `generateMetadata` and `generateViewport`
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -561,7 +561,7 @@ async function Post({ params }) {
 }
 ```
 
-Client hooks that read the route need the same treatment. In the App Shell, the params, and by extension the pathname, are unknown, so reading these hooks suspends, wherever the component renders. A nav or breadcrumb in a shared layout, for instance, suspends while Next.js generates the App Shell for any route below it that has dynamic params. Wrap the component that reads the hook in `<Suspense>` (push the read down to the smallest leaf so the rest stays prerendered), or the build fails:
+The same applies to client hooks that read the route. When the route's pathname is fully known, they resolve during prerendering and need no boundary. When it depends on dynamic params not yet known, they suspend, wherever the component sits. A nav or breadcrumb in a shared layout, for instance, suspends while Next.js generates the App Shell for any route below it that has dynamic params. Wrap the component that reads the hook in `<Suspense>` (push the read down to the smallest leaf so the rest stays prerendered), or the build fails:
 
 - [`usePathname`](/docs/app/api-reference/functions/use-pathname)
 - [`useParams`](/docs/app/api-reference/functions/use-params)

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -20,7 +20,7 @@ The migration is driven by **instant navigation validation**. With Cache Compone
 
 Start by removing the route segment configs (`dynamic`, `revalidate`, `fetchCache`), then follow the validation insights and errors. Each one names the code to fix, most often uncached data to cache with [`use cache`](/docs/app/api-reference/directives/use-cache) or runtime data to wrap in [`<Suspense>`](https://react.dev/reference/react/Suspense). If a route needs more work than you want to take on right now, you can [opt it out of validation](#opting-out-of-validation) and come back to it later.
 
-Your existing `fetch` caching keeps working as a separate layer, so let the insights and errors guide what to change.
+Your existing `fetch` and `unstable_cache` caching keeps working as a separate layer, so let the insights and errors guide what to change.
 
 Some surfaces have their own steps:
 
@@ -211,7 +211,7 @@ export default async function Page() {
 
 ## Following validation
 
-When a component would block a navigation, the dev overlay surfaces a **blocking-route** insight that names the component and points at two fixes: cache it, or stream it behind `<Suspense>`.
+Cache Components validates your routes in development and surfaces errors and insights in the dev overlay. Some look like this, naming the affected component and pointing at a fix:
 
 <FixCardGrid>
   <FixCard
@@ -237,11 +237,11 @@ When a component would block a navigation, the dev overlay surfaces a **blocking
   />
 </FixCardGrid>
 
-Work through the insights and errors until they're gone. For the full validation workflow, the DevTools, and CI testing, see the [instant navigation guide](/docs/app/guides/instant-navigation).
+Each card is clickable and opens a page with patterns, code samples, and trade-offs. Work through the insights and errors until they're gone. For the full validation workflow, the DevTools, and CI testing, see the [instant navigation guide](/docs/app/guides/instant-navigation).
 
 ## Opting out of validation
 
-A validation insight or error tells you a route won't render instantly. Resolve it by following the recommendation: cache the data with [`use cache`](/docs/app/api-reference/directives/use-cache) or wrap it in [`<Suspense>`](https://react.dev/reference/react/Suspense). If you don't want to deal with it right now, set the [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) config to `false` on the segment that raised it (a layout, page, or parallel slot), then come back to it later.
+A validation insight or error tells you a route won't render instantly. Resolve it by following the recommendation: cache the data with [`use cache`](/docs/app/api-reference/directives/use-cache) or wrap it in [`<Suspense>`](https://react.dev/reference/react/Suspense). If you're not ready to address it yet, set the [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) config to `false` on the segment that raised it (a layout, page, or parallel slot), then come back to it later.
 
 ```tsx filename="app/dashboard/layout.tsx"
 export const instant = false
@@ -381,11 +381,7 @@ export async function getUser(id) {
 }
 ```
 
-Similarly to the `fetch` cache, `unstable_cache` persists cached values across deployments and across serverless instances.
-
-`use cache` defaults to in-memory storage, so its entries are discarded when the serverless instance is destroyed and are scoped to a single deployment. Use [`use cache: remote`](/docs/app/api-reference/directives/use-cache-remote) or a [cache handler](/docs/app/api-reference/config/next-config-js/cacheHandlers) for storage that survives instance teardown. Even with durable storage, expect cached values to recompute after a new deployment.
-
-> **Good to know:** Like `unstable_cache`, a `use cache` function cannot read runtime data such as `cookies()` or `headers()`. Read it outside the cached function and pass what you need in as an argument.
+Like the `fetch` Data Cache, `unstable_cache` persists cached values across deployments and serverless instances, while `use cache` does not. See [`fetch` cache options](#fetch-cache-options) above for the storage details.
 
 ## On-demand revalidation (`revalidateTag`, `revalidatePath`, `updateTag`)
 
@@ -507,6 +503,8 @@ Paths you don't return are still served. Next.js serves the App Shell instantly,
 
 To produce the App Shell, pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary instead of awaiting it at the top of the component, so unknown params can still prerender.
 
+> **Good to know:** The client hooks [`usePathname`](/docs/app/api-reference/functions/use-pathname), [`useSelectedLayoutSegment`](/docs/app/api-reference/functions/use-selected-layout-segment), and [`useSelectedLayoutSegments`](/docs/app/api-reference/functions/use-selected-layout-segments) need the same treatment. On a route with dynamic params not covered by `generateStaticParams`, they suspend during prerendering because the pathname depends on the unknown param, so wrap the component that calls them in `<Suspense>` or the build fails. See [Next.js encountered URL data in a Client Component outside of Suspense](/docs/messages/blocking-prerender-client-hook).
+
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 // Before - awaiting params at the top blocks the shell
 export default async function Page({
@@ -565,7 +563,7 @@ async function Post({ params }) {
 
 ## `cookies`, `headers`, and `searchParams`
 
-**Wrap runtime data access in `<Suspense>`.** Without Cache Components, reading [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) opts the whole route into dynamic rendering. With Cache Components, accessing them outside a [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary raises [`Uncached data was accessed outside of <Suspense>`](/docs/messages/blocking-route). Move the access into a component wrapped in `<Suspense>` so the rest of the page prerenders as a static shell and the dynamic part streams in at request time.
+**Wrap runtime data access in `<Suspense>`.** Without Cache Components, reading [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) opts the whole route into dynamic rendering. With Cache Components, accessing them outside a [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary surfaces the [**blocking-route** insight](/docs/messages/blocking-prerender-dynamic). Move the access into a component wrapped in `<Suspense>` so the rest of the page prerenders as a static shell and the dynamic part streams in at request time.
 
 ```tsx filename="app/page.tsx" switcher
 import { cookies } from 'next/headers'
@@ -625,7 +623,7 @@ async function Dashboard() {
 }
 ```
 
-`params` and `searchParams` arrive as props on your page, and both are promises. Apply the same pattern: pass the promise straight through to the `<Suspense>`-wrapped component as a prop and `await` it there, rather than at the top of the page.
+Your page receives `params` and `searchParams` as props, and both are promises. Apply the same pattern: pass the promise straight through to the `<Suspense>`-wrapped component as a prop and `await` it there, rather than at the top of the page. You can also unwrap the promise inline with `.then()` and pass a plain value down; see [Streaming](/docs/app/guides/streaming) for the full pattern.
 
 ```tsx filename="app/page.tsx" switcher
 import { Suspense } from 'react'
@@ -719,7 +717,7 @@ async function getProducts() {
 }
 ```
 
-> **Good to know:** Reading uncached or runtime data in a `GET` handler bails out of prerendering by **throwing**. A `try/catch` you already have around other operations will catch that bail-out. This is harmless (prerendering has already stopped and the value isn't used), but a `catch` that logs the error produces noisy build-time logs. To quiet them, either set `experimental.hideLogsAfterAbort: true` to hide logs emitted after a bail-out, or call [`unstable_rethrow`](/docs/app/api-reference/functions/unstable_rethrow) at the top of your `catch` so the framework's control-flow error propagates instead of being logged.
+> **Good to know:** Reading uncached or runtime data in a `GET` handler bails out of prerendering by **throwing**. A `try/catch` you already have around other operations will catch that bail-out. This is harmless (prerendering has already stopped and the value isn't used), but a `catch` that logs the error produces noisy build-time logs. To quiet them, set `experimental.hideLogsAfterAbort: true` to hide logs emitted after a bail-out.
 
 ## `generateMetadata` and `generateViewport`
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -7,10 +7,41 @@ related:
   description: Learn about other behavior changes when Cache Components is enabled.
   links:
     - app/guides/preserving-ui-state
+    - app/guides/incremental-static-regeneration-cache-components
+    - app/api-reference/functions/generate-static-params
     - app/api-reference/config/next-config-js/cacheComponents
 ---
 
 When [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, route segment configs like `dynamic`, `revalidate`, and `fetchCache` are replaced by [`use cache`](/docs/app/api-reference/directives/use-cache) and [`cacheLife`](/docs/app/api-reference/functions/cacheLife).
+
+The migration is driven by **instant navigation validation**. With Cache Components enabled, Next.js validates in development whether navigating into each route renders instantly, and surfaces the code that would block it as an error or insight.
+
+Start by removing the route segment configs (`dynamic`, `revalidate`, `fetchCache`), then follow the validation insights and errors. Each one points you at uncached data to cache with [`use cache`](/docs/app/api-reference/directives/use-cache), or runtime data to wrap in [`<Suspense>`](https://react.dev/reference/react/Suspense). If a route needs more work than you want to take on right now, you can [opt it out of validation](#opting-out-of-validation) and come back to it later.
+
+You don't have to remove every cache. `use cache` stores entries in memory by default, scoped to a single deployment, so keep `fetch` cache options or `unstable_cache` where you want to protect an upstream resource or database from overload.
+
+Some surfaces have their own steps:
+
+- For routes with dynamic params, follow the [`generateStaticParams`](#generatestaticparams-and-dynamicparams) guidance.
+- For metadata, follow the [`generateMetadata` and `generateViewport`](#generatemetadata-and-generateviewport) guidance.
+
+The sections below cover each config and API and what to do with it under Cache Components.
+
+## Enable Cache Components
+
+Cache Components requires Next.js 16. If you're on Next.js 15 or earlier, upgrade first by following the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16). Coming from an older version, work through the [upgrade guides](/docs/app/guides/upgrading) to reach 16 before continuing.
+
+Then enable the [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) flag in `next.config.ts`:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig
+```
 
 ## `dynamic = "force-dynamic"`
 
@@ -176,9 +207,584 @@ export default async function Page() {
 }
 ```
 
+## Opting out of validation
+
+A validation insight or error tells you a route won't render instantly. Resolve it by following the recommendation: cache the data with [`use cache`](/docs/app/api-reference/directives/use-cache) or wrap it in [`<Suspense>`](https://react.dev/reference/react/Suspense). If you don't want to deal with it right now, set the [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) config to `false` on the segment that raised it (a layout, page, or parallel slot), then come back to it later.
+
+```tsx filename="app/dashboard/layout.tsx"
+export const instant = false
+```
+
+## `fetch` cache options
+
+**Move `cache` and `next` options to `use cache`.**
+
+Without Cache Components, you cache a request with `cache: 'force-cache'` and tune it with `next: { revalidate, tags }`.
+
+With Cache Components, wrap the fetch in a [`use cache`](/docs/app/api-reference/directives/use-cache) function. Fetches inside that scope are cached automatically, and `revalidate` and `tags` become [`cacheLife`](/docs/app/api-reference/functions/cacheLife) and [`cacheTag`](/docs/app/api-reference/functions/cacheTag).
+
+```tsx filename="app/page.tsx" switcher
+// Before
+export default async function Page() {
+  const res = await fetch('https://api.example.com/data', {
+    cache: 'force-cache',
+    next: { revalidate: 3600, tags: ['data'] },
+  })
+  const data = await res.json()
+  return <div>...</div>
+}
+```
+
+```jsx filename="app/page.js" switcher
+// Before
+export default async function Page() {
+  const res = await fetch('https://api.example.com/data', {
+    cache: 'force-cache',
+    next: { revalidate: 3600, tags: ['data'] },
+  })
+  const data = await res.json()
+  return <div>...</div>
+}
+```
+
+```tsx filename="app/page.tsx" switcher
+// After
+import { cacheLife, cacheTag } from 'next/cache'
+
+async function getData() {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('data')
+  const res = await fetch('https://api.example.com/data')
+  return res.json()
+}
+
+export default async function Page() {
+  const data = await getData()
+  return <div>...</div>
+}
+```
+
+```jsx filename="app/page.js" switcher
+// After
+import { cacheLife, cacheTag } from 'next/cache'
+
+async function getData() {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('data')
+  const res = await fetch('https://api.example.com/data')
+  return res.json()
+}
+
+export default async function Page() {
+  const data = await getData()
+  return <div>...</div>
+}
+```
+
+Note the persistence difference. The `fetch` Data Cache persists cached responses across deployments and across serverless instances.
+
+`use cache` defaults to in-memory storage, so its entries are discarded when the serverless instance is destroyed and are scoped to a single deployment. Use [`use cache: remote`](/docs/app/api-reference/directives/use-cache-remote) or a [cache handler](/docs/app/api-reference/config/next-config-js/cacheHandlers) for storage that survives instance teardown. Even with durable storage, expect cached values to recompute after a new deployment.
+
+## `unstable_cache`
+
+**Replace with `use cache`.**
+
+`unstable_cache` is replaced by the [`use cache`](/docs/app/api-reference/directives/use-cache) directive.
+
+Turn the wrapped function into a function with the `'use cache'` directive. The cache key is derived automatically from the arguments, so the key-parts array is no longer needed, and the `options` object maps to [`cacheLife`](/docs/app/api-reference/functions/cacheLife) and [`cacheTag`](/docs/app/api-reference/functions/cacheTag).
+
+```tsx filename="app/lib/data.ts" switcher
+// Before
+import { unstable_cache } from 'next/cache'
+import { db } from '@/lib/db'
+
+export const getUser = unstable_cache(
+  async (id: string) => {
+    return db.query.users.findFirst({ where: eq(users.id, id) })
+  },
+  ['user'], // cache key prefix
+  { tags: ['users'], revalidate: 3600 }
+)
+```
+
+```js filename="app/lib/data.js" switcher
+// Before
+import { unstable_cache } from 'next/cache'
+import { db } from '@/lib/db'
+
+export const getUser = unstable_cache(
+  async (id) => {
+    return db.query.users.findFirst({ where: eq(users.id, id) })
+  },
+  ['user'], // cache key prefix
+  { tags: ['users'], revalidate: 3600 }
+)
+```
+
+```tsx filename="app/lib/data.ts" switcher
+// After
+import { cacheLife, cacheTag } from 'next/cache'
+import { db } from '@/lib/db'
+
+export async function getUser(id: string) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('users')
+  return db.query.users.findFirst({ where: eq(users.id, id) })
+}
+```
+
+```js filename="app/lib/data.js" switcher
+// After
+import { cacheLife, cacheTag } from 'next/cache'
+import { db } from '@/lib/db'
+
+export async function getUser(id) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('users')
+  return db.query.users.findFirst({ where: eq(users.id, id) })
+}
+```
+
+Similarly to the `fetch` cache, `unstable_cache` persists cached values across deployments and across serverless instances.
+
+`use cache` defaults to in-memory storage, so its entries are discarded when the serverless instance is destroyed and are scoped to a single deployment. Use [`use cache: remote`](/docs/app/api-reference/directives/use-cache-remote) or a [cache handler](/docs/app/api-reference/config/next-config-js/cacheHandlers) for storage that survives instance teardown. Even with durable storage, expect cached values to recompute after a new deployment.
+
+> **Good to know:** Like `unstable_cache`, a `use cache` function cannot read runtime data such as `cookies()` or `headers()`. Read it outside the cached function and pass what you need in as an argument.
+
+## On-demand revalidation (`revalidateTag`, `revalidatePath`, `updateTag`)
+
+On-demand invalidation still works by tagging cached data and expiring it after an event. Tag data with [`cacheTag`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function instead of the `fetch` `next.tags` option, then choose the invalidation API by the behavior you want:
+
+- [`updateTag`](/docs/app/api-reference/functions/updateTag): for mutations whose result the user must see immediately (read-your-own-writes). Called from a Server Action, it expires the tag so the next request waits for fresh data instead of serving stale content.
+- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. Pass a cache profile like `'max'` to serve cached data while it refreshes in the background. Works in Server Actions and Route Handlers.
+- [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath): unchanged from the previous caching model.
+
+`updateTag` isn't exclusive to Cache Components (it also works with the previous caching model), but migrating is a good time to adopt it. After a mutation in a Server Action, reach for it when the user should see their own change right away.
+
+```tsx filename="app/actions.ts" switcher
+'use server'
+import { updateTag } from 'next/cache'
+
+export async function createPost(formData: FormData) {
+  // Create the post, then show it immediately on the next request
+  updateTag('posts')
+}
+```
+
+```js filename="app/actions.js" switcher
+'use server'
+import { updateTag } from 'next/cache'
+
+export async function createPost(formData) {
+  // Create the post, then show it immediately on the next request
+  updateTag('posts')
+}
+```
+
+> **Good to know:** `updateTag` can only be called from a Server Action; calling it elsewhere throws. In Route Handlers or webhooks, use `revalidateTag` instead.
+
+## `unstable_noStore`
+
+**Not needed.** `unstable_noStore` (`noStore()`) opts a component out of caching. With Cache Components, nothing is cached unless you add `use cache`, so you can remove it. If a component must run at request time, call [`connection()`](/docs/app/api-reference/functions/connection) before the work and wrap it in `<Suspense>`.
+
+```tsx filename="app/page.tsx" switcher
+// Before
+import { unstable_noStore as noStore } from 'next/cache'
+
+export default async function Page() {
+  noStore()
+  const data = await db.query('...')
+  return <div>...</div>
+}
+```
+
+```jsx filename="app/page.js" switcher
+// Before
+import { unstable_noStore as noStore } from 'next/cache'
+
+export default async function Page() {
+  noStore()
+  const data = await db.query('...')
+  return <div>...</div>
+}
+```
+
+```tsx filename="app/page.tsx" switcher
+// After - uncached by default, just remove noStore()
+export default async function Page() {
+  const data = await db.query('...')
+  return <div>...</div>
+}
+```
+
+```jsx filename="app/page.js" switcher
+// After - uncached by default, just remove noStore()
+export default async function Page() {
+  const data = await db.query('...')
+  return <div>...</div>
+}
+```
+
+## `generateStaticParams` and `dynamicParams`
+
+Two behaviors change for [dynamic routes](/docs/app/api-reference/file-conventions/dynamic-routes) when Cache Components is enabled.
+
+### `generateStaticParams` must return at least one param
+
+**Returning an empty array now errors.** Without Cache Components, returning `[]` defers every path to the first runtime visit. With Cache Components, [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) must return at least one param so Next.js can prerender the route and validate it produces a non-empty [App Shell](/docs/app/glossary#app-shell). An empty array raises [`empty-generate-static-params`](/docs/messages/empty-generate-static-params).
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+// Before - defer all paths to runtime
+export async function generateStaticParams() {
+  return []
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+// Before - defer all paths to runtime
+export async function generateStaticParams() {
+  return []
+}
+```
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+// After - return at least one param to prerender
+export async function generateStaticParams() {
+  const posts = await fetch('https://.../posts').then((res) => res.json())
+  return posts.slice(0, 1).map((post) => ({ slug: post.slug }))
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+// After - return at least one param to prerender
+export async function generateStaticParams() {
+  const posts = await fetch('https://.../posts').then((res) => res.json())
+  return posts.slice(0, 1).map((post) => ({ slug: post.slug }))
+}
+```
+
+Paths you don't return are still served. Next.js serves the App Shell instantly, then upgrades it in the background once the params are known. See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the full prerender-a-subset workflow.
+
+### `dynamicParams` no longer blocks the first visit
+
+**`dynamicParams: true` (the default) now serves an App Shell instead of blocking.** Previously, visiting a param not returned by `generateStaticParams` blocked the response while the page rendered. With Cache Components, Next.js serves the App Shell instantly, then upgrades it in the background with the now-known params. `dynamicParams: false` is unchanged: unspecified paths still 404.
+
+To produce the App Shell, pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary instead of awaiting it at the top of the component, so unknown params can still prerender.
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+// Before - awaiting params at the top blocks the shell
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <Post slug={slug} />
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+// Before - awaiting params at the top blocks the shell
+export default async function Page({ params }) {
+  const { slug } = await params
+  return <Post slug={slug} />
+}
+```
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+import { Suspense } from 'react'
+
+// After - await inside Suspense so the shell can prerender
+export default function Page({ params }: PageProps<'/blog/[slug]'>) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Post params={params} />
+    </Suspense>
+  )
+}
+
+async function Post({ params }: Pick<PageProps<'/blog/[slug]'>, 'params'>) {
+  const { slug } = await params
+  // ...
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+import { Suspense } from 'react'
+
+// After - await inside Suspense so the shell can prerender
+export default function Page({ params }) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Post params={params} />
+    </Suspense>
+  )
+}
+
+async function Post({ params }) {
+  const { slug } = await params
+  // ...
+}
+```
+
+## `cookies`, `headers`, and `searchParams`
+
+**Wrap runtime data access in `<Suspense>`.** Without Cache Components, reading [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) opts the whole route into dynamic rendering. With Cache Components, accessing them outside a [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary raises [`Uncached data was accessed outside of <Suspense>`](/docs/messages/blocking-route). Move the access into a component wrapped in `<Suspense>` so the rest of the page prerenders as a static shell and the dynamic part streams in at request time.
+
+```tsx filename="app/page.tsx" switcher
+import { cookies } from 'next/headers'
+
+// Before - reading cookies at the top makes the whole route dynamic
+export default async function Page() {
+  const theme = (await cookies()).get('theme')?.value
+  return <Dashboard theme={theme} />
+}
+```
+
+```jsx filename="app/page.js" switcher
+import { cookies } from 'next/headers'
+
+// Before - reading cookies at the top makes the whole route dynamic
+export default async function Page() {
+  const theme = (await cookies()).get('theme')?.value
+  return <Dashboard theme={theme} />
+}
+```
+
+```tsx filename="app/page.tsx" switcher
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+// After - the page prerenders; only Dashboard streams at request time
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dashboard />
+    </Suspense>
+  )
+}
+
+async function Dashboard() {
+  const theme = (await cookies()).get('theme')?.value
+  // ...
+}
+```
+
+```jsx filename="app/page.js" switcher
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+// After - the page prerenders; only Dashboard streams at request time
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dashboard />
+    </Suspense>
+  )
+}
+
+async function Dashboard() {
+  const theme = (await cookies()).get('theme')?.value
+  // ...
+}
+```
+
+`params` and `searchParams` arrive as props on your page, and both are promises. Apply the same pattern: pass the promise straight through to the `<Suspense>`-wrapped component as a prop and `await` it there, rather than at the top of the page.
+
+```tsx filename="app/page.tsx" switcher
+import { Suspense } from 'react'
+
+export default function Page({ searchParams }: PageProps<'/'>) {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Results searchParams={searchParams} />
+    </Suspense>
+  )
+}
+
+async function Results({ searchParams }: Pick<PageProps<'/'>, 'searchParams'>) {
+  const { query } = await searchParams
+  // ...
+}
+```
+
+```jsx filename="app/page.js" switcher
+import { Suspense } from 'react'
+
+export default function Page({ searchParams }) {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Results searchParams={searchParams} />
+    </Suspense>
+  )
+}
+
+async function Results({ searchParams }) {
+  const { query } = await searchParams
+  // ...
+}
+```
+
+## Route Handlers (`GET`)
+
+**Replace `dynamic = 'force-static'` with `use cache`.**
+
+Without Cache Components, a `GET` [Route Handler](/docs/app/api-reference/file-conventions/route) is dynamic unless you opt into caching with `export const dynamic = 'force-static'`. With Cache Components, `GET` handlers follow the same model as pages: they prerender when they don't access uncached or runtime data, and you cache uncached data with `use cache`. Remove the `dynamic` config and move the data access into a separate function marked with `use cache`. The directive can't be applied to the `GET` export itself, so the handler calls a cached helper.
+
+```ts filename="app/api/products/route.ts" switcher
+// Before
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const products = await db.query('SELECT * FROM products')
+  return Response.json(products)
+}
+```
+
+```js filename="app/api/products/route.js" switcher
+// Before
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const products = await db.query('SELECT * FROM products')
+  return Response.json(products)
+}
+```
+
+```ts filename="app/api/products/route.ts" switcher
+// After
+import { cacheLife } from 'next/cache'
+
+export async function GET() {
+  const products = await getProducts()
+  return Response.json(products)
+}
+
+async function getProducts() {
+  'use cache'
+  cacheLife('hours')
+  return db.query('SELECT * FROM products')
+}
+```
+
+```js filename="app/api/products/route.js" switcher
+// After
+import { cacheLife } from 'next/cache'
+
+export async function GET() {
+  const products = await getProducts()
+  return Response.json(products)
+}
+
+async function getProducts() {
+  'use cache'
+  cacheLife('hours')
+  return db.query('SELECT * FROM products')
+}
+```
+
+> **Good to know:** Reading uncached or runtime data in a `GET` handler bails out of prerendering by **throwing**. A `try/catch` you already have around other operations will catch that bail-out. This is harmless (prerendering has already stopped and the value isn't used), but a `catch` that logs the error produces noisy build-time logs. To quiet them, either set `experimental.hideLogsAfterAbort: true` to hide logs emitted after a bail-out, or call [`unstable_rethrow`](/docs/app/api-reference/functions/unstable_rethrow) at the top of your `catch` so the framework's control-flow error propagates instead of being logged.
+
+## `generateMetadata` and `generateViewport`
+
+**Cache external data with `use cache`, or mark intentionally dynamic pages.** Under Cache Components, [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) and [`generateViewport`](/docs/app/api-reference/functions/generate-viewport) follow the same rules as components. If they read runtime data (`cookies()`, `headers()`, `params`, `searchParams`) or fetch uncached data while the rest of the page is otherwise prerenderable, Next.js raises an error so the choice is explicit. If the metadata depends on external but not runtime data, add `use cache`.
+
+```tsx filename="app/page.tsx" switcher
+// Before
+export async function generateMetadata() {
+  const { title, description } = await db.query('site-metadata')
+  return { title, description }
+}
+```
+
+```tsx filename="app/page.tsx" switcher
+// After - cache external data
+export async function generateMetadata() {
+  'use cache'
+  const { title, description } = await db.query('site-metadata')
+  return { title, description }
+}
+```
+
+If the metadata genuinely needs runtime data, you can't wrap `generateMetadata` in `<Suspense>`. Instead, add a dynamic marker component to the page so the static content still prerenders while the metadata streams in.
+
+```tsx filename="app/page.tsx" switcher
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  // reads runtime data
+  return { title: 'Personalized Title' }
+}
+
+async function DynamicMarker() {
+  return (
+    <Suspense>
+      <Connection />
+    </Suspense>
+  )
+}
+
+async function Connection() {
+  await connection()
+  return null
+}
+
+export default function Page() {
+  return (
+    <>
+      <article>Static content</article>
+      <DynamicMarker />
+    </>
+  )
+}
+```
+
+See [`generateMetadata` with Cache Components](/docs/app/api-reference/functions/generate-metadata#with-cache-components) and [`generateViewport` with Cache Components](/docs/app/api-reference/functions/generate-viewport#with-cache-components) for the full set of fix options and trade-offs.
+
 ## `runtime = 'edge'`
 
 **Not supported.** Cache Components requires the Node.js runtime. Switch to the Node.js runtime (the default) by removing the [deprecated](/docs/messages/edge-runtime-deprecated) `runtime = 'edge'` export. If you need edge behavior for specific routes, use [Proxy](/docs/app/api-reference/file-conventions/proxy) instead.
+
+## `experimental_ppr`
+
+**Removed. Enable `cacheComponents` instead.** Next.js 16 removes the experimental Partial Prerendering flag (`experimental.ppr`) and the `experimental_ppr` route segment config. Partial Prerendering is now part of [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), so remove `experimental.ppr` from `next.config` and `experimental_ppr` from your segments. A [codemod](/docs/app/guides/upgrading/codemods#remove-experimental_ppr-route-segment-config-from-app-router-pages-and-layouts) removes the segment config for you.
+
+```tsx filename="app/page.tsx" switcher
+// Before - no longer needed
+export const experimental_ppr = true
+
+export default function Page() {
+  return <div>...</div>
+}
+```
+
+```jsx filename="app/page.js" switcher
+// Before - no longer needed
+export const experimental_ppr = true
+
+export default function Page() {
+  return <div>...</div>
+}
+```
+
+```tsx filename="app/page.tsx" switcher
+// After - remove it; cacheComponents enables Partial Prerendering
+export default function Page() {
+  return <div>...</div>
+}
+```
+
+```jsx filename="app/page.js" switcher
+// After - remove it; cacheComponents enables Partial Prerendering
+export default function Page() {
+  return <div>...</div>
+}
+```
 
 ## UI state preservation
 
@@ -186,8 +792,8 @@ export default async function Page() {
 
 If your code relied on unmounting to clear state, you may need to add explicit reset logic:
 
-- **Dropdowns and popovers** — stay open when navigating back. Close them in a `useLayoutEffect` cleanup function.
-- **Dialogs with initialization logic** — Effects that depend on dialog state (like focusing an input) won't re-fire if the state was preserved. Derive dialog state from the URL instead.
-- **Forms after submission** — input values and `useActionState` results (success/error messages) persist when returning. Reset in the submit handler or user action when possible, otherwise use a cleanup effect.
+- **Dropdowns and popovers**: stay open when navigating back. Close them in a `useLayoutEffect` cleanup function.
+- **Dialogs with initialization logic**: Effects that depend on dialog state (like focusing an input) won't re-fire if the state was preserved. Derive dialog state from the URL instead.
+- **Forms after submission**: input values and `useActionState` results (success/error messages) persist when returning. Reset in the submit handler or user action when possible, otherwise use a cleanup effect.
 
 See [Preserving UI state across navigations](/docs/app/guides/preserving-ui-state) for detailed examples of each pattern.

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -45,6 +45,8 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
+> **Good to know:** If you were using `experimental.dynamicIO` or `experimental.useCache`, `cacheComponents` replaces them. See the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16#experimentaldynamicio-and-experimentalusecache).
+
 ## `dynamic = "force-dynamic"`
 
 **Not needed.** All pages are dynamic by default.
@@ -503,8 +505,6 @@ Paths you don't return are still served. Next.js serves the App Shell instantly,
 
 To produce the App Shell, pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary instead of awaiting it at the top of the component, so unknown params can still prerender.
 
-> **Good to know:** The client hooks [`usePathname`](/docs/app/api-reference/functions/use-pathname), [`useSelectedLayoutSegment`](/docs/app/api-reference/functions/use-selected-layout-segment), and [`useSelectedLayoutSegments`](/docs/app/api-reference/functions/use-selected-layout-segments) need the same treatment. On a route with dynamic params not covered by `generateStaticParams`, they suspend during prerendering because the pathname depends on the unknown param, so wrap the component that calls them in `<Suspense>` or the build fails. See [Next.js encountered URL data in a Client Component outside of Suspense](/docs/messages/blocking-prerender-client-hook).
-
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 // Before - awaiting params at the top blocks the shell
 export default async function Page({
@@ -560,6 +560,15 @@ async function Post({ params }) {
   // ...
 }
 ```
+
+Client hooks that read the route need the same treatment. In the App Shell, the params, and by extension the pathname, are unknown, so reading these hooks suspends, wherever the component renders. A nav or breadcrumb in a shared layout, for instance, suspends while Next.js generates the App Shell for any route below it that has dynamic params. Wrap the component that reads the hook in `<Suspense>` (push the read down to the smallest leaf so the rest stays prerendered), or the build fails:
+
+- [`usePathname`](/docs/app/api-reference/functions/use-pathname)
+- [`useParams`](/docs/app/api-reference/functions/use-params)
+- [`useSelectedLayoutSegment`](/docs/app/api-reference/functions/use-selected-layout-segment)
+- [`useSelectedLayoutSegments`](/docs/app/api-reference/functions/use-selected-layout-segments)
+
+The [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) hook always needs a `<Suspense>` boundary, since search params are only known at request time. See [Next.js encountered URL data in a Client Component outside of Suspense](/docs/messages/blocking-prerender-client-hook) for fixes.
 
 ## `cookies`, `headers`, and `searchParams`
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -6,6 +6,8 @@ related:
   title: Next Steps
   description: Learn about other behavior changes when Cache Components is enabled.
   links:
+    - app/guides/instant-navigation
+    - app/getting-started/caching
     - app/guides/preserving-ui-state
     - app/guides/incremental-static-regeneration-cache-components
     - app/api-reference/functions/generate-static-params
@@ -16,9 +18,9 @@ When [Cache Components](/docs/app/api-reference/config/next-config-js/cacheCompo
 
 The migration is driven by **instant navigation validation**. With Cache Components enabled, Next.js validates in development whether navigating into each route renders instantly, and surfaces the code that would block it as an error or insight.
 
-Start by removing the route segment configs (`dynamic`, `revalidate`, `fetchCache`), then follow the validation insights and errors. Each one points you at uncached data to cache with [`use cache`](/docs/app/api-reference/directives/use-cache), or runtime data to wrap in [`<Suspense>`](https://react.dev/reference/react/Suspense). If a route needs more work than you want to take on right now, you can [opt it out of validation](#opting-out-of-validation) and come back to it later.
+Start by removing the route segment configs (`dynamic`, `revalidate`, `fetchCache`), then follow the validation insights and errors. Each one names the code to fix, most often uncached data to cache with [`use cache`](/docs/app/api-reference/directives/use-cache) or runtime data to wrap in [`<Suspense>`](https://react.dev/reference/react/Suspense). If a route needs more work than you want to take on right now, you can [opt it out of validation](#opting-out-of-validation) and come back to it later.
 
-You don't have to remove every cache. `use cache` stores entries in memory by default, scoped to a single deployment, so keep `fetch` cache options or `unstable_cache` where you want to protect an upstream resource or database from overload.
+Your existing `fetch` caching keeps working as a separate layer, so let the insights and errors guide what to change.
 
 Some surfaces have their own steps:
 
@@ -206,6 +208,36 @@ export default async function Page() {
   return <div>...</div>
 }
 ```
+
+## Following validation
+
+When a component would block a navigation, the dev overlay surfaces a **blocking-route** insight that names the component and points at two fixes: cache it, or stream it behind `<Suspense>`.
+
+<FixCardGrid>
+  <FixCard
+    group="cache"
+    title="Cache the component or data"
+    href="/docs/messages/blocking-prerender-dynamic#cache-the-component-or-data"
+    snippets={[
+      { text: 'async function Posts() {' },
+      { text: '  "use cache"', highlight: true },
+      { text: '  return <List items={…} />' },
+      { text: '}' },
+    ]}
+  />
+  <FixCard
+    group="stream"
+    title="Wrap in or move into Suspense"
+    href="/docs/messages/blocking-prerender-dynamic#wrap-in-or-move-into-suspense"
+    snippets={[
+      { text: '<Suspense fallback={…}>', highlight: true },
+      { text: '  <DataChild />' },
+      { text: '</Suspense>', highlight: true },
+    ]}
+  />
+</FixCardGrid>
+
+Work through the insights and errors until they're gone. For the full validation workflow, the DevTools, and CI testing, see the [instant navigation guide](/docs/app/guides/instant-navigation).
 
 ## Opting out of validation
 


### PR DESCRIPTION
Continuation of - https://github.com/vercel/next.js/pull/92382

### What?

Adds a `generateStaticParams` section to [Migrating to Cache Components](https://nextjs.org/docs/app/guides/migrating-to-cache-components).

### Why?

Developers migrating dynamic routes (for example blogs with `[slug]`) had no guidance in that guide for how `generateStaticParams` behaves with Cache Components, why `next build` can show ◐ instead of ○, or that `return []` becomes a build error.

### How?

- Link to `generateStaticParams` with Cache Components, dynamic routes with Cache Components, and the `empty-generate-static-params` message doc instead of duplicating full behavior.
- Before/after example: empty array vs at least one sample param.
- Short note on ◐ (Partial Prerender) with links to the public pages PPR section and glossary.


Related: https://github.com/vercel/next.js/pull/92507