### PR TITLE
Persist `'use cache: private'` entries in dev

### DIFF
--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -382,11 +382,15 @@ export interface PrivateUseCacheStore extends CommonUseCacheStore {
   readonly headers: ReadonlyHeaders
   readonly cookies: ReadonlyRequestCookies
 
-  /**
-   * Private caches don't currently need to track read root params for the cache
-   * key because they're not persisted anywhere.
-   */
   readonly rootParams: Params
+
+  /**
+   * DEV-only: Tracks which root param names were read during this cache
+   * invocation. In development, private caches are persisted (keyed by the
+   * request's cookies and headers), so reads of different root param values
+   * must produce different entries.
+   */
+  readonly readRootParamNames: Set<string> | undefined
 }
 
 export type UseCacheStore = PublicUseCacheStore | PrivateUseCacheStore

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -166,7 +166,12 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
     case 'private-cache': {
       // NOTE: In shell prerenders, we delay caches that used root params
       // in use-cache-wrapper, during the final prerender, so we don't
-      // need to do anything here
+      // need to do anything here.
+      // In dev, private caches are persisted and keyed by root params (like
+      // public caches), so we track which ones were read.
+      if (workUnitStore.readRootParamNames) {
+        workUnitStore.readRootParamNames.add(paramName)
+      }
       break
     }
     case 'prerender-runtime': {

--- a/packages/next/src/server/use-cache/handlers.ts
+++ b/packages/next/src/server/use-cache/handlers.ts
@@ -10,6 +10,7 @@ const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
 const handlersSymbol = Symbol.for('@next/cache-handlers')
 const handlersMapSymbol = Symbol.for('@next/cache-handlers-map')
 const handlersSetSymbol = Symbol.for('@next/cache-handlers-set')
+const privateHandlerSymbol = Symbol.for('@next/cache-handlers-private')
 
 /**
  * The reference to the cache handlers. We store the cache handlers on the
@@ -23,6 +24,8 @@ const reference: typeof globalThis & {
   }
   [handlersMapSymbol]?: Map<string, CacheHandler>
   [handlersSetSymbol]?: Set<CacheHandler>
+  // DEV-only
+  [privateHandlerSymbol]?: CacheHandler
 } = globalThis
 
 /**
@@ -76,6 +79,18 @@ export function initializeCacheHandlers(cacheMaxMemorySize: number): boolean {
   // Create a set of the cache handlers.
   reference[handlersSetSymbol] = new Set(reference[handlersMapSymbol].values())
 
+  // In development, private caches are persisted in a dedicated built-in
+  // in-memory handler so that warm reloads are fast. This must always be the
+  // built-in handler, never the user-configured `default` alias (which could be
+  // a remote or otherwise persistent handler), because private cache entries
+  // can hold data specific to the incoming request (for example, derived from
+  // its cookies or headers). It is gated on the dev server so production never
+  // persists private caches.
+  if (process.env.__NEXT_DEV_SERVER) {
+    reference[privateHandlerSymbol] =
+      createDefaultCacheHandler(cacheMaxMemorySize)
+  }
+
   return true
 }
 
@@ -92,6 +107,21 @@ export function getCacheHandler(kind: string): CacheHandler | undefined {
   }
 
   return reference[handlersMapSymbol].get(kind)
+}
+
+/**
+ * Get the dedicated in-memory cache handler that persists private caches in
+ * development. Returns `undefined` outside the dev server, where private caches
+ * must not be persisted. This is intentionally not part of the kind-keyed
+ * handlers map so that it can never be replaced by a user-configured handler.
+ */
+export function getPrivateCacheHandler(): CacheHandler | undefined {
+  // This should never be called before initializeCacheHandlers.
+  if (!reference[handlersMapSymbol]) {
+    throw new Error('Cache handlers not initialized')
+  }
+
+  return reference[privateHandlerSymbol]
 }
 
 /**

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -360,13 +360,18 @@ const COOKIES_EXCLUDED_FROM_PRIVATE_CACHE_KEY = new Set<string>([
 // spurious misses (a browser reload adds `cache-control`/`pragma` that an
 // initial navigation doesn't, and `accept`/`sec-fetch-*` differ between an HTML
 // navigation and an RSC or prefetch request for the same page), or are
-// connection- and proxy-level rather than application data. Header names are
-// lowercased by `HeadersAdapter`, so every entry here is lowercase.
+// connection- and proxy-level rather than application data. The `cookie` header
+// is excluded because cookies are keyed separately below (via the dedicated
+// cookie path, which applies `COOKIES_EXCLUDED_FROM_PRIVATE_CACHE_KEY`);
+// including the raw header would duplicate them and reintroduce the cookies
+// that path excludes. Header names are lowercased by `HeadersAdapter`, so every
+// entry here is lowercase.
 const HEADERS_EXCLUDED_FROM_PRIVATE_CACHE_KEY = new Set<string>([
   'accept',
   'accept-encoding',
   'cache-control',
   'connection',
+  'cookie',
   'if-match',
   'if-modified-since',
   'if-none-match',

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -65,7 +65,13 @@ import stringHash from 'next/dist/compiled/string-hash'
 import { DYNAMIC_EXPIRE, RUNTIME_PREFETCH_DYNAMIC_STALE } from './constants'
 import { NEXT_CACHE_ROOT_PARAM_TAG_ID } from '../../lib/constants'
 import type { CacheHandler } from '../lib/cache-handlers/types'
-import { getCacheHandler } from './handlers'
+import { getCacheHandler, getPrivateCacheHandler } from './handlers'
+import {
+  NEXT_HMR_REFRESH_HASH_COOKIE,
+  NEXT_INSTANT_TEST_COOKIE,
+} from '../../client/components/app-router-headers'
+import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
+import type { ReadonlyHeaders } from '../web/spec-extension/adapters/headers'
 import {
   NestedDynamicUseCacheError,
   UseCacheDeadlockError,
@@ -339,6 +345,84 @@ function computeRootParamsCacheKeySuffix(
   )
 }
 
+// Next-internal cookies that must not vary the private cache key, since they're
+// not part of the application's own cookie state. The instant-navigation cookie
+// toggles while a navigation lock is held, so including it would force spurious
+// misses. The HMR refresh hash is already part of the cache key (see
+// `cacheKeyParts`), so including its cookie too would just be redundant.
+const COOKIES_EXCLUDED_FROM_PRIVATE_CACHE_KEY = new Set<string>([
+  NEXT_HMR_REFRESH_HASH_COOKIE,
+  NEXT_INSTANT_TEST_COOKIE,
+])
+
+// Request and transport headers that must not vary the private cache key. They
+// either differ between otherwise-equivalent requests, which would cause
+// spurious misses (a browser reload adds `cache-control`/`pragma` that an
+// initial navigation doesn't, and `accept`/`sec-fetch-*` differ between an HTML
+// navigation and an RSC or prefetch request for the same page), or are
+// connection- and proxy-level rather than application data. Header names are
+// lowercased by `HeadersAdapter`, so every entry here is lowercase.
+const HEADERS_EXCLUDED_FROM_PRIVATE_CACHE_KEY = new Set<string>([
+  'accept',
+  'accept-encoding',
+  'cache-control',
+  'connection',
+  'if-match',
+  'if-modified-since',
+  'if-none-match',
+  'if-range',
+  'if-unmodified-since',
+  'keep-alive',
+  'pragma',
+  'priority',
+  'purpose',
+  'range',
+  'sec-fetch-dest',
+  'sec-fetch-mode',
+  'sec-fetch-site',
+  'sec-fetch-user',
+  'sec-purpose',
+  'te',
+  'upgrade',
+  'upgrade-insecure-requests',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-port',
+  'x-forwarded-proto',
+])
+
+// TODO: This varies the dev private cache key by the request's cookies and
+// headers (minus the transport and content-negotiation headers excluded above).
+// It's a heuristic: it still over-keys (a cache that reads only one cookie or
+// header varies by all of them) and the header denylist is necessarily
+// incomplete. Follow up by tracking which cookies and headers a cache function
+// actually reads (the same mechanism root params use via `readRootParamNames`)
+// and keying by only those. Note that Next-internal flight headers such as
+// `rsc` and `next-router-state-tree` are already stripped upstream in
+// `getHeaders`, so they never appear here.
+function computePrivateCacheKeyRequestSuffix(
+  cookies: ReadonlyRequestCookies,
+  headers: ReadonlyHeaders
+): string {
+  const relevantCookies = cookies
+    .getAll()
+    .filter(
+      (cookie) => !COOKIES_EXCLUDED_FROM_PRIVATE_CACHE_KEY.has(cookie.name)
+    )
+    .map((cookie): [string, string] => [cookie.name, cookie.value])
+    .sort(([nameA], [nameB]) => (nameA < nameB ? -1 : nameA > nameB ? 1 : 0))
+
+  const relevantHeaders = [...headers.entries()]
+    .filter(([name]) => !HEADERS_EXCLUDED_FROM_PRIVATE_CACHE_KEY.has(name))
+    .sort(([nameA], [nameB]) => (nameA < nameB ? -1 : nameA > nameB ? 1 : 0))
+
+  if (relevantCookies.length === 0 && relevantHeaders.length === 0) {
+    return ''
+  }
+
+  return JSON.stringify({ cookies: relevantCookies, headers: relevantHeaders })
+}
+
 function saveToResumeDataCache(
   resumeDataCache: ResumeDataCache | null,
   serializedCacheKey: string,
@@ -413,11 +497,15 @@ function saveToCacheHandler(
   cacheHandler: CacheHandler,
   workStore: WorkStore,
   id: string,
-  serializedCacheKey: string,
+  cacheHandlerKeyBase: string,
   savedCacheResult: Promise<CollectedCacheResult>,
   rootParams: Params | undefined
-): void {
-  const pendingCoarseEntry = savedCacheResult.then((collectedResult) => {
+): Promise<CollectedCacheResult> {
+  // Write the entry to the cache handler. With root params, this is a redirect
+  // entry at the coarse key plus the actual entry at the specific key;
+  // otherwise just the entry at the coarse key. Both set calls are fired
+  // together and awaited in parallel.
+  const combinedSetPromise = savedCacheResult.then(async (collectedResult) => {
     const { entry: fullEntry, readRootParamNames } = collectedResult
 
     // Use the combined set (union of all historically observed reads) for both
@@ -432,27 +520,26 @@ function saveToCacheHandler(
       ? addKnownRootParamNames(id, readRootParamNames)
       : knownRootParamsByFunctionId.get(id)
 
+    const setPromises: Promise<void>[] = []
+    let coarseEntry: CacheEntry = fullEntry
+
     if (rootParamNames && rootParamNames.size > 0 && rootParams) {
       const specificKey =
-        serializedCacheKey +
+        cacheHandlerKeyBase +
         computeRootParamsCacheKeySuffix(rootParams, rootParamNames)
 
-      const specificSetPromise = cacheHandler.set(
-        specificKey,
-        Promise.resolve(fullEntry)
+      setPromises.push(
+        cacheHandler.set(specificKey, Promise.resolve(fullEntry))
       )
-      workStore.pendingRevalidateWrites ??= []
-      workStore.pendingRevalidateWrites.push(specificSetPromise)
 
-      // Return a redirect entry for the coarse key. On a cold server (empty
-      // knownRootParamsByFunctionId), this entry's tags tell us which root
-      // params to include in the specific key for the follow-up lookup.
-
+      // The coarse key gets a redirect entry instead. On a cold server (empty
+      // knownRootParamsByFunctionId), its tags tell a reader which root params
+      // to include in the specific-key lookup.
       const rootParamTags = [...rootParamNames].map(
         (paramName) => NEXT_CACHE_ROOT_PARAM_TAG_ID + paramName
       )
 
-      return {
+      coarseEntry = {
         value: new ReadableStream({
           start(controller) {
             // Single byte so the entry has non-zero size in LRU caches.
@@ -468,12 +555,26 @@ function saveToCacheHandler(
       } satisfies CacheEntry
     }
 
-    return fullEntry
+    setPromises.push(
+      cacheHandler.set(cacheHandlerKeyBase, Promise.resolve(coarseEntry))
+    )
+
+    await Promise.all(setPromises)
   })
 
-  const promise = cacheHandler.set(serializedCacheKey, pendingCoarseEntry)
   workStore.pendingRevalidateWrites ??= []
-  workStore.pendingRevalidateWrites.push(promise)
+  workStore.pendingRevalidateWrites.push(combinedSetPromise)
+
+  // A cross-request joiner reads its recomputed specific key only after it has
+  // awaited this entry's metadata, so gate the metadata on the writes landing:
+  // that guarantees the entry is present when the joiner re-reads. A failed
+  // write shouldn't reject the metadata (the joiner just misses and
+  // regenerates), so settle either way; a collection failure still propagates
+  // through `savedCacheResult`.
+  return combinedSetPromise.then(
+    () => savedCacheResult,
+    () => savedCacheResult
+  )
 }
 
 function generateCacheEntry(
@@ -559,6 +660,7 @@ function createUseCacheStore(
         outerWorkUnitStore
       ),
       rootParams: outerWorkUnitStore.rootParams,
+      readRootParamNames: process.env.__NEXT_DEV_SERVER ? new Set() : undefined,
       headers: outerWorkUnitStore.headers,
       cookies: outerWorkUnitStore.cookies,
       outerOwnerStack: cacheContext.outerOwnerStack,
@@ -968,15 +1070,28 @@ async function collectResult(
   })
 
   const collectedTags = innerCacheStore.tags
-  // If cacheLife() was used to set an explicit revalidate time we use that.
-  // Otherwise, we use the lowest of all inner fetch()/unstable_cache() or nested "use cache".
-  // If they're lower than our default.
-  const collectedRevalidate =
-    innerCacheStore.explicitRevalidate !== undefined
+
+  // In development, private caches are forced to `revalidate: 0` and an
+  // `expire` of `DYNAMIC_EXPIRE` (5 minutes), the shortest expire not treated
+  // as dynamically shortened. The zero revalidate makes every read serve
+  // stale-while-revalidate (re-warming a fresh entry in the background) so warm
+  // reloads stay fast. The expire bounds how long an entry lingers in the dev
+  // in-memory cache.
+  const isPrivateCacheInDev = Boolean(
+    process.env.__NEXT_DEV_SERVER && cacheContext.kind === 'private'
+  )
+
+  // If cacheLife() was used to set an explicit revalidate/expire/stale time we
+  // use that. Otherwise, we use the lowest of all inner fetch(),
+  // unstable_cache() or nested "use cache", if they're lower than our default.
+  const collectedRevalidate = isPrivateCacheInDev
+    ? 0
+    : innerCacheStore.explicitRevalidate !== undefined
       ? innerCacheStore.explicitRevalidate
       : innerCacheStore.revalidate
-  const collectedExpire =
-    innerCacheStore.explicitExpire !== undefined
+  const collectedExpire = isPrivateCacheInDev
+    ? DYNAMIC_EXPIRE
+    : innerCacheStore.explicitExpire !== undefined
       ? innerCacheStore.explicitExpire
       : innerCacheStore.expire
   const collectedStale =
@@ -998,7 +1113,7 @@ async function collectResult(
     hasExplicitRevalidate: innerCacheStore.explicitRevalidate !== undefined,
     hasExplicitExpire: innerCacheStore.explicitExpire !== undefined,
     readRootParamNames:
-      innerCacheStore.type === 'cache'
+      innerCacheStore.type === 'cache' || isPrivateCacheInDev
         ? innerCacheStore.readRootParamNames
         : undefined,
     // The store accumulates this from nested public caches that propagated a
@@ -1512,16 +1627,23 @@ export async function cache(
     )
   }
 
-  // Two cases skip the cache handler lookup:
-  //   - Private caches go to the Resume Data Cache (RDC), not cache handlers.
-  //   - Probe re-executions short-circuit further down before any handler is
-  //     consulted, so the dev-server's hang-detection worker can boot without
-  //     registering handlers at all.
+  // Probe re-executions (the dev-server's hang-detection worker) short-circuit
+  // further down before any handler is consulted, so we skip handler selection
+  // entirely and the worker can boot without registering handlers at all.
   let cacheHandler: CacheHandler | undefined
-  if (!isPrivate && workStore.useCacheProbeMode === undefined) {
-    cacheHandler = getCacheHandler(kind)
-    if (!cacheHandler) {
-      throw new Error('Unknown cache handler: ' + kind)
+  if (workStore.useCacheProbeMode === undefined) {
+    if (isPrivate) {
+      // Private caches normally go to the Resume Data Cache (RDC), not a cache
+      // handler. In development we additionally persist them in a dedicated
+      // built-in in-memory handler so that warm reloads are fast.
+      if (process.env.__NEXT_DEV_SERVER) {
+        cacheHandler = getPrivateCacheHandler()
+      }
+    } else {
+      cacheHandler = getCacheHandler(kind)
+      if (!cacheHandler) {
+        throw new Error('Unknown cache handler: ' + kind)
+      }
     }
   }
 
@@ -1868,14 +1990,15 @@ export async function cache(
 
   const temporaryReferences = createClientTemporaryReferenceSet()
 
-  // For private caches, which are allowed to read cookies, we still don't
-  // need to include the cookies in the cache key. This is because we don't
-  // store the cache entries in a cache handler, but only in the Resume Data
-  // Cache (RDC). Private caches are only used during dynamic requests and
-  // runtime prefetches. For dynamic requests, the RDC is immutable, so it
-  // does not include any private caches. For runtime prefetches, the RDC is
-  // mutable, but only lives as long as the request, so the key does not
-  // need to include cookies.
+  // The base serialized cache key doesn't include the cookies or headers that
+  // private caches are allowed to read. In production this is because private
+  // cache entries aren't stored in a cache handler, only in the Resume Data
+  // Cache (RDC): private caches are only used during dynamic requests and
+  // runtime prefetches; for dynamic requests the RDC is immutable and excludes
+  // private caches, and for runtime prefetches it's mutable but lives only as
+  // long as the request. In development private caches are persisted across
+  // requests, so `cacheHandlerKeyBase` (below) additionally scopes the handler
+  // key by the request's cookies and headers.
   const cacheKeyParts: CacheKeyParts = hmrRefreshHash
     ? [buildId, id, args, hmrRefreshHash]
     : [buildId, id, args]
@@ -2010,16 +2133,32 @@ export async function cache(
         encodedCacheKeyParts
       : await encodeFormData(encodedCacheKeyParts)
 
+  const rootParams = workUnitStore.rootParams
+  const knownRootParamNames = knownRootParamsByFunctionId.get(id)
+
+  // The coarse cache-handler key. With no root params read, it locates the
+  // entry directly; otherwise it locates a redirect entry from which the
+  // specific key (this key + root params, computed below) is derived. For
+  // private caches in development (persisted in the built-in in-memory handler)
+  // it's additionally scoped by the request's cookies and headers, so entries
+  // for requests with different request data don't collide; keys derived from
+  // it inherit that scoping.
+  const cacheHandlerKeyBase =
+    process.env.__NEXT_DEV_SERVER && cacheContext.kind === 'private'
+      ? serializedCacheKey +
+        computePrivateCacheKeyRequestSuffix(
+          cacheContext.outerWorkUnitStore.cookies,
+          cacheContext.outerWorkUnitStore.headers
+        )
+      : serializedCacheKey
   // If we already know which root params this function reads, include them in
   // the cache handler key for a direct hit (skipping the redirect entry).
   // rootParams is undefined when nested inside unstable_cache.
-  const rootParams = workUnitStore.rootParams
-  const knownRootParamNames = knownRootParamsByFunctionId.get(id)
   let cacheHandlerKey =
     knownRootParamNames && rootParams
-      ? serializedCacheKey +
+      ? cacheHandlerKeyBase +
         computeRootParamsCacheKeySuffix(rootParams, knownRootParamNames)
-      : serializedCacheKey
+      : cacheHandlerKeyBase
 
   let stream: undefined | ReadableStream = undefined
 
@@ -2151,7 +2290,15 @@ export async function cache(
             }
             case 'request': {
               if (process.env.NODE_ENV === 'development') {
+                // These throws force the user to make an explicit cache life
+                // decision on an outer cache that an inner cache would
+                // otherwise silently shorten. A dev private cache's
+                // `revalidate` is forced to 0 by us (not by a nested cache), so
+                // it's excluded from the first throw to avoid a false positive.
+                // Its forced `expire` is exactly DYNAMIC_EXPIRE, so it never
+                // trips the second throw and needs no exclusion there.
                 if (
+                  cacheContext.kind !== 'private' &&
                   rdcResult.entry.revalidate === 0 &&
                   rdcResult.hasExplicitRevalidate === false
                 ) {
@@ -2495,6 +2642,15 @@ export async function cache(
       serializedCacheKey
     )
 
+    // Cross-request deduplication lets concurrent requests for the same key
+    // share a single fill. Private caches are skipped in production, where they
+    // hold request-specific data that must not be shared across requests. In
+    // development they're persisted and keyed by the request's cookies and
+    // headers, so concurrent requests with identical request data should share
+    // a fill too; that request-scoped `cacheHandlerKey` keeps requests with
+    // different cookies or headers in separate entries.
+    const skipCrossRequestDedupe = isPrivate && !process.env.__NEXT_DEV_SERVER
+
     try {
       // The loop handles cross-request root param mismatches: when a
       // cross-request joiner discovers that the leader's root params differ
@@ -2502,9 +2658,7 @@ export async function cache(
       // exits when stream is assigned (cross-request joiner match or leader
       // path) or via early return (prerender-dynamic).
       while (stream === undefined) {
-        // Cross-request deduplication. Private caches are skipped because they
-        // contain per-request data that must not be shared across requests.
-        const crossRequestPendingCacheInvocation = isPrivate
+        const crossRequestPendingCacheInvocation = skipCrossRequestDedupe
           ? undefined
           : crossRequestPendingCacheInvocations.get(cacheHandlerKey)
 
@@ -2531,7 +2685,7 @@ export async function cache(
             const updatedRootParamNames = knownRootParamsByFunctionId.get(id)
             if (updatedRootParamNames && rootParams) {
               const newCacheHandlerKey =
-                serializedCacheKey +
+                cacheHandlerKeyBase +
                 computeRootParamsCacheKeySuffix(
                   rootParams,
                   updatedRootParamNames
@@ -2577,7 +2731,7 @@ export async function cache(
             const updatedRootParamNames = knownRootParamsByFunctionId.get(id)
             if (updatedRootParamNames && rootParams) {
               const newCacheHandlerKey =
-                serializedCacheKey +
+                cacheHandlerKeyBase +
                 computeRootParamsCacheKeySuffix(
                   rootParams,
                   updatedRootParamNames
@@ -2610,7 +2764,7 @@ export async function cache(
         }
 
         // No pending cross-request invocation — become the leader.
-        if (!isPrivate) {
+        if (!skipCrossRequestDedupe) {
           debug?.(
             'registering as cross-request invocation leader',
             cacheHandlerKey
@@ -2653,7 +2807,7 @@ export async function cache(
             if (paramNames.size > 0) {
               addKnownRootParamNames(id, paramNames)
               cacheHandlerKey =
-                serializedCacheKey +
+                cacheHandlerKeyBase +
                 computeRootParamsCacheKeySuffix(rootParams, paramNames)
               entry = await cacheHandler.get(cacheHandlerKey, implicitTags)
             }
@@ -2896,6 +3050,13 @@ export async function cache(
 
           const { stream: newStream, pendingCacheResult } = result
 
+          // Cross-request joiners derive their metadata from this promise. By
+          // default it's the collected result, but when we write to a cache
+          // handler we swap in a promise that resolves only after the write has
+          // landed, so a joiner that re-reads its recomputed key finds the
+          // entry.
+          let metadataSource: Promise<CollectedCacheResult> = pendingCacheResult
+
           // When draft mode is enabled, we must not save the cache entry.
           if (!workStore.isDraftMode) {
             const savedCacheResult = saveToResumeDataCache(
@@ -2905,11 +3066,11 @@ export async function cache(
             )
 
             if (cacheHandler) {
-              saveToCacheHandler(
+              metadataSource = saveToCacheHandler(
                 cacheHandler,
                 workStore,
                 id,
-                serializedCacheKey,
+                cacheHandlerKeyBase,
                 savedCacheResult,
                 rootParams
               )
@@ -2919,7 +3080,7 @@ export async function cache(
           debug?.('leader resolved with generated entry', cacheHandlerKey)
 
           const pendingMetadata: Promise<CacheResultMetadata> =
-            pendingCacheResult.then((collected) => ({
+            metadataSource.then((collected) => ({
               tags: collected.entry.tags,
               revalidate: collected.entry.revalidate,
               expire: collected.entry.expire,
@@ -2941,14 +3102,6 @@ export async function cache(
             entry: sharedCacheEntry,
           })
         } else {
-          // If we have an entry at this point, this can't be a private cache
-          // entry.
-          if (cacheContext.kind === 'private') {
-            throw new InvariantError(
-              `A private cache entry must not be retrieved from the cache handler.`
-            )
-          }
-
           const entryMetadata: CacheResultMetadata = {
             tags: entry.tags,
             revalidate: entry.revalidate,
@@ -3052,7 +3205,7 @@ export async function cache(
                       cacheHandler,
                       workStore,
                       id,
-                      serializedCacheKey,
+                      cacheHandlerKeyBase,
                       savedCacheResult,
                       rootParams
                     )

--- a/test/development/app-dir/cache-components-dev-streaming/app/page.tsx
+++ b/test/development/app-dir/cache-components-dev-streaming/app/page.tsx
@@ -9,6 +9,11 @@ export default function Page() {
       <li>
         <Link href="/runtime-prefetch">/runtime-prefetch</Link>
       </li>
+      <li>
+        <Link href="/use-cache-private-runtime-prefetch">
+          /use-cache-private-runtime-prefetch
+        </Link>
+      </li>
     </ul>
   )
 }

--- a/test/development/app-dir/cache-components-dev-streaming/app/use-cache-private-runtime-prefetch/page.tsx
+++ b/test/development/app-dir/cache-components-dev-streaming/app/use-cache-private-runtime-prefetch/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { setTimeout } from 'timers/promises'
+
+export const prefetch = 'allow-runtime'
+
+async function PrivateCached() {
+  'use cache: private'
+  await setTimeout(1500)
+  return <p id="private">{new Date().toISOString()}</p>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="private-fallback">Loading...</p>}>
+      <PrivateCached />
+    </Suspense>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-streaming/app/use-cache-private/page.tsx
+++ b/test/development/app-dir/cache-components-dev-streaming/app/use-cache-private/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { setTimeout } from 'timers/promises'
+
+async function PrivateCached() {
+  'use cache: private'
+  await setTimeout(1500)
+  return <p id="private">{new Date().toISOString()}</p>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="private-fallback">Loading...</p>}>
+      <PrivateCached />
+    </Suspense>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-streaming/cache-components-dev-streaming.test.ts
+++ b/test/development/app-dir/cache-components-dev-streaming/cache-components-dev-streaming.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { retry, waitFor } from 'next-test-utils'
 
 describe('cache-components-dev-streaming', () => {
   const { next } = nextTestSetup({
@@ -26,6 +26,27 @@ describe('cache-components-dev-streaming', () => {
     // page load.
     await browser.refresh()
     expect(await browser.elementByCss('p').text()).toBeDateString()
+  })
+
+  it('streams a Suspense fallback above a private cache while filling it in the background', async () => {
+    const browser = await next.browser('/use-cache-private', {
+      waitHydration: false,
+      // do not wait for "load", we want to inspect the page as it streams in
+      waitUntil: 'commit',
+    })
+
+    // The loading boundary should be streamed immediately, without waiting for
+    // the private cache to be filled.
+    expect(await browser.elementByCss('#private-fallback').text()).toBe(
+      'Loading...'
+    )
+
+    // Eventually, the private cache content should be streamed in.
+    await retry(async () => {
+      expect(
+        await browser.elementByCssInstant('#private').text()
+      ).toBeDateString()
+    })
   })
 
   it('streams dynamic content immediately while a sibling cache is still filling', async () => {
@@ -112,6 +133,64 @@ describe('cache-components-dev-streaming', () => {
       runtime: false,
       dynamic: true,
     })
+  })
+
+  it('shows the private-cache fallback on a cold client navigation but not on a warm one', async () => {
+    // Uses a runtime-prefetch route, whose stream is held back until after the
+    // runtime stage, so a warm navigation reliably delivers the content with
+    // the shell and omits the fallback.
+    const browser = await next.browser('/')
+
+    // Cold navigation: the cache misses and fills in the background, so the
+    // fallback is shown until the content streams in.
+    await browser
+      .elementByCss('a[href="/use-cache-private-runtime-prefetch"]')
+      .click()
+    expect(await browser.elementByCss('#private-fallback').text()).toBe(
+      'Loading...'
+    )
+    await retry(async () => {
+      expect(
+        await browser.elementByCssInstant('#private').text()
+      ).toBeDateString()
+    })
+
+    // Wait for the background write to settle so the next navigation hits the
+    // warm entry instead of racing a pending write.
+    await waitFor(2000)
+
+    // Warm navigation: record whether the fallback ever enters the DOM during
+    // the navigation, even briefly. It shouldn't, since the warm content is
+    // delivered with the shell.
+    await browser.loadPage(new URL('/', next.url).href)
+    await browser.eval(() => {
+      ;(window as any).__privateFallbackSeen = false
+      new MutationObserver((records) => {
+        records.forEach((record) =>
+          record.addedNodes.forEach((node) => {
+            if (
+              node instanceof Element &&
+              (node.id === 'private-fallback' ||
+                node.querySelector('#private-fallback'))
+            ) {
+              ;(window as any).__privateFallbackSeen = true
+            }
+          })
+        )
+      }).observe(document.body, { childList: true, subtree: true })
+    })
+
+    await browser
+      .elementByCss('a[href="/use-cache-private-runtime-prefetch"]')
+      .click()
+    await retry(async () => {
+      expect(
+        await browser.elementByCssInstant('#private').text()
+      ).toBeDateString()
+    })
+    expect(
+      await browser.eval(() => (window as any).__privateFallbackSeen)
+    ).toBe(false)
   })
 
   // The following are smoke tests that Cache Components validation still

--- a/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
@@ -242,12 +242,7 @@ describe.each([
           }
         })
 
-        // TODO: Skipped until private caches are persisted in dev. They aren't
-        // persisted yet, so a warm reload re-runs them as a cache miss that
-        // resolves in the dynamic stage rather than the runtime stage.
-        // Re-enable once private caches are persisted, after which a warm
-        // reload is a hit that resolves in the runtime stage.
-        it.skip('cached data + private cache', async () => {
+        it('cached data + private cache', async () => {
           const path = '/private-cache'
 
           const assertLogs = async (browser: Playwright) => {

--- a/test/development/app-dir/cache-indicator/cache-indicator.test.ts
+++ b/test/development/app-dir/cache-indicator/cache-indicator.test.ts
@@ -271,26 +271,28 @@ describe('cache-indicator', () => {
       )
     })
 
-    // TODO: private `'use cache'` entries aren't persisted in dev yet, so they
-    // re-fill on every load and register as a cache miss each time. Until
-    // that's fixed, the Cold cache badge shows on every load. After this is
-    // fixed, flip the warm-reload assertion below to expect no badge.
-    it('shows the Cold cache badge on every load for a private cache (current limitation)', async () => {
+    it('shows the Cold cache badge on an initial cold load and not on a warm reload for a private cache', async () => {
       const browser = await next.browser('/private')
 
-      await retry(async () => {
-        expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
-          true
-        )
-      })
-
-      await browser.refresh()
+      // Cold load: the private cache misses and fills while streaming, so the
+      // cold verdict is replayed after load.
       await browser.elementById('private')
       await retry(async () => {
         expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
           true
         )
       })
+
+      // Warm reload: the private entry is now persisted in dev and served as a
+      // stale-while-revalidate hit, so it does not register as a cache miss and
+      // no badge appears. An absence can't be retried on, so wait out the
+      // replay-on-connect window and then assert it never showed.
+      await browser.refresh()
+      await browser.elementById('private')
+      await waitFor(500)
+      expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
+        false
+      )
     })
 
     it('shows cache-bypassing badge when cache is disabled', async () => {

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-dedup/app/[countryCode]/[lang]/use-cache-private/page.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-dedup/app/[countryCode]/[lang]/use-cache-private/page.tsx
@@ -1,0 +1,30 @@
+import { countryCode, lang } from 'next/root-params'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+async function getCachedData() {
+  'use cache: private'
+
+  // Simulate I/O latency so concurrent requests overlap.
+  await setTimeout(1000)
+
+  return {
+    countryCode: await countryCode(),
+    lang: await lang(),
+    random: Math.random(),
+  }
+}
+
+export default async function Page() {
+  await connection()
+
+  const result = await getCachedData()
+
+  return (
+    <p>
+      <span id="country">{result.countryCode}</span>{' '}
+      <span id="lang">{result.lang}</span>{' '}
+      <span id="random">{result.random}</span>
+    </p>
+  )
+}

--- a/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
@@ -258,6 +258,13 @@ describe('app-root-param-getters - private cache', () => {
 
       await waitForNoRedbox(browser)
       expect(await browser.elementById('param').text()).toBe('en us')
+
+      // A different set of root params must produce a separate entry. Since
+      // private caches are persisted in dev, this confirms the entry is keyed
+      // by root params and isn't reused for a different `[lang]/[locale]`.
+      await browser.loadPage(next.url + '/es/es/use-cache-private')
+      await waitForNoRedbox(browser)
+      expect(await browser.elementById('param').text()).toBe('es es')
     })
   } else {
     it('should allow using root params within a "use cache: private" - start', async () => {
@@ -287,7 +294,7 @@ describe('app-root-param-getters - cache - at build', () => {
 })
 
 describe('app-root-param-getters - cache dedup with root params', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, skipped, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'use-cache-dedup'),
     // In deploy mode, concurrent requests could hit different lambdas.
     skipDeployment: true,
@@ -315,5 +322,35 @@ describe('app-root-param-getters - cache dedup with root params', () => {
 
     // Both ca/fr requests should have the same result (deduped).
     expect(randomFr1).toBe(randomFr2)
+  })
+
+  it('should dedupe same root params and isolate different root params for private caches', async () => {
+    // Three concurrent requests: ca/en, ca/fr, ca/fr.
+    const [$en, $fr1, $fr2] = await Promise.all([
+      next.render$('/ca/en/use-cache-private'),
+      next.render$('/ca/fr/use-cache-private'),
+      next.render$('/ca/fr/use-cache-private'),
+    ])
+
+    const randomEn = $en('#random').text()
+    const randomFr1 = $fr1('#random').text()
+    const randomFr2 = $fr2('#random').text()
+
+    expect(randomEn).toBeTruthy()
+    expect(randomFr1).toBeTruthy()
+
+    // Different root params produce different entries, in dev and production.
+    expect(randomEn).not.toBe(randomFr1)
+
+    if (isNextDev) {
+      // In dev, private caches are persisted and participate in cross-request
+      // deduplication keyed by root params, so the two ca/fr requests join one
+      // in-flight invocation and share a single fill.
+      expect(randomFr1).toBe(randomFr2)
+    } else {
+      // In production, private caches are not persisted and are never deduped
+      // across requests, so each ca/fr request generates its own value.
+      expect(randomFr1).not.toBe(randomFr2)
+    }
   })
 })

--- a/test/e2e/app-dir/use-cache-private/app/stale-while-revalidate/page.tsx
+++ b/test/e2e/app-dir/use-cache-private/app/stale-while-revalidate/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+
+async function getPrivateValue() {
+  'use cache: private'
+  return new Date().toISOString()
+}
+
+async function PrivateValue() {
+  return <p id="value">{await getPrivateValue()}</p>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <PrivateValue />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/use-cache-private/app/update-tag/page.tsx
+++ b/test/e2e/app-dir/use-cache-private/app/update-tag/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react'
+import { cacheTag, updateTag } from 'next/cache'
+import { UpdateButton } from './update-button'
+
+const TAG = 'use-cache-private-update-tag'
+
+// Mutable state, co-located with the cached function and the server action so
+// they share the same module instance (and thus the same value) on the server.
+let current = 'initial'
+
+async function getPrivateValue() {
+  'use cache: private'
+  cacheTag(TAG)
+  return current
+}
+
+async function updateValue() {
+  'use server'
+  current = 'updated'
+  updateTag(TAG)
+}
+
+async function PrivateValue() {
+  return <p id="value">{await getPrivateValue()}</p>
+}
+
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<p>Loading...</p>}>
+        <PrivateValue />
+      </Suspense>
+      <UpdateButton action={updateValue} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache-private/app/update-tag/update-button.tsx
+++ b/test/e2e/app-dir/use-cache-private/app/update-tag/update-button.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export function UpdateButton({ action }: { action: () => Promise<void> }) {
+  return (
+    <button id="update" onClick={() => action()}>
+      Update
+    </button>
+  )
+}

--- a/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+++ b/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 const pprEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
@@ -36,5 +37,109 @@ describe('use-cache-private', () => {
     await browser.loadPage(new URL('/search-params?q=bar', next.url).href)
 
     expect(await browser.elementById('search-param').text()).toBe('bar')
+  })
+
+  it('serves a stale entry on reload in dev and warms a fresh one in the background', async () => {
+    const browser = await next.browser('/stale-while-revalidate')
+    const initialValue = await browser.waitForElementByCss('#value').text()
+
+    await browser.refresh()
+    const reloadedValue = await browser.waitForElementByCss('#value').text()
+
+    if (isNextDev) {
+      // In dev the private entry is persisted and forced to `revalidate: 0`, so
+      // it is always stale and served immediately on reload while a fresh entry
+      // warms in the background.
+      expect(reloadedValue).toBe(initialValue)
+
+      // A subsequent reload reflects the freshly warmed value.
+      await retry(async () => {
+        await browser.refresh()
+        const warmedValue = await browser.waitForElementByCss('#value').text()
+        expect(warmedValue).not.toBe(initialValue)
+      })
+    } else {
+      // In production private entries are not persisted, so every load re-runs
+      // the cache and shows a fresh value.
+      expect(reloadedValue).not.toBe(initialValue)
+    }
+  })
+
+  it('keys persisted entries by cookies in dev', async () => {
+    const browser = await next.browser('/stale-while-revalidate')
+
+    await browser.addCookie({ name: 'use-cache-private-test', value: 'a' })
+    await browser.refresh()
+    const valueA = await browser.waitForElementByCss('#value').text()
+
+    await browser.addCookie({ name: 'use-cache-private-test', value: 'b' })
+    await browser.refresh()
+    const valueB = await browser.waitForElementByCss('#value').text()
+
+    // A different cookie produces a different private entry.
+    expect(valueB).not.toBe(valueA)
+
+    await browser.addCookie({ name: 'use-cache-private-test', value: 'a' })
+    await browser.refresh()
+    const valueA2 = await browser.waitForElementByCss('#value').text()
+
+    if (isNextDev) {
+      // Switching back to the original cookie hits its own persisted entry,
+      // which proves the entry is keyed by the cookie (and not shared with the
+      // other cookie's entry).
+      expect(valueA2).toBe(valueA)
+    } else {
+      // Private entries are not persisted in production.
+      expect(valueA2).not.toBe(valueA)
+    }
+  })
+
+  it('keys persisted entries by headers in dev', async () => {
+    const renderValue = async (headerValue: string) => {
+      const $ = await next.render$('/stale-while-revalidate', undefined, {
+        headers: { 'x-use-cache-private-test': headerValue },
+      })
+      return $('#value').text()
+    }
+
+    const valueA = await renderValue('a')
+    const valueB = await renderValue('b')
+
+    // A different header value produces a different private entry.
+    expect(valueB).not.toBe(valueA)
+
+    const valueA2 = await renderValue('a')
+
+    if (isNextDev) {
+      // Re-sending the original header value hits its own persisted entry, which
+      // proves the entry is keyed by request headers (and not shared with the
+      // other header value's entry).
+      expect(valueA2).toBe(valueA)
+    } else {
+      // Private entries are not persisted in production.
+      expect(valueA2).not.toBe(valueA)
+    }
+  })
+
+  it('revalidates a persisted entry by tag in dev', async () => {
+    if (!isNextDev) {
+      // Private caches are only persisted in development, so tag revalidation
+      // of a persisted private entry is a dev-only concern.
+      return
+    }
+
+    const browser = await next.browser('/update-tag')
+    expect(await browser.waitForElementByCss('#value').text()).toBe('initial')
+
+    // The server action sets the value to 'updated' and revalidates the tag,
+    // then triggers a refresh. That refresh's private read must already reflect
+    // the new value: `updateTag` invalidated the persisted entry, so it is
+    // regenerated rather than served stale (which would still show 'initial' on
+    // this first read, only converging on a later one).
+    await browser.elementById('update').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#value').text()).toBe('updated')
+    })
   })
 })

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/private-dedup-cross-request/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/private-dedup-cross-request/page.tsx
@@ -1,0 +1,14 @@
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+async function PrivateCached() {
+  'use cache: private'
+  await setTimeout(1000)
+  return <p className="rand">{Math.random()}</p>
+}
+
+export default async function Page() {
+  await connection()
+
+  return <PrivateCached />
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1615,17 +1615,28 @@ describe('use-cache', () => {
     expect(first).toBe(second)
   })
 
-  it('should not dedupe private caches across concurrent requests', async () => {
+  it('dedupes private caches across concurrent requests in dev but not in production', async () => {
     const [first$, second$] = await Promise.all([
-      next.render$('/private-dedup'),
-      next.render$('/private-dedup'),
+      next.render$('/private-dedup-cross-request'),
+      next.render$('/private-dedup-cross-request'),
     ])
 
-    const firstValue = first$('.rand').first().text()
-    const secondValue = second$('.rand').first().text()
+    const firstValue = first$('.rand').text()
+    const secondValue = second$('.rand').text()
 
-    // Across requests, private caches must NOT be deduped.
-    expect(firstValue).not.toBe(secondValue)
+    if (isNextDev) {
+      // In dev, private caches are persisted and keyed by the request's cookies
+      // and headers, so two concurrent requests with identical request data
+      // join one in-flight invocation and share a single fill. Different
+      // cookies or headers yield different entries; that's covered by 'keys
+      // persisted entries by cookies in dev' and 'keys persisted entries by
+      // headers in dev' in the use-cache-private suite.
+      expect(firstValue).toBe(secondValue)
+    } else {
+      // In production, private caches are not persisted, so each request
+      // generates its own entry; across requests they are never deduped.
+      expect(firstValue).not.toBe(secondValue)
+    }
   })
 
   it('should stream the result of a deduped invocation', async () => {


### PR DESCRIPTION
Private caches were never stored in a cache handler, so every reload in `next dev` re-ran them from scratch and they registered as a cache miss on each load. This change persists `'use cache: private'` entries in development in a dedicated built-in in-memory handler so that warm reloads are fast. The handler is gated on `process.env.__NEXT_DEV_SERVER` and is kept out of the kind-keyed handlers map so it can never be replaced by a user-configured `default` handler: private cache entries can hold data specific to the incoming request (for example, derived from its cookies or headers) and must never reach a remote or otherwise persistent handler. Production keeps private caches non-persisted as before.

The coarse cache-handler key for a dev private cache is scoped by the request's cookies and headers so entries for requests with different request data don't collide. It excludes Next-internal cookies that aren't application data (the HMR refresh hash, already part of the cache key, and the instant-navigation cookie, which toggles while a navigation lock is held) and the transport and content-negotiation headers that vary between otherwise-equivalent requests (a browser reload adds `cache-control`, and `accept` and `sec-fetch-*` differ between an HTML navigation and an RSC request). Keying by only the cookies and headers a cache actually reads is left as a follow-up; read root params are already tracked that way, the same as for public caches. The cache life is forced to `revalidate: 0` with a 5-minute `expire`, so each read serves the stale entry immediately and warms a fresh one in the background through the existing stale-while-revalidate path.

Cross-request deduplication now applies to private caches in development too, so concurrent requests with identical request data share a single fill; it remains skipped in production where request-specific data must not be shared across requests. To make this deterministic, `saveToCacheHandler` resolves the metadata a cross-request joiner awaits only after the entry has been written to the handler, so the joiner finds it when re-reading its recomputed key. This closes a pre-existing race in that path, present for public caches too but never surfaced by their cross-request test, where the joiner's metadata could resolve before the handler write had landed.

The defensive invariant that rejected reading a private entry from a handler is removed: it only existed to narrow `cacheContext.kind` for a code path that no longer needs it, and dev now legitimately reads persisted private entries while production never registers a private handler to read from.