### PR TITLE
[turbopack] store cell dependency rdeps in a list instead of a set

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -704,9 +704,22 @@ impl TurboTasksBackend {
                     dependent_task = ?reader
                 )
                 .entered();
+                // Note: We use `task_pair` to lock the task and its reader at the same time. If we
+                // didn't and just locked the reader here, an invalidation could occur between
+                // grabbing the locks. If that happened, and if the task is "outdated" or doesn't
+                // have the dependency edge yet, the invalidation would be lost.
                 let mut queue = LeafDistanceUpdateQueue::new();
                 let reader = reader.unwrap();
-                if task.add_output_dependent(reader) {
+                // The reverse edge (`output_dependent`) is a list, not a set: only push it when the
+                // forward edge was genuinely newly inserted on the reader, otherwise a re-read
+                // would append a duplicate. The forward-edge-new signal also gates
+                // the leaf-distance update (a new dependency edge is exactly when
+                // the dependent's distance may need to grow). Both guards are held,
+                // so write order between the two edges does not matter.
+                let need_reverse = !reader_task.remove_outdated_output_dependencies(&task_id)
+                    && reader_task.add_output_dependencies(task_id);
+                if need_reverse {
+                    task.push_output_dependent(reader);
                     // Ensure that dependent leaf distance is strictly monotonic increasing
                     let leaf_distance = task.get_leaf_distance().copied().unwrap_or_default();
                     let reader_leaf_distance =
@@ -719,18 +732,8 @@ impl TurboTasksBackend {
                         );
                     }
                 }
-
-                drop(task);
-
-                // Note: We use `task_pair` earlier to lock the task and its reader at the same
-                // time. If we didn't and just locked the reader here, an invalidation could occur
-                // between grabbing the locks. If that happened, and if the task is "outdated" or
-                // doesn't have the dependency edge yet, the invalidation would be lost.
-
-                if !reader_task.remove_outdated_output_dependencies(&task_id) {
-                    let _ = reader_task.add_output_dependencies(task_id);
-                }
                 drop(reader_task);
+                drop(task);
 
                 queue.execute(&mut ctx);
             } else {
@@ -792,32 +795,37 @@ impl TurboTasksBackend {
             if let Some(mut reader_task) = reader_task
                 && (!task.immutable() || cfg!(feature = "verify_immutable"))
             {
+                // Note: We use `task_pair` to lock the task and its reader at the same time. If we
+                // didn't and just locked the reader here, an invalidation could occur between
+                // grabbing the locks. If that happened, and if the task is "outdated" or doesn't
+                // have the dependency edge yet, the invalidation would be lost.
                 let reader = reader.unwrap();
                 let reverse = CellRef { task: reader, cell };
-                if let Some(k) = key {
-                    let _ = task.add_cell_dependents_hashed((reverse, k));
-                } else {
-                    let _ = task.add_cell_dependents(reverse);
-                }
-                drop(task);
-
-                // Note: We use `task_pair` earlier to lock the task and its reader at the same
-                // time. If we didn't and just locked the reader here, an invalidation could occur
-                // between grabbing the locks. If that happened, and if the task is "outdated" or
-                // doesn't have the dependency edge yet, the invalidation would be lost.
-
                 let target = CellRef {
                     task: task_id,
                     cell,
                 };
-                if let Some(k) = key {
-                    if !reader_task.remove_outdated_cell_dependencies_hashed(&(target, k)) {
-                        let _ = reader_task.add_cell_dependencies_hashed((target, k));
-                    }
-                } else if !reader_task.remove_outdated_cell_dependencies(&target) {
-                    let _ = reader_task.add_cell_dependencies(target);
-                }
+                // The reverse edge (`cell_dependents`) is stored as a list, not a set, so it must
+                // only be pushed when the forward edge was genuinely newly inserted on the reader —
+                // otherwise a re-read would append a duplicate. Both guards are held here (via
+                // `task_pair`), so forward and reverse become visible atomically and their write
+                // order does not matter; only the `need_reverse` gate does.
+                let need_reverse = if let Some(k) = key {
+                    !reader_task.remove_outdated_cell_dependencies_hashed(&(target, k))
+                        && reader_task.add_cell_dependencies_hashed((target, k))
+                } else {
+                    !reader_task.remove_outdated_cell_dependencies(&target)
+                        && reader_task.add_cell_dependencies(target)
+                };
                 drop(reader_task);
+                if need_reverse {
+                    if let Some(k) = key {
+                        task.push_cell_dependents_hashed((reverse, k));
+                    } else {
+                        task.push_cell_dependents(reverse);
+                    }
+                }
+                drop(task);
             }
         }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -24,6 +24,7 @@ use std::{
 
 use parking_lot::Mutex;
 use rustc_hash::FxHasher;
+use smallvec::SmallVec;
 use turbo_tasks::{
     CellId, SharedReference, TaskExecutionReason, TaskId, TinyVec, TraitTypeId, ValueTypeId,
     backend::{CachedTaskTypeArc, CellHash, TransientTaskType},
@@ -40,6 +41,14 @@ use crate::{
 };
 
 type AutoSet<K, const I: usize> = auto_hash_map::AutoSet<K, BuildHasherDefault<FxHasher>, I>;
+
+/// Unordered list storage (`storage = "list"`). Backed by a `SmallVec` with `I` inline elements.
+///
+/// Unlike [`AutoSet`] it does NOT deduplicate — `push` always appends and `remove` is a linear
+/// `position` + `swap_remove`. Used for reverse dependency edges, whose uniqueness is guaranteed by
+/// the caller (the forward edge gates the reverse insert), so the hash-set overhead is unnecessary.
+/// A debug-only assertion in the generated `push_*` accessor checks the no-duplicate invariant.
+type List<T, const I: usize> = SmallVec<[T; I]>;
 
 /// Auto-map storage for key-value pairs.
 ///
@@ -75,15 +84,24 @@ struct TaskStorageSchema {
     aggregation_number: AggregationNumber,
 
     /// Tasks that depend on this task's output.
-
+    ///
+    /// Stored as an unordered [`List`] rather than a set: every insert is gated on the reader's
+    /// forward `output_dependencies` edge being newly added, so no duplicate is ever pushed.
+    ///
+    /// 6 inline elements: `List<TaskId, 6>` is 32 B (same as `4` or `5` would round to under the
+    /// `SmallVec` union layout's 16 B floor — `6 * 4 B = 24 B` inline payload + 8 B tag), and
+    /// keeps the whole boxed `TaskStorage` at 128 B, which is mimalloc's size class anyway.
+    /// Since `TaskStorage` is always heap-allocated, shrinking below 128 B saves nothing — so
+    /// spend the slack on inline dependent capacity to avoid heap spills for tasks with up to
+    /// 6 dependents.
     #[field(
-        storage = "auto_set",
+        storage = "list",
         category = "data",
         inline,
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    output_dependent: AutoSet<TaskId, 4>,
+    output_dependent: List<TaskId, 6>,
 
     /// The task's output value.
     /// Filtered during serialization to skip transient outputs (referencing transient tasks).
@@ -297,24 +315,28 @@ struct TaskStorageSchema {
     // =========================================================================
     /// Tasks that depend on this task's cells as a whole (keyless). Reverse of
     /// `cell_dependencies`. In a `cell_dependents` entry the `CellRef.task` field holds the
-    /// DEPENDENT task's id and `CellRef.cell` is this task's cell (see `CellDependency` docs).
+    /// DEPENDENT task's id and `CellRef.cell` is this task's cell.
+    ///
+    /// Stored as an unordered [`List`] rather than a set: every insert is gated on the reader's
+    /// forward `cell_dependencies` edge being newly added, so no duplicate is ever pushed.
     #[field(
-        storage = "auto_set",
+        storage = "list",
         category = "data",
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    cell_dependents: AutoSet<CellRef, 2>,
+    cell_dependents: List<CellRef, 2>,
 
     /// Tasks that depend on a hashed sub-value of this task's cells. Reverse of
-    /// `cell_dependencies_hashed`.
+    /// `cell_dependencies_hashed`. Gated like `cell_dependents`, so stored as an unordered
+    /// [`List`].
     #[field(
-        storage = "auto_set",
+        storage = "list",
         category = "data",
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    cell_dependents_hashed: AutoSet<(CellRef, u64), 1>,
+    cell_dependents_hashed: List<(CellRef, u64), 1>,
 
     /// Tasks that depend on collectibles of a specific type from this task.
     /// Maps TraitTypeId -> Set<TaskId>
@@ -915,6 +937,15 @@ where
         self.extend(items)
     }
 }
+impl<V, const I: usize> MergeRestore for List<V, I> {
+    type Item = V;
+    /// Appends without deduplication. Safe because the transient residue (in `self`) and the
+    /// disk-restored `items` are keyed by disjoint task-id spaces — transient residue is filtered
+    /// out of the persisted source — so no duplicate can arise from the merge.
+    fn merge_restore(&mut self, items: impl IntoIterator<Item = Self::Item>) {
+        self.extend(items)
+    }
+}
 
 /// Outcome of a `drop_partial` call: did residue (transient entries that
 /// can't be reconstructed from disk) survive the drop?
@@ -951,6 +982,20 @@ impl<T: IsTransient> DropPartial for Option<T> {
 
 impl<T: IsTransient + Hash + Eq, const I: usize> DropPartial for AutoSet<T, I> {
     fn drop_partial(&mut self) -> DropPartialOutcome {
+        self.retain(|t| t.is_transient());
+        if self.is_empty() {
+            DropPartialOutcome::Empty
+        } else {
+            self.shrink_to_fit();
+            DropPartialOutcome::HasResidue
+        }
+    }
+}
+
+impl<T: IsTransient, const I: usize> DropPartial for List<T, I> {
+    fn drop_partial(&mut self) -> DropPartialOutcome {
+        // `SmallVec::retain` passes `&mut T`; only the transient residue (entries that can't be
+        // reconstructed from disk) is kept.
         self.retain(|t| t.is_transient());
         if self.is_empty() {
             DropPartialOutcome::Empty
@@ -1019,9 +1064,7 @@ mod tests {
         storage.upper_mut().insert(TaskId::new(5).unwrap(), 3);
         assert_eq!(storage.upper().get(&TaskId::new(5).unwrap()), Some(&3));
 
-        storage
-            .output_dependent_mut()
-            .insert(TaskId::new(5).unwrap());
+        storage.output_dependent_mut().push(TaskId::new(5).unwrap());
         assert!(
             storage
                 .output_dependent()
@@ -1264,10 +1307,10 @@ mod tests {
         // Set inline data field via accessor methods
         original
             .output_dependent_mut()
-            .insert(TaskId::new(10).unwrap());
+            .push(TaskId::new(10).unwrap());
         original
             .output_dependent_mut()
-            .insert(TaskId::new(20).unwrap());
+            .push(TaskId::new(20).unwrap());
 
         // Set lazy data fields (persisted)
         original
@@ -1413,9 +1456,9 @@ mod tests {
         let mut storage = TaskStorage::new();
 
         // Mix persistent and transient references in a filter_transient data field.
-        storage.output_dependent_mut().insert(persistent_task(1));
-        storage.output_dependent_mut().insert(persistent_task(2));
-        storage.output_dependent_mut().insert(transient_task(3));
+        storage.output_dependent_mut().push(persistent_task(1));
+        storage.output_dependent_mut().push(persistent_task(2));
+        storage.output_dependent_mut().push(transient_task(3));
 
         // Lazy filter_transient data field.
         storage.cell_dependencies_mut().insert(CellRef {
@@ -1447,8 +1490,8 @@ mod tests {
         // Simulate a restore from disk: source has the persistent entries only
         // (transient ones would have been filtered during encode).
         let mut source = TaskStorage::new();
-        source.output_dependent_mut().insert(persistent_task(1));
-        source.output_dependent_mut().insert(persistent_task(2));
+        source.output_dependent_mut().push(persistent_task(1));
+        source.output_dependent_mut().push(persistent_task(2));
 
         storage.restore_data_from(source);
 
@@ -1512,8 +1555,8 @@ mod tests {
     fn drop_partial_resets_fields_without_transients() {
         let mut storage = TaskStorage::new();
 
-        storage.output_dependent_mut().insert(persistent_task(1));
-        storage.output_dependent_mut().insert(persistent_task(2));
+        storage.output_dependent_mut().push(persistent_task(1));
+        storage.output_dependent_mut().push(persistent_task(2));
         storage.flags.set_data_restored(true);
         storage.flags.set_meta_restored(true);
 
@@ -1526,6 +1569,40 @@ mod tests {
         );
 
         assert!(storage.output_dependent().is_empty());
+    }
+
+    /// A `list`-storage field (`output_dependent`) is backed by a `SmallVec`: it appends in order
+    /// and a serialize→deserialize round-trip preserves every distinct entry. (The trait
+    /// `push_*`/`remove_*`/`iter_*` accessors used by the read/cleanup paths are exercised
+    /// end-to-end by the integration suite; here we just confirm the storage field itself is a
+    /// list with the expected element layout and round-trips.)
+    #[test]
+    fn list_field_appends_and_roundtrips() {
+        let mut storage = TaskStorage::new();
+        storage.output_dependent_mut().push(persistent_task(1));
+        storage.output_dependent_mut().push(persistent_task(2));
+        storage.output_dependent_mut().push(persistent_task(3));
+        assert_eq!(storage.output_dependent().len(), 3);
+        // Insertion order is preserved (unlike a hash set).
+        assert_eq!(
+            storage.output_dependent().as_slice(),
+            &[persistent_task(1), persistent_task(2), persistent_task(3)]
+        );
+
+        let mut buffer = turbo_bincode::TurboBincodeBuffer::new();
+        {
+            let mut encoder = new_encoder(&mut buffer);
+            storage.encode_data(&mut encoder).expect("encode failed");
+        }
+        let mut decoded = TaskStorage::new();
+        {
+            let mut decoder = new_decoder(&buffer);
+            decoded.decode_data(&mut decoder).expect("decode failed");
+        }
+        assert_eq!(
+            decoded.output_dependent().as_slice(),
+            &[persistent_task(1), persistent_task(2), persistent_task(3)]
+        );
     }
 
     /// Regression: `drop_partial(true, true)` must clear persisted flag bits
@@ -1719,6 +1796,9 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_schema_size() {
+        // 128 B = mimalloc's size class for a boxed `TaskStorage`. The inline `output_dependent`
+        // list is sized (`List<TaskId, 6>`) to fill this class exactly: dropping below 128 B saves
+        // nothing at the allocator, so the slack buys inline dependent capacity instead.
         assert_eq!(
             size_of::<TaskStorage>(),
             128,

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -339,6 +339,7 @@ impl FieldInfo {
 enum StorageType {
     Direct,
     AutoSet,
+    List,
     AutoMap,
     CounterMap,
     Flag,
@@ -424,6 +425,7 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
                                 storage_type = Some(match lit_str.value().as_str() {
                                     "direct" => StorageType::Direct,
                                     "auto_set" => StorageType::AutoSet,
+                                    "list" => StorageType::List,
                                     "auto_map" => StorageType::AutoMap,
                                     "counter_map" => StorageType::CounterMap,
                                     "flag" => StorageType::Flag,
@@ -585,7 +587,7 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
     // lazy vec), but shrink_on_completion is meaningless for non-collection types.
     let is_collection = matches!(
         storage_type,
-        StorageType::AutoSet | StorageType::AutoMap | StorageType::CounterMap
+        StorageType::AutoSet | StorageType::List | StorageType::AutoMap | StorageType::CounterMap
     );
     if !is_collection {
         if shrink_on_completion {
@@ -816,19 +818,17 @@ fn gen_restore_inline_field(field: &FieldInfo) -> TokenStream {
                 }
             }
         }
-        StorageType::AutoSet => {
-            quote! {
-                if self.#field_name.is_empty() {
-                    self.#field_name = source.#field_name;
-                } else {
-                    self.#field_name.merge_restore(source.#field_name);
-                }
-            }
-        }
-        StorageType::CounterMap | StorageType::AutoMap => {
-            // CounterMap / AutoMap: transient residue (if any) is keyed by
-            // transient task ids; source entries are keyed by persistent ids.
-            // These key spaces are disjoint, so `extend` merges cleanly.
+        StorageType::AutoSet
+        | StorageType::List
+        | StorageType::CounterMap
+        | StorageType::AutoMap => {
+            // Collection storage: keep any transient residue already in `self` and fold the
+            // persisted `source` into it via `merge_restore`. The merge introduces no duplicate or
+            // double-count because the residue and the source occupy disjoint key spaces (residue
+            // is keyed by transient task ids, which are filtered out of the persisted source):
+            // - AutoSet unions (and would dedup anyway);
+            // - List appends (safe precisely because the key spaces are disjoint);
+            // - CounterMap / AutoMap extend by key.
             quote! {
                 if self.#field_name.is_empty() {
                     self.#field_name = source.#field_name;
@@ -1368,7 +1368,10 @@ fn generate_field_accessors(field: &FieldInfo) -> TokenStream {
 
     match field.storage_type {
         StorageType::Direct => generate_direct_field_accessors(field),
-        StorageType::AutoSet | StorageType::AutoMap | StorageType::CounterMap => {
+        StorageType::AutoSet
+        | StorageType::List
+        | StorageType::AutoMap
+        | StorageType::CounterMap => {
             generate_collection_field_accessors(field, field_name, field_type)
         }
         StorageType::Flag => {
@@ -1655,6 +1658,38 @@ fn generate_trait_accessor_methods(field: &FieldInfo) -> TokenStream {
             quote! {
                 #base_accessor
                 #set_ops
+            }
+        }
+        StorageType::List => {
+            // For List types, generate a read-only accessor plus list mutation methods
+            // (push/remove/iter/len/is_empty/set/extend). No `contains` accessor.
+            let ref_name = field.ref_ident();
+
+            let (return_type, doc_comment) = if is_option {
+                (
+                    quote! { Option<&#field_type> },
+                    "/// Get a reference to the list (may be None if not allocated, read-only)",
+                )
+            } else {
+                (
+                    quote! { &#field_type },
+                    "/// Get a reference to the list (read-only)",
+                )
+            };
+
+            let base_accessor = quote! {
+                #[doc = #doc_comment]
+                fn #ref_name(&self) -> #return_type {
+                    #check_access
+                    #ref_expr
+                }
+            };
+
+            let list_ops = generate_list_ops(field);
+
+            quote! {
+                #base_accessor
+                #list_ops
             }
         }
         StorageType::CounterMap => {
@@ -2198,6 +2233,275 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
         }
 
         #[doc = "Check if the set is empty"]
+        fn #is_empty_name(&self) -> bool {
+            #check_access
+            #is_empty_body
+        }
+    }
+}
+
+/// Generate List operations for a field (works for both inline and lazy storage).
+///
+/// A List is an unordered `SmallVec`-backed collection that does NOT deduplicate. It is used for
+/// reverse dependency edges, whose uniqueness is guaranteed by the caller (the forward edge gates
+/// the reverse insert). Therefore:
+/// - `push_{field}` appends unconditionally and returns `()` (no membership check in release). A
+///   `#[cfg(debug_assertions)]` linear scan asserts the no-duplicate invariant so any ungated
+///   insert is caught in debug/test builds.
+/// - `remove_{field}` does a linear `position` + `swap_remove`, returning whether it was present.
+/// - There is **no** `contains` accessor (nothing queries membership).
+/// - `extend_{field}` appends all items without a dedup pre-check.
+fn generate_list_ops(field: &FieldInfo) -> TokenStream {
+    let field_type = &field.field_type;
+
+    let Some(element_type) = extract_list_element_type(field_type) else {
+        return quote! {};
+    };
+
+    let check_access = field.check_access_call();
+    let track_modification = field.track_modification_call();
+    let mut_expr = field.collection_mut_expr();
+    let ref_expr = field.collection_ref_expr();
+
+    let take_expr = field.direct_take_expr();
+    let is_option = field.is_option_ref();
+
+    let push_name = field.prefixed_ident("push");
+    let extend_name = field.prefixed_ident("extend");
+    let remove_name = field.prefixed_ident("remove");
+    let set_name = field.prefixed_ident("set");
+    let iter_name = field.iter_ident();
+    let len_name = field.len_ident();
+    let is_empty_name = field.is_empty_ident();
+
+    let iter_body = if is_option {
+        quote! { #ref_expr.into_iter().flat_map(|list| list.iter().copied()) }
+    } else {
+        quote! { #ref_expr.iter().copied() }
+    };
+
+    let len_body = if is_option {
+        quote! { #ref_expr.map_or(0, |list| list.len()) }
+    } else {
+        quote! { #ref_expr.len() }
+    };
+
+    let is_empty_body = if is_option {
+        quote! { #ref_expr.is_none_or(|list| list.is_empty()) }
+    } else {
+        quote! { #ref_expr.is_empty() }
+    };
+
+    // Debug-only duplicate guard. The list relies on the caller (the forward edge) for uniqueness;
+    // this assertion continuously verifies that invariant in debug/test builds at zero release
+    // cost. It is the equivalent of the AutoSet membership check, but as a check rather than a
+    // dedup.
+    let dup_guard = if is_option {
+        quote! {
+            debug_assert!(
+                #ref_expr.is_none_or(|list| !list.iter().any(|existing| existing == &item)),
+                concat!("duplicate push into list field ", stringify!(#push_name)),
+            );
+        }
+    } else {
+        quote! {
+            debug_assert!(
+                !#ref_expr.iter().any(|existing| existing == &item),
+                concat!("duplicate push into list field ", stringify!(#push_name)),
+            );
+        }
+    };
+
+    let remove_body;
+    let push_body;
+    let set_body;
+    let extend_body;
+
+    if field.is_transient() {
+        remove_body = quote! {
+            if let Some(__idx) = #mut_expr.iter().position(|existing| existing == item) {
+                #mut_expr.swap_remove(__idx);
+                true
+            } else {
+                false
+            }
+        };
+        push_body = quote! {
+            #dup_guard
+            #mut_expr.push(item);
+        };
+        set_body = if is_option {
+            let unwraper = field.lazy_unwrap_closure();
+            let matches = field.lazy_matches_closure();
+            let ctor = field.lazy_constructor(quote! {list});
+            quote! {
+                let list = list;
+                self.typed_mut().set_lazy(#matches, #unwraper, #ctor)
+            }
+        } else {
+            quote! {
+                let old = #take_expr;
+                *#mut_expr = list;
+                Some(old)
+            }
+        };
+        extend_body = quote! {
+            #mut_expr.extend(items);
+        };
+    } else {
+        // Remove: only track modification if the item was actually present.
+        remove_body = if is_option {
+            let extractor = field.lazy_extractor_closure();
+            quote! {
+                let Some((idx, val)) = self.typed().find_lazy_ref(#extractor) else {
+                    return false;
+                };
+                let Some(__pos) = val.iter().position(|existing| existing == item) else {
+                    return false;
+                };
+                #track_modification
+                self.typed_mut().lazy_at_mut(idx, #extractor).swap_remove(__pos);
+                true
+            }
+        } else {
+            quote! {
+                let Some(__pos) = #ref_expr.iter().position(|existing| existing == item) else {
+                    return false;
+                };
+                #track_modification
+                #mut_expr.swap_remove(__pos);
+                true
+            }
+        };
+
+        // Push: append unconditionally (no dedup). The debug-only guard verifies uniqueness.
+        push_body = if is_option {
+            let extractor = field.lazy_extractor_closure();
+            let ctor = field.lazy_constructor(quote! { list });
+            quote! {
+                if let Some((idx, _existing)) = self.typed().find_lazy_ref(#extractor) {
+                    #dup_guard
+                    #track_modification
+                    self.typed_mut().lazy_at_mut(idx, #extractor).push(item);
+                } else {
+                    #track_modification
+                    let mut list = <#field_type as Default>::default();
+                    list.push(item);
+                    self.typed_mut().lazy.push(#ctor);
+                }
+            }
+        } else {
+            quote! {
+                #dup_guard
+                #track_modification
+                #mut_expr.push(item);
+            }
+        };
+
+        if is_option {
+            let extractor = field.lazy_extractor_closure();
+            let unwraper = field.lazy_unwrap_closure();
+            let ctor = field.lazy_constructor(quote! {list});
+            set_body = quote! {
+                if let Some((idx, old_ref)) = self.typed().find_lazy_ref(#extractor) {
+                    if old_ref == &list {
+                        return None;
+                    }
+                    #track_modification
+                    let old = std::mem::replace(&mut self.typed_mut().lazy[idx], #ctor);
+                    Some((#unwraper)(old))
+                } else {
+                    #track_modification
+                    self.typed_mut().lazy.push(#ctor);
+                    None
+                }
+            };
+        } else {
+            set_body = quote! {
+                if #ref_expr == &list {
+                    return None;
+                }
+                #track_modification
+                let old = #take_expr;
+                *#mut_expr = list;
+                Some(old)
+            };
+        }
+
+        // Extend: append all items (no dedup). Track modification only if at least one item is
+        // added.
+        extend_body = if is_option {
+            let extractor = field.lazy_extractor_closure();
+            let ctor = field.lazy_constructor(quote! { list });
+            quote! {
+                let mut iter = items.into_iter().peekable();
+                if iter.peek().is_none() {
+                    return;
+                }
+                if let Some((idx, _existing)) = self.typed().find_lazy_ref(#extractor) {
+                    #track_modification
+                    self.typed_mut().lazy_at_mut(idx, #extractor).extend(iter);
+                } else {
+                    #track_modification
+                    let list: #field_type = iter.collect();
+                    self.typed_mut().lazy.push(#ctor);
+                }
+            }
+        } else {
+            quote! {
+                let mut iter = items.into_iter().peekable();
+                if iter.peek().is_none() {
+                    return;
+                }
+                #track_modification
+                #mut_expr.extend(iter);
+            }
+        };
+    }
+
+    quote! {
+        #[doc = "Append an item to the list."]
+        #[doc = "Does NOT deduplicate: the caller must guarantee uniqueness (a debug assertion"]
+        #[doc = "checks this). Use this only for collections whose uniqueness is enforced elsewhere."]
+        fn #push_name(&mut self, item: #element_type) {
+            #check_access
+            #push_body
+        }
+
+        #[doc = "Append multiple items to the list from an iterator (no deduplication)."]
+        #[doc = "Only tracks modification if at least one item is added."]
+        fn #extend_name(&mut self, items: impl IntoIterator<Item = #element_type>) {
+            #check_access
+            #extend_body
+        }
+
+        #[doc = "Remove an item from the list via a linear search + swap-remove."]
+        #[doc = "Returns true if the item was present and removed, false if it wasn't present."]
+        fn #remove_name(&mut self, item: &#element_type) -> bool {
+            #check_access
+            #remove_body
+        }
+
+        #[doc = "Replace the entire list, returning the old list if present."]
+        #[doc = "Only tracks modification if the list actually changes."]
+        fn #set_name(&mut self, list: #field_type) -> Option<#field_type> {
+            #check_access
+            #set_body
+        }
+
+        #[doc = "Iterate over all items in the list"]
+        fn #iter_name(&self) -> impl Iterator<Item = #element_type> + '_ {
+            #check_access
+            #iter_body
+        }
+
+        #[doc = "Get the number of items in the list"]
+        fn #len_name(&self) -> usize {
+            #check_access
+            #len_body
+        }
+
+        #[doc = "Check if the list is empty"]
         fn #is_empty_name(&self) -> bool {
             #check_access
             #is_empty_body
@@ -2757,7 +3061,10 @@ fn generate_cleanup_after_execution(grouped_fields: &GroupedFields) -> TokenStre
 
         let is_collection = matches!(
             field.storage_type,
-            StorageType::AutoSet | StorageType::AutoMap | StorageType::CounterMap
+            StorageType::AutoSet
+                | StorageType::List
+                | StorageType::AutoMap
+                | StorageType::CounterMap
         );
 
         // Each arm returns bool: true = keep, false = remove
@@ -2873,7 +3180,10 @@ fn generate_drop_method(grouped_fields: &GroupedFields) -> TokenStream {
     fn category_inline_check(field: &FieldInfo) -> TokenStream {
         let field_name = &field.field_name;
         match field.storage_type {
-            StorageType::AutoMap | StorageType::AutoSet | StorageType::CounterMap => quote! {
+            StorageType::AutoMap
+            | StorageType::AutoSet
+            | StorageType::List
+            | StorageType::CounterMap => quote! {
                 self.#field_name.is_empty()
             },
             StorageType::Direct => quote! {
@@ -3121,6 +3431,21 @@ fn extract_set_element_type(ty: &Type) -> Option<TokenStream> {
     None
 }
 
+/// Extract the element type T from a `list`-storage field. The schema uses a `List<T, I>` alias
+/// (over `SmallVec<[T; I]>`) whose first generic argument is the element type — the same shape as
+/// `AutoSet<K, I>`, so the extraction logic matches.
+fn extract_list_element_type(ty: &Type) -> Option<TokenStream> {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && (segment.ident == "List" || segment.ident == "SmallVec")
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(quote! { #inner });
+    }
+    None
+}
+
 /// Extract key and value types from a map type (e.g., AutoMap<K, V> or CounterMap<K, V>)
 fn extract_map_types(ty: &Type, expected_name: &str) -> Option<(TokenStream, TokenStream)> {
     let (key_type, value_type) = extract_map_types_raw(ty, expected_name)?;
@@ -3359,7 +3684,11 @@ fn generate_filter_predicate(field: &FieldInfo) -> Option<(TokenStream, FilterPr
             quote! { |v| !v.is_transient() },
             FilterPredicateType::Option,
         )),
-        StorageType::AutoSet => Some((quote! { |k| !k.is_transient() }, FilterPredicateType::Set)),
+        StorageType::AutoSet | StorageType::List => {
+            // Both iterate elements and filter by transience; the `Set` encode arm
+            // (collect-filtered → encode length → encode each) works for a list too.
+            Some((quote! { |k| !k.is_transient() }, FilterPredicateType::Set))
+        }
         StorageType::CounterMap => Some((
             quote! { |(k, _)| !k.is_transient() },
             FilterPredicateType::CounterMap,


### PR DESCRIPTION
The logic for populating this is guarded by the 'forward dep set' so we can guarantee single inserts.  This saves