### PR TITLE
fix(pages-api): preserve middleware rewrite query

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -583,6 +583,7 @@ export default class NextNodeServer extends BaseServer<
         res: ServerResponse,
         ctx: {
           waitUntil: ReturnType<BaseServer['getWaitUntil']>
+          requestMeta?: RequestMeta
         }
       ) => Promise<void>
     }
@@ -594,6 +595,11 @@ export default class NextNodeServer extends BaseServer<
     addRequestMeta(req.originalRequest, 'distDir', this.distDir)
     await module.handler(req.originalRequest, res.originalResponse, {
       waitUntil: this.getWaitUntil(),
+      requestMeta: {
+        ...getRequestMeta(req.originalRequest),
+        query,
+        params: match.params,
+      },
     })
     return true
   }

--- a/test/e2e/middleware-rewrites/app/middleware.js
+++ b/test/e2e/middleware-rewrites/app/middleware.js
@@ -67,6 +67,14 @@ export async function middleware(request) {
     )
   }
 
+  if (url.pathname.startsWith('/middleware-rewrite-to-pages-api/')) {
+    const slug = url.pathname.split('/').pop()
+    url.pathname = `/api/proxy/${slug}`
+    url.searchParams.set('added', '1')
+    url.searchParams.set('extra', '2')
+    return NextResponse.rewrite(url)
+  }
+
   if (url.pathname.includes('/rewrite-to-static')) {
     request.nextUrl.pathname = '/static-ssg/post-1'
     return NextResponse.rewrite(request.nextUrl)

--- a/test/e2e/middleware-rewrites/app/pages/api/proxy/[...slug].js
+++ b/test/e2e/middleware-rewrites/app/pages/api/proxy/[...slug].js
@@ -1,0 +1,6 @@
+export default function handler(req, res) {
+  res.status(200).json({
+    url: req.url,
+    query: req.query,
+  })
+}

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -93,6 +93,23 @@ describe('Middleware Rewrite', () => {
       expect(json.headers['x-hello-from-middleware1']).toBe('hello')
     })
 
+    it('should pass middleware rewrite query values to pages api routes', async () => {
+      const res = await next.fetch(
+        '/middleware-rewrite-to-pages-api/bar?key=value'
+      )
+
+      expect(res.status).toBe(200)
+      await expect(res.json()).resolves.toEqual({
+        url: '/middleware-rewrite-to-pages-api/bar?key=value',
+        query: {
+          key: 'value',
+          added: '1',
+          extra: '2',
+          slug: ['bar'],
+        },
+      })
+    })
+
     it('should handle static dynamic rewrite from middleware correctly', async () => {
       const browser = await next.browser('/rewrite-to-static')
 


### PR DESCRIPTION
## What

- Preserves the routed `query` and `params` when invoking bundled Pages API route modules through `NextNodeServer.runApi`.
- Keeps `req.url` restored to the original request URL for compatibility.
- Adds an e2e regression test for a middleware rewrite from `/middleware-rewrite-to-pages-api/bar?key=value` to `/api/proxy/bar?added=1&extra=2`, asserting `req.query` includes the original query, rewrite query, and catch-all slug.

## Why

Middleware rewrites to Pages API routes currently restore `req.url` before the API route module prepares its context, but the routed query is not forwarded through request metadata. The API resolver then reparses the original URL and loses rewrite query values and dynamic route params.

Fixes #94647

## Duplicate check

Checked open PRs for:

- `middleware rewrite pages api query`
- `NextResponse.rewrite pages api query`
- `94647`

No open PR covered this issue.

## Checks

- `pnpm exec prettier --check packages/next/src/server/next-server.ts test/e2e/middleware-rewrites/app/middleware.js test/e2e/middleware-rewrites/app/pages/api/proxy/[...slug].js test/e2e/middleware-rewrites/test/index.test.ts`
- `pnpm exec jest --runInBand test/e2e/middleware-rewrites/test/index.test.ts -t "pages api routes"`
- `NEXT_TEST_MODE=dev pnpm exec jest --runInBand test/e2e/middleware-rewrites/test/index.test.ts -t "pages api routes"`
- pre-commit `lint-staged` (Prettier + ESLint)

I also ran `pnpm --dir packages/next build` to refresh local `dist` for isolated e2e tests. Compilation completed and my change passed type checking; the command exits non-zero locally during `generate_types` because of existing `packages/font` declaration resolution errors for `../dist/google` and `../dist/local/index`.
