### PR TITLE
[CC] Instrument tracers resolved through ProxyTracerProvider.getDelegateTracer

### DIFF
--- a/packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts
@@ -49,66 +49,103 @@ function extendTracerProviderForCacheComponents(): void {
   // to exit the workUnitAsyncStorage context when generating spans.
   const originalGetTracer = provider.getTracer.bind(provider)
   provider.getTracer = (...args) => {
-    const tracer = originalGetTracer.apply(provider, args)
-    if (WeakTracers.has(tracer)) {
-      return tracer
+    return instrumentTracerForCacheComponents(
+      originalGetTracer.apply(provider, args)
+    )
+  }
+
+  // Tracers acquired before a delegate provider was registered are
+  // ProxyTracers. This is the standard pattern of OTel instrumentation
+  // libraries: `InstrumentationAbstract` calls `trace.getTracer()` in its
+  // constructor, and SDKs (e.g. @sentry/node, @vercel/otel with custom
+  // instrumentations) construct instrumentations before registering the
+  // provider. A ProxyTracer resolves the actual tracer lazily through
+  // `ProxyTracerProvider.getDelegateTracer()`, which does not go through the
+  // patched `getTracer` above, so we need to instrument that resolution path
+  // as well. (On current @opentelemetry/api versions the proxy provider's
+  // `getTracer` routes through this method internally, so the patch above is
+  // subsumed by this one whenever the global provider is a proxy — the
+  // WeakSet makes the double instrumentation a no-op. We keep both patches so
+  // we don't depend on that internal routing detail and still cover non-proxy
+  // global providers.)
+  const proxyProvider = provider as typeof provider & {
+    getDelegateTracer?: (
+      name: string,
+      version?: string,
+      options?: unknown
+    ) => Tracer | undefined
+  }
+  if (typeof proxyProvider.getDelegateTracer === 'function') {
+    const originalGetDelegateTracer =
+      proxyProvider.getDelegateTracer.bind(proxyProvider)
+    proxyProvider.getDelegateTracer = (...args) => {
+      const tracer = originalGetDelegateTracer(...args)
+      return tracer === undefined
+        ? undefined
+        : instrumentTracerForCacheComponents(tracer)
     }
-    const originalStartSpan = tracer.startSpan
-    tracer.startSpan = (...startSpanArgs) => {
-      return workUnitAsyncStorage.exit(() =>
-        originalStartSpan.apply(tracer, startSpanArgs)
+  }
+}
+
+function instrumentTracerForCacheComponents(tracer: Tracer): Tracer {
+  if (WeakTracers.has(tracer)) {
+    return tracer
+  }
+  const originalStartSpan = tracer.startSpan
+  tracer.startSpan = (...startSpanArgs) => {
+    return workUnitAsyncStorage.exit(() =>
+      originalStartSpan.apply(tracer, startSpanArgs)
+    )
+  }
+
+  const originalStartActiveSpan = tracer.startActiveSpan
+  // @ts-ignore TS doesn't recognize the overloads correctly
+  tracer.startActiveSpan = (...startActiveSpanArgs: any[]) => {
+    const workUnitStore = workUnitAsyncStorage.getStore()
+    if (!workUnitStore) {
+      // @ts-ignore TS doesn't recognize the overloads correctly
+      return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
+    }
+
+    let fnIdx: number = 0
+    if (
+      startActiveSpanArgs.length === 2 &&
+      typeof startActiveSpanArgs[1] === 'function'
+    ) {
+      fnIdx = 1
+    } else if (
+      startActiveSpanArgs.length === 3 &&
+      typeof startActiveSpanArgs[2] === 'function'
+    ) {
+      fnIdx = 2
+    } else if (
+      startActiveSpanArgs.length > 3 &&
+      typeof startActiveSpanArgs[3] === 'function'
+    ) {
+      fnIdx = 3
+    }
+
+    if (fnIdx) {
+      const originalFn = startActiveSpanArgs[fnIdx]
+      if (isUseCacheFunction(originalFn)) {
+        console.error(
+          'A Cache Function (`use cache`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.'
+        )
+      }
+      startActiveSpanArgs[fnIdx] = withWorkUnitContext(
+        workUnitStore,
+        originalFn
       )
     }
 
-    const originalStartActiveSpan = tracer.startActiveSpan
-    // @ts-ignore TS doesn't recognize the overloads correctly
-    tracer.startActiveSpan = (...startActiveSpanArgs: any[]) => {
-      const workUnitStore = workUnitAsyncStorage.getStore()
-      if (!workUnitStore) {
-        // @ts-ignore TS doesn't recognize the overloads correctly
-        return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
-      }
-
-      let fnIdx: number = 0
-      if (
-        startActiveSpanArgs.length === 2 &&
-        typeof startActiveSpanArgs[1] === 'function'
-      ) {
-        fnIdx = 1
-      } else if (
-        startActiveSpanArgs.length === 3 &&
-        typeof startActiveSpanArgs[2] === 'function'
-      ) {
-        fnIdx = 2
-      } else if (
-        startActiveSpanArgs.length > 3 &&
-        typeof startActiveSpanArgs[3] === 'function'
-      ) {
-        fnIdx = 3
-      }
-
-      if (fnIdx) {
-        const originalFn = startActiveSpanArgs[fnIdx]
-        if (isUseCacheFunction(originalFn)) {
-          console.error(
-            'A Cache Function (`use cache`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.'
-          )
-        }
-        startActiveSpanArgs[fnIdx] = withWorkUnitContext(
-          workUnitStore,
-          originalFn
-        )
-      }
-
-      return workUnitAsyncStorage.exit(() => {
-        // @ts-ignore TS doesn't recognize the overloads correctly
-        return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
-      })
-    }
-
-    WeakTracers.add(tracer)
-    return tracer
+    return workUnitAsyncStorage.exit(() => {
+      // @ts-ignore TS doesn't recognize the overloads correctly
+      return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
+    })
   }
+
+  WeakTracers.add(tracer)
+  return tracer
 }
 
 const WeakTracers = new WeakSet<Tracer>()

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/cache/page.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/cache/page.tsx
@@ -7,6 +7,7 @@ import {
   InnerTraceActiveSpan,
   CachedTracedComponentActiveSpan,
   TracedComponentActiveSpan,
+  TracedComponentEarlyTracerActiveSpan,
 } from '../../traced-work'
 
 export function generateStaticParams() {
@@ -31,6 +32,7 @@ export default async function Page({
       <InnerTraceActiveSpan />
       <CachedTracedComponentActiveSpan />
       <TracedComponentActiveSpan />
+      <TracedComponentEarlyTracerActiveSpan />
     </>
   )
 }

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/fallback/page.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/fallback/page.tsx
@@ -7,6 +7,7 @@ import {
   InnerTraceActiveSpan,
   CachedTracedComponentActiveSpan,
   TracedComponentActiveSpan,
+  TracedComponentEarlyTracerActiveSpan,
 } from '../../traced-work'
 
 export function generateStaticParams() {
@@ -30,6 +31,7 @@ export default async function Page({
       <InnerTraceActiveSpan />
       <CachedTracedComponentActiveSpan />
       <TracedComponentActiveSpan />
+      <TracedComponentEarlyTracerActiveSpan />
     </>
   )
 }

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/server/page.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/server/page.tsx
@@ -7,6 +7,7 @@ import {
   InnerTraceActiveSpan,
   CachedTracedComponentActiveSpan,
   TracedComponentActiveSpan,
+  TracedComponentEarlyTracerActiveSpan,
 } from '../../traced-work'
 
 export function generateStaticParams() {
@@ -30,6 +31,7 @@ export default async function Page({
       <InnerTraceActiveSpan />
       <CachedTracedComponentActiveSpan />
       <TracedComponentActiveSpan />
+      <TracedComponentEarlyTracerActiveSpan />
     </>
   )
 }

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/traced-work.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/traced-work.tsx
@@ -1,4 +1,4 @@
-import { type Span, trace, context } from '@opentelemetry/api'
+import { type Span, type Tracer, trace, context } from '@opentelemetry/api'
 import { Suspense } from 'react'
 
 async function asyncWork() {
@@ -180,3 +180,42 @@ function Loading() {
 function Result({ children }: { children: React.ReactNode }) {
   return <p className="result">{children}</p>
 }
+
+function withEarlyTracerActiveSpan(fn) {
+  return function () {
+    // Acquired in instrumentation.node.ts before the provider was registered
+    // (a ProxyTracer), like OTel instrumentation libraries do in their
+    // constructors. Undefined during build prerendering, where instrumentation
+    // is not loaded — fall back to a render-time tracer which is equally inert
+    // there (no provider is registered either).
+    const tracer =
+      ((globalThis as any).__earlyTracer as Tracer | undefined) ??
+      trace.getTracer('early-tracer')
+    return tracer.startActiveSpan('span-early-active-span', fn)
+  }
+}
+
+export const TracedComponentEarlyTracerActiveSpan = withEarlyTracerActiveSpan(
+  async function (span: Span) {
+    async function Inner() {
+      const result = await asyncWork()
+      return <Result>{result}</Result>
+    }
+    return (
+      <section id="t9">
+        <h2>(Active Span) Tracer acquired before provider registration</h2>
+        <div>
+          <p>
+            Span Representative{' '}
+            <span className="span" suppressHydrationWarning>
+              {parseInt(span.spanContext().spanId.slice(10), 16)}
+            </span>
+          </p>
+          <Suspense fallback={<Loading />}>
+            <Inner />
+          </Suspense>
+        </div>
+      </section>
+    )
+  }
+)

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
@@ -56,8 +56,12 @@ describe('cache-components OTEL spans', () => {
       const t8 = await browser.elementByCss('#t8 .span')
       expect(parseInt(await t8.textContent())).not.toEqual(0)
 
+      const t9 = await browser.elementByCss('#t9 .span')
+      expect(parseInt(await t9.textContent())).not.toEqual(0)
+
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
+      console.log('t9', await t9.textContent())
     })
     it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Cache Component - with prerendering the page', async () => {
       // In dev there really isn't any prerendering but since this test case exists for prod testing I want to keep it exercised in the dev pathway too
@@ -106,8 +110,12 @@ describe('cache-components OTEL spans', () => {
       const t8 = await browser.elementByCss('#t8 .span')
       expect(parseInt(await t8.textContent())).not.toEqual(0)
 
+      const t9 = await browser.elementByCss('#t9 .span')
+      expect(parseInt(await t9.textContent())).not.toEqual(0)
+
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
+      console.log('t9', await t9.textContent())
     })
     it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - without prerendering the page', async () => {
       const browser = await next.browser('/novel/server')
@@ -125,7 +133,7 @@ describe('cache-components OTEL spans', () => {
              "<anonymous> app/traced-work.tsx (26:19)",
              "Inner app/traced-work.tsx (97:26)",
              "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
-             "Page app/[slug]/server/page.tsx (29:7)",
+             "Page app/[slug]/server/page.tsx (30:7)",
            ],
          }
         `)
@@ -143,7 +151,7 @@ describe('cache-components OTEL spans', () => {
              "eval app/traced-work.tsx (26:19)",
              "Inner app/traced-work.tsx (97:26)",
              "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
-             "Page app/[slug]/server/page.tsx (29:7)",
+             "Page app/[slug]/server/page.tsx (30:7)",
            ],
          }
         `)
@@ -157,8 +165,12 @@ describe('cache-components OTEL spans', () => {
       const t8 = await browser.elementByCss('#t8 .span')
       expect(parseInt(await t8.textContent())).not.toEqual(0)
 
+      const t9 = await browser.elementByCss('#t9 .span')
+      expect(parseInt(await t9.textContent())).not.toEqual(0)
+
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
+      console.log('t9', await t9.textContent())
     })
     it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - with prerendering the page', async () => {
       // In dev there really isn't any prerendering but since this test case exists for prod testing I want to keep it exercised in the dev pathway too
@@ -177,7 +189,7 @@ describe('cache-components OTEL spans', () => {
              "<anonymous> app/traced-work.tsx (26:19)",
              "Inner app/traced-work.tsx (97:26)",
              "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
-             "Page app/[slug]/server/page.tsx (29:7)",
+             "Page app/[slug]/server/page.tsx (30:7)",
            ],
          }
         `)
@@ -195,7 +207,7 @@ describe('cache-components OTEL spans', () => {
              "eval app/traced-work.tsx (26:19)",
              "Inner app/traced-work.tsx (97:26)",
              "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
-             "Page app/[slug]/server/page.tsx (29:7)",
+             "Page app/[slug]/server/page.tsx (30:7)",
            ],
          }
         `)
@@ -209,8 +221,12 @@ describe('cache-components OTEL spans', () => {
       const t8 = await browser.elementByCss('#t8 .span')
       expect(parseInt(await t8.textContent())).not.toEqual(0)
 
+      const t9 = await browser.elementByCss('#t9 .span')
+      expect(parseInt(await t9.textContent())).not.toEqual(0)
+
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
+      console.log('t9', await t9.textContent())
     })
   } else {
     it('should allow creating Spans during prerendering during the build - inside a Cache Components', async () => {
@@ -222,6 +238,9 @@ describe('cache-components OTEL spans', () => {
         const t8 = await browser.elementByCss('#t8 .span')
         // the span was prerendered during the build
         expect(parseInt(await t8.textContent())).toEqual(0)
+        const t9 = await browser.elementByCss('#t9 .span')
+        // the span was prerendered during the build
+        expect(parseInt(await t9.textContent())).toEqual(0)
 
         // load again
         await browser.loadPage(`${next.url}/prerendered/cache`)
@@ -231,6 +250,9 @@ describe('cache-components OTEL spans', () => {
         const t8again = await browser.elementByCss('#t8 .span')
         // the span was prerendered during the build
         expect(parseInt(await t8again.textContent())).toEqual(0)
+        const t9again = await browser.elementByCss('#t9 .span')
+        // the span was prerendered during the build
+        expect(parseInt(await t9again.textContent())).toEqual(0)
       }
 
       {
@@ -241,6 +263,9 @@ describe('cache-components OTEL spans', () => {
         const t8 = await browser.elementByCss('#t8 .span')
         // the span was prerendered during the build
         expect(parseInt(await t8.textContent())).toEqual(0)
+        const t9 = await browser.elementByCss('#t9 .span')
+        // the span was prerendered during the build
+        expect(parseInt(await t9.textContent())).toEqual(0)
 
         // load again
         await browser.loadPage(`${next.url}/prerendered/server`)
@@ -250,6 +275,9 @@ describe('cache-components OTEL spans', () => {
         const t8again = await browser.elementByCss('#t8 .span')
         // the span was prerendered during the build
         expect(parseInt(await t8again.textContent())).toEqual(0)
+        const t9again = await browser.elementByCss('#t9 .span')
+        // the span was prerendered during the build
+        expect(parseInt(await t9again.textContent())).toEqual(0)
       }
 
       {
@@ -260,6 +288,9 @@ describe('cache-components OTEL spans', () => {
         const t8 = await browser.elementByCss('#t8 .span')
         // the span was prerendered during the build
         expect(parseInt(await t8.textContent())).toEqual(0)
+        const t9 = await browser.elementByCss('#t9 .span')
+        // the span was prerendered during the build
+        expect(parseInt(await t9.textContent())).toEqual(0)
 
         // load again
         await browser.loadPage(`${next.url}/prerendered/fallback`)
@@ -269,6 +300,9 @@ describe('cache-components OTEL spans', () => {
         const t8again = await browser.elementByCss('#t8 .span')
         // the span was prerendered during the build
         expect(parseInt(await t8again.textContent())).toEqual(0)
+        const t9again = await browser.elementByCss('#t9 .span')
+        // the span was prerendered during the build
+        expect(parseInt(await t9again.textContent())).toEqual(0)
       }
     })
     it('should allow creating Spans during prerendering at runtime - inside a Cache Components', async () => {
@@ -283,6 +317,10 @@ describe('cache-components OTEL spans', () => {
         const t8value = parseInt(await t8.textContent())
         // the span was prerendered at runtime
         expect(t8value).not.toEqual(0)
+        const t9 = await browser.elementByCss('#t9 .span')
+        const t9value = parseInt(await t9.textContent())
+        // the span was prerendered at runtime
+        expect(t9value).not.toEqual(0)
 
         // load again
         await browser.loadPage(`${next.url}/novel/cache`)
@@ -295,6 +333,10 @@ describe('cache-components OTEL spans', () => {
         const t8againValue = parseInt(await t8again.textContent())
         // this page was cached so the span should be cached too
         expect(t8againValue).toEqual(t8value)
+        const t9again = await browser.elementByCss('#t9 .span')
+        const t9againValue = parseInt(await t9again.textContent())
+        // this page was cached so the span should be cached too
+        expect(t9againValue).toEqual(t9value)
       }
 
       {
@@ -307,6 +349,10 @@ describe('cache-components OTEL spans', () => {
         const t8value = parseInt(await t8.textContent())
         // the span was prerendered at runtime
         expect(t8value).not.toEqual(0)
+        const t9 = await browser.elementByCss('#t9 .span')
+        const t9value = parseInt(await t9.textContent())
+        // the span was prerendered at runtime
+        expect(t9value).not.toEqual(0)
 
         // load again
         await browser.loadPage(`${next.url}/novel/server`)
@@ -318,6 +364,10 @@ describe('cache-components OTEL spans', () => {
         const t8againValue = parseInt(await t8again.textContent())
         // this page was cached so the span should be cached too
         expect(t8againValue).toEqual(t8value)
+        const t9again = await browser.elementByCss('#t9 .span')
+        const t9againValue = parseInt(await t9again.textContent())
+        // this page was cached so the span should be cached too
+        expect(t9againValue).toEqual(t9value)
       }
     })
     it('should allow creating Spans during resuming a fallback - inside a Cache Component', async () => {
@@ -331,6 +381,10 @@ describe('cache-components OTEL spans', () => {
         const t8value = parseInt(await t8.textContent())
         // the span was prerendered at runtime
         expect(t8value).not.toEqual(0)
+        const t9 = await browser.elementByCss('#t9 .span')
+        const t9value = parseInt(await t9.textContent())
+        // the span was prerendered at runtime
+        expect(t9value).not.toEqual(0)
 
         // load again
         await browser.loadPage(`${next.url}/novel/fallback`)
@@ -345,6 +399,11 @@ describe('cache-components OTEL spans', () => {
         // this page renders the spans in the resume on each request
         expect(t8againValue).not.toEqual(t8value)
         expect(t8againValue).not.toEqual(0)
+        const t9again = await browser.elementByCss('#t9 .span')
+        const t9againValue = parseInt(await t9again.textContent())
+        // this page renders the spans in the resume on each request
+        expect(t9againValue).not.toEqual(t9value)
+        expect(t9againValue).not.toEqual(0)
       }
     })
   }

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/instrumentation.node.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/instrumentation.node.ts
@@ -1,7 +1,16 @@
+import { trace } from '@opentelemetry/api'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express'
+
+// OTel instrumentation libraries acquire their tracer in their constructor
+// (`InstrumentationAbstract` calls `trace.getTracer()`), before the SDK
+// registers the tracer provider. Such a tracer is a ProxyTracer that resolves
+// the actual tracer through `ProxyTracerProvider.getDelegateTracer()` instead
+// of `getTracer()`. We stash one here, before `sdk.start()`, to simulate that
+// pattern; app/traced-work.tsx creates spans with it.
+;(globalThis as any).__earlyTracer = trace.getTracer('early-tracer')
 
 const sdk = new NodeSDK({
   serviceName: 'nextjs-otel-app',


### PR DESCRIPTION
Fixes #94753

### Problem

#82350 allows OTel span creation while prerendering by wrapping tracers returned from the global provider's `getTracer`. But tracers acquired **before a delegate provider is registered** are `ProxyTracer`s, which resolve the real tracer through `ProxyTracerProvider.getDelegateTracer()` — never hitting the patched `getTracer`. Span-id generation then runs `RandomIdGenerator`'s raw `Math.random()` inside the prerender scope and fails it with `next-prerender-random`.

This is the standard constructor pattern of OTel instrumentation libraries (`InstrumentationAbstract` calls `trace.getTracer()` in its constructor): every `@sentry/node` integration does it (constructed before `initOpenTelemetry()` registers the provider), and `@vercel/otel` with `registerOTel({ instrumentations: [...] })` as well. In production this fails **every ISR revalidation** of PPR routes that touch an instrumented resource (pg, undici, …) — the static shell never refreshes — surfacing in Sentry as message-less `Error: null` (`StaticGenBailoutError`). Standalone repro: https://github.com/pnodet/next-prerender-random-repro

### Fix

Extract the tracer instrumentation into a helper and also apply it on the `getDelegateTracer` resolution path. On current `@opentelemetry/api` versions the proxy provider's `getTracer` routes through `getDelegateTracer` internally, so the original patch is subsumed by the new one whenever the global provider is a proxy (the WeakSet makes double instrumentation a no-op); both are kept so we don't depend on that internal routing detail and still cover non-proxy global providers.

### Test

Added `t9` to `cache-components-allow-otel-spans`: a span created from a tracer acquired in `instrumentation.node.ts` before `sdk.start()`. Without the fix, runtime prerendering fails with `Next.js encountered the unstable value Math.random() while prerendering` and the page degrades to per-request dynamic rendering; with the fix, the dev suite is 4/4 green and start mode matches baseline.

Note: `should allow creating Spans during prerendering at runtime` fails identically on **unmodified canary** (verified at both 658d3786e7 and a64db6f77f: `expect(t7againValue).toEqual(t7value)` on `/novel/cache` — the runtime-prerendered page is not served from cache on the second load). Pre-existing, not introduced or affected by this change.