### PR TITLE
router instrumentation: add transition settlement events (7/7)

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit, route mismatch, and abort hooks:
+The complete router transition lifecycle is experimental. Enable it to receive the third `event` argument and the `unstable_` commit, settled, mismatch, and abort hooks:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -68,13 +68,14 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-Then export the optional commit hook:
+Then export any of the optional `unstable_` lifecycle hooks:
 
 ```ts filename="instrumentation-client.ts" switcher
 import type {
   RouterTransitionAbortEvent,
   RouterTransitionCommitEvent,
   RouterTransitionRouteMismatchEvent,
+  RouterTransitionSettledEvent,
   RouterTransitionStartEvent,
   RouterTransitionType,
 } from 'next'
@@ -98,7 +99,18 @@ export function unstable_onRouterTransitionCommit(
   const start = starts.get(event.id)
   if (start !== undefined) {
     console.log('Time to navigation commit:', event.timestamp - start)
-    starts.delete(event.id)
+  }
+}
+
+export function unstable_onRouterTransitionSettled(
+  url: string,
+  navigationType: RouterTransitionType,
+  { id, timestamp }: RouterTransitionSettledEvent
+) {
+  const start = starts.get(id)
+  if (start !== undefined) {
+    console.log('Time to navigation settled:', timestamp - start)
+    starts.delete(id)
   }
 }
 
@@ -131,6 +143,13 @@ export function unstable_onRouterTransitionCommit(url, navigationType, event) {
   const start = starts.get(event.id)
   if (start !== undefined) {
     console.log('Time to navigation commit:', event.timestamp - start)
+  }
+}
+
+export function unstable_onRouterTransitionSettled(url, navigationType, event) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation settled:', event.timestamp - start)
     starts.delete(event.id)
   }
 }
@@ -156,14 +175,15 @@ Each hook receives the same three parameters:
 
 The available hooks are:
 
-| Hook                                       | Timing                                                                   |
-| ------------------------------------------ | ------------------------------------------------------------------------ |
-| `onRouterTransitionStart`                  | The navigation is dispatched.                                            |
-| `unstable_onRouterTransitionCommit`        | The first destination UI and URL commit.                                 |
-| `unstable_onRouterTransitionRouteMismatch` | The live route tree differs from the prefetched or predicted route tree. |
-| `unstable_onRouterTransitionAbort`         | The transition stops before completion.                                  |
+| Hook                                       | Timing                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `onRouterTransitionStart`                  | The navigation is dispatched.                                             |
+| `unstable_onRouterTransitionCommit`        | The first destination UI and URL commit.                                  |
+| `unstable_onRouterTransitionSettled`       | All router-owned response streams and retries finish.                     |
+| `unstable_onRouterTransitionRouteMismatch` | The live route tree differs from the prefetched or predicted route tree.  |
+| `unstable_onRouterTransitionAbort`         | The transition is superseded, falls back to a hard navigation, or errors. |
 
-`unstable_onRouterTransitionRouteMismatch` is diagnostic and non-terminal. It indicates that Next.js detected a different route tree and retried the navigation.
+`unstable_onRouterTransitionRouteMismatch` is diagnostic and non-terminal. It indicates that Next.js detected a different route tree and retried the navigation. The same transition will later settle or abort.
 
 The start event also includes:
 
@@ -177,7 +197,7 @@ The commit event also includes:
 
 Route entries use filesystem-style patterns, so `/blog/hello` may report `/blog/[slug]`.
 
-`unstable_onRouterTransitionAbort` receives a `reason` of `superseded`, `hard-navigation`, or `error`. Hook errors are isolated and do not affect navigation or other hooks.
+`unstable_onRouterTransitionAbort` receives a `reason` of `superseded`, `hard-navigation`, or `error`. Every started transition ends with either `unstable_onRouterTransitionSettled` or `unstable_onRouterTransitionAbort`. Hook errors are isolated and do not affect navigation or other hooks.
 
 ## Performance considerations
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/instrumentationClientInject.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/instrumentationClientInject.mdx
@@ -5,7 +5,7 @@ description: Inject additional client-side instrumentation modules before the us
 
 `instrumentationClientInject` is a list of modules that are imported on the client for their side effects before the user's [`instrumentation-client.{js,ts}`](/docs/app/api-reference/file-conventions/instrumentation-client) file runs, ahead of React hydration.
 
-This option is primarily intended for **`next.config.js` plugins** (for example, wrappers like `withSentry` or `withAnalytics` that extend a project's config). It lets such a plugin inject its own client instrumentation module — including a navigation hook — without requiring every project to author or modify an `instrumentation-client` file. Application code should generally continue to use the [`instrumentation-client.{js,ts}`](/docs/app/api-reference/file-conventions/instrumentation-client) file convention directly.
+This option is primarily intended for **`next.config.js` plugins** (for example, wrappers like `withSentry` or `withAnalytics` that extend a project's config). It lets such a plugin inject its own client instrumentation module, including navigation hooks, without requiring every project to author or modify an `instrumentation-client` file. Application code should generally continue to use the [`instrumentation-client.{js,ts}`](/docs/app/api-reference/file-conventions/instrumentation-client) file convention directly.
 
 A plugin typically appends its own module to whatever the project already has configured:
 
@@ -48,7 +48,9 @@ Modules run on the client in this order:
 
 ## Router navigation hook
 
-Each injected module may optionally export an `onRouterTransitionStart` function with the same signature as the one documented for the [`instrumentation-client` file convention](/docs/app/api-reference/file-conventions/instrumentation-client#router-navigation-tracking). Next.js composes a single hook that fans out to every exported `onRouterTransitionStart` on each navigation, calling them in array order, with the user file's hook running last.
+Each injected module may optionally export any of the router transition hooks documented for the [`instrumentation-client` file convention](/docs/app/api-reference/file-conventions/instrumentation-client#router-navigation-tracking). Next.js composes each hook across injected modules in array order, with the user file's hook running last.
+
+The `onRouterTransitionStart(url, navigationType)` hook is available by default. The third event argument and remaining `unstable_` lifecycle hooks require `experimental.instrumentationClientRouterTransitionEvents`.
 
 ```js filename="lib/sentry-client.js"
 // Side-effectful setup runs at load time.
@@ -57,9 +59,13 @@ setupSentry()
 export function onRouterTransitionStart(url, navigationType) {
   recordNavigationBreadcrumb(url, navigationType)
 }
+
+export function unstable_onRouterTransitionCommit(url, navigationType, event) {
+  recordNavigationCommit(url, navigationType, event)
+}
 ```
 
-Modules that do not export `onRouterTransitionStart` are skipped during navigation.
+Modules that do not export a particular hook are skipped when that hook fires. Errors thrown by one module do not prevent later modules from running.
 
 ## Version history
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -66,6 +66,7 @@ export interface FetchServerResponseOptions {
   readonly flightRouterState: FlightRouterState
   readonly nextUrl: string | null
   readonly isHmrRefresh?: boolean
+  readonly onResponseEnd?: () => void
 }
 
 export type StaticStageData<
@@ -141,6 +142,14 @@ export async function fetchServerResponse(
   options: FetchServerResponseOptions
 ): Promise<FetchServerResponseResult> {
   const { flightRouterState, nextUrl } = options
+  const onResponseEnd = options.onResponseEnd
+  let responseEndNotified = false
+  const notifyResponseEnd = () => {
+    if (!responseEndNotified) {
+      responseEndNotified = true
+      onResponseEnd?.()
+    }
+  }
 
   const headers: RequestHeaders = {
     // Enable flight response
@@ -189,8 +198,13 @@ export async function fetchServerResponse(
       url,
       headers,
       'auto',
-      shouldImmediatelyDecode
+      shouldImmediatelyDecode,
+      undefined,
+      onResponseEnd !== undefined
     )
+    if (onResponseEnd !== undefined) {
+      res.responseEnd.then(notifyResponseEnd, notifyResponseEnd)
+    }
 
     // If the fetch succeeds while we're in the offline state, notify the
     // offline module so it can short-circuit the polling loop.
@@ -325,6 +339,7 @@ export async function fetchServerResponse(
       }
     }
 
+    notifyResponseEnd()
     if (!isPageUnloading) {
       console.error(
         `Failed to fetch RSC payload for ${originalUrl}. Falling back to browser navigation.`,
@@ -353,6 +368,7 @@ export type RSCResponse<T> = {
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
   cacheData: Promise<FetchResponseCacheData | null>
+  responseEnd: Promise<void>
 }
 
 type FetchResponseCacheData = {
@@ -377,20 +393,97 @@ type FetchResponseCacheData = {
  * When cache components is disabled, returns the original response with
  * cacheData: null.
  */
-export async function processFetch(response: Response): Promise<{
+function trackReadableStream(stream: ReadableStream<Uint8Array<ArrayBuffer>>): {
+  stream: ReadableStream<Uint8Array<ArrayBuffer>>
+  responseEnd: Promise<void>
+} {
+  const reader = stream.getReader()
+  let resolveResponseEnd!: () => void
+  const responseEnd = new Promise<void>((resolve) => {
+    resolveResponseEnd = resolve
+  })
+  let finished = false
+  const finish = () => {
+    if (!finished) {
+      finished = true
+      resolveResponseEnd()
+    }
+  }
+
+  return {
+    stream: new ReadableStream<Uint8Array<ArrayBuffer>>({
+      async pull(controller) {
+        try {
+          const result = await reader.read()
+          if (result.done) {
+            finish()
+            controller.close()
+          } else {
+            controller.enqueue(result.value)
+          }
+        } catch (error) {
+          finish()
+          controller.error(error)
+        }
+      },
+      cancel(reason) {
+        finish()
+        return reader.cancel(reason)
+      },
+    }),
+    responseEnd,
+  }
+}
+
+function cloneResponseWithBody(
+  response: Response,
+  body: ReadableStream<Uint8Array>
+): Response {
+  const clonedResponse = new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
+  Object.defineProperty(clonedResponse, 'url', { value: response.url })
+  Object.defineProperty(clonedResponse, 'redirected', {
+    value: response.redirected,
+  })
+  return clonedResponse
+}
+
+export async function processFetch(
+  response: Response,
+  trackResponseEnd: boolean = false
+): Promise<{
   response: Response
   cacheData: FetchResponseCacheData | null
+  responseEnd: Promise<void>
 }> {
-  if (process.env.__NEXT_CACHE_COMPONENTS) {
-    if (!response.body) {
+  if (!response.body) {
+    if (process.env.__NEXT_CACHE_COMPONENTS) {
       throw new InvariantError(
         'Expected RSC navigation response to have a body'
       )
     }
+    return {
+      response,
+      cacheData: null,
+      responseEnd: Promise.resolve(),
+    }
+  }
 
-    const { stream, isPartial } = await stripIsPartialByte(response.body)
+  let responseStream = response.body
+  let responseEnd = Promise.resolve()
+  if (trackResponseEnd) {
+    const tracked = trackReadableStream(responseStream)
+    responseStream = tracked.stream
+    responseEnd = tracked.responseEnd
+  }
 
-    let responseStream: ReadableStream<Uint8Array>
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    const { stream, isPartial } = await stripIsPartialByte(responseStream)
+
+    let flightResponseStream: ReadableStream<Uint8Array>
     let cacheData: FetchResponseCacheData
 
     if (process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS) {
@@ -398,35 +491,37 @@ export async function processFetch(response: Response): Promise<{
       // extractor, and the shell-stage extractor. Tee twice.
       const [stream1, rest] = stream.tee()
       const [staticBodyClone, shellBodyClone] = rest.tee()
-      responseStream = stream1
+      flightResponseStream = stream1
       cacheData = {
         isResponsePartial: isPartial,
         staticBodyClone,
         shellBodyClone,
       }
     } else {
-      responseStream = stream
+      flightResponseStream = stream
       cacheData = { isResponsePartial: isPartial }
     }
 
-    const strippedResponse = new Response(responseStream, {
-      headers: response.headers,
-      status: response.status,
-      statusText: response.statusText,
-    })
-
-    // The Response constructor doesn't preserve `url` or `redirected` from
-    // the original. We need both: `url` for React DevTools and `redirected`
-    // for the redirect replay logic below.
-    Object.defineProperty(strippedResponse, 'url', { value: response.url })
-    Object.defineProperty(strippedResponse, 'redirected', {
-      value: response.redirected,
-    })
-
-    return { response: strippedResponse, cacheData }
+    return {
+      response: cloneResponseWithBody(response, flightResponseStream),
+      cacheData,
+      responseEnd,
+    }
   }
 
-  return { response, cacheData: null }
+  if (!trackResponseEnd) {
+    return {
+      response,
+      cacheData: null,
+      responseEnd,
+    }
+  }
+
+  return {
+    response: cloneResponseWithBody(response, responseStream),
+    cacheData: null,
+    responseEnd,
+  }
 }
 
 /**
@@ -544,7 +639,8 @@ export async function createFetch<T>(
   headers: RequestHeaders,
   fetchPriority: 'auto' | 'high' | 'low' | null,
   shouldImmediatelyDecode: boolean,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  trackResponseEnd: boolean = false
 ): Promise<RSCResponse<T>> {
   // TODO: In output: "export" mode, the headers do nothing. Omit them (and the
   // cache busting search param) from the request so they're
@@ -584,7 +680,10 @@ export async function createFetch<T>(
   // track them separately.
   let fetchUrl = new URL(url)
   await setCacheBustingSearchParam(fetchUrl, headers)
-  let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  let processed = fetch(fetchUrl, fetchOptions).then((response) =>
+    processFetch(response, trackResponseEnd)
+  )
+  const responseEnds = [processed.then(({ responseEnd }) => responseEnd)]
   let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
@@ -654,7 +753,10 @@ export async function createFetch<T>(
       // TODO: We should abort the previous request.
       fetchUrl = new URL(responseUrl)
       await setCacheBustingSearchParam(fetchUrl, headers)
-      processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+      processed = fetch(fetchUrl, fetchOptions).then((response) =>
+        processFetch(response, trackResponseEnd)
+      )
+      responseEnds.push(processed.then(({ responseEnd }) => responseEnd))
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
         ? createFromNextFetch<T>(fetchPromise, headers)
@@ -693,6 +795,7 @@ export async function createFetch<T>(
     flightResponsePromise: flightResponsePromise,
 
     cacheData: processed.then(({ cacheData }) => cacheData),
+    responseEnd: Promise.all(responseEnds).then(() => {}),
   }
 
   return rscResponse

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -44,7 +44,10 @@ import { FetchStrategy } from '../segment-cache/types'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
-import { routeMismatchRouterTransition } from '../router-transition'
+import {
+  beginRouterTransitionRequest,
+  routeMismatchRouterTransition,
+} from '../router-transition'
 import {
   getRenderedSearchFromVaryPath,
   type PageVaryPath,
@@ -125,6 +128,7 @@ const enum NavigationTaskExitStatus {
 
 export type NavigationRequestAccumulation = {
   separateRefreshUrls: Set<string> | null
+  prefetchedResponseEnds: Set<Promise<void>> | null
   /**
    * Set when a navigation creates new leaf segments that should be
    * scrolled to. Stays null when no new segments are created (e.g.
@@ -137,6 +141,17 @@ export type NavigationLock = Promise<void> | null
 
 const noop = () => {}
 
+function accumulatePrefetchedResponseEnd(
+  accumulation: NavigationRequestAccumulation,
+  responseEnd: Promise<void>
+): void {
+  let responseEnds = accumulation.prefetchedResponseEnds
+  if (responseEnds === null) {
+    responseEnds = accumulation.prefetchedResponseEnds = new Set()
+  }
+  responseEnds.add(responseEnd)
+}
+
 export function createInitialCacheNodeForHydration(
   navigatedAt: number,
   initialTree: RouteTree,
@@ -148,6 +163,7 @@ export function createInitialCacheNodeForHydration(
   // HTML document.
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
+    prefetchedResponseEnds: null,
     scrollRef: null,
   }
   const task = createCacheNodeOnNavigation(
@@ -377,7 +393,8 @@ function updateCacheNodeOnNavigation(
       // route hasn't changed. Otherwise (no prior node) mint a fresh one.
       oldCacheNode !== undefined
         ? oldCacheNode.bfcacheId
-        : generateBFCacheId(freshness)
+        : generateBFCacheId(freshness),
+      accumulation
     )
     newCacheNode = result.cacheNode
     needsDynamicRequest = result.needsDynamicRequest
@@ -661,7 +678,8 @@ function createCacheNodeOnNavigation(
     seedDynamicStaleAt,
     // This segment was not part of the previous route, so mint a fresh
     // bfcacheId.
-    generateBFCacheId(freshness)
+    generateBFCacheId(freshness),
+    accumulation
   )
   const newCacheNode = result.cacheNode
   const needsDynamicRequest = result.needsDynamicRequest
@@ -924,7 +942,8 @@ function createCacheNodeForSegment(
   seedHead: HeadData | null,
   freshness: FreshnessPolicy,
   dynamicStaleAt: number,
-  bfcacheId: number
+  bfcacheId: number,
+  accumulation: NavigationRequestAccumulation
 ): { cacheNode: CacheNode; needsDynamicRequest: boolean } {
   // Construct a new CacheNode using data from the BFCache, the client's
   // Segment Cache, or seeded from a server response.
@@ -1072,6 +1091,9 @@ function createCacheNodeForSegment(
 
   const segmentEntry = readSegmentCacheEntryForNavigation(now, tree.varyPath)
   if (segmentEntry !== null) {
+    if (!segmentEntry.isPartial) {
+      accumulatePrefetchedResponseEnd(accumulation, segmentEntry.responseEnd)
+    }
     switch (segmentEntry.status) {
       case EntryStatus.Fulfilled: {
         // Happy path: a cache hit
@@ -1178,6 +1200,12 @@ function createCacheNodeForSegment(
         metadataVaryPath
       )
       if (metadataEntry !== null) {
+        if (!metadataEntry.isPartial) {
+          accumulatePrefetchedResponseEnd(
+            accumulation,
+            metadataEntry.responseEnd
+          )
+        }
         switch (metadataEntry.status) {
           case EntryStatus.Fulfilled: {
             cachedHead = metadataEntry.rsc
@@ -1352,6 +1380,22 @@ function compareSegments(
 // mismatches, we will fall back to an MPA navigation, to prevent a retry loop.
 let previousNavigationDidMismatch = false
 
+export function trackPrefetchedResponseEnds(
+  accumulation: NavigationRequestAccumulation,
+  transitionId: string | null
+): void {
+  const responseEnds = accumulation.prefetchedResponseEnds
+  if (responseEnds === null) {
+    return
+  }
+  for (const responseEnd of responseEnds) {
+    const finishRequest = beginRouterTransitionRequest(transitionId)
+    if (finishRequest !== undefined) {
+      responseEnd.then(finishRequest, finishRequest)
+    }
+  }
+}
+
 // Writes a dynamic server response into the tree created by
 // updateCacheNodeOnNavigation. All pending promises that were spawned by the
 // navigation will be resolved, either with dynamic data from the server, or
@@ -1408,7 +1452,8 @@ export function spawnDynamicRequests(
     nextUrl,
     freshnessPolicy,
     routeCacheEntry,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 
   const separateRefreshUrls = accumulation.separateRefreshUrls
@@ -1461,7 +1506,8 @@ export function spawnDynamicRequests(
             nextUrl,
             freshnessPolicy,
             routeCacheEntry,
-            navigationLock
+            navigationLock,
+            transitionId
           )
         )
       }
@@ -1688,17 +1734,20 @@ async function fetchMissingDynamicData(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
   url: URL
   seed: NavigationSeed | null
 }> {
   try {
+    const finishRequest = beginRouterTransitionRequest(transitionId)
     const result = await fetchServerResponse(url, {
       flightRouterState: dynamicRequestTree,
       nextUrl,
       isHmrRefresh: freshnessPolicy === FreshnessPolicy.HMRRefresh,
+      onResponseEnd: finishRequest,
     })
     if (typeof result === 'string') {
       // fetchServerResponse will return an href to indicate that the SPA

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -9,6 +9,7 @@ import {
   getCurrentNavigationLock,
   spawnDynamicRequests,
   startPPRNavigation,
+  trackPrefetchedResponseEnds,
   type NavigationRequestAccumulation,
 } from '../ppr-navigations'
 import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
@@ -52,6 +53,7 @@ export function restoreReducer(
   // during restores and refreshes.
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
+    prefetchedResponseEnds: null,
     scrollRef: null,
   }
   const restoreSeed = convertServerPatchToFullTree(
@@ -80,6 +82,7 @@ export function restoreReducer(
   if (task === null) {
     return completeHardNavigation(state, restoredUrl, 'replace', transitionId)
   }
+  trackPrefetchedResponseEnds(accumulation, transitionId)
   spawnDynamicRequests(
     task,
     restoredUrl,

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -21,6 +21,7 @@ type RouterTransitionRecord = {
   resolvedUrl: string
   type: RouterTransitionType
   prefetch: RouterTransitionPrefetch
+  pendingRequests: number
   committed: boolean
   routeMismatchEmitted: boolean
 }
@@ -42,6 +43,7 @@ export function initializeRouterTransitionModules(
     instrumentationModules.some(
       (hooks) =>
         typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+        typeof hooks.unstable_onRouterTransitionSettled === 'function' ||
         typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
         typeof hooks.unstable_onRouterTransitionAbort === 'function'
     )
@@ -75,6 +77,7 @@ function hasLifecycleInstrumentation(): boolean {
     (hooks) =>
       typeof hooks.onRouterTransitionStart === 'function' ||
       typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+      typeof hooks.unstable_onRouterTransitionSettled === 'function' ||
       typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
       typeof hooks.unstable_onRouterTransitionAbort === 'function'
   )
@@ -100,11 +103,7 @@ export function startRouterTransition(
   }
 
   if (activeTransition !== null) {
-    if (activeTransition.committed) {
-      activeTransition = null
-    } else {
-      abortRouterTransition(activeTransition.id, 'superseded')
-    }
+    abortRouterTransition(activeTransition.id, 'superseded')
   }
 
   const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
@@ -113,6 +112,7 @@ export function startRouterTransition(
     resolvedUrl: url,
     type,
     prefetch: 'none',
+    pendingRequests: 0,
     committed: false,
     routeMismatchEmitted: false,
   }
@@ -143,6 +143,31 @@ export function setRouterTransitionPrefetch(
   }
 }
 
+export function beginRouterTransitionRequest(
+  id: string | null
+): (() => void) | undefined {
+  const record = getActiveTransition(id)
+  if (record === null) {
+    return undefined
+  }
+
+  record.pendingRequests++
+  const transitionId = record.id
+  let finished = false
+  return () => {
+    if (finished) {
+      return
+    }
+    finished = true
+    const current = getActiveTransition(transitionId)
+    if (current === null) {
+      return
+    }
+    current.pendingRequests--
+    scheduleSettle(current)
+  }
+}
+
 export function commitRouterTransition(
   id: string | null,
   url: string,
@@ -163,6 +188,7 @@ export function commitRouterTransition(
       prefetch: record.prefetch,
     })
   )
+  scheduleSettle(record)
 }
 
 export function routeMismatchRouterTransition(
@@ -203,6 +229,35 @@ export function abortRouterTransition(
       reason,
     })
   )
+}
+
+function scheduleSettle(record: RouterTransitionRecord): void {
+  if (!record.committed || record.pendingRequests !== 0) {
+    return
+  }
+
+  setTimeout(() => {
+    const current = getActiveTransition(record.id)
+    if (
+      current === null ||
+      !current.committed ||
+      current.pendingRequests !== 0
+    ) {
+      return
+    }
+
+    activeTransition = null
+    callHooks((hooks) =>
+      hooks.unstable_onRouterTransitionSettled?.(
+        current.resolvedUrl,
+        current.type,
+        {
+          id: current.id,
+          timestamp: timestamp(),
+        }
+      )
+    )
+  }, 0)
 }
 
 function classifySegment(segment: Segment): {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -235,6 +235,7 @@ export type RouteCacheEntry =
 
 type SegmentCacheEntryShared = {
   fetchStrategy: FetchStrategy
+  responseEnd: Promise<void>
 
   // Map-related fields.
   ref: UnknownMapEntry | null
@@ -311,6 +312,7 @@ export const MetadataOnlyRequestTree: FlightRouterState = [
 
 let routeCacheMap: CacheMap<RouteCacheEntry> = createCacheMap()
 let segmentCacheMap: CacheMap<SegmentCacheEntry> = createCacheMap()
+const resolvedResponseEnd = Promise.resolve()
 
 // All invalidation listeners for the whole cache are tracked in single set.
 // Since we don't yet support tag or path-based invalidation, there's no point
@@ -958,6 +960,7 @@ export function createDetachedSegmentCacheEntry(
     rsc: null,
     isPartial: true,
     promise: null,
+    responseEnd: resolvedResponseEnd,
 
     // Map-related fields
     ref: null,
@@ -2161,6 +2164,12 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
   const key = task.key
   const url = new URL(route.canonicalUrl, location.origin)
   const nextUrl = key.nextUrl
+  const responseEnd = createPromiseWithResolvers<void>()
+  if (fetchStrategy === FetchStrategy.Full) {
+    for (const entry of spawnedEntries.values()) {
+      entry.responseEnd = responseEnd.promise
+    }
+  }
 
   if (
     spawnedEntries.size === 1 &&
@@ -2212,6 +2221,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      responseEnd.resolve()
       return null
     }
 
@@ -2225,14 +2235,13 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // the proper way to handle this is to evict the stale route tree entry
       // then fill the cache with the new response.
       rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      responseEnd.resolve()
       return null
     }
 
     // Track when the network connection closes. Only meaningful for Full
     // (dynamic) prefetches which use incremental streaming. For buffered
     // paths, this is resolved immediately — see TODO in fetchRouteOnCacheMiss.
-    const closed = createPromiseWithResolvers<void>()
-
     let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null = null
     let prefetchStream: ReadableStream<Uint8Array>
     let bufferedResponseSize: number | null = null
@@ -2243,7 +2252,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // processed as it arrives.
       prefetchStream = createIncrementalPrefetchResponseStream(
         response.body,
-        closed.resolve,
+        responseEnd.resolve,
         function onResponseSizeUpdate(totalBytesReceivedSoFar) {
           // When processing a dynamic response, we don't know how large each
           // individual segment is, so approximate by assigning each segment
@@ -2263,7 +2272,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       const { stream, size } = await createNonTaskyPrefetchResponseStream(
         response.body
       )
-      closed.resolve()
+      responseEnd.resolve()
       prefetchStream = stream
       bufferedResponseSize = size
     }
@@ -2395,6 +2404,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     )
     if (typeof flightDatas === 'string') {
       rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      responseEnd.resolve()
       return null
     }
     const navigationSeed = convertServerPatchToFullTree(
@@ -2419,6 +2429,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       navigationSeed,
       spawnedEntries
     )
+    if (fetchStrategy === FetchStrategy.Full && fulfilledEntries !== null) {
+      for (const entry of fulfilledEntries) {
+        entry.responseEnd = responseEnd.promise
+      }
+    }
 
     // For buffered responses, update LRU sizes now that we know which
     // entries were fulfilled.
@@ -2435,7 +2450,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
 
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
-    return { value: null, closed: closed.promise }
+    return { value: null, closed: responseEnd.promise }
   } catch (error) {
     if (process.env.__NEXT_USE_OFFLINE) {
       const { checkOfflineError } =
@@ -2446,10 +2461,12 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
         // immediate expiration so it gets retried once the scheduler is
         // re-pinged after connectivity is restored.
         rejectSegmentEntriesIfStillPending(spawnedEntries, -1)
+        responseEnd.resolve()
         return null
       }
     }
     rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+    responseEnd.resolve()
     return null
   }
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -16,6 +16,7 @@ import { fetchServerResponse } from '../router-reducer/fetch-server-response'
 import {
   startPPRNavigation,
   spawnDynamicRequests,
+  trackPrefetchedResponseEnds,
   FreshnessPolicy,
   getCurrentNavigationLock,
   type NavigationLock,
@@ -48,6 +49,7 @@ import { isJavaScriptURLString } from '../../lib/javascript-url'
 import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
 import {
   abortRouterTransition,
+  beginRouterTransitionRequest,
   setRouterTransitionPrefetch,
 } from '../router-transition'
 
@@ -304,6 +306,7 @@ export function navigateToKnownRoute(
   }
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
+    prefetchedResponseEnds: null,
     scrollRef: null,
   }
   // We special case navigations to the exact same URL as the current location.
@@ -341,6 +344,7 @@ export function navigateToKnownRoute(
     accumulation
   )
   if (task !== null) {
+    trackPrefetchedResponseEnds(accumulation, transitionId)
     setRouterTransitionPrefetch(
       transitionId,
       task.dynamicRequestTree === null ? 'hit-route' : 'hit-shell'
@@ -483,9 +487,11 @@ async function navigateToUnknownRoute(
   }
 
   setRouterTransitionPrefetch(transitionId, 'miss')
+  const finishRequest = beginRouterTransitionRequest(transitionId)
   const promiseForDynamicServerResponse = fetchServerResponse(url, {
     flightRouterState: dynamicRequestTree,
     nextUrl,
+    onResponseEnd: finishRequest,
   })
   const result = await promiseForDynamicServerResponse
   if (typeof result === 'string') {

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -23,6 +23,8 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   prefetch: RouterTransitionPrefetch
 }
 
+export type RouterTransitionSettledEvent = RouterTransitionEvent
+
 export type RouterTransitionRouteMismatchEvent = RouterTransitionEvent
 
 export type RouterTransitionAbortEvent = RouterTransitionEvent & {
@@ -39,6 +41,11 @@ export type ClientInstrumentationHooks = {
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionCommitEvent
+  ) => void
+  unstable_onRouterTransitionSettled?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionSettledEvent
   ) => void
   unstable_onRouterTransitionRouteMismatch?: (
     url: string,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,6 +50,7 @@ export type {
   RouterTransitionEvent,
   RouterTransitionStartEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionSettledEvent,
   RouterTransitionRouteMismatchEvent,
   RouterTransitionAbortEvent,
 } from './client/router-transition-types'

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/instrumentation-client.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/instrumentation-client.ts
@@ -1,0 +1,41 @@
+type TransitionEvent = {
+  id: string
+  timestamp: number
+  fromRoutes?: string[]
+  routes?: string[]
+  prefetch?: string
+  prefetchIntent?: string
+}
+
+function record(phase: string, url: string, event: TransitionEvent) {
+  const events = ((window as any).__ROUTER_TRANSITION_EVENTS ??= [])
+  events.push({
+    phase,
+    url: new URL(url, window.location.href).pathname,
+    event,
+  })
+}
+
+export function onRouterTransitionStart(
+  url: string,
+  _navigationType: string,
+  event: TransitionEvent
+) {
+  record('start', url, event)
+}
+
+export function unstable_onRouterTransitionCommit(
+  url: string,
+  _navigationType: string,
+  event: TransitionEvent
+) {
+  record('commit', url, event)
+}
+
+export function unstable_onRouterTransitionSettled(
+  url: string,
+  _navigationType: string,
+  event: TransitionEvent
+) {
+  record('settled', url, event)
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
     cachedNavigations: true,
     appShells: true,
     varyParams: true,
+    instrumentationClientRouterTransitionEvents: true,
   },
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
+import { retry } from 'next-test-utils'
 
 // This suite asserts directly on App Shell prefetch responses, so every
 // `createRouterAct` call passes `{ includeAppShellRequests: true }`. By default
@@ -64,6 +65,68 @@ describe('App Shell prefetching', () => {
     expect(await browser.elementById('dynamic-content').text()).toEqual(
       'Post body for 124'
     )
+  })
+
+  it('reports an App Shell navigation as a shell prefetch hit', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/posts/1"]')
+          .click()
+      },
+      { includes: 'App shell for posts' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/posts/124"]').click()
+      expect(await browser.elementById('shell').text()).toEqual(
+        'App shell for posts'
+      )
+
+      const events = await browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
+      expect(events.map((event) => event.phase)).toEqual(['start', 'commit'])
+      expect(events[0]).toMatchObject({
+        phase: 'start',
+        url: '/posts/124',
+        event: {
+          fromRoutes: ['/'],
+          prefetchIntent: 'none',
+        },
+      })
+      expect(events[1]).toMatchObject({
+        phase: 'commit',
+        url: '/posts/124',
+        event: {
+          routes: ['/posts/[id]'],
+          prefetch: 'hit-shell',
+        },
+      })
+      expect(events[1].event.id).toBe(events[0].event.id)
+      expect(events[1].event.timestamp).toBeGreaterThanOrEqual(
+        events[0].event.timestamp
+      )
+    })
+
+    await retry(async () => {
+      const events = await browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
+      expect(events.map((event) => event.phase)).toEqual([
+        'start',
+        'commit',
+        'settled',
+      ])
+      expect(events[2].event.id).toBe(events[0].event.id)
+      expect(events[2].event.timestamp).toBeGreaterThanOrEqual(
+        events[1].event.timestamp
+      )
+    })
   })
 
   it('skips the per-link Speculative prefetch for a non-eager (allow-runtime) route', async () => {

--- a/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
@@ -1,7 +1,19 @@
 import { connection } from 'next/server'
+import { Suspense } from 'react'
 
-export default async function Page() {
+async function SlowContent() {
   await connection()
   await new Promise((resolve) => setTimeout(resolve, 500))
-  return <h1 id="slow-page">Slow page</h1>
+  return <p id="slow-content">Slow content</p>
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="slow-shell">Slow page</h1>
+      <Suspense fallback={<p id="slow-fallback">Loading</p>}>
+        <SlowContent />
+      </Suspense>
+    </>
+  )
 }

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -38,6 +38,14 @@ export function unstable_onRouterTransitionCommit(
   record('commit', href, navigateType, event)
 }
 
+export function unstable_onRouterTransitionSettled(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('settled', href, navigateType, event)
+}
+
 export function unstable_onRouterTransitionRouteMismatch(
   href: string,
   navigateType: string,

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -149,10 +149,10 @@ describe('Instrumentation Client Hook', () => {
       await retry(async () => {
         expect(
           (await getTransitionEvents(browser)).map((event) => event.phase)
-        ).toEqual(['start', 'commit'])
+        ).toEqual(['start', 'commit', 'settled'])
       })
 
-      const [start, commit] = await getTransitionEvents(browser)
+      const [start, commit, settled] = await getTransitionEvents(browser)
       expect(start.url).toBe('/some-page')
       expect(start.navigateType).toBe('push')
       expect(typeof start.event.id).toBe('string')
@@ -168,8 +168,12 @@ describe('Instrumentation Client Hook', () => {
         )
       }
       expect(commit.event.id).toBe(start.event.id)
+      expect(settled.event.id).toBe(start.event.id)
       expect(commit.event.timestamp).toBeGreaterThanOrEqual(
         start.event.timestamp
+      )
+      expect(settled.event.timestamp).toBeGreaterThanOrEqual(
+        commit.event.timestamp
       )
     })
 
@@ -182,7 +186,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((event) => event.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/blog/[slug]'])
 
       await browser.elementByCss('a[href="/dashboard"]').click()
@@ -192,7 +198,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((event) => event.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/dashboard', '/dashboard/@analytics'])
     })
 
@@ -202,22 +210,57 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementByCss('a[href="/blog/hello"]').click()
       await browser.elementById('blog-post')
       await retry(async () => {
-        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+        expect(
+          (await getTransitionEvents(browser)).some(
+            (event) => event.phase === 'commit'
+          )
+        ).toBe(true)
       })
-      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
-        '/blog/[slug]',
-      ])
+      expect(
+        (await getTransitionEvents(browser))
+          .filter((event) => event.phase === 'commit')
+          .at(-1).event.routes
+      ).toEqual(['/blog/[slug]'])
 
       await browser.elementByCss('a[href="/dashboard"]').click()
       await browser.elementById('dashboard')
       await browser.elementById('analytics')
       await retry(async () => {
-        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+        expect(
+          (await getTransitionEvents(browser))
+            .filter((event) => event.phase === 'commit')
+            .at(-1).event.routes
+        ).toEqual(['/dashboard', '/dashboard/@analytics'])
       })
-      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
-        '/dashboard',
-        '/dashboard/@analytics',
-      ])
+    })
+
+    it('commits the shell before the response settles', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/slow"]').click()
+      await browser.elementById('slow-shell')
+
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).some(
+            (event) => event.phase === 'commit'
+          )
+        ).toBe(true)
+      })
+      if (!process.env.IS_WEBPACK_TEST) {
+        expect(
+          (await getTransitionEvents(browser)).some(
+            (event) => event.phase === 'settled'
+          )
+        ).toBe(false)
+      }
+
+      await browser.elementById('slow-content')
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).map((event) => event.phase)
+        ).toEqual(['start', 'commit', 'settled'])
+      })
     })
 
     it('aborts a transition when it is superseded', async () => {
@@ -231,15 +274,20 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementByCss('a[href="/some-page"]').click()
       await browser.elementById('some-page')
       await retry(async () => {
-        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe(
+          'settled'
+        )
       })
 
       const events = await getTransitionEvents(browser)
       const firstId = events[0].event.id
-      const abort = events.find(
-        (event) => event.event.id === firstId && event.phase === 'abort'
+      const firstTerminalEvent = events.find(
+        (event) =>
+          event.event.id === firstId &&
+          (event.phase === 'abort' || event.phase === 'settled')
       )
-      expect(abort.event.reason).toBe('superseded')
+      expect(firstTerminalEvent.phase).toBe('abort')
+      expect(firstTerminalEvent.event.reason).toBe('superseded')
     })
   })
 


### PR DESCRIPTION
## Stack Position

(7/7) in the router instrumentation stack.

1. #94755: router instrumentation: refactor client hook dispatch (1/7)
2. #94766: router instrumentation: add transition start context (2/7)
3. #94756: router instrumentation: add transition commit events (3/7)
4. #94765: router instrumentation: add commit route and prefetch context (4/7)
5. #94757: router instrumentation: add transition abort events (5/7)
6. #94758: router instrumentation: add route mismatch events (6/7)
7. **#94737: router instrumentation: add transition settlement events (7/7)**

Parent: #94758

## Proposal

This stack extends `instrumentation-client` with a correlated App Router navigation lifecycle:

```ts
export function onRouterTransitionStart(url, navigationType, event) {}
export function unstable_onRouterTransitionCommit(url, navigationType, event) {}
export function unstable_onRouterTransitionSettled(url, navigationType, event) {}
export function unstable_onRouterTransitionRouteMismatch(
  url,
  navigationType,
  event
) {}
export function unstable_onRouterTransitionAbort(url, navigationType, event) {}
```

The extension is gated by:

```ts
const nextConfig = {
  experimental: {
    instrumentationClientRouterTransitionEvents: true,
  },
}
```

The existing two-argument start hook remains available without the flag. Libraries register the same hooks through `instrumentationClientInject`.

## Event Ownership

| Event | Context |
| --- | --- |
| Start | `id`, `timestamp`, source `fromRoutes`, and `prefetchIntent` |
| Commit | `id`, `timestamp`, destination `routes`, and observed `prefetch` result |
| Settled | `id` and terminal `timestamp` |
| Route mismatch | `id` and diagnostic `timestamp` |
| Abort | `id`, terminal `timestamp`, and `reason` |

Context is reported once at the point where it becomes authoritative. Consumers join the lifecycle by transition ID.

## Lifecycle Semantics

| Hook | Meaning |
| --- | --- |
| `onRouterTransitionStart` | The client navigation is dispatched. |
| `unstable_onRouterTransitionCommit` | The destination URL and first destination UI commit. |
| `unstable_onRouterTransitionSettled` | Router-owned responses, adopted prefetch responses, redirect replays, and retries complete. |
| `unstable_onRouterTransitionRouteMismatch` | The live route tree differs from the prefetched or predicted tree, causing a retry. |
| `unstable_onRouterTransitionAbort` | The transition is superseded, falls back to hard navigation, or errors. |

Within the current document, each started transition is intended to end with either settled or abort. Route mismatch is diagnostic and non-terminal.

## Expected Scenarios

| User scenario | Expected sequence | Start context | Commit context | Interpretation |
| --- | --- | --- | --- | --- |
| Fully prefetched route | `start -> commit -> settled` | Source routes and link intent | `prefetch: 'hit-route'` | Start-to-commit measures whether first destination UI was instant. |
| Partially prefetched App Shell | `start -> commit -> settled` | Source routes and link intent | `prefetch: 'hit-shell'` | Commit-to-settled measures remaining dynamic response time. |
| Prefetch miss | `start -> commit -> settled` | `prefetchIntent: 'auto'` or `'full'` | `prefetch: 'miss'` | A prefetch was intended, but no usable route or shell was available. |
| No prefetch intent | `start -> commit -> settled` | `prefetchIntent: 'none'` | Observed result, independent of intent | Baseline for imperative or prefetch-disabled navigation. |
| Back or forward | `start -> commit -> settled` | `prefetchIntent: 'none'` | Restored destination routes and `prefetch: 'none'` | Measures history restoration. |
| Mismatch before first UI | `start -> routeMismatch -> commit -> settled` | Original source and intent | Final committed routes and cache result | Measures recovery before visible destination UI. |
| Mismatch after shell commit | `start -> commit -> routeMismatch -> settled` | Original source and intent | Usually `prefetch: 'hit-shell'` | Explains additional work after an instant shell. |
| Hard navigation | `start -> commit? -> abort(hard-navigation)` | Always present | Present only if commit occurred | The SPA router abandoned the navigation. |
| Superseded navigation | `start -> commit? -> abort(superseded)`, then a new start | Always present | Present only if commit occurred | A newer navigation replaced the active transition. |
| Router error | `start -> commit? -> abort(error)` | Always present | Present only if commit occurred | The client navigation failed before settlement. |

## Derived Measurements

| Measurement | Calculation |
| --- | --- |
| Time to first destination UI | `commit.timestamp - start.timestamp` |
| Remaining navigation response time | `settled.timestamp - commit.timestamp` |
| Time until mismatch detection | `routeMismatch.timestamp - start.timestamp` |
| Recovery time after mismatch | terminal timestamp minus mismatch timestamp |
| Hard-navigation fallback rate | hard-navigation aborts divided by starts |
| Effective full-prefetch rate | route hits without mismatch divided by full-prefetch-intent starts |

## What This PR Adds

This final slice adds `unstable_onRouterTransitionSettled`, the successful terminal event. Settlement waits for router-owned response streams used by the navigation, including responses adopted from in-flight full prefetches.

Keeping settlement last isolates the response ownership and ref-counting work from the earlier start, commit, context, abort, and mismatch APIs.

## Reviewer Focus

- Which response streams become owned by an active navigation
- Ref-count balance across retries, redirects, and adopted prefetches
- Exactly-once terminal behavior

## Validation

- `pnpm build-all`
- App Router instrumentation client E2E: 18/18
- App Router with Cache Components: 18/18
- App Shell partial prefetching in production: 8/8

## Remaining Coverage

- Deterministic end-to-end route mismatch fixture
- Terminal delivery during page unload is best effort

<!-- NEXT_JS_LLM_PR -->
