### PR TITLE
codemod: write pnpm overrides to pnpm-workspace.yaml on pnpm v11+

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/README.md
@@ -1,0 +1,40 @@
+Verifies that on pnpm v11+, `@types/react` / `@types/react-dom` overrides are
+written to `pnpm-workspace.yaml#overrides` (merged into existing keys) rather
+than `package.json#pnpm.overrides`. pnpm v11 silently ignores
+`pnpm.overrides` in `package.json` — see
+https://github.com/pnpm/pnpm/issues/11536 and https://pnpm.io/settings.
+
+Run this fixture with pnpm v11+ on PATH.
+
+```diff
+diff --git a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/package.json b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/package.json
+index 5ec4c37f0b..131f5b9f4a 100644
+--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/package.json
++++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/package.json
+@@ -4,8 +4,8 @@
+     "dev": "next dev"
+   },
+   "dependencies": {
+-    "next": "14.3.0-canary.44",
+-    "react": "18.2.0",
+-    "react-dom": "18.2.0",
+-    "@types/react": "^18.2.0",
+-    "@types/react-dom": "^18.2.0"
++    "next": "15.0.4-canary.43",
++    "react": "19.0.0",
++    "react-dom": "19.0.0",
++    "@types/react": "19.0.0",
++    "@types/react-dom": "19.0.0"
+   }
+ }
+diff --git a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/pnpm-workspace.yaml b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/pnpm-workspace.yaml
+index ...
+--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/pnpm-workspace.yaml
++++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/pnpm-workspace.yaml
+@@ -1,2 +1,5 @@
+ allowBuilds:
+   sharp: false
++overrides:
++  '@types/react': 19.0.0
++  '@types/react-dom': 19.0.0
+```

--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pnpm-v11-overrides",
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "14.3.0-canary.44",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/pnpm-workspace.yaml
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-overrides/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: false

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -12,6 +12,7 @@ import path from 'path'
 import pc from 'picocolors'
 import {
   getPkgManager,
+  getPnpmMajorVersion,
   addPackageDependency,
   runInstallation,
 } from '../lib/handle-package'
@@ -359,7 +360,7 @@ export async function runUpgrade(
     overrides['@types/react-dom'] = versionMapping['@types/react-dom'].version
   }
 
-  writeOverridesField(appPackageJson, packageManager, overrides)
+  writeOverridesField(appPackageJson, packageManager, overrides, cwd)
 
   for (const [packageName, { version, required }] of Object.entries(
     versionMapping
@@ -644,7 +645,8 @@ async function suggestReactTypesCodemods(): Promise<boolean> {
 function writeOverridesField(
   packageJson: any,
   packageManager: PackageManager,
-  overrides: Record<string, string>
+  overrides: Record<string, string>,
+  cwd: string
 ) {
   const entries = Object.entries(overrides)
   // Avoids writing an empty overrides field into package.json
@@ -661,6 +663,17 @@ function writeOverridesField(
       packageJson.overrides[key] = value
     }
   } else if (packageManager === 'pnpm') {
+    // pnpm v11 silently ignores `pnpm.overrides` in package.json. The
+    // canonical location moved to `pnpm-workspace.yaml#overrides`.
+    // See https://pnpm.io/settings and https://github.com/pnpm/pnpm/issues/11536.
+    // When the version cannot be detected, assume the current (v11+) layout
+    // since that's the surface where silently-dropped overrides hurt most.
+    const pnpmMajorVersion = getPnpmMajorVersion()
+    if (pnpmMajorVersion === null || pnpmMajorVersion >= 11) {
+      writePnpmWorkspaceOverrides(cwd, overrides)
+      return
+    }
+
     // pnpm supports pnpm.overrides and pnpm.resolutions
     if (packageJson.resolutions) {
       for (const [key, value] of entries) {
@@ -701,6 +714,36 @@ function writeOverridesField(
       }
     }
   }
+}
+
+function writePnpmWorkspaceOverrides(
+  cwd: string,
+  overrides: Record<string, string>
+) {
+  // Deferred require so `js-yaml` is only loaded when we hit the pnpm v11+
+  // branch (i.e. not for npm/yarn/bun/pnpm-v10 upgrades). The package is CJS,
+  // so a sync `require()` keeps this function synchronous.
+  const yaml = require('js-yaml') as typeof import('js-yaml')
+
+  const filePath = path.join(cwd, 'pnpm-workspace.yaml')
+
+  let doc: Record<string, any> = {}
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, 'utf8')
+    const parsed = yaml.load(existing)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      doc = parsed as Record<string, any>
+    }
+  }
+
+  if (!doc.overrides || typeof doc.overrides !== 'object') {
+    doc.overrides = {}
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    doc.overrides[key] = value
+  }
+
+  fs.writeFileSync(filePath, yaml.dump(doc))
 }
 
 function warnDependenciesOutOfRange(

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -1,8 +1,56 @@
 import findUp from 'find-up'
 import execa from 'execa'
+import { execSync } from 'node:child_process'
 import { basename } from 'node:path'
 
 export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
+
+/**
+ * Get the full version string for the given package manager.
+ *
+ * First tries to parse from `npm_config_user_agent` (e.g., "pnpm/9.13.2 npm/? ..."),
+ * then falls back to spawning `<packageManager> --version`.
+ *
+ * Returns null if unable to determine the version.
+ *
+ * Mirrors `packages/create-next-app/helpers/get-pkg-manager.ts`.
+ */
+export function getPackageManagerVersion(
+  packageManager: PackageManager
+): string | null {
+  const userAgent = process.env.npm_config_user_agent || ''
+  const userAgentMatch = userAgent.match(
+    new RegExp(`${packageManager}/([\\d.]+[\\w.-]*)`)
+  )
+  if (userAgentMatch) {
+    return userAgentMatch[1]
+  }
+
+  try {
+    const version = execSync(`${packageManager} --version`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim()
+    if (/^\d+\.\d+\.\d+/.test(version)) {
+      return version
+    }
+  } catch {
+    // package manager not available or failed to run
+  }
+
+  return null
+}
+
+/**
+ * Get the major version of pnpm being used.
+ * Returns null if unable to determine the version.
+ */
+export function getPnpmMajorVersion(): number | null {
+  const version = getPackageManagerVersion('pnpm')
+  if (!version) return null
+  const major = parseInt(version.split('.')[0], 10)
+  return Number.isNaN(major) ? null : major
+}
 
 export function getPkgManager(baseDir: string): PackageManager {
   try {

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -14,6 +14,7 @@
     "find-up": "4.1.0",
     "globby": "11.0.1",
     "is-git-clean": "1.1.0",
+    "js-yaml": "4.1.0",
     "jscodeshift": "17.0.0",
     "picocolors": "1.0.0",
     "prompts": "2.4.2",
@@ -37,6 +38,7 @@
   "bin": "./bin/next-codemod.js",
   "devDependencies": {
     "@types/find-up": "4.0.0",
+    "@types/js-yaml": "4.0.9",
     "@types/jscodeshift": "0.11.0",
     "@types/prompts": "2.4.2",
     "@types/semver": "7.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,7 +323,7 @@ importers:
         version: 5.2.1(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.31.0
-        version: 2.31.0(eslint@9.37.0(jiti@2.6.1))
+        version: 2.31.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jest:
         specifier: 27.6.3
         version: 27.6.3(eslint@9.37.0(jiti@2.6.1))(jest@29.7.0(@types/node@20.17.6(patch_hash=9c31d25336aea4076b3cb942c35e59fd160c540947f01ea455a060367153f9fd))(babel-plugin-macros@3.1.0))(typescript@6.0.2)
@@ -1790,6 +1790,9 @@ importers:
       is-git-clean:
         specifier: 1.1.0
         version: 1.1.0
+      js-yaml:
+        specifier: 4.1.0
+        version: 4.1.0
       jscodeshift:
         specifier: 17.0.0
         version: 17.0.0(@babel/preset-env@7.26.9(@babel/core@7.26.10))
@@ -1809,6 +1812,9 @@ importers:
       '@types/find-up':
         specifier: 4.0.0
         version: 4.0.0
+      '@types/js-yaml':
+        specifier: 4.0.9
+        version: 4.0.9
       '@types/jscodeshift':
         specifier: 0.11.0
         version: 0.11.0
@@ -6470,6 +6476,9 @@ packages:
 
   '@types/jest@29.5.5':
     resolution: {integrity: sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/jscodeshift@0.11.0':
     resolution: {integrity: sha512-OcJgr5GznWCEx2Oeg4eMUZYwssTHFj/tU8grrNCKdFQtAEAa0ezDiPHbCdSkyWrRSurXrYbNbHdhxbbB76pXNg==}
@@ -23476,6 +23485,8 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.5.0
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/jscodeshift@0.11.0':
     dependencies:
       ast-types: 0.14.2
@@ -25897,7 +25908,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.2
@@ -27429,10 +27440,11 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -27473,7 +27485,7 @@ snapshots:
       - typescript
     optional: true
 
-  eslint-plugin-import@2.31.0(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -27484,7 +27496,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -27495,6 +27507,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Why

pnpm v11 silently stopped reading `pnpm.overrides` (and `pnpm.patchedDependencies`) from `package.json`. The canonical location moved to `pnpm-workspace.yaml#overrides`. There is no deprecation warning — see [pnpm/pnpm#11536](https://github.com/pnpm/pnpm/issues/11536) and [pnpm settings docs](https://pnpm.io/settings).

`next-codemod upgrade` uses overrides to pin `@types/react` / `@types/react-dom` during React major upgrades. On pnpm v11 those pins were a no-op.

## What

- Detect pnpm major version via `npm_config_user_agent` (with a `pnpm --version` fallback), mirroring the helper in `create-next-app`.
- On pnpm v11+ (or when the version cannot be determined), `writeOverridesField` routes through a new `writePnpmWorkspaceOverrides` helper that reads/merges/writes `pnpm-workspace.yaml#overrides`. Existing keys in the file are preserved.
- pnpm v10 and below keep writing `package.json#pnpm.overrides`.
- `js-yaml` is `require()`d lazily inside the v11+ branch, so non-pnpm and pre-v11 upgrades don't load it.
- Monorepo behavior is unchanged (still writes relative to `cwd`); pnpm overrides have always been workspace-root-only, so this matches the prior shortcoming rather than introducing a new one.

## Test plan

- [x] `pnpm --filter=@next/codemod build` passes.
- [ ] Manual: `pnpm test:upgrade-fixture pnpm-v11-overrides` with pnpm v11 on PATH — expect overrides merged into the existing `pnpm-workspace.yaml` (see fixture README for the expected diff).
- [ ] Existing fixtures continue to pass on pnpm v10.

<!-- NEXT_JS_LLM_PR -->