### PR TITLE
[cna] Include packages field in pnpm-workspace.yaml for pnpm v10.0-10.4

### DIFF
--- a/packages/create-next-app/helpers/get-pkg-manager.ts
+++ b/packages/create-next-app/helpers/get-pkg-manager.ts
@@ -63,3 +63,14 @@ export function getPnpmMajorVersion(): number | null {
   const major = parseInt(version.split('.')[0], 10)
   return Number.isNaN(major) ? null : major
 }
+
+/**
+ * Get the minor version of pnpm being used.
+ * Returns null if unable to determine the version.
+ */
+export function getPnpmMinorVersion(): number | null {
+  const version = getPackageManagerVersion('pnpm')
+  if (!version) return null
+  const minor = parseInt(version.split('.')[1], 10)
+  return Number.isNaN(minor) ? null : minor
+}

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -4,6 +4,7 @@ import { copy } from "../helpers/copy";
 import {
   getPackageManagerVersion,
   getPnpmMajorVersion,
+  getPnpmMinorVersion,
 } from "../helpers/get-pkg-manager";
 
 import { async as glob } from "fast-glob";
@@ -334,10 +335,12 @@ export const installTemplate = async ({
     // Only create pnpm-workspace.yaml for pnpm v10+.
     // In v9, having a pnpm-workspace.yaml (even with packages: []) causes
     // ERR_PNPM_ADDING_TO_ROOT errors when running `pnpm add`.
-    // In v10, the packages field can be omitted entirely.
-    // If we can't determine the version, assume latest (v10+) since we already
+    // In v10.5+, the packages field can be omitted entirely.
+    // In v10.0-10.4, the packages field is still required.
+    // If we can't determine the version, assume latest (v11+) since we already
     // know pnpm is being used at this point.
     const pnpmMajorVersion = getPnpmMajorVersion();
+    const pnpmMinorVersion = getPnpmMinorVersion();
     if (pnpmMajorVersion === null || pnpmMajorVersion >= 11) {
       // In pnpm v11, `ignoredBuiltDependencies` (and the other build-script
       // settings) were removed in favor of a single `allowBuilds` map where
@@ -358,20 +361,40 @@ export const installTemplate = async ({
         pnpmWorkspaceYaml,
       );
     } else if (pnpmMajorVersion >= 10) {
-      const pnpmWorkspaceYaml = [
-        "ignoredBuiltDependencies:",
-        // Sharp has prebuilt binaries for the platforms next-swc has binaries.
-        // If it needs to build binaries from source, next-swc wouldn't work either.
-        // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
-        "  - sharp",
-        // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
-        "  - unrs-resolver",
-        "",
-      ].join(os.EOL);
-      await fs.writeFile(
-        path.join(root, "pnpm-workspace.yaml"),
-        pnpmWorkspaceYaml,
-      );
+      if (pnpmMinorVersion === null || pnpmMinorVersion >= 5) {
+        // pnpm v10.5+ allows omitting the packages field
+        const pnpmWorkspaceYaml = [
+          "ignoredBuiltDependencies:",
+          // Sharp has prebuilt binaries for the platforms next-swc has binaries.
+          // If it needs to build binaries from source, next-swc wouldn't work either.
+          // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
+          "  - sharp",
+          // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
+          "  - unrs-resolver",
+          "",
+        ].join(os.EOL);
+        await fs.writeFile(
+          path.join(root, "pnpm-workspace.yaml"),
+          pnpmWorkspaceYaml,
+        );
+      } else {
+        // pnpm v10.0-10.4 requires the packages field
+        const pnpmWorkspaceYaml = [
+          "packages: []",
+          "ignoredBuiltDependencies:",
+          // Sharp has prebuilt binaries for the platforms next-swc has binaries.
+          // If it needs to build binaries from source, next-swc wouldn't work either.
+          // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
+          "  - sharp",
+          // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
+          "  - unrs-resolver",
+          "",
+        ].join(os.EOL);
+        await fs.writeFile(
+          path.join(root, "pnpm-workspace.yaml"),
+          pnpmWorkspaceYaml,
+        );
+      }
     }
   }
 

--- a/test/production/create-next-app/package-manager/pnpm.test.ts
+++ b/test/production/create-next-app/package-manager/pnpm.test.ts
@@ -93,7 +93,7 @@ describe('create-next-app with package manager pnpm', () => {
   // 1. We only need to verify the workspace file is created/not created
   // 2. The CI runs pnpm v9, but when testing v10 behavior, the workspace file
   //    created for v10 (without packages field) would fail with pnpm v9
-  it('should create pnpm-workspace.yaml with ignoredBuiltDependencies for pnpm v10', async () => {
+  it('should create pnpm-workspace.yaml with packages field for pnpm v10.0-10.4', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pnpm-v10-workspace'
       const res = await run(
@@ -126,6 +126,48 @@ describe('create-next-app with package manager pnpm', () => {
         path.join(cwd, projectName, 'pnpm-workspace.yaml'),
         'utf8'
       )
+      expect(workspaceYaml).toContain('packages: []')
+      expect(workspaceYaml).toContain('ignoredBuiltDependencies:')
+      expect(workspaceYaml).toContain('- sharp')
+      expect(workspaceYaml).toContain('- unrs-resolver')
+      expect(workspaceYaml).not.toContain('allowBuilds:')
+    })
+  })
+
+  it('should create pnpm-workspace.yaml without packages field for pnpm v10.5+', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'pnpm-v105-workspace'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--no-linter',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+          '--no-react-compiler',
+          '--no-agents-md',
+          '--skip-install',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+          env: { npm_config_user_agent: 'pnpm/10.5.0 npm/? node/v20.0.0' },
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files: ['package.json', 'pnpm-workspace.yaml'],
+      })
+      const workspaceYaml = fs.readFileSync(
+        path.join(cwd, projectName, 'pnpm-workspace.yaml'),
+        'utf8'
+      )
+      expect(workspaceYaml).not.toContain('packages: []')
       expect(workspaceYaml).toContain('ignoredBuiltDependencies:')
       expect(workspaceYaml).toContain('- sharp')
       expect(workspaceYaml).toContain('- unrs-resolver')


### PR DESCRIPTION
PR #88647 removed the packages field from pnpm-workspace.yaml for all pnpm v10+, assuming it is optional across all v10 versions. However, pnpm only made the packages field optional from v10.5.0. Versions 10.0-10.4.x still require it, causing pnpm install to fail with packages field missing or empty.

This adds a getPnpmMinorVersion() helper and uses it to distinguish between v10.0-10.4 (requires packages field) and v10.5+ (packages field can be omitted). The v11+ and v9 paths are unchanged.

