### PR TITLE
fix(codemod): write pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
@@ -23,12 +23,15 @@ index 5ec4c37f0b..131f5b9f4a 100644
 +    "react-dom": "19.0.0",
 +    "@types/react": "19.0.0",
 +    "@types/react-dom": "19.0.0"
-+  },
-+  "pnpm": {
-+    "overrides": {
-+      "@types/react": "19.0.0",
-+      "@types/react-dom": "19.0.0"
-+    }
-   }
- }
++  }
++}
+diff --git a/packages/next-codemod/bin/__testfixtures__/next-14-installed/pnpm-workspace.yaml b/packages/next-codemod/bin/__testfixtures__/next-14-installed/pnpm-workspace.yaml
+index e69de29bb2..fb3db0b6ec 100644
+--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/pnpm-workspace.yaml
++++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/pnpm-workspace.yaml
+@@ -0,0 +1,3 @@
++overrides:
++  "@types/react": "19.0.0"
++  "@types/react-dom": "19.0.0"
+```
 ```

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -641,7 +641,110 @@ async function suggestReactTypesCodemods(): Promise<boolean> {
   return runReactTypesCodemod
 }
 
-function writeOverridesField(
+export function updatePnpmWorkspaceYaml(
+  yamlContent: string,
+  newOverrides: Record<string, string>
+): string {
+  const lines = yamlContent.split(/\r?\n/)
+  const updatedLines: string[] = []
+  let inOverrides = false
+  let overridesFound = false
+  const writtenOverrides = new Set<string>()
+  const bufferedLines: string[] = []
+
+  // Determine/default indentation style
+  let indent = '  '
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trim()
+
+    if (inOverrides) {
+      // Check if we exited the overrides block
+      if (
+        trimmed.length > 0 &&
+        !trimmed.startsWith('#') &&
+        !/^\s+/.test(line)
+      ) {
+        for (const [key, val] of Object.entries(newOverrides)) {
+          if (!writtenOverrides.has(key)) {
+            updatedLines.push(`${indent}"${key}": "${val}"`)
+            writtenOverrides.add(key)
+          }
+        }
+        // Output buffered comments/empty lines
+        for (const buffered of bufferedLines) {
+          updatedLines.push(buffered)
+        }
+        bufferedLines.length = 0
+        inOverrides = false
+      }
+    }
+
+    if (/^overrides\s*:/.test(trimmed)) {
+      inOverrides = true
+      overridesFound = true
+      updatedLines.push(line)
+      continue
+    }
+
+    if (inOverrides) {
+      const match = line.match(
+        /^(\s+)['"]?([^'":\s]+)['"]?\s*:\s*['"]?([^'":\s][^'"]*?)['"]?\s*$/
+      )
+      if (match) {
+        // Output any buffered comments or empty lines before this key-value line
+        for (const buffered of bufferedLines) {
+          updatedLines.push(buffered)
+        }
+        bufferedLines.length = 0
+
+        indent = match[1]
+        const key = match[2]
+        if (newOverrides[key] !== undefined) {
+          updatedLines.push(`${indent}"${key}": "${newOverrides[key]}"`)
+          writtenOverrides.add(key)
+        } else {
+          updatedLines.push(line)
+        }
+      } else {
+        bufferedLines.push(line)
+      }
+    } else {
+      updatedLines.push(line)
+    }
+  }
+
+  if (inOverrides) {
+    for (const [key, val] of Object.entries(newOverrides)) {
+      if (!writtenOverrides.has(key)) {
+        updatedLines.push(`${indent}"${key}": "${val}"`)
+        writtenOverrides.add(key)
+      }
+    }
+    // Output buffered lines (comments/empty lines at the end of the block/file)
+    for (const buffered of bufferedLines) {
+      updatedLines.push(buffered)
+    }
+  }
+
+  if (!overridesFound) {
+    if (
+      updatedLines.length > 0 &&
+      updatedLines[updatedLines.length - 1].trim() !== ''
+    ) {
+      updatedLines.push('')
+    }
+    updatedLines.push('overrides:')
+    for (const [key, val] of Object.entries(newOverrides)) {
+      updatedLines.push(`  "${key}": "${val}"`)
+    }
+  }
+
+  return updatedLines.join('\n')
+}
+
+export function writeOverridesField(
   packageJson: any,
   packageManager: PackageManager,
   overrides: Record<string, string>
@@ -661,21 +764,28 @@ function writeOverridesField(
       packageJson.overrides[key] = value
     }
   } else if (packageManager === 'pnpm') {
-    // pnpm supports pnpm.overrides and pnpm.resolutions
-    if (packageJson.resolutions) {
-      for (const [key, value] of entries) {
-        packageJson.resolutions[key] = value
+    const mergedOverrides = {
+      ...(packageJson.pnpm?.overrides || {}),
+      ...(packageJson.resolutions || {}),
+      ...overrides,
+    }
+
+    const pnpmWorkspacePath = path.resolve(process.cwd(), 'pnpm-workspace.yaml')
+    let yamlContent = ''
+    if (fs.existsSync(pnpmWorkspacePath)) {
+      try {
+        yamlContent = fs.readFileSync(pnpmWorkspacePath, 'utf8')
+      } catch (err) {
+        console.warn(`${pc.yellow('⚠')} Failed to read ${pnpmWorkspacePath}.`)
       }
-    } else {
-      if (!packageJson.pnpm) {
-        packageJson.pnpm = {}
-      }
-      if (!packageJson.pnpm.overrides) {
-        packageJson.pnpm.overrides = {}
-      }
-      for (const [key, value] of entries) {
-        packageJson.pnpm.overrides[key] = value
-      }
+    }
+    const updatedYaml = updatePnpmWorkspaceYaml(yamlContent, mergedOverrides)
+    try {
+      fs.writeFileSync(pnpmWorkspacePath, updatedYaml, 'utf8')
+    } catch (err) {
+      console.warn(
+        `${pc.yellow('⚠')} Failed to write to ${pnpmWorkspacePath}.`
+      )
     }
   } else if (packageManager === 'yarn') {
     if (!packageJson.resolutions) {

--- a/packages/next-codemod/lib/__tests__/upgrade.test.js
+++ b/packages/next-codemod/lib/__tests__/upgrade.test.js
@@ -1,0 +1,162 @@
+/* global jest, describe, it, expect, beforeEach, afterEach */
+jest.autoMockOff()
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+describe('upgrade tool - updatePnpmWorkspaceYaml', () => {
+  it('should create overrides block when empty', () => {
+    const { updatePnpmWorkspaceYaml } = require('../../bin/upgrade')
+    const yaml = ''
+    const newOverrides = {
+      '@types/react': '19.0.0',
+      '@types/react-dom': '19.0.0',
+    }
+    const result = updatePnpmWorkspaceYaml(yaml, newOverrides)
+    expect(result.trim()).toBe(
+      `overrides:\n  "@types/react": "19.0.0"\n  "@types/react-dom": "19.0.0"`
+    )
+  })
+
+  it('should append overrides block to existing yaml without overrides', () => {
+    const { updatePnpmWorkspaceYaml } = require('../../bin/upgrade')
+    const yaml = 'packages:\n  - "packages/*"\n'
+    const newOverrides = {
+      '@types/react': '19.0.0',
+    }
+    const result = updatePnpmWorkspaceYaml(yaml, newOverrides)
+    expect(result).toBe(
+      `packages:\n  - "packages/*"\n\noverrides:\n  "@types/react": "19.0.0"`
+    )
+  })
+
+  it('should merge new overrides into existing overrides block', () => {
+    const { updatePnpmWorkspaceYaml } = require('../../bin/upgrade')
+    const yaml = `packages:
+  - "packages/*"
+
+overrides:
+  "foo": "1.0.0"
+  "@types/react": "18.2.0"
+`
+    const newOverrides = {
+      '@types/react': '19.0.0',
+      '@types/react-dom': '19.0.0',
+    }
+    const result = updatePnpmWorkspaceYaml(yaml, newOverrides)
+    expect(result).toBe(`packages:
+  - "packages/*"
+
+overrides:
+  "foo": "1.0.0"
+  "@types/react": "19.0.0"
+  "@types/react-dom": "19.0.0"
+`)
+  })
+
+  it('should preserve comments and formatting inside overrides block', () => {
+    const { updatePnpmWorkspaceYaml } = require('../../bin/upgrade')
+    const yaml = `overrides:
+  # This is a comment
+  "foo": "1.0.0"
+  @types/react: 18.2.0
+`
+    const newOverrides = {
+      '@types/react': '19.0.0',
+    }
+    const result = updatePnpmWorkspaceYaml(yaml, newOverrides)
+    expect(result).toBe(`overrides:
+  # This is a comment
+  "foo": "1.0.0"
+  "@types/react": "19.0.0"
+`)
+  })
+})
+
+describe('upgrade tool - writeOverridesField', () => {
+  let testProjectDir
+  let originalCwd
+
+  beforeEach(() => {
+    const tmpBase = process.env.NEXT_TEST_DIR || os.tmpdir()
+    testProjectDir = path.join(
+      tmpBase,
+      `upgrade-test-${Date.now()}-${(Math.random() * 1000) | 0}`
+    )
+    fs.mkdirSync(testProjectDir, { recursive: true })
+    originalCwd = process.cwd()
+  })
+
+  afterEach(() => {
+    // Always restore original cwd before trying to delete the temp folder to prevent EPERM on Windows
+    if (originalCwd) {
+      process.chdir(originalCwd)
+    }
+    if (testProjectDir && fs.existsSync(testProjectDir)) {
+      fs.rmSync(testProjectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should write pnpm overrides to pnpm-workspace.yaml and preserve package.json', () => {
+    delete require.cache[require.resolve('../../bin/upgrade')]
+    process.chdir(testProjectDir)
+    const { writeOverridesField } = require('../../bin/upgrade')
+
+    const packageJson = {
+      pnpm: {
+        overrides: {
+          foo: '1.0.0',
+        },
+      },
+      resolutions: {
+        bar: '2.0.0',
+      },
+    }
+
+    const overrides = {
+      '@types/react': '19.0.0',
+    }
+
+    writeOverridesField(packageJson, 'pnpm', overrides)
+
+    // Verify package.json is preserved (non-destructive)
+    expect(packageJson.pnpm.overrides.foo).toBe('1.0.0')
+    expect(packageJson.resolutions.bar).toBe('2.0.0')
+
+    // Verify pnpm-workspace.yaml creation and content
+    const workspaceYamlPath = path.join(testProjectDir, 'pnpm-workspace.yaml')
+    expect(fs.existsSync(workspaceYamlPath)).toBe(true)
+    const yamlContent = fs.readFileSync(workspaceYamlPath, 'utf8')
+    expect(yamlContent).toContain('overrides:')
+    expect(yamlContent).toContain('"foo": "1.0.0"')
+    expect(yamlContent).toContain('"bar": "2.0.0"')
+    expect(yamlContent).toContain('"@types/react": "19.0.0"')
+  })
+
+  it('should keep npm package.json overrides unchanged', () => {
+    delete require.cache[require.resolve('../../bin/upgrade')]
+    process.chdir(testProjectDir)
+    const { writeOverridesField } = require('../../bin/upgrade')
+
+    const packageJson = {
+      overrides: {
+        foo: '1.0.0',
+      },
+    }
+
+    const overrides = {
+      '@types/react': '19.0.0',
+    }
+
+    writeOverridesField(packageJson, 'npm', overrides)
+
+    expect(packageJson.overrides).toEqual({
+      foo: '1.0.0',
+      '@types/react': '19.0.0',
+    })
+
+    const workspaceYamlPath = path.join(testProjectDir, 'pnpm-workspace.yaml')
+    expect(fs.existsSync(workspaceYamlPath)).toBe(false)
+  })
+})


### PR DESCRIPTION
Description

Starting from pnpm v11, the package manager no longer reads configuration from the `pnpm` field in `package.json`, including `pnpm.overrides`.

The upgrade codemod currently writes React type overrides into `packageJson.pnpm.overrides`, which causes pnpm v11+ projects to emit warnings and ignore the generated overrides.

This change updates the pnpm path in `writeOverridesField()` to write and merge overrides into `pnpm-workspace.yaml` instead.

Changes

* Add support for updating `pnpm-workspace.yaml` with generated overrides.
* Merge generated overrides with existing overrides already present in the workspace file.
* Preserve existing npm, yarn, and bun behavior.
* Add tests covering workspace file creation and override merging.
* Update fixture documentation to reflect the new behavior.

Related Issue

Fixes #94653

Testing

* Added unit tests for override merging behavior.
* Verified linting with:

  ```bash
  pnpm exec eslint packages/next-codemod/bin/upgrade.ts
  ```
* Verified formatting with:

  ```bash
  git diff --check
  ```
