### PR TITLE
fix: handle shell errors when resuming Node streams

### DIFF
--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -612,18 +612,29 @@ export async function resumeToFizzStream(
   const run: <T>(fn: () => T) => T = runInContext ?? ((fn) => fn())
 
   const pt = new PassThrough()
+  const shellReady = new DetachedPromise<void>()
   const allReady = new DetachedPromise<void>()
 
   const pipeable = await run(() =>
     resumeToPipeableStream(element, postponedState, {
       ...streamOptions,
+      onShellReady() {
+        streamOptions?.onShellReady?.()
+        shellReady.resolve()
+      },
+      onShellError(error: unknown) {
+        streamOptions?.onShellError?.(error)
+        shellReady.reject(error)
+      },
       onAllReady() {
         streamOptions?.onAllReady?.()
         allReady.resolve()
       },
     })
   )
+
   pipeable.pipe(pt)
+  await shellReady.promise
 
   return {
     stream: pt,

--- a/test/production/app-dir/empty-shell-redirect-resume/app/layout.tsx
+++ b/test/production/app-dir/empty-shell-redirect-resume/app/layout.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react'
+import { cookies } from 'next/headers'
+
+export const instant = false
+
+async function LayoutContent({ children }: { children: ReactNode }) {
+  await cookies()
+  return children
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <LayoutContent>{children}</LayoutContent>
+      </body>
+    </html>
+  )
+}

--- a/test/production/app-dir/empty-shell-redirect-resume/app/login/page.tsx
+++ b/test/production/app-dir/empty-shell-redirect-resume/app/login/page.tsx
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export default async function LoginPage() {
+  const session = (await cookies()).get('session')
+
+  if (session) {
+    redirect('/search')
+  }
+
+  return <form id="login">Log in</form>
+}

--- a/test/production/app-dir/empty-shell-redirect-resume/app/search/page.tsx
+++ b/test/production/app-dir/empty-shell-redirect-resume/app/search/page.tsx
@@ -1,0 +1,3 @@
+export default function SearchPage() {
+  return <p>Search</p>
+}

--- a/test/production/app-dir/empty-shell-redirect-resume/empty-shell-redirect-resume.test.ts
+++ b/test/production/app-dir/empty-shell-redirect-resume/empty-shell-redirect-resume.test.ts
@@ -1,0 +1,30 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('empty shell redirect resume', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should build an empty shell with postponed state', async () => {
+    expect(await next.readFile('.next/server/app/login.html')).toBe('')
+
+    const metadata = JSON.parse(
+      await next.readFile('.next/server/app/login.meta')
+    )
+    expect(metadata.postponed).toBeTruthy()
+  })
+
+  it('should resume an empty shell with a redirect', async () => {
+    const response = await fetch(`${next.url}/login`, {
+      headers: {
+        cookie: 'session=valid',
+      },
+      signal: AbortSignal.timeout(3000),
+    })
+    const html = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(html).toContain('id="__next_error__"')
+    expect(html).toContain('NEXT_REDIRECT;replace;/search;307;')
+  })
+})

--- a/test/production/app-dir/empty-shell-redirect-resume/next.config.js
+++ b/test/production/app-dir/empty-shell-redirect-resume/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
The Node resume adapter returned its stream without observing whether React produced a resumable HTML shell. When an empty prerendered shell resumed into a redirect, React reported an onShellError, but Next.js continued into Flight injection and waited forever for an HTML chunk that would never arrive.

Wire the resume shell callbacks into a promise and await the result after starting the pipe. Shell errors now propagate into the existing app-render recovery path, matching the Web stream behavior and producing a complete error document containing the redirect signal.