### PR TITLE
docs: Route Handlers to be supported later on

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -312,6 +312,8 @@ If the parameter does not exist in the current route's root layout (see [Multipl
 
 ## Restrictions
 
+Most of these are permanent constraints of how root parameters work. The exception is [Route Handlers](/docs/app/api-reference/file-conventions/route), which are not supported yet but are planned for a future release.
+
 ### Server Components only
 
 Root parameter getters can only be used in Server Components:


### PR DESCRIPTION
I noticed the Restrictions section doesn't explicitly mention Route Handlers. It is only mentioned in a good to know. However, this is a temporary restriction. 