### PR TITLE
fix: correct 'to to' double word in pages-api template

### DIFF
--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -57,7 +57,7 @@ export async function handler(
   let srcPage = 'VAR_DEFINITION_PAGE'
 
   // turbopack doesn't normalize `/index` in the page name
-  // so we need to to process dynamic routes properly
+  // so we need to process dynamic routes properly
   // TODO: fix turbopack providing differing value from webpack
   if (process.env.TURBOPACK) {
     srcPage = srcPage.replace(/\/index$/, '') || '/'


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- Related issues linked using `fixes #number` — N/A, trivial typo fix
- Tests added — N/A, comment/string-only change
- Errors have a helpful link attached — N/A

## What?

Fixed a double word typo ('to to' → 'to') in the `pages-api` build template comment.

## Why?

The repeated word is a minor documentation quality issue.

## How?

Removed the duplicate 'to' in the comment string.

<!-- NEXT_JS_LLM_PR -->