### PR TITLE
Allow root params in the App Shell (client)

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -46,6 +46,7 @@ import {
   getFulfilledRouteVaryPath,
   getFulfilledSegmentVaryPath,
   getSegmentVaryPathForRequest,
+  getShellSegmentVaryPath,
   appendLayoutVaryPath,
   finalizeLayoutVaryPath,
   finalizePageVaryPath,
@@ -146,6 +147,11 @@ type RouteTreeShared = {
   // TODO: Remove the `segment` field, now that it can be reconstructed
   // from `param`.
   segment: FlightRouterStateSegment
+  // The vary path used to key this segment's App Shell entry: the segment's
+  // vary path with every non-root param replaced with Fallback (see
+  // getShellSegmentVaryPath). Precomputed once during tree construction so we
+  // don't have to recompute it on every shell request.
+  shellVaryPath: SegmentVaryPath
   refreshState: RefreshState | null
   slots: null | {
     [parallelRouteKey: string]: RouteTree
@@ -753,9 +759,12 @@ function deprecated_createOptimisticRouteTree(
 
   // We only need to clone the vary path if the route is a page.
   if (tree.isPage) {
+    // The shell vary path Fallbacks search params, so it's unaffected by the
+    // new rendered search and can be reused as-is.
     return {
       requestKey: tree.requestKey,
       segment: tree.segment,
+      shellVaryPath: tree.shellVaryPath,
       refreshState: tree.refreshState,
       varyPath: clonePageVaryPathWithNewSearchParams(
         tree.varyPath,
@@ -771,6 +780,7 @@ function deprecated_createOptimisticRouteTree(
   return {
     requestKey: tree.requestKey,
     segment: tree.segment,
+    shellVaryPath: tree.shellVaryPath,
     refreshState: tree.refreshState,
     varyPath: tree.varyPath,
     isPage: false,
@@ -1087,6 +1097,7 @@ export function createMetadataRouteTree(
   const metadata: RouteTree = {
     requestKey: HEAD_REQUEST_KEY,
     segment: HEAD_REQUEST_KEY,
+    shellVaryPath: getShellSegmentVaryPath(metadataVaryPath),
     refreshState: null,
     varyPath: metadataVaryPath,
     // The metadata isn't really a "page" (though it isn't really a "segment"
@@ -1325,7 +1336,10 @@ function convertTreePrefetchToRouteTree(
         childPartialVaryPath = appendLayoutVaryPath(
           partialVaryPath,
           childParamKey,
-          childSegmentName
+          childSegmentName,
+          // The child's param is a root param iff the child segment is at or
+          // above the root layout, which the server marks directly.
+          (childPrefetch.prefetchHints & PrefetchHint.IsRootLayoutOrAbove) !== 0
         )
         childSegment = [
           childSegmentName,
@@ -1397,6 +1411,7 @@ function convertTreePrefetchToRouteTree(
   return {
     requestKey,
     segment,
+    shellVaryPath: getShellSegmentVaryPath(varyPath),
     refreshState: null,
     // TODO: Cheating the type system here a bit because TypeScript can't tell
     // that the type of isPage and varyPath are consistent. The fix would be to
@@ -1468,6 +1483,11 @@ function convertFlightRouterStateToRouteTree(
 ): RouteTree {
   const originalSegment = flightRouterState[0]
 
+  // This segment's param (if any) is a root param iff the segment is at or
+  // above the root layout, which the server marks directly.
+  const isRootParam =
+    ((flightRouterState[4] ?? 0) & PrefetchHint.IsRootLayoutOrAbove) !== 0
+
   // If the FlightRouterState has a refresh state, then this segment is part of
   // an inactive parallel route. It has a different rendered search query than
   // the outer parent route. In order to construct the inactive route correctly,
@@ -1494,7 +1514,8 @@ function convertFlightRouterStateToRouteTree(
     partialVaryPath = appendLayoutVaryPath(
       parentPartialVaryPath,
       paramCacheKey,
-      paramName
+      paramName,
+      isRootParam
     )
     varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
     segment = originalSegment
@@ -1576,6 +1597,7 @@ function convertFlightRouterStateToRouteTree(
   return {
     requestKey,
     segment,
+    shellVaryPath: getShellSegmentVaryPath(varyPath),
     refreshState,
     // TODO: Cheating the type system here a bit because TypeScript can't tell
     // that the type of isPage and varyPath are consistent. The fix would be to
@@ -2722,8 +2744,6 @@ function writeSeedDataIntoCache(
   }
 }
 
-const EMPTY_VARY_PARAMS: Set<string> = new Set()
-
 function fulfillEntrySpawnedByRuntimePrefetch(
   now: number,
   fetchStrategy:
@@ -2753,29 +2773,25 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   // untrustworthy set could replace concrete params with Fallback and let
   // unrelated URLs read each other's content from the cache.
   //
-  // Override to an empty set for RuntimeShell prefetches. The shell is
-  // param-free by definition — that's the whole point of the strategy — so
-  // every param node in the vary path should be Fallback regardless of what
-  // the server reports.
-  // NOTE: It would be better not to override this value on the client. We
-  // should be able to trust the server. However, there's one known case where
-  // the server can over-report search params: the tracking proxy in
-  // `createVaryingSearchParams` registers `?` on any string property access,
-  // and `Promise.resolve(proxy)` reads `.then` during thenability detection,
-  // so just wrapping the proxy in a promise is enough to leak `?` into the
-  // accumulator. We also don't want to special case "then" access because it's
-  // perfectly valid to have a search param named "then". The plan to address
-  // this is to track each search param individually, rather than the entire
-  // query string as a whole.
-  //
-  // When non-null, this is the param set to re-key by; when null, the entry
-  // stays keyed by the request's concrete vary path.
-  const fulfilledVaryParams =
-    process.env.__NEXT_VARY_PARAMS && fetchStrategy !== FetchStrategy.Full
-      ? fetchStrategy === FetchStrategy.RuntimeShell
-        ? EMPTY_VARY_PARAMS
-        : segmentVaryParams
-      : null
+  // For RuntimeShell prefetches, always re-key to the precomputed shell vary
+  // path. A shell entry is spawned at a concrete param path but is reusable
+  // across all of them; tree.shellVaryPath (root-param values kept, every other
+  // param replaced with Fallback) is exactly the path that shell reads look it
+  // up under.
+  let fulfilledVaryPath: SegmentVaryPath | null = null
+  if (process.env.__NEXT_VARY_PARAMS) {
+    if (fetchStrategy === FetchStrategy.RuntimeShell) {
+      fulfilledVaryPath = tree.shellVaryPath
+    } else if (
+      fetchStrategy !== FetchStrategy.Full &&
+      segmentVaryParams !== null
+    ) {
+      fulfilledVaryPath = getFulfilledSegmentVaryPath(
+        tree.varyPath,
+        segmentVaryParams
+      )
+    }
+  }
 
   // We should only write into cache entries that are owned by us. Or create
   // a new one and write into that. We must never write over an entry that was
@@ -2791,11 +2807,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       staleAt,
       isPartial
     )
-    if (fulfilledVaryParams !== null) {
-      const fulfilledVaryPath = getFulfilledSegmentVaryPath(
-        tree.varyPath,
-        fulfilledVaryParams
-      )
+    if (fulfilledVaryPath !== null) {
       const isRevalidation = false
       setInCacheMap(
         segmentCacheMap,
@@ -2820,11 +2832,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
         staleAt,
         isPartial
       )
-      if (fulfilledVaryParams !== null) {
-        const fulfilledVaryPath = getFulfilledSegmentVaryPath(
-          tree.varyPath,
-          fulfilledVaryParams
-        )
+      if (fulfilledVaryPath !== null) {
         const isRevalidation = false
         setInCacheMap(
           segmentCacheMap,
@@ -2846,8 +2854,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
         isPartial
       )
       const varyPath =
-        fulfilledVaryParams !== null
-          ? getFulfilledSegmentVaryPath(tree.varyPath, fulfilledVaryParams)
+        fulfilledVaryPath !== null
+          ? fulfilledVaryPath
           : getSegmentVaryPathForRequest(fetchStrategy, tree)
       upsertSegmentEntry(now, varyPath, newEntry)
     }

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -44,6 +44,7 @@
  */
 
 import type { DynamicParamTypesShort } from '../../../shared/lib/app-router-types'
+import { PrefetchHint } from '../../../shared/lib/app-router-types'
 import type { RouteTree, FulfilledRouteCacheEntry } from './cache'
 import {
   EntryStatus,
@@ -61,6 +62,7 @@ import {
   finalizeLayoutVaryPath,
   finalizePageVaryPath,
   finalizeMetadataVaryPath,
+  getShellSegmentVaryPath,
   type PartialSegmentVaryPath,
   type PageVaryPath,
 } from './vary-path'
@@ -883,6 +885,11 @@ function reifyRouteTree(
 ): RouteTree {
   const originalSegment = pattern.segment
 
+  // This segment's param (if any) is a root param iff the segment is at or
+  // above the root layout, which the server marks directly.
+  const isRootParam =
+    (pattern.prefetchHints & PrefetchHint.IsRootLayoutOrAbove) !== 0
+
   let newSegment = originalSegment
   let partialVaryPath: PartialSegmentVaryPath | null
 
@@ -900,7 +907,8 @@ function reifyRouteTree(
       partialVaryPath = appendLayoutVaryPath(
         parentPartialVaryPath,
         newCacheKey,
-        paramName
+        paramName,
+        isRootParam
       )
     } else {
       // Param not found in resolvedParams - keep original and inherit partial
@@ -945,6 +953,7 @@ function reifyRouteTree(
     return {
       requestKey: pattern.requestKey,
       segment: newSegment,
+      shellVaryPath: getShellSegmentVaryPath(newVaryPath),
       refreshState: pattern.refreshState,
       slots: newSlots,
 
@@ -961,6 +970,7 @@ function reifyRouteTree(
     return {
       requestKey: pattern.requestKey,
       segment: newSegment,
+      shellVaryPath: getShellSegmentVaryPath(newVaryPath),
       refreshState: pattern.refreshState,
       slots: newSlots,
 

--- a/packages/next/src/client/components/segment-cache/vary-path.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.ts
@@ -37,6 +37,14 @@ export type VaryPath = {
    */
   id: string | null
   value: string | null | FallbackType
+  /**
+   * Whether this node corresponds to a root param — a path param at or above
+   * the application's root layout. Root params may appear in the App Shell, so
+   * the shell vary path keeps their concrete value instead of replacing it with
+   * Fallback. See getShellSegmentVaryPath. Only set on path param nodes;
+   * undefined (falsy) for structural and search param nodes.
+   */
+  isRootParam?: boolean
   parent: VaryPath | null
 }
 
@@ -142,11 +150,13 @@ export function getFulfilledRouteVaryPath(
 export function appendLayoutVaryPath(
   parentPath: PartialSegmentVaryPath | null,
   cacheKey: string,
-  paramName: string
+  paramName: string,
+  isRootParam: boolean
 ): PartialSegmentVaryPath {
   const varyPathPart: VaryPath = {
     id: paramName,
     value: cacheKey,
+    isRootParam,
     parent: parentPath,
   }
   return varyPathPart as PartialSegmentVaryPath
@@ -270,10 +280,11 @@ export function getSegmentVaryPathForRequest(
   const originalVaryPath = tree.varyPath
 
   if (fetchStrategy === FetchStrategy.RuntimeShell) {
-    // The Shell phase issues a runtime render with params omitted. The
-    // resulting entry is reusable across all concrete param values, so we
-    // key it at the shell vary path (every param substituted with Fallback).
-    return getShellSegmentVaryPath(originalVaryPath)
+    // The Shell phase issues a runtime render with non-root params omitted. The
+    // resulting entry is reusable across all concrete values of those params, so
+    // we key it at the precomputed shell vary path (every non-root param
+    // substituted with Fallback; root params keep their concrete value).
+    return tree.shellVaryPath
   }
 
   // Only page segments (and the special "metadata" segment, which is treated
@@ -362,6 +373,7 @@ export function getFulfilledSegmentVaryPath(
       original.id === null || varyParams.has(original.id)
         ? original.value
         : Fallback,
+    isRootParam: original.isRootParam,
     parent:
       original.parent === null
         ? null
@@ -370,23 +382,22 @@ export function getFulfilledSegmentVaryPath(
   return clone as SegmentVaryPath
 }
 
-function getShellSegmentVaryPath(original: VaryPath): SegmentVaryPath {
+export function getShellSegmentVaryPath(original: VaryPath): SegmentVaryPath {
   // Re-keys a segment's vary path to identify the "App Shell" entry for this
-  // segment position — a reusable, param-free loading state that can be served
-  // for any concrete navigation to this segment. Every param node (path
-  // params, search params) is replaced with Fallback; only structural nodes
-  // (request keys, etc.) keep their concrete value.
-  //
-  // NOTE: For now, we treat root params the same as non-root params and
-  // forbid them from the shell. Root params change less frequently than
-  // other params, though, so caching the shell across root param values is
-  // a potential future optimization. One way to model that would be to
-  // evict the entire client cache whenever a root param change is detected.
-  // Then we would no longer need to include them in the cache key, which
-  // would be consistent with how we treat session-based data like cookies.
+  // segment position — a reusable loading state that can be served for any
+  // concrete navigation to this segment. The shell is rendered with params
+  // omitted, with one exception: root params (path params at or above the root
+  // layout) may be accessed during the shell render, so the shell varies on
+  // them. Accordingly, we keep the concrete value of structural nodes (request
+  // keys, etc.) and root param nodes, and replace every other param node (non-
+  // root path params and search params) with Fallback.
   const clone: VaryPath = {
     id: original.id,
-    value: original.id === null ? original.value : Fallback,
+    value:
+      original.id === null || original.isRootParam === true
+        ? original.value
+        : Fallback,
+    isRootParam: original.isRootParam,
     parent:
       original.parent === null
         ? null


### PR DESCRIPTION
The App Shell is the generic loading state for a route. It does not depend on concrete param values, so it can be used for every navigation to a route before its params are known.

We've decided to special case root params: those that appear above the topmost layout for a given route. These are typically used for params that are low cardinality for a given session, such as the locale. So we allow them to appear in the generic part of the UI, even though they technically might change across pages.

We already treat root params as special during static generation, by always including them during fallback shell generation. So this decision is consistent with our existing treatment.

This PR updates the client to key App Shells by their root params. Currently, the client assumes that the shell never varies on _any_ params. This updates the assumption so that it only applies to non-root params.

A subsequent PR (#94738) will update the server, but these client changes do not depend on the server changes, so they can land first.

---

Stacked on #94771 (review/merge that first). Diff is shown against `acdlite/is-root-layout-or-above`; will retarget to `canary` once #94771 lands.

<!-- NEXT_JS_LLM_PR -->
