### PR TITLE
[CC] Exclude caches with low stale from static prerenders

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4377,7 +4377,6 @@ function runDevValidationInBackground(
   ctx: AppRenderContext,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
-  shellStage: RenderStage.Static | RenderStage.Runtime,
   getDevRenderDidError: () => boolean,
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
@@ -4432,8 +4431,7 @@ function runDevValidationInBackground(
             createRequestStore,
             getPayload,
             onError,
-            prerenderResumeDataCache,
-            shellStage
+            prerenderResumeDataCache
           )
 
           // Unlike the cold streamed render, which fills the caches, the warm
@@ -4480,8 +4478,7 @@ interface StagedDevRenderSetup {
  * the request store.
  */
 function setUpStagedDevRender(
-  requestStore: RequestStore,
-  shellStage: RenderStage.Static | RenderStage.Runtime
+  requestStore: RequestStore
 ): StagedDevRenderSetup {
   const cacheSignal = new CacheSignal()
   trackPendingModules(cacheSignal)
@@ -4501,7 +4498,6 @@ function setUpStagedDevRender(
     requestStore.headers
   )
   requestStore.cacheSignal = cacheSignal
-  requestStore.shellStage = shellStage
 
   const environmentName = () =>
     getEnvironmentNameForStage(stageController.currentStage)
@@ -4757,8 +4753,7 @@ async function renderWithWarmCachesForValidationInDev(
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
-  shellStage: RenderStage.Static | RenderStage.Runtime
+  prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>
 ): Promise<DevValidationInputs> {
   const { ComponentMod, setReactDebugChannel } = ctx.renderOpts
   const { clientModules } = getClientReferenceManifest()
@@ -4771,7 +4766,6 @@ async function renderWithWarmCachesForValidationInDev(
   })
 
   const requestStore = createRequestStore()
-  requestStore.shellStage = shellStage
   requestStore.resumeDataCache = createRenderResumeDataCache(
     prerenderResumeDataCache
   )
@@ -4874,7 +4868,7 @@ async function stagedRenderWithCachesInDev(
     prerenderResumeDataCache,
     stageController,
     environmentName,
-  } = setUpStagedDevRender(requestStore, shellStage)
+  } = setUpStagedDevRender(requestStore)
 
   let validationDebugChannel: AnyStream | undefined
   const debugChannel = setReactDebugChannel && createNodeDebugChannel()
@@ -4911,7 +4905,6 @@ async function stagedRenderWithCachesInDev(
       ctx,
       fallbackRouteParams,
       prerenderResumeDataCache,
-      shellStage,
       getDevRenderDidError,
       createRequestStore,
       getPayload,

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -90,13 +90,6 @@ export interface RequestStore extends CommonWorkUnitStore {
 
   // DEV-only
   usedDynamic?: boolean
-  /**
-   * Which shell this dev render produces: `Static` for an initial HTML load, a
-   * plain client navigation, or an HMR refresh; `Runtime` for a client
-   * navigation into a runtime-prefetch route, where the runtime-prefetchable
-   * content has already settled on the client.
-   */
-  shellStage?: RenderStage.Static | RenderStage.Runtime
 }
 
 export type InstantValidationSamples = {

--- a/packages/next/src/server/use-cache/constants.ts
+++ b/packages/next/src/server/use-cache/constants.ts
@@ -1,2 +1,2 @@
 export const DYNAMIC_EXPIRE = 300 // 5 minutes
-export const RUNTIME_PREFETCH_DYNAMIC_STALE = 30 // 30 seconds
+export const DYNAMIC_STALE = 30 // 30 seconds

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -62,7 +62,7 @@ import {
 } from '../app-render/create-error-handler'
 import { createDigestWithErrorCode } from '../../lib/error-telemetry-utils'
 import stringHash from 'next/dist/compiled/string-hash'
-import { DYNAMIC_EXPIRE, RUNTIME_PREFETCH_DYNAMIC_STALE } from './constants'
+import { DYNAMIC_EXPIRE, DYNAMIC_STALE } from './constants'
 import { NEXT_CACHE_ROOT_PARAM_TAG_ID } from '../../lib/constants'
 import type { CacheHandler } from '../lib/cache-handlers/types'
 import { getCacheHandler, getPrivateCacheHandler } from './handlers'
@@ -2358,17 +2358,18 @@ export async function cache(
           }
         }
 
-        if (rdcResult.entry.stale < RUNTIME_PREFETCH_DYNAMIC_STALE) {
+        if (rdcResult.entry.stale < DYNAMIC_STALE) {
           switch (workUnitStore.type) {
+            case 'prerender':
             case 'prerender-runtime':
-              // In a runtime prerender, if the cache entry will become
+              // If the cache entry will become
               // stale in less then 30 seconds, we consider this cache entry
               // dynamic as it's not worth prefetching. It's better to leave
               // a dynamic hole that can be filled during the navigation.
               debug?.(
                 'omitting entry',
                 serializedCacheKey,
-                'from runtime shell due to short stale value:',
+                'from shell due to short stale value:',
                 rdcResult.entry.stale
               )
               if (cacheSignal) {
@@ -2380,17 +2381,9 @@ export async function cache(
                 'dynamic "use cache"'
               )
             case 'request': {
-              // A short stale time excludes the entry from the runtime prefetch
-              // shell, but not from the static shell. We only replicate that
-              // exclusion (the `prerender-runtime` behavior) when this render
-              // produces the runtime prefetch shell: a client navigation into a
-              // runtime-prefetch route. An initial load, a plain navigation,
-              // and an HMR refresh produce the static shell, where the entry
-              // stays and resolves like the static prerender.
-              if (
-                process.env.NODE_ENV === 'development' &&
-                workUnitStore.shellStage === RenderStage.Runtime
-              ) {
+              // A short stale time excludes the entry from prerenders.
+              // We delay it here to match that.
+              if (process.env.NODE_ENV === 'development') {
                 // End the cache signal read (once, in case the expire block
                 // above already did) so the deferred value isn't counted as a
                 // pending read at a staged rendering boundary, then defer it to
@@ -2407,7 +2400,6 @@ export async function cache(
               }
               break
             }
-            case 'prerender':
             case 'prerender-ppr':
             case 'prerender-legacy':
             case 'cache':
@@ -2936,23 +2928,12 @@ export async function cache(
           }
         }
 
-        if (
-          entry !== undefined &&
-          entry.stale < RUNTIME_PREFETCH_DYNAMIC_STALE
-        ) {
+        if (entry !== undefined && entry.stale < DYNAMIC_STALE) {
           switch (workUnitStore.type) {
             case 'request': {
-              // A short stale time excludes the entry from the runtime prefetch
-              // shell, but not from the static shell. We only replicate that
-              // exclusion (the `prerender-runtime` behavior) when this render
-              // produces the runtime prefetch shell: a client navigation into a
-              // runtime-prefetch route. An initial load, a plain navigation,
-              // and an HMR refresh produce the static shell, where the entry
-              // stays and resolves like the static prerender.
-              if (
-                process.env.NODE_ENV === 'development' &&
-                workUnitStore.shellStage === RenderStage.Runtime
-              ) {
+              // A short stale time excludes the entry from prerenders.
+              // We delay it here to match that.
+              if (process.env.NODE_ENV === 'development') {
                 // End the cache signal read (once, in case the expire block
                 // above already did) so the deferred value isn't counted as a
                 // pending read at a staged rendering boundary, then defer it to

--- a/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
@@ -302,32 +302,16 @@ describe.each([
         it('cached data + short-stale cached data', async () => {
           const path = '/short-stale-cache'
 
-          // A short stale time excludes the entry from the runtime prefetch
-          // shell, but not from the static shell. So an initial load resolves
-          // it in the static stage (Prerender), and so does a navigation into a
-          // route without runtime prefetch. Only a navigation into a
-          // runtime-prefetch route excludes it, resolving it in the dynamic
-          // stage (Server). This asymmetry mirrors the build-time behavior,
-          // where a short stale time is omitted from the runtime prefetch but
-          // not from the static shell.
-          const shortStaleEnv =
-            !isInitialLoad && hasRuntimePrefetch ? 'Server' : 'Prerender'
+          // A short stale time excludes the entry from both the runtime prefetch
+          // shell and the static shell.
 
           const assertLogs = async (browser: Playwright) => {
             const logs = await browser.log()
             assertLog(logs, 'after cache read - layout', 'Prerender')
             assertLog(logs, 'after cache read - page', 'Prerender')
 
-            assertLog(
-              logs,
-              'after short-stale cache read - page',
-              shortStaleEnv
-            )
-            assertLog(
-              logs,
-              'after short-stale cache read - layout',
-              shortStaleEnv
-            )
+            assertLog(logs, 'after short-stale cache read - page', 'Server')
+            assertLog(logs, 'after short-stale cache read - layout', 'Server')
 
             assertLog(logs, 'after uncached fetch - layout', 'Server')
             assertLog(logs, 'after uncached fetch - page', 'Server')

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
         This page uses a short-lived private cache (with cacheLife("seconds")),
         which should not be included in a static prefetch, but should be
         included in a runtime prefetch, because it has a long enough stale time
-        (&ge; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
+        (&ge; DYNAMIC_STALE, 30s)
       </p>
       <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
         <ShortLivedCache />

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -11,8 +11,8 @@ export default async function Page() {
       <DebugRenderKind />
       <p id="intro">
         This page uses a short-lived private cache (staleTime &lt;
-        RUNTIME_PREFETCH_DYNAMIC_STALE, which is 30s), which should not be
-        included in a runtime prefetch
+        DYNAMIC_STALE, which is 30s), which should not be included in a runtime
+        prefetch
       </p>
       <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
         <CachedButShortLived />

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
         This page uses a short-lived public cache (with cacheLife("seconds")),
         which should not be included in a static prefetch, but should be
         included in a runtime prefetch, because it has a long enough stale time
-        (&ge; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
+        (&ge; DYNAMIC_STALE, 30s)
       </p>
       <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
         <ShortLivedCache />

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
         This page uses a short-lived public cache (expire &lt; DYNAMIC_EXPIRE,
         5min), which should not be included in a static prefetch, but should be
         included in a runtime prefetch, because it has a long enough stale time
-        (&ge; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
+        (&ge; DYNAMIC_STALE, 30s)
       </p>
       <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
         <ShortLivedCache />
@@ -25,7 +25,7 @@ export default async function Page() {
 async function ShortLivedCache() {
   'use cache'
   cacheLife({
-    stale: 60, // > RUNTIME_PREFETCH_DYNAMIC_STALE
+    stale: 60, // > DYNAMIC_STALE
     revalidate: 2 * 60,
     expire: 3 * 60, // < DYNAMIC_EXPIRE
   })

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
         This page uses a short-lived public cache (expire &lt; DYNAMIC_EXPIRE,
         5min), which should not be included in a static prefetch, and should
         also not be included in a runtime prefetch, because it has a short
-        enough stale time (&lt; RUNTIME_PREFETCH_DYNAMIC_STALE, 30s)
+        enough stale time (&lt; DYNAMIC_STALE, 30s)
       </p>
       <Suspense fallback={<div style={{ color: 'grey' }}>Loading...</div>}>
         <ShortLivedCache />
@@ -25,7 +25,7 @@ export default async function Page() {
 async function ShortLivedCache() {
   'use cache'
   cacheLife({
-    stale: 20, // < RUNTIME_PREFETCH_DYNAMIC_STALE
+    stale: 20, // < DYNAMIC_STALE
     revalidate: 2 * 60,
     expire: 3 * 60, // < DYNAMIC_EXPIRE
   })

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
@@ -716,7 +716,7 @@ describe('runtime prefetching', () => {
     it.each([
       {
         // If a cache has an expiration time under 5min (DYNAMIC_EXPIRE), we omit it from static prerenders.
-        // However, it should still be included in a runtime prefetch if its stale time is >=30s. (RUNTIME_PREFETCH_DYNAMIC_STALE)
+        // However, it should still be included in a runtime prefetch if its stale time is >=30s. (DYNAMIC_STALE)
         description:
           'includes short-lived public caches with a long enough staleTime',
         staticContent: 'This page uses a short-lived public cache',
@@ -724,7 +724,7 @@ describe('runtime prefetching', () => {
       },
       {
         // If a cache has an expiration time under 5min (DYNAMIC_EXPIRE), we omit it from static prerenders.
-        // However, it should still be included in a runtime prefetch if its stale time is >=30s. (RUNTIME_PREFETCH_DYNAMIC_STALE)
+        // However, it should still be included in a runtime prefetch if its stale time is >=30s. (DYNAMIC_STALE)
         // `cacheLife("seconds")` is deliberately set to have a stale time of 30s to stay above this treshold.
         description: 'includes public caches with cacheLife("seconds")',
         staticContent: 'This page uses a short-lived public cache',
@@ -732,7 +732,7 @@ describe('runtime prefetching', () => {
       },
       {
         // A Private cache will always be omitted from static prerenders.
-        // However, it should still be included in a runtime prefetch if its stale time is >=30s. (RUNTIME_PREFETCH_DYNAMIC_STALE)
+        // However, it should still be included in a runtime prefetch if its stale time is >=30s. (DYNAMIC_STALE)
         // `cacheLife("seconds")` is deliberately set to have a stale time of 30s to stay above this treshold.
         description: 'includes private caches with cacheLife("seconds")',
         staticContent: 'This page uses a short-lived private cache',
@@ -777,7 +777,7 @@ describe('runtime prefetching', () => {
     })
 
     it('omits short-lived public caches with a short enough staleTime', async () => {
-      // If a cache has a stale time below 30s (RUNTIME_PREFETCH_DYNAMIC_STALE), we should omit it from runtime prefetches.
+      // If a cache has a stale time below 30s (DYNAMIC_STALE), we should omit it from runtime prefetches.
 
       let page: Playwright.Page
       const browser = await next.browser('/', {
@@ -837,7 +837,7 @@ describe('runtime prefetching', () => {
     })
 
     it('omits private caches with a short enough staleTime', async () => {
-      // If a cache has a stale time below 30s (RUNTIME_PREFETCH_DYNAMIC_STALE), we should omit it from runtime prefetches.
+      // If a cache has a stale time below 30s (DYNAMIC_STALE), we should omit it from runtime prefetches.
 
       let page: Playwright.Page
       const browser = await next.browser('/', {

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-short-stale/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-short-stale/page.tsx
@@ -1,0 +1,33 @@
+import { cacheLife } from 'next/cache'
+import { Suspense } from 'react'
+
+async function getCachedRandom() {
+  'use cache'
+  // Long-lived (stale >= DYNAMIC_STALE, expire >= DYNAMIC_EXPIRE): stays in the
+  // static shell.
+  cacheLife({ stale: 60, revalidate: 100, expire: 1000 })
+  return Math.random()
+}
+
+async function ShortStaleCache() {
+  'use cache'
+  // Long expire (>= DYNAMIC_EXPIRE, 5min) and a non-zero revalidate, but a
+  // stale time below DYNAMIC_STALE (30s). This isolates the short-stale
+  // exclusion: the entry is omitted from the static shell purely because of its
+  // short stale time, not because of a short expire or revalidate: 0.
+  cacheLife({ stale: 18, revalidate: 100, expire: 1000 })
+  return <p id="y">{new Date().toISOString()}</p>
+}
+
+export default async function Page() {
+  const x = await getCachedRandom()
+
+  return (
+    <>
+      <p id="x">{x}</p>
+      <Suspense fallback={<p id="y">Loading...</p>}>
+        <ShortStaleCache />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/next.config.js
+++ b/test/e2e/app-dir/use-cache/next.config.js
@@ -13,7 +13,9 @@ const nextConfig = {
   },
   cacheLife: {
     frequent: {
-      stale: 19,
+      // >= DYNAMIC_STALE (30s) so the cache is still eligible for the static
+      // shell. A shorter stale time would exclude it from static prerenders.
+      stale: 30,
       revalidate: 100,
       expire: 300,
     },

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -529,6 +529,9 @@ describe('use-cache', () => {
           '/cache-fetch',
           '/cache-fetch-no-store',
           '/cache-life',
+          // Without cache components this page is fully static. With cache
+          // components its short-stale cache becomes a dynamic hole.
+          !withCacheComponents && '/cache-life-short-stale',
           '/cache-tag',
           '/directive-in-node-modules/with-handler',
           '/directive-in-node-modules/without-handler',
@@ -589,14 +592,14 @@ describe('use-cache', () => {
       const cacheLifeMeta = JSON.parse(
         await next.readFile('.next/server/app/cache-life.meta')
       )
-      expect(cacheLifeMeta.headers['x-nextjs-stale-time']).toBe('19')
+      expect(cacheLifeMeta.headers['x-nextjs-stale-time']).toBe('30')
 
       if (withCacheComponents) {
         const cacheLifeWithDynamicMeta = JSON.parse(
           await next.readFile('.next/server/app/cache-life-with-dynamic.meta')
         )
         expect(cacheLifeWithDynamicMeta.headers['x-nextjs-stale-time']).toBe(
-          '19'
+          '30'
         )
       }
     })
@@ -625,6 +628,28 @@ describe('use-cache', () => {
         })
 
         expect(await browser.elementById('y').text()).toBe('Loading...')
+      })
+
+      it('should omit caches with a short stale time from prerendered shells', async () => {
+        // Disable JS as a hack to see what's included in the static shell
+        let browser = await next.browser('/cache-life-short-stale', {
+          disableJavaScript: true,
+        })
+
+        expect(await browser.elementById('x').text()).toBeTruthy()
+        // We expect the cache to be excluded, so it's showing a suspense fallback
+        expect(await browser.elementById('y').text()).toBe('Loading...')
+
+        // If we let JS run, we should see the cache's actual value
+        browser = await next.browser('/cache-life-short-stale', {
+          pushErrorAsConsoleLog: true,
+        })
+
+        await retry(async () => {
+          expect(await browser.elementById('y').text()).toBeDateString()
+        })
+
+        await assertNoConsoleErrors(browser)
       })
     }
 


### PR DESCRIPTION
In #[94645](https://github.com/vercel/next.js/pull/94645) we discovered that there's a disparity between how we handle caches with low stale time (<30s): runtime prerenders exclude them, but static prerenders do not. We should avoid situations where a static prerender contains data that a runtime prerender of the same page doesn't. Also, the motivation is the same in both cases: if something goes stale that quickly, it's generally not worth prefetching.