### PR TITLE
Warn on prefetch={true} navigation without Partial Prefetching (dev)

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -7,6 +7,7 @@ import type {
 import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type { HeadData } from '../../../shared/lib/app-router-types'
 import {
+  PrefetchHint,
   SubtreePrefetchHints,
   propagateSubtreeBits,
 } from '../../../shared/lib/app-router-types'
@@ -241,6 +242,36 @@ export function navigateToKnownRoute(
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.__NEXT_CACHE_COMPONENTS
+  ) {
+    // Warn when navigating via a `<Link prefetch={true}>` to a route that has
+    // not opted into Partial Prefetching. Such a link does a legacy "full"
+    // prefetch that includes the route's dynamic data, defeating the
+    // static/dynamic split that Cache Components provides.
+    //
+    // This runs at navigation time (rather than prefetch time) so that, in dev
+    // where we don't prefetch, the warning only appears when you actually
+    // navigate to the route — existing apps with many `prefetch={true}` links
+    // aren't flooded with warnings the moment they enable Cache Components.
+    const link = getLinkForCurrentNavigation()
+    if (
+      link !== null &&
+      link.fetchStrategy === FetchStrategy.Full &&
+      (navigationSeed.routeTree.prefetchHints &
+        PrefetchHint.SubtreeHasPartialPrefetching) ===
+        0
+    ) {
+      console.error(
+        `A <Link prefetch={true}> navigated to "${url.pathname}", but Partial ` +
+          `Prefetching is not enabled for that route, so its dynamic data was ` +
+          `included in the prefetch. Enable Partial Prefetching app-wide by ` +
+          `setting \`partialPrefetching: true\` in next.config, or per-route by ` +
+          `exporting \`const prefetch = 'partial'\` from the page or layout.`
+      )
+    }
+  }
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/control-route/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/control-route/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// No partial prefetching opt-in, same as /default-route. The difference is the
+// link to this route uses the default prefetch (not `prefetch={true}`), so the
+// warning should NOT fire even though the route hasn't opted in.
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Control static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Control dynamic</div>
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/default-route/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/default-route/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// No partial prefetching opt-in. Navigating here via a `prefetch={true}` link
+// should emit the dev warning.
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Default static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Default dynamic</div>
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/page.tsx
@@ -1,0 +1,29 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          {/* prefetch={true} + no partial prefetching opt-in => should warn */}
+          <LinkAccordion href="/default-route" prefetch={true}>
+            /default-route
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* prefetch={true} but the route opts into partial prefetching =>
+              should NOT warn */}
+          <LinkAccordion href="/partial-route" prefetch={true}>
+            /partial-route
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* default prefetch (not a "full" prefetch) => should NOT warn,
+              even though the route has no partial prefetching opt-in */}
+          <LinkAccordion href="/control-route">/control-route</LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/app/partial-route/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/app/partial-route/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// Opts into partial prefetching at the segment level. Navigating here via a
+// `prefetch={true}` link should NOT warn.
+export const prefetch = 'partial'
+
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Partial static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Partial dynamic</div>
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/components/link-accordion.tsx
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-partial-warning/next.config.js
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/prefetch-true-partial-warning/prefetch-true-partial-warning.test.ts
+++ b/test/e2e/app-dir/prefetch-true-partial-warning/prefetch-true-partial-warning.test.ts
@@ -1,0 +1,83 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('prefetch-true-partial-warning', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // The warning is only emitted in development. In dev we don't prefetch, so it
+  // fires at navigation time instead.
+  if (!isNextDev) {
+    it('is skipped outside of dev', () => {})
+    return
+  }
+
+  // A stable substring of the dev warning emitted from navigation.ts.
+  const WARNING = 'Partial Prefetching is not enabled'
+
+  async function navigateViaAccordion(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    href: string
+  ) {
+    const toggle = await browser.elementByCss(
+      `input[data-link-accordion="${href}"]`
+    )
+    await toggle.click()
+    const link = await browser.elementByCss(`a[href="${href}"]`)
+    await link.click()
+  }
+
+  it('warns when a prefetch={true} link navigates to a route without partial prefetching', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/default-route')
+
+    // Wait for the navigation to fully complete (dynamic content rendered).
+    // The warning fires synchronously at the start of the navigation, so by
+    // now it must already be in the console log.
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Default dynamic'
+    )
+
+    expect(await browser.log()).toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
+
+  it('does not warn when the target route opts into partial prefetching', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/partial-route')
+
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Partial dynamic'
+    )
+
+    expect(await browser.log()).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
+
+  it('does not warn for a default (non-full) prefetch link', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/control-route')
+
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Control dynamic'
+    )
+
+    expect(await browser.log()).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
+})


### PR DESCRIPTION
Under Cache Components, a `<Link prefetch={true}>` pointing at a route that hasn't enabled Partial Prefetching quietly falls back to a legacy full prefetch: it pulls down the route's dynamic data instead of just the static shell, defeating the static/dynamic split. In development we now surface this with a console error that explains the fallback and points at how to opt in — app-wide with `partialPrefetching`, or per-route with `prefetch = 'partial'`.

The check runs when the navigation happens, not when the link is prefetched. Dev doesn't prefetch, so navigation is the only point where both the originating link's fetch strategy and the resolved route tree are in hand; it also means an app that has just turned on Cache Components isn't flooded with warnings for every `prefetch={true}` link on the page, since you only hear about a route when you actually navigate to it. The decision reads a single hint at the root of the resolved route tree that records whether any segment in the route opted into Partial Prefetching.

Scope: the warning fires on every qualifying navigation, including ones to fully static routes where a full prefetch costs nothing. Suppressing it for fully-static targets is deferred — the route-level "has dynamic data" signal isn't cheaply available on cache-served repeat navigations.

<!-- NEXT_JS_LLM_PR -->