### PR TITLE
fix: ignore aborted http request errors

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -73,6 +73,7 @@ import { LRUCache } from '../lib/lru-cache'
 import { getMiddlewareRouteMatcher } from '../../shared/lib/router/utils/middleware-route-matcher'
 import { DetachedPromise } from '../../lib/detached-promise'
 import { isPostpone } from '../lib/router-utils/is-postpone'
+import { isNodeHttpRequestAbortError } from '../pipe-readable'
 import { generateInterceptionRoutesRewrites } from '../../lib/generate-interception-routes-rewrites'
 import { buildCustomRoute } from '../../lib/build-custom-route'
 import { decorateServerError } from '../../shared/lib/error-source'
@@ -353,6 +354,10 @@ export default class DevServer extends Server {
       this.logErrorWithOriginalStack(reason, 'unhandledRejection')
     })
     process.on('uncaughtException', (err) => {
+      if (isNodeHttpRequestAbortError(err)) {
+        return
+      }
+
       this.logErrorWithOriginalStack(err, 'uncaughtException')
     })
   }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -17,7 +17,11 @@ import { DecodeError } from '../../shared/lib/utils'
 import { findPagesDir } from '../../lib/find-pages-dir'
 import { setupFsCheck } from './router-utils/filesystem'
 import { proxyRequest } from './router-utils/proxy-request'
-import { isAbortError, pipeToNodeResponse } from '../pipe-readable'
+import {
+  isAbortError,
+  isNodeHttpRequestAbortError,
+  pipeToNodeResponse,
+} from '../pipe-readable'
 import { getResolveRoutes } from './router-utils/resolve-routes'
 import { addRequestMeta, getRequestMeta } from '../request-meta'
 import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
@@ -794,9 +798,12 @@ export async function initialize(opts: {
     type: 'uncaughtException' | 'unhandledRejection',
     err: Error | undefined
   ) => {
-    if (isPostpone(err)) {
-      // React postpones that are unhandled might end up logged here but they're
-      // not really errors. They're just part of rendering.
+    if (
+      isPostpone(err) ||
+      (type === 'uncaughtException' && isNodeHttpRequestAbortError(err))
+    ) {
+      // These are expected control-flow errors and should not show up as
+      // application exceptions.
       return
     }
     if (type === 'unhandledRejection') {

--- a/packages/next/src/server/node-environment-extensions/process-error-handlers.ts
+++ b/packages/next/src/server/node-environment-extensions/process-error-handlers.ts
@@ -1,4 +1,5 @@
 import { isPostpone } from '../lib/router-utils/is-postpone'
+import { isNodeHttpRequestAbortError } from '../pipe-readable'
 
 let _global = globalThis as typeof globalThis & {
   nextInitializedProcessErrorHandlers?: boolean
@@ -81,7 +82,7 @@ export function installProcessErrorHandlers(
   // is unrelated to the late-awaiting pattern. However, for similar reasons,
   // we still shouldn't crash the process. Just log it.
   process.on('uncaughtException', (reason: unknown) => {
-    if (isPostpone(reason)) {
+    if (isPostpone(reason) || isNodeHttpRequestAbortError(reason)) {
       return
     }
     console.error(reason)

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -14,6 +14,14 @@ export function isAbortError(e: any): e is Error & { name: 'AbortError' } {
   return e?.name === 'AbortError' || e?.name === ResponseAbortedName
 }
 
+export function isNodeHttpRequestAbortError(
+  e: any
+): e is Error & { code: 'ECONNRESET' } {
+  // Node emits this when a client disconnects before the HTTP request has been
+  // fully consumed.
+  return e?.code === 'ECONNRESET' && e?.message === 'aborted'
+}
+
 const HAS_CLIENT_COMPONENT_METRICS_ENABLED =
   'performance' in globalThis && process.env.NEXT_OTEL_PERFORMANCE_PREFIX
 

--- a/test/e2e/cancel-request/app/edge-route/route.ts
+++ b/test/e2e/cancel-request/app/edge-route/route.ts
@@ -48,3 +48,21 @@ export async function GET(req: NextRequest): Promise<Response> {
   const i = await old.finished
   return new Response(`${i}`)
 }
+
+export async function POST(req: NextRequest): Promise<Response> {
+  if (req.nextUrl.searchParams.has('compile')) {
+    return new Response(null, { status: 204 })
+  }
+
+  if (req.nextUrl.searchParams.has('sse')) {
+    const stream = new TransformStream()
+
+    return new Response(stream.readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+      },
+    })
+  }
+
+  return new Response(null, { status: 404 })
+}

--- a/test/e2e/cancel-request/app/node-route/route.ts
+++ b/test/e2e/cancel-request/app/node-route/route.ts
@@ -50,3 +50,21 @@ export async function GET(req: NextRequest): Promise<Response> {
   const i = await old.finished
   return new Response(`${i}`)
 }
+
+export async function POST(req: NextRequest): Promise<Response> {
+  if (req.nextUrl.searchParams.has('compile')) {
+    return new Response(null, { status: 204 })
+  }
+
+  if (req.nextUrl.searchParams.has('sse')) {
+    const stream = new TransformStream()
+
+    return new Response(stream.readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+      },
+    })
+  }
+
+  return new Response(null, { status: 404 })
+}

--- a/test/e2e/cancel-request/stream-cancel.test.ts
+++ b/test/e2e/cancel-request/stream-cancel.test.ts
@@ -1,21 +1,43 @@
 import { nextTestSetup } from 'e2e-utils'
 import { sleep } from './sleep'
-import { get } from 'http'
+import { request } from 'http'
 
 describe('streaming responses cancel inner stream after disconnect', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
 
-  function prime(url: string, noData?: boolean) {
+  function prime(
+    url: string,
+    noData?: boolean,
+    init: { method?: string; body?: string } = {}
+  ) {
     return new Promise<void>((resolve, reject) => {
       url = new URL(url, next.url).href
+      const { method = 'GET', body } = init
+      const headers = body
+        ? {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body),
+          }
+        : undefined
+      let abortTimer: ReturnType<typeof setTimeout> | undefined
 
       // There's a bug in node-fetch v2 where aborting the fetch will never abort
       // the connection, because the body is a transformed stream that doesn't
       // close the connection stream.
       // https://github.com/node-fetch/node-fetch/pull/670
-      const req = get(url, async (res) => {
+      const req = request(url, { method, headers }, async (res) => {
+        if (noData) {
+          if (abortTimer) {
+            clearTimeout(abortTimer)
+          }
+
+          res.destroy()
+          resolve()
+          return
+        }
+
         while (true) {
           const value = res.read(1)
           if (value) break
@@ -26,7 +48,6 @@ describe('streaming responses cancel inner stream after disconnect', () => {
         resolve()
       })
       req.on('error', reject)
-      req.end()
 
       if (noData) {
         req.on('error', (e) => {
@@ -37,11 +58,17 @@ describe('streaming responses cancel inner stream after disconnect', () => {
           }
         })
 
-        setTimeout(() => {
+        abortTimer = setTimeout(() => {
           req.abort()
           resolve()
         }, 100)
       }
+
+      if (body) {
+        req.write(body)
+      }
+
+      req.end()
     })
   }
 
@@ -83,6 +110,33 @@ describe('streaming responses cancel inner stream after disconnect', () => {
       const res = await next.fetch(path)
       const i = await res.text()
       expect(i).toBe('0')
+    }, 2500)
+  })
+
+  describe.each([
+    ['edge app route handler', '/edge-route'],
+    ['node app route handler', '/node-route'],
+  ])('%s', (_name, path) => {
+    beforeAll(async () => {
+      await next.fetch(path + '?compile', {
+        method: 'POST',
+        body: '{}',
+      })
+    })
+
+    it('does not log aborted POST stream responses as uncaught exceptions', async () => {
+      const outputStart = next.cliOutput.length
+
+      await prime(path + '?sse', true, {
+        method: 'POST',
+        body: JSON.stringify({ foo: 'bar' }),
+      })
+      await sleep(500)
+
+      const newOutput = next.cliOutput.slice(outputStart)
+      expect(newOutput).not.toContain('uncaughtException')
+      expect(newOutput).not.toContain('ECONNRESET')
+      expect(newOutput).not.toContain('Error: aborted')
     }, 2500)
   })
 })


### PR DESCRIPTION
## Summary
- Treat Node HTTP `ECONNRESET`/`aborted` request disconnects as expected aborts in server error handlers
- Avoid logging aborted POST streaming responses as `uncaughtException`
- Add App Route POST SSE disconnect coverage for both edge and node runtimes

Fixes #56529

## Tests
- `pnpm prettier --check packages/next/src/server/pipe-readable.ts packages/next/src/server/lib/router-server.ts packages/next/src/server/dev/next-dev-server.ts packages/next/src/server/node-environment-extensions/process-error-handlers.ts test/e2e/cancel-request/stream-cancel.test.ts test/e2e/cancel-request/app/node-route/route.ts test/e2e/cancel-request/app/edge-route/route.ts`
- `git diff --check`
- `NEXT_TEST_MODE=dev IS_WEBPACK_TEST=1 HEADLESS=true NEXT_SKIP_ISOLATE=1 pnpm exec jest --runInBand test/e2e/cancel-request/stream-cancel.test.ts`
- `NEXT_TEST_MODE=start IS_WEBPACK_TEST=1 HEADLESS=true NEXT_SKIP_ISOLATE=1 pnpm exec jest --runInBand test/e2e/cancel-request/stream-cancel.test.ts`
- `NEXT_TEST_MODE=dev IS_WEBPACK_TEST=1 HEADLESS=true pnpm exec jest --runInBand test/e2e/cancel-request/stream-cancel.test.ts`

Note: `pnpm --dir packages/next build` reaches the type generation step, then fails on the existing `@next/font` declaration issue (`../font/google/index.d.ts` and `../font/local/index.d.ts` cannot resolve their generated dist modules).