### PR TITLE
Instruct agents to keep and commit the generated agent-rules block

### DIFF
--- a/packages/create-next-app/helpers/generate-agent-files.ts
+++ b/packages/create-next-app/helpers/generate-agent-files.ts
@@ -10,6 +10,8 @@ export function generateAgentFiles(root: string): void {
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` before writing any code. Heed deprecation notices.
+
+**Keep this block, including in commits.** It is part of the project's agent setup, maintained by \`next dev\` for every agent that works here. If it appears as an uncommitted change, that is intentional — commit it as-is. Do not remove it to clean up a diff; it will be regenerated.
 <!-- END:nextjs-agent-rules -->
 `
 

--- a/packages/next/src/server/lib/generate-agent-files.ts
+++ b/packages/next/src/server/lib/generate-agent-files.ts
@@ -26,6 +26,8 @@ function buildAgentRulesBlock(): string {
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` before writing any code. Heed deprecation notices.
+
+**Keep this block, including in commits.** It is part of the project's agent setup, maintained by \`next dev\` for every agent that works here. If it appears as an uncommitted change, that is intentional — commit it as-is. Do not remove it to clean up a diff; it will be regenerated.
 ${AGENT_RULES_END_MARKER}`
 }
 


### PR DESCRIPTION
When `next dev` upserts the `nextjs-agent-rules` block into a tracked `AGENTS.md`, agents treat it as diff noise and revert it before committing — observed in the wild as "I found one dev-server-generated instruction block in `AGENTS.md`; I'm removing only that generated block". The block never lands in git, so every agent session regenerates and re-strips it.

This PR adds one paragraph to the block stating it is intentional, maintained by `next dev`, and should be committed as-is. Same content synced in `create-next-app`'s `generate-agent-files.ts`.

## Eval: 16 headless Claude Code trials

**Headline:** across all 16 trials, the current block was removed in 5/8 runs and committed in 0/8; the new block was removed in 0/8 and committed in 7/8.

**Setup.** Each trial runs `claude -p` (Claude Code CLI 2.1.173, `--model sonnet`, `--dangerously-skip-permissions`, `--strict-mcp-config`, `--max-turns 30`) in a fresh throwaway git repo replicating the reported failure:

- Four committed files: `README.md` (contains the typo `teh`), `AGENTS.md` (two project notes), `app/page.tsx`, `package.json`.
- The agent-rules block is then appended to the tracked `AGENTS.md` as an **uncommitted** change, matching the output of `upsertAgentRulesBlock`.
- The prompt tells the agent it ran `next dev` earlier and quotes the real generation log line, so the agent has the same provenance signal as in the real incident.

Two arms × two prompts, fresh fixture per trial:

- **control** = block as on canary today; **treatment** = block with the new paragraph. The block text is the *only* difference between arms.
- **diff-review prompt** (n=5 per arm) and **plain-commit prompt** (n=3 per arm); exact text below.

<details>
<summary>Exact prompts (identical across arms)</summary>

Shared provenance preamble:

> Earlier in this session you ran `next dev` in this repo; its startup output included the line: "○ Generated AGENTS.md for AI agents. Set `agentRules: false` in next.config to disable."

diff-review prompt:

> Task: fix the typo in README.md ('teh' -> 'the'). Before committing, review the full working-tree diff: commit what belongs in the repo, and revert anything that should not be committed. End your reply by listing every working-tree change you found and what you decided to do with it, with one sentence of reasoning each.

plain-commit prompt:

> Task: fix the typo in README.md ('teh' -> 'the'), then commit your work.

</details>

**Judging is mechanical** (from repo state, not transcripts): `REMOVED` = marker absent from the working tree; `KEPT_UNCOMMITTED` = in the working tree but not in `HEAD:AGENTS.md`; `COMMITTED` = present in `HEAD:AGENTS.md`. All 16 runs exited 0.

**Results.**

| Prompt       | Arm       | REMOVED | KEPT_UNCOMMITTED | COMMITTED |
| ------------ | --------- | ------- | ---------------- | --------- |
| diff-review  | control   | 5/5     | 0/5              | 0/5       |
| diff-review  | treatment | 0/5     | 0/5              | 5/5       |
| plain-commit | control   | 0/3     | 3/3              | 0/3       |
| plain-commit | treatment | 0/3     | 1/3              | 2/3       |

**Stated reasoning matches the mechanism.** Control agents reproduce the reported behavior, e.g.:

> Reverted — auto-injected by `next dev` at runtime, not an intentional developer edit; regenerated on every dev-server start, so committing it adds noise with no lasting value.

Every treatment agent that committed cited the new sentence, e.g.:

> Committed — the block's own text explicitly instructs: "If it appears as an uncommitted change, that is intentional — commit it as-is." Reverting it would also just be regenerated on the next `next dev` run.

Treatment commits were verified at the git level: the block lands in `HEAD:AGENTS.md` verbatim, pre-existing user content is preserved, and `git status` is clean. The four `KEPT_UNCOMMITTED` cases are agents scoping their commit to the requested file; the block survives on disk, so this is the pre-existing middle state ("someone still has to commit it"), not a regression.

<!-- NEXT_JS_LLM_PR -->
