### PR TITLE
Fix instant validation for catch-all parallel routes

### DIFF
--- a/packages/next/src/build/normalize-catchall-routes.test.ts
+++ b/packages/next/src/build/normalize-catchall-routes.test.ts
@@ -100,8 +100,7 @@ describe('normalizeCatchallRoutes', () => {
     })
   })
 
-  // TODO-APP: Enable this test once support for optional catch-all slots is added.
-  it.skip('should only match optional catch-all paths to the "index" of a segment', () => {
+  it('should match optional catch-all slots at and below their segment', () => {
     const appPaths = {
       '/': ['/page'],
       '/[[...catchAll]]': ['/@slot/[[...catchAll]]/page'],

--- a/packages/next/src/build/normalize-catchall-routes.ts
+++ b/packages/next/src/build/normalize-catchall-routes.ts
@@ -43,8 +43,6 @@ export function normalizeCatchAllRoutes(
         // check if there's not already a slot value that could match the catch-all
         !appPaths[appPath].some((path) => hasMatchedSlots(path, catchAllRoute))
       ) {
-        // optional catch-all routes are not currently supported, but leaving this logic in place
-        // for when they are eventually supported.
         if (isOptionalCatchAll(catchAllRoute)) {
           // optional catch-all routes should match both the root segment and any segment after it
           // for example, `/[[...slug]]` should match `/` and `/foo` and `/foo/bar`
@@ -88,8 +86,16 @@ function isMatchableSlot(segment: string): boolean {
 const catchAllRouteRegex = /\[?\[\.\.\./
 
 function isCatchAllRoute(pathname: string): boolean {
-  // Optional catch-all slots are not currently supported, and as such they are not considered when checking for match compatability.
-  return !isOptionalCatchAll(pathname) && isCatchAll(pathname)
+  if (!isCatchAll(pathname)) {
+    return false
+  }
+
+  // Only normalize optional catch-alls in parallel slots. Normal optional
+  // catch-all routes already participate in route matching directly, and
+  // propagating them here could override more specific routes.
+  return (
+    !isOptionalCatchAll(pathname) || pathname.split('/').some(isMatchableSlot)
+  )
 }
 
 function isOptionalCatchAll(pathname: string): boolean {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6642,8 +6642,15 @@ async function validateInstantConfigInBuildWithSample(
     fallbackRouteParams = fallbackRouteParamsMut
   }
 
-  const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
+  const interpolatedSampleParams = interpolateParallelRouteParams(
+    loaderTree,
     sampleParams,
+    outerCtx.pagePath,
+    fallbackRouteParams
+  )
+
+  const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
+    interpolatedSampleParams,
     fallbackRouteParams,
     false
   )
@@ -6706,7 +6713,7 @@ async function validateInstantConfigInBuildWithSample(
       workStore,
       parsedRequestHeaders: outerCtx.parsedRequestHeaders,
       getDynamicParamFromSegment,
-      interpolatedParams: sampleParams,
+      interpolatedParams: interpolatedSampleParams,
       query: sampleQuery,
       isPrefetch: false,
       isPossibleServerAction: false,

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -821,6 +821,17 @@ function segmentConsumesURLDepth(segment: Segment): boolean {
 }
 
 /**
+ * Catchall segments capture every remaining URL segment, so there are no
+ * intermediate loader tree nodes where a deeper navigation boundary can be
+ * placed.
+ */
+function isCatchallSegment(segment: Segment): boolean {
+  if (typeof segment === 'string') return false
+  const type = segment[2]
+  return type === 'c' || type === 'oc' || type.startsWith('ci')
+}
+
+/**
  * Walks the LoaderTree to discover validation depth bounds.
  *
  * Each route group between URL segments represents a potential
@@ -1044,6 +1055,11 @@ export async function createCombinedPayloadAtDepth(
     if (consumesUrlDepth) {
       nextUrlDepth++
       currentGroupDepth = 0
+      if (isCatchallSegment(segment)) {
+        // A catchall extends beyond every remaining URL boundary, so its
+        // loader tree node must become the boundary for all deeper depths.
+        nextUrlDepth = Infinity
+      }
     } else if (isGroup) {
       currentGroupDepth++
     }

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -789,9 +789,9 @@ type TreeResult = {
    * Surfaced in the missing-boundary fallback message as a pointer
    * to "something inside the subtree that didn't render". */
   firstModFilePath: string | null
-  /** How deep in the tree the config was found. Higher = more specific.
-   * Used to prefer deeper configs over shallower ones when multiple
-   * slots have configs. */
+  /** Root-relative URL segment depth where the config was found.
+   * Higher = more specific. Used to prefer deeper configs over shallower
+   * ones when multiple slots have configs. */
   configDepth: number
 }
 
@@ -1014,7 +1014,8 @@ export async function createCombinedPayloadAtDepth(
     parentPath: SegmentPath | null,
     key: string | null,
     urlDepthConsumed: number,
-    groupDepthConsumed: number
+    groupDepthConsumed: number,
+    absoluteSegmentDepth: number
   ): Promise<TreeResult> {
     const { parallelRoutes } = parseLoaderTree(loaderTree)
 
@@ -1052,6 +1053,9 @@ export async function createCombinedPayloadAtDepth(
     // real navigation boundary.
     let nextUrlDepth = urlDepthConsumed
     let currentGroupDepth = groupDepthConsumed
+    const childSegmentDepth = consumesUrlDepth
+      ? absoluteSegmentDepth + 1
+      : absoluteSegmentDepth
     if (consumesUrlDepth) {
       nextUrlDepth++
       currentGroupDepth = 0
@@ -1099,7 +1103,7 @@ export async function createCombinedPayloadAtDepth(
           path,
           parallelRouteKey,
           false /* isInsideRuntimePrefetch */,
-          0 /* segmentDepth */
+          childSegmentDepth
         )
         slotResults.set(parallelRouteKey, result)
         slots[parallelRouteKey] = result.seedData
@@ -1153,7 +1157,8 @@ export async function createCombinedPayloadAtDepth(
         path,
         parallelRouteKey,
         nextUrlDepth,
-        currentGroupDepth
+        currentGroupDepth,
+        childSegmentDepth
       )
       slotResults.set(parallelRouteKey, result)
       slots[parallelRouteKey] = result.seedData
@@ -1350,7 +1355,8 @@ export async function createCombinedPayloadAtDepth(
       null /* parentPath */,
       null /* key */,
       0 /* urlDepthConsumed */,
-      0 /* groupDepthConsumed */
+      0 /* groupDepthConsumed */,
+      0 /* absoluteSegmentDepth */
     )
 
   if (!requiresInstantUI) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -172,6 +172,12 @@ export default async function Page() {
           <DebugLinks href="/suspense-in-root/parallel/slot-config-children-suspended" />
         </li>
         <li>
+          <DebugLinks href="/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/reference" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/reference" />
+        </li>
+        <li>
           <DebugLinks href="/suspense-in-root/parallel/conditional-breadcrumbs/show-both/unblocked" />
         </li>
         <li>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/@breadcrumbs/[...catchall]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/@breadcrumbs/[...catchall]/page.tsx
@@ -1,0 +1,5 @@
+export const instant = { level: 'experimental-error' }
+
+export default function Page() {
+  return <nav>catchall breadcrumbs</nav>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/@breadcrumbs/default.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/@breadcrumbs/default.tsx
@@ -1,0 +1,3 @@
+export default function BreadcrumbsDefault() {
+  return null
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <Suspense fallback="loading...">{children}</Suspense>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/reference/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/reference/page.tsx
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  await cookies()
+  return <p>catchall breadcrumbs dynamic page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/catchall-breadcrumbs/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+
+export default function Layout({
+  children,
+  breadcrumbs,
+}: {
+  children: ReactNode
+  breadcrumbs: ReactNode
+}) {
+  return (
+    <main>
+      <div>{breadcrumbs}</div>
+      <Suspense fallback="loading...">{children}</Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/@breadcrumbs/[[...catchall]]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/@breadcrumbs/[[...catchall]]/page.tsx
@@ -1,0 +1,5 @@
+export const instant = { level: 'experimental-error' }
+
+export default function Page() {
+  return <nav>optional catchall breadcrumbs</nav>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/@breadcrumbs/default.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/@breadcrumbs/default.tsx
@@ -1,0 +1,3 @@
+export default function BreadcrumbsDefault() {
+  return null
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <Suspense fallback="loading...">{children}</Suspense>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/reference/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/reference/page.tsx
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  await cookies()
+  return <p>optional catchall breadcrumbs dynamic page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/optional-catchall-breadcrumbs/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+
+export default function Layout({
+  children,
+  breadcrumbs,
+}: {
+  children: ReactNode
+  breadcrumbs: ReactNode
+}) {
+  return (
+    <main>
+      <div>{breadcrumbs}</div>
+      <Suspense fallback="loading...">{children}</Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
@@ -485,6 +485,88 @@ describe('instant validation - parallel slot configs', () => {
       })
     })
 
+    describe('catchall slot configs', () => {
+      it('catches dynamic content below the catchall entry point', async () => {
+        const href =
+          '/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/reference'
+        if (isNextDev) {
+          const browser = await navigateTo(href)
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/parallel/catchall-breadcrumbs/@breadcrumbs/[...catchall]/page.tsx (1:24) @ instant
+           > 1 | export const instant = { level: 'experimental-error' }
+               |                        ^",
+                 "stack": [
+                   "instant app/suspense-in-root/parallel/catchall-breadcrumbs/@breadcrumbs/[...catchall]/page.tsx (1:24)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1319",
+             "description": "Next.js encountered runtime data during a navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/reference/page.tsx (4:16) @ Page
+           > 4 |   await cookies()
+               |                ^",
+             "stack": [
+               "Page app/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/reference/page.tsx (4:16)",
+             ],
+           }
+          `)
+        } else {
+          const result = await prerender(href)
+          expect(extractBuildValidationError(result.cliOutput)).toContain(
+            'Error: Route "/suspense-in-root/parallel/catchall-breadcrumbs/docs/api/reference": Next.js encountered runtime data during prerendering or a navigation.'
+          )
+          expect(result.exitCode).toBe(1)
+        }
+      })
+
+      it('catches dynamic content below the optional catchall entry point', async () => {
+        const href =
+          '/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/reference'
+        if (isNextDev) {
+          const browser = await navigateTo(href)
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/parallel/optional-catchall-breadcrumbs/@breadcrumbs/[[...catchall]]/page.tsx (1:24) @ instant
+           > 1 | export const instant = { level: 'experimental-error' }
+               |                        ^",
+                 "stack": [
+                   "instant app/suspense-in-root/parallel/optional-catchall-breadcrumbs/@breadcrumbs/[[...catchall]]/page.tsx (1:24)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1319",
+             "description": "Next.js encountered runtime data during a navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/reference/page.tsx (4:16) @ Page
+           > 4 |   await cookies()
+               |                ^",
+             "stack": [
+               "Page app/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/reference/page.tsx (4:16)",
+             ],
+           }
+          `)
+        } else {
+          const result = await prerender(href)
+          expect(extractBuildValidationError(result.cliOutput)).toContain(
+            'Error: Route "/suspense-in-root/parallel/optional-catchall-breadcrumbs/docs/api/reference": Next.js encountered runtime data during prerendering or a navigation.'
+          )
+          expect(result.exitCode).toBe(1)
+        }
+      })
+    })
+
     describe('conditional slot rendering', () => {
       it('valid - both slots render, no cookies', async () => {
         const href =

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -3138,11 +3138,26 @@ describe('instant validation', () => {
           )
           expect(extractBuildValidationError(result.cliOutput))
             .toMatchInlineSnapshot(`
-           "Error [InvariantError]: Invariant: An unexpected error occurred during instant validation. This is a bug in Next.js.
-               at ignore-listed frames {
-             [cause]: Error [InvariantError]: Invariant: Missing value for segment key: "catchall" with dynamic param type: c. This is a bug in Next.js.
-                 at ignore-listed frames
-           }
+           "Error: Route "/suspense-in-root/static/config-depth-preference/deeper/still/deep": Next.js encountered runtime data during prerendering or a navigation.
+
+           \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.
+
+           Ways to fix this:
+             - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#wrap-in-or-move-into-suspense
+             - [cache] For \`params\`: if the params are known, prerender them with \`generateStaticParams\`
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#for-known-params-prerender
+             - [block] Set \`export const instant = false\` to silence this warning and allow a blocking route
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#allow-blocking-route
+               at div (<anonymous>)
+               at div (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at a (<anonymous>)
+           Build-time instant validation failed for route "/suspense-in-root/static/config-depth-preference/deeper/still/deep".
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/static/config-depth-preference/deeper/still/deep" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
            Stopping prerender due to instant validation errors."
           `)
           expect(result.exitCode).toBe(1)
@@ -3320,11 +3335,26 @@ describe('instant validation', () => {
           )
           expect(extractBuildValidationError(result.cliOutput))
             .toMatchInlineSnapshot(`
-           "Error [InvariantError]: Invariant: An unexpected error occurred during instant validation. This is a bug in Next.js.
-               at ignore-listed frames {
-             [cause]: Error [InvariantError]: Invariant: Missing value for segment key: "catchall" with dynamic param type: c. This is a bug in Next.js.
-                 at ignore-listed frames
-           }
+           "Error: Route "/suspense-in-root/static/cross-slot-blocking/inner/deep": Next.js encountered runtime data during prerendering or a navigation.
+
+           \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.
+
+           Ways to fix this:
+             - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#wrap-in-or-move-into-suspense
+             - [cache] For \`params\`: if the params are known, prerender them with \`generateStaticParams\`
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#for-known-params-prerender
+             - [block] Set \`export const instant = false\` to silence this warning and allow a blocking route
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#allow-blocking-route
+               at div (<anonymous>)
+               at div (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at a (<anonymous>)
+           Build-time instant validation failed for route "/suspense-in-root/static/cross-slot-blocking/inner/deep".
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/static/cross-slot-blocking/inner/deep" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
            Stopping prerender due to instant validation errors."
           `)
           expect(result.exitCode).toBe(1)

--- a/test/lib/e2e-utils/instant-validation.ts
+++ b/test/lib/e2e-utils/instant-validation.ts
@@ -69,7 +69,15 @@ export function extractBuildValidationError(
   }
 
   const output = cliOutput.slice(start.endIndex, end.index).trim()
-  return getDeterministicOutput(output, { isMinified })
+  const deterministicOutput = getDeterministicOutput(output, { isMinified })
+
+  if (deterministicOutput.includes('Error [InvariantError]: Invariant:')) {
+    throw new Error(
+      `Instant validation produced an internal Next.js error:\n${deterministicOutput}`
+    )
+  }
+
+  return deterministicOutput
 }
 
 export function normalizeValidationUrl(url: string): string {


### PR DESCRIPTION
Build-time instant validation constructed its synthetic render from raw sample params. Unlike the normal render path, it skipped parallel route interpolation, causing catch-all slots to throw a missing segment invariant instead of reporting validation errors.

Interpolate sample params before constructing dynamic segments. Also treat catch-all segments as spanning the remaining URL depths so deeper sibling content is validated at the catch-all boundary.

Add build and dev coverage for catch-all and optional catch-all slots, update the expected diagnostics, and prevent instant-validation tests from accepting internal invariant errors.