### PR TITLE
router instrumentation: add route mismatch events (6/7)

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit and abort hooks:
+Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit, route mismatch, and abort hooks:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -74,6 +74,7 @@ Then export the optional commit hook:
 import type {
   RouterTransitionAbortEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionRouteMismatchEvent,
   RouterTransitionStartEvent,
   RouterTransitionType,
 } from 'next'
@@ -108,6 +109,14 @@ export function unstable_onRouterTransitionAbort(
 ) {
   starts.delete(id)
 }
+
+export function unstable_onRouterTransitionRouteMismatch(
+  url: string,
+  navigationType: RouterTransitionType,
+  event: RouterTransitionRouteMismatchEvent
+) {
+  console.log('Route mismatch:', event.id, url)
+}
 ```
 
 ```js filename="instrumentation-client.js" switcher
@@ -129,6 +138,14 @@ export function unstable_onRouterTransitionCommit(url, navigationType, event) {
 export function unstable_onRouterTransitionAbort(url, navigationType, event) {
   starts.delete(event.id)
 }
+
+export function unstable_onRouterTransitionRouteMismatch(
+  url,
+  navigationType,
+  event
+) {
+  console.log('Route mismatch:', event.id, url)
+}
 ```
 
 Each hook receives the same three parameters:
@@ -139,11 +156,14 @@ Each hook receives the same three parameters:
 
 The available hooks are:
 
-| Hook                                | Timing                                   |
-| ----------------------------------- | ---------------------------------------- |
-| `onRouterTransitionStart`           | The navigation is dispatched.            |
-| `unstable_onRouterTransitionCommit` | The first destination UI and URL commit. |
-| `unstable_onRouterTransitionAbort`  | The transition stops before completion.  |
+| Hook                                       | Timing                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------ |
+| `onRouterTransitionStart`                  | The navigation is dispatched.                                            |
+| `unstable_onRouterTransitionCommit`        | The first destination UI and URL commit.                                 |
+| `unstable_onRouterTransitionRouteMismatch` | The live route tree differs from the prefetched or predicted route tree. |
+| `unstable_onRouterTransitionAbort`         | The transition stops before completion.                                  |
+
+`unstable_onRouterTransitionRouteMismatch` is diagnostic and non-terminal. It indicates that Next.js detected a different route tree and retried the navigation.
 
 The start event also includes:
 

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -44,6 +44,7 @@ import { FetchStrategy } from '../segment-cache/types'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
+import { routeMismatchRouterTransition } from '../router-transition'
 import {
   getRenderedSearchFromVaryPath,
   type PageVaryPath,
@@ -111,10 +112,15 @@ const enum NavigationTaskExitStatus {
    */
   SoftRetry = 1,
   /**
-   * Some data failed to load in an unrecoverable way, e.g. in an inactive
-   * parallel route. Fall back to a hard (MPA-style) retry.
+   * Some data failed to load in an unrecoverable way. Fall back to a hard
+   * (MPA-style) retry.
    */
   HardRetry = 2,
+  /**
+   * A route tree mismatch occurred inside an inactive parallel route. Fall
+   * back to a hard retry.
+   */
+  HardMismatch = 3,
 }
 
 export type NavigationRequestAccumulation = {
@@ -1376,7 +1382,8 @@ export function spawnDynamicRequests(
   // server-patch retry logic so it can inherit the intent if the original
   // transition hasn't committed yet.
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
   if (dynamicRequestTree === null) {
@@ -1469,7 +1476,8 @@ export function spawnDynamicRequests(
     primaryRequestPromise,
     refreshRequestPromises,
     routeCacheEntry,
-    navigateType
+    navigateType,
+    transitionId
   )
   // `finishNavigationTask` is responsible for error handling, so we can attach
   // noop callbacks to this promise.
@@ -1484,7 +1492,8 @@ async function finishNavigationTask(
     ReturnType<typeof fetchMissingDynamicData>
   > | null,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null
 ): Promise<void> {
   // Wait for all the requests to finish, or for the first one to fail.
   let exitStatus = await waitForRequestsToFinish(
@@ -1508,13 +1517,18 @@ async function finishNavigationTask(
       previousNavigationDidMismatch = false
       return
     }
-    case NavigationTaskExitStatus.SoftRetry: {
-      // Some data failed to finish loading. Trigger a soft retry.
-      // TODO: As an extra precaution against soft retry loops, consider
-      // tracking whether a navigation was itself triggered by a retry. If two
-      // happen in a row, fall back to a hard retry.
-      const isHardRetry = false
+    case NavigationTaskExitStatus.SoftRetry:
+    case NavigationTaskExitStatus.HardRetry:
+    case NavigationTaskExitStatus.HardMismatch: {
+      const isHardRetry = exitStatus !== NavigationTaskExitStatus.SoftRetry
+      const isMismatch = exitStatus !== NavigationTaskExitStatus.HardRetry
       const primaryRequestResult = await primaryRequestPromise
+      if (isMismatch) {
+        routeMismatchRouterTransition(
+          transitionId,
+          primaryRequestResult.url.href
+        )
+      }
       dispatchRetryDueToTreeMismatch(
         isHardRetry,
         primaryRequestResult.url,
@@ -1522,29 +1536,8 @@ async function finishNavigationTask(
         primaryRequestResult.seed,
         task.route,
         routeCacheEntry,
-        navigateType
-      )
-      return
-    }
-    case NavigationTaskExitStatus.HardRetry: {
-      // Some data failed to finish loading in a non-recoverable way, such as a
-      // network error. Trigger an MPA navigation.
-      //
-      // Hard navigating/refreshing is how we prevent an infinite retry loop
-      // caused by a network error — when the network fails, we fall back to the
-      // browser behavior for offline navigations. In the future, Next.js may
-      // introduce its own custom handling of offline navigations, but that
-      // doesn't exist yet.
-      const isHardRetry = true
-      const primaryRequestResult = await primaryRequestPromise
-      dispatchRetryDueToTreeMismatch(
-        isHardRetry,
-        primaryRequestResult.url,
-        nextUrl,
-        primaryRequestResult.seed,
-        task.route,
-        routeCacheEntry,
-        navigateType
+        navigateType,
+        transitionId
       )
       return
     }
@@ -1614,7 +1607,8 @@ function dispatchRetryDueToTreeMismatch(
   // a dynamic rewrite so future predictions bail out.
   routeCacheEntry: FulfilledRouteCacheEntry | null,
   // The original navigation's push/replace intent.
-  originalNavigateType: 'push' | 'replace'
+  originalNavigateType: 'push' | 'replace',
+  transitionId: string | null
 ) {
   // If the navigation used a route prediction, mark it as having a dynamic
   // rewrite since it resulted in a mismatch.
@@ -1682,7 +1676,7 @@ function dispatchRetryDueToTreeMismatch(
     seed,
     mpa: isHardRetry,
     navigateType: retryNavigateType,
-    transitionId: null,
+    transitionId,
   }
   dispatchAppRouterAction(retryAction)
 }
@@ -1999,7 +1993,7 @@ function abortRemainingPendingTasks(
       // TODO: An alternative could be to trigger a soft refresh but to _not_
       // re-use the inactive parallel routes this time. Similar to what would
       // happen if were to do a hard refrehs, but without the HTML page.
-      exitStatus = NavigationTaskExitStatus.HardRetry
+      exitStatus = NavigationTaskExitStatus.HardMismatch
     }
   } else {
     // This segment finished. (An error here is treated as Done because they are

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -93,7 +93,8 @@ export function restoreReducer(
     null,
     // History traversal always uses 'replace'.
     'replace',
-    navigationLock
+    navigationLock,
+    transitionId
   )
   return completeTraverseNavigation(
     state,

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -22,6 +22,7 @@ type RouterTransitionRecord = {
   type: RouterTransitionType
   prefetch: RouterTransitionPrefetch
   committed: boolean
+  routeMismatchEmitted: boolean
 }
 
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
@@ -41,6 +42,7 @@ export function initializeRouterTransitionModules(
     instrumentationModules.some(
       (hooks) =>
         typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+        typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
         typeof hooks.unstable_onRouterTransitionAbort === 'function'
     )
   ) {
@@ -73,6 +75,7 @@ function hasLifecycleInstrumentation(): boolean {
     (hooks) =>
       typeof hooks.onRouterTransitionStart === 'function' ||
       typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+      typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
       typeof hooks.unstable_onRouterTransitionAbort === 'function'
   )
 }
@@ -97,7 +100,11 @@ export function startRouterTransition(
   }
 
   if (activeTransition !== null) {
-    abortRouterTransition(activeTransition.id, 'superseded')
+    if (activeTransition.committed) {
+      activeTransition = null
+    } else {
+      abortRouterTransition(activeTransition.id, 'superseded')
+    }
   }
 
   const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
@@ -107,6 +114,7 @@ export function startRouterTransition(
     type,
     prefetch: 'none',
     committed: false,
+    routeMismatchEmitted: false,
   }
   activeTransition = record
 
@@ -155,7 +163,25 @@ export function commitRouterTransition(
       prefetch: record.prefetch,
     })
   )
-  activeTransition = null
+}
+
+export function routeMismatchRouterTransition(
+  id: string | null,
+  url: string
+): void {
+  const record = getActiveTransition(id)
+  if (record === null || record.routeMismatchEmitted) {
+    return
+  }
+
+  record.routeMismatchEmitted = true
+  record.resolvedUrl = url
+  callHooks((hooks) =>
+    hooks.unstable_onRouterTransitionRouteMismatch?.(url, record.type, {
+      id: record.id,
+      timestamp: timestamp(),
+    })
+  )
 }
 
 export function abortRouterTransition(

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -354,7 +354,8 @@ export function navigateToKnownRoute(
         accumulation,
         routeCacheEntry,
         navigateType,
-        navigationLock
+        navigationLock,
+        transitionId
       )
     }
     return completeSoftNavigation(

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -23,6 +23,8 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   prefetch: RouterTransitionPrefetch
 }
 
+export type RouterTransitionRouteMismatchEvent = RouterTransitionEvent
+
 export type RouterTransitionAbortEvent = RouterTransitionEvent & {
   reason: 'superseded' | 'hard-navigation' | 'error'
 }
@@ -37,6 +39,11 @@ export type ClientInstrumentationHooks = {
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionCommitEvent
+  ) => void
+  unstable_onRouterTransitionRouteMismatch?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionRouteMismatchEvent
   ) => void
   unstable_onRouterTransitionAbort?: (
     url: string,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,6 +50,7 @@ export type {
   RouterTransitionEvent,
   RouterTransitionStartEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionRouteMismatchEvent,
   RouterTransitionAbortEvent,
 } from './client/router-transition-types'
 

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -38,6 +38,14 @@ export function unstable_onRouterTransitionCommit(
   record('commit', href, navigateType, event)
 }
 
+export function unstable_onRouterTransitionRouteMismatch(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('route-mismatch', href, navigateType, event)
+}
+
 export function unstable_onRouterTransitionAbort(
   href: string,
   navigateType: string,


### PR DESCRIPTION
## Stack Position

(6/7) in the router instrumentation stack.

1. #94755: router instrumentation: refactor client hook dispatch (1/7)
2. #94766: router instrumentation: add transition start context (2/7)
3. #94756: router instrumentation: add transition commit events (3/7)
4. #94765: router instrumentation: add commit route and prefetch context (4/7)
5. #94757: router instrumentation: add transition abort events (5/7)
6. **#94758: router instrumentation: add route mismatch events (6/7)**
7. #94737: router instrumentation: add transition settlement events (7/7)

Parent: #94757
Next: #94737

## What This PR Does

Adds the diagnostic, non-terminal `unstable_onRouterTransitionRouteMismatch` event.

A mismatch means the live server route tree differs from the prefetched or predicted tree, so Next.js retries the navigation. It is distinct from `prefetch: 'miss'`, which means no usable prefetched entry was available.

| Scenario | Expected ordering |
| --- | --- |
| Before first destination UI | `start -> routeMismatch -> commit` |
| After an App Shell commit | `start -> commit -> routeMismatch` |
| Hard retry without a route-tree inconsistency | No route mismatch event |

## Design

- The same transition ID survives the retry.
- At most one mismatch event is emitted per transition.
- Mismatch carries only ID and timestamp because it marks that the prediction was wrong, not a new authoritative route state.
- A committed transition remains active for a later App Shell response mismatch.

## Not In This PR

- Response completion and successful terminal settlement

## Reviewer Focus

- Route-tree mismatch versus an ordinary prefetch miss
- Retry ID propagation before and after commit
- Mismatch remains diagnostic rather than terminal

## Validation

- `pnpm build-all`
- `pnpm --filter=next types`

A deterministic end-to-end mismatch fixture remains a coverage gap.

<!-- NEXT_JS_LLM_PR -->
