### PR TITLE
fix: correct 'the the' double word in MCP tool description

### DIFF
--- a/packages/next/src/server/mcp/tools/get-project-metadata.ts
+++ b/packages/next/src/server/mcp/tools/get-project-metadata.ts
@@ -10,7 +10,7 @@ export function registerGetProjectMetadataTool(
     'get_project_metadata',
     {
       description:
-        'Returns the the metadata of this Next.js project, including project path, dev server URL, etc.',
+        'Returns the metadata of this Next.js project, including project path, dev server URL, etc.',
       inputSchema: {},
     },
     async (_request) => {


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- Related issues linked using `fixes #number` — N/A, trivial typo fix
- Tests added — N/A, comment/string-only change
- Errors have a helpful link attached — N/A

## What?

Fixed a double word typo ('the the' → 'the') in the MCP `get_project_metadata` tool description string.

## Why?

The repeated word is a minor documentation quality issue in a user-facing tool description.

## How?

Removed the duplicate 'the' in the description string literal.