### PR TITLE
test: add PPR resume segment id collision regression test

### DIFF
--- a/test/e2e/app-dir/cache-components-resume-segment-ids/app/dynamic-footer.tsx
+++ b/test/e2e/app-dir/cache-components-resume-segment-ids/app/dynamic-footer.tsx
@@ -1,0 +1,23 @@
+import { connection } from 'next/server'
+
+// Mirrors a request-time footer: a genuinely dynamic boundary that
+// postpones, making the route Partial Prerender and storing a postponed
+// state alongside the prerendered HTML. Its content is large enough that
+// the runtime resume outlines parts of it into NEW hidden segments
+// (allocated from the stored nextSegmentId counter).
+export async function DynamicFooter() {
+  await connection()
+
+  const rows = Array.from({ length: 600 }, (_, i) => `footer-row-${i}`)
+
+  return (
+    <footer id="dynamic-footer">
+      <p>rendered at request time</p>
+      <ul>
+        {rows.map((row) => (
+          <li key={row}>{row}</li>
+        ))}
+      </ul>
+    </footer>
+  )
+}

--- a/test/e2e/app-dir/cache-components-resume-segment-ids/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-resume-segment-ids/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-resume-segment-ids/app/page.tsx
+++ b/test/e2e/app-dir/cache-components-resume-segment-ids/app/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import { DynamicFooter } from './dynamic-footer'
+import { LongWidget } from './widget'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>resume segment ids</h1>
+      {[0, 1, 2].map((index) => (
+        <Suspense
+          fallback={<p className="long-widget-fallback">…</p>}
+          key={index}
+        >
+          <LongWidget index={index} />
+        </Suspense>
+      ))}
+      <Suspense fallback={<footer>footer fallback</footer>}>
+        <DynamicFooter />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-resume-segment-ids/app/widget.tsx
+++ b/test/e2e/app-dir/cache-components-resume-segment-ids/app/widget.tsx
@@ -1,0 +1,30 @@
+import { cacheLife } from 'next/cache'
+
+async function getLongLivedData(index: number) {
+  'use cache'
+  // Resolves during the build prerender and gets outlined into hidden
+  // segments baked into the static document — but goes stale quickly, so
+  // runtime requests re-render these boundaries in a fresh continuation.
+  cacheLife({ stale: 5, revalidate: 10, expire: 300 })
+
+  return `long-widget-${index}-data`
+}
+
+export async function LongWidget({ index }: { index: number }) {
+  const data = await getLongLivedData(index)
+
+  // Render enough content that React outlines this boundary into a hidden
+  // segment (content larger than progressiveChunkSize) instead of inlining.
+  const filler = Array.from({ length: 600 }, (_, i) => `${data}-row-${i}`)
+
+  return (
+    <div className="long-widget">
+      <p>{data}</p>
+      <ul>
+        {filler.map((row) => (
+          <li key={row}>{row}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components-resume-segment-ids/cache-components-resume-segment-ids.test.ts
+++ b/test/e2e/app-dir/cache-components-resume-segment-ids/cache-components-resume-segment-ids.test.ts
@@ -1,0 +1,95 @@
+import { nextTestSetup } from 'e2e-utils'
+
+const SEGMENT_RE = /<div hidden id="([^"]*S:[0-9a-f]+)">/g
+const COMPLETION_RE = /\$RC\("([^"]+)","([^"]+)"\)/g
+
+function collectSegmentIds(html: string): string[] {
+  return Array.from(html.matchAll(SEGMENT_RE), (m) => m[1])
+}
+
+function findDuplicates(ids: string[]): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+
+  for (const id of ids) {
+    if (seen.has(id)) {
+      duplicates.add(id)
+    }
+    seen.add(id)
+  }
+
+  return [...duplicates]
+}
+
+// The page is a Partial Prerender: the stored HTML contains hidden segments
+// for the outlined cached widgets (written by the build-time resume pass),
+// while the stored postponed state still carries the segment id counter from
+// before that pass. The runtime resume that renders the dynamic footer
+// allocates new segment ids from that stale counter, producing duplicate
+// `S:x` ids in a single document. React's inline $RC("B:x", "S:x")
+// completion script resolves elements via getElementById, so a duplicated
+// segment id swaps the wrong fragment into the wrong Suspense hole and
+// visibly corrupts the page.
+describe('cache-components-resume-segment-ids', () => {
+  const { next, isNextStart, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (!isNextStart) {
+    it('only runs against next build && next start', () => {})
+    return
+  }
+
+  async function fetchHomeHtml(): Promise<string> {
+    const res = await next.fetch('/')
+    expect(res.status).toBe(200)
+    return res.text()
+  }
+
+  it('does not emit duplicate hidden segment ids when resuming', async () => {
+    const html = await fetchHomeHtml()
+    const segments = collectSegmentIds(html)
+
+    expect(findDuplicates(segments)).toEqual([])
+  })
+
+  it('references an unambiguous segment from every completion script', async () => {
+    const html = await fetchHomeHtml()
+    const segments = collectSegmentIds(html)
+
+    const completions = Array.from(
+      html.matchAll(COMPLETION_RE),
+      (m) => m[2]
+    ).filter((id) => id.includes('S:'))
+
+    expect(completions.length).toBeGreaterThan(0)
+
+    for (const segmentId of completions) {
+      const occurrences = segments.filter((id) => id === segmentId).length
+      expect(`${segmentId}:${occurrences}`).toBe(`${segmentId}:1`)
+    }
+  })
+
+  it('renders widget and footer content into their own boundaries', async () => {
+    const html = await fetchHomeHtml()
+
+    for (let index = 0; index < 3; index++) {
+      expect(html).toContain(`long-widget-${index}-data`)
+    }
+    expect(html).toContain('footer-row-0')
+
+    // The footer boundary must not receive widget content (the visible
+    // corruption mode of the id collision).
+    const footerStart = html.indexOf('<footer id="dynamic-footer">')
+    if (footerStart !== -1) {
+      const footerEnd = html.indexOf('</footer>', footerStart)
+      const footerHtml = html.slice(footerStart, footerEnd)
+      expect(footerHtml).not.toContain('long-widget')
+    }
+  })
+})

--- a/test/e2e/app-dir/cache-components-resume-segment-ids/next.config.js
+++ b/test/e2e/app-dir/cache-components-resume-segment-ids/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Related issue: #94670

### What?

Adds an e2e regression test asserting that a Partial Prerender response never contains duplicate Fizz segment ids (`<div hidden id="S:x">`), that every `$RC("B:x","S:x")` completion script references an unambiguous segment, and that boundary content is not swapped between Suspense holes.

### Why?

On Next.js 16.2.9 (current `latest`) the fixture in this PR reproduces a visible page corruption out of the box:

- At build time, the stored HTML for a PPR route is composed of two Fizz passes: the prerender prelude plus the resume-and-abort pass that materializes postponed-but-not-dynamic boundaries (outlined as hidden segments, ids allocated past the prelude's counter).
- The postponed state persisted in the route's `.meta` still carries the **pre-resume** `nextSegmentId` (e.g. `nextSegmentId: 2` while the stored document already contains `S:2`–`S:4`).
- At request time, the resume render for the dynamic boundary allocates new segment ids from that stale counter, producing duplicate `S:x` ids in a single document. Since `$RC` resolves elements via `getElementById`, the wrong fragment is moved into the wrong Suspense hole — in the fixture, the dynamic footer literally receives a cached widget's content.

Version matrix established with this fixture:

| Version | web streams path | node streams path |
|---|---|---|
| 16.2.9 (latest) | broken | flag not available |
| 16.3.0-canary.0 – .37 | broken | ok (opt-in) |
| 16.3.0-canary.38+ | broken (`experimental.useNodeStreams: false`) | ok (default since #94311) |

So current canary passes this test by default because #94311 switched the default serving path to Node streams — the web-streams resume path still has the stale-counter issue (reproducible on canary with `experimental.useNodeStreams: false`), and the entire stable 16.2.x line is affected with no opt-out.

This test pins the now-correct default behavior so the collision cannot regress, and documents the failure mode. Happy to follow up with a targeted fix for the web-streams path (persisting the advanced segment counter after the build-time resume pass) if that path is expected to remain supported — or this can simply guard the default path if web streams are on the way out.

### How?

Fixture: `cacheComponents: true`, three Suspense-wrapped `'use cache'` widgets large enough to be outlined into hidden segments in the stored document (`expire` ≥ 5 minutes so they are included in the static shell), plus one large `await connection()` boundary so the route is a Partial Prerender with a stored postponed state and a runtime resume that allocates new segment ids.