### PR TITLE
Add Plumeria to the CSS-in-JS libraries list for App Router in the styling documentation

### DIFF
--- a/docs/01-app/02-guides/css-in-js.mdx
+++ b/docs/01-app/02-guides/css-in-js.mdx
@@ -19,6 +19,7 @@ The following libraries are supported in Client Components in the `app` director
 - [`@mui/material`](https://mui.com/material-ui/guides/next-js-app-router/)
 - [`@mui/joy`](https://mui.com/joy-ui/integrations/next-js-app-router/)
 - [`pandacss`](https://panda-css.com)
+- [`plumeria`](https://plumeria.dev)
 - [`styled-jsx`](#styled-jsx)
 - [`styled-components`](#styled-components)
 - [`stylex`](https://stylexjs.com)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?
Add Plumeria to the CSS-in-JS libraries list in the styling documentation.

### Why?
[Plumeria](https://plumeria.dev)  is a zero-runtime atomic CSS-in-JS library with native Next.js App Router and Turbopack(Webpack) support. It compiles styles at build time via SWC with no JavaScript runtime overhead.

### How?
Added a single entry to the existing CSS-in-JS library list.
