### PR TITLE
Treat empty resume bodies as dynamic render requests

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -376,7 +376,7 @@ export async function handler(
   }
 
   if (
-    !getRequestMeta(req, 'postponed') &&
+    typeof getRequestMeta(req, 'postponed') !== 'string' &&
     couldSupportPPR &&
     req.headers[NEXT_RESUME_HEADER] === '1' &&
     req.method === 'POST'
@@ -470,6 +470,7 @@ export async function handler(
   const minimalPostponed = isRoutePPREnabled
     ? getRequestMeta(req, 'postponed')
     : undefined
+  const hasPostponedState = typeof minimalPostponed === 'string'
 
   // If PPR is enabled, and this is a RSC request (but not a prefetch), then
   // we can use this fact to only generate the flight data for the request
@@ -486,11 +487,11 @@ export async function handler(
     // Only do this for routes that have a concrete prefetchDataRoute.
     !staticPrefetchDataRoute
 
-  // During a PPR revalidation, the RSC request is not dynamic if we do not have the postponed data.
-  // We only attach the postponed data during a resume. If there's no postponed data, then it must be a revalidation.
-  // This is to ensure that we don't bypass the cache during a revalidation.
+  // During a PPR revalidation, the RSC request is not dynamic if postponed
+  // metadata is absent. An empty string represents a resume request without
+  // postponed state, which should perform a full dynamic render.
   if (isMinimalMode) {
-    isDynamicRSCRequest = isDynamicRSCRequest && !!minimalPostponed
+    isDynamicRSCRequest = isDynamicRSCRequest && hasPostponedState
   }
 
   // Need to read this before it's stripped by stripFlightHeaders. We don't
@@ -546,7 +547,7 @@ export async function handler(
     !isSSG ||
     // If this request has provided postponed data, it supports dynamic
     // HTML.
-    typeof minimalPostponed === 'string' ||
+    hasPostponedState ||
     // If this handler supports onCacheEntryV2, then we can only support
     // dynamic responses if it's a dynamic RSC request and not in minimal mode. If it
     // doesn't support it we must fallback to the default behavior.
@@ -583,7 +584,7 @@ export async function handler(
     isSSG &&
     !supportsDynamicResponse &&
     !isPossibleServerAction &&
-    !minimalPostponed &&
+    !hasPostponedState &&
     !isDynamicRSCRequest
   ) {
     // For normal SSG routes we cache by the fully resolved pathname. For
@@ -1595,7 +1596,7 @@ export async function handler(
 
       // If this is a resume request in minimal mode it is streamed with dynamic
       // content and should not be cached.
-      if (minimalPostponed) {
+      if (hasPostponedState) {
         cacheControl = { revalidate: 0, expire: undefined }
       }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1131,7 +1131,7 @@ export default abstract class Server<
           // we should error, as it represents an unprocessable request.
           if (
             getRequestMeta(req, 'isNextDataReq') &&
-            getRequestMeta(req, 'postponed')
+            typeof getRequestMeta(req, 'postponed') === 'string'
           ) {
             // The server understood that this is a PPR resume request, as the
             // headers were included to correctly indicate a resume request, but
@@ -2266,6 +2266,7 @@ export default abstract class Server<
     const minimalPostponed = isRoutePPREnabled
       ? getRequestMeta(req, 'postponed')
       : undefined
+    const hasPostponedState = typeof minimalPostponed === 'string'
 
     // we need to ensure the status code if /404 is visited directly
     if (is404Page && !isNextDataRequest && !isRSCRequest) {
@@ -2282,7 +2283,7 @@ export default abstract class Server<
       // Server actions can use non-GET/HEAD methods.
       !isPossibleServerAction &&
       // Resume can use non-GET/HEAD methods.
-      !minimalPostponed &&
+      !hasPostponedState &&
       !is404Page &&
       !is500Page &&
       pathname !== '/_error' &&

--- a/test/production/app-dir/empty-resume/app/dynamic/[slug]/page.tsx
+++ b/test/production/app-dir/empty-resume/app/dynamic/[slug]/page.tsx
@@ -1,0 +1,16 @@
+import { connection } from 'next/server'
+
+export function generateStaticParams() {
+  return [{ slug: 'a' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  await connection()
+  const { slug } = await params
+
+  return <p id="slug">{slug}</p>
+}

--- a/test/production/app-dir/empty-resume/app/layout.tsx
+++ b/test/production/app-dir/empty-resume/app/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode, Suspense } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback="loading">{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/production/app-dir/empty-resume/empty-resume.test.ts
+++ b/test/production/app-dir/empty-resume/empty-resume.test.ts
@@ -1,0 +1,60 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createNowRouteMatches } from 'next-test-utils'
+
+describe('empty resume', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    // This test synthesizes an adapter invocation using private runtime
+    // switches; it does not exercise the deployed platform proxy.
+    skipDeployment: true,
+    env: {
+      NEXT_PRIVATE_TEST_HEADERS: '1',
+      NEXT_PRIVATE_MINIMAL_MODE: '1',
+    },
+  })
+
+  it('treats an empty Next-Resume body as a dynamic RSC request', async () => {
+    const slug = 'cold-rdc'
+    const response = await next.fetch(`/dynamic/${slug}`, {
+      method: 'POST',
+      headers: {
+        rsc: '1',
+        'next-resume': '1',
+        'next-router-state-tree': JSON.stringify(['', {}, null, 'refetch']),
+        // These headers emulate the platform routing a concrete pathname to
+        // the generated dynamic route entrypoint.
+        'x-matched-path': '/dynamic/[slug]',
+        'x-now-route-matches': createNowRouteMatches({ slug }).toString(),
+      },
+      // An empty postponed state represents a cold RDC lookup. Next.js
+      // should perform a full dynamic render instead of attempting a resume.
+      body: '',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/x-component')
+    expect(response.headers.get('cache-control')).toContain('no-store')
+    expect(await response.text()).toContain(slug)
+  })
+
+  it('treats an empty Next-Resume body as a full dynamic HTML render', async () => {
+    const slug = 'cold-html'
+    const response = await next.fetch(`/dynamic/${slug}`, {
+      method: 'POST',
+      headers: {
+        'next-resume': '1',
+        'x-matched-path': '/dynamic/[slug]',
+        'x-now-route-matches': createNowRouteMatches({ slug }).toString(),
+      },
+      body: '',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/html')
+    expect(response.headers.get('cache-control')).toContain('no-store')
+
+    const html = await response.text()
+    expect(html).toContain(slug)
+    expect(html).toContain('</html>')
+  })
+})

--- a/test/production/app-dir/empty-resume/empty-resume.test.ts
+++ b/test/production/app-dir/empty-resume/empty-resume.test.ts
@@ -15,7 +15,7 @@ describe('empty resume', () => {
 
   it('treats an empty Next-Resume body as a dynamic RSC request', async () => {
     const slug = 'cold-rdc'
-    const response = await next.fetch(`/dynamic/${slug}`, {
+    const response = await next.fetch(`/dynamic/${slug}.rsc`, {
       method: 'POST',
       headers: {
         rsc: '1',

--- a/test/production/app-dir/empty-resume/next.config.js
+++ b/test/production/app-dir/empty-resume/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Distinguish an absent postponed state from an empty one so cold RDC resume requests perform a full dynamic RSC render instead of being rejected or treated as revalidation.