### PR TITLE
router instrumentation: add transition start context (2/7)

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -43,33 +43,70 @@ window.addEventListener('error', (event) => {
 
 ## Router navigation tracking
 
-You can export an `onRouterTransitionStart` function to receive notifications when navigation begins:
+You can export `onRouterTransitionStart` to observe the start of App Router navigations:
 
-```ts filename="instrumentation-client.ts" switcher
-performance.mark('app-init')
-
+```ts filename="instrumentation-client.ts"
 export function onRouterTransitionStart(
   url: string,
   navigationType: 'push' | 'replace' | 'traverse'
 ) {
-  console.log(`Navigation started: ${navigationType} to ${url}`)
-  performance.mark(`nav-start-${Date.now()}`)
+  console.log(url, navigationType)
+}
+```
+
+Additional router transition information is experimental. Enable it to receive a third `event` argument:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    instrumentationClientRouterTransitionEvents: true,
+  },
+}
+
+export default nextConfig
+```
+
+The event includes the transition metadata and source context known when the navigation is dispatched:
+
+```ts filename="instrumentation-client.ts" switcher
+import type { RouterTransitionStartEvent, RouterTransitionType } from 'next'
+
+export function onRouterTransitionStart(
+  url: string,
+  navigationType: RouterTransitionType,
+  { id, timestamp, fromRoutes, prefetchIntent }: RouterTransitionStartEvent
+) {
+  console.log(id, timestamp, url, navigationType, fromRoutes, prefetchIntent)
 }
 ```
 
 ```js filename="instrumentation-client.js" switcher
-performance.mark('app-init')
-
-export function onRouterTransitionStart(url, navigationType) {
-  console.log(`Navigation started: ${navigationType} to ${url}`)
-  performance.mark(`nav-start-${Date.now()}`)
+export function onRouterTransitionStart(url, navigationType, event) {
+  console.log(
+    event.id,
+    event.timestamp,
+    url,
+    navigationType,
+    event.fromRoutes,
+    event.prefetchIntent
+  )
 }
 ```
 
-The `onRouterTransitionStart` function receives two parameters:
+`onRouterTransitionStart` receives:
 
 - `url: string` - The URL being navigated to
 - `navigationType: 'push' | 'replace' | 'traverse'` - The type of navigation
+- `event.id` - An opaque ID shared by events for this transition
+- `event.timestamp` - A framework-captured Unix timestamp in milliseconds
+- `event.fromRoutes` - Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order
+- `event.prefetchIntent` - Whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`)
+
+Route entries use filesystem-style patterns, so a navigation away from `/blog/hello` may report `/blog/[slug]`.
+
+Hook errors are isolated and do not affect navigation or other hooks.
 
 ## Performance considerations
 
@@ -89,7 +126,7 @@ This timing makes it ideal for setting up error tracking, analytics, and perform
 
 ## See also
 
-`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export their own `onRouterTransitionStart`. Application code should continue to use this file convention directly.
+`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition start hook. Application code should continue to use this file convention directly.
 
 ## Examples
 
@@ -223,6 +260,7 @@ if (!window.ResizeObserver) {
 
 ## Version history
 
-| Version | Changes                             |
-| ------- | ----------------------------------- |
-| `v15.3` | `instrumentation-client` introduced |
+| Version   | Changes                                               |
+| --------- | ----------------------------------------------------- |
+| `v16.3.0` | Experimental router transition start event introduced |
+| `v15.3`   | `instrumentation-client` introduced                   |

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -102,7 +102,7 @@ export function onRouterTransitionStart(url, navigationType, event) {
 - `event.id` - An opaque ID shared by events for this transition
 - `event.timestamp` - A framework-captured Unix timestamp in milliseconds
 - `event.fromRoutes` - Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order
-- `event.prefetchIntent` - Whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`)
+- `event.prefetchIntent` - For link navigations, whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`). For navigations with no associated link (programmatic `router.push()`/`router.replace()`, or browser back/forward) this is `null`, since no link prefetch intent applies
 
 Route entries use filesystem-style patterns, so a navigation away from `/blog/hello` may report `/blog/[slug]`.
 

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -378,6 +378,8 @@ export function getDefineEnv({
       config.experimental.gestureTransition ?? false,
     'process.env.__NEXT_OPTIMISTIC_ROUTING':
       config.experimental.optimisticRouting ?? false,
+    'process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS':
+      config.experimental.instrumentationClientRouterTransitionEvents ?? false,
     'process.env.__NEXT_APP_SHELLS': config.experimental.appShells ?? false,
     'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_EXPOSE_TESTING_API':

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -22,6 +22,7 @@ import {
   FetchStrategy,
   type PrefetchTaskFetchStrategy,
 } from '../components/segment-cache/types'
+import type { RouterTransitionPrefetchIntent } from '../router-transition-types'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -256,7 +257,8 @@ function linkClicked(
   replace?: boolean,
   scroll?: boolean,
   onNavigate?: OnNavigateEventHandler,
-  transitionTypes?: string[]
+  transitionTypes?: string[],
+  prefetchIntent: RouterTransitionPrefetchIntent = 'none'
 ): void {
   if (typeof window !== 'undefined') {
     const { nodeName } = e.currentTarget
@@ -308,7 +310,8 @@ function linkClicked(
         replace ? 'replace' : 'push',
         scroll === false ? ScrollBehavior.NoScroll : ScrollBehavior.Default,
         linkInstanceRef.current,
-        transitionTypes
+        transitionTypes,
+        prefetchIntent
       )
     })
   }
@@ -376,6 +379,8 @@ export default function LinkComponent(
   const router = React.useContext(AppRouterContext)
 
   const prefetchEnabled = prefetchProp !== false
+  const prefetchIntent: RouterTransitionPrefetchIntent =
+    prefetchProp === false ? 'none' : prefetchProp === true ? 'full' : 'auto'
 
   const fetchStrategy =
     prefetchProp !== false
@@ -692,7 +697,8 @@ export default function LinkComponent(
         replace,
         scroll,
         onNavigate,
-        transitionTypes
+        transitionTypes,
+        prefetchIntent
       )
     },
     onMouseEnter(e) {

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -383,8 +383,8 @@ export default function LinkComponent(
     prefetchProp === false ? 'none' : prefetchProp === true ? 'full' : 'auto'
 
   const fetchStrategy =
-    prefetchProp !== false
-      ? getFetchStrategyFromPrefetchProp(prefetchProp)
+    prefetchIntent !== 'none'
+      ? getFetchStrategyFromPrefetchIntent(prefetchIntent)
       : // TODO: it makes no sense to assign a fetchStrategy when prefetching is disabled.
         FetchStrategy.PPR
 
@@ -805,26 +805,23 @@ export const useLinkStatus = () => {
   return useContext(LinkStatusContext)
 }
 
-function getFetchStrategyFromPrefetchProp(
-  prefetchProp: Exclude<LinkProps['prefetch'], undefined | false>
+function getFetchStrategyFromPrefetchIntent(
+  prefetchIntent: Exclude<RouterTransitionPrefetchIntent, 'none'>
 ): PrefetchTaskFetchStrategy {
   if (process.env.__NEXT_CACHE_COMPONENTS) {
-    if (prefetchProp === true) {
+    if (prefetchIntent === 'full') {
       return FetchStrategy.Full
     }
 
-    // `null` or `"auto"`: this is the default "auto" mode, where we will prefetch partially if the link is in the viewport.
-    // This will also include invalid prop values that don't match the types specified here.
-    // (although those should've been filtered out by prop validation in dev)
-    prefetchProp satisfies null | 'auto'
+    // `"auto"`: the default mode, where we will prefetch partially if the link is in the viewport.
+    prefetchIntent satisfies 'auto'
     return FetchStrategy.PPR
   } else {
-    return prefetchProp === null || prefetchProp === 'auto'
+    return prefetchIntent === 'auto'
       ? // We default to PPR, and we'll discover whether or not the route supports it with the initial prefetch.
         FetchStrategy.PPR
-      : // In the old implementation without runtime prefetches, `prefetch={true}` forces all dynamic data to be prefetched.
-        // To preserve backwards-compatibility, anything other than `false`, `null`, or `"auto"` results in a full prefetch.
-        // (although invalid values should've been filtered out by prop validation in dev)
+      : // In the old implementation without runtime prefetches, `prefetch={true}` (`'full'`) forces all dynamic
+        // data to be prefetched, preserving backwards-compatibility.
         FetchStrategy.Full
   }
 }

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -264,7 +264,7 @@ export function dispatchNavigateAction(
   scrollBehavior: ScrollBehavior,
   linkInstanceRef: LinkInstance | null,
   transitionTypes: string[] | undefined,
-  prefetchIntent: RouterTransitionPrefetchIntent
+  prefetchIntent: RouterTransitionPrefetchIntent | null
 ): void {
   // TODO: This stuff could just go into the reducer. Leaving as-is for now
   // since we're about to rewrite all the router reducer stuff anyway.
@@ -306,7 +306,9 @@ export function dispatchTraverseAction(
     href,
     'traverse',
     getAppRouterActionQueue().state.tree,
-    'none'
+    // Traversals (browser back/forward) have no associated link, so there is no
+    // prefetch intent to report.
+    null
   )
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
@@ -438,7 +440,9 @@ export const publicAppRouterInstance: AppRouterInstance = {
           : ScrollBehavior.Default,
         null,
         options?.transitionTypes,
-        'none'
+        // Programmatic navigations have no associated link, so there is no
+        // prefetch intent to report.
+        null
       )
     })
   },
@@ -457,7 +461,9 @@ export const publicAppRouterInstance: AppRouterInstance = {
           : ScrollBehavior.Default,
         null,
         options?.transitionTypes,
-        'none'
+        // Programmatic navigations have no associated link, so there is no
+        // prefetch intent to report.
+        null
       )
     })
   },

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -35,6 +35,7 @@ import type {
   PrefetchOptions,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import { setLinkForCurrentNavigation, type LinkInstance } from './links'
+import type { RouterTransitionPrefetchIntent } from '../router-transition-types'
 import type { GlobalErrorComponent } from './builtin/global-error'
 import { isJavaScriptURLString } from '../lib/javascript-url'
 import { startRouterTransition } from './router-transition'
@@ -262,7 +263,8 @@ export function dispatchNavigateAction(
   navigateType: NavigateAction['navigateType'],
   scrollBehavior: ScrollBehavior,
   linkInstanceRef: LinkInstance | null,
-  transitionTypes: string[] | undefined
+  transitionTypes: string[] | undefined,
+  prefetchIntent: RouterTransitionPrefetchIntent
 ): void {
   // TODO: This stuff could just go into the reducer. Leaving as-is for now
   // since we're about to rewrite all the router reducer stuff anyway.
@@ -279,7 +281,12 @@ export function dispatchNavigateAction(
   }
 
   setLinkForCurrentNavigation(linkInstanceRef)
-  startRouterTransition(href, navigateType)
+  startRouterTransition(
+    href,
+    navigateType,
+    getAppRouterActionQueue().state.tree,
+    prefetchIntent
+  )
 
   dispatchAppRouterAction({
     type: ACTION_NAVIGATE,
@@ -295,7 +302,12 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
-  startRouterTransition(href, 'traverse')
+  startRouterTransition(
+    href,
+    'traverse',
+    getAppRouterActionQueue().state.tree,
+    'none'
+  )
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
     url: new URL(href),
@@ -425,7 +437,8 @@ export const publicAppRouterInstance: AppRouterInstance = {
           ? ScrollBehavior.NoScroll
           : ScrollBehavior.Default,
         null,
-        options?.transitionTypes
+        options?.transitionTypes,
+        'none'
       )
     })
   },
@@ -443,7 +456,8 @@ export const publicAppRouterInstance: AppRouterInstance = {
           ? ScrollBehavior.NoScroll
           : ScrollBehavior.Default,
         null,
-        options?.transitionTypes
+        options?.transitionTypes,
+        'none'
       )
     })
   },

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -306,8 +306,6 @@ export function dispatchTraverseAction(
     href,
     'traverse',
     getAppRouterActionQueue().state.tree,
-    // Traversals (browser back/forward) have no associated link, so there is no
-    // prefetch intent to report.
     null
   )
   dispatchAppRouterAction({
@@ -440,8 +438,6 @@ export const publicAppRouterInstance: AppRouterInstance = {
           : ScrollBehavior.Default,
         null,
         options?.transitionTypes,
-        // Programmatic navigations have no associated link, so there is no
-        // prefetch intent to report.
         null
       )
     })
@@ -461,8 +457,6 @@ export const publicAppRouterInstance: AppRouterInstance = {
           : ScrollBehavior.Default,
         null,
         options?.transitionTypes,
-        // Programmatic navigations have no associated link, so there is no
-        // prefetch intent to report.
         null
       )
     })

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -1,7 +1,36 @@
-import { computeChangedPath } from './compute-changed-path'
-import { PrefetchHint } from '../../../shared/lib/app-router-types'
+import {
+  computeChangedPath,
+  segmentToSourcePagePathname,
+} from './compute-changed-path'
+import {
+  type FlightRouterState,
+  type Segment,
+  PrefetchHint,
+} from '../../../shared/lib/app-router-types'
+import { getActiveRoutePaths } from '../router-transition'
 
 describe('computeChangedPath', () => {
+  const sourceRouteSegmentCases: Array<[Segment, string]> = [
+    [['slug', 'hello', 'd', null], '[slug]'],
+    [['slug', 'hello', 'c', null], '[...slug]'],
+    [['slug', 'hello', 'oc', null], '[[...slug]]'],
+    [['slug', 'hello', 'di(.)', null], '(.)[slug]'],
+    [['slug', 'hello', 'di(..)', null], '(..)[slug]'],
+    [['slug', 'hello', 'di(..)(..)', null], '(..)(..)[slug]'],
+    [['slug', 'hello', 'di(...)', null], '(...)[slug]'],
+    [['slug', 'hello', 'ci(.)', null], '(.)[...slug]'],
+    [['slug', 'hello', 'ci(..)', null], '(..)[...slug]'],
+    [['slug', 'hello', 'ci(..)(..)', null], '(..)(..)[...slug]'],
+    [['slug', 'hello', 'ci(...)', null], '(...)[...slug]'],
+  ]
+
+  it.each(sourceRouteSegmentCases)(
+    'formats source route segment %j as %s',
+    (segment, expected) => {
+      expect(segmentToSourcePagePathname(segment)).toBe(expected)
+    }
+  )
+
   it('should return the correct path', () => {
     expect(
       computeChangedPath(
@@ -57,5 +86,37 @@ describe('computeChangedPath', () => {
         ]
       )
     ).toBe('/')
+  })
+
+  it('normalizes active route paths', () => {
+    const tree: FlightRouterState = [
+      '',
+      {
+        children: [
+          'children',
+          {
+            children: [
+              '(group)',
+              {
+                children: ['/_not-found', {}],
+              },
+            ],
+          },
+        ],
+        modal: [
+          '(__SLOT__)',
+          {
+            children: [
+              ['slug', 'hello', 'd', null],
+              {
+                children: ['__PAGE__', {}],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    expect(getActiveRoutePaths(tree)).toEqual(['/_not-found', '/@modal/[slug]'])
   })
 })

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -3,11 +3,9 @@ import {
   segmentToSourcePagePathname,
 } from './compute-changed-path'
 import {
-  type FlightRouterState,
   type Segment,
   PrefetchHint,
 } from '../../../shared/lib/app-router-types'
-import { getActiveRoutePaths } from '../router-transition'
 
 describe('computeChangedPath', () => {
   const sourceRouteSegmentCases: Array<[Segment, string]> = [
@@ -86,37 +84,5 @@ describe('computeChangedPath', () => {
         ]
       )
     ).toBe('/')
-  })
-
-  it('normalizes active route paths', () => {
-    const tree: FlightRouterState = [
-      '',
-      {
-        children: [
-          'children',
-          {
-            children: [
-              '(group)',
-              {
-                children: ['/_not-found', {}],
-              },
-            ],
-          },
-        ],
-        modal: [
-          '(__SLOT__)',
-          {
-            children: [
-              ['slug', 'hello', 'd', null],
-              {
-                children: ['__PAGE__', {}],
-              },
-            ],
-          },
-        ],
-      },
-    ]
-
-    expect(getActiveRoutePaths(tree)).toEqual(['/_not-found', '/@modal/[slug]'])
   })
 })

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -27,7 +27,7 @@ const segmentToPathname = (segment: Segment): string => {
   return segment[1]
 }
 
-const segmentToSourcePagePathname = (segment: Segment): string => {
+export const segmentToSourcePagePathname = (segment: Segment): string => {
   if (typeof segment === 'string') {
     if (segment === 'children') return ''
     if (segment.startsWith(PAGE_SEGMENT_KEY)) return 'page'

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -47,7 +47,7 @@ export function startRouterTransition(
   url: string,
   type: RouterTransitionType,
   fromTree: FlightRouterState,
-  prefetchIntent: RouterTransitionPrefetchIntent
+  prefetchIntent: RouterTransitionPrefetchIntent | null
 ): void {
   if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
     callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -49,29 +49,29 @@ export function startRouterTransition(
   fromTree: FlightRouterState,
   prefetchIntent: RouterTransitionPrefetchIntent | null
 ): void {
-  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
-    callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))
-    return
-  }
+  // Positive flag check so the instrumentation-only path is removed by DCE when disabled.
+  if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    if (
+      !instrumentationModules.some(
+        (hooks) => typeof hooks.onRouterTransitionStart === 'function'
+      )
+    ) {
+      return
+    }
 
-  if (
-    !instrumentationModules.some(
-      (hooks) => typeof hooks.onRouterTransitionStart === 'function'
+    const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
+
+    callHooks((hooks) =>
+      hooks.onRouterTransitionStart?.(url, type, {
+        id,
+        timestamp: timestamp(),
+        fromRoutes: getActiveRoutePaths(fromTree),
+        prefetchIntent,
+      })
     )
-  ) {
-    return
+  } else {
+    callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type, null))
   }
-
-  const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
-
-  callHooks((hooks) =>
-    hooks.onRouterTransitionStart?.(url, type, {
-      id,
-      timestamp: timestamp(),
-      fromRoutes: getActiveRoutePaths(fromTree),
-      prefetchIntent,
-    })
-  )
 }
 
 function classifySegment(segment: Segment): {

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -98,7 +98,7 @@ function classifySegment(segment: Segment): {
   return { path: sourceSegment, isPage: false }
 }
 
-export function getActiveRoutePaths(tree: FlightRouterState): string[] {
+function getActiveRoutePaths(tree: FlightRouterState): string[] {
   const routes: Array<{ path: string; primary: boolean }> = []
 
   function visit(

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -1,10 +1,22 @@
 import type {
+  FlightRouterState,
+  Segment,
+} from '../../shared/lib/app-router-types'
+import {
+  DEFAULT_SEGMENT_KEY,
+  isGroupSegment,
+  NOT_FOUND_SEGMENT_KEY,
+} from '../../shared/lib/segment'
+import { segmentToSourcePagePathname } from './router-reducer/compute-changed-path'
+import type {
   ClientInstrumentationHooks,
   ClientInstrumentationModules,
+  RouterTransitionPrefetchIntent,
   RouterTransitionType,
 } from '../router-transition-types'
 
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
+let nextTransitionId = 0
 
 export function initializeRouterTransitionModules(
   modules: ClientInstrumentationModules
@@ -27,9 +39,106 @@ function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
   }
 }
 
+function timestamp(): number {
+  return performance.timeOrigin + performance.now()
+}
+
 export function startRouterTransition(
   url: string,
-  type: RouterTransitionType
+  type: RouterTransitionType,
+  fromTree: FlightRouterState,
+  prefetchIntent: RouterTransitionPrefetchIntent
 ): void {
-  callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))
+  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type))
+    return
+  }
+
+  if (
+    !instrumentationModules.some(
+      (hooks) => typeof hooks.onRouterTransitionStart === 'function'
+    )
+  ) {
+    return
+  }
+
+  const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
+
+  callHooks((hooks) =>
+    hooks.onRouterTransitionStart?.(url, type, {
+      id,
+      timestamp: timestamp(),
+      fromRoutes: getActiveRoutePaths(fromTree),
+      prefetchIntent,
+    })
+  )
+}
+
+function classifySegment(segment: Segment): {
+  path: string | null
+  isPage: boolean
+} {
+  const sourceSegment = segmentToSourcePagePathname(segment)
+  if (sourceSegment === 'page') {
+    return { path: null, isPage: true }
+  }
+  if (
+    sourceSegment === '' ||
+    sourceSegment === '(__SLOT__)' ||
+    isGroupSegment(sourceSegment)
+  ) {
+    return { path: null, isPage: false }
+  }
+  if (sourceSegment === DEFAULT_SEGMENT_KEY) {
+    return { path: 'default', isPage: false }
+  }
+  if (sourceSegment === NOT_FOUND_SEGMENT_KEY) {
+    return { path: '_not-found', isPage: false }
+  }
+  return { path: sourceSegment, isPage: false }
+}
+
+export function getActiveRoutePaths(tree: FlightRouterState): string[] {
+  const routes: Array<{ path: string; primary: boolean }> = []
+
+  function visit(
+    node: FlightRouterState,
+    segments: string[],
+    primary: boolean
+  ): void {
+    const segment = classifySegment(node[0])
+    const nextSegments =
+      segment.path === null ? segments : [...segments, segment.path]
+    const parallelRoutes = node[1]
+    const keys = Object.keys(parallelRoutes)
+
+    if (keys.length === 0 || segment.isPage) {
+      routes.push({
+        path: `/${nextSegments.join('/')}`,
+        primary,
+      })
+      return
+    }
+
+    if (parallelRoutes.children !== undefined) {
+      visit(parallelRoutes.children, nextSegments, primary)
+    }
+
+    for (const key of keys.sort()) {
+      if (key === 'children') {
+        continue
+      }
+      visit(parallelRoutes[key], [...nextSegments, `@${key}`], false)
+    }
+  }
+
+  visit(tree, [], true)
+  return routes
+    .sort((a, b) => {
+      if (a.primary !== b.primary) {
+        return a.primary ? -1 : 1
+      }
+      return a.path.localeCompare(b.path)
+    })
+    .map((route) => route.path)
 }

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -9,7 +9,9 @@ export type RouterTransitionEvent = {
 
 export type RouterTransitionStartEvent = RouterTransitionEvent & {
   fromRoutes: string[]
-  prefetchIntent: RouterTransitionPrefetchIntent
+  // `null` for programmatic navigations (`router.push()`/`router.replace()`),
+  // which have no associated link and therefore no prefetch intent.
+  prefetchIntent: RouterTransitionPrefetchIntent | null
 }
 
 export type ClientInstrumentationHooks = {

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -1,9 +1,22 @@
 export type RouterTransitionType = 'push' | 'replace' | 'traverse'
 
+export type RouterTransitionPrefetchIntent = 'full' | 'auto' | 'none'
+
+export type RouterTransitionEvent = {
+  id: string
+  timestamp: number
+}
+
+export type RouterTransitionStartEvent = RouterTransitionEvent & {
+  fromRoutes: string[]
+  prefetchIntent: RouterTransitionPrefetchIntent
+}
+
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
-    navigationType: RouterTransitionType
+    navigationType: RouterTransitionType,
+    event?: RouterTransitionStartEvent
   ) => void
 }
 

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -9,8 +9,7 @@ export type RouterTransitionEvent = {
 
 export type RouterTransitionStartEvent = RouterTransitionEvent & {
   fromRoutes: string[]
-  // `null` for programmatic navigations (`router.push()`/`router.replace()`),
-  // which have no associated link and therefore no prefetch intent.
+  // `null` for non-prefetch transitions.
   prefetchIntent: RouterTransitionPrefetchIntent | null
 }
 
@@ -18,7 +17,7 @@ export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
     navigationType: RouterTransitionType,
-    event?: RouterTransitionStartEvent
+    event: RouterTransitionStartEvent | null
   ) => void
 }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -224,6 +224,7 @@ export const experimentalSchema = {
   dynamicOnHover: z.boolean().optional(),
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
+  instrumentationClientRouterTransitionEvents: z.boolean().optional(),
   appShells: z.boolean().optional(),
   varyParams: z.boolean().optional(),
   prefetchInlining: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -477,6 +477,7 @@ export interface ExperimentalConfig {
   dynamicOnHover?: boolean
   useOffline?: boolean
   optimisticRouting?: boolean
+  instrumentationClientRouterTransitionEvents?: boolean
   /**
    * Enables App Shell prefetching: a route's reusable, param-free loading
    * state is prefetched once per session and served instantly for any
@@ -2025,6 +2026,7 @@ export const defaultConfig = Object.freeze({
     useOffline: false,
     varyParams: true,
     optimisticRouting: true,
+    instrumentationClientRouterTransitionEvents: false,
     prefetchInlining: true,
     preloadEntriesOnStart: true,
     clientRouterFilter: true,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -43,6 +43,12 @@ export type {
 export type { Instant } from './build/segment-config/app/app-segment-config'
 
 export type { Instrumentation } from './server/instrumentation/types'
+export type {
+  RouterTransitionType,
+  RouterTransitionPrefetchIntent,
+  RouterTransitionEvent,
+  RouterTransitionStartEvent,
+} from './client/router-transition-types'
 
 /**
  * Stub route type for typedRoutes before `next dev` or `next build` is run

--- a/test/e2e/instrumentation-client-hook/app-router/app/(marketing)/about/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/(marketing)/about/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="about">About</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/blog/[slug]/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/blog/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="blog-post">Blog post</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/dashboard/@analytics/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/dashboard/@analytics/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="analytics">Analytics</p>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/dashboard/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+export default function DashboardLayout({
+  children,
+  analytics,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode
+}) {
+  return (
+    <>
+      {children}
+      {analytics}
+    </>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/dashboard/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="dashboard">Dashboard</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/gallery/@modal/(.)photos/[id]/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/gallery/@modal/(.)photos/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="photo-modal">Photo modal</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/gallery/@modal/default.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/gallery/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/gallery/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/gallery/layout.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function GalleryLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <>
+      {children}
+      {modal}
+    </>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/gallery/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/gallery/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1 id="gallery">Gallery</h1>
+      <Link href="/gallery/photos/1">Photo 1</Link>
+    </div>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/gallery/photos/[id]/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/gallery/photos/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="photo">Photo</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
@@ -9,7 +9,15 @@ export default function RootLayout({ children }) {
             <Link href="/">Home</Link>
           </li>
           <li>
-            <Link href="/some-page">Some Page</Link>
+            <Link href="/some-page" prefetch={true}>
+              Some Page
+            </Link>
+          </li>
+          <li>
+            <Link href="/dashboard">Dashboard</Link>
+          </li>
+          <li>
+            <Link href="/blog/hello">Blog post</Link>
           </li>
         </ul>
         {children}

--- a/test/e2e/instrumentation-client-hook/app-router/app/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/page.tsx
@@ -1,3 +1,10 @@
+import { PushButton } from './push-button'
+
 export default function Page() {
-  return <h1 id="home">Home</h1>
+  return (
+    <>
+      <h1 id="home">Home</h1>
+      <PushButton />
+    </>
+  )
 }

--- a/test/e2e/instrumentation-client-hook/app-router/app/push-button.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/push-button.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function PushButton() {
+  const router = useRouter()
+  return (
+    <button id="push-some-page" onClick={() => router.push('/some-page')}>
+      Push some page
+    </button>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -1,11 +1,31 @@
 ;(window as any).__INSTRUMENTATION_CLIENT_EXECUTED_AT = performance.now()
+;(window as any).__ROUTER_TRANSITION_EVENTS = []
 
 const start = performance.now()
 while (performance.now() - start < 20) {
   // Intentionally block for 20ms to test instrumentation timing
 }
 
-export function onRouterTransitionStart(href: string, navigateType: string) {
+function record(
+  phase: string,
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  ;(window as any).__ROUTER_TRANSITION_EVENTS.push({
+    phase,
+    url: new URL(href, window.location.href).pathname,
+    navigateType,
+    event,
+  })
+}
+
+export function onRouterTransitionStart(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname}`)
+  record('start', href, navigateType, event)
 }

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -181,6 +181,31 @@ describe('Instrumentation Client Hook', () => {
         (await getTransitionEvents(browser)).at(-1).event.fromRoutes
       ).toEqual(['/dashboard', '/dashboard/@analytics'])
     })
+
+    it('omits route groups from fromRoutes', async () => {
+      const browser = await next.browser('/about')
+
+      await browser.elementByCss('a[href="/"]').click()
+      await browser.elementById('home')
+
+      expect(
+        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+      ).toEqual(['/about'])
+    })
+
+    it('reports intercepted route patterns in fromRoutes', async () => {
+      const browser = await next.browser('/gallery')
+
+      await browser.elementByCss('a[href="/gallery/photos/1"]').click()
+      await browser.elementById('photo-modal')
+
+      await browser.elementByCss('a[href="/"]').click()
+      await browser.elementById('home')
+
+      expect(
+        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+      ).toEqual(['/gallery', '/gallery/@modal/(.)photos/[id]'])
+    })
   })
 
   describe.each([

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -146,6 +146,19 @@ describe('Instrumentation Client Hook', () => {
       expect(start.event.prefetchIntent).toBe('full')
     })
 
+    it('reports a null prefetch intent for programmatic navigation', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementById('push-some-page').click()
+      await browser.elementById('some-page')
+
+      const [start] = await getTransitionEvents(browser)
+      expect(start.phase).toBe('start')
+      expect(start.url).toBe('/some-page')
+      expect(start.navigateType).toBe('push')
+      expect(start.event.prefetchIntent).toBe(null)
+    })
+
     it('uses route patterns and puts the primary source route first', async () => {
       const browser = await next.browser('/')
 

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -98,6 +98,76 @@ describe('Instrumentation Client Hook', () => {
         '[Router Transition Start] [traverse] /some-page',
       ])
     })
+
+    it('preserves the legacy two-argument start hook without the experimental flag', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+
+      expect(
+        await browser.eval(`
+          window.__ROUTER_TRANSITION_EVENTS.map((event) => ({
+            phase: event.phase,
+            hasEvent: event.event !== undefined,
+          }))
+        `)
+      ).toEqual([{ phase: 'start', hasEvent: false }])
+    })
+  })
+
+  describe('router transition start context', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'app-router'),
+      nextConfig: {
+        experimental: {
+          instrumentationClientRouterTransitionEvents: true,
+        },
+      },
+    })
+
+    async function getTransitionEvents(browser) {
+      return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
+    }
+
+    it('reports transition metadata, source routes, and prefetch intent', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+
+      const [start] = await getTransitionEvents(browser)
+      expect(start.phase).toBe('start')
+      expect(start.url).toBe('/some-page')
+      expect(start.navigateType).toBe('push')
+      expect(typeof start.event.id).toBe('string')
+      expect(start.event.timestamp).toBeGreaterThan(0)
+      expect(start.event.fromRoutes).toEqual(['/'])
+      expect(start.event.prefetchIntent).toBe('full')
+    })
+
+    it('uses route patterns and puts the primary source route first', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/blog/hello"]').click()
+      await browser.elementById('blog-post')
+      await browser.elementByCss('a[href="/"]').click()
+      await browser.elementById('home')
+
+      expect(
+        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+      ).toEqual(['/blog/[slug]'])
+
+      await browser.elementByCss('a[href="/dashboard"]').click()
+      await browser.elementById('dashboard')
+      await browser.elementById('analytics')
+      await browser.elementByCss('a[href="/"]').click()
+      await browser.elementById('home')
+
+      expect(
+        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+      ).toEqual(['/dashboard', '/dashboard/@analytics'])
+    })
   })
 
   describe.each([

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -109,7 +109,7 @@ describe('Instrumentation Client Hook', () => {
         await browser.eval(`
           window.__ROUTER_TRANSITION_EVENTS.map((event) => ({
             phase: event.phase,
-            hasEvent: event.event !== undefined,
+            hasEvent: event.event != null,
           }))
         `)
       ).toEqual([{ phase: 'start', hasEvent: false }])

--- a/test/production/app-dir/instrumentation-client-dce/app/layout.tsx
+++ b/test/production/app-dir/instrumentation-client-dce/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/instrumentation-client-dce/app/other/page.tsx
+++ b/test/production/app-dir/instrumentation-client-dce/app/other/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="other">Other</h1>
+}

--- a/test/production/app-dir/instrumentation-client-dce/app/page.tsx
+++ b/test/production/app-dir/instrumentation-client-dce/app/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1 id="home">Home</h1>
+      <Link href="/other">Other</Link>
+    </div>
+  )
+}

--- a/test/production/app-dir/instrumentation-client-dce/instrumentation-client-dce.test.ts
+++ b/test/production/app-dir/instrumentation-client-dce/instrumentation-client-dce.test.ts
@@ -1,0 +1,52 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// The router transition instrumentation only emits the rich transition event
+// (which carries `fromRoutes`) when the experimental flag is enabled. That code
+// path is gated behind `process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS`,
+// which is replaced with a literal at build time so the disabled path can be
+// dead-code-eliminated. `fromRoutes` is the marker: in client runtime code it
+// appears only inside that gated branch, and object keys survive minification.
+describe('instrumentation client router transition events - dead code elimination', () => {
+  describe('when the experimental flag is enabled', () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      nextConfig: {
+        experimental: { instrumentationClientRouterTransitionEvents: true },
+      },
+    })
+    if (skipped) return
+
+    it('keeps the transition event payload in the client bundle', async () => {
+      const $ = await next.render$('/')
+      const chunkContents = await Promise.all(
+        $('script[src]')
+          .toArray()
+          .map((el) => next.fetch($(el).attr('src')).then((res) => res.text()))
+      )
+
+      expect(
+        chunkContents.some((content) => content.includes('fromRoutes'))
+      ).toBe(true)
+    })
+  })
+
+  describe('when the experimental flag is disabled', () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+    })
+    if (skipped) return
+
+    it('removes the transition event payload from the client bundle', async () => {
+      const $ = await next.render$('/')
+      const chunkContents = await Promise.all(
+        $('script[src]')
+          .toArray()
+          .map((el) => next.fetch($(el).attr('src')).then((res) => res.text()))
+      )
+
+      expect(
+        chunkContents.some((content) => content.includes('fromRoutes'))
+      ).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Stack Position

(2/7) in the router instrumentation stack.

1. #94755: router instrumentation: refactor client hook dispatch (1/7)
2. **#94766: router instrumentation: add transition start context (2/7)**
3. #94756: router instrumentation: add transition commit events (3/7)
4. #94765: router instrumentation: add commit route and prefetch context (4/7)
5. #94757: router instrumentation: add transition abort events (5/7)
6. #94758: router instrumentation: add route mismatch events (6/7)
7. #94737: router instrumentation: add transition settlement events (7/7)

Parent: #94755
Next: #94756

## What This PR Does

Adds an experimental third argument to the existing start hook:

```ts
export function onRouterTransitionStart(url, navigationType, event) {}
```

The event contains:

- `id` and framework-captured Unix `timestamp` in milliseconds
- `fromRoutes`: route patterns visible when navigation is dispatched
- `prefetchIntent`: `full`, `auto`, or `none`

The primary `children` route is first, followed by visible parallel slots in deterministic order.

## Design

Start owns the context that is authoritative before navigation work begins: the screen being left and the caller's prefetch intent. Destination routes and the cache result actually used are reported by commit instead. Consumers correlate them by transition ID.

Without `experimental.instrumentationClientRouterTransitionEvents`, the existing two-argument hook behavior is unchanged.

## Not In This PR

- Destination routes or observed prefetch result
- Commit, abort, mismatch, or settled hooks

## Reviewer Focus

- Route pattern extraction, including dynamic and parallel routes
- Primary route ordering
- Link intent propagation and experimental gating

## Validation

- `pnpm build-all`
- `pnpm --filter=next build`
- App Router instrumentation client E2E: 15/15

<!-- NEXT_JS_LLM_PR -->
