### PR TITLE
docs: clarify Server Function event handler errors

### DIFF
--- a/docs/01-app/01-getting-started/07-mutating-data.mdx
+++ b/docs/01-app/01-getting-started/07-mutating-data.mdx
@@ -331,6 +331,8 @@ export default function LikeButton({ initialLikes }) {
 }
 ```
 
+> **Good to know:** When you call a Server Function directly from an event handler, handle expected errors as return values or catch thrown errors yourself. If you want an unhandled error to route to the nearest [`error.js`](/docs/app/getting-started/error-handling#handling-uncaught-exceptions) boundary, invoke the action inside a Transition, for example with [`startTransition`](https://react.dev/reference/react/startTransition) or `useActionState` as shown below.
+
 ## Examples
 
 ### Showing a pending state


### PR DESCRIPTION
﻿## Summary

Clarifies the Server Functions event handler docs so readers know that directly awaiting a Server Function in an event handler requires handling expected errors or catching thrown errors locally.

Also points readers to `startTransition` / `useActionState` when they want unhandled errors to bubble to the nearest `error.js` boundary.

Fixes #76803

## Tests

- `pnpm prettier --check docs/01-app/01-getting-started/07-mutating-data.mdx`
- `git diff --check`
