### PR TITLE
[turbopack] Add `chunk_group_bootstrap_params` and the chunk-loading global to the build manifest

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1315,26 +1315,30 @@ impl AppEndpoint {
                 .await?;
 
         // We only need the client runtime entries for pages not for Route Handlers
-        let (availability_info, client_shared_chunks) = if is_app_page {
-            let client_shared_chunk_group = get_app_client_shared_chunk_group(
-                AssetIdent::from_path(project.project_path().owned().await?)
-                    .with_modifier(rcstr!("client-shared-chunks"))
-                    .into_vc(),
-                this.app_project.client_runtime_entries(),
-                *module_graphs.full,
-                *client_chunking_context,
-            );
+        let (availability_info, client_shared_chunks, client_chunk_group_bootstrap_params) =
+            if is_app_page {
+                let client_shared_chunk_group = get_app_client_shared_chunk_group(
+                    AssetIdent::from_path(project.project_path().owned().await?)
+                        .with_modifier(rcstr!("client-shared-chunks"))
+                        .into_vc(),
+                    this.app_project.client_runtime_entries(),
+                    *module_graphs.full,
+                    *client_chunking_context,
+                );
 
-            client_assets.extend(client_shared_chunk_group.all_assets().await?);
+                client_assets.extend(client_shared_chunk_group.all_assets().await?);
 
-            let client_shared_chunk_group = client_shared_chunk_group.await?;
-            (
-                client_shared_chunk_group.availability_info,
-                client_shared_chunk_group.assets.owned().await?,
-            )
-        } else {
-            (AvailabilityInfo::root(), vec![])
-        };
+                let client_shared_chunk_group = client_shared_chunk_group.await?;
+                (
+                    client_shared_chunk_group.availability_info,
+                    client_shared_chunk_group.assets.owned().await?,
+                    client_shared_chunk_group
+                        .chunk_group_bootstrap_params
+                        .clone(),
+                )
+            } else {
+                (AvailabilityInfo::root(), vec![], None)
+            };
 
         let client_references_chunks = get_app_client_references_chunks(
             *client_references,
@@ -1446,6 +1450,12 @@ impl AppEndpoint {
                 m.insert(app_entry.original_name.clone(), page_hmr_chunks);
                 m
             };
+            let chunk_loading_global = (*project
+                .next_config()
+                .turbopack_chunk_loading_global()
+                .await?)
+                .clone()
+                .unwrap_or_else(|| rcstr!("TURBOPACK"));
             let build_manifest = BuildManifest {
                 output_path: node_root.join(&format!(
                     "server/app{manifest_path_prefix}/build-manifest.json",
@@ -1455,6 +1465,14 @@ impl AppEndpoint {
                 root_main_files: client_shared_chunks,
                 polyfill_files: polyfill_output_asset.into_iter().collect(),
                 root_main_files_per_page,
+                pages_chunk_group_bootstrap_params: client_chunk_group_bootstrap_params
+                    .map(|params| {
+                        let mut m = FxIndexMap::default();
+                        m.insert(app_entry.original_name.clone(), params);
+                        m
+                    })
+                    .unwrap_or_default(),
+                chunk_loading_global,
             };
             server_assets.insert(ResolvedVc::upcast(build_manifest.resolved_cell()));
         }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1242,6 +1242,9 @@ impl PageEndpoint {
     async fn build_manifest(
         &self,
         client_chunks: ResolvedVc<OutputAssets>,
+        // Inline bootstrap params, present when the bootstrap is inlined rather
+        // than emitted as a per-route chunk.
+        chunk_group_bootstrap_params: Option<RcStr>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let node_root = self.pages_project.project().node_root().owned().await?;
         let client_relative_path = self
@@ -1253,11 +1256,27 @@ impl PageEndpoint {
 
         // Check if we should include pages in the manifest
         let pages_structure = self.pages_structure.await?;
-        let pages = if pages_structure.should_create_pages_entries {
-            fxindexmap!(self.pathname.clone() => client_chunks)
-        } else {
-            fxindexmap![] // Empty pages when no user pages should be created
-        };
+        let (pages, pages_chunk_group_bootstrap_params) =
+            if pages_structure.should_create_pages_entries {
+                (
+                    fxindexmap!(self.pathname.clone() => client_chunks),
+                    chunk_group_bootstrap_params
+                        .map(|params| fxindexmap!(self.pathname.clone() => params))
+                        .unwrap_or_default(),
+                )
+            } else {
+                // Empty when no user pages should be created
+                (fxindexmap![], fxindexmap![])
+            };
+
+        let chunk_loading_global = (*self
+            .pages_project
+            .project()
+            .next_config()
+            .turbopack_chunk_loading_global()
+            .await?)
+            .clone()
+            .unwrap_or_else(|| rcstr!("TURBOPACK"));
 
         let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
         let build_manifest = BuildManifest {
@@ -1269,6 +1288,8 @@ impl PageEndpoint {
             polyfill_files: Default::default(),
             root_main_files: Default::default(),
             root_main_files_per_page: Default::default(),
+            pages_chunk_group_bootstrap_params,
+            chunk_loading_global,
         };
         Ok(Vc::upcast(build_manifest.cell()))
     }
@@ -1323,7 +1344,10 @@ impl PageEndpoint {
             PageEndpointType::Html => {
                 let client_chunk_group = self.client_chunk_group();
                 client_assets.extend(client_chunk_group.all_assets().await?.iter().copied());
-                let client_chunks = *client_chunk_group.await?.assets;
+                let client_chunk_group_ref = client_chunk_group.await?;
+                let client_chunks = *client_chunk_group_ref.assets;
+                let chunk_group_bootstrap_params =
+                    client_chunk_group_ref.chunk_group_bootstrap_params.clone();
 
                 // Compile any service workers registered via `navigator.serviceWorker.register(new
                 // URL(...), { scope })` reachable from this page's client graph.
@@ -1337,7 +1361,10 @@ impl PageEndpoint {
                     .copied(),
                 );
 
-                let build_manifest = self.build_manifest(client_chunks).to_resolved().await?;
+                let build_manifest = self
+                    .build_manifest(client_chunks, chunk_group_bootstrap_params)
+                    .to_resolved()
+                    .await?;
                 let page_loader = self.page_loader(client_chunks).to_resolved().await?;
                 let client_build_manifest = self
                     .client_build_manifest(*page_loader)

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -33,7 +33,7 @@ regress = { workspace = true }
 remove_console = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 serde_path_to_error = { workspace = true }
 smallvec = { workspace = true }
 swc_sourcemap = { workspace = true }

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -6,6 +6,7 @@ mod encode_uri_component;
 use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexMap, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc, trace::TraceRawVcs,
@@ -40,6 +41,12 @@ pub struct BuildManifest {
     /// page-specific scripts without polluting the shared `rootMainFiles`.
     #[bincode(with = "turbo_bincode::indexmap")]
     pub root_main_files_per_page: FxIndexMap<RcStr, Vec<ResolvedVc<Box<dyn OutputAsset>>>>,
+    /// Per-page inline chunk group bootstrap params, as JSON. Empty when the
+    /// bootstrap is emitted as a per-route chunk instead (e.g. dev).
+    #[bincode(with = "turbo_bincode::indexmap")]
+    pub pages_chunk_group_bootstrap_params: FxIndexMap<RcStr, RcStr>,
+    /// The `globalThis[...]` chunk-loading global the runtime drains.
+    pub chunk_loading_global: RcStr,
 }
 
 #[turbo_tasks::value_impl]
@@ -101,6 +108,9 @@ impl Asset for BuildManifest {
             pub pages: FxIndexMap<RcStr, Vec<RcStr>>,
             pub amp_first_pages: Vec<RcStr>,
             pub root_main_files_tree: FxIndexMap<RcStr, Vec<RcStr>>,
+            // The values are already JSON; store them as `RawValue` so they are emitted verbatim.
+            pub pages_chunk_group_bootstrap_params: FxIndexMap<RcStr, Box<RawValue>>,
+            pub chunk_loading_global: RcStr,
         }
 
         let pages: Vec<(RcStr, Vec<RcStr>)> = self
@@ -195,6 +205,12 @@ impl Asset for BuildManifest {
             polyfill_files,
             root_main_files,
             root_main_files_tree: FxIndexMap::from_iter(root_main_files_tree),
+            pages_chunk_group_bootstrap_params: self
+                .pages_chunk_group_bootstrap_params
+                .iter()
+                .map(|(k, v)| Ok((k.clone(), RawValue::from_string(v.to_string())?)))
+                .collect::<Result<FxIndexMap<_, _>>>()?,
+            chunk_loading_global: self.chunk_loading_global.clone(),
             ..Default::default()
         };
 

--- a/packages/next/src/server/get-page-files.ts
+++ b/packages/next/src/server/get-page-files.ts
@@ -14,6 +14,10 @@ export type BuildManifest = {
     '/_app': readonly string[]
     [page: string]: readonly string[]
   }
+  // Per-page Turbopack chunk-group bootstrap params, as a JSON string.
+  pagesChunkGroupBootstrapParams?: { [page: string]: string }
+  // The chunk-loading global the runtime drains (default "TURBOPACK").
+  chunkLoadingGlobal?: string
 }
 
 export function getPageFiles(

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -417,6 +417,7 @@ export class TurbopackManifestLoader {
       lowPriorityFiles,
       rootMainFiles: [],
       rootMainFilesTree: {},
+      pagesChunkGroupBootstrapParams: {},
     }
     for (const m of manifests) {
       Object.assign(manifest.pages, m.pages)
@@ -426,6 +427,14 @@ export class TurbopackManifestLoader {
       if (m.rootMainFilesTree) {
         Object.assign(manifest.rootMainFilesTree!, m.rootMainFilesTree)
       }
+      if (m.pagesChunkGroupBootstrapParams) {
+        Object.assign(
+          manifest.pagesChunkGroupBootstrapParams!,
+          m.pagesChunkGroupBootstrapParams
+        )
+      }
+      if (m.chunkLoadingGlobal)
+        manifest.chunkLoadingGlobal = m.chunkLoadingGlobal
     }
     manifest.pages = sortObjectByKey(manifest.pages) as BuildManifest['pages']
     return manifest
@@ -575,6 +584,7 @@ export class TurbopackManifestLoader {
       rewrites,
       sortedPageKeys
     )
+
     const clientBuildManifestJs = `self.__BUILD_MANIFEST = ${JSON.stringify(
       clientBuildManifest,
       null,


### PR DESCRIPTION
This PR inserts the bootstrapping parameters into the build manifest so they can then be inlined in https://github.com/vercel/next.js/pull/94666.