### PR TITLE
[agents-md] Index bundled docs instead of downloading into .next-docs

### DIFF
--- a/packages/next-codemod/bin/agents-md.ts
+++ b/packages/next-codemod/bin/agents-md.ts
@@ -10,6 +10,8 @@ import pc from 'picocolors'
 import { BadInput } from './shared'
 import {
   getNextjsVersion,
+  getBundledDocsInfo,
+  getBundledDocsLinkPath,
   pullDocs,
   collectDocFiles,
   buildDocTree,
@@ -74,8 +76,20 @@ export async function runAgentsMd(options: AgentsMdOptions): Promise<void> {
   }
 
   const claudeMdPath = path.join(cwd, targetFile)
-  const docsPath = path.join(cwd, DOCS_DIR_NAME)
-  const docsLinkPath = `./${DOCS_DIR_NAME}`
+
+  // Next.js >= 16.2.0 ships its docs inside the published package. When the
+  // installed version matches the requested one, index the bundled docs
+  // directly instead of downloading a copy into .next-docs.
+  const bundledDocs = getBundledDocsInfo(cwd)
+  const useBundledDocs =
+    bundledDocs !== null && bundledDocs.version === nextjsVersion
+
+  const docsPath = useBundledDocs
+    ? bundledDocs.docsPath
+    : path.join(cwd, DOCS_DIR_NAME)
+  const docsLinkPath = useBundledDocs
+    ? getBundledDocsLinkPath(cwd, bundledDocs.docsPath)
+    : `./${DOCS_DIR_NAME}`
 
   let sizeBefore = 0
   let isNewFile = true
@@ -87,18 +101,24 @@ export async function runAgentsMd(options: AgentsMdOptions): Promise<void> {
     isNewFile = false
   }
 
-  console.log(
-    `\nDownloading Next.js ${pc.cyan(nextjsVersion)} documentation to ${pc.cyan(DOCS_DIR_NAME)}...`
-  )
+  if (useBundledDocs) {
+    console.log(
+      `\nUsing the docs bundled with Next.js ${pc.cyan(nextjsVersion)} at ${pc.cyan(docsLinkPath)} (no download needed).`
+    )
+  } else {
+    console.log(
+      `\nDownloading Next.js ${pc.cyan(nextjsVersion)} documentation to ${pc.cyan(DOCS_DIR_NAME)}...`
+    )
 
-  const pullResult = await pullDocs({
-    cwd,
-    version: nextjsVersion,
-    docsDir: docsPath,
-  })
+    const pullResult = await pullDocs({
+      cwd,
+      version: nextjsVersion,
+      docsDir: docsPath,
+    })
 
-  if (!pullResult.success) {
-    throw new BadInput(`Failed to pull docs: ${pullResult.error}`)
+    if (!pullResult.success) {
+      throw new BadInput(`Failed to pull docs: ${pullResult.error}`)
+    }
   }
 
   const docFiles = collectDocFiles(docsPath)
@@ -115,7 +135,9 @@ export async function runAgentsMd(options: AgentsMdOptions): Promise<void> {
 
   const sizeAfter = Buffer.byteLength(newContent, 'utf-8')
 
-  const gitignoreResult = ensureGitignoreEntry(cwd)
+  // .next-docs only exists on the download path; bundled docs live in
+  // node_modules, which is already ignored.
+  const gitignoreResult = useBundledDocs ? null : ensureGitignoreEntry(cwd)
 
   const action = isNewFile ? 'Created' : 'Updated'
   const sizeInfo = isNewFile
@@ -123,7 +145,7 @@ export async function runAgentsMd(options: AgentsMdOptions): Promise<void> {
     : `${formatSize(sizeBefore)} → ${formatSize(sizeAfter)}`
 
   console.log(`${pc.green('✓')} ${action} ${pc.bold(targetFile)} (${sizeInfo})`)
-  if (gitignoreResult.updated) {
+  if (gitignoreResult?.updated) {
     console.log(
       `${pc.green('✓')} Added ${pc.bold(DOCS_DIR_NAME)} to .gitignore`
     )

--- a/packages/next-codemod/lib/__tests__/agents-md-e2e.test.js
+++ b/packages/next-codemod/lib/__tests__/agents-md-e2e.test.js
@@ -293,6 +293,123 @@ This is my project documentation.
     }
   }, 30000) // Increase timeout for git clone
 
+  describe('bundled docs (Next.js >= 16.2.0)', () => {
+    // Simulate an install of a Next.js version that ships docs inside the
+    // published package at node_modules/next/dist/docs.
+    function setupBundledNext(projectDir, version) {
+      const nextDir = path.join(projectDir, 'node_modules', 'next')
+      const gettingStartedDir = path.join(
+        nextDir,
+        'dist',
+        'docs',
+        '01-app',
+        '01-getting-started'
+      )
+      fs.mkdirSync(gettingStartedDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(nextDir, 'package.json'),
+        JSON.stringify({ name: 'next', version })
+      )
+      fs.writeFileSync(
+        path.join(nextDir, 'dist', 'docs', 'index.md'),
+        '# Next.js Docs'
+      )
+      fs.writeFileSync(
+        path.join(gettingStartedDir, '01-installation.md'),
+        '# Installation'
+      )
+      fs.writeFileSync(
+        path.join(gettingStartedDir, '02-project-structure.md'),
+        '# Project Structure'
+      )
+    }
+
+    it('indexes bundled docs instead of downloading when installed Next.js ships them', async () => {
+      setupBundledNext(testProjectDir, '16.2.0')
+
+      const originalCwd = process.cwd()
+      process.chdir(testProjectDir)
+
+      try {
+        await runAgentsMd({ output: 'CLAUDE.md' })
+
+        // No .next-docs copy and no .gitignore entry for it
+        expect(fs.existsSync(path.join(testProjectDir, '.next-docs'))).toBe(
+          false
+        )
+        expect(fs.existsSync(path.join(testProjectDir, '.gitignore'))).toBe(
+          false
+        )
+
+        const claudeMdContent = fs.readFileSync(
+          path.join(testProjectDir, 'CLAUDE.md'),
+          'utf-8'
+        )
+        expect(claudeMdContent).toContain(
+          'root: ./node_modules/next/dist/docs'
+        )
+        expect(claudeMdContent).toContain('01-installation.md')
+
+        const output = consoleOutput.join('\n')
+        expect(output).toContain('bundled with Next.js')
+        expect(output).not.toContain('Downloading')
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it('uses bundled docs when --version matches the installed version', async () => {
+      setupBundledNext(testProjectDir, '16.2.0')
+
+      const originalCwd = process.cwd()
+      process.chdir(testProjectDir)
+
+      try {
+        await runAgentsMd({ version: '16.2.0', output: 'AGENTS.md' })
+
+        expect(fs.existsSync(path.join(testProjectDir, '.next-docs'))).toBe(
+          false
+        )
+
+        const agentsMdContent = fs.readFileSync(
+          path.join(testProjectDir, 'AGENTS.md'),
+          'utf-8'
+        )
+        expect(agentsMdContent).toContain(
+          'root: ./node_modules/next/dist/docs'
+        )
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it('falls back to downloading when --version differs from the installed version', async () => {
+      setupBundledNext(testProjectDir, '16.2.0')
+
+      const originalCwd = process.cwd()
+      process.chdir(testProjectDir)
+
+      try {
+        await runAgentsMd({ version: '15.0.0', output: 'CLAUDE.md' })
+
+        expect(fs.existsSync(path.join(testProjectDir, '.next-docs'))).toBe(
+          true
+        )
+
+        const claudeMdContent = fs.readFileSync(
+          path.join(testProjectDir, 'CLAUDE.md'),
+          'utf-8'
+        )
+        expect(claudeMdContent).toContain('root: ./.next-docs')
+
+        const output = consoleOutput.join('\n')
+        expect(output).toContain('Downloading')
+      } finally {
+        process.chdir(originalCwd)
+      }
+    }, 30000) // Increase timeout for git clone
+  })
+
   describe('getNextjsVersion', () => {
     const fixturesDir = path.join(__dirname, 'fixtures/agents-md')
 

--- a/packages/next-codemod/lib/agents-md.ts
+++ b/packages/next-codemod/lib/agents-md.ts
@@ -43,6 +43,42 @@ export function getNextjsVersion(cwd: string): NextjsVersionResult {
   }
 }
 
+interface BundledDocsInfo {
+  docsPath: string
+  version: string
+}
+
+/**
+ * Next.js ships its documentation inside the published package (at
+ * `dist/docs`) since 16.2.0. When the install resolved from `cwd` has
+ * bundled docs, the index can point at them directly instead of
+ * downloading a copy into `.next-docs`.
+ */
+export function getBundledDocsInfo(cwd: string): BundledDocsInfo | null {
+  try {
+    const nextPkgPath = require.resolve('next/package.json', { paths: [cwd] })
+    const pkg = JSON.parse(fs.readFileSync(nextPkgPath, 'utf-8'))
+    const docsPath = path.join(path.dirname(nextPkgPath), 'dist', 'docs')
+    if (!pkg.version || collectDocFiles(docsPath).length === 0) {
+      return null
+    }
+    return { docsPath, version: pkg.version }
+  } catch {
+    return null
+  }
+}
+
+export function getBundledDocsLinkPath(cwd: string, docsPath: string): string {
+  // Prefer the conventional path when it resolves from the project
+  // (covers hoisted installs; pnpm exposes next via a node_modules symlink).
+  const conventional = path.join(cwd, 'node_modules', 'next', 'dist', 'docs')
+  if (fs.existsSync(conventional)) {
+    return './node_modules/next/dist/docs'
+  }
+  const relative = path.relative(cwd, docsPath).replace(/\\/g, '/')
+  return relative.startsWith('.') ? relative : `./${relative}`
+}
+
 function versionToGitHubTag(version: string): string {
   return version.startsWith('v') ? version : `v${version}`
 }


### PR DESCRIPTION
Since 16.2.0 the published `next` package ships its docs at `dist/docs` (#89850), but `codemod agents-md` still git-clones a copy into `.next-docs`. When the install resolved from `cwd` has bundled docs and its version matches the requested one, the generated index now points at `./node_modules/next/dist/docs` directly — no clone, no `.next-docs`, no `.gitignore` entry. Older versions and explicit `--version` mismatches keep the download path.

Covered by new e2e tests: bundled-docs indexing, `--version` match, and download fallback on mismatch.

<!-- NEXT_JS_LLM_PR -->
