### PR TITLE
[turbopack] Add `inline_chunk_group_bootstrap` to `BrowserChunkingContext` and `chunk_group_bootstrap_params` to `ChunkGroupResult`

### DIFF
--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -168,6 +168,7 @@ pub async fn get_app_client_references_chunks(
                 referenced_assets: ResolvedVc::cell(vec![]),
                 references: ResolvedVc::cell(vec![]),
                 availability_info: client_availability_info,
+                chunk_group_bootstrap_params: None,
             }
             .resolved_cell();
             let mut current_ssr_chunk_group = ChunkGroupResult::empty_resolved();

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -880,6 +880,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 referenced_assets: OutputAssets::empty_resolved(),
                 references: ResolvedVc::cell(references),
                 availability_info,
+                chunk_group_bootstrap_params: None,
             }
             .cell())
         }
@@ -988,11 +989,28 @@ impl ChunkingContext for BrowserChunkingContext {
                 );
             }
 
-            assets.push(ResolvedVc::upcast(
-                self.generate_evaluate_chunk(ident, other_assets, entries, *module_graph)
-                    .to_resolved()
-                    .await?,
-            ));
+            // The evaluate chunk registers this entry's chunks/modules onto the
+            // `globalThis[TURBOPACK]` queue. When `shared_runtime` is enabled we return that chunk
+            // group's bootstrap params for Next to inline into the HTML and skip emitting the
+            // per-route evaluate chunk file. Only `ChunkGroup::Entry` groups (the page/app client
+            // entries Next renders into HTML) can be inlined. When `shared_runtime` is disabled the
+            // evaluate chunk itself carries the runtime, so it is always emitted as an asset.
+            let evaluate_chunk = self
+                .generate_evaluate_chunk(ident, other_assets, entries, *module_graph)
+                .to_resolved()
+                .await?;
+            let chunk_group_bootstrap_params =
+                if this.shared_runtime && matches!(chunk_group, ChunkGroup::Entry(_)) {
+                    Some(
+                        evaluate_chunk
+                            .chunk_group_bootstrap_params()
+                            .owned()
+                            .await?,
+                    )
+                } else {
+                    assets.push(ResolvedVc::upcast(evaluate_chunk));
+                    None
+                };
 
             // The shared runtime chunk must be the LAST asset of the group. It drains
             // the registration queue set up by the chunks above, so it has to load
@@ -1017,6 +1035,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 referenced_assets: OutputAssets::empty_resolved(),
                 references: ResolvedVc::cell(references),
                 availability_info,
+                chunk_group_bootstrap_params,
             }
             .cell())
         }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -129,6 +129,7 @@ pub struct ChunkGroupResult {
     pub referenced_assets: ResolvedVc<OutputAssets>,
     pub references: ResolvedVc<OutputAssetsReferences>,
     pub availability_info: AvailabilityInfo,
+    pub chunk_group_bootstrap_params: Option<RcStr>,
 }
 
 impl ChunkGroupResult {
@@ -138,6 +139,7 @@ impl ChunkGroupResult {
             referenced_assets: ResolvedVc::cell(vec![]),
             references: ResolvedVc::cell(vec![]),
             availability_info: AvailabilityInfo::root(),
+            chunk_group_bootstrap_params: None,
         }
         .cell()
     }
@@ -148,6 +150,7 @@ impl ChunkGroupResult {
             referenced_assets: ResolvedVc::cell(vec![]),
             references: ResolvedVc::cell(vec![]),
             availability_info: AvailabilityInfo::root(),
+            chunk_group_bootstrap_params: None,
         }
         .resolved_cell()
     }
@@ -181,6 +184,7 @@ impl ChunkGroupResult {
                 .to_resolved()
                 .await?,
             availability_info: next.availability_info,
+            chunk_group_bootstrap_params: next.chunk_group_bootstrap_params.clone(),
         }
         .cell())
     }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -545,6 +545,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 referenced_assets: OutputAssets::empty_resolved(),
                 references: ResolvedVc::cell(references),
                 availability_info,
+                chunk_group_bootstrap_params: None,
             }
             .cell())
         }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/runtime/shared_browser_runtime/output/1ece_tests_snapshot_runtime_shared_browser_runtime_input_index_1gcut8q.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/runtime/shared_browser_runtime/output/1ece_tests_snapshot_runtime_shared_browser_runtime_input_index_1gcut8q.js
@@ -1,4 +1,0 @@
-(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
-    "output/1ece_tests_snapshot_runtime_shared_browser_runtime_input_index_1gcut8q.js",
-    {"otherChunks":["output/1jsg_tests_snapshot_runtime_shared_browser_runtime_input_index_16pxwu5.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/shared_browser_runtime/input/index.js [test] (ecmascript)"]}
-]);

--- a/turbopack/crates/turbopack-tests/tests/snapshot/runtime/shared_browser_runtime/output/1jsg_tests_snapshot_runtime_shared_browser_runtime_input_index_1gcut8q.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/runtime/shared_browser_runtime/output/1jsg_tests_snapshot_runtime_shared_browser_runtime_input_index_1gcut8q.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}


### PR DESCRIPTION
We used to generate the runtime file for each `ChunkGroupResult` in `evaluated_chunk_group()`, I've added `chunk_group_bootstrap_params` which are the parameters that were unique to each chunk group. These are inlined into each page's HTML in https://github.com/vercel/next.js/pull/94666. They look like:

```javascript
{"otherChunks":["output/0_9x_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_1mqgz2-._.js"],
"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js [test] (ecmascript)"]}
```

Whether or not the inline-able code is generated is based on the `inline_chunk_group_bootstrap` which is still false in all cases at the moment but will be turned to true in https://github.com/vercel/next.js/pull/94666.