### PR TITLE
Serve experimental service workers at `/service-worker.js`

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -596,6 +596,7 @@ export async function handleEntrypoints({
   currentEntrypoints.global.error = entrypoints.pagesErrorEndpoint
 
   currentEntrypoints.global.instrumentation = entrypoints.instrumentation
+  currentEntrypoints.global.serviceWorker = entrypoints.serviceWorker
 
   currentEntrypoints.page.clear()
   currentEntrypoints.app.clear()
@@ -780,6 +781,54 @@ export async function handleEntrypoints({
     )
     dev.serverFields.actualMiddlewareFile = undefined
     dev.serverFields.middleware = undefined
+  }
+
+  // Build the single-chunk service-worker bundle so it exists on disk and is
+  // served at /service-worker.js. In dev, we also subscribe to changes on the
+  // service-worker endpoint so editing the service-worker source rebuilds the
+  // bundle without restarting the dev server, and we push a full page reload so
+  // the browser re-fetches the worker and runs its install/activate lifecycle
+  // to pick up the change.
+  const { serviceWorker } = entrypoints
+  if (serviceWorker) {
+    const key = getEntryKey('root', 'server', 'service-worker')
+    const endpoint = serviceWorker.endpoint
+
+    async function processServiceWorker() {
+      const finishBuilding = dev.hooks.startBuilding(
+        'service-worker',
+        undefined,
+        true
+      )
+      const writtenEndpoint = await endpoint.writeToDisk()
+      dev.hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
+      processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
+      finishBuilding()
+    }
+    await processServiceWorker()
+
+    if (dev) {
+      dev.hooks.subscribeToChanges(
+        key,
+        /** includeIssues=*/ false,
+        endpoint,
+        async () => {
+          await processServiceWorker()
+          return {
+            type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
+            data: 'service-worker has changed',
+          }
+        },
+        (e) => {
+          return {
+            type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
+            data: `error in service-worker subscription: ${e}`,
+          }
+        }
+      )
+    }
+  } else {
+    currentEntryIssues.delete(getEntryKey('root', 'server', 'service-worker'))
   }
 
   await dev.hooks.propagateServerField(

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -536,6 +536,14 @@ export async function initialize(opts: {
             )
           }
         }
+
+        // A service worker must always be revalidated so the browser picks up updates.
+        if (
+          !res.getHeader('cache-control') &&
+          matchedOutput.type === 'serviceWorker'
+        ) {
+          res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        }
         if (!(req.method === 'GET' || req.method === 'HEAD')) {
           res.setHeader('Allow', ['GET', 'HEAD'])
           res.statusCode = 405

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -55,6 +55,7 @@ export type FsOutput = {
     | 'publicFolder'
     | 'nextStaticFolder'
     | 'legacyStaticFolder'
+    | 'serviceWorker'
     | 'devVirtualFsItem'
 
   itemPath: string
@@ -524,6 +525,28 @@ export async function setupFsCheck(opts: {
         }
       }
 
+      // Service worker (experimental.turbopackServiceWorkerPath): a single
+      // self-contained bundle served at the root-scoped URL "/service-worker.js".
+      // It is emitted to "<distDir>/service-worker.js" only when configured, so
+      // when the feature is off the file is absent and we fall through.
+      if (itemPath === '/service-worker.js') {
+        const swFsPath = path.join(distDir, 'service-worker.js')
+        const swExists = await fs
+          .access(swFsPath)
+          .then(() => true)
+          .catch(() => false)
+        if (swExists) {
+          // Dedicated "serviceWorker" output served at a root-scoped URL with
+          // no-cache headers (see router-server.ts) so the browser always
+          // revalidates and picks up service-worker updates.
+          return {
+            type: 'serviceWorker',
+            fsPath: swFsPath,
+            itemPath: swFsPath,
+          }
+        }
+      }
+
       const itemsToCheck: Array<[Set<string>, FsOutput['type']]> = [
         [this.devVirtualFsItems, 'devVirtualFsItem'],
         [nextStaticFolderItems, 'nextStaticFolder'],
@@ -652,6 +675,7 @@ export async function setupFsCheck(opts: {
             case 'appFile':
             case 'pageFile':
             case 'nextImage':
+            case 'serviceWorker':
             case 'devVirtualFsItem': {
               break
             }


### PR DESCRIPTION
This PR takes the service worker built in https://github.com/vercel/next.js/pull/94730 and then serves it at `/service-worker.js` so it can be registered by the app, eg.:

```javascript
wait navigator.serviceWorker.register('/service-worker.js', {
  // ...
})
```