### PR TITLE
router instrumentation: add transition commit events (3/7)

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive a third `event` argument:
+Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_onRouterTransitionCommit` hook:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -68,39 +68,72 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-The event includes the transition metadata and source context known when the navigation is dispatched:
+Then export the optional commit hook:
 
 ```ts filename="instrumentation-client.ts" switcher
-import type { RouterTransitionStartEvent, RouterTransitionType } from 'next'
+import type {
+  RouterTransitionCommitEvent,
+  RouterTransitionStartEvent,
+  RouterTransitionType,
+} from 'next'
+
+const starts = new Map<string, number>()
 
 export function onRouterTransitionStart(
   url: string,
   navigationType: RouterTransitionType,
   { id, timestamp, fromRoutes, prefetchIntent }: RouterTransitionStartEvent
 ) {
-  console.log(id, timestamp, url, navigationType, fromRoutes, prefetchIntent)
+  console.log('Navigating from:', fromRoutes, prefetchIntent)
+  starts.set(id, timestamp)
+}
+
+export function unstable_onRouterTransitionCommit(
+  url: string,
+  navigationType: RouterTransitionType,
+  event: RouterTransitionCommitEvent
+) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation commit:', event.timestamp - start)
+    starts.delete(event.id)
+  }
 }
 ```
 
 ```js filename="instrumentation-client.js" switcher
+const starts = new Map()
+
 export function onRouterTransitionStart(url, navigationType, event) {
-  console.log(
-    event.id,
-    event.timestamp,
-    url,
-    navigationType,
-    event.fromRoutes,
-    event.prefetchIntent
-  )
+  console.log('Navigating from:', event.fromRoutes, event.prefetchIntent)
+  starts.set(event.id, event.timestamp)
+}
+
+export function unstable_onRouterTransitionCommit(url, navigationType, event) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation commit:', event.timestamp - start)
+    starts.delete(event.id)
+  }
 }
 ```
 
-`onRouterTransitionStart` receives:
+Each hook receives the same three parameters:
 
 - `url: string` - The URL being navigated to
 - `navigationType: 'push' | 'replace' | 'traverse'` - The type of navigation
 - `event.id` - An opaque ID shared by events for this transition
 - `event.timestamp` - A framework-captured Unix timestamp in milliseconds
+
+The available hooks are:
+
+| Hook                                | Timing                                   |
+| ----------------------------------- | ---------------------------------------- |
+| `onRouterTransitionStart`           | The navigation is dispatched.            |
+| `unstable_onRouterTransitionCommit` | The first destination UI and URL commit. |
+
+The start event (`onRouterTransitionStart`) also includes:
+
 - `event.fromRoutes` - Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order
 - `event.prefetchIntent` - For link navigations, whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`). For navigations with no associated link (programmatic `router.push()`/`router.replace()`, or browser back/forward) this is `null`, since no link prefetch intent applies
 
@@ -126,7 +159,7 @@ This timing makes it ideal for setting up error tracking, analytics, and perform
 
 ## See also
 
-`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition start hook. Application code should continue to use this file convention directly.
+`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition hooks. Application code should continue to use this file convention directly.
 
 ## Examples
 
@@ -260,7 +293,7 @@ if (!window.ResizeObserver) {
 
 ## Version history
 
-| Version   | Changes                                               |
-| --------- | ----------------------------------------------------- |
-| `v16.3.0` | Experimental router transition start event introduced |
-| `v15.3`   | `instrumentation-client` introduced                   |
+| Version   | Changes                                                   |
+| --------- | --------------------------------------------------------- |
+| `v16.3.0` | Experimental router transition lifecycle hooks introduced |
+| `v15.3`   | `instrumentation-client` introduced                       |

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -281,7 +281,7 @@ export function dispatchNavigateAction(
   }
 
   setLinkForCurrentNavigation(linkInstanceRef)
-  startRouterTransition(
+  const transitionId = startRouterTransition(
     href,
     navigateType,
     getAppRouterActionQueue().state.tree,
@@ -295,6 +295,7 @@ export function dispatchNavigateAction(
     locationSearch: location.search,
     scrollBehavior,
     navigateType,
+    transitionId,
   })
 }
 
@@ -302,7 +303,7 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
-  startRouterTransition(
+  const transitionId = startRouterTransition(
     href,
     'traverse',
     getAppRouterActionQueue().state.tree,
@@ -312,6 +313,7 @@ export function dispatchTraverseAction(
     type: ACTION_RESTORE,
     url: new URL(href),
     historyState,
+    transitionId,
   })
 }
 
@@ -365,7 +367,8 @@ function gesturePush(href: string, options?: NavigateOptions): void {
       state.nextUrl,
       freshnessPolicy,
       scrollBehavior,
-      'push'
+      'push',
+      null
     )
     dispatchGestureState(forkedGestureState)
   }

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -51,6 +51,7 @@ import DefaultGlobalError from './builtin/global-error'
 import { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-app'
 import { getAssetTokenQuery } from '../../shared/lib/deployment-id'
+import { commitRouterTransition } from './router-transition'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -68,7 +69,8 @@ function HistoryUpdater({
       window.next.__pendingUrl = undefined
     }
 
-    const { tree, pushRef, canonicalUrl, renderedSearch } = appRouterState
+    const { tree, pushRef, canonicalUrl, renderedSearch, transitionId } =
+      appRouterState
 
     const appHistoryState: AppHistoryState = {
       tree,
@@ -97,6 +99,7 @@ function HistoryUpdater({
       window.history.replaceState(historyState, '', canonicalUrl)
     }
 
+    commitRouterTransition(transitionId, canonicalUrl)
     setLastCommittedTree(tree)
   }, [appRouterState])
 
@@ -229,6 +232,7 @@ function Router({
         type: ACTION_RESTORE,
         url: new URL(window.location.href),
         historyState: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
+        transitionId: null,
       })
     }
 
@@ -319,6 +323,7 @@ function Router({
           type: ACTION_RESTORE,
           url: new URL(url ?? href, href),
           historyState: appHistoryState,
+          transitionId: null,
         })
       })
     }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -269,6 +269,7 @@ export function createInitialRouterState({
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??
       null,
     previousNextUrl: null,
+    transitionId: null,
     debugInfo: null,
   }
 

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1682,6 +1682,7 @@ function dispatchRetryDueToTreeMismatch(
     seed,
     mpa: isHardRetry,
     navigateType: retryNavigateType,
+    transitionId: null,
   }
   dispatchAppRouterAction(retryAction)
 }

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -24,16 +24,17 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, isExternalUrl, navigateType, scrollBehavior } = action
+  const { url, isExternalUrl, navigateType, scrollBehavior, transitionId } =
+    action
 
   if (isExternalUrl) {
-    return completeHardNavigation(state, url, navigateType)
+    return completeHardNavigation(state, url, navigateType, transitionId)
   }
 
   // Handles case where `<meta http-equiv="refresh">` tag is present,
   // which will trigger an MPA navigation.
   if (document.getElementById('__next-page-redirect')) {
-    return completeHardNavigation(state, url, navigateType)
+    return completeHardNavigation(state, url, navigateType, transitionId)
   }
 
   // Temporary glue code between the router reducer and the new navigation
@@ -51,6 +52,7 @@ export function navigateReducer(
     state.nextUrl,
     FreshnessPolicy.Default,
     scrollBehavior,
-    navigateType
+    navigateType,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -99,6 +99,7 @@ export function refreshDynamicData(
     // cache entry to mark as having a dynamic rewrite on mismatch. If a
     // mismatch occurs, the retry handler will traverse the known route tree
     // to find and mark the entry.
+    null,
     null
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -32,6 +32,7 @@ export function restoreReducer(
   let treeToRestore: FlightRouterState | undefined
   let renderedSearch: string | undefined
   const historyState = action.historyState
+  const transitionId = action.transitionId
   if (historyState) {
     treeToRestore = historyState.tree
     renderedSearch = historyState.renderedSearch
@@ -77,7 +78,7 @@ export function restoreReducer(
   )
 
   if (task === null) {
-    return completeHardNavigation(state, restoredUrl, 'replace')
+    return completeHardNavigation(state, restoredUrl, 'replace', transitionId)
   }
   spawnDynamicRequests(
     task,
@@ -100,6 +101,7 @@ export function restoreReducer(
     renderedSearch,
     task.node,
     task.route,
-    restoredNextUrl
+    restoredNextUrl,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -385,7 +385,14 @@ export function serverActionReducer(
             navigateType
           )
           reject(redirectError)
-          return completeHardNavigation(state, redirectLocation, navigateType)
+          // A server action redirect is not a router transition, so there is
+          // no transition id to correlate.
+          return completeHardNavigation(
+            state,
+            redirectLocation,
+            navigateType,
+            null
+          )
         } else {
           // Internal redirect. Triggers an SPA navigation.
           const redirectWithBasepath = createHrefFromUrl(
@@ -425,7 +432,12 @@ export function serverActionReducer(
         // an external redirect.
         // TODO: We should refactor the action response type to be more explicit
         // about the various response types.
-        return completeHardNavigation(state, redirectLocation, navigateType)
+        return completeHardNavigation(
+          state,
+          redirectLocation,
+          navigateType,
+          null
+        )
       }
 
       if (typeof flightData === 'string') {
@@ -434,7 +446,8 @@ export function serverActionReducer(
         return completeHardNavigation(
           state,
           new URL(flightData, location.origin),
-          navigateType
+          navigateType,
+          null
         )
       }
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -518,6 +518,7 @@ export function serverActionReducer(
           // have the route tree from the server response. If a mismatch occurs
           // during dynamic data fetch, the retry handler will traverse the
           // known route tree to mark the entry as having a dynamic rewrite.
+          null,
           null
         )
       }
@@ -534,7 +535,8 @@ export function serverActionReducer(
         nextUrl,
         freshnessPolicy,
         scrollBehavior,
-        navigateType
+        navigateType,
+        null
       )
     },
     (e: any) => {

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -25,10 +25,11 @@ export function serverPatchReducer(
   const retryUrl = new URL(action.url, location.origin)
   const retrySeed = action.seed
   const navigateType = action.navigateType
+  const transitionId = action.transitionId
   if (retryMpa || retrySeed === null) {
     // If the server did not send back data during the mismatch, fall back to
     // an MPA navigation.
-    return completeHardNavigation(state, retryUrl, navigateType)
+    return completeHardNavigation(state, retryUrl, navigateType, transitionId)
   }
   const currentUrl = new URL(state.canonicalUrl, location.origin)
   const currentRenderedSearch = state.renderedSearch
@@ -64,6 +65,7 @@ export function serverPatchReducer(
     // Server patch (retry) navigations don't use route prediction. This is
     // typically a retry after a previous mismatch, so the route was already
     // marked as having a dynamic rewrite when the mismatch was detected.
-    null
+    null,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -92,6 +92,7 @@ export interface NavigateAction {
   locationSearch: Location['search']
   navigateType: 'push' | 'replace'
   scrollBehavior: ScrollBehavior
+  transitionId: string | null
 }
 
 /**
@@ -107,6 +108,7 @@ export interface RestoreAction {
   type: typeof ACTION_RESTORE
   url: URL
   historyState: AppHistoryState | undefined
+  transitionId: string | null
 }
 
 export type AppHistoryState = {
@@ -125,6 +127,7 @@ export interface ServerPatchAction {
   seed: NavigationSeed | null
   mpa: boolean
   navigateType: 'push' | 'replace'
+  transitionId: string | null
 }
 
 /**
@@ -245,6 +248,11 @@ export type AppRouterState = {
    * The previous next-url that was used previous to a dynamic navigation.
    */
   previousNextUrl: string | null
+
+  /**
+   * Identifies the router transition represented by this state, if any.
+   */
+  transitionId: string | null
 
   debugInfo: Array<unknown> | null
 }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -15,8 +15,15 @@ import type {
   RouterTransitionType,
 } from '../router-transition-types'
 
+type RouterTransitionRecord = {
+  id: string
+  type: RouterTransitionType
+  committed: boolean
+}
+
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
 let nextTransitionId = 0
+let activeTransition: RouterTransitionRecord | null = null
 
 export function initializeRouterTransitionModules(
   modules: ClientInstrumentationModules
@@ -24,6 +31,23 @@ export function initializeRouterTransitionModules(
   instrumentationModules = modules.filter(
     (module): module is ClientInstrumentationHooks => module != null
   )
+
+  if (
+    !process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS &&
+    process.env.NODE_ENV !== 'production' &&
+    instrumentationModules.some(
+      (hooks) => typeof hooks.unstable_onRouterTransitionCommit === 'function'
+    )
+  ) {
+    console.warn(
+      'Router transition lifecycle hooks in instrumentation-client require ' +
+        '`experimental.instrumentationClientRouterTransitionEvents` to be enabled.'
+    )
+  }
+}
+
+function timestamp(): number {
+  return performance.timeOrigin + performance.now()
 }
 
 function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
@@ -39,8 +63,16 @@ function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
   }
 }
 
-function timestamp(): number {
-  return performance.timeOrigin + performance.now()
+function hasLifecycleInstrumentation(): boolean {
+  return instrumentationModules.some(
+    (hooks) =>
+      typeof hooks.onRouterTransitionStart === 'function' ||
+      typeof hooks.unstable_onRouterTransitionCommit === 'function'
+  )
+}
+
+function getActiveTransition(id: string | null): RouterTransitionRecord | null {
+  return id !== null && activeTransition?.id === id ? activeTransition : null
 }
 
 export function startRouterTransition(
@@ -48,18 +80,20 @@ export function startRouterTransition(
   type: RouterTransitionType,
   fromTree: FlightRouterState,
   prefetchIntent: RouterTransitionPrefetchIntent | null
-): void {
+): string | null {
   // Positive flag check so the instrumentation-only path is removed by DCE when disabled.
   if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
-    if (
-      !instrumentationModules.some(
-        (hooks) => typeof hooks.onRouterTransitionStart === 'function'
-      )
-    ) {
-      return
+    if (!hasLifecycleInstrumentation()) {
+      return null
     }
 
     const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
+    const record: RouterTransitionRecord = {
+      id,
+      type,
+      committed: false,
+    }
+    activeTransition = record
 
     callHooks((hooks) =>
       hooks.onRouterTransitionStart?.(url, type, {
@@ -69,9 +103,26 @@ export function startRouterTransition(
         prefetchIntent,
       })
     )
+    return id
   } else {
     callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type, null))
+    return null
   }
+}
+
+export function commitRouterTransition(id: string | null, url: string): void {
+  const record = getActiveTransition(id)
+  if (record === null || record.committed) {
+    return
+  }
+
+  record.committed = true
+  callHooks((hooks) =>
+    hooks.unstable_onRouterTransitionCommit?.(url, record.type, {
+      id: record.id,
+      timestamp: timestamp(),
+    })
+  )
 }
 
 function classifySegment(segment: Segment): {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -65,7 +65,8 @@ export function navigate(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null
 ): AppRouterState | Promise<AppRouterState> {
   let navigationLock: NavigationLock = null
 
@@ -91,7 +92,8 @@ export function navigate(
         freshnessPolicy,
         scrollBehavior,
         navigateType,
-        navigationLock
+        navigationLock,
+        transitionId
       )
     }
   }
@@ -107,7 +109,8 @@ export function navigate(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 }
 
@@ -122,7 +125,8 @@ function navigateImpl(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): AppRouterState | Promise<AppRouterState> {
   const now = Date.now()
   const href = url.href
@@ -144,7 +148,8 @@ function navigateImpl(
       scrollBehavior,
       navigateType,
       route,
-      navigationLock
+      navigationLock,
+      transitionId
     )
   }
 
@@ -181,7 +186,8 @@ function navigateImpl(
           scrollBehavior,
           navigateType,
           optimisticRoute,
-          navigationLock
+          navigationLock,
+          transitionId
         )
       }
     }
@@ -204,7 +210,8 @@ function navigateImpl(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   ).catch(() => {
     // If the navigation fails, return the current state
     return state
@@ -238,7 +245,8 @@ export function navigateToKnownRoute(
   // In these cases, if a mismatch occurs, we still mark the route as having a
   // dynamic rewrite by traversing the known route tree (see
   // dispatchRetryDueToTreeMismatch).
-  routeCacheEntry: FulfilledRouteCacheEntry | null
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  transitionId: string | null
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
@@ -350,11 +358,12 @@ export function navigateToKnownRoute(
       navigateType,
       scrollBehavior,
       accumulation.scrollRef,
-      debugInfo
+      debugInfo,
+      transitionId
     )
   }
   // Could not perform a SPA navigation. Revert to a full-page (MPA) navigation.
-  return completeHardNavigation(state, url, navigateType)
+  return completeHardNavigation(state, url, navigateType, transitionId)
 }
 
 function navigateUsingPrefetchedRouteTree(
@@ -370,7 +379,8 @@ function navigateUsingPrefetchedRouteTree(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
   route: FulfilledRouteCacheEntry,
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): AppRouterState {
   const routeTree = route.tree
   const canonicalUrl = route.canonicalUrl + url.hash
@@ -399,7 +409,8 @@ function navigateUsingPrefetchedRouteTree(
     navigateType,
     navigationLock,
     null,
-    route
+    route,
+    transitionId
   )
 }
 
@@ -427,7 +438,8 @@ async function navigateToUnknownRoute(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<AppRouterState> {
   // Runs when a navigation happens but there's no cached prefetch we can use.
   // Don't bother to wait for a prefetch response; go straight to a full
@@ -467,7 +479,12 @@ async function navigateToUnknownRoute(
   if (typeof result === 'string') {
     // This is an MPA navigation.
     const redirectUrl = new URL(result, location.origin)
-    return completeHardNavigation(state, redirectUrl, navigateType)
+    return completeHardNavigation(
+      state,
+      redirectUrl,
+      navigateType,
+      transitionId
+    )
   }
 
   const {
@@ -615,14 +632,16 @@ async function navigateToUnknownRoute(
     // came directly from the server. If a mismatch occurs during dynamic data
     // fetch, the retry handler will traverse the known route tree to mark the
     // entry as having a dynamic rewrite.
-    null
+    null,
+    transitionId
   )
 }
 
 export function completeHardNavigation(
   state: AppRouterState,
   url: URL,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null = null
 ): AppRouterState {
   if (isJavaScriptURLString(url.href)) {
     console.error(
@@ -649,6 +668,7 @@ export function completeHardNavigation(
     tree: state.tree,
     nextUrl: state.nextUrl,
     previousNextUrl: state.previousNextUrl,
+    transitionId,
     debugInfo: null,
   }
   return newState
@@ -665,7 +685,8 @@ export function completeSoftNavigation(
   navigateType: 'push' | 'replace',
   scrollBehavior: ScrollBehavior,
   scrollRef: ScrollRef | null,
-  collectedDebugInfo: Array<unknown> | null
+  collectedDebugInfo: Array<unknown> | null,
+  transitionId: string | null
 ) {
   // The "Next-Url" is a special representation of the URL that Next.js
   // uses to implement interception routes.
@@ -787,6 +808,7 @@ export function completeSoftNavigation(
     tree,
     nextUrl: nextUrlForNewRoute,
     previousNextUrl,
+    transitionId,
     debugInfo: collectedDebugInfo,
   }
   return newState
@@ -798,7 +820,8 @@ export function completeTraverseNavigation(
   renderedSearch: string,
   cache: CacheNode,
   tree: FlightRouterState,
-  nextUrl: string | null
+  nextUrl: string | null,
+  transitionId: string | null
 ) {
   return {
     // Set canonical url
@@ -819,6 +842,7 @@ export function completeTraverseNavigation(
     // Next-Url that was used to fetch the data. Anywhere we fetch using the
     // canonical URL, there should be a corresponding Next-Url.
     previousNextUrl: null,
+    transitionId,
     debugInfo: null,
   }
 }
@@ -1048,7 +1072,8 @@ async function ensurePrefetchThenNavigate(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<AppRouterState> {
   const link = getLinkForCurrentNavigation()
   const fetchStrategy = link !== null ? link.fetchStrategy : FetchStrategy.PPR
@@ -1079,7 +1104,8 @@ async function ensurePrefetchThenNavigate(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 
   // Only transition to captured-SPA once the navigation is known to be an SPA.

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -641,7 +641,7 @@ export function completeHardNavigation(
   state: AppRouterState,
   url: URL,
   navigateType: 'push' | 'replace',
-  transitionId: string | null = null
+  transitionId: string | null
 ): AppRouterState {
   if (isJavaScriptURLString(url.href)) {
     console.error(

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -13,11 +13,18 @@ export type RouterTransitionStartEvent = RouterTransitionEvent & {
   prefetchIntent: RouterTransitionPrefetchIntent | null
 }
 
+export type RouterTransitionCommitEvent = RouterTransitionEvent
+
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionStartEvent | null
+  ) => void
+  unstable_onRouterTransitionCommit?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionCommitEvent
   ) => void
 }
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -48,6 +48,7 @@ export type {
   RouterTransitionPrefetchIntent,
   RouterTransitionEvent,
   RouterTransitionStartEvent,
+  RouterTransitionCommitEvent,
 } from './client/router-transition-types'
 
 /**

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -29,3 +29,11 @@ export function onRouterTransitionStart(
   console.log(`[Router Transition Start] [${navigateType}] ${pathname}`)
   record('start', href, navigateType, event)
 }
+
+export function unstable_onRouterTransitionCommit(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('commit', href, navigateType, event)
+}

--- a/test/e2e/instrumentation-client-hook/inject/inject-a.js
+++ b/test/e2e/instrumentation-client-hook/inject/inject-a.js
@@ -9,3 +9,8 @@ export function onRouterTransitionStart(href, navigateType) {
     throw new Error('inject a transition hook failed')
   }
 }
+
+export function unstable_onRouterTransitionCommit(href, navigateType) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} a`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/inject-b.js
+++ b/test/e2e/instrumentation-client-hook/inject/inject-b.js
@@ -6,3 +6,8 @@ export function onRouterTransitionStart(href, navigateType) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname} b`)
 }
+
+export function unstable_onRouterTransitionCommit(href, navigateType) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} b`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/inject/instrumentation-client.ts
@@ -6,3 +6,11 @@ export function onRouterTransitionStart(href: string, navigateType: string) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname} user`)
 }
+
+export function unstable_onRouterTransitionCommit(
+  href: string,
+  navigateType: string
+) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} user`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/next.config.mjs
+++ b/test/e2e/instrumentation-client-hook/inject/next.config.mjs
@@ -6,4 +6,7 @@ export default {
     './inject-a.js',
     './inject-b.js',
   ],
+  experimental: {
+    instrumentationClientRouterTransitionEvents: true,
+  },
 }

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -57,6 +57,16 @@ describe('Instrumentation Client Hook', () => {
     return result
   }
 
+  function filterNavigationCommitLogs(logs: Array<{ message: string }>) {
+    const result = []
+    for (const log of logs) {
+      if (log.message.startsWith('[Router Transition Commit]')) {
+        result.push(log.message)
+      }
+    }
+    return result
+  }
+
   describe('onRouterTransitionStart', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'app-router'),
@@ -116,7 +126,7 @@ describe('Instrumentation Client Hook', () => {
     })
   })
 
-  describe('router transition start context', () => {
+  describe('router transition lifecycle', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'app-router'),
       nextConfig: {
@@ -130,20 +140,29 @@ describe('Instrumentation Client Hook', () => {
       return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
     }
 
-    it('reports transition metadata, source routes, and prefetch intent', async () => {
+    it('reports correlated start and commit events', async () => {
       const browser = await next.browser('/')
 
       await browser.elementByCss('a[href="/some-page"]').click()
       await browser.elementById('some-page')
 
-      const [start] = await getTransitionEvents(browser)
-      expect(start.phase).toBe('start')
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).map((event) => event.phase)
+        ).toEqual(['start', 'commit'])
+      })
+
+      const [start, commit] = await getTransitionEvents(browser)
       expect(start.url).toBe('/some-page')
       expect(start.navigateType).toBe('push')
       expect(typeof start.event.id).toBe('string')
       expect(start.event.timestamp).toBeGreaterThan(0)
       expect(start.event.fromRoutes).toEqual(['/'])
       expect(start.event.prefetchIntent).toBe('full')
+      expect(commit.event.id).toBe(start.event.id)
+      expect(commit.event.timestamp).toBeGreaterThanOrEqual(
+        start.event.timestamp
+      )
     })
 
     it('reports a null prefetch intent for programmatic navigation', async () => {
@@ -168,7 +187,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/blog/[slug]'])
 
       await browser.elementByCss('a[href="/dashboard"]').click()
@@ -178,7 +199,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/dashboard', '/dashboard/@analytics'])
     })
 
@@ -189,7 +212,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/about'])
     })
 
@@ -203,7 +228,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/gallery', '/gallery/@modal/(.)photos/[id]'])
     })
   })
@@ -267,6 +294,15 @@ describe('Instrumentation Client Hook', () => {
         '[Router Transition Start] [push] / a',
         '[Router Transition Start] [push] / b',
         '[Router Transition Start] [push] / user',
+      ])
+
+      expect(filterNavigationCommitLogs(await browser.log())).toEqual([
+        '[Router Transition Commit] [push] /some-page a',
+        '[Router Transition Commit] [push] /some-page b',
+        '[Router Transition Commit] [push] /some-page user',
+        '[Router Transition Commit] [push] / a',
+        '[Router Transition Commit] [push] / b',
+        '[Router Transition Commit] [push] / user',
       ])
     })
 


### PR DESCRIPTION
## Stack Position

(3/7) in the router instrumentation stack.

1. #94755: router instrumentation: refactor client hook dispatch (1/7)
2. #94766: router instrumentation: add transition start context (2/7)
3. **#94756: router instrumentation: add transition commit events (3/7)**
4. #94765: router instrumentation: add commit route and prefetch context (4/7)
5. #94757: router instrumentation: add transition abort events (5/7)
6. #94758: router instrumentation: add route mismatch events (6/7)
7. #94737: router instrumentation: add transition settlement events (7/7)

Parent: #94766
Next: #94765

## What This PR Does

Adds the correlated commit milestone:

```ts
export function unstable_onRouterTransitionCommit(
  url,
  navigationType,
  event
) {}
```

Start and commit share a transition ID and each carries a framework-captured timestamp. Commit fires when the destination URL and first destination UI commit.

## Why This Boundary Matters

`commit.timestamp - start.timestamp` measures time to the first destination UI, including whether a navigation was effectively instant. This slice isolates that timing contract from route extraction and prefetch classification.

## Not In This PR

- Destination route patterns or observed prefetch result
- Abort, mismatch, or settled events

Source routes and prefetch intent are already available on start. Consumers join the events by ID.

## Reviewer Focus

- Transition ID propagation through both router paths
- The exact commit boundary in `HistoryUpdater`
- Duplicate commit prevention and legacy behavior when the flag is disabled

## Validation

- `pnpm build-all`
- Focused App Router instrumentation coverage: 3 passed

<!-- NEXT_JS_LLM_PR -->
