### PR TITLE
Add codemod to remove `unstable_` prefix from `catchError` and `retry`

### DIFF
--- a/docs/01-app/02-guides/upgrading/codemods.mdx
+++ b/docs/01-app/02-guides/upgrading/codemods.mdx
@@ -61,6 +61,44 @@ npx @next/codemod upgrade canary
 
 ## Codemods
 
+### 16.3
+
+#### Remove `unstable_` prefix from `catchError` and `retry`
+
+##### `remove-unstable-catch-error-retry`
+
+```bash filename="Terminal"
+npx @next/codemod@latest remove-unstable-catch-error-retry .
+```
+
+This codemod removes the `unstable_` prefix from the stabilized `catchError` API (imported from `next/error`) and the `retry` error prop.
+
+For example:
+
+```tsx filename="app/error.tsx"
+'use client'
+import { unstable_catchError } from 'next/error'
+
+function ErrorBoundary({ error, reset, unstable_retry }) {
+  return <button onClick={() => unstable_retry()}>Retry</button>
+}
+
+export default unstable_catchError(ErrorBoundary)
+```
+
+Transforms into:
+
+```tsx filename="app/error.tsx"
+'use client'
+import { catchError } from 'next/error'
+
+function ErrorBoundary({ error, reset, retry }) {
+  return <button onClick={() => retry()}>Retry</button>
+}
+
+export default catchError(ErrorBoundary)
+```
+
 ### 16.0
 
 #### Remove `experimental_ppr` Route Segment Config from App Router pages and layouts

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -143,4 +143,10 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'remove-experimental-ppr',
     version: '16.0.0-canary.11',
   },
+  {
+    title:
+      'Remove `unstable_` prefix from the stabilized `catchError` API and `retry` error prop',
+    value: 'remove-unstable-catch-error-retry',
+    version: '16.3.0-canary.47',
+  },
 ]

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-alias.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-alias.input.tsx
@@ -1,0 +1,9 @@
+// @ts-nocheck
+/* eslint-disable */
+// Alias with same API name, alias should be removed.
+import { unstable_catchError as catchError } from 'next/error'
+// Custom alias should be preserved.
+import { unstable_catchError as withCatch } from 'next/error'
+
+export const a = catchError(CompA)
+export const b = withCatch(CompB)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-alias.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-alias.output.tsx
@@ -1,0 +1,9 @@
+// @ts-nocheck
+/* eslint-disable */
+// Alias with same API name, alias should be removed.
+import { catchError } from 'next/error'
+// Custom alias should be preserved.
+import { catchError as withCatch } from 'next/error'
+
+export const a = catchError(CompA)
+export const b = withCatch(CompB)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export-collapse.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export-collapse.input.tsx
@@ -1,0 +1,4 @@
+// @ts-nocheck
+/* eslint-disable */
+// Re-export already aliased to the stable name collapses to a bare export.
+export { unstable_catchError as catchError } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export-collapse.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export-collapse.output.tsx
@@ -1,4 +1,4 @@
 // @ts-nocheck
 /* eslint-disable */
+// Re-export already aliased to the stable name collapses to a bare export.
 export { catchError } from 'next/error'
-export { catchError as myCatch } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export.input.tsx
@@ -1,0 +1,5 @@
+// @ts-nocheck
+/* eslint-disable */
+export { unstable_catchError } from 'next/error'
+export { unstable_catchError as catchError } from 'next/error'
+export { unstable_catchError as myCatch } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export.input.tsx
@@ -1,5 +1,4 @@
 // @ts-nocheck
 /* eslint-disable */
 export { unstable_catchError } from 'next/error'
-export { unstable_catchError as catchError } from 'next/error'
 export { unstable_catchError as myCatch } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-export.output.tsx
@@ -1,0 +1,5 @@
+// @ts-nocheck
+/* eslint-disable */
+export { catchError } from 'next/error'
+export { catchError } from 'next/error'
+export { catchError as myCatch } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-import.input.tsx
@@ -1,0 +1,9 @@
+// @ts-nocheck
+/* eslint-disable */
+import { unstable_catchError, type ErrorInfo } from 'next/error'
+
+function CustomErrorBoundary(props, errorInfo: ErrorInfo) {
+  return <div>{String(errorInfo.error)}</div>
+}
+
+export default unstable_catchError(CustomErrorBoundary)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-import.output.tsx
@@ -1,0 +1,9 @@
+// @ts-nocheck
+/* eslint-disable */
+import { catchError, type ErrorInfo } from 'next/error'
+
+function CustomErrorBoundary(props, errorInfo: ErrorInfo) {
+  return <div>{String(errorInfo.error)}</div>
+}
+
+export default catchError(CustomErrorBoundary)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-require.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-require.input.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+/* eslint-disable */
+const { unstable_catchError } = require('next/error')
+const nextError = require('next/error')
+
+export const a = unstable_catchError(CompA)
+export const b = nextError.unstable_catchError(CompB)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-require.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/catch-error-require.output.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+/* eslint-disable */
+const { catchError } = require('next/error')
+const nextError = require('next/error')
+
+export const a = catchError(CompA)
+export const b = nextError.catchError(CompB)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-catch-error-local.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-catch-error-local.input.tsx
@@ -1,0 +1,10 @@
+// @ts-nocheck
+/* eslint-disable */
+import { unstable_catchError } from 'next/error'
+
+// A pre-existing local `catchError` must keep working after the migration.
+function catchError() {
+  return 'local'
+}
+
+export default unstable_catchError(catchError())

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-catch-error-local.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-catch-error-local.output.tsx
@@ -1,0 +1,10 @@
+// @ts-nocheck
+/* eslint-disable */
+import { catchError as unstable_catchError } from 'next/error'
+
+// A pre-existing local `catchError` must keep working after the migration.
+function catchError() {
+  return 'local'
+}
+
+export default unstable_catchError(catchError())

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-retry-outer.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-retry-outer.input.tsx
@@ -1,0 +1,13 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+// A pre-existing `retry` helper must keep working after the migration.
+function retry() {
+  return 'helper'
+}
+
+export default function Error({ error, reset, unstable_retry }) {
+  retry()
+  return unstable_retry()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-retry-outer.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/collision-retry-outer.output.tsx
@@ -1,0 +1,13 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+// A pre-existing `retry` helper must keep working after the migration.
+function retry() {
+  return 'helper'
+}
+
+export default function Error({ error, reset, retry: unstable_retry }) {
+  retry()
+  return unstable_retry()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/combined.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/combined.input.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+import { unstable_catchError, type ErrorInfo } from 'next/error'
+
+function Boundary(props: {}, { error, reset, unstable_retry }: ErrorInfo) {
+  return (
+    <div>
+      <p>{String(error)}</p>
+      <button onClick={() => reset()}>Reset</button>
+      <button onClick={() => unstable_retry()}>Retry</button>
+    </div>
+  )
+}
+
+export default unstable_catchError(Boundary)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/combined.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/combined.output.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+import { catchError, type ErrorInfo } from 'next/error'
+
+function Boundary(props: {}, { error, reset, retry }: ErrorInfo) {
+  return (
+    (<div>
+      <p>{String(error)}</p>
+      <button onClick={() => reset()}>Reset</button>
+      <button onClick={() => retry()}>Retry</button>
+    </div>)
+  );
+}
+
+export default catchError(Boundary)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-dedup.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-dedup.input.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+/* eslint-disable */
+// Compatibility barrel exposing both names: collapsing must not duplicate the
+// `catchError` export (a duplicate named export is a syntax error).
+export { unstable_catchError } from 'next/error'
+export { catchError } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-dedup.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-dedup.output.tsx
@@ -1,0 +1,5 @@
+// @ts-nocheck
+/* eslint-disable */
+// Compatibility barrel exposing both names: collapsing must not duplicate the
+// `catchError` export (a duplicate named export is a syntax error).
+export { catchError } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-type-and-value.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-type-and-value.input.tsx
@@ -1,0 +1,5 @@
+// @ts-nocheck
+/* eslint-disable */
+// A type-only export and a runtime value export can share a name; keep both.
+export type { catchError } from './types'
+export { unstable_catchError as catchError } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-type-and-value.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/export-type-and-value.output.tsx
@@ -1,0 +1,5 @@
+// @ts-nocheck
+/* eslint-disable */
+// A type-only export and a runtime value export can share a name; keep both.
+export type { catchError } from './types'
+export { catchError } from 'next/error'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/local-barrel-export.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/local-barrel-export.input.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+/* eslint-disable */
+// A barrel that imports then re-exports the binding must stay valid ESM.
+import { unstable_catchError } from 'next/error'
+
+export { unstable_catchError }
+export { unstable_catchError as createBoundary }

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/local-barrel-export.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/local-barrel-export.output.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+/* eslint-disable */
+// A barrel that imports then re-exports the binding must stay valid ESM.
+import { catchError } from 'next/error'
+
+export { catchError }
+export { catchError as createBoundary }

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-non-next-source.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-non-next-source.input.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+/* eslint-disable */
+// `unstable_catchError` from a non-next/error module must be left untouched.
+import { unstable_catchError } from './my-utils'
+
+export default unstable_catchError(Component)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-non-next-source.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-non-next-source.output.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+/* eslint-disable */
+// `unstable_catchError` from a non-next/error module must be left untouched.
+import { unstable_catchError } from './my-utils'
+
+export default unstable_catchError(Component)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-retry-no-reset.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-retry-no-reset.input.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+/* eslint-disable */
+// Destructure without the sibling `reset` prop: not the error component shape.
+export function widget({ unstable_retry }) {
+  return unstable_retry()
+}
+
+// Plain (non-destructured) parameter named unstable_retry is left untouched too.
+export function compute(unstable_retry) {
+  return unstable_retry(5)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-retry-no-reset.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-retry-no-reset.output.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+/* eslint-disable */
+// Destructure without the sibling `reset` prop: not the error component shape.
+export function widget({ unstable_retry }) {
+  return unstable_retry()
+}
+
+// Plain (non-destructured) parameter named unstable_retry is left untouched too.
+export function compute(unstable_retry) {
+  return unstable_retry(5)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-object.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-object.input.tsx
@@ -1,0 +1,8 @@
+// @ts-nocheck
+/* eslint-disable */
+// An object literal / member access with no sibling `reset` is not error props.
+const config = { unstable_retry: true }
+
+export function getRetry() {
+  return config.unstable_retry
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-object.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-object.output.tsx
@@ -1,0 +1,8 @@
+// @ts-nocheck
+/* eslint-disable */
+// An object literal / member access with no sibling `reset` is not error props.
+const config = { unstable_retry: true }
+
+export function getRetry() {
+  return config.unstable_retry
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-retry-import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-retry-import.input.tsx
@@ -1,0 +1,8 @@
+// @ts-nocheck
+/* eslint-disable */
+// `unstable_retry` from an unrelated library is not the error prop; leave it.
+import { unstable_retry } from 'some-library'
+
+export default function useThing() {
+  return unstable_retry()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-retry-import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/negative-unrelated-retry-import.output.tsx
@@ -1,0 +1,8 @@
+// @ts-nocheck
+/* eslint-disable */
+// `unstable_retry` from an unrelated library is not the error prop; leave it.
+import { unstable_retry } from 'some-library'
+
+export default function useThing() {
+  return unstable_retry()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-global-error.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-global-error.input.tsx
@@ -1,0 +1,19 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+export default function GlobalError(props: {
+  error: Error & { digest?: string }
+  reset: () => void
+  unstable_retry: () => void
+}) {
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!</h2>
+        <button onClick={() => props.reset()}>Try again</button>
+        <button onClick={() => props.unstable_retry()}>Retry</button>
+      </body>
+    </html>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-global-error.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-global-error.output.tsx
@@ -1,0 +1,19 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+export default function GlobalError(props: {
+  error: Error & { digest?: string }
+  reset: () => void
+  retry: () => void
+}) {
+  return (
+    (<html>
+      <body>
+        <h2>Something went wrong!</h2>
+        <button onClick={() => props.reset()}>Try again</button>
+        <button onClick={() => props.retry()}>Retry</button>
+      </body>
+    </html>)
+  );
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-prop.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-prop.input.tsx
@@ -1,0 +1,21 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+export default function Error({
+  error,
+  reset,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+  unstable_retry: () => void
+}) {
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <button onClick={() => reset()}>Try again</button>
+      <button onClick={() => unstable_retry()}>Retry</button>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-prop.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/retry-prop.output.tsx
@@ -1,0 +1,21 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+export default function Error({
+  error,
+  reset,
+  retry,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+  retry: () => void
+}) {
+  return (
+    (<div>
+      <h2>Something went wrong!</h2>
+      <button onClick={() => reset()}>Try again</button>
+      <button onClick={() => retry()}>Retry</button>
+    </div>)
+  );
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-distinct-props.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-distinct-props.input.tsx
@@ -1,0 +1,13 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+// Only the binding that also accesses `reset` is the error component.
+export function ErrorComp(props) {
+  return props.reset() || props.unstable_retry()
+}
+
+// A different `props` binding (no sibling `reset`) must be left untouched.
+export function Other(props) {
+  return props.unstable_retry()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-distinct-props.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-distinct-props.output.tsx
@@ -1,0 +1,13 @@
+// @ts-nocheck
+/* eslint-disable */
+'use client'
+
+// Only the binding that also accesses `reset` is the error component.
+export function ErrorComp(props) {
+  return props.reset() || props.retry();
+}
+
+// A different `props` binding (no sibling `reset`) must be left untouched.
+export function Other(props) {
+  return props.unstable_retry()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-catch-error.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-catch-error.input.tsx
@@ -1,0 +1,10 @@
+// @ts-nocheck
+/* eslint-disable */
+import { unstable_catchError } from 'next/error'
+
+function outer() {
+  const unstable_catchError = () => 'local'
+  return unstable_catchError()
+}
+
+export default unstable_catchError(Component)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-catch-error.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-catch-error.output.tsx
@@ -1,0 +1,10 @@
+// @ts-nocheck
+/* eslint-disable */
+import { catchError } from 'next/error'
+
+function outer() {
+  const unstable_catchError = () => 'local'
+  return unstable_catchError()
+}
+
+export default catchError(Component)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-namespace.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-namespace.input.tsx
@@ -1,0 +1,10 @@
+// @ts-nocheck
+/* eslint-disable */
+import * as nextError from 'next/error'
+
+function inner(nextError) {
+  // Local parameter shadows the namespace import; must NOT be rewritten.
+  return nextError.unstable_catchError
+}
+
+export default nextError.unstable_catchError(Component)

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-namespace.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-catch-error-retry/scope-shadowed-namespace.output.tsx
@@ -1,0 +1,10 @@
+// @ts-nocheck
+/* eslint-disable */
+import * as nextError from 'next/error'
+
+function inner(nextError) {
+  // Local parameter shadows the namespace import; must NOT be rewritten.
+  return nextError.unstable_catchError
+}
+
+export default nextError.catchError(Component)

--- a/packages/next-codemod/transforms/__tests__/remove-unstable-catch-error-retry.test.js
+++ b/packages/next-codemod/transforms/__tests__/remove-unstable-catch-error-retry.test.js
@@ -1,7 +1,8 @@
-/* global jest */
+/* global jest, describe, it, expect */
 jest.autoMockOff()
 const defineTest = require('jscodeshift/dist/testUtils').defineTest
-const { readdirSync } = require('fs')
+const jscodeshift = require('jscodeshift')
+const { readdirSync, readFileSync } = require('fs')
 const { join } = require('path')
 
 const fixtureDir = 'remove-unstable-catch-error-retry'
@@ -14,3 +15,18 @@ for (const fixture of fixtures) {
   const prefix = `${fixtureDir}/${fixture}`;
   defineTest(__dirname, fixtureDir, null, prefix, { parser: 'tsx' });
 }
+
+// Guard: every expected output must be syntactically valid (e.g. no dangling or
+// duplicate exports introduced while collapsing/renaming).
+describe(`${fixtureDir} outputs are valid syntax`, () => {
+  const tsx = jscodeshift.withParser('tsx')
+  const outputs = readdirSync(fixtureDirPath).filter(file =>
+    file.endsWith('.output.tsx')
+  )
+  for (const file of outputs) {
+    it(`${file} parses`, () => {
+      const source = readFileSync(join(fixtureDirPath, file), 'utf8')
+      expect(() => tsx(source)).not.toThrow()
+    })
+  }
+})

--- a/packages/next-codemod/transforms/__tests__/remove-unstable-catch-error-retry.test.js
+++ b/packages/next-codemod/transforms/__tests__/remove-unstable-catch-error-retry.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'remove-unstable-catch-error-retry'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.tsx'))
+  .map(file => file.replace('.input.tsx', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, fixtureDir, null, prefix, { parser: 'tsx' });
+}

--- a/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
+++ b/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
@@ -141,12 +141,16 @@ export default function transformer(
 
   // Drops duplicate named exports (keeping the first) that collapsing aliases can
   // create, since duplicate ESM export names are a syntax error. Only removes
-  // duplicates, which never exist in valid input.
+  // duplicates, which never exist in valid input. Type-only and value exports
+  // live in separate namespaces, so they are tracked separately and never
+  // conflated (a `export type { x }` next to `export { x }` is valid).
   function dedupeExports(): void {
-    const seen = new Set<string>()
+    const seenValue = new Set<string>()
+    const seenType = new Set<string>()
     root.find(j.ExportNamedDeclaration).forEach((path) => {
       const specifiers = path.node.specifiers
       if (!specifiers || specifiers.length === 0) return
+      const declIsType = (path.node as any).exportKind === 'type'
       const kept = specifiers.filter((specifier: any) => {
         if (
           specifier.type !== 'ExportSpecifier' ||
@@ -154,6 +158,8 @@ export default function transformer(
         ) {
           return true
         }
+        const seen =
+          declIsType || specifier.exportKind === 'type' ? seenType : seenValue
         if (seen.has(specifier.exported.name)) return false
         seen.add(specifier.exported.name)
         return true

--- a/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
+++ b/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
@@ -2,29 +2,31 @@ import type { API, FileInfo, Options } from 'jscodeshift'
 import { createParserFromPath } from '../lib/parser'
 
 // `catchError` and the `retry` error prop dropped their `unstable_` prefix when
-// they stabilized. This codemod migrates both:
+// they stabilized. This codemod migrates both, scoped narrowly so it never
+// rewrites unrelated identifiers that happen to share the name:
 //
-//   1. `unstable_catchError` is a named export of `next/error`, so it is renamed
-//      wherever it is imported/required/re-exported from that module (and at its
-//      usage sites).
+//   1. `unstable_catchError` is a named export of `next/error`. Only references
+//      bound to that import are renamed; a local that shadows the name in a
+//      nested scope is left untouched (scope-aware rename).
 //   2. `unstable_retry` is a framework-injected prop on `error`/`global-error`
-//      components. It has no import to anchor on, so the reserved-prefix
-//      identifier is renamed wherever it appears.
+//      components and on `ErrorInfo` (the `catchError` callback argument). It
+//      has no import to anchor on, so it is renamed only in error-prop-shaped
+//      positions: a destructure, type, or member access that also carries the
+//      sibling `reset` prop. Unrelated imports, locals, parameters, and object
+//      literals named `unstable_retry` are left untouched.
 
-// Named exports keyed by the module they come from. Extend this when more named
-// exports from these modules stabilize.
+// Named exports keyed by the module they come from.
 const IMPORT_RENAMES_BY_SOURCE: Record<string, Record<string, string>> = {
   'next/error': {
     unstable_catchError: 'catchError',
   },
 }
 
-// Framework-injected props that stabilized. These are not importable, so they
-// are renamed by identifier. The `unstable_` prefix is reserved for Next.js
-// APIs, which makes the bare identifier match unambiguous.
-const PROP_RENAMES: Record<string, string> = {
-  unstable_retry: 'retry',
-}
+// Stabilized framework-injected props. `sibling` is a co-located prop that must
+// be present for a position to be treated as the error-prop shape.
+const PROP_RENAMES: Array<{ from: string; to: string; sibling: string }> = [
+  { from: 'unstable_retry', to: 'retry', sibling: 'reset' },
+]
 
 export default function transformer(
   file: FileInfo,
@@ -35,19 +37,76 @@ export default function transformer(
   const root = j(file.source)
   let hasChanges = false
 
-  // Renames a stabilized named export across every form it can be imported,
-  // re-exported, required, or accessed from `source`.
-  function renameImportedApis(
+  function isWithin(path: any, ancestor: any): boolean {
+    let cur = path
+    while (cur) {
+      if (cur.node === ancestor.node) return true
+      cur = cur.parent
+    }
+    return false
+  }
+
+  // True when `path` is an identifier used as a value reference, not a binding,
+  // declaration, import/export specifier, property key, or member property.
+  function isReferencePosition(path: any): boolean {
+    const node = path.node
+    const parent = path.parent?.node
+    if (!parent) return false
+    switch (parent.type) {
+      case 'ImportSpecifier':
+      case 'ImportDefaultSpecifier':
+      case 'ImportNamespaceSpecifier':
+      case 'ExportSpecifier':
+        return false
+      case 'ObjectProperty':
+      case 'Property':
+      case 'ObjectMethod':
+      case 'ClassMethod':
+      case 'ClassProperty':
+      case 'TSPropertySignature':
+        if (parent.key === node && !parent.computed) return false
+        break
+      case 'MemberExpression':
+      case 'OptionalMemberExpression':
+        if (parent.property === node && !parent.computed) return false
+        break
+      case 'VariableDeclarator':
+      case 'FunctionDeclaration':
+      case 'FunctionExpression':
+      case 'ClassDeclaration':
+        if (parent.id === node) return false
+        break
+    }
+    return true
+  }
+
+  // Renames value references of `oldName` to `newName` that resolve to
+  // `bindingScope`, skipping anything inside `declPath` (the binding site) and
+  // any reference that resolves to a different (shadowing) scope. Must run
+  // before the binding itself is renamed so scope lookup still finds `oldName`.
+  function renameReferences(
+    oldName: string,
+    newName: string,
+    bindingScope: any,
+    declPath: any
+  ): void {
+    root.find(j.Identifier, { name: oldName }).forEach((path) => {
+      if (declPath && isWithin(path, declPath)) return
+      if (!isReferencePosition(path)) return
+      const scope = path.scope
+      if (scope && scope.lookup(oldName) === bindingScope) {
+        path.node.name = newName
+      }
+    })
+  }
+
+  function renameImportedApi(
     source: string,
     mapping: Record<string, string>
   ): boolean {
     let changed = false
     const shouldRename = (name: string): boolean => name in mapping
-
-    // Local identifiers that need their usage sites renamed after the
-    // import/require binding itself is renamed.
-    const identifierRenames: Array<{ oldName: string; newName: string }> = []
-    // Variables bound to the whole module: `import * as m`, `const m = require(...)`.
+    // Variables bound to the whole module: `import * as m`, `const m = require()`.
     const moduleVariables = new Set<string>()
 
     // import { unstable_catchError } from 'next/error'
@@ -55,32 +114,34 @@ export default function transformer(
       .find(j.ImportDeclaration, { source: { value: source } })
       .forEach((path) => {
         path.node.specifiers?.forEach((specifier) => {
-          if (
-            specifier.type === 'ImportSpecifier' &&
-            specifier.imported?.type === 'Identifier' &&
-            shouldRename(specifier.imported.name)
-          ) {
-            const oldName = specifier.imported.name
-            const newName = mapping[oldName]
-
-            if (specifier.local && specifier.local.name === newName) {
-              // { unstable_catchError as catchError } -> { catchError }
-              const newSpecifier = j.importSpecifier(j.identifier(newName))
-              const specifierIndex = path.node.specifiers.indexOf(specifier)
-              path.node.specifiers[specifierIndex] = newSpecifier
-              identifierRenames.push({ oldName, newName })
-            } else {
-              specifier.imported = j.identifier(newName)
-              if (!specifier.local || specifier.local.name === oldName) {
-                identifierRenames.push({ oldName, newName })
-              }
-            }
-
-            changed = true
-          } else if (specifier.type === 'ImportNamespaceSpecifier') {
-            // import * as nextError from 'next/error'
+          if (specifier.type === 'ImportNamespaceSpecifier') {
             moduleVariables.add(specifier.local.name)
+            return
           }
+          if (
+            specifier.type !== 'ImportSpecifier' ||
+            specifier.imported?.type !== 'Identifier' ||
+            !shouldRename(specifier.imported.name)
+          ) {
+            return
+          }
+          const oldName = specifier.imported.name
+          const newName = mapping[oldName]
+          const localName = specifier.local ? specifier.local.name : oldName
+
+          if (localName === newName) {
+            // import { unstable_x as x } -> import { x }
+            const idx = path.node.specifiers.indexOf(specifier)
+            path.node.specifiers[idx] = j.importSpecifier(j.identifier(newName))
+          } else if (localName === oldName) {
+            // import { unstable_x } -> import { x }; rename bound references
+            renameReferences(oldName, newName, path.scope, path)
+            specifier.imported = j.identifier(newName)
+          } else {
+            // import { unstable_x as foo } -> import { x as foo }; keep usages
+            specifier.imported = j.identifier(newName)
+          }
+          changed = true
         })
       })
 
@@ -90,283 +151,269 @@ export default function transformer(
       .forEach((path) => {
         path.node.specifiers?.forEach((specifier) => {
           if (
-            specifier.type === 'ExportSpecifier' &&
-            specifier.local?.type === 'Identifier' &&
-            shouldRename(specifier.local.name)
+            specifier.type !== 'ExportSpecifier' ||
+            specifier.local?.type !== 'Identifier' ||
+            !shouldRename(specifier.local.name)
           ) {
-            const oldName = specifier.local.name
-            const newName = mapping[oldName]
-
-            if (specifier.exported && specifier.exported.name === newName) {
-              // export { unstable_catchError as catchError } -> export { catchError }
-              // Replace with a fresh shorthand specifier so recast collapses the
-              // now-redundant alias instead of printing `catchError as catchError`.
-              const specifierIndex = path.node.specifiers.indexOf(specifier)
-              path.node.specifiers[specifierIndex] = j.exportSpecifier.from({
-                local: j.identifier(newName),
-                exported: j.identifier(newName),
-              })
-            } else {
-              specifier.local = j.identifier(newName)
-              if (!specifier.exported || specifier.exported.name === oldName) {
-                // export { unstable_catchError } -> export { catchError }
-                specifier.exported = j.identifier(newName)
-              }
-              // Otherwise keep a custom alias: { unstable_catchError as myCatch }.
-            }
-
-            changed = true
+            return
           }
+          const oldName = specifier.local.name
+          const newName = mapping[oldName]
+
+          if (specifier.exported && specifier.exported.name === newName) {
+            // export { unstable_x as x } -> export { x }
+            const idx = path.node.specifiers.indexOf(specifier)
+            path.node.specifiers[idx] = j.exportSpecifier.from({
+              local: j.identifier(newName),
+              exported: j.identifier(newName),
+            })
+          } else {
+            specifier.local = j.identifier(newName)
+            if (!specifier.exported || specifier.exported.name === oldName) {
+              specifier.exported = j.identifier(newName)
+            }
+          }
+          changed = true
         })
       })
 
     // const { unstable_catchError } = require('next/error')
+    // const nextError = require('next/error')
     root
       .find(j.CallExpression, { callee: { name: 'require' } })
       .forEach((path) => {
         if (
-          path.node.arguments[0]?.type === 'StringLiteral' &&
-          path.node.arguments[0].value === source
+          path.node.arguments[0]?.type !== 'StringLiteral' ||
+          path.node.arguments[0].value !== source
         ) {
-          const parent = path.parent?.node
-          if (
-            parent?.type === 'VariableDeclarator' &&
-            parent.id?.type === 'Identifier'
-          ) {
-            moduleVariables.add(parent.id.name)
-          }
-
-          if (
-            parent?.type === 'VariableDeclarator' &&
-            parent.id?.type === 'ObjectPattern'
-          ) {
-            renameObjectPattern(parent.id, mapping, identifierRenames, () => {
-              changed = true
-            })
-          }
+          return
         }
-      })
+        const declaratorPath = path.parent
+        const parent = declaratorPath?.node
+        if (parent?.type !== 'VariableDeclarator') return
 
-    // const { unstable_catchError } = await import('next/error')
-    root.find(j.AwaitExpression).forEach((path) => {
-      const arg = path.node.argument
-      if (
-        arg?.type === 'CallExpression' &&
-        arg.callee?.type === 'Import' &&
-        arg.arguments[0]?.type === 'StringLiteral' &&
-        arg.arguments[0].value === source
-      ) {
-        const parent = path.parent?.node
-        if (
-          parent?.type === 'VariableDeclarator' &&
-          parent.id?.type === 'Identifier'
-        ) {
+        if (parent.id?.type === 'Identifier') {
           moduleVariables.add(parent.id.name)
+          return
         }
+        if (parent.id?.type !== 'ObjectPattern') return
 
-        if (
-          parent?.type === 'VariableDeclarator' &&
-          parent.id?.type === 'ObjectPattern'
-        ) {
-          renameObjectPattern(parent.id, mapping, identifierRenames, () => {
-            changed = true
-          })
-        }
-      }
-    })
+        parent.id.properties?.forEach((property: any) => {
+          if (
+            property.type !== 'ObjectProperty' ||
+            property.key?.type !== 'Identifier' ||
+            !shouldRename(property.key.name)
+          ) {
+            return
+          }
+          const oldName = property.key.name
+          const newName = mapping[oldName]
+          const valueName =
+            property.value?.type === 'Identifier' ? property.value.name : null
 
-    // import('next/error').then(({ unstable_catchError }) => ...)
-    root.find(j.CallExpression).forEach((path) => {
-      if (
-        path.node.callee?.type === 'MemberExpression' &&
-        path.node.callee.property?.type === 'Identifier' &&
-        path.node.callee.property.name === 'then' &&
-        path.node.callee.object?.type === 'CallExpression' &&
-        path.node.callee.object.callee?.type === 'Import' &&
-        path.node.callee.object.arguments[0]?.type === 'StringLiteral' &&
-        path.node.callee.object.arguments[0].value === source &&
-        path.node.arguments.length > 0
-      ) {
-        const callback = path.node.arguments[0]
-        let params = null
-
-        if (
-          callback.type === 'ArrowFunctionExpression' ||
-          callback.type === 'FunctionExpression'
-        ) {
-          params = callback.params
-        }
-
-        if (params && params.length > 0 && params[0].type === 'ObjectPattern') {
-          renameObjectPattern(params[0], mapping, identifierRenames, () => {
-            changed = true
-          })
-        }
-      }
-    })
+          if (valueName === oldName) {
+            renameReferences(
+              oldName,
+              newName,
+              declaratorPath.scope,
+              declaratorPath
+            )
+            property.key = j.identifier(newName)
+            property.value = j.identifier(newName)
+            property.shorthand = true
+          } else if (valueName === newName) {
+            property.key = j.identifier(newName)
+            property.value = j.identifier(newName)
+            property.shorthand = true
+          } else {
+            // const { unstable_x: foo } = require(...): rename the source key only
+            property.key = j.identifier(newName)
+          }
+          changed = true
+        })
+      })
 
     // require('next/error').unstable_catchError and nextError.unstable_catchError
     root.find(j.MemberExpression).forEach((path) => {
       const node = path.node
-
       const isRequireOfSource =
         node.object?.type === 'CallExpression' &&
         node.object.callee?.type === 'Identifier' &&
         node.object.callee.name === 'require' &&
         node.object.arguments[0]?.type === 'StringLiteral' &&
         node.object.arguments[0].value === source
-
-      const isModuleVariable =
+      const isModuleVar =
         node.object?.type === 'Identifier' &&
         moduleVariables.has(node.object.name)
-
-      if (!isRequireOfSource && !isModuleVariable) {
-        return
-      }
+      if (!isRequireOfSource && !isModuleVar) return
 
       if (
-        node.computed &&
-        node.property?.type === 'StringLiteral' &&
-        shouldRename(node.property.value)
-      ) {
-        node.property = j.stringLiteral(mapping[node.property.value])
-        changed = true
-      } else if (
         !node.computed &&
         node.property?.type === 'Identifier' &&
         shouldRename(node.property.name)
       ) {
         node.property = j.identifier(mapping[node.property.name])
         changed = true
+      } else if (
+        node.computed &&
+        node.property?.type === 'StringLiteral' &&
+        shouldRename(node.property.value)
+      ) {
+        node.property = j.stringLiteral(mapping[node.property.value])
+        changed = true
       }
-    })
-
-    // Rename usage sites of locally-bound names, skipping the declarations
-    // themselves (those were handled above).
-    identifierRenames.forEach(({ oldName, newName }) => {
-      root
-        .find(j.Identifier, { name: oldName })
-        .filter((identifierPath) => {
-          const parent = identifierPath.parent
-          return !(
-            parent.node.type === 'ImportSpecifier' ||
-            parent.node.type === 'ExportSpecifier' ||
-            (parent.node.type === 'ObjectProperty' &&
-              parent.node.key === identifierPath.node) ||
-            (parent.node.type === 'VariableDeclarator' &&
-              parent.node.id === identifierPath.node) ||
-            (parent.node.type === 'FunctionDeclaration' &&
-              parent.node.id === identifierPath.node) ||
-            (parent.node.type === 'Property' &&
-              parent.node.key === identifierPath.node &&
-              !parent.node.computed)
-          )
-        })
-        .forEach((identifierPath) => {
-          identifierPath.node.name = newName
-        })
     })
 
     return changed
   }
 
-  // Renames keys (and shorthand values) of a destructuring pattern that match
-  // the mapping, queuing usage-site renames for renamed bindings.
-  function renameObjectPattern(
-    objectPattern: any,
-    mapping: Record<string, string>,
-    identifierRenames: Array<{ oldName: string; newName: string }>,
-    onChange: () => void
-  ): void {
-    objectPattern.properties?.forEach((property: any) => {
-      if (
-        property.type === 'ObjectProperty' &&
-        property.key?.type === 'Identifier' &&
-        property.key.name in mapping
-      ) {
-        const oldName = property.key.name
-        const newName = mapping[oldName]
-
-        property.key = j.identifier(newName)
-
-        if (!property.value) {
-          property.value = j.identifier(newName)
-          identifierRenames.push({ oldName, newName })
-        } else if (property.value.type === 'Identifier') {
-          const localName = property.value.name
-          if (localName === oldName) {
-            property.value = j.identifier(newName)
-            identifierRenames.push({ oldName, newName })
-          } else if (localName === newName) {
-            // { unstable_catchError: catchError } -> { catchError }
-            property.value = j.identifier(newName)
-            property.shorthand = true
-            identifierRenames.push({ oldName, newName })
-          }
-        }
-
-        onChange()
-      }
-    })
+  function hasSibling(properties: any[], siblingName: string): boolean {
+    return (properties || []).some(
+      (pr) =>
+        (pr.type === 'ObjectProperty' || pr.type === 'Property') &&
+        pr.key?.type === 'Identifier' &&
+        pr.key.name === siblingName
+    )
   }
 
-  // Renames a stabilized prop by its (reserved-prefix) identifier everywhere it
-  // appears: destructured params, type members, call/usage sites, and member
-  // access. Import/export specifiers are skipped so an unrelated same-named
-  // import is never broken.
-  function renameStabilizedProps(mapping: Record<string, string>): boolean {
+  function renameTypeMember(
+    members: any[],
+    oldName: string,
+    newName: string,
+    sibling: string
+  ): boolean {
+    const hasResetSibling = (members || []).some(
+      (m) =>
+        m.type === 'TSPropertySignature' &&
+        m.key?.type === 'Identifier' &&
+        m.key.name === sibling
+    )
+    if (!hasResetSibling) return false
+    let changed = false
+    members.forEach((m) => {
+      if (
+        m.type === 'TSPropertySignature' &&
+        m.key?.type === 'Identifier' &&
+        m.key.name === oldName
+      ) {
+        m.key = j.identifier(newName)
+        changed = true
+      }
+    })
+    return changed
+  }
+
+  function renameStabilizedProp(rename: {
+    from: string
+    to: string
+    sibling: string
+  }): boolean {
+    const { from: oldName, to: newName, sibling } = rename
     let changed = false
 
-    Object.keys(mapping).forEach((oldName) => {
-      const newName = mapping[oldName]
-
-      root.find(j.Identifier, { name: oldName }).forEach((path) => {
-        const parentType = path.parent?.node?.type
+    // 1. Destructured prop: { error, reset, unstable_retry } (param or const)
+    root.find(j.ObjectPattern).forEach((patternPath) => {
+      const props = patternPath.node.properties || []
+      if (!hasSibling(props, sibling)) return
+      props.forEach((property: any) => {
         if (
-          parentType === 'ImportSpecifier' ||
-          parentType === 'ImportDefaultSpecifier' ||
-          parentType === 'ImportNamespaceSpecifier' ||
-          parentType === 'ExportSpecifier'
+          property.type !== 'ObjectProperty' ||
+          property.key?.type !== 'Identifier' ||
+          property.key.name !== oldName
         ) {
           return
         }
-        path.node.name = newName
+        const value = property.value
+        if (value?.type === 'Identifier' && value.name === oldName) {
+          // shorthand { unstable_retry }
+          renameReferences(oldName, newName, patternPath.scope, patternPath)
+          property.key = j.identifier(newName)
+          property.value = j.identifier(newName)
+          property.shorthand = true
+        } else if (
+          value?.type === 'AssignmentPattern' &&
+          value.left?.type === 'Identifier' &&
+          value.left.name === oldName
+        ) {
+          // { unstable_retry = defaultValue }
+          renameReferences(oldName, newName, patternPath.scope, patternPath)
+          property.key = j.identifier(newName)
+          value.left = j.identifier(newName)
+          property.shorthand = true
+        } else {
+          // { unstable_retry: localAlias }: rename the source key only
+          property.key = j.identifier(newName)
+        }
         changed = true
       })
+    })
 
-      // Computed access: props['unstable_retry'] or { ['unstable_retry']: ... }
-      root.find(j.StringLiteral, { value: oldName }).forEach((path) => {
-        const parent = path.parent?.node
-        const isComputedMember =
-          parent?.type === 'MemberExpression' &&
-          parent.computed &&
-          parent.property === path.node
-        const isComputedKey =
-          (parent?.type === 'ObjectProperty' ||
-            parent?.type === 'Property' ||
-            parent?.type === 'TSPropertySignature') &&
-          parent.computed &&
-          parent.key === path.node
+    // 2. Type members: { error: ...; reset: ...; unstable_retry: ... }
+    root.find(j.TSTypeLiteral).forEach((p) => {
+      if (renameTypeMember(p.node.members, oldName, newName, sibling)) {
+        changed = true
+      }
+    })
+    root.find(j.TSInterfaceBody).forEach((p) => {
+      if (renameTypeMember(p.node.body, oldName, newName, sibling)) {
+        changed = true
+      }
+    })
 
-        if (isComputedMember || isComputedKey) {
-          path.node.value = newName
+    // 3. Member access: props.unstable_retry where props.reset is also accessed
+    const siblingObjects = new Set<string>()
+    root.find(j.MemberExpression).forEach((path) => {
+      const node = path.node
+      if (
+        node.object?.type === 'Identifier' &&
+        !node.computed &&
+        node.property?.type === 'Identifier' &&
+        node.property.name === sibling
+      ) {
+        siblingObjects.add(node.object.name)
+      }
+    })
+    if (siblingObjects.size > 0) {
+      root.find(j.MemberExpression).forEach((path) => {
+        const node = path.node
+        if (
+          node.object?.type !== 'Identifier' ||
+          !siblingObjects.has(node.object.name)
+        ) {
+          return
+        }
+        if (
+          !node.computed &&
+          node.property?.type === 'Identifier' &&
+          node.property.name === oldName
+        ) {
+          node.property = j.identifier(newName)
+          changed = true
+        } else if (
+          node.computed &&
+          node.property?.type === 'StringLiteral' &&
+          node.property.value === oldName
+        ) {
+          node.property = j.stringLiteral(newName)
           changed = true
         }
       })
-    })
+    }
 
     return changed
   }
 
   try {
     for (const source of Object.keys(IMPORT_RENAMES_BY_SOURCE)) {
-      if (renameImportedApis(source, IMPORT_RENAMES_BY_SOURCE[source])) {
+      if (renameImportedApi(source, IMPORT_RENAMES_BY_SOURCE[source])) {
         hasChanges = true
       }
     }
 
-    if (renameStabilizedProps(PROP_RENAMES)) {
-      hasChanges = true
+    for (const rename of PROP_RENAMES) {
+      if (renameStabilizedProp(rename)) {
+        hasChanges = true
+      }
     }
 
     return hasChanges ? root.toSource(options) : file.source

--- a/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
+++ b/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
@@ -107,7 +107,18 @@ export default function transformer(
     let changed = false
     const shouldRename = (name: string): boolean => name in mapping
     // Variables bound to the whole module: `import * as m`, `const m = require()`.
-    const moduleVariables = new Set<string>()
+    // Keyed by name -> the binding scopes where that name is the module binding,
+    // so a shadowing local of the same name is never treated as the module.
+    const moduleVariables = new Map<string, any[]>()
+    const addModuleVariable = (name: string, scope: any): void => {
+      const scopes = moduleVariables.get(name) || []
+      scopes.push(scope)
+      moduleVariables.set(name, scopes)
+    }
+    const isModuleVariable = (name: string, scope: any): boolean => {
+      const scopes = moduleVariables.get(name)
+      return !!scopes && scopes.indexOf(scope) !== -1
+    }
 
     // import { unstable_catchError } from 'next/error'
     root
@@ -115,7 +126,7 @@ export default function transformer(
       .forEach((path) => {
         path.node.specifiers?.forEach((specifier) => {
           if (specifier.type === 'ImportNamespaceSpecifier') {
-            moduleVariables.add(specifier.local.name)
+            addModuleVariable(specifier.local.name, path.scope)
             return
           }
           if (
@@ -193,7 +204,7 @@ export default function transformer(
         if (parent?.type !== 'VariableDeclarator') return
 
         if (parent.id?.type === 'Identifier') {
-          moduleVariables.add(parent.id.name)
+          addModuleVariable(parent.id.name, declaratorPath.scope)
           return
         }
         if (parent.id?.type !== 'ObjectPattern') return
@@ -244,7 +255,8 @@ export default function transformer(
         node.object.arguments[0].value === source
       const isModuleVar =
         node.object?.type === 'Identifier' &&
-        moduleVariables.has(node.object.name)
+        !!path.scope &&
+        isModuleVariable(node.object.name, path.scope.lookup(node.object.name))
       if (!isRequireOfSource && !isModuleVar) return
 
       if (
@@ -360,8 +372,10 @@ export default function transformer(
       }
     })
 
-    // 3. Member access: props.unstable_retry where props.reset is also accessed
-    const siblingObjects = new Set<string>()
+    // 3. Member access: obj.unstable_retry where the SAME `obj` binding also has
+    // an `obj.reset` access. Matching is by binding identity (scope lookup), not
+    // by name, so a same-named object in another scope is never rewritten.
+    const siblingBindingScopes = new Map<string, Set<any>>()
     root.find(j.MemberExpression).forEach((path) => {
       const node = path.node
       if (
@@ -370,18 +384,23 @@ export default function transformer(
         node.property?.type === 'Identifier' &&
         node.property.name === sibling
       ) {
-        siblingObjects.add(node.object.name)
+        const objName = node.object.name
+        const bindingScope = path.scope ? path.scope.lookup(objName) : null
+        const set = siblingBindingScopes.get(objName) || new Set()
+        set.add(bindingScope)
+        siblingBindingScopes.set(objName, set)
       }
     })
-    if (siblingObjects.size > 0) {
+    if (siblingBindingScopes.size > 0) {
       root.find(j.MemberExpression).forEach((path) => {
         const node = path.node
-        if (
-          node.object?.type !== 'Identifier' ||
-          !siblingObjects.has(node.object.name)
-        ) {
-          return
-        }
+        if (node.object?.type !== 'Identifier') return
+        const set = siblingBindingScopes.get(node.object.name)
+        if (!set) return
+        const bindingScope = path.scope
+          ? path.scope.lookup(node.object.name)
+          : null
+        if (!set.has(bindingScope)) return
         if (
           !node.computed &&
           node.property?.type === 'Identifier' &&

--- a/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
+++ b/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
@@ -107,6 +107,66 @@ export default function transformer(
     return !!(scope && scope.lookup(name))
   }
 
+  // Source-less re-exports of a renamed local binding, e.g.
+  //   import { unstable_catchError } from 'next/error'
+  //   export { unstable_catchError }        -> export { catchError }
+  //   export { unstable_catchError as foo } -> export { catchError as foo }
+  // Only specifiers whose local resolves to `bindingScope` are touched.
+  function renameLocalExports(
+    oldName: string,
+    newName: string,
+    bindingScope: any
+  ): void {
+    root.find(j.ExportNamedDeclaration).forEach((path) => {
+      if (path.node.source) return
+      const scope = path.scope
+      if (!scope || scope.lookup(oldName) !== bindingScope) return
+      path.node.specifiers?.forEach((specifier) => {
+        if (
+          specifier.type !== 'ExportSpecifier' ||
+          specifier.local?.type !== 'Identifier' ||
+          specifier.local.name !== oldName
+        ) {
+          return
+        }
+        const exportedWasOld =
+          !specifier.exported || specifier.exported.name === oldName
+        specifier.local = j.identifier(newName)
+        if (exportedWasOld) {
+          specifier.exported = j.identifier(newName)
+        }
+      })
+    })
+  }
+
+  // Drops duplicate named exports (keeping the first) that collapsing aliases can
+  // create, since duplicate ESM export names are a syntax error. Only removes
+  // duplicates, which never exist in valid input.
+  function dedupeExports(): void {
+    const seen = new Set<string>()
+    root.find(j.ExportNamedDeclaration).forEach((path) => {
+      const specifiers = path.node.specifiers
+      if (!specifiers || specifiers.length === 0) return
+      const kept = specifiers.filter((specifier: any) => {
+        if (
+          specifier.type !== 'ExportSpecifier' ||
+          specifier.exported?.type !== 'Identifier'
+        ) {
+          return true
+        }
+        if (seen.has(specifier.exported.name)) return false
+        seen.add(specifier.exported.name)
+        return true
+      })
+      if (kept.length === specifiers.length) return
+      if (kept.length === 0 && !path.node.declaration) {
+        j(path).remove()
+      } else {
+        path.node.specifiers = kept
+      }
+    })
+  }
+
   function renameImportedApi(
     source: string,
     mapping: Record<string, string>
@@ -162,7 +222,9 @@ export default function transformer(
               )
             } else {
               // import { unstable_x } -> import { x }; rename bound references
+              // and any source-less re-export of this binding.
               renameReferences(oldName, newName, path.scope, path)
+              renameLocalExports(oldName, newName, path.scope)
               specifier.imported = j.identifier(newName)
             }
           } else {
@@ -299,6 +361,8 @@ export default function transformer(
         changed = true
       }
     })
+
+    if (changed) dedupeExports()
 
     return changed
   }

--- a/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
+++ b/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
@@ -76,6 +76,8 @@ export default function transformer(
       case 'ClassDeclaration':
         if (parent.id === node) return false
         break
+      default:
+        break
     }
     return true
   }

--- a/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
+++ b/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
@@ -1,0 +1,377 @@
+import type { API, FileInfo, Options } from 'jscodeshift'
+import { createParserFromPath } from '../lib/parser'
+
+// `catchError` and the `retry` error prop dropped their `unstable_` prefix when
+// they stabilized. This codemod migrates both:
+//
+//   1. `unstable_catchError` is a named export of `next/error`, so it is renamed
+//      wherever it is imported/required/re-exported from that module (and at its
+//      usage sites).
+//   2. `unstable_retry` is a framework-injected prop on `error`/`global-error`
+//      components. It has no import to anchor on, so the reserved-prefix
+//      identifier is renamed wherever it appears.
+
+// Named exports keyed by the module they come from. Extend this when more named
+// exports from these modules stabilize.
+const IMPORT_RENAMES_BY_SOURCE: Record<string, Record<string, string>> = {
+  'next/error': {
+    unstable_catchError: 'catchError',
+  },
+}
+
+// Framework-injected props that stabilized. These are not importable, so they
+// are renamed by identifier. The `unstable_` prefix is reserved for Next.js
+// APIs, which makes the bare identifier match unambiguous.
+const PROP_RENAMES: Record<string, string> = {
+  unstable_retry: 'retry',
+}
+
+export default function transformer(
+  file: FileInfo,
+  _api: API,
+  options: Options
+) {
+  const j = createParserFromPath(file.path)
+  const root = j(file.source)
+  let hasChanges = false
+
+  // Renames a stabilized named export across every form it can be imported,
+  // re-exported, required, or accessed from `source`.
+  function renameImportedApis(
+    source: string,
+    mapping: Record<string, string>
+  ): boolean {
+    let changed = false
+    const shouldRename = (name: string): boolean => name in mapping
+
+    // Local identifiers that need their usage sites renamed after the
+    // import/require binding itself is renamed.
+    const identifierRenames: Array<{ oldName: string; newName: string }> = []
+    // Variables bound to the whole module: `import * as m`, `const m = require(...)`.
+    const moduleVariables = new Set<string>()
+
+    // import { unstable_catchError } from 'next/error'
+    root
+      .find(j.ImportDeclaration, { source: { value: source } })
+      .forEach((path) => {
+        path.node.specifiers?.forEach((specifier) => {
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported?.type === 'Identifier' &&
+            shouldRename(specifier.imported.name)
+          ) {
+            const oldName = specifier.imported.name
+            const newName = mapping[oldName]
+
+            if (specifier.local && specifier.local.name === newName) {
+              // { unstable_catchError as catchError } -> { catchError }
+              const newSpecifier = j.importSpecifier(j.identifier(newName))
+              const specifierIndex = path.node.specifiers.indexOf(specifier)
+              path.node.specifiers[specifierIndex] = newSpecifier
+              identifierRenames.push({ oldName, newName })
+            } else {
+              specifier.imported = j.identifier(newName)
+              if (!specifier.local || specifier.local.name === oldName) {
+                identifierRenames.push({ oldName, newName })
+              }
+            }
+
+            changed = true
+          } else if (specifier.type === 'ImportNamespaceSpecifier') {
+            // import * as nextError from 'next/error'
+            moduleVariables.add(specifier.local.name)
+          }
+        })
+      })
+
+    // export { unstable_catchError } from 'next/error'
+    root
+      .find(j.ExportNamedDeclaration, { source: { value: source } })
+      .forEach((path) => {
+        path.node.specifiers?.forEach((specifier) => {
+          if (
+            specifier.type === 'ExportSpecifier' &&
+            specifier.local?.type === 'Identifier' &&
+            shouldRename(specifier.local.name)
+          ) {
+            const oldName = specifier.local.name
+            const newName = mapping[oldName]
+
+            if (specifier.exported && specifier.exported.name === newName) {
+              // export { unstable_catchError as catchError } -> export { catchError }
+              // Replace with a fresh shorthand specifier so recast collapses the
+              // now-redundant alias instead of printing `catchError as catchError`.
+              const specifierIndex = path.node.specifiers.indexOf(specifier)
+              path.node.specifiers[specifierIndex] = j.exportSpecifier.from({
+                local: j.identifier(newName),
+                exported: j.identifier(newName),
+              })
+            } else {
+              specifier.local = j.identifier(newName)
+              if (!specifier.exported || specifier.exported.name === oldName) {
+                // export { unstable_catchError } -> export { catchError }
+                specifier.exported = j.identifier(newName)
+              }
+              // Otherwise keep a custom alias: { unstable_catchError as myCatch }.
+            }
+
+            changed = true
+          }
+        })
+      })
+
+    // const { unstable_catchError } = require('next/error')
+    root
+      .find(j.CallExpression, { callee: { name: 'require' } })
+      .forEach((path) => {
+        if (
+          path.node.arguments[0]?.type === 'StringLiteral' &&
+          path.node.arguments[0].value === source
+        ) {
+          const parent = path.parent?.node
+          if (
+            parent?.type === 'VariableDeclarator' &&
+            parent.id?.type === 'Identifier'
+          ) {
+            moduleVariables.add(parent.id.name)
+          }
+
+          if (
+            parent?.type === 'VariableDeclarator' &&
+            parent.id?.type === 'ObjectPattern'
+          ) {
+            renameObjectPattern(parent.id, mapping, identifierRenames, () => {
+              changed = true
+            })
+          }
+        }
+      })
+
+    // const { unstable_catchError } = await import('next/error')
+    root.find(j.AwaitExpression).forEach((path) => {
+      const arg = path.node.argument
+      if (
+        arg?.type === 'CallExpression' &&
+        arg.callee?.type === 'Import' &&
+        arg.arguments[0]?.type === 'StringLiteral' &&
+        arg.arguments[0].value === source
+      ) {
+        const parent = path.parent?.node
+        if (
+          parent?.type === 'VariableDeclarator' &&
+          parent.id?.type === 'Identifier'
+        ) {
+          moduleVariables.add(parent.id.name)
+        }
+
+        if (
+          parent?.type === 'VariableDeclarator' &&
+          parent.id?.type === 'ObjectPattern'
+        ) {
+          renameObjectPattern(parent.id, mapping, identifierRenames, () => {
+            changed = true
+          })
+        }
+      }
+    })
+
+    // import('next/error').then(({ unstable_catchError }) => ...)
+    root.find(j.CallExpression).forEach((path) => {
+      if (
+        path.node.callee?.type === 'MemberExpression' &&
+        path.node.callee.property?.type === 'Identifier' &&
+        path.node.callee.property.name === 'then' &&
+        path.node.callee.object?.type === 'CallExpression' &&
+        path.node.callee.object.callee?.type === 'Import' &&
+        path.node.callee.object.arguments[0]?.type === 'StringLiteral' &&
+        path.node.callee.object.arguments[0].value === source &&
+        path.node.arguments.length > 0
+      ) {
+        const callback = path.node.arguments[0]
+        let params = null
+
+        if (
+          callback.type === 'ArrowFunctionExpression' ||
+          callback.type === 'FunctionExpression'
+        ) {
+          params = callback.params
+        }
+
+        if (params && params.length > 0 && params[0].type === 'ObjectPattern') {
+          renameObjectPattern(params[0], mapping, identifierRenames, () => {
+            changed = true
+          })
+        }
+      }
+    })
+
+    // require('next/error').unstable_catchError and nextError.unstable_catchError
+    root.find(j.MemberExpression).forEach((path) => {
+      const node = path.node
+
+      const isRequireOfSource =
+        node.object?.type === 'CallExpression' &&
+        node.object.callee?.type === 'Identifier' &&
+        node.object.callee.name === 'require' &&
+        node.object.arguments[0]?.type === 'StringLiteral' &&
+        node.object.arguments[0].value === source
+
+      const isModuleVariable =
+        node.object?.type === 'Identifier' &&
+        moduleVariables.has(node.object.name)
+
+      if (!isRequireOfSource && !isModuleVariable) {
+        return
+      }
+
+      if (
+        node.computed &&
+        node.property?.type === 'StringLiteral' &&
+        shouldRename(node.property.value)
+      ) {
+        node.property = j.stringLiteral(mapping[node.property.value])
+        changed = true
+      } else if (
+        !node.computed &&
+        node.property?.type === 'Identifier' &&
+        shouldRename(node.property.name)
+      ) {
+        node.property = j.identifier(mapping[node.property.name])
+        changed = true
+      }
+    })
+
+    // Rename usage sites of locally-bound names, skipping the declarations
+    // themselves (those were handled above).
+    identifierRenames.forEach(({ oldName, newName }) => {
+      root
+        .find(j.Identifier, { name: oldName })
+        .filter((identifierPath) => {
+          const parent = identifierPath.parent
+          return !(
+            parent.node.type === 'ImportSpecifier' ||
+            parent.node.type === 'ExportSpecifier' ||
+            (parent.node.type === 'ObjectProperty' &&
+              parent.node.key === identifierPath.node) ||
+            (parent.node.type === 'VariableDeclarator' &&
+              parent.node.id === identifierPath.node) ||
+            (parent.node.type === 'FunctionDeclaration' &&
+              parent.node.id === identifierPath.node) ||
+            (parent.node.type === 'Property' &&
+              parent.node.key === identifierPath.node &&
+              !parent.node.computed)
+          )
+        })
+        .forEach((identifierPath) => {
+          identifierPath.node.name = newName
+        })
+    })
+
+    return changed
+  }
+
+  // Renames keys (and shorthand values) of a destructuring pattern that match
+  // the mapping, queuing usage-site renames for renamed bindings.
+  function renameObjectPattern(
+    objectPattern: any,
+    mapping: Record<string, string>,
+    identifierRenames: Array<{ oldName: string; newName: string }>,
+    onChange: () => void
+  ): void {
+    objectPattern.properties?.forEach((property: any) => {
+      if (
+        property.type === 'ObjectProperty' &&
+        property.key?.type === 'Identifier' &&
+        property.key.name in mapping
+      ) {
+        const oldName = property.key.name
+        const newName = mapping[oldName]
+
+        property.key = j.identifier(newName)
+
+        if (!property.value) {
+          property.value = j.identifier(newName)
+          identifierRenames.push({ oldName, newName })
+        } else if (property.value.type === 'Identifier') {
+          const localName = property.value.name
+          if (localName === oldName) {
+            property.value = j.identifier(newName)
+            identifierRenames.push({ oldName, newName })
+          } else if (localName === newName) {
+            // { unstable_catchError: catchError } -> { catchError }
+            property.value = j.identifier(newName)
+            property.shorthand = true
+            identifierRenames.push({ oldName, newName })
+          }
+        }
+
+        onChange()
+      }
+    })
+  }
+
+  // Renames a stabilized prop by its (reserved-prefix) identifier everywhere it
+  // appears: destructured params, type members, call/usage sites, and member
+  // access. Import/export specifiers are skipped so an unrelated same-named
+  // import is never broken.
+  function renameStabilizedProps(mapping: Record<string, string>): boolean {
+    let changed = false
+
+    Object.keys(mapping).forEach((oldName) => {
+      const newName = mapping[oldName]
+
+      root.find(j.Identifier, { name: oldName }).forEach((path) => {
+        const parentType = path.parent?.node?.type
+        if (
+          parentType === 'ImportSpecifier' ||
+          parentType === 'ImportDefaultSpecifier' ||
+          parentType === 'ImportNamespaceSpecifier' ||
+          parentType === 'ExportSpecifier'
+        ) {
+          return
+        }
+        path.node.name = newName
+        changed = true
+      })
+
+      // Computed access: props['unstable_retry'] or { ['unstable_retry']: ... }
+      root.find(j.StringLiteral, { value: oldName }).forEach((path) => {
+        const parent = path.parent?.node
+        const isComputedMember =
+          parent?.type === 'MemberExpression' &&
+          parent.computed &&
+          parent.property === path.node
+        const isComputedKey =
+          (parent?.type === 'ObjectProperty' ||
+            parent?.type === 'Property' ||
+            parent?.type === 'TSPropertySignature') &&
+          parent.computed &&
+          parent.key === path.node
+
+        if (isComputedMember || isComputedKey) {
+          path.node.value = newName
+          changed = true
+        }
+      })
+    })
+
+    return changed
+  }
+
+  try {
+    for (const source of Object.keys(IMPORT_RENAMES_BY_SOURCE)) {
+      if (renameImportedApis(source, IMPORT_RENAMES_BY_SOURCE[source])) {
+        hasChanges = true
+      }
+    }
+
+    if (renameStabilizedProps(PROP_RENAMES)) {
+      hasChanges = true
+    }
+
+    return hasChanges ? root.toSource(options) : file.source
+  } catch (error) {
+    console.warn(`Failed to transform ${file.path}: ${error.message}`)
+    return file.source
+  }
+}

--- a/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
+++ b/packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts
@@ -100,6 +100,13 @@ export default function transformer(
     })
   }
 
+  // True when `name` already resolves to a binding visible at `scope`. Used to
+  // detect a collision before renaming a binding onto the stable name, so we can
+  // alias instead of shadowing/duplicating an existing `catchError`/`retry`.
+  function nameInScope(scope: any, name: string): boolean {
+    return !!(scope && scope.lookup(name))
+  }
+
   function renameImportedApi(
     source: string,
     mapping: Record<string, string>
@@ -145,9 +152,19 @@ export default function transformer(
             const idx = path.node.specifiers.indexOf(specifier)
             path.node.specifiers[idx] = j.importSpecifier(j.identifier(newName))
           } else if (localName === oldName) {
-            // import { unstable_x } -> import { x }; rename bound references
-            renameReferences(oldName, newName, path.scope, path)
-            specifier.imported = j.identifier(newName)
+            if (nameInScope(path.scope, newName)) {
+              // `catchError` already exists in scope: alias to keep the local
+              // name so existing references and the existing binding are safe.
+              const idx = path.node.specifiers.indexOf(specifier)
+              path.node.specifiers[idx] = j.importSpecifier(
+                j.identifier(newName),
+                j.identifier(oldName)
+              )
+            } else {
+              // import { unstable_x } -> import { x }; rename bound references
+              renameReferences(oldName, newName, path.scope, path)
+              specifier.imported = j.identifier(newName)
+            }
           } else {
             // import { unstable_x as foo } -> import { x as foo }; keep usages
             specifier.imported = j.identifier(newName)
@@ -223,15 +240,22 @@ export default function transformer(
             property.value?.type === 'Identifier' ? property.value.name : null
 
           if (valueName === oldName) {
-            renameReferences(
-              oldName,
-              newName,
-              declaratorPath.scope,
-              declaratorPath
-            )
-            property.key = j.identifier(newName)
-            property.value = j.identifier(newName)
-            property.shorthand = true
+            if (nameInScope(declaratorPath.scope, newName)) {
+              // `catchError` already exists in scope: keep the local name.
+              property.key = j.identifier(newName)
+              property.value = j.identifier(oldName)
+              property.shorthand = false
+            } else {
+              renameReferences(
+                oldName,
+                newName,
+                declaratorPath.scope,
+                declaratorPath
+              )
+              property.key = j.identifier(newName)
+              property.value = j.identifier(newName)
+              property.shorthand = true
+            }
           } else if (valueName === newName) {
             property.key = j.identifier(newName)
             property.value = j.identifier(newName)
@@ -294,20 +318,17 @@ export default function transformer(
     newName: string,
     sibling: string
   ): boolean {
-    const hasResetSibling = (members || []).some(
-      (m) =>
-        m.type === 'TSPropertySignature' &&
-        m.key?.type === 'Identifier' &&
-        m.key.name === sibling
-    )
+    const isMember = (m: any, name: string): boolean =>
+      m.type === 'TSPropertySignature' &&
+      m.key?.type === 'Identifier' &&
+      m.key.name === name
+    const hasResetSibling = (members || []).some((m) => isMember(m, sibling))
     if (!hasResetSibling) return false
+    // Skip if `retry` already exists as a member to avoid a duplicate key.
+    if ((members || []).some((m) => isMember(m, newName))) return false
     let changed = false
     members.forEach((m) => {
-      if (
-        m.type === 'TSPropertySignature' &&
-        m.key?.type === 'Identifier' &&
-        m.key.name === oldName
-      ) {
+      if (isMember(m, oldName)) {
         m.key = j.identifier(newName)
         changed = true
       }
@@ -336,22 +357,37 @@ export default function transformer(
           return
         }
         const value = property.value
+        // If `retry` is already bound in this scope, aliasing onto it would
+        // shadow the existing binding or duplicate it; keep the local name.
+        const collides = nameInScope(patternPath.scope, newName)
         if (value?.type === 'Identifier' && value.name === oldName) {
-          // shorthand { unstable_retry }
-          renameReferences(oldName, newName, patternPath.scope, patternPath)
-          property.key = j.identifier(newName)
-          property.value = j.identifier(newName)
-          property.shorthand = true
+          if (collides) {
+            // { retry: unstable_retry }: read the new prop, keep the local name.
+            property.key = j.identifier(newName)
+            property.value = j.identifier(oldName)
+            property.shorthand = false
+          } else {
+            // shorthand { unstable_retry } -> { retry }
+            renameReferences(oldName, newName, patternPath.scope, patternPath)
+            property.key = j.identifier(newName)
+            property.value = j.identifier(newName)
+            property.shorthand = true
+          }
         } else if (
           value?.type === 'AssignmentPattern' &&
           value.left?.type === 'Identifier' &&
           value.left.name === oldName
         ) {
           // { unstable_retry = defaultValue }
-          renameReferences(oldName, newName, patternPath.scope, patternPath)
-          property.key = j.identifier(newName)
-          value.left = j.identifier(newName)
-          property.shorthand = true
+          if (collides) {
+            property.key = j.identifier(newName)
+            property.shorthand = false
+          } else {
+            renameReferences(oldName, newName, patternPath.scope, patternPath)
+            property.key = j.identifier(newName)
+            value.left = j.identifier(newName)
+            property.shorthand = true
+          }
         } else {
           // { unstable_retry: localAlias }: rename the source key only
           property.key = j.identifier(newName)


### PR DESCRIPTION
### What?

Adds a new `@next/codemod` transform, `remove-unstable-catch-error-retry`, that migrates user code from the `unstable_`-prefixed `catchError` API and `retry` error prop to their stabilized names. `catchError` and the `retry` error prop dropped their `unstable_` prefix in `v16.3.0-canary.47` (#94610, re-landed in #94623).

It:

- Renames `unstable_catchError` to `catchError` for `next/error` named imports, re-exports, `require`, dynamic `import()`, `.then()` destructuring, and namespace/member access (including usage sites).
- Renames the framework-injected `unstable_retry` error prop to `retry` (destructured params, type annotations, call sites, and member access).

```tsx filename="app/error.tsx"
'use client'
import { unstable_catchError } from 'next/error'

function ErrorBoundary({ error, reset, unstable_retry }) {
  return <button onClick={() => unstable_retry()}>Retry</button>
}

export default unstable_catchError(ErrorBoundary)
```

Transforms into:

```tsx filename="app/error.tsx"
'use client'
import { catchError } from 'next/error'

function ErrorBoundary({ error, reset, retry }) {
  return <button onClick={() => retry()}>Retry</button>
}

export default catchError(ErrorBoundary)
```

### Why?

The existing `remove-unstable-prefix` codemod is hardcoded to `next/cache` and is registered at `16.0.0-canary.10`, so it cannot cover these two APIs. Folding them into that entry would also make `@next/codemod upgrade` skip them for anyone upgrading from 16.1/16.2 to 16.3, because `suggestCodemods` version-gates by slicing `TRANSFORMER_INQUIRER_CHOICES`. A dedicated transform registered at `16.3.0-canary.47` is selected correctly during upgrades.

### How?

- New transform `packages/next-codemod/transforms/remove-unstable-catch-error-retry.ts`. The import-rename logic follows the proven `remove-unstable-prefix` structure, parameterized to `next/error`. `unstable_retry` has no import to anchor on, so it is renamed by its reserved-prefix identifier (import/export specifiers are skipped so an unrelated same-named import is never broken).
- Registered in `TRANSFORMER_INQUIRER_CHOICES` (`lib/utils.ts`) at `16.3.0-canary.47`, kept in ascending version order.
- Tests and fixtures covering named import, alias (same-name collapse and custom alias), re-export, require + member access, the `error`/`global-error` `retry` prop, and a combined file.
- Documented under a new `16.3` section in `codemods.mdx`.

### Verification

- `pnpm --filter @next/codemod build` (tsc, exit 0)
- `pnpm --filter @next/codemod test -- remove-unstable-catch-error-retry` (7/7 passed)
- `pnpm --filter @next/codemod test -- remove-unstable-prefix` (9/9 passed, no regression)
- `prettier --check` and `eslint` clean on changed source files (also enforced by lint-staged on commit)

<!-- NEXT_JS_LLM_PR -->
