### PR TITLE
fix: retry visible link prefetches on reconnect

### DIFF
--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -351,6 +351,16 @@ function rescheduleLinkPrefetch(
   }
 }
 
+function rescheduleVisibleLinksOnReconnect() {
+  for (const instance of prefetchableAndVisible) {
+    rescheduleLinkPrefetch(instance, PrefetchPriority.Default)
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', rescheduleVisibleLinksOnReconnect)
+}
+
 export function pingVisibleLinks(
   nextUrl: string | null,
   tree: FlightRouterState

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1234,6 +1234,30 @@ function rejectSegmentCacheEntry(
   }
 }
 
+function isIntentionalAbortError(error: unknown): boolean {
+  return (
+    typeof DOMException === 'function' &&
+    error instanceof DOMException &&
+    (error.name === 'AbortError' || error.name === 'TimeoutError')
+  )
+}
+
+function shouldExpirePrefetchOnNetworkError(error: unknown): boolean {
+  if (process.env.__NEXT_USE_OFFLINE) {
+    const { checkOfflineError } =
+      require('../offline') as typeof import('../offline')
+    if (checkOfflineError(error)) {
+      return true
+    }
+  }
+
+  return (
+    typeof navigator !== 'undefined' &&
+    navigator.onLine === false &&
+    !isIntentionalAbortError(error)
+  )
+}
+
 type RouteTreeAccumulator = {
   metadataVaryPath: PageVaryPath | null
 }
@@ -1890,17 +1914,11 @@ export async function fetchRouteOnCacheMiss(
     // decoding the response. If we're offline, reject with staleAt=-1 so the
     // entry immediately expires and gets retried once the scheduler is
     // re-pinged after connectivity is restored.
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        // Unlike navigations and server actions, prefetches don't await
-        // waitForConnection — they just reject the cache entry with an
-        // immediate expiration so it gets retried once the scheduler is
-        // re-pinged after connectivity is restored.
-        rejectRouteCacheEntry(entry, -1)
-        return null
-      }
+    if (shouldExpirePrefetchOnNetworkError(error)) {
+      // Prefetches do not block on connectivity. Expire immediately so a
+      // reconnect can retry the entry.
+      rejectRouteCacheEntry(entry, -1)
+      return null
     }
     rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
     return null
@@ -2100,17 +2118,11 @@ export async function fetchSegmentsOnCacheMiss(
   } catch (error) {
     // Either the connection itself failed, or something bad happened while
     // decoding the response.
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        // Unlike navigations and server actions, prefetches don't await
-        // waitForConnection — they just reject the cache entry with an
-        // immediate expiration so it gets retried once the scheduler is
-        // re-pinged after connectivity is restored.
-        rejectRemainingSegmentsInBundle(segments, -1)
-        return null
-      }
+    if (shouldExpirePrefetchOnNetworkError(error)) {
+      // Prefetches do not block on connectivity. Expire immediately so a
+      // reconnect can retry the entry.
+      rejectRemainingSegmentsInBundle(segments, -1)
+      return null
     }
     rejectRemainingSegmentsInBundle(segments, Date.now() + 10 * 1000)
     return null
@@ -2412,17 +2424,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // the scheduler can track the number of concurrent network connections.
     return { value: null, closed: closed.promise }
   } catch (error) {
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        // Unlike navigations and server actions, prefetches don't await
-        // waitForConnection — they just reject the cache entry with an
-        // immediate expiration so it gets retried once the scheduler is
-        // re-pinged after connectivity is restored.
-        rejectSegmentEntriesIfStillPending(spawnedEntries, -1)
-        return null
-      }
+    if (shouldExpirePrefetchOnNetworkError(error)) {
+      // Prefetches do not block on connectivity. Expire immediately so a
+      // reconnect can retry the entry.
+      rejectSegmentEntriesIfStillPending(spawnedEntries, -1)
+      return null
     }
     rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
     return null

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -1,4 +1,5 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
 import { waitFor, retry } from 'next-test-utils'
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
@@ -157,6 +158,46 @@ describe('app dir - prefetching', () => {
       await browser.elementByCss('#to-static-page').click()
       await browser.waitForElementByCss('#static-page')
     }, 'no-requests')
+  })
+
+  it('should prefetch visible links after reconnecting', async () => {
+    let page: Playwright.Page
+    let recordRequests = false
+    const requests: string[] = []
+
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+        p.on('request', (req) => {
+          if (!recordRequests) {
+            return
+          }
+          if (req.headers()['rsc'] === '1') {
+            requests.push(new URL(req.url()).pathname)
+          }
+        })
+      },
+    })
+
+    await page!.context().setOffline(true)
+
+    const failedPrefetch = page!.waitForEvent('requestfailed', (req) => {
+      return (
+        new URL(req.url()).pathname === '/static-page' &&
+        req.headers()['rsc'] === '1'
+      )
+    })
+
+    await browser.elementByCss('#accordion-to-static-page').click()
+    await browser.waitForElementByCss('#to-static-page')
+    await failedPrefetch
+
+    recordRequests = true
+    await page!.context().setOffline(false)
+
+    await retry(async () => {
+      expect(requests).toContain('/static-page')
+    })
   })
 
   it('should not prefetch for a bot user agent', async () => {


### PR DESCRIPTION
### What?

Retry visible App Router link/form prefetches when the browser comes back online.

### Why?

Fixes #69999. If a visible `<Link>` attempted to prefetch while the browser was offline, the failed route or segment cache entry could remain rejected for the normal retry window. Since the link was already visible, reconnecting did not trigger a new visibility event, so the route stayed unprefetched until another user interaction or cache change happened.

### How?

- Listen for the browser `online` event in the shared link prefetch registry and reschedule every currently visible prefetchable instance.
- Treat prefetch failures that happen while `navigator.onLine === false` as immediately expired cache entries, matching the existing experimental offline behavior without requiring `experimental.useOffline`.
- Keep intentional abort/timeout errors on the existing retry path.
- Add an app-prefetch e2e regression that uses Playwright network emulation to fail a visible link prefetch offline, restore connectivity, and assert the RSC prefetch retries.

### Verification

- `pnpm --filter @next/font build`
- `pnpm --filter next build`
- `pnpm exec eslint --config eslint.cli.config.mjs packages/next/src/client/components/links.ts packages/next/src/client/components/segment-cache/cache.ts test/e2e/app-dir/app-prefetch/prefetching.test.ts`
- `NEXT_TEST_MODE=start IS_WEBPACK_TEST=1 HEADLESS=true NEXT_TEST_PREFER_OFFLINE=1 pnpm exec jest --runInBand test/e2e/app-dir/app-prefetch/prefetching.test.ts -t "should prefetch visible links after reconnecting"`
- `NEXT_TEST_MODE=start IS_WEBPACK_TEST=1 HEADLESS=true NEXT_TEST_PREFER_OFFLINE=1 NEXT_SKIP_ISOLATE=1 pnpm exec jest --runInBand test/e2e/app-dir/app-prefetch/prefetching.test.ts -t "should (not fetch again when a static page was prefetched|prefetch visible links after reconnecting)"`

<!-- NEXT_JS_LLM_PR -->
