### PR TITLE
Register running dev servers in a machine-wide registry for tooling discovery

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -33,6 +33,10 @@ import {
   isPortIsReserved,
 } from '../lib/helpers/get-reserved-port'
 import { getCacheDirectory } from '../lib/helpers/get-cache-directory'
+import {
+  registerDevServer,
+  unregisterDevServer,
+} from '../lib/helpers/dev-server-registry'
 import { getGitBranch } from '../lib/helpers/git'
 import os from 'os'
 import fs from 'node:fs'
@@ -193,6 +197,7 @@ process.on('SIGTERM', () => handleSessionStop('SIGTERM'))
 
 // exit event must be synchronous
 process.on('exit', () => {
+  unregisterDevServer(child?.pid)
   child?.kill('SIGKILL')
   // Catch aggressive kills (e.g. OOM, unhandled exception) that bypass handleSessionStop.
   // SIGKILL of the parent cannot be caught; for all other exits this ensures state is written.
@@ -439,6 +444,20 @@ const nextDev = async (
             if (msg.distDir) {
               // Store the distDir from the child process for telemetry and trace uploads.
               distDir = msg.distDir
+            }
+
+            // Register in the machine-wide dev server registry so external
+            // tooling can discover this server without scanning ports.
+            if (child?.pid) {
+              registerDevServer(child.pid, {
+                projectDir: dir,
+                url:
+                  typeof msg.appUrl === 'string' && msg.appUrl
+                    ? msg.appUrl
+                    : `http://localhost:${port}`,
+                port,
+                startedAt: Date.now(),
+              })
             }
 
             resolved = true

--- a/packages/next/src/lib/helpers/dev-server-registry.ts
+++ b/packages/next/src/lib/helpers/dev-server-registry.ts
@@ -1,0 +1,97 @@
+import path from 'path'
+import fs from 'node:fs'
+import { getCacheDirectory } from './get-cache-directory'
+
+/**
+ * Registry of running `next dev` servers, shared across all projects on this
+ * machine. External tooling (e.g. MCP clients) reads this file to discover
+ * running dev servers without scanning ports.
+ *
+ * Entries are keyed by the dev server's process id. Entries from processes
+ * that died without cleaning up (e.g. SIGKILL) are dropped whenever the
+ * registry is rewritten. Process ids can be recycled by the OS, so readers
+ * must verify an entry by connecting to its `url` before relying on it.
+ */
+export type DevServerRegistryEntry = {
+  projectDir: string
+  url: string
+  port: number
+  startedAt: number
+}
+
+export type DevServerRegistry = Record<string, DevServerRegistryEntry>
+
+// Single shared file for all projects, next to dev-state.json.
+export const DEV_SERVER_REGISTRY_FILE = path.join(
+  getCacheDirectory('nextjs-nodejs'),
+  'dev-servers.json'
+)
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function readRegistry(file: string): DevServerRegistry {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'))
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed
+    }
+  } catch {
+    // Missing or corrupt file — treat as empty
+  }
+  return {}
+}
+
+function writeRegistry(file: string, registry: DevServerRegistry): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  const { sync: writeFileAtomicSync } =
+    require('next/dist/compiled/write-file-atomic') as typeof import('next/dist/compiled/write-file-atomic')
+  writeFileAtomicSync(file, JSON.stringify(registry))
+}
+
+function withoutDeadEntries(registry: DevServerRegistry): DevServerRegistry {
+  const alive: DevServerRegistry = {}
+  for (const [pid, entry] of Object.entries(registry)) {
+    if (isProcessAlive(Number(pid))) {
+      alive[pid] = entry
+    }
+  }
+  return alive
+}
+
+export function registerDevServer(
+  pid: number,
+  entry: DevServerRegistryEntry,
+  file: string = DEV_SERVER_REGISTRY_FILE
+): void {
+  if (process.env.NEXT_DISABLE_DEV_SERVER_REGISTRY) return
+  try {
+    const registry = withoutDeadEntries(readRegistry(file))
+    registry[String(pid)] = entry
+    writeRegistry(file, registry)
+  } catch {
+    // Best effort — discovery must never interfere with the dev server
+  }
+}
+
+export function unregisterDevServer(
+  pid: number | undefined,
+  file: string = DEV_SERVER_REGISTRY_FILE
+): void {
+  if (process.env.NEXT_DISABLE_DEV_SERVER_REGISTRY) return
+  if (pid == null) return
+  try {
+    if (!fs.existsSync(file)) return
+    const registry = withoutDeadEntries(readRegistry(file))
+    delete registry[String(pid)]
+    writeRegistry(file, registry)
+  } catch {
+    // Best effort — must be safe to call from an exit handler
+  }
+}

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -668,6 +668,9 @@ if (process.env.NEXT_PRIVATE_WORKER && process.send) {
         nextServerReady: true,
         port: process.env.PORT,
         distDir: result.distDir,
+        // The exact URL the server announced (set when the server started
+        // listening), so the parent process doesn't have to re-derive it.
+        appUrl: process.env.__NEXT_PRIVATE_ORIGIN,
       })
     }
   })

--- a/test/unit/dev-server-registry.test.ts
+++ b/test/unit/dev-server-registry.test.ts
@@ -1,0 +1,102 @@
+import os from 'os'
+import fs from 'fs'
+import { join } from 'path'
+import { spawnSync } from 'child_process'
+import {
+  registerDevServer,
+  unregisterDevServer,
+  type DevServerRegistryEntry,
+} from 'next/dist/lib/helpers/dev-server-registry'
+
+function tmpRegistryFile(): string {
+  const dir = fs.mkdtempSync(join(os.tmpdir(), 'dev-server-registry-'))
+  return join(dir, 'dev-servers.json')
+}
+
+function makeEntry(
+  overrides: Partial<DevServerRegistryEntry> = {}
+): DevServerRegistryEntry {
+  return {
+    projectDir: '/tmp/my-app',
+    url: 'http://localhost:3000',
+    port: 3000,
+    startedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+// Spawn a short-lived process and wait for it to exit, so its pid is
+// guaranteed to be dead (spawnSync reaps the child before returning).
+function getDeadPid(): number {
+  const result = spawnSync(process.execPath, ['-e', ''])
+  return result.pid
+}
+
+describe('dev-server-registry', () => {
+  it('registers an entry keyed by pid', () => {
+    const file = tmpRegistryFile()
+    const entry = makeEntry()
+
+    registerDevServer(process.pid, entry, file)
+
+    const registry = JSON.parse(fs.readFileSync(file, 'utf8'))
+    expect(registry).toEqual({ [String(process.pid)]: entry })
+  })
+
+  it('drops entries whose process is no longer alive', () => {
+    const file = tmpRegistryFile()
+    const deadPid = getDeadPid()
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        [String(deadPid)]: makeEntry({ port: 3001 }),
+      })
+    )
+
+    const entry = makeEntry()
+    registerDevServer(process.pid, entry, file)
+
+    const registry = JSON.parse(fs.readFileSync(file, 'utf8'))
+    expect(registry[String(deadPid)]).toBeUndefined()
+    expect(registry[String(process.pid)]).toEqual(entry)
+  })
+
+  it('unregisters an entry', () => {
+    const file = tmpRegistryFile()
+    registerDevServer(process.pid, makeEntry(), file)
+
+    unregisterDevServer(process.pid, file)
+
+    const registry = JSON.parse(fs.readFileSync(file, 'utf8'))
+    expect(registry).toEqual({})
+  })
+
+  it('recovers from a corrupt registry file', () => {
+    const file = tmpRegistryFile()
+    fs.writeFileSync(file, 'not json{')
+
+    const entry = makeEntry()
+    expect(() => registerDevServer(process.pid, entry, file)).not.toThrow()
+
+    const registry = JSON.parse(fs.readFileSync(file, 'utf8'))
+    expect(registry).toEqual({ [String(process.pid)]: entry })
+  })
+
+  it('unregister is a no-op when the file does not exist', () => {
+    const file = tmpRegistryFile()
+
+    expect(() => unregisterDevServer(process.pid, file)).not.toThrow()
+    expect(fs.existsSync(file)).toBe(false)
+  })
+
+  it('does nothing when NEXT_DISABLE_DEV_SERVER_REGISTRY is set', () => {
+    const file = tmpRegistryFile()
+    process.env.NEXT_DISABLE_DEV_SERVER_REGISTRY = '1'
+    try {
+      registerDevServer(process.pid, makeEntry(), file)
+      expect(fs.existsSync(file)).toBe(false)
+    } finally {
+      delete process.env.NEXT_DISABLE_DEV_SERVER_REGISTRY
+    }
+  })
+})


### PR DESCRIPTION
External tools (e.g. MCP clients) currently discover running dev servers by scanning common ports and sniffing the process table, which is fragile and misses non-default ports. `next dev` now registers itself in a machine-wide `dev-servers.json` (next to `dev-state.json` in the `nextjs-nodejs` cache directory) when the server is ready, and unregisters in the `exit` handler.

Entries are keyed by the server process pid with `projectDir`, `url`, `port`, and `startedAt`. Stale entries from processes that died without cleanup (e.g. SIGKILL) are dropped on rewrite via a pid liveness check; since pids can be recycled, readers must verify an entry by connecting to its `url` before relying on it. The child now includes the announced `appUrl` (`__NEXT_PRIVATE_ORIGIN`) in the `nextServerReady` IPC message so the parent records the exact origin instead of re-deriving it. Opt out with `NEXT_DISABLE_DEV_SERVER_REGISTRY=1`. Covered by `test/unit/dev-server-registry.test.ts`.

<!-- NEXT_JS_LLM_PR -->