### PR TITLE
Serve stale `'use cache'` entries in the dev server until they expire

### DIFF
--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -5,6 +5,11 @@
  * likely going to get evicted before we get to use it anyway. However, we also
  * don't want to reuse a stale entry for too long so stale entries should be
  * considered expired/missing in such cache handlers.
+ *
+ * The dev server (`next dev`) is the exception: to keep reloads fast it serves
+ * stale entries until they expire, relying on the wrapper's
+ * stale-while-revalidate path to warm a fresh entry in the background. See
+ * `get` for where this branches.
  */
 
 import { LRUCache } from '../lru-cache'
@@ -77,13 +82,17 @@ export function createDefaultCacheHandler(maxSize: number): CacheHandler {
       }
 
       const entry = privateEntry.entry
+
+      // The dev server serves stale entries until they expire (see the file
+      // overview); production drops them once past the revalidate time.
+      const maxAgeSeconds = process.env.__NEXT_DEV_SERVER
+        ? entry.expire
+        : entry.revalidate
+
       if (
         performance.timeOrigin + performance.now() >
-        entry.timestamp + entry.revalidate * 1000
+        entry.timestamp + maxAgeSeconds * 1000
       ) {
-        // In-memory caches should expire after revalidate time because it is
-        // unlikely that a new entry will be able to be used before it is dropped
-        // from the cache.
         debug?.('get', cacheKey, 'expired')
 
         return undefined

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/data-fetching.tsx
@@ -19,16 +19,13 @@ export async function ShortLivedCache({
 
 async function getShortLivedCachedData(_key: string) {
   'use cache'
-  // TODO(make-dev-fast): This should be able to use `cacheLife('seconds')`. We
-  // use a long `revalidate` instead so the entry stays a fresh hit for the
-  // duration of the test, isolating it from the in-memory handler dropping the
-  // entry at `revalidate` (and thus from dev SWR). `expire` stays under 5
-  // minutes so the entry is still short-lived (excluded from the static shell,
-  // deferred to the runtime stage), and `stale` stays at the runtime-prefetch
-  // threshold so it is not also excluded from the runtime prefetch shell. Once
-  // the dev in-memory handler serves stale entries (SWR), flip this back to
-  // `cacheLife('seconds')`.
-  cacheLife({ stale: 30, revalidate: 120, expire: 240 })
+  // `seconds` is a short-lived profile (its expire is under 5 minutes), so the
+  // entry is excluded from the static shell and deferred to the runtime stage,
+  // while its stale time at the runtime-prefetch threshold keeps it in the
+  // runtime prefetch shell. On a warm reload the entry may be past its 1s
+  // revalidate, but the dev server serves it stale (SWR), so it resolves as a
+  // hit at the runtime stage instead of a cold miss.
+  cacheLife('seconds')
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-stale-cache/data-fetching.tsx
@@ -24,13 +24,9 @@ async function getShortStaleCachedData(_key: string) {
   // an initial load, and a navigation into a route without runtime prefetch,
   // resolves it during the static stage. The short stale time excludes it from
   // the runtime prefetch shell, so a navigation into a runtime-prefetch route
-  // resolves it dynamically instead. The long revalidate keeps the entry a
-  // fresh hit for the duration of the test, isolating it from the in-memory
-  // handler dropping the entry at `revalidate` (and thus from dev
-  // stale-while-revalidate).
-  // TODO(make-dev-fast): Once the dev in-memory handler serves stale entries
-  // (SWR), the long revalidate can be dropped.
-  cacheLife({ stale: 10, revalidate: 120, expire: 3600 })
+  // resolves it dynamically instead. On a warm reload the entry may be past its
+  // 1s revalidate, but the dev server serves it stale (SWR), so it stays a hit.
+  cacheLife({ stale: 10, revalidate: 1, expire: 3600 })
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/data-fetching.tsx
@@ -19,16 +19,13 @@ export async function ShortLivedCache({
 
 async function getShortLivedCachedData(_key: string) {
   'use cache'
-  // TODO(make-dev-fast): This should be able to use `cacheLife('seconds')`. We
-  // use a long `revalidate` instead so the entry stays a fresh hit for the
-  // duration of the test, isolating it from the in-memory handler dropping the
-  // entry at `revalidate` (and thus from dev SWR). `expire` stays under 5
-  // minutes so the entry is still short-lived (excluded from the static shell,
-  // deferred to the runtime stage), and `stale` stays at the runtime-prefetch
-  // threshold so it is not also excluded from the runtime prefetch shell. Once
-  // the dev in-memory handler serves stale entries (SWR), flip this back to
-  // `cacheLife('seconds')`.
-  cacheLife({ stale: 30, revalidate: 120, expire: 240 })
+  // `seconds` is a short-lived profile (its expire is under 5 minutes), so the
+  // entry is excluded from the static shell and deferred to the runtime stage,
+  // while its stale time at the runtime-prefetch threshold keeps it in the
+  // runtime prefetch shell. On a warm reload the entry may be past its 1s
+  // revalidate, but the dev server serves it stale (SWR), so it resolves as a
+  // hit at the runtime stage instead of a cold miss.
+  cacheLife('seconds')
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-stale-cache/data-fetching.tsx
@@ -24,13 +24,9 @@ async function getShortStaleCachedData(_key: string) {
   // an initial load, and a navigation into a route without runtime prefetch,
   // resolves it during the static stage. The short stale time excludes it from
   // the runtime prefetch shell, so a navigation into a runtime-prefetch route
-  // resolves it dynamically instead. The long revalidate keeps the entry a
-  // fresh hit for the duration of the test, isolating it from the in-memory
-  // handler dropping the entry at `revalidate` (and thus from dev
-  // stale-while-revalidate).
-  // TODO(make-dev-fast): Once the dev in-memory handler serves stale entries
-  // (SWR), the long revalidate can be dropped.
-  cacheLife({ stale: 10, revalidate: 120, expire: 3600 })
+  // resolves it dynamically instead. On a warm reload the entry may be past its
+  // 1s revalidate, but the dev server serves it stale (SWR), so it stays a hit.
+  cacheLife({ stale: 10, revalidate: 1, expire: 3600 })
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }

--- a/test/development/app-dir/cache-indicator/app/short-lived/page.tsx
+++ b/test/development/app-dir/cache-indicator/app/short-lived/page.tsx
@@ -3,14 +3,11 @@ import { Suspense } from 'react'
 
 async function ShortLivedData() {
   'use cache'
-  // TODO(make-dev-fast): This should be able to use `cacheLife('seconds')`. We
-  // use a long `revalidate` instead so the entry stays a fresh hit on the warm
-  // reload of the page, isolating this test from the in-memory handler dropping
-  // the entry at `revalidate` (and thus from dev SWR). `expire` stays under 5
-  // minutes so it is still short-lived (deferred, out of the static shell).
-  // Once the dev in-memory handler serves stale entries (SWR), flip this back
-  // to `cacheLife('seconds')`.
-  cacheLife({ stale: 30, revalidate: 120, expire: 240 })
+  // A short-lived profile (`seconds`): out of the static shell, deferred to the
+  // runtime stage. On a warm reload the entry may be past its 1s revalidate,
+  // but the dev server serves it stale (SWR), so the reload is a cache hit and
+  // does not show the cold-cache badge.
+  cacheLife('seconds')
   await new Promise((resolve) => setTimeout(resolve, 100))
   return <p id="short-lived">{Math.random()}</p>
 }

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/stale-while-revalidate/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/stale-while-revalidate/page.tsx
@@ -1,0 +1,29 @@
+import { connection } from 'next/server'
+import { cacheLife } from 'next/cache'
+import { Suspense } from 'react'
+
+async function getCachedValue() {
+  // A request-time cache (after `connection()`) uses a remote cache: a plain
+  // `'use cache'` is a no-op on a deployment without a memory cache. With no
+  // remote handler configured this falls back to the default handler, which
+  // does have a memory cache under `next start` and `next dev`.
+  'use cache: remote'
+  // A short `revalidate` so the entry goes stale quickly, paired with a long
+  // `expire` that keeps it well inside the dev stale-while-revalidate window.
+  cacheLife({ stale: 30, revalidate: 2, expire: 300 })
+  return Math.random()
+}
+
+async function Dynamic() {
+  // Render at request time so the page isn't prerendered as static HTML.
+  await connection()
+  return <p id="value">{await getCachedValue()}</p>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="loading">Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -3,6 +3,7 @@ import {
   assertNoConsoleErrors,
   waitForNoErrorToast,
   retry,
+  waitFor,
 } from 'next-test-utils'
 import type { Playwright } from 'e2e-utils'
 import stripAnsi from 'strip-ansi'
@@ -1635,6 +1636,36 @@ describe('use-cache', () => {
     // The loading boundaries of both inner cache functions are expected to be
     // shown while the page is loading.
     expect(html).toIncludeRepeated('<p class="loading">Loading...</p>', 2)
+  })
+
+  it('serves a stale cache entry on reload in dev and warms a fresh one in the background', async () => {
+    const browser = await next.browser('/stale-while-revalidate')
+    const initialValue = await browser.waitForElementByCss('#value').text()
+
+    // Let the 2s `revalidate` elapse. The entry is now stale, but still far
+    // inside its 300s `expire` window.
+    await waitFor(3000)
+
+    await browser.refresh()
+    const reloadedValue = await browser.waitForElementByCss('#value').text()
+
+    if (isNextDev) {
+      // In dev the default in-memory cache handler serves the stale entry
+      // instead of dropping it at `revalidate`, so the reload shows the
+      // previous value immediately and warms a fresh entry in the background.
+      expect(reloadedValue).toBe(initialValue)
+
+      // A subsequent reload reflects the freshly warmed value.
+      await retry(async () => {
+        await browser.refresh()
+        const warmedValue = await browser.waitForElementByCss('#value').text()
+        expect(warmedValue).not.toBe(initialValue)
+      })
+    } else {
+      // In production the in-memory handler keeps dropping the entry at
+      // `revalidate`, so the reload re-runs the cache and shows a fresh value.
+      expect(reloadedValue).not.toBe(initialValue)
+    }
   })
 })
 


### PR DESCRIPTION
The default in-memory cache handler drops an entry once it goes stale (past its `revalidate` time) rather than serving it: in-memory entries are fragile, so warming a replacement in the background isn't worth it when it's likely to be evicted before it's used, and we don't want to keep reusing a stale entry for too long either. With this change the dev server (`next dev`) makes an exception and serves the stale entry until it actually expires, using `expire` as the drop threshold instead of `revalidate` and relying on the wrapper's existing stale-while-revalidate path to warm a fresh entry in the background. Production (`next start`) and `next build --debug-prerender` keep the previous drop-at-`revalidate` behavior, so the change is gated on `process.env.__NEXT_DEV_SERVER`. The tag-based discard is preserved, so `revalidateTag` still invalidates in dev.

This change has two motivations. It keeps the dev inner loop fast, turning a warm reload of a short-lived cache into an immediate hit instead of a cold miss that re-runs the cache. It is also the foundation for upcoming dev-only caching changes that depend on the handler serving stale entries: persisting `'use cache: private'` entries in dev, and keeping `cacheMaxMemorySize: 0` fast in dev. Both serve a previous value while warming a fresh one in the background, which only works once the handler stops dropping stale entries in dev.

This also lets us drop the workarounds that several Cache Components dev fixtures used to isolate themselves from the handler dropping the entry at `revalidate`. The short-lived fixtures go back to `cacheLife('seconds')` and the short-stale fixtures drop their long `revalidate`. Their warm reloads are now stale hits served by the dev server, which is the behavior these tests are meant to exercise and which removes the short-lived hit/miss flakiness at its source.

A new `use-cache` test pins the behavior directly: in dev a reload after `revalidate` serves the previous value immediately and warms a fresh one in the background, while a `next start` build of the same fixture re-runs the cache and shows a fresh value.