### PR TITLE
[turbopack] Optimize cell_dependency representation

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -70,8 +70,8 @@ use crate::{
     },
     backing_storage::{SnapshotItem, SnapshotMeta, compute_task_type_hash},
     data::{
-        ActivenessState, CellDependency, CellRef, CollectibleRef, CollectiblesRef, Dirtyness,
-        InProgressCellState, InProgressState, InProgressStateInner, OutputValue, TransientTask,
+        ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
+        InProgressState, InProgressStateInner, OutputValue, TransientTask,
     },
     error::TaskError,
     kv_backing_storage::TurboBackingStorage,
@@ -793,8 +793,12 @@ impl TurboTasksBackend {
                 && (!task.immutable() || cfg!(feature = "verify_immutable"))
             {
                 let reader = reader.unwrap();
-                let _ = task
-                    .add_cell_dependents(CellDependency::new(CellRef { task: reader, cell }, key));
+                let reverse = CellRef { task: reader, cell };
+                if let Some(k) = key {
+                    let _ = task.add_cell_dependents_hashed((reverse, k));
+                } else {
+                    let _ = task.add_cell_dependents(reverse);
+                }
                 drop(task);
 
                 // Note: We use `task_pair` earlier to lock the task and its reader at the same
@@ -806,9 +810,12 @@ impl TurboTasksBackend {
                     task: task_id,
                     cell,
                 };
-                let dep = CellDependency::new(target, key);
-                if !reader_task.remove_outdated_cell_dependencies(&dep) {
-                    let _ = reader_task.add_cell_dependencies(dep);
+                if let Some(k) = key {
+                    if !reader_task.remove_outdated_cell_dependencies_hashed(&(target, k)) {
+                        let _ = reader_task.add_cell_dependencies_hashed((target, k));
+                    }
+                } else if !reader_task.remove_outdated_cell_dependencies(&target) {
+                    let _ = reader_task.add_cell_dependencies(target);
                 }
                 drop(reader_task);
             }
@@ -1924,8 +1931,8 @@ impl TurboTasksBackend {
                 // We copy to outdated which allows us to detect when we drop a dependency, but we
                 // keep existing dependencies in place to avoid redoing the
                 // dependency registration work if we re-read them
-                let cell_dependencies_all = task.iter_cell_dependencies_all().collect();
-                task.set_outdated_cell_dependencies_all(cell_dependencies_all);
+                let cell_dependencies = task.iter_cell_dependencies().collect();
+                task.set_outdated_cell_dependencies(cell_dependencies);
                 let cell_dependencies_hashed = task.iter_cell_dependencies_hashed().collect();
                 task.set_outdated_cell_dependencies_hashed(cell_dependencies_hashed);
 
@@ -2263,9 +2270,10 @@ impl TurboTasksBackend {
             && task.is_collectibles_dependencies_empty()
         {
             Some(
-                // Collect all dependencies on tasks to check if all dependencies are immutable
+                // Collect all dependencies on tasks to check if all dependencies are immutable.
                 task.iter_output_dependencies()
-                    .chain(task.iter_cell_dependencies().map(|dep| dep.cell_ref().task))
+                    .chain(task.iter_cell_dependencies().map(|r| r.task))
+                    .chain(task.iter_cell_dependencies_hashed().map(|(r, _)| r.task))
                     .collect::<FxHashSet<_>>(),
             )
         } else {
@@ -2305,6 +2313,10 @@ impl TurboTasksBackend {
             old_edges.extend(
                 task.iter_outdated_cell_dependencies()
                     .map(OutdatedEdge::CellDependency),
+            );
+            old_edges.extend(
+                task.iter_outdated_cell_dependencies_hashed()
+                    .map(|(r, k)| OutdatedEdge::HashedCellDependency(r, k)),
             );
             old_edges.extend(
                 task.iter_outdated_output_dependencies()

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -827,7 +827,7 @@ impl TurboTasksBackend {
         } = options;
 
         let mut ctx = self.execute_context(turbo_tasks);
-        let (track_dependencies, mut task, reader_task) = if self.should_track_dependencies()
+        let (mut task, reader_task) = if self.should_track_dependencies()
             && !matches!(tracking, ReadCellTracking::Untracked)
             && let Some(reader_id) = reader
             && reader_id != task_id
@@ -836,9 +836,9 @@ impl TurboTasksBackend {
             // condition. See below.
             // TODO(sokra): solve that in a more performant way.
             let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
-            (true, task, Some(reader))
+            (task, Some(reader))
         } else {
-            (false, ctx.task(task_id, TaskDataCategory::All), None)
+            (ctx.task(task_id, TaskDataCategory::All), None)
         };
 
         let content = if final_read_hint {
@@ -871,7 +871,7 @@ impl TurboTasksBackend {
         let max_id = task.get_cell_type_max_index(&cell.type_id).copied();
         let Some(max_id) = max_id else {
             let task_desc = task.get_task_description();
-            if track_dependencies && tracking.should_track(true) {
+            if tracking.should_track(true) {
                 add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             bail!(
@@ -880,7 +880,7 @@ impl TurboTasksBackend {
         };
         if cell.index >= max_id {
             let task_desc = task.get_task_description();
-            if track_dependencies && tracking.should_track(true) {
+            if tracking.should_track(true) {
                 add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             bail!("Cell {cell:?} no longer exists in task {task_desc} (index out of bounds)");

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -453,7 +453,6 @@ impl TurboTasksBackend {
         let mut ctx = self.execute_context(turbo_tasks);
         let need_reader_task = if self.should_track_dependencies()
             && !matches!(options.tracking, ReadTracking::Untracked)
-            && reader.is_some_and(|reader_id| reader_id != task_id)
             && let Some(reader_id) = reader
             && reader_id != task_id
         {
@@ -821,7 +820,7 @@ impl TurboTasksBackend {
         } = options;
 
         let mut ctx = self.execute_context(turbo_tasks);
-        let (mut task, reader_task) = if self.should_track_dependencies()
+        let (track_dependencies, mut task, reader_task) = if self.should_track_dependencies()
             && !matches!(tracking, ReadCellTracking::Untracked)
             && let Some(reader_id) = reader
             && reader_id != task_id
@@ -830,9 +829,9 @@ impl TurboTasksBackend {
             // condition. See below.
             // TODO(sokra): solve that in a more performant way.
             let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
-            (task, Some(reader))
+            (true, task, Some(reader))
         } else {
-            (ctx.task(task_id, TaskDataCategory::All), None)
+            (false, ctx.task(task_id, TaskDataCategory::All), None)
         };
 
         let content = if final_read_hint {
@@ -865,7 +864,7 @@ impl TurboTasksBackend {
         let max_id = task.get_cell_type_max_index(&cell.type_id).copied();
         let Some(max_id) = max_id else {
             let task_desc = task.get_task_description();
-            if tracking.should_track(true) {
+            if track_dependencies && tracking.should_track(true) {
                 add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             bail!(
@@ -874,7 +873,7 @@ impl TurboTasksBackend {
         };
         if cell.index >= max_id {
             let task_desc = task.get_task_description();
-            if tracking.should_track(true) {
+            if track_dependencies && tracking.should_track(true) {
                 add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             bail!("Cell {cell:?} no longer exists in task {task_desc} (index out of bounds)");
@@ -1922,8 +1921,13 @@ impl TurboTasksBackend {
 
             if self.should_track_dependencies() {
                 // Make all dependencies outdated
-                let cell_dependencies = task.iter_cell_dependencies().collect();
-                task.set_outdated_cell_dependencies(cell_dependencies);
+                // We copy to outdated which allows us to detect when we drop a dependency, but we
+                // keep existing dependencies in place to avoid redoing the
+                // dependency registration work if we re-read them
+                let cell_dependencies_all = task.iter_cell_dependencies_all().collect();
+                task.set_outdated_cell_dependencies_all(cell_dependencies_all);
+                let cell_dependencies_hashed = task.iter_cell_dependencies_hashed().collect();
+                task.set_outdated_cell_dependencies_hashed(cell_dependencies_hashed);
 
                 let outdated_output_dependencies = task.iter_output_dependencies().collect();
                 task.set_outdated_output_dependencies(outdated_output_dependencies);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -9,7 +9,7 @@ use crate::{
     backend::{
         TaskDataCategory,
         operation::{
-            AggregatedDataUpdate, ExecuteContext, Operation, TaskGuard,
+            AggregatedDataUpdate, ExecuteContext, Operation,
             aggregation_update::{
                 AggregationUpdateJob, AggregationUpdateQueue, InnerOfUppersLostFollowersJob,
                 get_aggregation_number, get_uppers, is_aggregating_node,
@@ -17,7 +17,7 @@ use crate::{
         },
         storage_schema::TaskStorageAccessors,
     },
-    data::{CellDependency, CellRef, CollectibleRef, CollectiblesRef},
+    data::{CellRef, CollectibleRef, CollectiblesRef},
 };
 
 #[derive(Encode, Decode, Clone)]
@@ -48,7 +48,8 @@ impl Default for CleanupOldEdgesOperation {
 pub enum OutdatedEdge {
     Child(TaskId),
     Collectible(CollectibleRef, i32),
-    CellDependency(CellDependency),
+    CellDependency(CellRef),
+    HashedCellDependency(CellRef, u64),
     OutputDependency(TaskId),
     CollectiblesDependency(CollectiblesRef),
 }
@@ -166,17 +167,32 @@ impl CleanupOldEdgesOperation {
                                     AggregatedDataUpdate::new().collectibles_update(collectibles),
                                 ));
                             }
-                            OutdatedEdge::CellDependency(dep) => {
-                                let (
-                                    CellRef {
-                                        task: cell_task_id,
-                                        cell,
-                                    },
-                                    key,
-                                ) = dep.into_parts();
+                            OutdatedEdge::CellDependency(forward) => {
+                                let CellRef {
+                                    task: cell_task_id,
+                                    cell,
+                                } = forward;
                                 {
                                     let mut task = ctx.task(cell_task_id, TaskDataCategory::Data);
-                                    task.remove_cell_dependents(&CellDependency::new(
+                                    task.remove_cell_dependents(&CellRef {
+                                        task: task_id,
+                                        cell,
+                                    });
+                                }
+                                {
+                                    let mut task = ctx.task(task_id, TaskDataCategory::Data);
+                                    task.remove_cell_dependencies(&forward);
+                                }
+                            }
+                            OutdatedEdge::HashedCellDependency(forward, key) => {
+                                // ame as above but in the `_hashed` sets.
+                                let CellRef {
+                                    task: cell_task_id,
+                                    cell,
+                                } = forward;
+                                {
+                                    let mut task = ctx.task(cell_task_id, TaskDataCategory::Data);
+                                    task.remove_cell_dependents_hashed(&(
                                         CellRef {
                                             task: task_id,
                                             cell,
@@ -186,7 +202,7 @@ impl CleanupOldEdgesOperation {
                                 }
                                 {
                                     let mut task = ctx.task(task_id, TaskDataCategory::Data);
-                                    task.remove_cell_dependencies(&dep);
+                                    task.remove_cell_dependencies_hashed(&(forward, key));
                                 }
                             }
                             OutdatedEdge::OutputDependency(output_task_id) => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -9,7 +9,7 @@ use crate::{
     backend::{
         TaskDataCategory,
         operation::{
-            AggregatedDataUpdate, ExecuteContext, Operation,
+            AggregatedDataUpdate, ExecuteContext, Operation, TaskGuard,
             aggregation_update::{
                 AggregationUpdateJob, AggregationUpdateQueue, InnerOfUppersLostFollowersJob,
                 get_aggregation_number, get_uppers, is_aggregating_node,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -31,7 +31,9 @@ use crate::{
         storage::{SpecificTaskDataCategory, StorageWriteGuard},
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    data::{ActivenessState, CollectibleRef, Dirtyness, InProgressState, TransientTask},
+    data::{
+        ActivenessState, CellDependency, CollectibleRef, Dirtyness, InProgressState, TransientTask,
+    },
 };
 
 pub trait Operation: Encode + Decode<()> + Default + TryFrom<AnyOperation, Error = ()> {
@@ -1297,6 +1299,92 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
     fn get_task_name(&self) -> String {
         let task_type = self.get_task_type().to_owned();
         format!("{task_type}")
+    }
+
+    // ============ Cell dependency edges (CellDependency API over split storage) ============
+    //
+    // Cell dependency edges are stored split into a keyless set (`*_all: AutoSet<CellRef>`) and a
+    // keyed set (`*_hashed: AutoSet<(CellRef, u64)>`) so the common keyless edge doesn't pay for
+    // the `CellDependency` enum tag + `u64`. These methods preserve the original
+    // `CellDependency`-based API by dispatching/merging over the two generated accessor sets, so
+    // callers don't need to know about the split.
+
+    fn remove_cell_dependencies(&mut self, dep: &CellDependency) -> bool {
+        match *dep {
+            CellDependency::All(r) => self.remove_cell_dependencies_all(&r),
+            CellDependency::Hash(r, k) => self.remove_cell_dependencies_hashed(&(r, k)),
+        }
+    }
+    fn remove_outdated_cell_dependencies(&mut self, dep: &CellDependency) -> bool {
+        match *dep {
+            CellDependency::All(r) => self.remove_outdated_cell_dependencies_all(&r),
+            CellDependency::Hash(r, k) => self.remove_outdated_cell_dependencies_hashed(&(r, k)),
+        }
+    }
+
+    fn cell_dependencies_contains(&self, dep: &CellDependency) -> bool {
+        match *dep {
+            CellDependency::All(r) => self.cell_dependencies_all_contains(&r),
+            CellDependency::Hash(r, k) => self.cell_dependencies_hashed_contains(&(r, k)),
+        }
+    }
+
+    fn outdated_cell_dependencies_contains(&self, dep: &CellDependency) -> bool {
+        match *dep {
+            CellDependency::All(r) => self.outdated_cell_dependencies_all_contains(&r),
+            CellDependency::Hash(r, k) => self.outdated_cell_dependencies_hashed_contains(&(r, k)),
+        }
+    }
+
+    fn add_cell_dependencies(&mut self, dep: CellDependency) -> bool {
+        match dep {
+            CellDependency::All(r) => self.add_cell_dependencies_all(r),
+            CellDependency::Hash(r, k) => self.add_cell_dependencies_hashed((r, k)),
+        }
+    }
+
+    fn add_cell_dependents(&mut self, dep: CellDependency) -> bool {
+        match dep {
+            CellDependency::All(r) => self.add_cell_dependents_all(r),
+            CellDependency::Hash(r, k) => self.add_cell_dependents_hashed((r, k)),
+        }
+    }
+
+    fn remove_cell_dependents(&mut self, dep: &CellDependency) -> bool {
+        match *dep {
+            CellDependency::All(r) => self.remove_cell_dependents_all(&r),
+            CellDependency::Hash(r, k) => self.remove_cell_dependents_hashed(&(r, k)),
+        }
+    }
+
+    /// Iterate all forward cell dependencies as `CellDependency` (keyless then keyed).
+    fn iter_cell_dependencies(&self) -> impl Iterator<Item = CellDependency> + '_ {
+        self.iter_cell_dependencies_all()
+            .map(CellDependency::All)
+            .chain(
+                self.iter_cell_dependencies_hashed()
+                    .map(|(r, k)| CellDependency::Hash(r, k)),
+            )
+    }
+
+    /// Iterate all outdated forward cell dependencies as `CellDependency`.
+    fn iter_outdated_cell_dependencies(&self) -> impl Iterator<Item = CellDependency> + '_ {
+        self.iter_outdated_cell_dependencies_all()
+            .map(CellDependency::All)
+            .chain(
+                self.iter_outdated_cell_dependencies_hashed()
+                    .map(|(r, k)| CellDependency::Hash(r, k)),
+            )
+    }
+
+    /// Iterate all reverse cell dependents as `CellDependency`.
+    fn iter_cell_dependents(&self) -> impl Iterator<Item = CellDependency> + '_ {
+        self.iter_cell_dependents_all()
+            .map(CellDependency::All)
+            .chain(
+                self.iter_cell_dependents_hashed()
+                    .map(|(r, k)| CellDependency::Hash(r, k)),
+            )
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -31,9 +31,7 @@ use crate::{
         storage::{SpecificTaskDataCategory, StorageWriteGuard},
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    data::{
-        ActivenessState, CellDependency, CollectibleRef, Dirtyness, InProgressState, TransientTask,
-    },
+    data::{ActivenessState, CollectibleRef, Dirtyness, InProgressState, TransientTask},
 };
 
 pub trait Operation: Encode + Decode<()> + Default + TryFrom<AnyOperation, Error = ()> {
@@ -1300,92 +1298,6 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         let task_type = self.get_task_type().to_owned();
         format!("{task_type}")
     }
-
-    // ============ Cell dependency edges (CellDependency API over split storage) ============
-    //
-    // Cell dependency edges are stored split into a keyless set (`*_all: AutoSet<CellRef>`) and a
-    // keyed set (`*_hashed: AutoSet<(CellRef, u64)>`) so the common keyless edge doesn't pay for
-    // the `CellDependency` enum tag + `u64`. These methods preserve the original
-    // `CellDependency`-based API by dispatching/merging over the two generated accessor sets, so
-    // callers don't need to know about the split.
-
-    fn remove_cell_dependencies(&mut self, dep: &CellDependency) -> bool {
-        match *dep {
-            CellDependency::All(r) => self.remove_cell_dependencies_all(&r),
-            CellDependency::Hash(r, k) => self.remove_cell_dependencies_hashed(&(r, k)),
-        }
-    }
-    fn remove_outdated_cell_dependencies(&mut self, dep: &CellDependency) -> bool {
-        match *dep {
-            CellDependency::All(r) => self.remove_outdated_cell_dependencies_all(&r),
-            CellDependency::Hash(r, k) => self.remove_outdated_cell_dependencies_hashed(&(r, k)),
-        }
-    }
-
-    fn cell_dependencies_contains(&self, dep: &CellDependency) -> bool {
-        match *dep {
-            CellDependency::All(r) => self.cell_dependencies_all_contains(&r),
-            CellDependency::Hash(r, k) => self.cell_dependencies_hashed_contains(&(r, k)),
-        }
-    }
-
-    fn outdated_cell_dependencies_contains(&self, dep: &CellDependency) -> bool {
-        match *dep {
-            CellDependency::All(r) => self.outdated_cell_dependencies_all_contains(&r),
-            CellDependency::Hash(r, k) => self.outdated_cell_dependencies_hashed_contains(&(r, k)),
-        }
-    }
-
-    fn add_cell_dependencies(&mut self, dep: CellDependency) -> bool {
-        match dep {
-            CellDependency::All(r) => self.add_cell_dependencies_all(r),
-            CellDependency::Hash(r, k) => self.add_cell_dependencies_hashed((r, k)),
-        }
-    }
-
-    fn add_cell_dependents(&mut self, dep: CellDependency) -> bool {
-        match dep {
-            CellDependency::All(r) => self.add_cell_dependents_all(r),
-            CellDependency::Hash(r, k) => self.add_cell_dependents_hashed((r, k)),
-        }
-    }
-
-    fn remove_cell_dependents(&mut self, dep: &CellDependency) -> bool {
-        match *dep {
-            CellDependency::All(r) => self.remove_cell_dependents_all(&r),
-            CellDependency::Hash(r, k) => self.remove_cell_dependents_hashed(&(r, k)),
-        }
-    }
-
-    /// Iterate all forward cell dependencies as `CellDependency` (keyless then keyed).
-    fn iter_cell_dependencies(&self) -> impl Iterator<Item = CellDependency> + '_ {
-        self.iter_cell_dependencies_all()
-            .map(CellDependency::All)
-            .chain(
-                self.iter_cell_dependencies_hashed()
-                    .map(|(r, k)| CellDependency::Hash(r, k)),
-            )
-    }
-
-    /// Iterate all outdated forward cell dependencies as `CellDependency`.
-    fn iter_outdated_cell_dependencies(&self) -> impl Iterator<Item = CellDependency> + '_ {
-        self.iter_outdated_cell_dependencies_all()
-            .map(CellDependency::All)
-            .chain(
-                self.iter_outdated_cell_dependencies_hashed()
-                    .map(|(r, k)| CellDependency::Hash(r, k)),
-            )
-    }
-
-    /// Iterate all reverse cell dependents as `CellDependency`.
-    fn iter_cell_dependents(&self) -> impl Iterator<Item = CellDependency> + '_ {
-        self.iter_cell_dependents_all()
-            .map(CellDependency::All)
-            .chain(
-                self.iter_cell_dependents_hashed()
-                    .map(|(r, k)| CellDependency::Hash(r, k)),
-            )
-    }
 }
 
 pub struct TaskGuardImpl<'a> {
@@ -1470,7 +1382,11 @@ impl TaskGuard for TaskGuardImpl<'_> {
             .map(|target| (target, TaskDataCategory::Meta))
             .chain(
                 self.iter_cell_dependencies()
-                    .map(|dep| (dep.cell_ref().task, TaskDataCategory::All)),
+                    .map(|r| (r.task, TaskDataCategory::All)),
+            )
+            .chain(
+                self.iter_cell_dependencies_hashed()
+                    .map(|(r, _)| (r.task, TaskDataCategory::All)),
             )
             .chain(
                 self.iter_collectibles_dependencies()

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         storage_schema::TaskStorageAccessors,
     },
-    data::{CellDependency, CellRef},
+    data::CellRef,
 };
 
 #[derive(Encode, Decode, Clone, Default)]
@@ -132,29 +132,43 @@ impl UpdateCellOperation {
             });
 
             // Collect dependent tasks only when not skipping invalidation.
-            // The iterator borrows from `task`, so it must be scoped to drop before
+            // The iterators borrow from `task`, so they must be scoped to drop before
             // we mutably borrow `task` again in the fast path.
             let mut dependent_tasks: FxIndexMap<TaskId, SmallVec<[Option<u64>; 2]>> =
                 FxIndexMap::default();
             if !skip_invalidation {
-                let tasks_with_keys = task.iter_cell_dependents().filter_map(|dep| {
-                    let (
-                        CellRef {
-                            task: dependent_task,
-                            cell: dependent_cell,
-                        },
-                        key,
-                    ) = dep.into_parts();
-                    (dependent_cell == cell
-                        && key.is_none_or(|key_hash| {
-                            updated_key_hashes_set
-                                .as_ref()
-                                .is_none_or(|set| set.contains(&key_hash))
-                        }))
-                    .then_some((dependent_task, key))
-                });
-                for (task, key) in tasks_with_keys {
-                    dependent_tasks.entry(task).or_default().push(key);
+                // Keyless dependents: always invalidate when the cell matches.
+                for CellRef {
+                    task: dependent_task,
+                    cell: dependent_cell,
+                } in task.iter_cell_dependents()
+                {
+                    if dependent_cell == cell {
+                        dependent_tasks
+                            .entry(dependent_task)
+                            .or_default()
+                            .push(None);
+                    }
+                }
+                // Keyed dependents: invalidate only when the changed sub-value (key) matches.
+                for (
+                    CellRef {
+                        task: dependent_task,
+                        cell: dependent_cell,
+                    },
+                    key_hash,
+                ) in task.iter_cell_dependents_hashed()
+                {
+                    if dependent_cell == cell
+                        && updated_key_hashes_set
+                            .as_ref()
+                            .is_none_or(|set| set.contains(&key_hash))
+                    {
+                        dependent_tasks
+                            .entry(dependent_task)
+                            .or_default()
+                            .push(Some(key_hash));
+                    }
                 }
             }
 
@@ -281,15 +295,27 @@ impl Operation for UpdateCellOperation {
                         let mut make_stale = false;
                         let dependent = ctx.task(dependent_task_id, TaskDataCategory::All);
                         for key in keys.iter().copied() {
-                            let dep = CellDependency::new(cell_ref, key);
-                            if dependent.outdated_cell_dependencies_contains(&dep) {
+                            let (in_outdated, in_current) = if let Some(k) = key {
+                                let in_outdated = dependent
+                                    .outdated_cell_dependencies_hashed_contains(&(cell_ref, k));
+                                let in_current = !in_outdated
+                                    && dependent.cell_dependencies_hashed_contains(&(cell_ref, k));
+                                (in_outdated, in_current)
+                            } else {
+                                let in_outdated =
+                                    dependent.outdated_cell_dependencies_contains(&cell_ref);
+                                let in_current =
+                                    !in_outdated && dependent.cell_dependencies_contains(&cell_ref);
+                                (in_outdated, in_current)
+                            };
+                            if in_outdated {
                                 // cell dependency is outdated, so it hasn't read the cell yet
                                 // and doesn't need to be invalidated.
                                 // We do not need to make the task stale in this case.
                                 // But importantly we still need to make the task dirty as it should
                                 // no longer be considered as
                                 // "recomputation".
-                            } else if !dependent.cell_dependencies_contains(&dep) {
+                            } else if !in_current {
                                 // cell dependency has been removed, so the task doesn't depend on
                                 // the cell anymore and doesn't need
                                 // to be invalidated

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -255,7 +255,7 @@ struct TaskStorageSchema {
         shrink_on_completion,
         drop_on_completion_if_immutable
     )]
-    cell_dependencies_all: AutoSet<CellRef, 1>,
+    cell_dependencies_all: AutoSet<CellRef, 2>,
 
     /// Cells this task depends on, narrowed to a hashed sub-value (`CellDependency::Hash`). Rare.
     #[field(
@@ -283,7 +283,7 @@ struct TaskStorageSchema {
 
     /// Outdated keyless cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
-    outdated_cell_dependencies_all: AutoSet<CellRef, 1>,
+    outdated_cell_dependencies_all: AutoSet<CellRef, 2>,
 
     /// Outdated hashed cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
@@ -305,7 +305,7 @@ struct TaskStorageSchema {
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    cell_dependents_all: AutoSet<CellRef, 1>,
+    cell_dependents_all: AutoSet<CellRef, 2>,
 
     /// Tasks that depend on a hashed sub-value of this task's cells. Reverse of
     /// `cell_dependencies_hashed`.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -34,9 +34,9 @@ use turbo_tasks::{
 use crate::{
     backend::{cell_data::CellData, counter_map::CounterMap},
     data::{
-        ActivenessState, AggregationNumber, CellDependency, CollectibleRef, CollectiblesRef,
-        Dirtyness, InProgressCellState, InProgressState, LeafDistance, OutputValue, RootType,
-        TransientTask,
+        ActivenessState, AggregationNumber, CellDependency, CellRef, CollectibleRef,
+        CollectiblesRef, Dirtyness, InProgressCellState, InProgressState, LeafDistance,
+        OutputValue, RootType, TransientTask,
     },
 };
 
@@ -245,7 +245,9 @@ struct TaskStorageSchema {
     )]
     output_dependencies: AutoSet<TaskId, 6>,
 
-    /// Cells this task depends on.
+    /// Cells this task depends on as a whole (keyless `CellDependency::All`). The common case;
+    /// kept separate from `cell_dependencies_hashed` so it stores a bare `CellRef` instead of the
+    /// wider `CellDependency` enum (no tag, no `u64`).
     #[field(
         storage = "auto_set",
         category = "data",
@@ -253,7 +255,17 @@ struct TaskStorageSchema {
         shrink_on_completion,
         drop_on_completion_if_immutable
     )]
-    cell_dependencies: AutoSet<CellDependency, 1>,
+    cell_dependencies_all: AutoSet<CellRef, 1>,
+
+    /// Cells this task depends on, narrowed to a hashed sub-value (`CellDependency::Hash`). Rare.
+    #[field(
+        storage = "auto_set",
+        category = "data",
+        filter_transient,
+        shrink_on_completion,
+        drop_on_completion_if_immutable
+    )]
+    cell_dependencies_hashed: AutoSet<(CellRef, u64), 1>,
 
     /// Collectibles this task depends on.
     #[field(
@@ -269,9 +281,13 @@ struct TaskStorageSchema {
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
     outdated_output_dependencies: AutoSet<TaskId, 6>,
 
-    /// Outdated cell dependencies to be cleaned up (transient).
+    /// Outdated keyless cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
-    outdated_cell_dependencies: AutoSet<CellDependency, 1>,
+    outdated_cell_dependencies_all: AutoSet<CellRef, 1>,
+
+    /// Outdated hashed cell dependencies to be cleaned up (transient).
+    #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
+    outdated_cell_dependencies_hashed: AutoSet<(CellRef, u64), 1>,
 
     /// Outdated collectibles dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
@@ -280,13 +296,26 @@ struct TaskStorageSchema {
     // =========================================================================
     // DEPENDENTS - Tasks that depend on this task's cells
     // =========================================================================
+    /// Tasks that depend on this task's cells as a whole (keyless). Reverse of
+    /// `cell_dependencies_all`. In a `cell_dependents` entry the `CellRef.task` field holds the
+    /// DEPENDENT task's id and `CellRef.cell` is this task's cell (see `CellDependency` docs).
     #[field(
         storage = "auto_set",
         category = "data",
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    cell_dependents: AutoSet<CellDependency, 1>,
+    cell_dependents_all: AutoSet<CellRef, 1>,
+
+    /// Tasks that depend on a hashed sub-value of this task's cells. Reverse of
+    /// `cell_dependencies_hashed`.
+    #[field(
+        storage = "auto_set",
+        category = "data",
+        filter_transient,
+        drop_on_completion_if_immutable
+    )]
+    cell_dependents_hashed: AutoSet<(CellRef, u64), 1>,
 
     /// Tasks that depend on collectibles of a specific type from this task.
     /// Maps TraitTypeId -> Set<TaskId>
@@ -855,6 +884,16 @@ impl IsTransient for CellDependency {
         CellDependency::is_transient(self)
     }
 }
+impl IsTransient for CellRef {
+    fn is_transient(&self) -> bool {
+        CellRef::is_transient(self)
+    }
+}
+impl IsTransient for (CellRef, u64) {
+    fn is_transient(&self) -> bool {
+        self.0.is_transient()
+    }
+}
 
 /// Defines a strategy for merging data from disk into this storage item.
 ///
@@ -957,7 +996,7 @@ mod tests {
     use turbo_tasks::{CellId, TaskId};
 
     use super::*;
-    use crate::data::{AggregationNumber, CellDependency, CellRef, Dirtyness, OutputValue};
+    use crate::data::{AggregationNumber, CellRef, Dirtyness, OutputValue};
 
     #[test]
     fn test_accessors() {
@@ -1243,15 +1282,13 @@ mod tests {
         original
             .output_dependencies_mut()
             .insert(TaskId::new(200).unwrap());
-        original
-            .cell_dependencies_mut()
-            .insert(CellDependency::All(CellRef {
-                task: TaskId::new(1).unwrap(),
-                cell: CellId {
-                    type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
-                    index: 0,
-                },
-            }));
+        original.cell_dependencies_all_mut().insert(CellRef {
+            task: TaskId::new(1).unwrap(),
+            cell: CellId {
+                type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
+                index: 0,
+            },
+        });
 
         // Set lazy data transient field (should NOT be serialized)
         original
@@ -1304,7 +1341,7 @@ mod tests {
                 .unwrap()
                 .contains(&TaskId::new(200).unwrap())
         );
-        assert_eq!(decoded.cell_dependencies().unwrap().len(), 1);
+        assert_eq!(decoded.cell_dependencies_all().unwrap().len(), 1);
 
         // Verify transient fields were NOT decoded
         assert!(decoded.outdated_output_dependencies().is_none());
@@ -1390,15 +1427,13 @@ mod tests {
         storage.output_dependent_mut().insert(transient_task(3));
 
         // Lazy filter_transient data field.
-        storage
-            .cell_dependencies_mut()
-            .insert(CellDependency::All(CellRef {
-                task: persistent_task(10),
-                cell: CellId {
-                    type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
-                    index: 0,
-                },
-            }));
+        storage.cell_dependencies_all_mut().insert(CellRef {
+            task: persistent_task(10),
+            cell: CellId {
+                type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
+                index: 0,
+            },
+        });
 
         // Mark as restored so the task is eligible for dropping.
         storage.flags.set_data_restored(true);
@@ -1416,7 +1451,7 @@ mod tests {
         assert_eq!(storage.output_dependent().len(), 1);
         // Lazy non-filter-transient residue: cell_dependencies had only persistent
         // entries and should be dropped entirely.
-        assert!(storage.cell_dependencies().is_none());
+        assert!(storage.cell_dependencies_all().is_none());
         // data_restored cleared; meta_restored untouched.
         assert!(!storage.flags.data_restored());
         assert!(storage.flags.meta_restored());

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -34,9 +34,8 @@ use turbo_tasks::{
 use crate::{
     backend::{cell_data::CellData, counter_map::CounterMap},
     data::{
-        ActivenessState, AggregationNumber, CellDependency, CellRef, CollectibleRef,
-        CollectiblesRef, Dirtyness, InProgressCellState, InProgressState, LeafDistance,
-        OutputValue, RootType, TransientTask,
+        ActivenessState, AggregationNumber, CellRef, CollectibleRef, CollectiblesRef, Dirtyness,
+        InProgressCellState, InProgressState, LeafDistance, OutputValue, RootType, TransientTask,
     },
 };
 
@@ -255,7 +254,7 @@ struct TaskStorageSchema {
         shrink_on_completion,
         drop_on_completion_if_immutable
     )]
-    cell_dependencies_all: AutoSet<CellRef, 2>,
+    cell_dependencies: AutoSet<CellRef, 2>,
 
     /// Cells this task depends on, narrowed to a hashed sub-value (`CellDependency::Hash`). Rare.
     #[field(
@@ -283,7 +282,7 @@ struct TaskStorageSchema {
 
     /// Outdated keyless cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
-    outdated_cell_dependencies_all: AutoSet<CellRef, 2>,
+    outdated_cell_dependencies: AutoSet<CellRef, 2>,
 
     /// Outdated hashed cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
@@ -297,7 +296,7 @@ struct TaskStorageSchema {
     // DEPENDENTS - Tasks that depend on this task's cells
     // =========================================================================
     /// Tasks that depend on this task's cells as a whole (keyless). Reverse of
-    /// `cell_dependencies_all`. In a `cell_dependents` entry the `CellRef.task` field holds the
+    /// `cell_dependencies`. In a `cell_dependents` entry the `CellRef.task` field holds the
     /// DEPENDENT task's id and `CellRef.cell` is this task's cell (see `CellDependency` docs).
     #[field(
         storage = "auto_set",
@@ -305,7 +304,7 @@ struct TaskStorageSchema {
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    cell_dependents_all: AutoSet<CellRef, 2>,
+    cell_dependents: AutoSet<CellRef, 2>,
 
     /// Tasks that depend on a hashed sub-value of this task's cells. Reverse of
     /// `cell_dependencies_hashed`.
@@ -879,11 +878,6 @@ impl IsTransient for (TraitTypeId, TaskId) {
         self.1.is_transient()
     }
 }
-impl IsTransient for CellDependency {
-    fn is_transient(&self) -> bool {
-        CellDependency::is_transient(self)
-    }
-}
 impl IsTransient for CellRef {
     fn is_transient(&self) -> bool {
         CellRef::is_transient(self)
@@ -1282,7 +1276,7 @@ mod tests {
         original
             .output_dependencies_mut()
             .insert(TaskId::new(200).unwrap());
-        original.cell_dependencies_all_mut().insert(CellRef {
+        original.cell_dependencies_mut().insert(CellRef {
             task: TaskId::new(1).unwrap(),
             cell: CellId {
                 type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
@@ -1341,7 +1335,7 @@ mod tests {
                 .unwrap()
                 .contains(&TaskId::new(200).unwrap())
         );
-        assert_eq!(decoded.cell_dependencies_all().unwrap().len(), 1);
+        assert_eq!(decoded.cell_dependencies().unwrap().len(), 1);
 
         // Verify transient fields were NOT decoded
         assert!(decoded.outdated_output_dependencies().is_none());
@@ -1427,7 +1421,7 @@ mod tests {
         storage.output_dependent_mut().insert(transient_task(3));
 
         // Lazy filter_transient data field.
-        storage.cell_dependencies_all_mut().insert(CellRef {
+        storage.cell_dependencies_mut().insert(CellRef {
             task: persistent_task(10),
             cell: CellId {
                 type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
@@ -1451,7 +1445,7 @@ mod tests {
         assert_eq!(storage.output_dependent().len(), 1);
         // Lazy non-filter-transient residue: cell_dependencies had only persistent
         // entries and should be dropped entirely.
-        assert!(storage.cell_dependencies_all().is_none());
+        assert!(storage.cell_dependencies().is_none());
         // data_restored cleared; meta_restored untouched.
         assert!(!storage.flags.data_restored());
         assert!(storage.flags.meta_restored());

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -79,49 +79,6 @@ impl CollectiblesRef {
     }
 }
 
-/// An edge between a [`CellRef`] and a task, optionally narrowed by a hashed sub-key.
-///
-/// Used both as a forward and reverse edge:
-/// - In `cell_dependencies`, the [`CellRef`] is the cell another task owns that this task depends
-///   on.
-/// - In `cell_dependents`, the [`CellRef`]'s `task` is the dependent task and `cell` is the cell of
-///   the storing task; the `task` field is reused as the dependent's id rather than the cell's
-///   owning task. The fields encode the same bits either way.
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Encode, Decode)]
-pub enum CellDependency {
-    /// Depend on the cell as a whole.
-    All(CellRef),
-    /// Depend only on the sub-value identified by this hash key.
-    Hash(CellRef, u64),
-}
-
-impl CellDependency {
-    pub fn cell_ref(&self) -> CellRef {
-        match *self {
-            CellDependency::All(c) | CellDependency::Hash(c, _) => c,
-        }
-    }
-
-    /// Decompose into the underlying `(CellRef, Option<u64>)` in a single match.
-    pub fn into_parts(self) -> (CellRef, Option<u64>) {
-        match self {
-            CellDependency::All(c) => (c, None),
-            CellDependency::Hash(c, k) => (c, Some(k)),
-        }
-    }
-
-    pub fn new(cell_ref: CellRef, key: Option<u64>) -> Self {
-        match key {
-            None => CellDependency::All(cell_ref),
-            Some(k) => CellDependency::Hash(cell_ref, k),
-        }
-    }
-
-    pub fn is_transient(&self) -> bool {
-        self.cell_ref().is_transient()
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum OutputValue {
     Cell(CellRef),


### PR DESCRIPTION
Split the representtation of cell dependencies to split `hashed` and `non-hashed` dependencies into separate structures

Hashed deps are rare but the bloat the size of the edge representation so a distinct field can optimize for the common case.


|                        | canary   | branch   | delta            |  persistence disabled  |  gap     |
-------------------------|----------|----------|------------------| ---------------------- | ---------|
| maxRSS median          | 16.74 GB | 15.69 GB | −1.05 GB (−6.2%) |  13.86 GB              |  1.83 GB |
| maxRSS max (worst run) | 18.14 GB | 16.19 GB | −1.95 GB         |  14.16 GB              |  2.03 GB |

This closes 1/3 of the gap from enabling persistence. 

Time metrics were ~neutral but i didn't take the time to quiet my machine.  I would assume there is a small perf benefit from this approach, but memory is the goal

