### PR TITLE
Remove the logic where we skip eviction after persistence if we are non idle

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2935,11 +2935,6 @@ impl TurboTasksBackend {
                                 // be evicted).
                                 let mut ran_eviction = false;
                                 if self.should_evict() && (new_data || !evicted) {
-                                    if check_idle_ended!() {
-                                        // need to start all the way over so we catch the next
-                                        // signal
-                                        continue 'outer;
-                                    }
                                     evicted = true;
                                     ran_eviction = true;
                                     self.storage.evict_after_snapshot(background_span.id());


### PR DESCRIPTION
Currently after a persistence cycle in dev when eviction is enabled, we check for `idle`, if turbo tasks is no longer idle we skip eviction.

The idea is simply that eviction takes a lot of locks and will fight with any in flight computation.  This is true, but i don't think it is important.  eviction takes <20ms on the largest applications and the memory freed will generally unlock perf wins elsewhere through reducing memory pressure.

The eviction logic is defensive and we will back off evicting tasks that appear to be in flight (restoring/inprogress/activeness flags all prevent eviction).

So the upside here is that eviction cannot be skipped. The downside is a window of extra lock contention if eviction races with the application,  but this is similar to (and cheaper than) computation racing with persistence.