### PR TITLE
[CC] refactor staged rendering codepaths in params/searchParams

### DIFF
--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -89,30 +89,28 @@ export function createParamsFromClient(
         throw new InvariantError(
           'createParamsFromClient should not be called inside generateStaticParams.'
         )
-      case 'request':
-        if (process.env.NODE_ENV === 'development') {
-          // Semantically we only need the dev tracking when running in `next dev`
-          // but since you would never use next dev with production NODE_ENV we use this
-          // as a proxy so we can statically exclude this code from production builds.
-          const fallbackParams = workUnitStore.fallbackParams
-          // Client params are not runtime prefetchable
-          const isRuntimePrefetchable = false
-          return createRenderParamsInDev(
-            underlyingParams,
-            fallbackParams,
-            workStore,
-            workUnitStore,
-            isRuntimePrefetchable
-          )
-        } else if (workUnitStore.validationSamples) {
+      case 'request': {
+        if (workUnitStore.validationSamples) {
           return createClientParamsInInstantValidation(
             underlyingParams,
             workStore,
             workUnitStore.validationSamples
           )
+        }
+        if (process.env.NODE_ENV === 'development') {
+          const fallbackParams = workUnitStore.fallbackParams
+          const userspaceParams = underlyingParams
+          return createRenderParamsInDev(
+            underlyingParams,
+            userspaceParams,
+            fallbackParams,
+            workStore,
+            workUnitStore
+          )
         } else {
           return createRenderParamsInProd(underlyingParams)
         }
+      }
       default:
         workUnitStore satisfies never
     }
@@ -186,18 +184,14 @@ export function createServerParamsForRoute(
       }
       case 'request':
         if (process.env.NODE_ENV === 'development') {
-          // Semantically we only need the dev tracking when running in `next dev`
-          // but since you would never use next dev with production NODE_ENV we use this
-          // as a proxy so we can statically exclude this code from production builds.
           const fallbackParams = workUnitStore.fallbackParams
-          // Route params are not runtime prefetchable
-          const isRuntimePrefetchable = false
+          const userspaceParams = underlyingParams
           return createRenderParamsInDev(
             underlyingParams,
+            userspaceParams,
             fallbackParams,
             workStore,
-            workUnitStore,
-            isRuntimePrefetchable
+            workUnitStore
           )
         } else {
           return createRenderParamsInProd(underlyingParams)
@@ -255,72 +249,16 @@ export function createServerParamsForServerSegment(
           varyParamsAccumulator,
           isRuntimePrefetchable
         )
-      case 'request':
-        if (process.env.NODE_ENV === 'development') {
-          // Semantically we only need the dev tracking when running in `next dev`
-          // but since you would never use next dev with production NODE_ENV we use this
-          // as a proxy so we can statically exclude this code from production builds.
-          const fallbackParams = workUnitStore.fallbackParams
-          return createRenderParamsInDev(
-            underlyingParams,
-            fallbackParams,
-            workStore,
-            workUnitStore,
-            isRuntimePrefetchable
-          )
-        }
-
-        if (workUnitStore.asyncApiPromises && workUnitStore.validationSamples) {
-          return createServerParamsInInstantValidation(
-            underlyingParams,
-            workStore,
-            workUnitStore.validationSamples,
-            workUnitStore.asyncApiPromises,
-            isRuntimePrefetchable
-          )
-        }
-
-        const { stagedRendering } = workUnitStore
-
-        if (workUnitStore.asyncApiPromises && stagedRendering) {
-          // We're rendering in stages for cachedNavigations.
-          const hasFallbackParams = hasFallbackRouteParams(
-            underlyingParams,
-            workUnitStore.fallbackParams
-          )
-
-          // If we're rendering with shells, even static params must be delayed to exclude them from the shell.
-          // NOTE: For a dynamic request, assume we're recovering a static shell.
-          // If a session shell is needed, we do it in a separate render
-          if (
-            process.env.__NEXT_APP_SHELLS &&
-            // Params are non-empty, and there's no fallback params, so all params are static
-            !isEmptyParams(underlyingParams) &&
-            !hasFallbackParams
-          ) {
-            const paramsStages = RENDER_STAGES_BY_DATA_KIND.staticLinkData
-            const stage = isRuntimePrefetchable
-              ? paramsStages.early
-              : paramsStages.late
-            return stagedRendering.delayUntilStage(
-              stage,
-              'params',
-              underlyingParams
-            )
-          }
-
-          // Otherwise, only delay if we have fallbacks params
-          if (hasFallbackParams) {
-            return makePromiseFromTrigger(
-              isRuntimePrefetchable
-                ? workUnitStore.asyncApiPromises.earlySharedParamsParent
-                : workUnitStore.asyncApiPromises.sharedParamsParent,
-              underlyingParams
-            )
-          }
-        }
-
-        return createRenderParamsInProd(underlyingParams)
+      case 'request': {
+        return createRenderParamsForPage(
+          workStore,
+          workUnitStore,
+          underlyingParams,
+          optionalCatchAllParamName,
+          varyParamsAccumulator,
+          isRuntimePrefetchable
+        )
+      }
       default:
         workUnitStore satisfies never
     }
@@ -531,6 +469,157 @@ function createRuntimePrerenderParams(
   return stagedRendering.waitForStage(stage).then(() => result)
 }
 
+function createRenderParamsForPage(
+  workStore: WorkStore,
+  workUnitStore: RequestStore,
+  underlyingParams: Params,
+  optionalCatchAllParamName: string | null,
+  varyParamsAccumulator: VaryParamsAccumulator | null,
+  isRuntimePrefetchable: boolean
+) {
+  const { stagedRendering, asyncApiPromises, validationSamples } = workUnitStore
+
+  // Distinguish the params that we expose to userspace (potentially wrapped in proxies)
+  // and the underlying object containing params values. We do this because wrappers
+  // like `instrumentParamsPromiseWithDevWarnings` need to be able to get the known param names
+  // without triggering other wrapper proxies.
+  let userspaceParams = underlyingParams
+  if (validationSamples) {
+    userspaceParams = createServerParamsProxyForInstantValidation(
+      underlyingParams,
+      workStore,
+      validationSamples
+    )
+  }
+  if (varyParamsAccumulator) {
+    userspaceParams = createVaryingParams(
+      varyParamsAccumulator,
+      userspaceParams,
+      optionalCatchAllParamName
+    )
+  }
+
+  if (stagedRendering && asyncApiPromises) {
+    return createStagedRenderParams(
+      workStore,
+      workUnitStore,
+      stagedRendering,
+      asyncApiPromises,
+      underlyingParams,
+      userspaceParams,
+      isRuntimePrefetchable
+    )
+  }
+
+  // No staged rendering = no cacheComponents, or cacheComponents prod without cachedNavigations
+  if (process.env.NODE_ENV === 'development') {
+    const fallbackParams = workUnitStore.fallbackParams
+    return createRenderParamsInDev(
+      underlyingParams,
+      userspaceParams,
+      fallbackParams,
+      workStore,
+      workUnitStore
+    )
+  } else {
+    return createRenderParamsInProd(userspaceParams)
+  }
+}
+
+function createStagedRenderParams(
+  workStore: WorkStore,
+  workUnitStore: RequestStore,
+  stagedRendering: NonNullable<RequestStore['stagedRendering']>,
+  asyncApiPromises: NonNullable<RequestStore['asyncApiPromises']>,
+  underlyingParams: Params,
+  userspaceParams: Params,
+  isRuntimePrefetchable: boolean
+) {
+  const promise = createStagedRenderParamsImpl(
+    workUnitStore,
+    stagedRendering,
+    asyncApiPromises,
+    underlyingParams,
+    userspaceParams,
+    isRuntimePrefetchable
+  )
+  if (process.env.NODE_ENV === 'development') {
+    return instrumentParamsPromiseWithDevWarnings(
+      underlyingParams,
+      promise,
+      workStore
+    )
+  } else {
+    return promise
+  }
+}
+
+function createStagedRenderParamsImpl(
+  workUnitStore: RequestStore,
+  stagedRendering: NonNullable<RequestStore['stagedRendering']>,
+  asyncApiPromises: NonNullable<RequestStore['asyncApiPromises']>,
+  /** The actual param values, without any instrumentation */
+  underlyingParams: Params,
+  /** The params object to return to userspace, possibly wrapped in a proxy */
+  userspaceParams: Params,
+  isRuntimePrefetchable: boolean
+) {
+  const hasFallbackParams = hasFallbackRouteParams(
+    underlyingParams,
+    workUnitStore.fallbackParams
+  )
+
+  // If we're rendering with shells, even static params must be delayed to exclude them from the shell.
+  // For a dynamic request we generally want a static shell (session shells come from a separate render).
+  if (
+    process.env.__NEXT_APP_SHELLS &&
+    // Params are non-empty, and there's no fallback params, so all params are static
+    !isEmptyParams(underlyingParams) &&
+    !hasFallbackParams
+  ) {
+    const staticParamsStages = RENDER_STAGES_BY_DATA_KIND.staticLinkData
+    const stage = isRuntimePrefetchable
+      ? staticParamsStages.early
+      : staticParamsStages.late
+    return stagedRendering.delayUntilStage(stage, 'params', userspaceParams)
+  }
+
+  // Otherwise, only delay if we have fallback params
+  if (hasFallbackParams) {
+    return createParamsPromiseFromTrigger(
+      isRuntimePrefetchable
+        ? asyncApiPromises.earlySharedParamsParent
+        : asyncApiPromises.sharedParamsParent,
+      userspaceParams
+    )
+  }
+
+  return makeUntrackedParams(userspaceParams)
+}
+
+function createParamsPromiseFromTrigger(
+  trigger: Promise<any>,
+  userspaceParams: Params
+) {
+  if (process.env.NODE_ENV === 'development') {
+    // We wrap each instance of params in a `new Promise()`, which lets us show each
+    // await a different set of values. This is important when all awaits
+    // are in third party which would otherwise track all the way to the
+    // internal params.
+    const promise: Promise<Params> = new Promise((resolve, reject) => {
+      trigger.then(() => resolve(userspaceParams), reject)
+    })
+    promise.catch(noop)
+    // @ts-expect-error
+    promise.displayName = 'params'
+    return promise
+  } else {
+    return makePromiseFromTrigger(trigger, userspaceParams)
+  }
+}
+
+function noop() {}
+
 function isEmptyParams(params: Params): boolean {
   for (const _paramKey in params) {
     return false
@@ -552,26 +641,18 @@ function hasFallbackRouteParams(
   return false
 }
 
-function createServerParamsInInstantValidation(
+function createServerParamsProxyForInstantValidation(
   underlyingParams: Params,
   workStore: WorkStore,
-  validationSamples: NonNullable<RequestStore['validationSamples']>,
-  asyncApiPromises: NonNullable<RequestStore['asyncApiPromises']>,
-  isRuntimePrefetchable: boolean
-): Promise<Params> {
+  validationSamples: NonNullable<RequestStore['validationSamples']>
+): Params {
   const { createExhaustiveParamsProxy } =
     require('../app-render/instant-validation/instant-samples') as typeof import('../app-render/instant-validation/instant-samples')
   const declaredParams = new Set(Object.keys(validationSamples.params ?? {}))
-  const proxiedUnderlying = createExhaustiveParamsProxy(
+  return createExhaustiveParamsProxy(
     underlyingParams,
     declaredParams,
     workStore.route
-  )
-  return makePromiseFromTrigger(
-    isRuntimePrefetchable
-      ? asyncApiPromises.earlySharedParamsParent
-      : asyncApiPromises.sharedParamsParent,
-    proxiedUnderlying
   )
 }
 
@@ -591,23 +672,23 @@ function createClientParamsInInstantValidation(
   return Promise.resolve(proxiedUnderlying)
 }
 
-function createRenderParamsInProd(underlyingParams: Params): Promise<Params> {
-  return makeUntrackedParams(underlyingParams)
+function createRenderParamsInProd(userspaceParams: Params): Promise<Params> {
+  return makeUntrackedParams(userspaceParams)
 }
 
 function createRenderParamsInDev(
   underlyingParams: Params,
+  userpaceParams: Params,
   fallbackParams: OpaqueFallbackRouteParams | null | undefined,
   workStore: WorkStore,
-  requestStore: RequestStore,
-  isRuntimePrefetchable: boolean
+  requestStore: RequestStore
 ): Promise<Params> {
   return makeDynamicallyTrackedParamsWithDevWarnings(
     underlyingParams,
+    userpaceParams,
     hasFallbackRouteParams(underlyingParams, fallbackParams),
     workStore,
-    requestStore,
-    isRuntimePrefetchable
+    requestStore
   )
 }
 
@@ -738,32 +819,11 @@ function makeUntrackedParams(underlyingParams: Params): Promise<Params> {
 
 function makeDynamicallyTrackedParamsWithDevWarnings(
   underlyingParams: Params,
+  userspaceParams: Params,
   hasFallbackParams: boolean,
   workStore: WorkStore,
-  requestStore: RequestStore,
-  isRuntimePrefetchable: boolean
+  requestStore: RequestStore
 ): Promise<Params> {
-  if (requestStore.asyncApiPromises && hasFallbackParams) {
-    // We wrap each instance of params in a `new Promise()`, because deduping
-    // them across requests doesn't work anyway and this let us show each
-    // await a different set of values. This is important when all awaits
-    // are in third party which would otherwise track all the way to the
-    // internal params.
-    const sharedParamsParent = isRuntimePrefetchable
-      ? requestStore.asyncApiPromises.earlySharedParamsParent
-      : requestStore.asyncApiPromises.sharedParamsParent
-    const promise: Promise<Params> = new Promise((resolve, reject) => {
-      sharedParamsParent.then(() => resolve(underlyingParams), reject)
-    })
-    // @ts-expect-error
-    promise.displayName = 'params'
-    return instrumentParamsPromiseWithDevWarnings(
-      underlyingParams,
-      promise,
-      workStore
-    )
-  }
-
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {
     return cachedParams
@@ -774,12 +834,12 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
   // instrument the promise with spreadable properties of ReactPromise.
   const promise = hasFallbackParams
     ? makeDevtoolsIOAwarePromise(
-        underlyingParams,
+        userspaceParams,
         requestStore,
         RenderStage.Runtime
       )
     : // We don't want to force an environment transition when this params is not part of the fallback params set
-      Promise.resolve(underlyingParams)
+      Promise.resolve(userspaceParams)
 
   const proxiedPromise = instrumentParamsPromiseWithDevWarnings(
     underlyingParams,

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -144,7 +144,6 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
         } catch (err) {
           return Promise.reject(err)
         }
-        break
       }
 
       const { stagedRendering } = workUnitStore

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -270,45 +270,96 @@ function createRenderSearchParams(
   requestStore: RequestStore,
   isRuntimePrefetchable: boolean
 ): Promise<SearchParams> {
+  const { asyncApiPromises, validationSamples } = requestStore
+
+  if (asyncApiPromises) {
+    let userspaceSearchParams = underlyingSearchParams
+    if (validationSamples) {
+      userspaceSearchParams = createSearchParamsProxyForInstantValidation(
+        workStore,
+        validationSamples,
+        underlyingSearchParams
+      )
+    }
+
+    return createStagedRenderSearchParams(
+      workStore,
+      asyncApiPromises,
+      isRuntimePrefetchable,
+      underlyingSearchParams,
+      userspaceSearchParams
+    )
+  }
+
+  // No staged rendering = no cacheComponents, or cacheComponents prod without cachedNavigations
+
   if (workStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
     // dictionary object.
     return Promise.resolve({})
-  } else {
-    if (process.env.NODE_ENV === 'development') {
-      // Semantically we only need the dev tracking when running in `next dev`
-      // but since you would never use next dev with production NODE_ENV we use this
-      // as a proxy so we can statically exclude this code from production builds.
-      return makeUntrackedSearchParamsWithDevWarnings(
-        underlyingSearchParams,
-        workStore,
-        requestStore,
-        isRuntimePrefetchable
-      )
-    } else if (requestStore.asyncApiPromises) {
-      if (requestStore.validationSamples) {
-        const { createExhaustiveSearchParamsProxy } =
-          require('../app-render/instant-validation/instant-samples') as typeof import('../app-render/instant-validation/instant-samples')
-        const declaredKeys = new Set(
-          Object.keys(requestStore.validationSamples.searchParams ?? {})
-        )
-        underlyingSearchParams = createExhaustiveSearchParamsProxy(
-          underlyingSearchParams,
-          declaredKeys,
-          workStore.route
-        )
-      }
-
-      return makePromiseFromTrigger(
-        isRuntimePrefetchable
-          ? requestStore.asyncApiPromises.earlySharedSearchParamsParent
-          : requestStore.asyncApiPromises.sharedSearchParamsParent,
-        underlyingSearchParams
-      )
-    } else {
-      return makeUntrackedSearchParams(underlyingSearchParams)
-    }
   }
+
+  if (process.env.NODE_ENV === 'development') {
+    // Semantically we only need the dev tracking when running in `next dev`
+    // but since you would never use next dev with production NODE_ENV we use this
+    // as a proxy so we can statically exclude this code from production builds.
+    return makeUntrackedSearchParamsWithDevWarnings(
+      underlyingSearchParams,
+      workStore,
+      requestStore
+    )
+  } else {
+    return makeUntrackedSearchParams(underlyingSearchParams)
+  }
+}
+
+function createStagedRenderSearchParams(
+  workStore: WorkStore,
+  asyncApiPromises: NonNullable<RequestStore['asyncApiPromises']>,
+  isRuntimePrefetchable: boolean,
+  underlyingSearchParams: SearchParams,
+  userspaceSearchParams: SearchParams
+): Promise<SearchParams> {
+  const trigger = isRuntimePrefetchable
+    ? asyncApiPromises.earlySharedSearchParamsParent
+    : asyncApiPromises.sharedSearchParamsParent
+
+  if (process.env.NODE_ENV === 'development') {
+    // We wrap each instance of searchParams in a `new Promise()`.
+    // This is important when all awaits are in third party which would otherwise
+    // track all the way to the internal params.
+    const promise = new Promise<SearchParams>((resolve, reject) => {
+      trigger.then(() => resolve(userspaceSearchParams), reject)
+    })
+    // @ts-expect-error
+    promise.displayName = 'searchParams'
+    promise.catch(ignoreReject)
+
+    return instrumentSearchParamsPromiseWithDevWarnings(
+      underlyingSearchParams,
+      promise,
+      workStore
+    )
+  } else {
+    return makePromiseFromTrigger(trigger, userspaceSearchParams)
+  }
+}
+
+function createSearchParamsProxyForInstantValidation(
+  workStore: WorkStore,
+  validationSamples: NonNullable<RequestStore['validationSamples']>,
+  underlyingSearchParams: SearchParams
+) {
+  const { createExhaustiveSearchParamsProxy } =
+    require('../app-render/instant-validation/instant-samples') as typeof import('../app-render/instant-validation/instant-samples')
+  const declaredKeys = new Set(
+    Object.keys(validationSamples.searchParams ?? {})
+  )
+  return createExhaustiveSearchParamsProxy(
+    underlyingSearchParams,
+    declaredKeys,
+    workStore.route
+  )
 }
 
 interface CacheLifetime {}
@@ -483,39 +534,25 @@ function makeUntrackedSearchParams(
 function makeUntrackedSearchParamsWithDevWarnings(
   underlyingSearchParams: SearchParams,
   workStore: WorkStore,
-  requestStore: RequestStore,
-  isRuntimePrefetchable: boolean
+  requestStore: RequestStore
 ): Promise<SearchParams> {
-  if (requestStore.asyncApiPromises) {
-    // Do not cache the resulting promise. If we do, we'll only show the first "awaited at"
-    // across all segments that receive searchParams.
-    return makeUntrackedSearchParamsWithDevWarningsImpl(
-      underlyingSearchParams,
-      workStore,
-      requestStore,
-      isRuntimePrefetchable
-    )
-  } else {
-    const cachedSearchParams = CachedSearchParams.get(underlyingSearchParams)
-    if (cachedSearchParams) {
-      return cachedSearchParams
-    }
-    const promise = makeUntrackedSearchParamsWithDevWarningsImpl(
-      underlyingSearchParams,
-      workStore,
-      requestStore,
-      isRuntimePrefetchable
-    )
-    CachedSearchParams.set(requestStore, promise)
-    return promise
+  const cachedSearchParams = CachedSearchParams.get(underlyingSearchParams)
+  if (cachedSearchParams) {
+    return cachedSearchParams
   }
+  const promise = makeUntrackedSearchParamsWithDevWarningsImpl(
+    underlyingSearchParams,
+    workStore,
+    requestStore
+  )
+  CachedSearchParams.set(requestStore, promise)
+  return promise
 }
 
 function makeUntrackedSearchParamsWithDevWarningsImpl(
   underlyingSearchParams: SearchParams,
   workStore: WorkStore,
-  requestStore: RequestStore,
-  isRuntimePrefetchable: boolean
+  requestStore: RequestStore
 ): Promise<SearchParams> {
   const promiseInitialized = { current: false }
   const proxiedUnderlying = instrumentSearchParamsObjectWithDevWarnings(
@@ -524,26 +561,12 @@ function makeUntrackedSearchParamsWithDevWarningsImpl(
     promiseInitialized
   )
 
-  let promise: Promise<SearchParams>
-  if (requestStore.asyncApiPromises) {
-    // We wrap each instance of searchParams in a `new Promise()`.
-    // This is important when all awaits are in third party which would otherwise
-    // track all the way to the internal params.
-    const sharedSearchParamsParent = isRuntimePrefetchable
-      ? requestStore.asyncApiPromises.earlySharedSearchParamsParent
-      : requestStore.asyncApiPromises.sharedSearchParamsParent
-    promise = new Promise((resolve, reject) => {
-      sharedSearchParamsParent.then(() => resolve(proxiedUnderlying), reject)
-    })
-    // @ts-expect-error
-    promise.displayName = 'searchParams'
-  } else {
-    promise = makeDevtoolsIOAwarePromise(
-      proxiedUnderlying,
-      requestStore,
-      RenderStage.Runtime
-    )
-  }
+  const promise = makeDevtoolsIOAwarePromise(
+    proxiedUnderlying,
+    requestStore,
+    RenderStage.Runtime
+  )
+
   promise.then(
     () => {
       promiseInitialized.current = true


### PR DESCRIPTION
The 'request' codepath in params/searchParams was forked `process.env.NODE_ENV === 'development'`, but that's a leftover from when dev was the only place where we did staged rendering. It didn't account for conditions like `--debug-prerender`, and now makes it generally confusing to reason about. This PR simplifies the flow so that renders that care about stages are clearly distinguished, and dev is just a minor variation within that (generally adding some extra warnings via proxies)