### PR TITLE
Move `warnOnce` imports into statements guarded by `process.env.NODE_ENV === 'development'`

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -7,7 +7,6 @@ import { AppRouterContext } from '../../shared/lib/app-router-context.shared-run
 import { useMergedRef } from '../use-merged-ref'
 import { isAbsoluteUrl } from '../../shared/lib/utils'
 import { addBasePath } from '../add-base-path'
-import { warnOnce } from '../../shared/lib/utils/warn-once'
 import { ScrollBehavior } from '../components/router-reducer/router-reducer-types'
 import type { PENDING_LINK_STATUS } from '../components/links'
 import {
@@ -513,6 +512,8 @@ export default function LinkComponent(
   const formattedHref = formatStringOrUrl(resolvedHref)
 
   if (process.env.NODE_ENV !== 'production') {
+    const { warnOnce } =
+      require('../../shared/lib/utils/warn-once') as typeof import('../../shared/lib/utils/warn-once')
     if (props.locale) {
       warnOnce(
         'The `locale` prop is not supported in `next/link` while using the `app` router. Read more about app router internalization: https://nextjs.org/docs/app/building-your-application/routing/internationalization'

--- a/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
+++ b/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
@@ -19,7 +19,6 @@ import {
   getAccessFallbackErrorTypeByStatus,
   isHTTPAccessFallbackError,
 } from './http-access-fallback'
-import { warnOnce } from '../../../shared/lib/utils/warn-once'
 import { MissingSlotContext } from '../../../shared/lib/app-router-context.shared-runtime'
 
 interface HTTPAccessFallbackBoundaryProps {
@@ -62,6 +61,8 @@ class HTTPAccessFallbackErrorBoundary extends React.Component<
       // A missing children slot is the typical not-found case, so no need to warn
       !this.props.missingSlots.has('children')
     ) {
+      const { warnOnce } =
+        require('../../../shared/lib/utils/warn-once') as typeof import('../../../shared/lib/utils/warn-once')
       let warningMessage =
         'No default component was found for a parallel route rendered on this page. Falling back to nearest NotFound boundary.\n' +
         'Learn more: https://nextjs.org/docs/app/building-your-application/routing/parallel-routes#defaultjs\n\n'

--- a/packages/next/src/client/image-component.tsx
+++ b/packages/next/src/client/image-component.tsx
@@ -26,7 +26,6 @@ import type {
 } from '../shared/lib/image-config'
 import { imageConfigDefault } from '../shared/lib/image-config'
 import { ImageConfigContext } from '../shared/lib/image-config-context.shared-runtime'
-import { warnOnce } from '../shared/lib/utils/warn-once'
 import { RouterContext } from '../shared/lib/router-context.shared-runtime'
 
 // This is replaced by webpack alias
@@ -116,6 +115,8 @@ function handleLoading(
       onLoadingCompleteRef.current(img)
     }
     if (process.env.NODE_ENV !== 'production') {
+      const { warnOnce } =
+        require('../shared/lib/utils/warn-once') as typeof import('../shared/lib/utils/warn-once')
       const origSrc = new URL(src, 'http://n').searchParams.get('url') || src
       if (img.getAttribute('data-nimg') === 'fill') {
         if (!unoptimized && (!sizesInput || sizesInput === '100vw')) {

--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -1,4 +1,3 @@
-import { warnOnce } from './utils/warn-once'
 import { getAssetToken, getDeploymentId } from './deployment-id'
 import { getImageBlurSvg } from './image-blur-svg'
 import { imageConfigDefault } from './image-config'
@@ -462,6 +461,8 @@ export function getImgProps(
   const qualityInt = getInt(quality)
 
   if (process.env.NODE_ENV !== 'production') {
+    const { warnOnce } =
+      require('./utils/warn-once') as typeof import('./utils/warn-once')
     if (config.output === 'export' && isDefaultLoader && !unoptimized) {
       throw new Error(
         `Image Optimization using the default loader is not compatible with \`{ output: 'export' }\`.

--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -3,7 +3,6 @@
 import React, { useContext, type JSX } from 'react'
 import Effect from './side-effect'
 import { HeadManagerContext } from './head-manager-context.shared-runtime'
-import { warnOnce } from './utils/warn-once'
 
 export function defaultHead(): JSX.Element[] {
   const head = [
@@ -129,6 +128,8 @@ function reduceComponents(
     .map((c: React.ReactElement<any>, i: number) => {
       const key = c.key || i
       if (process.env.NODE_ENV === 'development') {
+        const { warnOnce } =
+          require('./utils/warn-once') as typeof import('./utils/warn-once')
         // omit JSON-LD structured data snippets from the warning
         if (c.type === 'script' && c.props['type'] !== 'application/ld+json') {
           const srcMessage = c.props['src']

--- a/packages/next/src/shared/lib/router/utils/disable-smooth-scroll.ts
+++ b/packages/next/src/shared/lib/router/utils/disable-smooth-scroll.ts
@@ -1,5 +1,3 @@
-import { warnOnce } from '../../utils/warn-once'
-
 /**
  * Run function with `scroll-behavior: auto` applied to `<html/>`.
  * This css change will be reverted after the function finishes.
@@ -24,6 +22,8 @@ export function disableSmoothScrollDuringRouteTransition(
       process.env.NODE_ENV === 'development' &&
       getComputedStyle(htmlElement).scrollBehavior === 'smooth'
     ) {
+      const { warnOnce } =
+        require('../../utils/warn-once') as typeof import('../../utils/warn-once')
       warnOnce(
         'Detected `scroll-behavior: smooth` on the `<html>` element. To disable smooth scrolling during route transitions, ' +
           'add `data-scroll-behavior="smooth"` to your <html> element. ' +


### PR DESCRIPTION
The context is this message from @icyJoseph:

```
I wonder if you've also look a little at DCE? This module, https://nextjs.org/_next/static/immutable/chunks/2uxebeysomvt2.js ships every time...
```

https://nextjs.org/_next/static/immutable/chunks/2uxebeysomvt2.js corresponds to this `warnOnce` helper: https://github.com/vercel/next.js/blob/643e34a59183f90ae9d2db9a64673781316ce786/packages/next/src/shared/lib/utils/warn-once.ts#L1

That doesn't do anything because Turbopack appears to be attempting to remove unused imports before doing dead-code removal. If the imports are moved though into the `(process.env.NODE_ENV !== 'production')` guard, this module won't get shipped into production. The patch to do this is pretty small so this PR does that, I'm going to look into whether its possible to reorder it so unused imports are looked at after dead code is removed.