### PR TITLE
[turbopack] Inline the chunk group bootstrap in Next.js to drop the per-route runtime

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1626,6 +1626,7 @@ impl Project {
             nested_async_chunking: self
                 .next_config()
                 .turbo_nested_async_chunking(self.next_mode(), true),
+            shared_runtime: self.next_config().turbo_shared_runtime(self.next_mode()),
             debug_ids: self.next_config().turbopack_debug_ids(),
             worker_asset_prefix: self.next_config().turbopack_worker_asset_prefix(),
             should_use_absolute_url_references: self.next_config().inline_css(),

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -482,6 +482,7 @@ pub struct ClientChunkingContextOptions {
     pub no_mangling: Vc<bool>,
     pub scope_hoisting: Vc<bool>,
     pub nested_async_chunking: Vc<bool>,
+    pub shared_runtime: Vc<bool>,
     pub debug_ids: Vc<bool>,
     pub worker_asset_prefix: Vc<Option<RcStr>>,
     pub should_use_absolute_url_references: Vc<bool>,
@@ -525,6 +526,7 @@ pub async fn get_client_chunking_context(
         no_mangling,
         scope_hoisting,
         nested_async_chunking,
+        shared_runtime,
         debug_ids,
         worker_asset_prefix,
         should_use_absolute_url_references,
@@ -622,7 +624,8 @@ pub async fn get_client_chunking_context(
                 },
             )
             .chunk_content_hashing(ContentHashing::Direct { length: 13 })
-            .module_merging(*scope_hoisting.await?);
+            .module_merging(*scope_hoisting.await?)
+            .shared_runtime(*shared_runtime.await?);
     }
 
     Ok(Vc::upcast(builder.build()))

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1372,6 +1372,7 @@ pub struct ExperimentalConfig {
     turbopack_tree_shaking: Option<bool>,
     turbopack_scope_hoisting: Option<bool>,
     turbopack_generate_component_chunks: Option<bool>,
+    turbopack_shared_runtime: Option<bool>,
     /// Custom URL prefix for Web Worker URLs (the entrypoint and the module
     /// chunks loaded inside the worker) produced by
     /// `new Worker(new URL(..., import.meta.url))`. Mirrors webpack's
@@ -2525,6 +2526,16 @@ impl NextConfig {
                 .turbopack_generate_component_chunks
                 .unwrap_or(false),
         )
+    }
+
+    #[turbo_tasks::function]
+    pub async fn turbo_shared_runtime(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
+        Ok(Vc::cell(match *mode.await? {
+            // The shared runtime / inlined bootstrap is a production-only optimization; in
+            // development the per-route runtime is required for HMR.
+            NextMode::Development => false,
+            NextMode::Build => self.experimental.turbopack_shared_runtime.unwrap_or(false),
+        }))
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -174,6 +174,9 @@ export function getDefineEnv({
     'process.env.__NEXT_APP_NEW_SCROLL_HANDLER': Boolean(
       config.experimental.appNewScrollHandler
     ),
+    'process.env.__NEXT_TURBOPACK_SHARED_RUNTIME': Boolean(
+      config.experimental.turbopackSharedRuntime
+    ),
     'process.env.__NEXT_PPR': isPPREnabled,
     'process.env.__NEXT_CACHE_COMPONENTS': isCacheComponentsEnabled,
     'process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS': Boolean(

--- a/packages/next/src/client/route-loader.ts
+++ b/packages/next/src/client/route-loader.ts
@@ -12,6 +12,8 @@ declare global {
   interface Window {
     __BUILD_MANIFEST?: Record<string, string[]>
     __BUILD_MANIFEST_CB?: Function
+    __TURBOPACK_PAGE_BOOTSTRAP?: Record<string, unknown>
+    __TURBOPACK_CHUNK_LOADING_GLOBAL?: string
     __SERVER_FILES_MANIFEST?: RequiredServerFilesManifest
     __MIDDLEWARE_MATCHERS?: ProxyMatcher[]
     __MIDDLEWARE_MATCHERS_CB?: Function
@@ -246,6 +248,22 @@ export function createRouteLoader(assetPrefix: string): RouteLoader {
   const styleSheets: Map<string, Promise<RouteStyleSheet>> = new Map()
   const routes: Map<string, Future<RouteLoaderEntry> | RouteLoaderEntry> =
     new Map()
+  const bootstrappedRoutes: Set<string> = new Set()
+
+  // Bootstrap a client-loaded route (navigation/prefetch) so its entry registers via
+  // `window.__NEXT_P`. The initial page is bootstrapped in the document.
+  function bootstrapRoute(route: string): void {
+    // Gated for DCE
+    if (!process.env.__NEXT_TURBOPACK_SHARED_RUNTIME) return
+    if (process.env.NODE_ENV === 'development') return
+    if (bootstrappedRoutes.has(route)) return
+    const params = self.__TURBOPACK_PAGE_BOOTSTRAP?.[route]
+    const global = self.__TURBOPACK_CHUNK_LOADING_GLOBAL
+    if (params == null) return
+    // `global` is always defined alongside the params map (see manifest-loader).
+    bootstrappedRoutes.add(route)
+    ;(self as any)[global!].push(params)
+  }
 
   function maybeExecuteScript(
     src: TrustedScriptURL | string
@@ -345,7 +363,10 @@ export function createRouteLoader(assetPrefix: string): RouteLoader {
               return Promise.all([
                 entrypoints.has(route)
                   ? []
-                  : Promise.all(scripts.map(maybeExecuteScript)),
+                  : Promise.all(scripts.map(maybeExecuteScript)).then((r) => {
+                      bootstrapRoute(route)
+                      return r
+                    }),
                 Promise.all(css.map(fetchStyleSheet)),
               ] as const)
             })

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -12,7 +12,10 @@ import type {
 import type { ScriptProps } from '../client/script'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 
-import { getPageFiles } from '../server/get-page-files'
+import {
+  getPageFiles,
+  getTurbopackChunkGroupBootstrap,
+} from '../server/get-page-files'
 import type { BuildManifest } from '../server/get-page-files'
 import { htmlEscapeJsonString } from '../shared/lib/htmlescape'
 import isError from '../lib/is-error'
@@ -128,6 +131,35 @@ function getDynamicChunks(
   })
 }
 
+// Builds one inline <script> seeding the runtime queue with the shared (`/_app`) and
+// current route's bootstrap params, before the shared runtime chunk drains it.
+function getInlineBootstrapScript(context: HtmlProps, props: OriginProps) {
+  const { buildManifest, __NEXT_DATA__, crossOrigin } = context
+  // Only Turbopack production builds populate these; nothing to inline otherwise.
+  if (
+    !buildManifest.pagesChunkGroupBootstrapParams ||
+    !buildManifest.chunkLoadingGlobal
+  ) {
+    return null
+  }
+  const bootstrap = getTurbopackChunkGroupBootstrap(
+    buildManifest.pagesChunkGroupBootstrapParams,
+    buildManifest.chunkLoadingGlobal,
+    ['/_app', __NEXT_DATA__.page]
+  )
+  if (!bootstrap) return null
+
+  const html = htmlEscapeJsonString(bootstrap)
+  return (
+    <script
+      key="turbopack-bootstrap"
+      nonce={props.nonce}
+      crossOrigin={props.crossOrigin || crossOrigin}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
+
 function getScripts(
   context: HtmlProps,
   props: OriginProps,
@@ -148,7 +180,7 @@ function getScripts(
     file.endsWith('.js')
   )
 
-  return [...normalScripts, ...lowPriorityScripts].map((file) => {
+  const scripts = [...normalScripts, ...lowPriorityScripts].map((file) => {
     // static/immutable/chunks/51e975e7b637a580.js should use the immutable id, while
     // static/Yj152X97rfGgF7NPcJEZs/_ssgManifest.js should use the deployment id
     const query = file.startsWith('static/immutable/chunks')
@@ -165,6 +197,10 @@ function getScripts(
       />
     )
   })
+
+  // Emit the bootstrap before the chunk <script>s so the queue exists first.
+  const bootstrapScript = getInlineBootstrapScript(context, props)
+  return bootstrapScript ? [bootstrapScript, ...scripts] : scripts
 }
 
 function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -28,6 +28,8 @@ import type {
   WorkUnitStore,
 } from '../app-render/work-unit-async-storage.external'
 import type { NextParsedUrlQuery } from '../request-meta'
+import { getTurbopackChunkGroupBootstrap } from '../get-page-files'
+import { UNDERSCORE_NOT_FOUND_ROUTE_ENTRY } from '../../shared/lib/entry-constants'
 import type { LoaderTree } from '../lib/app-dir-module'
 import type { AppPageModule } from '../route-modules/app-page/module'
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'
@@ -3312,9 +3314,21 @@ async function renderToStream(
   // bootstrap script is executed, which depends on it during hydration.
   // For MPA navigations (page reload, direct URL entry), the request ID
   // header is not present, so we generate a random one.
-  let bootstrapScriptContent = process.env.__NEXT_DEV_SERVER
-    ? `self.__next_r=${JSON.stringify(requestId ?? crypto.randomUUID())}`
-    : undefined
+  let bootstrapScriptContent: string | undefined
+  if (process.env.__NEXT_DEV_SERVER) {
+    bootstrapScriptContent = `self.__next_r=${JSON.stringify(
+      requestId ?? crypto.randomUUID()
+    )}`
+  } else if (
+    buildManifest.pagesChunkGroupBootstrapParams &&
+    buildManifest.chunkLoadingGlobal
+  ) {
+    bootstrapScriptContent = getTurbopackChunkGroupBootstrap(
+      buildManifest.pagesChunkGroupBootstrapParams,
+      buildManifest.chunkLoadingGlobal,
+      [page]
+    )
+  }
 
   // Instant Navigation Testing API: embed the cookie-guarded bootstrap so it
   // runs before the client bootstrap module reads self.__next_instant_test as
@@ -4115,8 +4129,22 @@ async function renderToStream(
         subresourceIntegrityManifest,
         getAssetQueryString(ctx, false),
         nonce,
-        '/_not-found/page'
+        UNDERSCORE_NOT_FOUND_ROUTE_ENTRY
       )
+
+      let errorBootstrapScriptContent: string | undefined
+      if (process.env.__NEXT_DEV_SERVER) {
+        errorBootstrapScriptContent = bootstrapScriptContent
+      } else if (
+        buildManifest.pagesChunkGroupBootstrapParams &&
+        buildManifest.chunkLoadingGlobal
+      ) {
+        errorBootstrapScriptContent = getTurbopackChunkGroupBootstrap(
+          buildManifest.pagesChunkGroupBootstrapParams,
+          buildManifest.chunkLoadingGlobal,
+          [UNDERSCORE_NOT_FOUND_ROUTE_ENTRY]
+        )
+      }
 
       if (process.env.__NEXT_USE_NODE_STREAMS) {
         // MARK: nodeStreams errorRecovery RSC + HTML
@@ -4173,7 +4201,7 @@ async function renderToStream(
               />,
               {
                 nonce,
-                bootstrapScriptContent,
+                bootstrapScriptContent: errorBootstrapScriptContent,
                 bootstrapScripts: [errorBootstrapScript],
                 formState,
               },
@@ -4272,7 +4300,7 @@ async function renderToStream(
               />,
               {
                 nonce,
-                bootstrapScriptContent,
+                bootstrapScriptContent: errorBootstrapScriptContent,
                 bootstrapScripts: [errorBootstrapScript],
                 formState,
               }
@@ -7771,13 +7799,25 @@ async function prerenderToStream(
     page
   )
 
+  let bootstrapScriptContent =
+    buildManifest.pagesChunkGroupBootstrapParams &&
+    buildManifest.chunkLoadingGlobal
+      ? getTurbopackChunkGroupBootstrap(
+          buildManifest.pagesChunkGroupBootstrapParams,
+          buildManifest.chunkLoadingGlobal,
+          [page]
+        )
+      : undefined
+
   // Instant Navigation Testing API: when exposed, embed the cookie-guarded
   // bootstrap into the prerendered prelude so the cached static shell carries
   // it and it runs before the client bootstrap module reads
   // self.__next_instant_test.
-  let bootstrapScriptContent = renderOpts.experimental.exposeTestingApi
-    ? await getInstantTestBootstrapScriptContent()
-    : undefined
+  if (renderOpts.experimental.exposeTestingApi) {
+    bootstrapScriptContent =
+      (bootstrapScriptContent ? `${bootstrapScriptContent};` : '') +
+      (await getInstantTestBootstrapScriptContent())
+  }
 
   // In development the static shell is served without a dynamic resume, so it
   // must carry the debug-channel request id (self.__next_r) itself for
@@ -8141,6 +8181,7 @@ async function prerenderToStream(
                 )
               }
             },
+            bootstrapScriptContent,
             bootstrapScripts: [bootstrapScript],
           }
         )
@@ -9149,8 +9190,18 @@ async function prerenderToStream(
       subresourceIntegrityManifest,
       getAssetQueryString(ctx, false),
       nonce,
-      '/_not-found/page'
+      UNDERSCORE_NOT_FOUND_ROUTE_ENTRY
     )
+
+    const errorBootstrapScriptContent =
+      buildManifest.pagesChunkGroupBootstrapParams &&
+      buildManifest.chunkLoadingGlobal
+        ? getTurbopackChunkGroupBootstrap(
+            buildManifest.pagesChunkGroupBootstrapParams,
+            buildManifest.chunkLoadingGlobal,
+            [UNDERSCORE_NOT_FOUND_ROUTE_ENTRY]
+          )
+        : undefined
 
     if (cacheComponents) {
       const originalFlightPrerenderResult = reactServerPrerenderResult
@@ -9322,6 +9373,7 @@ async function prerenderToStream(
               />,
               {
                 nonce,
+                bootstrapScriptContent: errorBootstrapScriptContent,
                 bootstrapScripts: [errorBootstrapScript],
                 formState,
                 signal: errorClientReactController.signal,
@@ -9561,6 +9613,7 @@ async function prerenderToStream(
         />,
         {
           nonce,
+          bootstrapScriptContent: errorBootstrapScriptContent,
           bootstrapScripts: [errorBootstrapScript],
           formState,
         },

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -387,6 +387,7 @@ export const experimentalSchema = {
   turbopackRemoveUnusedExports: z.boolean().optional(),
   turbopackScopeHoisting: z.boolean().optional(),
   turbopackGenerateComponentChunks: z.boolean().optional(),
+  turbopackSharedRuntime: z.boolean().optional(),
   turbopackChunkingHeuristics: z
     .object({
       firstPageLoadPriority: z.number().min(0).max(1).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -784,6 +784,13 @@ export interface ExperimentalConfig {
   turbopackGenerateComponentChunks?: boolean
 
   /**
+   * Share the browser runtime across routes in a single `runtime.js` asset and inline the
+   * per-route chunk-group bootstrap into the HTML, dropping the per-route runtime. Defaults to
+   * false. Only applies to production builds; has no effect in development mode.
+   */
+  turbopackSharedRuntime?: boolean
+
+  /**
    * (`next --turbopack` only) Traffic-related hints for the production chunker. These change the
    * assumptions Turbopack makes when making chunk merging decisions.
    */

--- a/packages/next/src/server/get-page-files.ts
+++ b/packages/next/src/server/get-page-files.ts
@@ -14,10 +14,36 @@ export type BuildManifest = {
     '/_app': readonly string[]
     [page: string]: readonly string[]
   }
-  // Per-page Turbopack chunk-group bootstrap params, as a JSON string.
-  pagesChunkGroupBootstrapParams?: { [page: string]: string }
+  // Per-page Turbopack chunk-group bootstrap params, stored as raw JSON.
+  pagesChunkGroupBootstrapParams?: { [page: string]: object }
   // The chunk-loading global the runtime drains (default "TURBOPACK").
   chunkLoadingGlobal?: string
+}
+
+/**
+ * Builds inline `globalThis[<global>].push(<params>)` bootstrap content for the given
+ * pages, seeding the runtime queue before the shared runtime chunk drains it. Only call
+ * this for Turbopack production builds (the only builds that populate
+ * `pagesChunkGroupBootstrapParams` / `chunkLoadingGlobal`). Returns undefined when none
+ * of the given pages have inlined params.
+ */
+export function getTurbopackChunkGroupBootstrap(
+  paramsByPage: { [page: string]: object },
+  chunkLoadingGlobal: string,
+  pages: readonly string[]
+): string | undefined {
+  const g = JSON.stringify(chunkLoadingGlobal)
+  const statements = pages
+    .map((page) => paramsByPage[page])
+    .filter(Boolean)
+    .map(
+      (params) =>
+        `(globalThis[${g}] || (globalThis[${g}] = [])).push(${JSON.stringify(
+          params
+        )});`
+    )
+
+  return statements.length > 0 ? statements.join('\n') : undefined
 }
 
 export function getPageFiles(

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -585,11 +585,34 @@ export class TurbopackManifestLoader {
       sortedPageKeys
     )
 
-    const clientBuildManifestJs = `self.__BUILD_MANIFEST = ${JSON.stringify(
-      clientBuildManifest,
-      null,
-      2
-    )};self.__BUILD_MANIFEST_CB && self.__BUILD_MANIFEST_CB()`
+    // Expose each route's bootstrap params and the chunk-loading global to the client
+    // so `route-loader` can instantiate a navigated page's entry module. The server
+    // stores params as raw JSON per route.
+    const pageBootstrapParams: Record<string, unknown> = {}
+    let chunkLoadingGlobal: string | undefined
+    for (const m of this.buildManifests.values()) {
+      if (m.chunkLoadingGlobal) chunkLoadingGlobal = m.chunkLoadingGlobal
+      for (const [route, params] of Object.entries(
+        m.pagesChunkGroupBootstrapParams ?? {}
+      )) {
+        pageBootstrapParams[route] = params
+      }
+    }
+
+    // Only emit the bootstrap globals when a route actually inlined its bootstrap (shared runtime
+    // enabled).
+    const hasBootstrapParams = Object.keys(pageBootstrapParams).length > 0
+    const clientBuildManifestJs =
+      `self.__BUILD_MANIFEST = ${JSON.stringify(clientBuildManifest, null, 2)};` +
+      (hasBootstrapParams
+        ? `self.__TURBOPACK_PAGE_BOOTSTRAP = ${JSON.stringify(pageBootstrapParams)};` +
+          (chunkLoadingGlobal
+            ? `self.__TURBOPACK_CHUNK_LOADING_GLOBAL = ${JSON.stringify(
+                chunkLoadingGlobal
+              )};`
+            : '')
+        : '') +
+      `self.__BUILD_MANIFEST_CB && self.__BUILD_MANIFEST_CB()`
 
     writeFileAtomic(
       join(this.distDir, buildManifestPath),

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -1197,6 +1197,8 @@ describe('Production Usage', () => {
     for (const script of $('script').toArray()) {
       // application/json doesn't need async
       if (
+        // Inline scripts (no `src`) can't be deferred.
+        !script.attribs.src ||
         script.attribs.type === 'application/json' ||
         script.attribs.src.includes('polyfills')
       ) {


### PR DESCRIPTION
This PR builds on top of the other PRs in this stack, it is the PR that switches to inlining the bootstrap code and dropping the runtime file that each route had.