### PR TITLE
router instrumentation: add transition abort events (5/7)

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_onRouterTransitionCommit` hook:
+Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit and abort hooks:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -72,6 +72,7 @@ Then export the optional commit hook:
 
 ```ts filename="instrumentation-client.ts" switcher
 import type {
+  RouterTransitionAbortEvent,
   RouterTransitionCommitEvent,
   RouterTransitionStartEvent,
   RouterTransitionType,
@@ -99,6 +100,14 @@ export function unstable_onRouterTransitionCommit(
     starts.delete(event.id)
   }
 }
+
+export function unstable_onRouterTransitionAbort(
+  url: string,
+  navigationType: RouterTransitionType,
+  { id }: RouterTransitionAbortEvent
+) {
+  starts.delete(id)
+}
 ```
 
 ```js filename="instrumentation-client.js" switcher
@@ -116,6 +125,10 @@ export function unstable_onRouterTransitionCommit(url, navigationType, event) {
     starts.delete(event.id)
   }
 }
+
+export function unstable_onRouterTransitionAbort(url, navigationType, event) {
+  starts.delete(event.id)
+}
 ```
 
 Each hook receives the same three parameters:
@@ -130,6 +143,7 @@ The available hooks are:
 | ----------------------------------- | ---------------------------------------- |
 | `onRouterTransitionStart`           | The navigation is dispatched.            |
 | `unstable_onRouterTransitionCommit` | The first destination UI and URL commit. |
+| `unstable_onRouterTransitionAbort`  | The transition stops before completion.  |
 
 The start event also includes:
 
@@ -143,7 +157,7 @@ The commit event also includes:
 
 Route entries use filesystem-style patterns, so `/blog/hello` may report `/blog/[slug]`.
 
-Hook errors are isolated and do not affect navigation or other hooks.
+`unstable_onRouterTransitionAbort` receives a `reason` of `superseded`, `hard-navigation`, or `error`. Hook errors are isolated and do not affect navigation or other hooks.
 
 ## Performance considerations
 

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -6,6 +6,7 @@ import {
   ACTION_SERVER_ACTION,
   ACTION_NAVIGATE,
   ACTION_RESTORE,
+  ACTION_SERVER_PATCH,
   type NavigateAction,
   ACTION_HMR_REFRESH,
   PrefetchKind,
@@ -38,7 +39,10 @@ import { setLinkForCurrentNavigation, type LinkInstance } from './links'
 import type { RouterTransitionPrefetchIntent } from '../router-transition-types'
 import type { GlobalErrorComponent } from './builtin/global-error'
 import { isJavaScriptURLString } from '../lib/javascript-url'
-import { startRouterTransition } from './router-transition'
+import {
+  abortRouterTransition,
+  startRouterTransition,
+} from './router-transition'
 
 export type DispatchStatePromise = React.Dispatch<ReducerState>
 
@@ -63,6 +67,14 @@ export type ActionQueueNode = {
   resolve: (value: ReducerState) => void
   reject: (err: Error) => void
   discarded?: boolean
+}
+
+function getActionTransitionId(action: ReducerActions): string | null {
+  return action.type === ACTION_NAVIGATE ||
+    action.type === ACTION_RESTORE ||
+    action.type === ACTION_SERVER_PATCH
+    ? action.transitionId
+    : null
 }
 
 function runRemainingActions(
@@ -133,6 +145,7 @@ async function runAction({
   if (isThenable(actionResult)) {
     actionResult.then(handleResult, (err) => {
       runRemainingActions(actionQueue, setState)
+      abortRouterTransition(getActionTransitionId(action.payload), 'error')
       action.reject(err)
     })
   } else {

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -18,6 +18,7 @@ import type {
 
 type RouterTransitionRecord = {
   id: string
+  resolvedUrl: string
   type: RouterTransitionType
   prefetch: RouterTransitionPrefetch
   committed: boolean
@@ -38,7 +39,9 @@ export function initializeRouterTransitionModules(
     !process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS &&
     process.env.NODE_ENV !== 'production' &&
     instrumentationModules.some(
-      (hooks) => typeof hooks.unstable_onRouterTransitionCommit === 'function'
+      (hooks) =>
+        typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+        typeof hooks.unstable_onRouterTransitionAbort === 'function'
     )
   ) {
     console.warn(
@@ -69,7 +72,8 @@ function hasLifecycleInstrumentation(): boolean {
   return instrumentationModules.some(
     (hooks) =>
       typeof hooks.onRouterTransitionStart === 'function' ||
-      typeof hooks.unstable_onRouterTransitionCommit === 'function'
+      typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+      typeof hooks.unstable_onRouterTransitionAbort === 'function'
   )
 }
 
@@ -92,9 +96,14 @@ export function startRouterTransition(
     return null
   }
 
+  if (activeTransition !== null) {
+    abortRouterTransition(activeTransition.id, 'superseded')
+  }
+
   const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
   const record: RouterTransitionRecord = {
     id,
+    resolvedUrl: url,
     type,
     prefetch: 'none',
     committed: false,
@@ -137,12 +146,35 @@ export function commitRouterTransition(
   }
 
   record.committed = true
+  record.resolvedUrl = url
   callHooks((hooks) =>
     hooks.unstable_onRouterTransitionCommit?.(url, record.type, {
       id: record.id,
       timestamp: timestamp(),
       routes: getActiveRoutePaths(tree),
       prefetch: record.prefetch,
+    })
+  )
+  activeTransition = null
+}
+
+export function abortRouterTransition(
+  id: string | null,
+  reason: 'superseded' | 'hard-navigation' | 'error',
+  url?: string
+): void {
+  const record = getActiveTransition(id)
+  if (record === null) {
+    return
+  }
+
+  record.resolvedUrl = url ?? record.resolvedUrl
+  activeTransition = null
+  callHooks((hooks) =>
+    hooks.unstable_onRouterTransitionAbort?.(record.resolvedUrl, record.type, {
+      id: record.id,
+      timestamp: timestamp(),
+      reason,
     })
   )
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -46,7 +46,10 @@ import { ScrollBehavior } from '../router-reducer/router-reducer-types'
 import { computeChangedPath } from '../router-reducer/compute-changed-path'
 import { isJavaScriptURLString } from '../../lib/javascript-url'
 import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
-import { setRouterTransitionPrefetch } from '../router-transition'
+import {
+  abortRouterTransition,
+  setRouterTransitionPrefetch,
+} from '../router-transition'
 
 /**
  * Navigate to a new URL, using the Segment Cache to construct a response.
@@ -215,6 +218,7 @@ function navigateImpl(
     navigationLock,
     transitionId
   ).catch(() => {
+    abortRouterTransition(transitionId, 'error')
     // If the navigation fails, return the current state
     return state
   })
@@ -637,8 +641,10 @@ export function completeHardNavigation(
     console.error(
       'Next.js has blocked a javascript: URL as a security precaution.'
     )
+    abortRouterTransition(transitionId, 'error', url.href)
     return state
   }
+  abortRouterTransition(transitionId, 'hard-navigation', url.href)
   const newState: AppRouterState = {
     canonicalUrl:
       url.origin === location.origin ? createHrefFromUrl(url) : url.href,

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -23,6 +23,10 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   prefetch: RouterTransitionPrefetch
 }
 
+export type RouterTransitionAbortEvent = RouterTransitionEvent & {
+  reason: 'superseded' | 'hard-navigation' | 'error'
+}
+
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
@@ -33,6 +37,11 @@ export type ClientInstrumentationHooks = {
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionCommitEvent
+  ) => void
+  unstable_onRouterTransitionAbort?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionAbortEvent
   ) => void
 }
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,6 +50,7 @@ export type {
   RouterTransitionEvent,
   RouterTransitionStartEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionAbortEvent,
 } from './client/router-transition-types'
 
 /**

--- a/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
@@ -19,6 +19,11 @@ export default function RootLayout({ children }) {
           <li>
             <Link href="/blog/hello">Blog post</Link>
           </li>
+          <li>
+            <Link href="/slow" prefetch={true}>
+              Slow page
+            </Link>
+          </li>
         </ul>
         {children}
       </body>

--- a/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return <h1 id="slow-page">Slow page</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -37,3 +37,11 @@ export function unstable_onRouterTransitionCommit(
 ) {
   record('commit', href, navigateType, event)
 }
+
+export function unstable_onRouterTransitionAbort(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('abort', href, navigateType, event)
+}

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -219,6 +219,28 @@ describe('Instrumentation Client Hook', () => {
         '/dashboard/@analytics',
       ])
     })
+
+    it('aborts a transition when it is superseded', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/slow"]').click()
+      await retry(async () => {
+        expect((await getTransitionEvents(browser))[0].phase).toBe('start')
+      })
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await retry(async () => {
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+      })
+
+      const events = await getTransitionEvents(browser)
+      const firstId = events[0].event.id
+      const abort = events.find(
+        (event) => event.event.id === firstId && event.phase === 'abort'
+      )
+      expect(abort.event.reason).toBe('superseded')
+    })
   })
 
   describe.each([


### PR DESCRIPTION
## Stack Position

(5/7) in the router instrumentation stack.

1. #94755: router instrumentation: refactor client hook dispatch (1/7)
2. #94766: router instrumentation: add transition start context (2/7)
3. #94756: router instrumentation: add transition commit events (3/7)
4. #94765: router instrumentation: add commit route and prefetch context (4/7)
5. **#94757: router instrumentation: add transition abort events (5/7)**
6. #94758: router instrumentation: add route mismatch events (6/7)
7. #94737: router instrumentation: add transition settlement events (7/7)

Parent: #94765
Next: #94758

## What This PR Does

Adds `unstable_onRouterTransitionAbort` for client transitions that do not complete successfully.

| Reason | Meaning |
| --- | --- |
| `superseded` | A newer navigation replaced the active transition. |
| `hard-navigation` | The client router fell back to a document navigation. |
| `error` | Router processing failed or a blocked URL stopped the transition. |

The event carries the transition ID, a terminal timestamp, and the reason.

## Design

- A new navigation aborts the active unsettled transition before its own start event.
- Hard-navigation fallbacks and router failures have distinct reasons.
- Terminal events do not repeat start or commit context; consumers join by ID.

## Not In This PR

- Route mismatch diagnostics
- Successful settlement and response-close accounting

## Reviewer Focus

- Ordering when one navigation supersedes another
- Hard-navigation versus error classification
- Exactly-once abort delivery

## Validation

- `pnpm build-all`
- Superseded navigation E2E: 1 passed

<!-- NEXT_JS_LLM_PR -->
