### PR TITLE
router instrumentation: add commit route and prefetch context (4/7)

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1391,11 +1391,10 @@ fn insert_package_alias(import_map: &mut ImportMap, prefix: &str, package_root: 
 
 /// Handles instrumentation-client.ts bundling logic.
 ///
-/// Resolves the `private-next-instrumentation-client` alias to a virtual module
-/// that first requires each entry of `instrumentationClientInject` for side
-/// effects (in array order) and then re-exports the user's
-/// `instrumentation-client.{pageExt}` file via the
-/// `private-next-instrumentation-client-user` alias.
+/// Without injected modules, resolves `private-next-instrumentation-client`
+/// directly to the user's `instrumentation-client.{pageExt}` file. Otherwise,
+/// resolves it to a virtual module containing each injected module in array
+/// order, followed by the user's instrumentation module.
 async fn insert_instrumentation_client_alias(
     import_map: &mut ImportMap,
     project_path: FileSystemPath,
@@ -1412,9 +1411,9 @@ async fn insert_instrumentation_client_alias(
         ImportMapping::Ignore.resolved_cell(),
     ];
 
-    let injects = next_config.instrumentation_client_inject().await?;
+    let modules = next_config.instrumentation_client_inject().await?;
 
-    if injects.is_empty() {
+    if modules.is_empty() {
         insert_alias_to_alternatives(
             import_map,
             rcstr!("private-next-instrumentation-client"),
@@ -1431,25 +1430,18 @@ async fn insert_instrumentation_client_alias(
         user_file_alternatives,
     );
 
-    let injects = injects
+    let modules = modules
         .iter()
         .map(|s| s.as_str())
         .chain(std::iter::once("private-next-instrumentation-client-user"));
-
-    let mut body = String::new();
-    for (i, spec) in injects.clone().enumerate() {
-        body.push_str(&format!(
-            "var mod_{i} = require({});\n",
-            serde_json::to_string(spec)?
-        ));
+    let mut body = String::from("module.exports = [");
+    for (i, spec) in modules.enumerate() {
+        if i > 0 {
+            body.push(',');
+        }
+        body.push_str(&format!("require({})", serde_json::to_string(spec)?));
     }
-    body.push_str("module.exports = { onRouterTransitionStart(url, type) {\n");
-    for (i, _) in injects.enumerate() {
-        body.push_str(&format!(
-            "    mod_{i}?.onRouterTransitionStart?.(url, type);\n"
-        ));
-    }
-    body.push_str("}};\n");
+    body.push_str("];\n");
 
     let virtual_source = VirtualSource::new(
         // Use cjs here in case the user has type:module in the package.json. We do intentionally

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -136,7 +136,12 @@ The start event also includes:
 - `fromRoutes`: Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order.
 - `prefetchIntent`: Whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`).
 
-Route entries use filesystem-style patterns, so a navigation away from `/blog/hello` may report `/blog/[slug]`.
+The commit event also includes:
+
+- `routes`: Active route patterns in the destination UI. The primary `children` route is first, followed by parallel slots in deterministic order.
+- `prefetch`: Whether the navigation used a fully cached route (`hit-route`), a cached shell with dynamic data remaining (`hit-shell`), no matching prefetch (`miss`), or did not use prefetching (`none`).
+
+Route entries use filesystem-style patterns, so `/blog/hello` may report `/blog/[slug]`.
 
 Hook errors are isolated and do not affect navigation or other hooks.
 

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive a third `event` argument:
+Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_onRouterTransitionCommit` hook:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -68,41 +68,73 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-The event includes the transition metadata and source context known when the navigation is dispatched:
+Then export the optional commit hook:
 
 ```ts filename="instrumentation-client.ts" switcher
-import type { RouterTransitionStartEvent, RouterTransitionType } from 'next'
+import type {
+  RouterTransitionCommitEvent,
+  RouterTransitionStartEvent,
+  RouterTransitionType,
+} from 'next'
+
+const starts = new Map<string, number>()
 
 export function onRouterTransitionStart(
   url: string,
   navigationType: RouterTransitionType,
   { id, timestamp, fromRoutes, prefetchIntent }: RouterTransitionStartEvent
 ) {
-  console.log(id, timestamp, url, navigationType, fromRoutes, prefetchIntent)
+  console.log('Navigating from:', fromRoutes, prefetchIntent)
+  starts.set(id, timestamp)
+}
+
+export function unstable_onRouterTransitionCommit(
+  url: string,
+  navigationType: RouterTransitionType,
+  event: RouterTransitionCommitEvent
+) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation commit:', event.timestamp - start)
+    starts.delete(event.id)
+  }
 }
 ```
 
 ```js filename="instrumentation-client.js" switcher
+const starts = new Map()
+
 export function onRouterTransitionStart(url, navigationType, event) {
-  console.log(
-    event.id,
-    event.timestamp,
-    url,
-    navigationType,
-    event.fromRoutes,
-    event.prefetchIntent
-  )
+  console.log('Navigating from:', event.fromRoutes, event.prefetchIntent)
+  starts.set(event.id, event.timestamp)
+}
+
+export function unstable_onRouterTransitionCommit(url, navigationType, event) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation commit:', event.timestamp - start)
+    starts.delete(event.id)
+  }
 }
 ```
 
-`onRouterTransitionStart` receives:
+Each hook receives the same three parameters:
 
 - `url: string` - The URL being navigated to
 - `navigationType: 'push' | 'replace' | 'traverse'` - The type of navigation
-- `event.id` - An opaque ID shared by events for this transition
-- `event.timestamp` - A framework-captured Unix timestamp in milliseconds
-- `event.fromRoutes` - Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order
-- `event.prefetchIntent` - Whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`)
+- `event` - The transition ID, a framework-captured Unix timestamp in milliseconds, and any hook-specific fields
+
+The available hooks are:
+
+| Hook                                | Timing                                   |
+| ----------------------------------- | ---------------------------------------- |
+| `onRouterTransitionStart`           | The navigation is dispatched.            |
+| `unstable_onRouterTransitionCommit` | The first destination UI and URL commit. |
+
+The start event also includes:
+
+- `fromRoutes`: Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order.
+- `prefetchIntent`: Whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`).
 
 Route entries use filesystem-style patterns, so a navigation away from `/blog/hello` may report `/blog/[slug]`.
 
@@ -126,7 +158,7 @@ This timing makes it ideal for setting up error tracking, analytics, and perform
 
 ## See also
 
-`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition start hook. Application code should continue to use this file convention directly.
+`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition hooks. Application code should continue to use this file convention directly.
 
 ## Examples
 
@@ -260,7 +292,7 @@ if (!window.ResizeObserver) {
 
 ## Version history
 
-| Version   | Changes                                               |
-| --------- | ----------------------------------------------------- |
-| `v16.3.0` | Experimental router transition start event introduced |
-| `v15.3`   | `instrumentation-client` introduced                   |
+| Version   | Changes                                                   |
+| --------- | --------------------------------------------------------- |
+| `v16.3.0` | Experimental router transition lifecycle hooks introduced |
+| `v15.3`   | `instrumentation-client` introduced                       |

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -43,33 +43,70 @@ window.addEventListener('error', (event) => {
 
 ## Router navigation tracking
 
-You can export an `onRouterTransitionStart` function to receive notifications when navigation begins:
+You can export `onRouterTransitionStart` to observe the start of App Router navigations:
 
-```ts filename="instrumentation-client.ts" switcher
-performance.mark('app-init')
-
+```ts filename="instrumentation-client.ts"
 export function onRouterTransitionStart(
   url: string,
   navigationType: 'push' | 'replace' | 'traverse'
 ) {
-  console.log(`Navigation started: ${navigationType} to ${url}`)
-  performance.mark(`nav-start-${Date.now()}`)
+  console.log(url, navigationType)
+}
+```
+
+Additional router transition information is experimental. Enable it to receive a third `event` argument:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    instrumentationClientRouterTransitionEvents: true,
+  },
+}
+
+export default nextConfig
+```
+
+The event includes the transition metadata and source context known when the navigation is dispatched:
+
+```ts filename="instrumentation-client.ts" switcher
+import type { RouterTransitionStartEvent, RouterTransitionType } from 'next'
+
+export function onRouterTransitionStart(
+  url: string,
+  navigationType: RouterTransitionType,
+  { id, timestamp, fromRoutes, prefetchIntent }: RouterTransitionStartEvent
+) {
+  console.log(id, timestamp, url, navigationType, fromRoutes, prefetchIntent)
 }
 ```
 
 ```js filename="instrumentation-client.js" switcher
-performance.mark('app-init')
-
-export function onRouterTransitionStart(url, navigationType) {
-  console.log(`Navigation started: ${navigationType} to ${url}`)
-  performance.mark(`nav-start-${Date.now()}`)
+export function onRouterTransitionStart(url, navigationType, event) {
+  console.log(
+    event.id,
+    event.timestamp,
+    url,
+    navigationType,
+    event.fromRoutes,
+    event.prefetchIntent
+  )
 }
 ```
 
-The `onRouterTransitionStart` function receives two parameters:
+`onRouterTransitionStart` receives:
 
 - `url: string` - The URL being navigated to
 - `navigationType: 'push' | 'replace' | 'traverse'` - The type of navigation
+- `event.id` - An opaque ID shared by events for this transition
+- `event.timestamp` - A framework-captured Unix timestamp in milliseconds
+- `event.fromRoutes` - Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order
+- `event.prefetchIntent` - Whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`)
+
+Route entries use filesystem-style patterns, so a navigation away from `/blog/hello` may report `/blog/[slug]`.
+
+Hook errors are isolated and do not affect navigation or other hooks.
 
 ## Performance considerations
 
@@ -89,7 +126,7 @@ This timing makes it ideal for setting up error tracking, analytics, and perform
 
 ## See also
 
-`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export their own `onRouterTransitionStart`. Application code should continue to use this file convention directly.
+`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition start hook. Application code should continue to use this file convention directly.
 
 ## Examples
 
@@ -223,6 +260,7 @@ if (!window.ResizeObserver) {
 
 ## Version history
 
-| Version | Changes                             |
-| ------- | ----------------------------------- |
-| `v15.3` | `instrumentation-client` introduced |
+| Version   | Changes                                               |
+| --------- | ----------------------------------------------------- |
+| `v16.3.0` | Experimental router transition start event introduced |
+| `v15.3`   | `instrumentation-client` introduced                   |

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -152,11 +152,10 @@ export function createWebpackAliases({
           // `private-next-instrumentation-client` resolves to a placeholder
           // file whose contents are replaced at build time by
           // `next-instrumentation-client-loader` (registered via a
-          // `module.rules` entry in webpack-config.ts). The emitted module
-          // requires each `instrumentationClientInject` entry for side effects,
-          // then re-exports the user's `instrumentation-client.{pageExt}` file
-          // (resolved through the `private-next-instrumentation-client-user`
-          // alias below).
+          // `module.rules` entry in webpack-config.ts). The emitted module lists
+          // each configured instrumentation module, followed by the user's
+          // `instrumentation-client.{pageExt}` file (resolved through the
+          // `private-next-instrumentation-client-user` alias below).
           'private-next-instrumentation-client':
             INSTRUMENTATION_CLIENT_STUB_PATH,
           'private-next-instrumentation-client-user': [

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -378,6 +378,8 @@ export function getDefineEnv({
       config.experimental.gestureTransition ?? false,
     'process.env.__NEXT_OPTIMISTIC_ROUTING':
       config.experimental.optimisticRouting ?? false,
+    'process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS':
+      config.experimental.instrumentationClientRouterTransitionEvents ?? false,
     'process.env.__NEXT_APP_SHELLS': config.experimental.appShells ?? false,
     'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_EXPOSE_TESTING_API':

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1930,16 +1930,15 @@ export default async function getBaseWebpackConfig(
           sideEffects: false,
         },
         // The placeholder file aliased from `private-next-instrumentation-client`.
-        // The loader replaces its contents with a synthetic module that
-        // requires each `instrumentationClientInject` entry, then re-exports
-        // the user's `instrumentation-client.{pageExt}` (composing
-        // `onRouterTransitionStart` hooks across all of them).
+        // The loader replaces its contents with a synthetic module containing
+        // each `instrumentationClientInject` entry, followed by the user's
+        // `instrumentation-client.{pageExt}` module.
         {
           test: /[\\/]next[\\/]dist[\\/](esm[\\/])?build[\\/]webpack[\\/]loaders[\\/]instrumentation-client-stub\.js$/,
           use: {
             loader: 'next-instrumentation-client-loader',
             options: {
-              injects: JSON.stringify(config.instrumentationClientInject),
+              modules: config.instrumentationClientInject,
             },
           },
         },

--- a/packages/next/src/build/webpack/loaders/next-instrumentation-client-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-instrumentation-client-loader.ts
@@ -1,73 +1,34 @@
-import { promisify } from 'util'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 
-/**
- * Loader options for `next-instrumentation-client-loader`. The list of inject
- * specifiers is JSON-stringified so it can travel through the loader query
- * string.
- */
 export type InstrumentationClientLoaderOptions = {
-  /** JSON-stringified `string[]` of module specifiers. */
-  injects: string
+  modules: string[]
 }
 
 const NextInstrumentationClientLoader: webpack.LoaderDefinitionFunction<InstrumentationClientLoaderOptions> =
-  function () {
-    const callback = this.async()
-    const { injects: injectsStringified } = this.getOptions()
-    const injects = JSON.parse(injectsStringified || '[]') as string[]
+  async function () {
+    const { modules } = this.getOptions()
 
-    // No injects: the alias is a transparent passthrough to the user's
-    // `instrumentation-client.{pageExt}` (or the empty module fallback).
-    if (injects.length === 0) {
-      callback(
-        null,
-        `module.exports = require('private-next-instrumentation-client-user');\n`
-      )
-      return
+    if (modules.length === 0) {
+      return `module.exports = require('private-next-instrumentation-client-user');\n`
     }
 
-    // Resolve each inject specifier against the project root so the emitted
+    // Resolve each module specifier against the project root so the emitted
     // `require()` calls don't get resolved relative to the stub's location
     // inside `node_modules/next/`. Bare specifiers (npm package names) are
     // resolved against the project's `node_modules`.
-    const resolve = promisify(this.resolve)
+    const resolve = this.getResolve()
     const rootContext = this.rootContext
+    const resolvedModules = await Promise.all(
+      modules.map((spec) => resolve(rootContext, spec))
+    )
+    const allModules = [
+      ...resolvedModules,
+      'private-next-instrumentation-client-user',
+    ]
 
-    Promise.all(injects.map((spec) => resolve(rootContext, spec)))
-      .then((resolvedInjects) => {
-        const allModules = [
-          ...resolvedInjects,
-          'private-next-instrumentation-client-user',
-        ]
-
-        const lines: string[] = []
-        allModules.forEach((spec, i) => {
-          lines.push(`var mod_${i} = require(${JSON.stringify(spec)});`)
-        })
-
-        // Compose a single `onRouterTransitionStart` that fans out to every
-        // module's hook (when exported), in array order, with the user file's
-        // hook running last.
-        const hookCalls = allModules
-          .map(
-            // Webpack doesn't transpile this, so use a manual version of optional chaining.
-            (_, i) =>
-              `    mod_${i} && mod_${i}.onRouterTransitionStart && mod_${i}.onRouterTransitionStart(url, type);`
-          )
-          .join('\n')
-
-        lines.push(
-          `module.exports = {`,
-          `  onRouterTransitionStart: function (url, type) {`,
-          hookCalls,
-          `  },`,
-          `};`
-        )
-
-        callback(null, lines.join('\n') + '\n')
-      })
-      .catch((err) => callback(err))
+    return `module.exports = [${allModules
+      .map((spec) => `require(${JSON.stringify(spec)})`)
+      .join(',')}];\n`
   }
 
 export default NextInstrumentationClientLoader

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -24,6 +24,7 @@ import {
   type PrefetchTaskFetchStrategy,
 } from '../components/segment-cache/types'
 import { errorOnce } from '../../shared/lib/utils/error-once'
+import type { RouterTransitionPrefetchIntent } from '../router-transition-types'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -258,7 +259,8 @@ function linkClicked(
   replace?: boolean,
   scroll?: boolean,
   onNavigate?: OnNavigateEventHandler,
-  transitionTypes?: string[]
+  transitionTypes?: string[],
+  prefetchIntent: RouterTransitionPrefetchIntent = 'none'
 ): void {
   if (typeof window !== 'undefined') {
     const { nodeName } = e.currentTarget
@@ -310,7 +312,8 @@ function linkClicked(
         replace ? 'replace' : 'push',
         scroll === false ? ScrollBehavior.NoScroll : ScrollBehavior.Default,
         linkInstanceRef.current,
-        transitionTypes
+        transitionTypes,
+        prefetchIntent
       )
     })
   }
@@ -378,6 +381,8 @@ export default function LinkComponent(
   const router = React.useContext(AppRouterContext)
 
   const prefetchEnabled = prefetchProp !== false
+  const prefetchIntent: RouterTransitionPrefetchIntent =
+    prefetchProp === false ? 'none' : prefetchProp === true ? 'full' : 'auto'
 
   const fetchStrategy =
     prefetchProp !== false
@@ -692,7 +697,8 @@ export default function LinkComponent(
         replace,
         scroll,
         onNavigate,
-        transitionTypes
+        transitionTypes,
+        prefetchIntent
       )
     },
     onMouseEnter(e) {

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -27,6 +27,8 @@ import type { StaticIndicatorState } from './dev/hot-reloader/app/hot-reloader-a
 import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-helpers'
 import { getDeploymentId } from '../shared/lib/deployment-id'
 import { setNavigationBuildId } from './navigation-build-id'
+import type { ClientInstrumentationModules } from './router-transition-types'
+import { initializeRouterTransitionModules } from './components/router-transition'
 
 /// <reference types="react-dom/experimental" />
 
@@ -339,15 +341,8 @@ const reactRootOptions: ReactDOMClient.RootOptions = {
   onUncaughtError,
 }
 
-export type ClientInstrumentationHooks = {
-  onRouterTransitionStart?: (
-    url: string,
-    navigationType: 'push' | 'replace' | 'traverse'
-  ) => void
-}
-
 export async function hydrate(
-  instrumentationHooks: ClientInstrumentationHooks | null,
+  instrumentationModules: ClientInstrumentationModules,
   assetPrefix: string
 ) {
   let staticIndicatorState: StaticIndicatorState | undefined
@@ -376,6 +371,8 @@ export async function hydrate(
     setNavigationBuildId(getDeploymentId()!)
   }
 
+  initializeRouterTransitionModules(instrumentationModules)
+
   const initialTimestamp = Date.now()
   const actionQueue: AppRouterActionQueue = createMutableActionQueue(
     createInitialRouterState({
@@ -383,8 +380,7 @@ export async function hydrate(
       initialRSCPayload,
       initialFlightStreamForCache,
       location: window.location,
-    }),
-    instrumentationHooks
+    })
   )
 
   const reactEl = (

--- a/packages/next/src/client/app-next-dev.ts
+++ b/packages/next/src/client/app-next-dev.ts
@@ -8,14 +8,14 @@ import { getOwnerStack } from '../next-devtools/userspace/app/errors/stitched-er
 import { isRecoverableError } from './react-client-callbacks/on-recoverable-error'
 
 // eslint-disable-next-line @next/internal/typechecked-require
-const instrumentationHooks = require('../lib/require-instrumentation-client')
+const instrumentationModules = require('../lib/require-instrumentation-client')
 
 appBootstrap((assetPrefix) => {
   const enableCacheIndicator = process.env.__NEXT_CACHE_COMPONENTS
 
   const { hydrate } = require('./app-index') as typeof import('./app-index')
   try {
-    hydrate(instrumentationHooks, assetPrefix)
+    hydrate(instrumentationModules, assetPrefix)
   } finally {
     renderAppDevOverlay(getOwnerStack, isRecoverableError, enableCacheIndicator)
   }

--- a/packages/next/src/client/app-next-turbopack.ts
+++ b/packages/next/src/client/app-next-turbopack.ts
@@ -6,12 +6,12 @@ window.next.turbopack = true
 ;(self as any).__webpack_hash__ = ''
 
 // eslint-disable-next-line @next/internal/typechecked-require
-const instrumentationHooks = require('../lib/require-instrumentation-client')
+const instrumentationModules = require('../lib/require-instrumentation-client')
 
 appBootstrap((assetPrefix) => {
   const { hydrate } = require('./app-index') as typeof import('./app-index')
   try {
-    hydrate(instrumentationHooks, assetPrefix)
+    hydrate(instrumentationModules, assetPrefix)
   } finally {
     if (process.env.__NEXT_DEV_SERVER) {
       const enableCacheIndicator = process.env.__NEXT_CACHE_COMPONENTS

--- a/packages/next/src/client/app-next.ts
+++ b/packages/next/src/client/app-next.ts
@@ -3,7 +3,7 @@
 import './app-webpack'
 import { appBootstrap } from './app-bootstrap'
 
-const instrumentationHooks =
+const instrumentationModules =
   // eslint-disable-next-line @next/internal/typechecked-require -- not a module
   require('../lib/require-instrumentation-client')
 
@@ -14,5 +14,5 @@ appBootstrap((assetPrefix) => {
   require('next/dist/client/components/app-router')
   // eslint-disable-next-line @next/internal/typechecked-require -- Why not relative imports?
   require('next/dist/client/components/layout-router')
-  hydrate(instrumentationHooks, assetPrefix)
+  hydrate(instrumentationModules, assetPrefix)
 })

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -35,9 +35,9 @@ import type {
   PrefetchOptions,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import { setLinkForCurrentNavigation, type LinkInstance } from './links'
-import type { ClientInstrumentationHooks } from '../app-index'
 import type { GlobalErrorComponent } from './builtin/global-error'
 import { isJavaScriptURLString } from '../lib/javascript-url'
+import { startRouterTransition } from './router-transition'
 
 export type DispatchStatePromise = React.Dispatch<ReducerState>
 
@@ -45,10 +45,6 @@ export type AppRouterActionQueue = {
   state: AppRouterState
   dispatch: (payload: ReducerActions, setState: DispatchStatePromise) => void
   action: (state: AppRouterState, action: ReducerActions) => ReducerState
-
-  onRouterTransitionStart:
-    | ((url: string, type: 'push' | 'replace' | 'traverse') => void)
-    | null
 
   pending: ActionQueueNode | null
   needsRefresh?: boolean
@@ -218,8 +214,7 @@ function dispatchAction(
 let globalActionQueue: AppRouterActionQueue | null = null
 
 export function createMutableActionQueue(
-  initialState: AppRouterState,
-  instrumentationHooks: ClientInstrumentationHooks | null
+  initialState: AppRouterState
 ): AppRouterActionQueue {
   const actionQueue: AppRouterActionQueue = {
     state: initialState,
@@ -231,12 +226,6 @@ export function createMutableActionQueue(
     },
     pending: null,
     last: null,
-    onRouterTransitionStart:
-      instrumentationHooks !== null &&
-      typeof instrumentationHooks.onRouterTransitionStart === 'function'
-        ? // This profiling hook will be called at the start of every navigation.
-          instrumentationHooks.onRouterTransitionStart
-        : null,
   }
 
   if (typeof window !== 'undefined') {
@@ -268,13 +257,6 @@ function getAppRouterActionQueue(): AppRouterActionQueue {
   return globalActionQueue
 }
 
-function getProfilingHookForOnNavigationStart() {
-  if (globalActionQueue !== null) {
-    return globalActionQueue.onRouterTransitionStart
-  }
-  return null
-}
-
 export function dispatchNavigateAction(
   href: string,
   navigateType: NavigateAction['navigateType'],
@@ -297,11 +279,7 @@ export function dispatchNavigateAction(
   }
 
   setLinkForCurrentNavigation(linkInstanceRef)
-
-  const onRouterTransitionStart = getProfilingHookForOnNavigationStart()
-  if (onRouterTransitionStart !== null) {
-    onRouterTransitionStart(href, navigateType)
-  }
+  startRouterTransition(href, navigateType)
 
   dispatchAppRouterAction({
     type: ACTION_NAVIGATE,
@@ -317,10 +295,7 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
-  const onRouterTransitionStart = getProfilingHookForOnNavigationStart()
-  if (onRouterTransitionStart !== null) {
-    onRouterTransitionStart(href, 'traverse')
-  }
+  startRouterTransition(href, 'traverse')
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
     url: new URL(href),

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -281,7 +281,7 @@ export function dispatchNavigateAction(
   }
 
   setLinkForCurrentNavigation(linkInstanceRef)
-  startRouterTransition(
+  const transitionId = startRouterTransition(
     href,
     navigateType,
     getAppRouterActionQueue().state.tree,
@@ -295,6 +295,7 @@ export function dispatchNavigateAction(
     locationSearch: location.search,
     scrollBehavior,
     navigateType,
+    transitionId,
   })
 }
 
@@ -302,7 +303,7 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
-  startRouterTransition(
+  const transitionId = startRouterTransition(
     href,
     'traverse',
     getAppRouterActionQueue().state.tree,
@@ -312,6 +313,7 @@ export function dispatchTraverseAction(
     type: ACTION_RESTORE,
     url: new URL(href),
     historyState,
+    transitionId,
   })
 }
 
@@ -365,7 +367,8 @@ function gesturePush(href: string, options?: NavigateOptions): void {
       state.nextUrl,
       freshnessPolicy,
       scrollBehavior,
-      'push'
+      'push',
+      null
     )
     dispatchGestureState(forkedGestureState)
   }

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -35,6 +35,7 @@ import type {
   PrefetchOptions,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import { setLinkForCurrentNavigation, type LinkInstance } from './links'
+import type { RouterTransitionPrefetchIntent } from '../router-transition-types'
 import type { GlobalErrorComponent } from './builtin/global-error'
 import { isJavaScriptURLString } from '../lib/javascript-url'
 import { startRouterTransition } from './router-transition'
@@ -262,7 +263,8 @@ export function dispatchNavigateAction(
   navigateType: NavigateAction['navigateType'],
   scrollBehavior: ScrollBehavior,
   linkInstanceRef: LinkInstance | null,
-  transitionTypes: string[] | undefined
+  transitionTypes: string[] | undefined,
+  prefetchIntent: RouterTransitionPrefetchIntent
 ): void {
   // TODO: This stuff could just go into the reducer. Leaving as-is for now
   // since we're about to rewrite all the router reducer stuff anyway.
@@ -279,7 +281,12 @@ export function dispatchNavigateAction(
   }
 
   setLinkForCurrentNavigation(linkInstanceRef)
-  startRouterTransition(href, navigateType)
+  startRouterTransition(
+    href,
+    navigateType,
+    getAppRouterActionQueue().state.tree,
+    prefetchIntent
+  )
 
   dispatchAppRouterAction({
     type: ACTION_NAVIGATE,
@@ -295,7 +302,12 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
-  startRouterTransition(href, 'traverse')
+  startRouterTransition(
+    href,
+    'traverse',
+    getAppRouterActionQueue().state.tree,
+    'none'
+  )
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
     url: new URL(href),
@@ -425,7 +437,8 @@ export const publicAppRouterInstance: AppRouterInstance = {
           ? ScrollBehavior.NoScroll
           : ScrollBehavior.Default,
         null,
-        options?.transitionTypes
+        options?.transitionTypes,
+        'none'
       )
     })
   },
@@ -443,7 +456,8 @@ export const publicAppRouterInstance: AppRouterInstance = {
           ? ScrollBehavior.NoScroll
           : ScrollBehavior.Default,
         null,
-        options?.transitionTypes
+        options?.transitionTypes,
+        'none'
       )
     })
   },

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -99,7 +99,7 @@ function HistoryUpdater({
       window.history.replaceState(historyState, '', canonicalUrl)
     }
 
-    commitRouterTransition(transitionId, canonicalUrl)
+    commitRouterTransition(transitionId, canonicalUrl, tree)
     setLastCommittedTree(tree)
   }, [appRouterState])
 

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -51,6 +51,7 @@ import DefaultGlobalError from './builtin/global-error'
 import { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-app'
 import { getAssetTokenQuery } from '../../shared/lib/deployment-id'
+import { commitRouterTransition } from './router-transition'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -68,7 +69,8 @@ function HistoryUpdater({
       window.next.__pendingUrl = undefined
     }
 
-    const { tree, pushRef, canonicalUrl, renderedSearch } = appRouterState
+    const { tree, pushRef, canonicalUrl, renderedSearch, transitionId } =
+      appRouterState
 
     const appHistoryState: AppHistoryState = {
       tree,
@@ -97,6 +99,7 @@ function HistoryUpdater({
       window.history.replaceState(historyState, '', canonicalUrl)
     }
 
+    commitRouterTransition(transitionId, canonicalUrl)
     setLastCommittedTree(tree)
   }, [appRouterState])
 
@@ -229,6 +232,7 @@ function Router({
         type: ACTION_RESTORE,
         url: new URL(window.location.href),
         historyState: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
+        transitionId: null,
       })
     }
 
@@ -319,6 +323,7 @@ function Router({
           type: ACTION_RESTORE,
           url: new URL(url ?? href, href),
           historyState: appHistoryState,
+          transitionId: null,
         })
       })
     }

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -1,7 +1,36 @@
-import { computeChangedPath } from './compute-changed-path'
-import { PrefetchHint } from '../../../shared/lib/app-router-types'
+import {
+  computeChangedPath,
+  segmentToSourcePagePathname,
+} from './compute-changed-path'
+import {
+  type FlightRouterState,
+  type Segment,
+  PrefetchHint,
+} from '../../../shared/lib/app-router-types'
+import { getActiveRoutePaths } from '../router-transition'
 
 describe('computeChangedPath', () => {
+  const sourceRouteSegmentCases: Array<[Segment, string]> = [
+    [['slug', 'hello', 'd', null], '[slug]'],
+    [['slug', 'hello', 'c', null], '[...slug]'],
+    [['slug', 'hello', 'oc', null], '[[...slug]]'],
+    [['slug', 'hello', 'di(.)', null], '(.)[slug]'],
+    [['slug', 'hello', 'di(..)', null], '(..)[slug]'],
+    [['slug', 'hello', 'di(..)(..)', null], '(..)(..)[slug]'],
+    [['slug', 'hello', 'di(...)', null], '(...)[slug]'],
+    [['slug', 'hello', 'ci(.)', null], '(.)[...slug]'],
+    [['slug', 'hello', 'ci(..)', null], '(..)[...slug]'],
+    [['slug', 'hello', 'ci(..)(..)', null], '(..)(..)[...slug]'],
+    [['slug', 'hello', 'ci(...)', null], '(...)[...slug]'],
+  ]
+
+  it.each(sourceRouteSegmentCases)(
+    'formats source route segment %j as %s',
+    (segment, expected) => {
+      expect(segmentToSourcePagePathname(segment)).toBe(expected)
+    }
+  )
+
   it('should return the correct path', () => {
     expect(
       computeChangedPath(
@@ -57,5 +86,37 @@ describe('computeChangedPath', () => {
         ]
       )
     ).toBe('/')
+  })
+
+  it('normalizes active route paths', () => {
+    const tree: FlightRouterState = [
+      '',
+      {
+        children: [
+          'children',
+          {
+            children: [
+              '(group)',
+              {
+                children: ['/_not-found', {}],
+              },
+            ],
+          },
+        ],
+        modal: [
+          '(__SLOT__)',
+          {
+            children: [
+              ['slug', 'hello', 'd', null],
+              {
+                children: ['__PAGE__', {}],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    expect(getActiveRoutePaths(tree)).toEqual(['/_not-found', '/@modal/[slug]'])
   })
 })

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -27,7 +27,7 @@ const segmentToPathname = (segment: Segment): string => {
   return segment[1]
 }
 
-const segmentToSourcePagePathname = (segment: Segment): string => {
+export const segmentToSourcePagePathname = (segment: Segment): string => {
   if (typeof segment === 'string') {
     if (segment === 'children') return ''
     if (segment.startsWith(PAGE_SEGMENT_KEY)) return 'page'

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -265,6 +265,7 @@ export function createInitialRouterState({
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??
       null,
     previousNextUrl: null,
+    transitionId: null,
     debugInfo: null,
   }
 

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1682,6 +1682,7 @@ function dispatchRetryDueToTreeMismatch(
     seed,
     mpa: isHardRetry,
     navigateType: retryNavigateType,
+    transitionId: null,
   }
   dispatchAppRouterAction(retryAction)
 }

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -24,16 +24,17 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, isExternalUrl, navigateType, scrollBehavior } = action
+  const { url, isExternalUrl, navigateType, scrollBehavior, transitionId } =
+    action
 
   if (isExternalUrl) {
-    return completeHardNavigation(state, url, navigateType)
+    return completeHardNavigation(state, url, navigateType, transitionId)
   }
 
   // Handles case where `<meta http-equiv="refresh">` tag is present,
   // which will trigger an MPA navigation.
   if (document.getElementById('__next-page-redirect')) {
-    return completeHardNavigation(state, url, navigateType)
+    return completeHardNavigation(state, url, navigateType, transitionId)
   }
 
   // Temporary glue code between the router reducer and the new navigation
@@ -51,6 +52,7 @@ export function navigateReducer(
     state.nextUrl,
     FreshnessPolicy.Default,
     scrollBehavior,
-    navigateType
+    navigateType,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -99,6 +99,7 @@ export function refreshDynamicData(
     // cache entry to mark as having a dynamic rewrite on mismatch. If a
     // mismatch occurs, the retry handler will traverse the known route tree
     // to find and mark the entry.
+    null,
     null
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -32,6 +32,7 @@ export function restoreReducer(
   let treeToRestore: FlightRouterState | undefined
   let renderedSearch: string | undefined
   const historyState = action.historyState
+  const transitionId = action.transitionId
   if (historyState) {
     treeToRestore = historyState.tree
     renderedSearch = historyState.renderedSearch
@@ -77,7 +78,7 @@ export function restoreReducer(
   )
 
   if (task === null) {
-    return completeHardNavigation(state, restoredUrl, 'replace')
+    return completeHardNavigation(state, restoredUrl, 'replace', transitionId)
   }
   spawnDynamicRequests(
     task,
@@ -100,6 +101,7 @@ export function restoreReducer(
     renderedSearch,
     task.node,
     task.route,
-    restoredNextUrl
+    restoredNextUrl,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -518,6 +518,7 @@ export function serverActionReducer(
           // have the route tree from the server response. If a mismatch occurs
           // during dynamic data fetch, the retry handler will traverse the
           // known route tree to mark the entry as having a dynamic rewrite.
+          null,
           null
         )
       }
@@ -534,7 +535,8 @@ export function serverActionReducer(
         nextUrl,
         freshnessPolicy,
         scrollBehavior,
-        navigateType
+        navigateType,
+        null
       )
     },
     (e: any) => {

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -25,10 +25,11 @@ export function serverPatchReducer(
   const retryUrl = new URL(action.url, location.origin)
   const retrySeed = action.seed
   const navigateType = action.navigateType
+  const transitionId = action.transitionId
   if (retryMpa || retrySeed === null) {
     // If the server did not send back data during the mismatch, fall back to
     // an MPA navigation.
-    return completeHardNavigation(state, retryUrl, navigateType)
+    return completeHardNavigation(state, retryUrl, navigateType, transitionId)
   }
   const currentUrl = new URL(state.canonicalUrl, location.origin)
   const currentRenderedSearch = state.renderedSearch
@@ -64,6 +65,7 @@ export function serverPatchReducer(
     // Server patch (retry) navigations don't use route prediction. This is
     // typically a retry after a previous mismatch, so the route was already
     // marked as having a dynamic rewrite when the mismatch was detected.
-    null
+    null,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -92,6 +92,7 @@ export interface NavigateAction {
   locationSearch: Location['search']
   navigateType: 'push' | 'replace'
   scrollBehavior: ScrollBehavior
+  transitionId: string | null
 }
 
 /**
@@ -107,6 +108,7 @@ export interface RestoreAction {
   type: typeof ACTION_RESTORE
   url: URL
   historyState: AppHistoryState | undefined
+  transitionId: string | null
 }
 
 export type AppHistoryState = {
@@ -125,6 +127,7 @@ export interface ServerPatchAction {
   seed: NavigationSeed | null
   mpa: boolean
   navigateType: 'push' | 'replace'
+  transitionId: string | null
 }
 
 /**
@@ -245,6 +248,11 @@ export type AppRouterState = {
    * The previous next-url that was used previous to a dynamic navigation.
    */
   previousNextUrl: string | null
+
+  /**
+   * Identifies the router transition represented by this state, if any.
+   */
+  transitionId: string | null
 
   debugInfo: Array<unknown> | null
 }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -1,0 +1,35 @@
+import type {
+  ClientInstrumentationHooks,
+  ClientInstrumentationModules,
+  RouterTransitionType,
+} from '../router-transition-types'
+
+let instrumentationModules: readonly ClientInstrumentationHooks[] = []
+
+export function initializeRouterTransitionModules(
+  modules: ClientInstrumentationModules
+): void {
+  instrumentationModules = modules.filter(
+    (module): module is ClientInstrumentationHooks => module != null
+  )
+}
+
+function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
+  for (const hooks of instrumentationModules) {
+    try {
+      invoke(hooks)
+    } catch (error) {
+      console.error(
+        'An instrumentation-client router transition hook failed',
+        error
+      )
+    }
+  }
+}
+
+export function startRouterTransition(
+  url: string,
+  type: RouterTransitionType
+): void {
+  callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))
+}

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -15,8 +15,15 @@ import type {
   RouterTransitionType,
 } from '../router-transition-types'
 
+type RouterTransitionRecord = {
+  id: string
+  type: RouterTransitionType
+  committed: boolean
+}
+
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
 let nextTransitionId = 0
+let activeTransition: RouterTransitionRecord | null = null
 
 export function initializeRouterTransitionModules(
   modules: ClientInstrumentationModules
@@ -24,6 +31,23 @@ export function initializeRouterTransitionModules(
   instrumentationModules = modules.filter(
     (module): module is ClientInstrumentationHooks => module != null
   )
+
+  if (
+    !process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS &&
+    process.env.NODE_ENV !== 'production' &&
+    instrumentationModules.some(
+      (hooks) => typeof hooks.unstable_onRouterTransitionCommit === 'function'
+    )
+  ) {
+    console.warn(
+      'Router transition lifecycle hooks in instrumentation-client require ' +
+        '`experimental.instrumentationClientRouterTransitionEvents` to be enabled.'
+    )
+  }
+}
+
+function timestamp(): number {
+  return performance.timeOrigin + performance.now()
 }
 
 function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
@@ -39,8 +63,16 @@ function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
   }
 }
 
-function timestamp(): number {
-  return performance.timeOrigin + performance.now()
+function hasLifecycleInstrumentation(): boolean {
+  return instrumentationModules.some(
+    (hooks) =>
+      typeof hooks.onRouterTransitionStart === 'function' ||
+      typeof hooks.unstable_onRouterTransitionCommit === 'function'
+  )
+}
+
+function getActiveTransition(id: string | null): RouterTransitionRecord | null {
+  return id !== null && activeTransition?.id === id ? activeTransition : null
 }
 
 export function startRouterTransition(
@@ -48,21 +80,23 @@ export function startRouterTransition(
   type: RouterTransitionType,
   fromTree: FlightRouterState,
   prefetchIntent: RouterTransitionPrefetchIntent
-): void {
+): string | null {
   if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
     callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))
-    return
+    return null
   }
 
-  if (
-    !instrumentationModules.some(
-      (hooks) => typeof hooks.onRouterTransitionStart === 'function'
-    )
-  ) {
-    return
+  if (!hasLifecycleInstrumentation()) {
+    return null
   }
 
   const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
+  const record: RouterTransitionRecord = {
+    id,
+    type,
+    committed: false,
+  }
+  activeTransition = record
 
   callHooks((hooks) =>
     hooks.onRouterTransitionStart?.(url, type, {
@@ -70,6 +104,22 @@ export function startRouterTransition(
       timestamp: timestamp(),
       fromRoutes: getActiveRoutePaths(fromTree),
       prefetchIntent,
+    })
+  )
+  return id
+}
+
+export function commitRouterTransition(id: string | null, url: string): void {
+  const record = getActiveTransition(id)
+  if (record === null || record.committed) {
+    return
+  }
+
+  record.committed = true
+  callHooks((hooks) =>
+    hooks.unstable_onRouterTransitionCommit?.(url, record.type, {
+      id: record.id,
+      timestamp: timestamp(),
     })
   )
 }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -11,6 +11,7 @@ import { segmentToSourcePagePathname } from './router-reducer/compute-changed-pa
 import type {
   ClientInstrumentationHooks,
   ClientInstrumentationModules,
+  RouterTransitionPrefetch,
   RouterTransitionPrefetchIntent,
   RouterTransitionType,
 } from '../router-transition-types'
@@ -18,6 +19,7 @@ import type {
 type RouterTransitionRecord = {
   id: string
   type: RouterTransitionType
+  prefetch: RouterTransitionPrefetch
   committed: boolean
 }
 
@@ -94,6 +96,7 @@ export function startRouterTransition(
   const record: RouterTransitionRecord = {
     id,
     type,
+    prefetch: 'none',
     committed: false,
   }
   activeTransition = record
@@ -109,7 +112,25 @@ export function startRouterTransition(
   return id
 }
 
-export function commitRouterTransition(id: string | null, url: string): void {
+export function setRouterTransitionPrefetch(
+  id: string | null,
+  prefetch: RouterTransitionPrefetch
+): void {
+  const record = getActiveTransition(id)
+  if (record !== null) {
+    // A route prediction can provide a tree after the prefetch cache misses.
+    // Preserve the miss instead of later reclassifying it as a shell hit.
+    if (record.prefetch !== 'miss') {
+      record.prefetch = prefetch
+    }
+  }
+}
+
+export function commitRouterTransition(
+  id: string | null,
+  url: string,
+  tree: FlightRouterState
+): void {
   const record = getActiveTransition(id)
   if (record === null || record.committed) {
     return
@@ -120,6 +141,8 @@ export function commitRouterTransition(id: string | null, url: string): void {
     hooks.unstable_onRouterTransitionCommit?.(url, record.type, {
       id: record.id,
       timestamp: timestamp(),
+      routes: getActiveRoutePaths(tree),
+      prefetch: record.prefetch,
     })
   )
 }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -1,10 +1,22 @@
 import type {
+  FlightRouterState,
+  Segment,
+} from '../../shared/lib/app-router-types'
+import {
+  DEFAULT_SEGMENT_KEY,
+  isGroupSegment,
+  NOT_FOUND_SEGMENT_KEY,
+} from '../../shared/lib/segment'
+import { segmentToSourcePagePathname } from './router-reducer/compute-changed-path'
+import type {
   ClientInstrumentationHooks,
   ClientInstrumentationModules,
+  RouterTransitionPrefetchIntent,
   RouterTransitionType,
 } from '../router-transition-types'
 
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
+let nextTransitionId = 0
 
 export function initializeRouterTransitionModules(
   modules: ClientInstrumentationModules
@@ -27,9 +39,106 @@ function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
   }
 }
 
+function timestamp(): number {
+  return performance.timeOrigin + performance.now()
+}
+
 export function startRouterTransition(
   url: string,
-  type: RouterTransitionType
+  type: RouterTransitionType,
+  fromTree: FlightRouterState,
+  prefetchIntent: RouterTransitionPrefetchIntent
 ): void {
-  callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))
+  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))
+    return
+  }
+
+  if (
+    !instrumentationModules.some(
+      (hooks) => typeof hooks.onRouterTransitionStart === 'function'
+    )
+  ) {
+    return
+  }
+
+  const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
+
+  callHooks((hooks) =>
+    hooks.onRouterTransitionStart?.(url, type, {
+      id,
+      timestamp: timestamp(),
+      fromRoutes: getActiveRoutePaths(fromTree),
+      prefetchIntent,
+    })
+  )
+}
+
+function classifySegment(segment: Segment): {
+  path: string | null
+  isPage: boolean
+} {
+  const sourceSegment = segmentToSourcePagePathname(segment)
+  if (sourceSegment === 'page') {
+    return { path: null, isPage: true }
+  }
+  if (
+    sourceSegment === '' ||
+    sourceSegment === '(__SLOT__)' ||
+    isGroupSegment(sourceSegment)
+  ) {
+    return { path: null, isPage: false }
+  }
+  if (sourceSegment === DEFAULT_SEGMENT_KEY) {
+    return { path: 'default', isPage: false }
+  }
+  if (sourceSegment === NOT_FOUND_SEGMENT_KEY) {
+    return { path: '_not-found', isPage: false }
+  }
+  return { path: sourceSegment, isPage: false }
+}
+
+export function getActiveRoutePaths(tree: FlightRouterState): string[] {
+  const routes: Array<{ path: string; primary: boolean }> = []
+
+  function visit(
+    node: FlightRouterState,
+    segments: string[],
+    primary: boolean
+  ): void {
+    const segment = classifySegment(node[0])
+    const nextSegments =
+      segment.path === null ? segments : [...segments, segment.path]
+    const parallelRoutes = node[1]
+    const keys = Object.keys(parallelRoutes)
+
+    if (keys.length === 0 || segment.isPage) {
+      routes.push({
+        path: `/${nextSegments.join('/')}`,
+        primary,
+      })
+      return
+    }
+
+    if (parallelRoutes.children !== undefined) {
+      visit(parallelRoutes.children, nextSegments, primary)
+    }
+
+    for (const key of keys.sort()) {
+      if (key === 'children') {
+        continue
+      }
+      visit(parallelRoutes[key], [...nextSegments, `@${key}`], false)
+    }
+  }
+
+  visit(tree, [], true)
+  return routes
+    .sort((a, b) => {
+      if (a.primary !== b.primary) {
+        return a.primary ? -1 : 1
+      }
+      return a.path.localeCompare(b.path)
+    })
+    .map((route) => route.path)
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -46,6 +46,7 @@ import { ScrollBehavior } from '../router-reducer/router-reducer-types'
 import { computeChangedPath } from '../router-reducer/compute-changed-path'
 import { isJavaScriptURLString } from '../../lib/javascript-url'
 import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
+import { setRouterTransitionPrefetch } from '../router-transition'
 
 /**
  * Navigate to a new URL, using the Segment Cache to construct a response.
@@ -173,6 +174,7 @@ function navigateImpl(
       )
       if (optimisticRoute !== null) {
         // We have an optimistic route tree. Proceed with the normal flow.
+        setRouterTransitionPrefetch(transitionId, 'miss')
         return navigateUsingPrefetchedRouteTree(
           now,
           state,
@@ -335,6 +337,10 @@ export function navigateToKnownRoute(
     accumulation
   )
   if (task !== null) {
+    setRouterTransitionPrefetch(
+      transitionId,
+      task.dynamicRequestTree === null ? 'hit-route' : 'hit-shell'
+    )
     if (freshnessPolicy !== FreshnessPolicy.Gesture) {
       spawnDynamicRequests(
         task,
@@ -471,6 +477,7 @@ async function navigateToUnknownRoute(
       break
   }
 
+  setRouterTransitionPrefetch(transitionId, 'miss')
   const promiseForDynamicServerResponse = fetchServerResponse(url, {
     flightRouterState: dynamicRequestTree,
     nextUrl,

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -65,7 +65,8 @@ export function navigate(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null
 ): AppRouterState | Promise<AppRouterState> {
   let navigationLock: NavigationLock = null
 
@@ -91,7 +92,8 @@ export function navigate(
         freshnessPolicy,
         scrollBehavior,
         navigateType,
-        navigationLock
+        navigationLock,
+        transitionId
       )
     }
   }
@@ -107,7 +109,8 @@ export function navigate(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 }
 
@@ -122,7 +125,8 @@ function navigateImpl(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): AppRouterState | Promise<AppRouterState> {
   const now = Date.now()
   const href = url.href
@@ -144,7 +148,8 @@ function navigateImpl(
       scrollBehavior,
       navigateType,
       route,
-      navigationLock
+      navigationLock,
+      transitionId
     )
   }
 
@@ -181,7 +186,8 @@ function navigateImpl(
           scrollBehavior,
           navigateType,
           optimisticRoute,
-          navigationLock
+          navigationLock,
+          transitionId
         )
       }
     }
@@ -204,7 +210,8 @@ function navigateImpl(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   ).catch(() => {
     // If the navigation fails, return the current state
     return state
@@ -238,7 +245,8 @@ export function navigateToKnownRoute(
   // In these cases, if a mismatch occurs, we still mark the route as having a
   // dynamic rewrite by traversing the known route tree (see
   // dispatchRetryDueToTreeMismatch).
-  routeCacheEntry: FulfilledRouteCacheEntry | null
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  transitionId: string | null
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
@@ -350,11 +358,12 @@ export function navigateToKnownRoute(
       navigateType,
       scrollBehavior,
       accumulation.scrollRef,
-      debugInfo
+      debugInfo,
+      transitionId
     )
   }
   // Could not perform a SPA navigation. Revert to a full-page (MPA) navigation.
-  return completeHardNavigation(state, url, navigateType)
+  return completeHardNavigation(state, url, navigateType, transitionId)
 }
 
 function navigateUsingPrefetchedRouteTree(
@@ -370,7 +379,8 @@ function navigateUsingPrefetchedRouteTree(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
   route: FulfilledRouteCacheEntry,
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): AppRouterState {
   const routeTree = route.tree
   const canonicalUrl = route.canonicalUrl + url.hash
@@ -399,7 +409,8 @@ function navigateUsingPrefetchedRouteTree(
     navigateType,
     navigationLock,
     null,
-    route
+    route,
+    transitionId
   )
 }
 
@@ -427,7 +438,8 @@ async function navigateToUnknownRoute(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<AppRouterState> {
   // Runs when a navigation happens but there's no cached prefetch we can use.
   // Don't bother to wait for a prefetch response; go straight to a full
@@ -467,7 +479,12 @@ async function navigateToUnknownRoute(
   if (typeof result === 'string') {
     // This is an MPA navigation.
     const redirectUrl = new URL(result, location.origin)
-    return completeHardNavigation(state, redirectUrl, navigateType)
+    return completeHardNavigation(
+      state,
+      redirectUrl,
+      navigateType,
+      transitionId
+    )
   }
 
   const {
@@ -598,14 +615,16 @@ async function navigateToUnknownRoute(
     // came directly from the server. If a mismatch occurs during dynamic data
     // fetch, the retry handler will traverse the known route tree to mark the
     // entry as having a dynamic rewrite.
-    null
+    null,
+    transitionId
   )
 }
 
 export function completeHardNavigation(
   state: AppRouterState,
   url: URL,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null = null
 ): AppRouterState {
   if (isJavaScriptURLString(url.href)) {
     console.error(
@@ -632,6 +651,7 @@ export function completeHardNavigation(
     tree: state.tree,
     nextUrl: state.nextUrl,
     previousNextUrl: state.previousNextUrl,
+    transitionId,
     debugInfo: null,
   }
   return newState
@@ -648,7 +668,8 @@ export function completeSoftNavigation(
   navigateType: 'push' | 'replace',
   scrollBehavior: ScrollBehavior,
   scrollRef: ScrollRef | null,
-  collectedDebugInfo: Array<unknown> | null
+  collectedDebugInfo: Array<unknown> | null,
+  transitionId: string | null
 ) {
   // The "Next-Url" is a special representation of the URL that Next.js
   // uses to implement interception routes.
@@ -770,6 +791,7 @@ export function completeSoftNavigation(
     tree,
     nextUrl: nextUrlForNewRoute,
     previousNextUrl,
+    transitionId,
     debugInfo: collectedDebugInfo,
   }
   return newState
@@ -781,7 +803,8 @@ export function completeTraverseNavigation(
   renderedSearch: string,
   cache: CacheNode,
   tree: FlightRouterState,
-  nextUrl: string | null
+  nextUrl: string | null,
+  transitionId: string | null
 ) {
   return {
     // Set canonical url
@@ -802,6 +825,7 @@ export function completeTraverseNavigation(
     // Next-Url that was used to fetch the data. Anywhere we fetch using the
     // canonical URL, there should be a corresponding Next-Url.
     previousNextUrl: null,
+    transitionId,
     debugInfo: null,
   }
 }
@@ -1031,7 +1055,8 @@ async function ensurePrefetchThenNavigate(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<AppRouterState> {
   const link = getLinkForCurrentNavigation()
   const fetchStrategy = link !== null ? link.fetchStrategy : FetchStrategy.PPR
@@ -1062,7 +1087,8 @@ async function ensurePrefetchThenNavigate(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 
   // Only transition to captured-SPA once the navigation is known to be an SPA.

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -1,0 +1,16 @@
+export type RouterTransitionType = 'push' | 'replace' | 'traverse'
+
+export type ClientInstrumentationHooks = {
+  onRouterTransitionStart?: (
+    url: string,
+    navigationType: RouterTransitionType
+  ) => void
+}
+
+export type ClientInstrumentationModule =
+  | ClientInstrumentationHooks
+  | null
+  | undefined
+
+export type ClientInstrumentationModules =
+  readonly ClientInstrumentationModule[]

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -12,11 +12,18 @@ export type RouterTransitionStartEvent = RouterTransitionEvent & {
   prefetchIntent: RouterTransitionPrefetchIntent
 }
 
+export type RouterTransitionCommitEvent = RouterTransitionEvent
+
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
     navigationType: RouterTransitionType,
     event?: RouterTransitionStartEvent
+  ) => void
+  unstable_onRouterTransitionCommit?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionCommitEvent
   ) => void
 }
 

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -1,9 +1,22 @@
 export type RouterTransitionType = 'push' | 'replace' | 'traverse'
 
+export type RouterTransitionPrefetchIntent = 'full' | 'auto' | 'none'
+
+export type RouterTransitionEvent = {
+  id: string
+  timestamp: number
+}
+
+export type RouterTransitionStartEvent = RouterTransitionEvent & {
+  fromRoutes: string[]
+  prefetchIntent: RouterTransitionPrefetchIntent
+}
+
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
-    navigationType: RouterTransitionType
+    navigationType: RouterTransitionType,
+    event?: RouterTransitionStartEvent
   ) => void
 }
 

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -1,5 +1,11 @@
 export type RouterTransitionType = 'push' | 'replace' | 'traverse'
 
+export type RouterTransitionPrefetch =
+  | 'hit-route'
+  | 'hit-shell'
+  | 'miss'
+  | 'none'
+
 export type RouterTransitionPrefetchIntent = 'full' | 'auto' | 'none'
 
 export type RouterTransitionEvent = {
@@ -12,7 +18,10 @@ export type RouterTransitionStartEvent = RouterTransitionEvent & {
   prefetchIntent: RouterTransitionPrefetchIntent
 }
 
-export type RouterTransitionCommitEvent = RouterTransitionEvent
+export type RouterTransitionCommitEvent = RouterTransitionEvent & {
+  routes: string[]
+  prefetch: RouterTransitionPrefetch
+}
 
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (

--- a/packages/next/src/lib/require-instrumentation-client.ts
+++ b/packages/next/src/lib/require-instrumentation-client.ts
@@ -1,14 +1,17 @@
 /**
- * This module imports the client instrumentation hook from the project root.
+ * This module imports the configured client instrumentation modules.
  *
  * The `private-next-instrumentation-client` module is automatically aliased to
- * the `instrumentation-client.ts` file in the project root by webpack or turbopack.
+ * either the user's instrumentation module or a generated module array.
  */
 if (process.env.NODE_ENV === 'development') {
   const measureName = 'Client Instrumentation Hook'
   const startTime = performance.now()
   // eslint-disable-next-line @next/internal/typechecked-require -- Not a module.
-  module.exports = require('private-next-instrumentation-client')
+  const instrumentationClient = require('private-next-instrumentation-client')
+  module.exports = Array.isArray(instrumentationClient)
+    ? instrumentationClient
+    : [instrumentationClient]
   const endTime = performance.now()
   const duration = endTime - startTime
 
@@ -23,5 +26,8 @@ if (process.env.NODE_ENV === 'development') {
   }
 } else {
   // eslint-disable-next-line @next/internal/typechecked-require -- Not a module.
-  module.exports = require('private-next-instrumentation-client')
+  const instrumentationClient = require('private-next-instrumentation-client')
+  module.exports = Array.isArray(instrumentationClient)
+    ? instrumentationClient
+    : [instrumentationClient]
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2310,7 +2310,7 @@ function App<T>({
     location: null,
   })
 
-  const actionQueue = createMutableActionQueue(initialState, null)
+  const actionQueue = createMutableActionQueue(initialState)
 
   const { HeadManagerContext } =
     require('../../shared/lib/head-manager-context.shared-runtime') as typeof import('../../shared/lib/head-manager-context.shared-runtime')
@@ -2371,7 +2371,7 @@ function ErrorApp<T>({
     location: null,
   })
 
-  const actionQueue = createMutableActionQueue(initialState, null)
+  const actionQueue = createMutableActionQueue(initialState)
 
   return (
     <ImageConfigContext.Provider value={images ?? imageConfigDefault}>

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -224,6 +224,7 @@ export const experimentalSchema = {
   dynamicOnHover: z.boolean().optional(),
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
+  instrumentationClientRouterTransitionEvents: z.boolean().optional(),
   appShells: z.boolean().optional(),
   varyParams: z.boolean().optional(),
   prefetchInlining: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -475,6 +475,7 @@ export interface ExperimentalConfig {
   dynamicOnHover?: boolean
   useOffline?: boolean
   optimisticRouting?: boolean
+  instrumentationClientRouterTransitionEvents?: boolean
   /**
    * Enables App Shell prefetching: a route's reusable, param-free loading
    * state is prefetched once per session and served instantly for any
@@ -1999,6 +2000,7 @@ export const defaultConfig = Object.freeze({
     useOffline: false,
     varyParams: true,
     optimisticRouting: true,
+    instrumentationClientRouterTransitionEvents: false,
     prefetchInlining: true,
     preloadEntriesOnStart: true,
     clientRouterFilter: true,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -43,6 +43,12 @@ export type {
 export type { Instant } from './build/segment-config/app/app-segment-config'
 
 export type { Instrumentation } from './server/instrumentation/types'
+export type {
+  RouterTransitionType,
+  RouterTransitionPrefetchIntent,
+  RouterTransitionEvent,
+  RouterTransitionStartEvent,
+} from './client/router-transition-types'
 
 /**
  * Stub route type for typedRoutes before `next dev` or `next build` is run

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -45,6 +45,7 @@ export type { Instant } from './build/segment-config/app/app-segment-config'
 export type { Instrumentation } from './server/instrumentation/types'
 export type {
   RouterTransitionType,
+  RouterTransitionPrefetch,
   RouterTransitionPrefetchIntent,
   RouterTransitionEvent,
   RouterTransitionStartEvent,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -48,6 +48,7 @@ export type {
   RouterTransitionPrefetchIntent,
   RouterTransitionEvent,
   RouterTransitionStartEvent,
+  RouterTransitionCommitEvent,
 } from './client/router-transition-types'
 
 /**

--- a/test/e2e/instrumentation-client-hook/app-router/app/blog/[slug]/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/blog/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="blog-post">Blog post</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/dashboard/@analytics/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/dashboard/@analytics/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="analytics">Analytics</p>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/dashboard/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+export default function DashboardLayout({
+  children,
+  analytics,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode
+}) {
+  return (
+    <>
+      {children}
+      {analytics}
+    </>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/dashboard/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="dashboard">Dashboard</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
@@ -9,7 +9,15 @@ export default function RootLayout({ children }) {
             <Link href="/">Home</Link>
           </li>
           <li>
-            <Link href="/some-page">Some Page</Link>
+            <Link href="/some-page" prefetch={true}>
+              Some Page
+            </Link>
+          </li>
+          <li>
+            <Link href="/dashboard">Dashboard</Link>
+          </li>
+          <li>
+            <Link href="/blog/hello">Blog post</Link>
           </li>
         </ul>
         {children}

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -1,11 +1,31 @@
 ;(window as any).__INSTRUMENTATION_CLIENT_EXECUTED_AT = performance.now()
+;(window as any).__ROUTER_TRANSITION_EVENTS = []
 
 const start = performance.now()
 while (performance.now() - start < 20) {
   // Intentionally block for 20ms to test instrumentation timing
 }
 
-export function onRouterTransitionStart(href: string, navigateType: string) {
+function record(
+  phase: string,
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  ;(window as any).__ROUTER_TRANSITION_EVENTS.push({
+    phase,
+    url: new URL(href, window.location.href).pathname,
+    navigateType,
+    event,
+  })
+}
+
+export function onRouterTransitionStart(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname}`)
+  record('start', href, navigateType, event)
 }

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -29,3 +29,11 @@ export function onRouterTransitionStart(
   console.log(`[Router Transition Start] [${navigateType}] ${pathname}`)
   record('start', href, navigateType, event)
 }
+
+export function unstable_onRouterTransitionCommit(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('commit', href, navigateType, event)
+}

--- a/test/e2e/instrumentation-client-hook/inject/inject-a.js
+++ b/test/e2e/instrumentation-client-hook/inject/inject-a.js
@@ -5,4 +5,7 @@ window.__INJECT_A_EXECUTED_AT = performance.now()
 export function onRouterTransitionStart(href, navigateType) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname} a`)
+  if (window.__THROW_INJECT_A) {
+    throw new Error('inject a transition hook failed')
+  }
 }

--- a/test/e2e/instrumentation-client-hook/inject/inject-a.js
+++ b/test/e2e/instrumentation-client-hook/inject/inject-a.js
@@ -9,3 +9,8 @@ export function onRouterTransitionStart(href, navigateType) {
     throw new Error('inject a transition hook failed')
   }
 }
+
+export function unstable_onRouterTransitionCommit(href, navigateType) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} a`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/inject-b.js
+++ b/test/e2e/instrumentation-client-hook/inject/inject-b.js
@@ -6,3 +6,8 @@ export function onRouterTransitionStart(href, navigateType) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname} b`)
 }
+
+export function unstable_onRouterTransitionCommit(href, navigateType) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} b`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/inject-late-hook.cjs
+++ b/test/e2e/instrumentation-client-hook/inject/inject-late-hook.cjs
@@ -1,0 +1,14 @@
+window.__INJECT_ORDER = window.__INJECT_ORDER || []
+window.__INJECT_ORDER.push('late-hook')
+
+const hooks = {}
+module.exports = hooks
+
+window.__INSTALL_LATE_INSTRUMENTATION_HOOK = () => {
+  hooks.onRouterTransitionStart = (href, navigateType) => {
+    const pathname = new URL(href, window.location.href).pathname
+    console.log(
+      `[Router Transition Start] [${navigateType}] ${pathname} late-hook`
+    )
+  }
+}

--- a/test/e2e/instrumentation-client-hook/inject/inject-side-effect.cjs
+++ b/test/e2e/instrumentation-client-hook/inject/inject-side-effect.cjs
@@ -1,0 +1,4 @@
+window.__INJECT_ORDER = window.__INJECT_ORDER || []
+window.__INJECT_ORDER.push('side-effect')
+
+module.exports = null

--- a/test/e2e/instrumentation-client-hook/inject/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/inject/instrumentation-client.ts
@@ -6,3 +6,11 @@ export function onRouterTransitionStart(href: string, navigateType: string) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname} user`)
 }
+
+export function unstable_onRouterTransitionCommit(
+  href: string,
+  navigateType: string
+) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} user`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/next.config.mjs
+++ b/test/e2e/instrumentation-client-hook/inject/next.config.mjs
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
 export default {
-  instrumentationClientInject: ['./inject-a.js', './inject-b.js'],
+  instrumentationClientInject: [
+    './inject-side-effect.cjs',
+    './inject-late-hook.cjs',
+    './inject-a.js',
+    './inject-b.js',
+  ],
 }

--- a/test/e2e/instrumentation-client-hook/inject/next.config.mjs
+++ b/test/e2e/instrumentation-client-hook/inject/next.config.mjs
@@ -6,4 +6,7 @@ export default {
     './inject-a.js',
     './inject-b.js',
   ],
+  experimental: {
+    instrumentationClientRouterTransitionEvents: true,
+  },
 }

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -115,31 +115,32 @@ describe('Instrumentation Client Hook', () => {
       packageJson,
     })
 
-    it('runs each injected entry before the user instrumentation-client and before hydration, in array order', async () => {
+    it('runs each injected module before the user instrumentation-client and before hydration, in array order', async () => {
       const browser = await next.browser('/')
 
       const order = await browser.eval(`window.__INJECT_ORDER`)
-      expect(order).toEqual(['a', 'b', 'user'])
+      expect(order).toEqual(['side-effect', 'late-hook', 'a', 'b', 'user'])
 
-      const injectA = await browser.eval(`window.__INJECT_A_EXECUTED_AT`)
-      const injectB = await browser.eval(`window.__INJECT_B_EXECUTED_AT`)
+      const moduleA = await browser.eval(`window.__INJECT_A_EXECUTED_AT`)
+      const moduleB = await browser.eval(`window.__INJECT_B_EXECUTED_AT`)
       const userTime = await browser.eval(
         `window.__INSTRUMENTATION_CLIENT_EXECUTED_AT`
       )
       const hydrationTime = await browser.eval(`window.__NEXT_HYDRATED_AT`)
 
-      expect(injectA).toBeDefined()
-      expect(injectB).toBeDefined()
+      expect(moduleA).toBeDefined()
+      expect(moduleB).toBeDefined()
       expect(userTime).toBeDefined()
       expect(hydrationTime).toBeDefined()
 
-      expect(injectA).toBeLessThanOrEqual(injectB)
-      expect(injectB).toBeLessThanOrEqual(userTime)
+      expect(moduleA).toBeLessThanOrEqual(moduleB)
+      expect(moduleB).toBeLessThanOrEqual(userTime)
       expect(userTime).toBeLessThan(hydrationTime)
     })
 
-    it('still surfaces onRouterTransitionStart from the user instrumentation-client when injects are configured', async () => {
+    it('surfaces onRouterTransitionStart from every injected module', async () => {
       const browser = await next.browser('/')
+      await browser.eval(`window.__INSTALL_LATE_INSTRUMENTATION_HOOK()`)
 
       const linkToSomePage = await browser.elementByCss('a[href="/some-page"]')
       await linkToSomePage.click()
@@ -150,13 +151,39 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(filterNavigationStartLogs(await browser.log())).toEqual([
+        '[Router Transition Start] [push] /some-page late-hook',
         '[Router Transition Start] [push] /some-page a',
         '[Router Transition Start] [push] /some-page b',
         '[Router Transition Start] [push] /some-page user',
+        '[Router Transition Start] [push] / late-hook',
         '[Router Transition Start] [push] / a',
         '[Router Transition Start] [push] / b',
         '[Router Transition Start] [push] / user',
       ])
+    })
+
+    it('isolates hook errors between injected modules', async () => {
+      const browser = await next.browser('/')
+
+      await browser.eval(`window.__INSTALL_LATE_INSTRUMENTATION_HOOK()`)
+      await browser.eval(`window.__THROW_INJECT_A = true`)
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+
+      const logs = await browser.log()
+      expect(filterNavigationStartLogs(logs)).toEqual([
+        '[Router Transition Start] [push] /some-page late-hook',
+        '[Router Transition Start] [push] /some-page a',
+        '[Router Transition Start] [push] /some-page b',
+        '[Router Transition Start] [push] /some-page user',
+      ])
+      expect(
+        logs.filter((log) =>
+          log.message.includes(
+            'An instrumentation-client router transition hook failed'
+          )
+        )
+      ).toHaveLength(1)
     })
   })
 

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -98,6 +98,76 @@ describe('Instrumentation Client Hook', () => {
         '[Router Transition Start] [traverse] /some-page',
       ])
     })
+
+    it('preserves the legacy two-argument start hook without the experimental flag', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+
+      expect(
+        await browser.eval(`
+          window.__ROUTER_TRANSITION_EVENTS.map((event) => ({
+            phase: event.phase,
+            hasEvent: event.event !== undefined,
+          }))
+        `)
+      ).toEqual([{ phase: 'start', hasEvent: false }])
+    })
+  })
+
+  describe('router transition start context', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'app-router'),
+      nextConfig: {
+        experimental: {
+          instrumentationClientRouterTransitionEvents: true,
+        },
+      },
+    })
+
+    async function getTransitionEvents(browser) {
+      return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
+    }
+
+    it('reports transition metadata, source routes, and prefetch intent', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+
+      const [start] = await getTransitionEvents(browser)
+      expect(start.phase).toBe('start')
+      expect(start.url).toBe('/some-page')
+      expect(start.navigateType).toBe('push')
+      expect(typeof start.event.id).toBe('string')
+      expect(start.event.timestamp).toBeGreaterThan(0)
+      expect(start.event.fromRoutes).toEqual(['/'])
+      expect(start.event.prefetchIntent).toBe('full')
+    })
+
+    it('uses route patterns and puts the primary source route first', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/blog/hello"]').click()
+      await browser.elementById('blog-post')
+      await browser.elementByCss('a[href="/"]').click()
+      await browser.elementById('home')
+
+      expect(
+        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+      ).toEqual(['/blog/[slug]'])
+
+      await browser.elementByCss('a[href="/dashboard"]').click()
+      await browser.elementById('dashboard')
+      await browser.elementById('analytics')
+      await browser.elementByCss('a[href="/"]').click()
+      await browser.elementById('home')
+
+      expect(
+        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+      ).toEqual(['/dashboard', '/dashboard/@analytics'])
+    })
   })
 
   describe.each([

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -57,6 +57,16 @@ describe('Instrumentation Client Hook', () => {
     return result
   }
 
+  function filterNavigationCommitLogs(logs: Array<{ message: string }>) {
+    const result = []
+    for (const log of logs) {
+      if (log.message.startsWith('[Router Transition Commit]')) {
+        result.push(log.message)
+      }
+    }
+    return result
+  }
+
   describe('onRouterTransitionStart', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'app-router'),
@@ -116,7 +126,7 @@ describe('Instrumentation Client Hook', () => {
     })
   })
 
-  describe('router transition start context', () => {
+  describe('router transition lifecycle', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'app-router'),
       nextConfig: {
@@ -130,20 +140,29 @@ describe('Instrumentation Client Hook', () => {
       return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
     }
 
-    it('reports transition metadata, source routes, and prefetch intent', async () => {
+    it('reports correlated start and commit events', async () => {
       const browser = await next.browser('/')
 
       await browser.elementByCss('a[href="/some-page"]').click()
       await browser.elementById('some-page')
 
-      const [start] = await getTransitionEvents(browser)
-      expect(start.phase).toBe('start')
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).map((event) => event.phase)
+        ).toEqual(['start', 'commit'])
+      })
+
+      const [start, commit] = await getTransitionEvents(browser)
       expect(start.url).toBe('/some-page')
       expect(start.navigateType).toBe('push')
       expect(typeof start.event.id).toBe('string')
       expect(start.event.timestamp).toBeGreaterThan(0)
       expect(start.event.fromRoutes).toEqual(['/'])
       expect(start.event.prefetchIntent).toBe('full')
+      expect(commit.event.id).toBe(start.event.id)
+      expect(commit.event.timestamp).toBeGreaterThanOrEqual(
+        start.event.timestamp
+      )
     })
 
     it('uses route patterns and puts the primary source route first', async () => {
@@ -229,6 +248,15 @@ describe('Instrumentation Client Hook', () => {
         '[Router Transition Start] [push] / a',
         '[Router Transition Start] [push] / b',
         '[Router Transition Start] [push] / user',
+      ])
+
+      expect(filterNavigationCommitLogs(await browser.log())).toEqual([
+        '[Router Transition Commit] [push] /some-page a',
+        '[Router Transition Commit] [push] /some-page b',
+        '[Router Transition Commit] [push] /some-page user',
+        '[Router Transition Commit] [push] / a',
+        '[Router Transition Commit] [push] / b',
+        '[Router Transition Commit] [push] / user',
       ])
     })
 

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -140,7 +140,7 @@ describe('Instrumentation Client Hook', () => {
       return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
     }
 
-    it('reports correlated start and commit events', async () => {
+    it('reports correlated lifecycle events and route information', async () => {
       const browser = await next.browser('/')
 
       await browser.elementByCss('a[href="/some-page"]').click()
@@ -159,6 +159,14 @@ describe('Instrumentation Client Hook', () => {
       expect(start.event.timestamp).toBeGreaterThan(0)
       expect(start.event.fromRoutes).toEqual(['/'])
       expect(start.event.prefetchIntent).toBe('full')
+      expect(commit.event.routes).toEqual(['/some-page'])
+      if (isNextDev) {
+        expect(commit.event.prefetch).toBe('miss')
+      } else {
+        expect(['hit-route', 'hit-shell', 'miss']).toContain(
+          commit.event.prefetch
+        )
+      }
       expect(commit.event.id).toBe(start.event.id)
       expect(commit.event.timestamp).toBeGreaterThanOrEqual(
         start.event.timestamp
@@ -186,6 +194,30 @@ describe('Instrumentation Client Hook', () => {
       expect(
         (await getTransitionEvents(browser)).at(-1).event.fromRoutes
       ).toEqual(['/dashboard', '/dashboard/@analytics'])
+    })
+
+    it('uses route patterns and puts the primary destination route first', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/blog/hello"]').click()
+      await browser.elementById('blog-post')
+      await retry(async () => {
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+      })
+      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
+        '/blog/[slug]',
+      ])
+
+      await browser.elementByCss('a[href="/dashboard"]').click()
+      await browser.elementById('dashboard')
+      await browser.elementById('analytics')
+      await retry(async () => {
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+      })
+      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
+        '/dashboard',
+        '/dashboard/@analytics',
+      ])
     })
   })
 


### PR DESCRIPTION
## Stack Position

(4/7) in the router instrumentation stack.

1. #94755: router instrumentation: refactor client hook dispatch (1/7)
2. #94766: router instrumentation: add transition start context (2/7)
3. #94756: router instrumentation: add transition commit events (3/7)
4. **#94765: router instrumentation: add commit route and prefetch context (4/7)**
5. #94757: router instrumentation: add transition abort events (5/7)
6. #94758: router instrumentation: add route mismatch events (6/7)
7. #94737: router instrumentation: add transition settlement events (7/7)

Parent: #94756
Next: #94757

## What This PR Does

Adds destination context to the commit event:

- `routes`: active destination route patterns
- `prefetch`: `hit-route`, `hit-shell`, `miss`, or `none`

The primary `children` route is first, followed by visible parallel slots in deterministic order.

## Design

Commit owns the context that becomes authoritative when destination UI first appears: which routes committed and which cache result the navigation actually used.

Source routes and prefetch intent remain on start. They are not repeated on commit; consumers correlate both events by transition ID.

## Not In This PR

- Abort, mismatch, or settled hooks
- Response-close accounting

## Reviewer Focus

- Destination route extraction and parallel-route ordering
- Full route hits versus reusable App Shell hits
- Preserving a cache miss when later route prediction supplies a tree

## Validation

- `pnpm build-all`
- Focused route and prefetch instrumentation coverage: 2 passed

<!-- NEXT_JS_LLM_PR -->
