### PR TITLE
[turbopack] Use `final_read_hint` in top level turbo tasks

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2487,16 +2487,6 @@ async fn get_all_compilation_issues_inner_operation(
     Ok(Vc::cell(()))
 }
 
-#[turbo_tasks::function(operation, root)]
-async fn get_all_compilation_issues_operation(
-    container: ResolvedVc<ProjectContainer>,
-) -> Result<Vc<OperationResult>> {
-    let inner_op = get_all_compilation_issues_inner_operation(container);
-    let filter = container.project().issue_filter().await?;
-    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &filter).await?;
-    Ok(OperationResult { issues, effects }.cell())
-}
-
 /// Returns the build-feature-usage telemetry summary for this project — the set of
 /// `(featureName, invocationCount)` pairs reported to the Next.js telemetry service.
 ///
@@ -2538,6 +2528,16 @@ pub async fn project_feature_usage(
 pub async fn project_get_all_compilation_issues(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
 ) -> napi::Result<TurbopackResult<()>> {
+    #[turbo_tasks::function(operation, root)]
+    async fn get_all_compilation_issues_operation(
+        container: ResolvedVc<ProjectContainer>,
+    ) -> Result<Vc<OperationResult>> {
+        let inner_op = get_all_compilation_issues_inner_operation(container);
+        let filter = container.project().issue_filter().await?;
+        let (_, issues, effects) =
+            strongly_consistent_catch_collectables(inner_op, &filter).await?;
+        Ok(OperationResult { issues, effects }.cell())
+    }
     let container = project.container;
     let issues = project
         .turbopack_ctx

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1362,6 +1362,7 @@ pub async fn project_write_all_entrypoints_to_disk(
                 let DeferredEntrypointInfo(entrypoints, deferred_entries) =
                     &*deferred_entrypoint_info_operation(container)
                         .read_strongly_consistent()
+                        .final_read_hint()
                         .await?;
 
                 Ok(compute_deferred_phase_build_paths(
@@ -1707,6 +1708,7 @@ pub async fn project_entrypoints(
                 effects: _,
             } = &*entrypoints_with_issues_op
                 .read_strongly_consistent()
+                .final_read_hint()
                 .await?;
 
             Ok((entrypoints.clone(), issues.clone()))
@@ -1813,7 +1815,10 @@ async fn hmr_update_with_issues_operation(
     // consumers in `hot-reloader-turbopack.ts` (`subscribeToServerHmr` and
     // `subscribeToClientHmrEvents`) rely on this read *throwing* on build-graph
     // failures to trigger their recovery paths
-    let update = update_op.read_strongly_consistent().await?;
+    let update = update_op
+        .read_strongly_consistent()
+        .final_read_hint()
+        .await?;
     let filter = project.issue_filter().await?;
     let issues = get_issues(update_op, &filter).await?;
     let effects = Arc::new(take_effects(update_op).await?);
@@ -2539,7 +2544,8 @@ pub async fn project_get_all_compilation_issues(
         .turbo_tasks()
         .run_once(async move {
             let op = get_all_compilation_issues_operation(container);
-            let OperationResult { issues, effects: _ } = &*op.read_strongly_consistent().await?;
+            let OperationResult { issues, effects: _ } =
+                &*op.read_strongly_consistent().final_read_hint().await?;
             Ok(issues.clone())
         })
         .await

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -453,7 +453,7 @@ pub async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
     Arc<Vec<ReadRef<PlainIssue>>>,
     Arc<Effects>,
 )> {
-    let result = source_op.read_strongly_consistent().await;
+    let result = source_op.read_strongly_consistent().final_read_hint().await;
     let issues = get_issues(source_op, filter).await?;
     let effects = Arc::new(take_effects(source_op).await?);
 

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -566,6 +566,12 @@ where
 {
     let mut attempts = 0usize;
     loop {
+        // final_read_hint because
+        // 1. in the retry case we have just invalidated the operation so we need to recompute
+        //    anyway (not wasteful)
+        // 2. the callers are in top level tasks and the value type inside T is holding a
+        //    non-serializable effects value.  This strongly implies the rest of the data is
+        //    ephemeral often just readrefs on other cells.  So we don't need to keep it.
         let value = op.read_strongly_consistent().final_read_hint().await?;
         // Deref the `ReadRef<T>` to the read target (`T` for non-transparent types).
         let effects = get_effects(&*value);

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -566,7 +566,7 @@ where
 {
     let mut attempts = 0usize;
     loop {
-        let value = op.read_strongly_consistent().await?;
+        let value = op.read_strongly_consistent().final_read_hint().await?;
         // Deref the `ReadRef<T>` to the read target (`T` for non-transparent types).
         let effects = get_effects(&*value);
         match effects.apply().await {


### PR DESCRIPTION
Use `final_read_hint` on top level turbo tasks

For many top level tasks where we are returning data there is no need for turbo-tasks to hold on to it afterwars, but these are typically also _transient_ and thus un-evictable.  So use the `final_read_hint` to allow turbo tasks to drop the cell after reading it.

The biggest impact here is HmrUpdateWithIssues that holds a potentially large hmr instruction.

From a simple benchmark loading 50 routes on a large site this drops the post eviction heap from 4.3G->2.5G

