### PR TITLE
[turbo-tasks] Shrink RawVc to 8 bytes and CellId to 4 bytes

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/cell_data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/cell_data.rs
@@ -58,11 +58,11 @@ impl MergeRestore for CellData {
                     // value is more authoritative than the decoded one.
                     debug_assert!(
                         !matches!(
-                            registry::get_value_type(k.type_id).evictability,
+                            registry::get_value_type(k.type_id()).evictability,
                             Evictability::Always,
                         ),
                         "Found an evictable cell in a task we are restoring into: {}",
-                        registry::get_value_type(k.type_id).ty.name,
+                        registry::get_value_type(k.type_id()).ty.name,
                     );
                 }
             }
@@ -84,12 +84,12 @@ impl DropPartial for CellData {
     /// - `Evictability::Never` — value type holds session-scoped state that must not leave memory
     ///   (`State<>` cells, file watchers, worker pools).
     fn drop_partial(&mut self) -> DropPartialOutcome {
-        self.0.retain(
-            |cell_id, _| match registry::get_value_type(cell_id.type_id).evictability {
+        self.0.retain(|cell_id, _| {
+            match registry::get_value_type(cell_id.type_id()).evictability {
                 Evictability::Always => false,
                 Evictability::Expensive | Evictability::Never => true,
-            },
-        );
+            }
+        });
         if self.0.is_empty() {
             return DropPartialOutcome::Empty;
         }
@@ -141,7 +141,7 @@ impl TurboBincodeEncode for CellData {
             .iter()
             .filter(|(cell, _)| {
                 matches!(
-                    registry::get_value_type(cell.type_id).persistence,
+                    registry::get_value_type(cell.type_id()).persistence,
                     ValueTypePersistence::Persistable(_, _),
                 )
             })
@@ -149,7 +149,7 @@ impl TurboBincodeEncode for CellData {
         count.encode(encoder)?;
         // TODO: consider sorting by type_id and delta encoding indices to reduce serialized size
         for (cell_id, reference) in self.0.iter() {
-            let value_type = registry::get_value_type(cell_id.type_id);
+            let value_type = registry::get_value_type(cell_id.type_id());
             let ValueTypePersistence::Persistable(encode_fn, _) = value_type.persistence else {
                 continue;
             };
@@ -173,7 +173,7 @@ impl<Context> TurboBincodeDecode<Context> for CellData {
         let mut map = InnerMap::with_capacity_and_hasher(count, BuildHasherDefault::default());
         for _ in 0..count {
             let cell = CellId::decode(decoder)?;
-            let value_type = registry::get_value_type(cell.type_id);
+            let value_type = registry::get_value_type(cell.type_id());
             let ValueTypePersistence::Persistable(_, decode_fn) = value_type.persistence else {
                 return Err(DecodeError::OtherString(format!(
                     "cell of type {} has no bincode decoder",
@@ -227,10 +227,7 @@ mod tests {
     struct HashOnlyV(#[allow(dead_code)] u32);
 
     fn cell_of<V: VcValueType>(index: u32) -> CellId {
-        CellId {
-            type_id: V::get_value_type_id(),
-            index,
-        }
+        CellId::new(V::get_value_type_id(), index)
     }
 
     fn dummy_ref() -> SharedReference {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -29,10 +29,10 @@ use tokio::time::{Duration, Instant};
 use tracing::{Span, trace_span};
 use turbo_bincode::{TurboBincodeBuffer, new_turbo_bincode_decoder, new_turbo_bincode_encoder};
 use turbo_tasks::{
-    CellId, DynTaskInputsStorage, RawVc, ReadCellOptions, ReadCellTracking, ReadConsistency,
-    ReadOutputOptions, ReadTracking, SharedReference, TRANSIENT_TASK_BIT, TaskExecutionReason,
-    TaskId, TaskPersistence, TaskPriority, TraitTypeId, TurboTasks, TurboTasksCallApi,
-    TurboTasksPanic, ValueTypeId,
+    CellId, DynTaskInputsStorage, RawVc, RawVcUnpacked, ReadCellOptions, ReadCellTracking,
+    ReadConsistency, ReadOutputOptions, ReadTracking, SharedReference, TRANSIENT_TASK_BIT,
+    TaskExecutionReason, TaskId, TaskPersistence, TaskPriority, TraitTypeId, TurboTasks,
+    TurboTasksCallApi, TurboTasksPanic, ValueTypeId,
     backend::{
         Backend, CachedTaskType, CachedTaskTypeArc, CellContent, CellHash, TaskExecutionSpec,
         TransientTaskType, TurboTaskContextError, TurboTaskLocalContextError, TurboTasksError,
@@ -689,8 +689,8 @@ impl TurboTasksBackend {
 
         if let Some(output) = task.get_output() {
             let result = match output {
-                OutputValue::Cell(cell) => Ok(Ok(RawVc::TaskCell(cell.task, cell.cell))),
-                OutputValue::Output(task) => Ok(Ok(RawVc::TaskOutput(*task))),
+                OutputValue::Cell(cell) => Ok(Ok(RawVc::task_cell(cell.task, cell.cell))),
+                OutputValue::Output(task) => Ok(Ok(RawVc::task_output(*task))),
                 OutputValue::Error(error) => Err(error.clone()),
             };
             if let Some(mut reader_task) = reader_task.take()
@@ -2328,8 +2328,8 @@ impl TurboTasksBackend {
         let current_output = task.get_output();
         #[cfg(feature = "verify_determinism")]
         let no_output_set = current_output.is_none();
-        let new_output = match result {
-            Ok(RawVc::TaskOutput(output_task_id)) => {
+        let new_output = match result.map(RawVc::unpack) {
+            Ok(RawVcUnpacked::TaskOutput(output_task_id)) => {
                 if let Some(OutputValue::Output(current_task_id)) = current_output
                     && *current_task_id == output_task_id
                 {
@@ -2338,7 +2338,7 @@ impl TurboTasksBackend {
                     Some(OutputValue::Output(output_task_id))
                 }
             }
-            Ok(RawVc::TaskCell(output_task_id, cell)) => {
+            Ok(RawVcUnpacked::TaskCell(output_task_id, cell)) => {
                 if let Some(OutputValue::Cell(CellRef {
                     task: current_task_id,
                     cell: current_cell,
@@ -2354,7 +2354,7 @@ impl TurboTasksBackend {
                     }))
                 }
             }
-            Ok(RawVc::LocalOutput(..)) => {
+            Ok(RawVcUnpacked::LocalOutput(..)) => {
                 panic!("Non-local tasks must not return a local Vc");
             }
             Err(err) => {
@@ -3043,7 +3043,7 @@ impl TurboTasksBackend {
             for (collectible, count) in task.iter_aggregated_collectibles() {
                 if *count > 0 && collectible.collectible_type == collectible_type {
                     *collectibles
-                        .entry(RawVc::TaskCell(
+                        .entry(RawVc::task_cell(
                             collectible.cell.task,
                             collectible.cell.cell,
                         ))
@@ -3053,7 +3053,7 @@ impl TurboTasksBackend {
             for (&collectible, &count) in task.iter_collectibles() {
                 if collectible.collectible_type == collectible_type {
                     *collectibles
-                        .entry(RawVc::TaskCell(
+                        .entry(RawVc::task_cell(
                             collectible.cell.task,
                             collectible.cell.cell,
                         ))
@@ -3086,7 +3086,7 @@ impl TurboTasksBackend {
     ) {
         self.assert_valid_collectible(task_id, collectible);
 
-        let RawVc::TaskCell(collectible_task, cell) = collectible else {
+        let RawVcUnpacked::TaskCell(collectible_task, cell) = collectible.unpack() else {
             panic!("Collectibles need to be resolved");
         };
         let cell = CellRef {
@@ -3114,7 +3114,7 @@ impl TurboTasksBackend {
     ) {
         self.assert_valid_collectible(task_id, collectible);
 
-        let RawVc::TaskCell(collectible_task, cell) = collectible else {
+        let RawVcUnpacked::TaskCell(collectible_task, cell) = collectible.unpack() else {
             panic!("Collectibles need to be resolved");
         };
         let cell = CellRef {
@@ -3438,7 +3438,7 @@ impl TurboTasksBackend {
 
     fn assert_valid_collectible(&self, task_id: TaskId, collectible: RawVc) {
         // these checks occur in a potentially hot codepath, but they're cheap
-        let RawVc::TaskCell(col_task_id, col_cell_id) = collectible else {
+        let RawVcUnpacked::TaskCell(col_task_id, col_cell_id) = collectible.unpack() else {
             // This should never happen: The collectible APIs use ResolvedVc
             let task_info = if let Some(col_task_ty) = collectible
                 .try_get_task_id()

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -851,7 +851,7 @@ impl TurboTasksBackend {
                 add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             return Ok(Ok(TypedCellContent(
-                cell.type_id,
+                cell.type_id(),
                 CellContent(Some(content)),
             )));
         }
@@ -868,7 +868,7 @@ impl TurboTasksBackend {
         let is_cancelled = matches!(in_progress, Some(InProgressState::Canceled));
 
         // Check cell index range (cell might not exist at all)
-        let max_id = task.get_cell_type_max_index(&cell.type_id).copied();
+        let max_id = task.get_cell_type_max_index(&cell.type_id()).copied();
         let Some(max_id) = max_id else {
             let task_desc = task.get_task_description();
             if tracking.should_track(true) {
@@ -878,7 +878,7 @@ impl TurboTasksBackend {
                 "Cell {cell:?} no longer exists in task {task_desc} (no cell of this type exists)",
             );
         };
-        if cell.index >= max_id {
+        if cell.index() >= max_id {
             let task_desc = task.get_task_description();
             if tracking.should_track(true) {
                 add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
@@ -904,8 +904,8 @@ impl TurboTasksBackend {
 
         let _span = tracing::trace_span!(
             "recomputation",
-            cell_type = get_value_type(cell.type_id).ty.global_name,
-            cell_index = cell.index
+            cell_type = get_value_type(cell.type_id()).ty.global_name,
+            cell_index = cell.index()
         )
         .entered();
 
@@ -1712,7 +1712,7 @@ impl TurboTasksBackend {
         inner_cached(
             self,
             task_type,
-            cell_id.map(|c| c.type_id),
+            cell_id.map(|c| c.type_id()),
             &mut FxHashSet::default(),
         )
     }
@@ -2771,8 +2771,8 @@ impl TurboTasksBackend {
                 .iter_cell_data()
                 .filter_map(|(cell, _)| {
                     cell_counters
-                        .get(&cell.type_id)
-                        .is_none_or(|start_index| cell.index >= *start_index)
+                        .get(&cell.type_id())
+                        .is_none_or(|start_index| cell.index() >= *start_index)
                         .then_some(*cell)
                 })
                 .collect();
@@ -2787,8 +2787,8 @@ impl TurboTasksBackend {
                 .iter_cell_data_hash()
                 .filter_map(|(cell, _)| {
                     cell_counters
-                        .get(&cell.type_id)
-                        .is_none_or(|start_index| cell.index >= *start_index)
+                        .get(&cell.type_id())
+                        .is_none_or(|start_index| cell.index() >= *start_index)
                         .then_some(*cell)
                 })
                 .collect();
@@ -3008,9 +3008,9 @@ impl TurboTasksBackend {
         let mut ctx = self.execute_context(turbo_tasks);
         let task = ctx.task(task_id, TaskDataCategory::Data);
         if let Some(content) = task.get_cell_data(&cell).cloned() {
-            Ok(CellContent(Some(content)).into_typed(cell.type_id))
+            Ok(CellContent(Some(content)).into_typed(cell.type_id()))
         } else {
-            Ok(CellContent(None).into_typed(cell.type_id))
+            Ok(CellContent(None).into_typed(cell.type_id()))
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -3086,7 +3086,7 @@ impl TurboTasksBackend {
     ) {
         self.assert_valid_collectible(task_id, collectible);
 
-        let RawVcUnpacked::TaskCell(collectible_task, cell) = collectible.unpack() else {
+        let Some((collectible_task, cell)) = collectible.as_task_cell() else {
             panic!("Collectibles need to be resolved");
         };
         let cell = CellRef {
@@ -3114,7 +3114,7 @@ impl TurboTasksBackend {
     ) {
         self.assert_valid_collectible(task_id, collectible);
 
-        let RawVcUnpacked::TaskCell(collectible_task, cell) = collectible.unpack() else {
+        let Some((collectible_task, cell)) = collectible.as_task_cell() else {
             panic!("Collectibles need to be resolved");
         };
         let cell = CellRef {
@@ -3438,7 +3438,7 @@ impl TurboTasksBackend {
 
     fn assert_valid_collectible(&self, task_id: TaskId, collectible: RawVc) {
         // these checks occur in a potentially hot codepath, but they're cheap
-        let RawVcUnpacked::TaskCell(col_task_id, col_cell_id) = collectible.unpack() else {
+        let Some((col_task_id, col_cell_id)) = collectible.as_task_cell() else {
             // This should never happen: The collectible APIs use ResolvedVc
             let task_info = if let Some(col_task_ty) = collectible
                 .try_get_task_id()

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -58,7 +58,7 @@ impl UpdateCellOperation {
         #[cfg(not(feature = "verify_determinism"))] _verification_mode: VerificationMode,
         mut ctx: impl ExecuteContext<'_>,
     ) {
-        let value_type = registry::get_value_type(cell.type_id);
+        let value_type = registry::get_value_type(cell.type_id());
         // `content_hash` is only ever supplied for `HashOnly` cells — only the
         // `"hash"`-mode write path emits a hash, and no other mode consumes
         // it. (It can still be `None` for `HashOnly` when the cell is being
@@ -97,7 +97,9 @@ impl UpdateCellOperation {
                     let cell_type = value_type.ty.global_name;
                     eprintln!(
                         "Task {} updated cell #{} (type: {}) while recomputing",
-                        task_description, cell.index, cell_type
+                        task_description,
+                        cell.index(),
+                        cell_type
                     );
                 }
                 return;
@@ -211,7 +213,7 @@ impl UpdateCellOperation {
                     dependent_tasks,
                     #[cfg(feature = "task_dirty_cause")]
                     has_updated_key_hashes,
-                    content: content.map(|r| r.into_typed(cell.type_id)),
+                    content: content.map(|r| r.into_typed(cell.type_id())),
                     queue: AggregationUpdateQueue::new(),
                 }
                 .execute(&mut ctx);
@@ -252,7 +254,7 @@ impl UpdateCellOperation {
             UpdateCellOperation::InvalidateWhenCellDependency { cell_ref, .. }
             | UpdateCellOperation::FinalCellChange { cell_ref, .. } => {
                 matches!(
-                    registry::get_value_type(cell_ref.cell.type_id).persistence,
+                    registry::get_value_type(cell_ref.cell.type_id()).persistence,
                     ValueTypePersistence::Persistable(_, _),
                 )
             }
@@ -330,7 +332,7 @@ impl Operation for UpdateCellOperation {
                             make_stale,
                             #[cfg(feature = "task_dirty_cause")]
                             TaskDirtyCause::CellChange {
-                                value_type: cell_ref.cell.type_id,
+                                value_type: cell_ref.cell.type_id(),
                                 keys: has_updated_key_hashes.then_some(keys).unwrap_or_default(),
                             },
                             queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -956,7 +956,7 @@ mod tests {
     use crate::backing_storage::SnapshotItem;
 
     fn non_transient_task(id: u32) -> TaskId {
-        // TRANSIENT_TASK_BIT is 0x8000_0000; any id without that bit is non-transient.
+        // TRANSIENT_TASK_BIT is 0x2000_0000; any id without that bit is non-transient.
         TaskId::new(id).expect("id must be non-zero")
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -1278,10 +1278,7 @@ mod tests {
             .insert(TaskId::new(200).unwrap());
         original.cell_dependencies_mut().insert(CellRef {
             task: TaskId::new(1).unwrap(),
-            cell: CellId {
-                type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
-                index: 0,
-            },
+            cell: CellId::new(unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) }, 0),
         });
 
         // Set lazy data transient field (should NOT be serialized)
@@ -1423,10 +1420,7 @@ mod tests {
         // Lazy filter_transient data field.
         storage.cell_dependencies_mut().insert(CellRef {
             task: persistent_task(10),
-            cell: CellId {
-                type_id: unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) },
-                index: 0,
-            },
+            cell: CellId::new(unsafe { turbo_tasks::ValueTypeId::new_unchecked(1) }, 0),
         });
 
         // Mark as restored so the task is eligible for dropping.
@@ -1616,17 +1610,11 @@ mod tests {
         }
 
         fn keepable_cell(index: u32) -> CellId {
-            CellId {
-                type_id: Keepable::get_value_type_id(),
-                index,
-            }
+            CellId::new(Keepable::get_value_type_id(), index)
         }
 
         fn keep_me_cell(index: u32) -> CellId {
-            CellId {
-                type_id: KeepMe::get_value_type_id(),
-                index,
-            }
+            CellId::new(KeepMe::get_value_type_id(), index)
         }
 
         #[test]

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -800,7 +800,7 @@ mod cached_task_type_tests {
 
     /// Build a `Some(RawVc::TaskOutput(..))` this value.
     fn make_this(id: u32) -> Option<RawVc> {
-        Some(RawVc::TaskOutput(
+        Some(RawVc::task_output(
             TaskId::new(id).expect("non-zero task id"),
         ))
     }

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -171,16 +171,8 @@ impl Debug for TaskId {
 
 unsafe impl crate::NonLocalValue for TaskId {}
 
-/// `TaskId` values are constrained to 31 bits so the id fits alongside a
-/// [`crate::CellId`] (32 bits) inside the 64-bit packed [`crate::RawVc`], which
-/// reserves bit 31 of its word as the `LocalOutput` discriminator. Bit 30 marks
-/// transient tasks; bit 31 is always zero. The transient flag is intentionally
-/// a property of the *value* (not of any `RawVc` wrapper) because transience is
-/// computed from a bare `TaskId` in many places (storage, aggregation, child
-/// connection).
-///
-/// This splits the id space into ~1.07B persistent ids (`1..=0x3FFF_FFFF`) and
-/// ~1.07B transient ids (`0x4000_0000..=0x7FFF_FFFF`).
+/// `TaskId` values are constrained to 31 bits to preserve a niche for [`crate::RawVc`]. Bit 30
+/// marks transient tasks; bit 31 is always zero.
 pub const TRANSIENT_TASK_BIT: u32 = 0x4000_0000;
 
 /// The largest value a [`TaskId`] may hold (31 bits set).

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -137,12 +137,17 @@ macro_rules! define_id {
 
 define_id!(
     TaskId: u32,
+    // Capped below `u32::MAX` so the id fits in 30 bits when packed into `RawVc`.
     max = TASK_ID_MAX,
     derive(Serialize, Deserialize, Encode, Decode),
     serde(transparent),
 );
+define_id!(
+    ValueTypeId: u16,
+    // Capped below `u16::MAX` so the id fits in 10 bits when packed into `CellId`.
+    max = crate::CellId::MAX_VALUE_TYPE_ID,
+);
 define_id!(FunctionId: u16);
-define_id!(ValueTypeId: u16);
 define_id!(TraitTypeId: u16);
 define_id!(
     LocalTaskId: u32,
@@ -304,5 +309,13 @@ mod tests {
         assert!(TaskId::MAX.is_transient());
         assert!(!TaskId::new(TRANSIENT_TASK_BIT - 1).unwrap().is_transient());
         assert!(TaskId::new(TRANSIENT_TASK_BIT).unwrap().is_transient());
+    }
+
+    /// `ValueTypeId::MAX` is capped to the 10-bit field it occupies in `CellId`,
+    /// not the full `u16::MAX`.
+    #[test]
+    fn value_type_id_max_is_capped() {
+        assert_eq!(*ValueTypeId::MAX, crate::CellId::MAX_VALUE_TYPE_ID);
+        assert!(*ValueTypeId::MAX < u16::MAX);
     }
 }

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -137,7 +137,7 @@ macro_rules! define_id {
 
 define_id!(
     TaskId: u32,
-    // Capped below `u32::MAX` so the id fits in 30 bits when packed into `RawVc`.
+    // Capped below `u32::MAX` so the id fits in 31 bits when packed into `RawVc`.
     max = TASK_ID_MAX,
     derive(Serialize, Deserialize, Encode, Decode),
     serde(transparent),
@@ -171,19 +171,20 @@ impl Debug for TaskId {
 
 unsafe impl crate::NonLocalValue for TaskId {}
 
-/// `TaskId` values are constrained to 30 bits so the id fits alongside a
-/// [`crate::CellId`] (32 bits) and a 2-bit tag inside the 64-bit packed
-/// [`crate::RawVc`]. Bit 29 marks transient tasks; bits 30 and 31 are always
-/// zero. The transient flag is intentionally a property of the *value* (not of
-/// any `RawVc` wrapper) because transience is computed from a bare `TaskId` in
-/// many places (storage, aggregation, child connection).
+/// `TaskId` values are constrained to 31 bits so the id fits alongside a
+/// [`crate::CellId`] (32 bits) inside the 64-bit packed [`crate::RawVc`], which
+/// reserves bit 31 of its word as the `LocalOutput` discriminator. Bit 30 marks
+/// transient tasks; bit 31 is always zero. The transient flag is intentionally
+/// a property of the *value* (not of any `RawVc` wrapper) because transience is
+/// computed from a bare `TaskId` in many places (storage, aggregation, child
+/// connection).
 ///
-/// This splits the id space into ~536M persistent ids (`1..=0x1FFF_FFFF`) and
-/// ~536M transient ids (`0x2000_0000..=0x3FFF_FFFF`).
-pub const TRANSIENT_TASK_BIT: u32 = 0x2000_0000;
+/// This splits the id space into ~1.07B persistent ids (`1..=0x3FFF_FFFF`) and
+/// ~1.07B transient ids (`0x4000_0000..=0x7FFF_FFFF`).
+pub const TRANSIENT_TASK_BIT: u32 = 0x4000_0000;
 
-/// The largest value a [`TaskId`] may hold (30 bits set).
-pub const TASK_ID_MAX: u32 = 0x3FFF_FFFF;
+/// The largest value a [`TaskId`] may hold (31 bits set).
+pub const TASK_ID_MAX: u32 = 0x7FFF_FFFF;
 
 impl TaskId {
     pub fn is_transient(&self) -> bool {
@@ -300,12 +301,12 @@ mod tests {
     use super::*;
 
     /// The `max` override on `define_id!` must actually take effect for
-    /// `TaskId` (capped to 30 bits) without affecting the transient-bit math:
-    /// the largest id is still transient and uses only the low 30 bits, so it
+    /// `TaskId` (capped to 31 bits) without affecting the transient-bit math:
+    /// the largest id is still transient and uses only the low 31 bits, so it
     /// round-trips through `RawVc`'s packed representation.
     #[test]
     fn task_id_max_is_capped_and_transient() {
-        assert_eq!(*TaskId::MAX & !TASK_ID_MAX, 0, "MAX must fit in 30 bits");
+        assert_eq!(*TaskId::MAX & !TASK_ID_MAX, 0, "MAX must fit in 31 bits");
         assert!(TaskId::MAX.is_transient());
         assert!(!TaskId::new(TRANSIENT_TASK_BIT - 1).unwrap().is_transient());
         assert!(TaskId::new(TRANSIENT_TASK_BIT).unwrap().is_transient());

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -70,6 +70,13 @@ macro_rules! define_id {
                 }
                 unsafe { NonZeroU64::new_unchecked(self.id.get() as u64) }
             }
+            /// Allows `const` conversion to [`NonZero<$primitive>`]
+            pub const fn to_non_zero_primitive(self) -> NonZero<$primitive> {
+                self.id
+            }
+            pub const fn to_primitive(self) -> $primitive {
+                self.id.get()
+            }
         }
 
         impl Display for $name {

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -22,6 +22,7 @@ use crate::{
 macro_rules! define_id {
     (
         $name:ident : $primitive:ty
+        $(,max = $max:expr)?
         $(,derive($($derive:ty),*))?
         $(,serde($serde:tt))?
         $(,doc = $doc:literal)*
@@ -36,7 +37,15 @@ macro_rules! define_id {
 
         impl $name {
             pub const MIN: Self = Self { id: NonZero::<$primitive>::MIN };
-            pub const MAX: Self = Self { id: NonZero::<$primitive>::MAX };
+            // `max` defaults to the primitive's max; types packed into a smaller
+            // bit field (e.g. `TaskId` in `RawVc`) override it.
+            pub const MAX: Self = {
+                let _max: $primitive = NonZero::<$primitive>::MAX.get();
+                $( let _max: $primitive = $max; )?
+                // SAFETY: `_max` is either `NonZero::MAX` or a caller-provided
+                // positive constant; both are non-zero.
+                Self { id: unsafe { NonZero::<$primitive>::new_unchecked(_max) } }
+            };
 
             /// Constructs a wrapper type from the numeric identifier.
             ///
@@ -126,7 +135,12 @@ macro_rules! define_id {
     };
 }
 
-define_id!(TaskId: u32, derive(Serialize, Deserialize, Encode, Decode), serde(transparent));
+define_id!(
+    TaskId: u32,
+    max = TASK_ID_MAX,
+    derive(Serialize, Deserialize, Encode, Decode),
+    serde(transparent),
+);
 define_id!(FunctionId: u16);
 define_id!(ValueTypeId: u16);
 define_id!(TraitTypeId: u16);
@@ -152,7 +166,19 @@ impl Debug for TaskId {
 
 unsafe impl crate::NonLocalValue for TaskId {}
 
-pub const TRANSIENT_TASK_BIT: u32 = 0x8000_0000;
+/// `TaskId` values are constrained to 30 bits so the id fits alongside a
+/// [`crate::CellId`] (32 bits) and a 2-bit tag inside the 64-bit packed
+/// [`crate::RawVc`]. Bit 29 marks transient tasks; bits 30 and 31 are always
+/// zero. The transient flag is intentionally a property of the *value* (not of
+/// any `RawVc` wrapper) because transience is computed from a bare `TaskId` in
+/// many places (storage, aggregation, child connection).
+///
+/// This splits the id space into ~536M persistent ids (`1..=0x1FFF_FFFF`) and
+/// ~536M transient ids (`0x2000_0000..=0x3FFF_FFFF`).
+pub const TRANSIENT_TASK_BIT: u32 = 0x2000_0000;
+
+/// The largest value a [`TaskId`] may hold (30 bits set).
+pub const TASK_ID_MAX: u32 = 0x3FFF_FFFF;
 
 impl TaskId {
     pub fn is_transient(&self) -> bool {
@@ -263,3 +289,20 @@ make_registered_serializable!(
     registry::get_native_function,
     registry::validate_function_id,
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `max` override on `define_id!` must actually take effect for
+    /// `TaskId` (capped to 30 bits) without affecting the transient-bit math:
+    /// the largest id is still transient and uses only the low 30 bits, so it
+    /// round-trips through `RawVc`'s packed representation.
+    #[test]
+    fn task_id_max_is_capped_and_transient() {
+        assert_eq!(*TaskId::MAX & !TASK_ID_MAX, 0, "MAX must fit in 30 bits");
+        assert!(TaskId::MAX.is_transient());
+        assert!(!TaskId::new(TRANSIENT_TASK_BIT - 1).unwrap().is_transient());
+        assert!(TaskId::new(TRANSIENT_TASK_BIT).unwrap().is_transient());
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -295,28 +295,3 @@ make_registered_serializable!(
     registry::get_native_function,
     registry::validate_function_id,
 );
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The `max` override on `define_id!` must actually take effect for
-    /// `TaskId` (capped to 31 bits) without affecting the transient-bit math:
-    /// the largest id is still transient and uses only the low 31 bits, so it
-    /// round-trips through `RawVc`'s packed representation.
-    #[test]
-    fn task_id_max_is_capped_and_transient() {
-        assert_eq!(*TaskId::MAX & !TASK_ID_MAX, 0, "MAX must fit in 31 bits");
-        assert!(TaskId::MAX.is_transient());
-        assert!(!TaskId::new(TRANSIENT_TASK_BIT - 1).unwrap().is_transient());
-        assert!(TaskId::new(TRANSIENT_TASK_BIT).unwrap().is_transient());
-    }
-
-    /// `ValueTypeId::MAX` is capped to the 10-bit field it occupies in `CellId`,
-    /// not the full `u16::MAX`.
-    #[test]
-    fn value_type_id_max_is_capped() {
-        assert_eq!(*ValueTypeId::MAX, crate::CellId::MAX_VALUE_TYPE_ID);
-        assert!(*ValueTypeId::MAX < u16::MAX);
-    }
-}

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -123,7 +123,7 @@ pub use crate::{
     value_type::{Evictability, TraitMethod, TraitType, ValueType, ValueTypePersistence},
     vc::{
         CellId, Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, RawVc,
-        ReadRawVcFuture, ReadVcFuture, ResolveOperationVcFuture, ResolveRawVcFuture,
+        RawVcUnpacked, ReadRawVcFuture, ReadVcFuture, ResolveOperationVcFuture, ResolveRawVcFuture,
         ResolveVcFuture, ResolvedVc, ToResolvedVcFuture, Upcast, UpcastStrict, ValueDefault, Vc,
         VcCast, VcCellCompareMode, VcCellHashedCompareMode, VcCellKeyedCompareMode, VcCellNewMode,
         VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,

--- a/turbopack/crates/turbo-tasks/src/local_task_tracker.rs
+++ b/turbopack/crates/turbo-tasks/src/local_task_tracker.rs
@@ -119,7 +119,7 @@ mod tests {
     use super::*;
 
     fn dummy_output() -> OutputContent {
-        OutputContent::Link(crate::RawVc::TaskOutput(
+        OutputContent::Link(crate::RawVc::task_output(
             crate::TaskId::try_from(1).unwrap(),
         ))
     }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -28,8 +28,8 @@ use turbo_tasks_hash::{DeterministicHash, hash_xxh3_hash128};
 
 use crate::{
     CellId, Completion, InvalidationReason, InvalidationReasonSet, OutputContent, RawVc,
-    RawVcUnpacked, ReadCellOptions, ReadOutputOptions, ResolvedVc, SharedReference, TaskId,
-    TraitMethod, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
+    ReadCellOptions, ReadOutputOptions, ResolvedVc, SharedReference, TaskId, TraitMethod,
+    ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
     backend::{
         Backend, CellContent, CellHash, TaskCollectiblesMap, TaskExecutionSpec, TransientTaskType,
         TurboTasksExecutionError, TypedCellContent, VerificationMode,
@@ -789,7 +789,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         // avoid creating a wrapper task if self is already resolved
         // for resolved cells we already know the value type so we can lookup the
         // function
-        if let RawVcUnpacked::TaskCell(_, cell_id) = this.unpack() {
+        if let Some((_, cell_id)) = this.as_task_cell() {
             match registry::get_value_type(cell_id.type_id()).get_trait_method(trait_method) {
                 Some(native_fn) => {
                     if let Some(filter) = native_fn.arg_meta.filter_owned {

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -789,8 +789,8 @@ impl<B: Backend + 'static> TurboTasks<B> {
         // avoid creating a wrapper task if self is already resolved
         // for resolved cells we already know the value type so we can lookup the
         // function
-        if let RawVc::TaskCell(_, CellId { type_id, .. }) = this {
-            match registry::get_value_type(type_id).get_trait_method(trait_method) {
+        if let RawVc::TaskCell(_, cell_id) = this {
+            match registry::get_value_type(cell_id.type_id()).get_trait_method(trait_method) {
                 Some(native_fn) => {
                     if let Some(filter) = native_fn.arg_meta.filter_owned {
                         let (resolved, mut arg) = (filter)(arg);
@@ -2222,10 +2222,15 @@ pub fn find_cell_by_id(ty: ValueTypeId) -> CurrentCellRef {
         let map = ts.cell_counters.as_mut().unwrap();
         let current_index = map.entry(ty).or_default();
         let index = *current_index;
+        assert!(
+            index <= CellId::MAX_CELL_INDEX,
+            "task allocated more than {} cells of a single type",
+            CellId::MAX_CELL_INDEX as u64 + 1,
+        );
         *current_index += 1;
         CurrentCellRef {
             current_task,
-            index: CellId { type_id: ty, index },
+            index: CellId::new(ty, index),
         }
     })
 }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -28,8 +28,8 @@ use turbo_tasks_hash::{DeterministicHash, hash_xxh3_hash128};
 
 use crate::{
     CellId, Completion, InvalidationReason, InvalidationReasonSet, OutputContent, RawVc,
-    ReadCellOptions, ReadOutputOptions, ResolvedVc, SharedReference, TaskId, TraitMethod,
-    ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
+    RawVcUnpacked, ReadCellOptions, ReadOutputOptions, ResolvedVc, SharedReference, TaskId,
+    TraitMethod, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
     backend::{
         Backend, CellContent, CellHash, TaskCollectiblesMap, TaskExecutionSpec, TransientTaskType,
         TurboTasksExecutionError, TypedCellContent, VerificationMode,
@@ -747,7 +747,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         arg: &mut dyn DynTaskInputsStorage,
         persistence: TaskPersistence,
     ) -> RawVc {
-        RawVc::TaskOutput(self.backend.get_or_create_task(
+        RawVc::task_output(self.backend.get_or_create_task(
             native_fn,
             this,
             arg,
@@ -789,7 +789,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         // avoid creating a wrapper task if self is already resolved
         // for resolved cells we already know the value type so we can lookup the
         // function
-        if let RawVc::TaskCell(_, cell_id) = this {
+        if let RawVcUnpacked::TaskCell(_, cell_id) = this.unpack() {
             match registry::get_value_type(cell_id.type_id()).get_trait_method(trait_method) {
                 Some(native_fn) => {
                     if let Some(filter) = native_fn.arg_meta.filter_owned {
@@ -875,7 +875,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             priority,
         );
 
-        RawVc::LocalOutput(execution_id, local_task_id, persistence)
+        RawVc::local_output(execution_id, local_task_id, persistence)
     }
 
     fn begin_foreground_job(&self) {
@@ -2202,7 +2202,7 @@ impl CurrentCellRef {
 
 impl From<CurrentCellRef> for RawVc {
     fn from(cell: CurrentCellRef) -> Self {
-        RawVc::TaskCell(cell.current_task, cell.index)
+        RawVc::task_cell(cell.current_task, cell.index)
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -118,6 +118,13 @@ trait Registerable: 'static + Eq + std::hash::Hash {
     type Id: Copy + From<NonZeroU16> + std::ops::Deref<Target = u16> + std::fmt::Display;
     const TYPE_NAME: &'static str;
 
+    /// The largest id that may be assigned to this registry item. Ids are
+    /// assigned sequentially from 1, so this also bounds the number of items.
+    ///
+    /// `ValueType` is capped tighter than `u16::MAX` because [`ValueTypeId`] is
+    /// packed into 10 bits of [`crate::CellId`].
+    const MAX_ID: u16 = u16::MAX;
+
     /// Get the global registry type used for sorting and uniqueness validation
     fn ty(&self) -> &RegistryType;
 }
@@ -134,6 +141,7 @@ impl Registerable for NativeFunction {
 impl Registerable for ValueType {
     type Id = ValueTypeId;
     const TYPE_NAME: &'static str = "Value";
+    const MAX_ID: u16 = crate::CellId::MAX_VALUE_TYPE_ID;
     fn ty(&self) -> &RegistryType {
         &self.ty
     }
@@ -164,6 +172,12 @@ fn init_registry<T: Registerable>(mut items: Vec<&'static T>) -> Box<[&'static T
             );
         }
         prev_name = Some(global_name);
+        assert!(
+            u16::from(id) <= T::MAX_ID,
+            "too many {ty} items registered: id {id} exceeds the cap of {max}",
+            ty = T::TYPE_NAME,
+            max = T::MAX_ID,
+        );
         // SAFETY: Single-threaded during Lazy init; no concurrent readers yet.
         unsafe { std::ptr::write(SyncUnsafeCell::raw_get(&item.ty().id), u16::from(id)) };
         id = id.checked_add(1).expect("overflowing item ids");

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -118,11 +118,7 @@ trait Registerable: 'static + Eq + std::hash::Hash {
     type Id: Copy + From<NonZeroU16> + std::ops::Deref<Target = u16> + std::fmt::Display;
     const TYPE_NAME: &'static str;
 
-    /// The largest id that may be assigned to this registry item. Ids are
-    /// assigned sequentially from 1, so this also bounds the number of items.
-    ///
-    /// `ValueType` is capped tighter than `u16::MAX` because [`ValueTypeId`] is
-    /// packed into 10 bits of [`crate::CellId`].
+    /// The largest id that may be assigned to this registry item.
     const MAX_ID: u16 = u16::MAX;
 
     /// Get the global registry type used for sorting and uniqueness validation

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -137,7 +137,7 @@ impl Registerable for NativeFunction {
 impl Registerable for ValueType {
     type Id = ValueTypeId;
     const TYPE_NAME: &'static str = "Value";
-    const MAX_ID: u16 = crate::CellId::MAX_VALUE_TYPE_ID;
+    const MAX_ID: u16 = ValueTypeId::MAX.to_primitive();
     fn ty(&self) -> &RegistryType {
         &self.ty
     }

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -3,9 +3,9 @@ use std::{fmt, sync::Arc};
 use anyhow::{Result, bail};
 
 use crate::{
-    DynTaskInputs, HeapDynTaskInputsStorage, OutputContent, RawVc, RawVcUnpacked, TaskPersistence,
-    TraitMethod, TurboTasks, ValueTypeId, backend::Backend, event::Event,
-    macro_helpers::NativeFunction, registry,
+    DynTaskInputs, HeapDynTaskInputsStorage, OutputContent, RawVc, TaskPersistence, TraitMethod,
+    TurboTasks, ValueTypeId, backend::Backend, event::Event, macro_helpers::NativeFunction,
+    registry,
 };
 
 /// A potentially in-flight local task stored in `CurrentGlobalTaskState::local_tasks`.
@@ -73,7 +73,7 @@ impl LocalTaskType {
         turbo_tasks: Arc<TurboTasks<B>>,
     ) -> Result<RawVc> {
         let this = this.resolve().await?;
-        let RawVcUnpacked::TaskCell(_, cell_id) = this.unpack() else {
+        let Some((_, cell_id)) = this.as_task_cell() else {
             bail!("Trait method receiver must be a cell");
         };
 

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -3,9 +3,9 @@ use std::{fmt, sync::Arc};
 use anyhow::{Result, bail};
 
 use crate::{
-    CellId, DynTaskInputs, HeapDynTaskInputsStorage, OutputContent, RawVc, TaskPersistence,
-    TraitMethod, TurboTasks, ValueTypeId, backend::Backend, event::Event,
-    macro_helpers::NativeFunction, registry,
+    DynTaskInputs, HeapDynTaskInputsStorage, OutputContent, RawVc, TaskPersistence, TraitMethod,
+    TurboTasks, ValueTypeId, backend::Backend, event::Event, macro_helpers::NativeFunction,
+    registry,
 };
 
 /// A potentially in-flight local task stored in `CurrentGlobalTaskState::local_tasks`.
@@ -73,11 +73,11 @@ impl LocalTaskType {
         turbo_tasks: Arc<TurboTasks<B>>,
     ) -> Result<RawVc> {
         let this = this.resolve().await?;
-        let RawVc::TaskCell(_, CellId { type_id, .. }) = this else {
+        let RawVc::TaskCell(_, cell_id) = this else {
             bail!("Trait method receiver must be a cell");
         };
 
-        let native_fn = Self::resolve_trait_method_from_value(trait_method, type_id)?;
+        let native_fn = Self::resolve_trait_method_from_value(trait_method, cell_id.type_id())?;
         let arg = native_fn.arg_meta.filter_and_resolve(arg).await?;
         let mut arg = HeapDynTaskInputsStorage::new(arg);
         Ok(turbo_tasks.native_call(native_fn, Some(this), &mut arg, persistence))

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -3,9 +3,9 @@ use std::{fmt, sync::Arc};
 use anyhow::{Result, bail};
 
 use crate::{
-    DynTaskInputs, HeapDynTaskInputsStorage, OutputContent, RawVc, TaskPersistence, TraitMethod,
-    TurboTasks, ValueTypeId, backend::Backend, event::Event, macro_helpers::NativeFunction,
-    registry,
+    DynTaskInputs, HeapDynTaskInputsStorage, OutputContent, RawVc, RawVcUnpacked, TaskPersistence,
+    TraitMethod, TurboTasks, ValueTypeId, backend::Backend, event::Event,
+    macro_helpers::NativeFunction, registry,
 };
 
 /// A potentially in-flight local task stored in `CurrentGlobalTaskState::local_tasks`.
@@ -73,7 +73,7 @@ impl LocalTaskType {
         turbo_tasks: Arc<TurboTasks<B>>,
     ) -> Result<RawVc> {
         let this = this.resolve().await?;
-        let RawVc::TaskCell(_, cell_id) = this else {
+        let RawVcUnpacked::TaskCell(_, cell_id) = this.unpack() else {
             bail!("Trait method receiver must be a cell");
         };
 

--- a/turbopack/crates/turbo-tasks/src/vc/README.md
+++ b/turbopack/crates/turbo-tasks/src/vc/README.md
@@ -77,9 +77,9 @@ Because cells are keyed by a combination of their type and construction order, *
 
 There are a couple of explicit "subtypes" of `Vc`. These can both be cheaply converted back into a `Vc`.
 
-- **[`ResolvedVc`]:** *(aka [`RawVc::TaskCell`])* A reference to a cell constructed within a task, as part of a [`Vc::cell`] or `value_type.cell()` constructor. As the cell has been constructed at least once, the concrete type of the cell is known (allowing [downcasting][ResolvedVc::try_downcast]). This is stored as a combination of a task id, a type id, and a cell id.
+- **[`ResolvedVc`]:** *(aka [`RawVcUnpacked::TaskCell`])* A reference to a cell constructed within a task, as part of a [`Vc::cell`] or `value_type.cell()` constructor. As the cell has been constructed at least once, the concrete type of the cell is known (allowing [downcasting][ResolvedVc::try_downcast]). This is stored as a combination of a task id, a type id, and a cell id.
 
-- **[`OperationVc`]:** *(aka [`RawVc::TaskOutput`])* The synchronous return value of a [`turbo_tasks::function`]. Internally, this is stored using a task id. [`OperationVc`]s must first be [`connect`][crate::OperationVc::connect]ed before being read.
+- **[`OperationVc`]:** *(aka [`RawVcUnpacked::TaskOutput`])* The synchronous return value of a [`turbo_tasks::function`]. Internally, this is stored using a task id. [`OperationVc`]s must first be [`connect`][crate::OperationVc::connect]ed before being read.
 
 [`ResolvedVc`] is almost always preferred over the more awkward [`OperationVc`] API, but [`OperationVc`] can be useful when dealing with [collectibles], when you need to [read the result of a function with strong consistency][crate::OperationVc::read_strongly_consistent], or with [`State`].
 
@@ -100,8 +100,8 @@ This means that `Vc` often uses the same in-memory representation as a `Resolved
 [`turbo_tasks::function`]: crate::function
 [`State`]: crate::State
 [Non-Local]: crate::NonLocalValue
-[rtc]: crate::RawVc::TaskCell
-[rto]: crate::RawVc::TaskOutput
+[rtc]: crate::RawVcUnpacked::TaskCell
+[rto]: crate::RawVcUnpacked::TaskOutput
 [loc]: #optimization-local-outputs
 [eq]: #equality--hashing
 [resolve]: crate::ResolvedVc::try_downcast
@@ -133,7 +133,7 @@ Currently, all inconsistent tasks are polled to completion. Future versions of t
 
 ## Optimization: Local Outputs
 
-In addition to the potentially-explicit "resolved" and "operation" representations of a `Vc`, there's another internal representation of a `Vc`, known as a "Local `Vc`", or [`RawVc::LocalOutput`].
+In addition to the potentially-explicit "resolved" and "operation" representations of a `Vc`, there's another internal representation of a `Vc`, known as a "Local `Vc`", or [`RawVcUnpacked::LocalOutput`].
 
 This is a special case of the synchronous return value of a [`turbo_tasks::function`] when some of its arguments have not yet been resolved. These are stored in task-local state that is freed after their parent non-local task exits.
 

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -355,7 +355,7 @@ where
     pub async fn debug_identifier(vc: Self) -> Result<String> {
         let resolved = vc.to_resolved().await?;
         let raw_vc: RawVc = resolved.node.node;
-        if let RawVcUnpacked::TaskCell(task_id, cell_id) = raw_vc.unpack() {
+        if let Some((task_id, cell_id)) = raw_vc.as_task_cell() {
             let value_name = registry::get_value_type(cell_id.type_id()).ty.name;
             Ok(format!(
                 "{value_name}#{index}: {task_id}",

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -355,9 +355,12 @@ where
     pub async fn debug_identifier(vc: Self) -> Result<String> {
         let resolved = vc.to_resolved().await?;
         let raw_vc: RawVc = resolved.node.node;
-        if let RawVc::TaskCell(task_id, CellId { type_id, index }) = raw_vc {
-            let value_ty = registry::get_value_type(type_id);
-            Ok(format!("{}#{}: {}", value_ty.ty.name, index, task_id))
+        if let RawVc::TaskCell(task_id, cell_id) = raw_vc {
+            let value_name = registry::get_value_type(cell_id.type_id()).ty.name;
+            Ok(format!(
+                "{value_name}#{index}: {task_id}",
+                index = cell_id.index(),
+            ))
         } else {
             unreachable!()
         }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     default::ValueDefault,
     local::NonLocalValue,
     operation::{OperationValue, OperationVc, ResolveOperationVcFuture},
-    raw::{CellId, RawVc, ReadRawVcFuture, ResolveRawVcFuture},
+    raw::{CellId, RawVc, RawVcUnpacked, ReadRawVcFuture, ResolveRawVcFuture},
     read::{ReadOwnedVcFuture, ReadVcFuture, VcDefaultRead, VcRead, VcTransparentRead},
     resolved::ResolvedVc,
     traits::{Dynamic, Upcast, UpcastStrict, VcValueTrait, VcValueType},
@@ -355,7 +355,7 @@ where
     pub async fn debug_identifier(vc: Self) -> Result<String> {
         let resolved = vc.to_resolved().await?;
         let raw_vc: RawVc = resolved.node.node;
-        if let RawVc::TaskCell(task_id, cell_id) = raw_vc {
+        if let RawVcUnpacked::TaskCell(task_id, cell_id) = raw_vc.unpack() {
             let value_name = registry::get_value_type(cell_id.type_id()).ty.name;
             Ok(format!(
                 "{value_name}#{index}: {task_id}",

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -456,7 +456,7 @@ where
     /// local or non-local cells, so this function is mostly useful inside tests and internally in
     /// turbo-tasks.
     pub fn is_local(self) -> bool {
-        self.node.is_local()
+        self.node.is_local_output()
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -13,9 +13,8 @@ use serde::{Deserialize, Serialize};
 pub use turbo_tasks_macros::OperationValue;
 
 use crate::{
-    CollectiblesSource, RawVc, RawVcUnpacked, ReadVcFuture, ResolvedVc, TaskInput, UpcastStrict,
-    Vc, VcValueTrait, VcValueTraitCast, VcValueType, marker_trait::impl_auto_marker_trait,
-    trace::TraceRawVcs,
+    CollectiblesSource, RawVc, ReadVcFuture, ResolvedVc, TaskInput, UpcastStrict, Vc, VcValueTrait,
+    VcValueTraitCast, VcValueType, marker_trait::impl_auto_marker_trait, trace::TraceRawVcs,
 };
 
 /// A future returned by [`OperationVc::resolve`] that connects an [`OperationVc<T>`] and resolves
@@ -110,7 +109,7 @@ impl<T: ?Sized> OperationVc<T> {
     #[deprecated = "This is an internal function. Use #[turbo_tasks::function(operation)] instead."]
     pub fn cell_private(node: Vc<T>) -> Self {
         debug_assert!(
-            matches!(node.node.unpack(), RawVcUnpacked::TaskOutput(..)),
+            node.node.as_task_output().is_some(),
             "OperationVc::cell_private must be called on the immediate return value of a task \
              function"
         );
@@ -247,7 +246,7 @@ where
     type Error = anyhow::Error;
 
     fn try_from(raw: RawVc) -> Result<Self> {
-        if !matches!(raw.unpack(), RawVcUnpacked::TaskOutput(..)) {
+        if raw.as_task_output().is_none() {
             anyhow::bail!("Given RawVc {raw:?} is not a TaskOutput");
         }
         Ok(Self {

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -13,8 +13,9 @@ use serde::{Deserialize, Serialize};
 pub use turbo_tasks_macros::OperationValue;
 
 use crate::{
-    CollectiblesSource, RawVc, ReadVcFuture, ResolvedVc, TaskInput, UpcastStrict, Vc, VcValueTrait,
-    VcValueTraitCast, VcValueType, marker_trait::impl_auto_marker_trait, trace::TraceRawVcs,
+    CollectiblesSource, RawVc, RawVcUnpacked, ReadVcFuture, ResolvedVc, TaskInput, UpcastStrict,
+    Vc, VcValueTrait, VcValueTraitCast, VcValueType, marker_trait::impl_auto_marker_trait,
+    trace::TraceRawVcs,
 };
 
 /// A future returned by [`OperationVc::resolve`] that connects an [`OperationVc<T>`] and resolves
@@ -109,7 +110,7 @@ impl<T: ?Sized> OperationVc<T> {
     #[deprecated = "This is an internal function. Use #[turbo_tasks::function(operation)] instead."]
     pub fn cell_private(node: Vc<T>) -> Self {
         debug_assert!(
-            matches!(node.node, RawVc::TaskOutput(..)),
+            matches!(node.node.unpack(), RawVcUnpacked::TaskOutput(..)),
             "OperationVc::cell_private must be called on the immediate return value of a task \
              function"
         );
@@ -246,7 +247,7 @@ where
     type Error = anyhow::Error;
 
     fn try_from(raw: RawVc) -> Result<Self> {
-        if !matches!(raw, RawVc::TaskOutput(..)) {
+        if !matches!(raw.unpack(), RawVcUnpacked::TaskOutput(..)) {
             anyhow::bail!("Given RawVc {raw:?} is not a TaskOutput");
         }
         Ok(Self {

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{Debug, Display},
     future::Future,
+    num::NonZeroU32,
     pin::Pin,
     sync::Arc,
     task::{Poll, ready},
@@ -25,15 +26,83 @@ use crate::{
     turbo_tasks,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
-pub struct CellId {
-    pub type_id: ValueTypeId,
-    pub index: u32,
+/// Identifies a specific cell within a task: a [`ValueTypeId`] paired with a
+/// sequentially-allocated index within that type.
+///
+/// Packed into a single [`NonZeroU32`] to keep [`RawVc`] small:
+/// ```text
+/// bits 31..=22 (10 bits): ValueTypeId logical value, 1..=1023
+/// bits 21..=0  (22 bits): cell index, 0..=4_194_303
+/// ```
+/// Because the `ValueTypeId` is always `>= 1`, the packed word is always
+/// `>= (1 << CELL_INDEX_BITS)` and therefore never zero, which gives the type a
+/// niche (`Option<CellId>` is still 4 bytes).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
+pub struct CellId(NonZeroU32);
+
+/// Number of low bits used for the cell index.
+const CELL_INDEX_BITS: u32 = 22;
+/// Mask selecting the cell index bits.
+const CELL_INDEX_MASK: u32 = (1 << CELL_INDEX_BITS) - 1;
+
+impl CellId {
+    /// Maximum `ValueTypeId` logical value that fits in the 10-bit type field.
+    pub const MAX_VALUE_TYPE_ID: u16 = (1 << (u32::BITS - CELL_INDEX_BITS)) as u16 - 1;
+    /// Maximum cell index that fits in the 22-bit index field.
+    pub const MAX_CELL_INDEX: u32 = CELL_INDEX_MASK;
+
+    /// Packs a `type_id` and `index` into a single word.
+    ///
+    /// Panics in debug builds if `type_id` exceeds the 10-bit cap or `index`
+    /// exceeds the 22-bit cap. Those caps are enforced at the allocation sites
+    /// (`init_registry` for type ids, `find_cell_by_id` for indices).
+    pub fn new(type_id: ValueTypeId, index: u32) -> Self {
+        let type_id = *type_id;
+        debug_assert!(
+            type_id <= Self::MAX_VALUE_TYPE_ID,
+            "ValueTypeId {} exceeds the {} cap packed into CellId",
+            type_id,
+            Self::MAX_VALUE_TYPE_ID,
+        );
+        debug_assert!(
+            index <= Self::MAX_CELL_INDEX,
+            "cell index {} exceeds the {} cap packed into CellId",
+            index,
+            Self::MAX_CELL_INDEX,
+        );
+        let packed = ((type_id as u32) << CELL_INDEX_BITS) | (index & CELL_INDEX_MASK);
+        // SAFETY: `type_id >= 1`, so `packed >= (1 << CELL_INDEX_BITS) > 0`.
+        CellId(unsafe { NonZeroU32::new_unchecked(packed) })
+    }
+
+    pub fn type_id(self) -> ValueTypeId {
+        let type_id = (self.0.get() >> CELL_INDEX_BITS) as u16;
+        // SAFETY: the high bits always hold a `ValueTypeId` of `1..=1023` by construction.
+        unsafe { ValueTypeId::new_unchecked(type_id) }
+    }
+
+    pub fn index(self) -> u32 {
+        self.0.get() & CELL_INDEX_MASK
+    }
+}
+
+impl Debug for CellId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CellId")
+            .field("type_id", &self.type_id())
+            .field("index", &self.index())
+            .finish()
+    }
 }
 
 impl Display for CellId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}#{}", get_value_type(self.type_id).ty.name, self.index)
+        write!(
+            f,
+            "{}#{}",
+            get_value_type(self.type_id()).ty.name,
+            self.index()
+        )
     }
 }
 
@@ -202,7 +271,7 @@ impl RawVc {
 
     pub fn try_get_type_id(&self) -> Option<ValueTypeId> {
         match self {
-            RawVc::TaskCell(_, CellId { type_id, .. }) => Some(*type_id),
+            RawVc::TaskCell(_, cell_id) => Some(cell_id.type_id()),
             RawVc::TaskOutput(..) | RawVc::LocalOutput(..) => None,
         }
     }
@@ -212,7 +281,7 @@ impl RawVc {
     pub(crate) fn resolved_has_trait(&self, trait_id: TraitTypeId) -> bool {
         match self {
             RawVc::TaskCell(_task_id, cell_id) => {
-                get_value_type(cell_id.type_id).has_trait(&trait_id)
+                get_value_type(cell_id.type_id()).has_trait(&trait_id)
             }
             _ => unreachable!("resolved_has_trait must be called with a RawVc::TaskCell"),
         }
@@ -222,7 +291,7 @@ impl RawVc {
     /// information in `RawVc::TaskCell` (we don't actually need to read the cell!).
     pub(crate) fn resolved_is_type(&self, type_id: ValueTypeId) -> bool {
         match self {
-            RawVc::TaskCell(_task_id, cell_id) => cell_id.type_id == type_id,
+            RawVc::TaskCell(_task_id, cell_id) => cell_id.type_id() == type_id,
             _ => unreachable!("resolved_is_type must be called with a RawVc::TaskCell"),
         }
     }
@@ -541,3 +610,46 @@ impl Future for ReadRawVcFuture {
 }
 
 impl Unpin for ReadRawVcFuture {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `CellId` must pack into 4 bytes and keep its niche so `Option<CellId>`
+    /// stays 4 bytes — this is the whole point of [`RawVc`] shrinking.
+    #[test]
+    fn cell_id_is_four_bytes() {
+        assert_eq!(size_of::<CellId>(), 4);
+        assert_eq!(size_of::<Option<CellId>>(), 4);
+    }
+
+    /// Packing and unpacking a `(type_id, index)` pair must round-trip across
+    /// the full range of both fields, including the boundary values.
+    #[test]
+    fn cell_id_pack_unpack_round_trip() {
+        let type_ids = [1u16, 2, 100, CellId::MAX_VALUE_TYPE_ID];
+        let indices = [0u32, 1, 12345, CellId::MAX_CELL_INDEX];
+        for &raw_ty in &type_ids {
+            // SAFETY: all test values are >= 1.
+            let type_id = unsafe { ValueTypeId::new_unchecked(raw_ty) };
+            for &index in &indices {
+                let cell = CellId::new(type_id, index);
+                assert_eq!(cell.type_id(), type_id, "type_id round-trip for {raw_ty}");
+                assert_eq!(cell.index(), index, "index round-trip for {index}");
+            }
+        }
+    }
+
+    /// Distinct `(type_id, index)` pairs must pack to distinct words — the
+    /// packing is a bijection, which is what lets us derive `Eq`/`Hash`.
+    #[test]
+    fn cell_id_packing_is_bijective() {
+        // SAFETY: ids are >= 1.
+        let a = CellId::new(unsafe { ValueTypeId::new_unchecked(1) }, 0);
+        let b = CellId::new(unsafe { ValueTypeId::new_unchecked(1) }, 1);
+        let c = CellId::new(unsafe { ValueTypeId::new_unchecked(2) }, 0);
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -135,16 +135,23 @@ impl Display for CellId {
 ///
 /// `RawVc` is one of three logical variants (see [`RawVcUnpacked`]) bit-packed
 /// into a single [`NonZeroU64`] so that `RawVc` is 8 bytes (and `Option<RawVc>`
-/// stays 8 bytes via the niche). A 2-bit tag lives in the low bits:
+/// stays 8 bytes via the niche).
+///
+/// Bit 31 is the discriminator between a local output and a task variant; the
+/// two task variants are then told apart by whether the [`CellId`] field (the
+/// high 32 bits) is zero — which is unambiguous because every `CellId` is
+/// non-zero (its `ValueTypeId` is `>= 1`):
 ///
 /// ```text
-/// tag 0b00  TaskOutput:  tag | TaskId(30) << 2
-/// tag 0b01  TaskCell:    tag | TaskId(30) << 2 | CellId(32) << 32
-/// tag 0b10  LocalOutput: tag | transient(1) << 2 | ExecutionId(16) << 3 | LocalTaskId(32) << 19
+/// bit31 = 1                  LocalOutput: 1<<31 | transient(1) | ExecutionId(16) << 1 | LocalTaskId(32) << 32
+/// bit31 = 0, bits32..63 == 0 TaskOutput:  TaskId(31)
+/// bit31 = 0, bits32..63 != 0 TaskCell:    TaskId(31) | CellId(32) << 32
 /// ```
 ///
-/// The word is never zero: `TaskOutput`/`TaskCell` carry a `TaskId >= 1` shifted
-/// left by 2 (so `>= 4`), and `LocalOutput` always has the `0b10` tag bit set.
+/// The `TaskId` occupies bits `0..=30` (31 bits) unshifted, so a task variant's
+/// word equals its `TaskId` value (plus the cell field for `TaskCell`). The word
+/// is never zero: `TaskOutput`/`TaskCell` carry a `TaskId >= 1`, and
+/// `LocalOutput` always has bit 31 set.
 ///
 /// Construct values with [`RawVc::task_output`], [`RawVc::task_cell`], and
 /// [`RawVc::local_output`]; read them back with [`RawVc::unpack`].
@@ -179,39 +186,42 @@ pub enum RawVcUnpacked {
     LocalOutput(ExecutionId, LocalTaskId, TaskPersistence),
 }
 
-/// 2-bit tag mask.
-const RAW_VC_TAG_MASK: u64 = 0b11;
-const RAW_VC_TAG_OUTPUT: u64 = 0b00;
-const RAW_VC_TAG_CELL: u64 = 0b01;
-const RAW_VC_TAG_LOCAL: u64 = 0b10;
+/// Bit 31 discriminates `LocalOutput` (set) from the task variants (clear).
+/// It is free for the task variants because a `TaskId` is only 31 bits
+/// (`bits 0..=30`) and the `CellId` lives in the high 32 bits (`32..=63`).
+const RAW_VC_LOCAL_FLAG: u64 = 1 << 31;
 
-/// Bit width / shift of the `TaskId` value inside `TaskOutput` / `TaskCell`.
-const RAW_VC_TASK_SHIFT: u64 = 2;
+/// Mask of the `TaskId` value inside `TaskOutput` / `TaskCell` (bits `0..=30`).
 const RAW_VC_TASK_MASK: u64 = TASK_ID_MAX as u64;
-/// Shift of the packed `CellId` word inside `TaskCell`.
+/// Shift of the packed `CellId` word inside `TaskCell`. A zero high word means
+/// `TaskOutput`; a non-zero one means `TaskCell`.
 const RAW_VC_CELL_SHIFT: u64 = 32;
-/// `LocalOutput` field shifts.
-const RAW_VC_LOCAL_TRANSIENT_SHIFT: u64 = 2;
-const RAW_VC_LOCAL_EXECUTION_SHIFT: u64 = 3;
-const RAW_VC_LOCAL_TASK_SHIFT: u64 = 19;
+
+/// `LocalOutput` field layout (the `RAW_VC_LOCAL_FLAG` bit is always set).
+const RAW_VC_LOCAL_TRANSIENT_SHIFT: u64 = 0;
+const RAW_VC_LOCAL_EXECUTION_SHIFT: u64 = 1;
+const RAW_VC_LOCAL_TASK_SHIFT: u64 = 32;
 
 impl RawVc {
-    /// Packs the synchronous return value of a task.
+    /// Packs the synchronous return value of a task. The word is simply the
+    /// `TaskId` value: bit 31 clear (a task variant) and the cell field zero
+    /// (no cell).
     pub fn task_output(task: TaskId) -> Self {
         let task = *task as u64;
-        debug_assert!(task <= RAW_VC_TASK_MASK, "TaskId exceeds 30 bits");
-        Self::from_bits(RAW_VC_TAG_OUTPUT | (task << RAW_VC_TASK_SHIFT))
+        debug_assert!(task <= RAW_VC_TASK_MASK, "TaskId exceeds 31 bits");
+        Self::from_bits(task)
     }
 
-    /// Packs a pointer to a specific cell within a task.
+    /// Packs a pointer to a specific cell within a task: the `TaskId` in the low
+    /// bits and the non-zero `CellId` in the high 32 bits.
     pub fn task_cell(task: TaskId, cell: CellId) -> Self {
         let task = *task as u64;
-        debug_assert!(task <= RAW_VC_TASK_MASK, "TaskId exceeds 30 bits");
+        debug_assert!(task <= RAW_VC_TASK_MASK, "TaskId exceeds 31 bits");
         let cell = cell.raw() as u64;
-        Self::from_bits(RAW_VC_TAG_CELL | (task << RAW_VC_TASK_SHIFT) | (cell << RAW_VC_CELL_SHIFT))
+        Self::from_bits(task | (cell << RAW_VC_CELL_SHIFT))
     }
 
-    /// Packs the synchronous return value of a local task.
+    /// Packs the synchronous return value of a local task, marked by bit 31.
     pub fn local_output(
         execution_id: ExecutionId,
         local_task_id: LocalTaskId,
@@ -221,7 +231,7 @@ impl RawVc {
         let execution_id = *execution_id as u64;
         let local_task_id = *local_task_id as u64;
         Self::from_bits(
-            RAW_VC_TAG_LOCAL
+            RAW_VC_LOCAL_FLAG
                 | (transient << RAW_VC_LOCAL_TRANSIENT_SHIFT)
                 | (execution_id << RAW_VC_LOCAL_EXECUTION_SHIFT)
                 | (local_task_id << RAW_VC_LOCAL_TASK_SHIFT),
@@ -230,8 +240,9 @@ impl RawVc {
 
     #[inline]
     fn from_bits(bits: u64) -> Self {
-        // SAFETY: every constructor sets a non-zero bit — `TaskId << 2 >= 4` for
-        // the task variants, and the `0b10` tag for local outputs.
+        // SAFETY: every constructor produces a non-zero word — the task variants
+        // carry a `TaskId >= 1` in the low bits, and `LocalOutput` always sets
+        // `RAW_VC_LOCAL_FLAG`.
         RawVc(unsafe { NonZeroU64::new_unchecked(bits) })
     }
 
@@ -240,9 +251,25 @@ impl RawVc {
         self.0.get()
     }
 
+    /// The high 32 bits — the `CellId` slot. Zero for `TaskOutput`, the non-zero
+    /// packed `CellId` for `TaskCell`, and the `LocalTaskId` for `LocalOutput`.
     #[inline]
-    fn tag(self) -> u64 {
-        self.bits() & RAW_VC_TAG_MASK
+    fn cell_word(self) -> u32 {
+        (self.bits() >> RAW_VC_CELL_SHIFT) as u32
+    }
+
+    /// True for `TaskCell`: a task variant (bit 31 clear) whose cell field is
+    /// non-zero.
+    #[inline]
+    fn is_cell(self) -> bool {
+        !self.is_local() && self.cell_word() != 0
+    }
+
+    /// True for `TaskOutput`: a task variant (bit 31 clear) whose cell field is
+    /// zero.
+    #[inline]
+    fn is_output(self) -> bool {
+        !self.is_local() && self.cell_word() == 0
     }
 
     /// Reads the `TaskId` from a `TaskOutput` / `TaskCell` word.
@@ -250,7 +277,7 @@ impl RawVc {
     /// Produces a garbage value if this is a `LocalOutput` word
     #[inline]
     fn read_task_id(self) -> TaskId {
-        let id = ((self.bits() >> RAW_VC_TASK_SHIFT) & RAW_VC_TASK_MASK) as u32;
+        let id = (self.bits() & RAW_VC_TASK_MASK) as u32;
         // SAFETY: a non-zero `TaskId` was packed in by construction.
         unsafe { TaskId::new_unchecked(id) }
     }
@@ -260,40 +287,39 @@ impl RawVc {
     /// Produces a garbage value if this is a `LocalOutput` or `TaskOutput` word
     #[inline]
     fn read_cell(self) -> CellId {
-        let raw = (self.bits() >> RAW_VC_CELL_SHIFT) as u32;
         // SAFETY: a valid packed `CellId` was stored in the high 32 bits.
-        unsafe { CellId::from_raw(raw) }
+        unsafe { CellId::from_raw(self.cell_word()) }
     }
 
     /// Unpacks into the logical [`RawVcUnpacked`] enum for matching.
     pub fn unpack(self) -> RawVcUnpacked {
-        match self.tag() {
-            RAW_VC_TAG_OUTPUT => RawVcUnpacked::TaskOutput(self.read_task_id()),
-            RAW_VC_TAG_CELL => RawVcUnpacked::TaskCell(self.read_task_id(), self.read_cell()),
-            RAW_VC_TAG_LOCAL => {
-                let (execution_id, local_task_id, persistence) = self.decode_local_output();
-                RawVcUnpacked::LocalOutput(execution_id, local_task_id, persistence)
-            }
-            _ => unreachable!("invalid RawVc tag"),
+        if self.is_local() {
+            let (execution_id, local_task_id, persistence) = self.decode_local_output();
+            RawVcUnpacked::LocalOutput(execution_id, local_task_id, persistence)
+        } else if self.cell_word() != 0 {
+            RawVcUnpacked::TaskCell(self.read_task_id(), self.read_cell())
+        } else {
+            RawVcUnpacked::TaskOutput(self.read_task_id())
         }
     }
 
     /// Returns the [`TaskId`] if this is a `TaskOutput`, otherwise `None`.
     ///
     /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
-    /// the `TaskOutput` case: it reads just the tag and the task bits.
+    /// the `TaskOutput` case: it reads just the discriminator and the task bits.
     pub fn as_task_output(self) -> Option<TaskId> {
-        (self.tag() == RAW_VC_TAG_OUTPUT).then(|| self.read_task_id())
+        self.is_output().then(|| self.read_task_id())
     }
 
     /// Returns the `(TaskId, CellId)` pair if this is a `TaskCell`, otherwise
     /// `None`.
     ///
     /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
-    /// the `TaskCell` case: it reads just the tag, the task bits, and the cell
-    /// bits.
+    /// the `TaskCell` case: it reads just the discriminator, the task bits, and
+    /// the cell bits.
     pub fn as_task_cell(self) -> Option<(TaskId, CellId)> {
-        (self.tag() == RAW_VC_TAG_CELL).then(|| (self.read_task_id(), self.read_cell()))
+        self.is_cell()
+            .then(|| (self.read_task_id(), self.read_cell()))
     }
 
     /// Returns the `(ExecutionId, LocalTaskId, TaskPersistence)` triple if this
@@ -302,11 +328,11 @@ impl RawVc {
     /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
     /// the `LocalOutput` case.
     pub fn as_local_output(self) -> Option<(ExecutionId, LocalTaskId, TaskPersistence)> {
-        (self.tag() == RAW_VC_TAG_LOCAL).then(|| self.decode_local_output())
+        self.is_local().then(|| self.decode_local_output())
     }
 
-    /// Decodes the fields of a `LocalOutput` word. Only valid when the tag is
-    /// [`RAW_VC_TAG_LOCAL`].
+    /// Decodes the fields of a `LocalOutput` word. Only valid when
+    /// [`RAW_VC_LOCAL_FLAG`] is set.
     fn decode_local_output(self) -> (ExecutionId, LocalTaskId, TaskPersistence) {
         let bits = self.bits();
         let persistence = if (bits >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1 {
@@ -364,11 +390,11 @@ impl Display for RawVc {
 
 impl RawVc {
     pub fn is_resolved(&self) -> bool {
-        self.tag() == RAW_VC_TAG_CELL
+        self.is_cell()
     }
 
     pub fn is_local(&self) -> bool {
-        self.tag() == RAW_VC_TAG_LOCAL
+        self.bits() & RAW_VC_LOCAL_FLAG != 0
     }
 
     /// Returns `true` if the task this `RawVc` reads from cannot be serialized and will not be
@@ -376,10 +402,12 @@ impl RawVc {
     ///
     /// See [`TaskPersistence`] for more details.
     pub fn is_transient(&self) -> bool {
-        match self.tag() {
-            RAW_VC_TAG_OUTPUT | RAW_VC_TAG_CELL => self.read_task_id().is_transient(),
+        if self.is_local() {
             // LocalOutput: the transient flag is stored as a bit.
-            _ => (self.bits() >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1,
+            (self.bits() >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1
+        } else {
+            // TaskOutput / TaskCell: transience is a property of the TaskId value.
+            self.read_task_id().is_transient()
         }
     }
 
@@ -438,19 +466,18 @@ impl RawVc {
     }
 
     pub fn try_get_task_id(&self) -> Option<TaskId> {
-        matches!(self.tag(), RAW_VC_TAG_OUTPUT | RAW_VC_TAG_CELL).then(|| self.read_task_id())
+        (!self.is_local()).then(|| self.read_task_id())
     }
 
     pub fn try_get_type_id(&self) -> Option<ValueTypeId> {
-        (self.tag() == RAW_VC_TAG_CELL).then(|| self.read_cell().type_id())
+        self.is_cell().then(|| self.read_cell().type_id())
     }
 
     /// For a cell that's already resolved, synchronously check if it implements a trait using the
     /// type information in `RawVc::TaskCell` (we don't actually need to read the cell!).
     pub(crate) fn resolved_has_trait(&self, trait_id: TraitTypeId) -> bool {
-        debug_assert_eq!(
-            self.tag(),
-            RAW_VC_TAG_CELL,
+        debug_assert!(
+            self.is_cell(),
             "resolved_has_trait must be called with a RawVc::TaskCell"
         );
         get_value_type(self.read_cell().type_id()).has_trait(&trait_id)
@@ -459,9 +486,8 @@ impl RawVc {
     /// For a cell that's already resolved, synchronously check if it is a given type using the type
     /// information in `RawVc::TaskCell` (we don't actually need to read the cell!).
     pub(crate) fn resolved_is_type(&self, type_id: ValueTypeId) -> bool {
-        debug_assert_eq!(
-            self.tag(),
-            RAW_VC_TAG_CELL,
+        debug_assert!(
+            self.is_cell(),
             "resolved_is_type must be called with a RawVc::TaskCell"
         );
         self.read_cell().type_id() == type_id
@@ -900,5 +926,34 @@ mod tests {
                 assert_eq!(vc.as_task_cell(), None);
             }
         }
+    }
+
+    /// The discriminator relies on the cell field being zero for `TaskOutput`
+    /// and non-zero for `TaskCell`. A `TaskOutput` and a `TaskCell` that share
+    /// the same `TaskId` must still be told apart, and a `LocalOutput` whose
+    /// `LocalTaskId` populates the high bits (the cell-field region) must remain
+    /// a `LocalOutput` because bit 31 wins.
+    #[test]
+    fn raw_vc_discriminator_is_unambiguous() {
+        // SAFETY: all ids are >= 1.
+        let task = unsafe { TaskId::new_unchecked(123) };
+        let cell = CellId::new(unsafe { ValueTypeId::new_unchecked(1) }, 0);
+
+        let output = RawVc::task_output(task);
+        let task_cell = RawVc::task_cell(task, cell);
+        assert!(output.is_output() && !output.is_cell() && !output.is_local());
+        assert!(task_cell.is_cell() && !task_cell.is_output() && !task_cell.is_local());
+        // Same TaskId, different variants, distinct words.
+        assert_ne!(output, task_cell);
+        assert_eq!(output.read_task_id(), task_cell.read_task_id());
+
+        // A LocalOutput with a max LocalTaskId fills the high 32 bits; it must
+        // not be misread as a TaskCell.
+        let local = RawVc::local_output(
+            unsafe { ExecutionId::new_unchecked(u16::MAX) },
+            unsafe { LocalTaskId::new_unchecked(u32::MAX) },
+            TaskPersistence::Persistent,
+        );
+        assert!(local.is_local() && !local.is_cell() && !local.is_output());
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -285,6 +285,24 @@ impl RawVc {
             _ => unreachable!("invalid RawVc tag"),
         }
     }
+
+    /// Returns the [`TaskId`] if this is a `TaskOutput`, otherwise `None`.
+    ///
+    /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
+    /// the `TaskOutput` case: it reads just the tag and the task bits.
+    pub fn as_task_output(self) -> Option<TaskId> {
+        (self.tag() == RAW_VC_TAG_OUTPUT).then(|| self.read_task_id())
+    }
+
+    /// Returns the `(TaskId, CellId)` pair if this is a `TaskCell`, otherwise
+    /// `None`.
+    ///
+    /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
+    /// the `TaskCell` case: it reads just the tag, the task bits, and the cell
+    /// bits.
+    pub fn as_task_cell(self) -> Option<(TaskId, CellId)> {
+        (self.tag() == RAW_VC_TAG_CELL).then(|| (self.read_task_id(), self.read_cell()))
+    }
 }
 
 impl Debug for RawVc {
@@ -396,7 +414,7 @@ impl RawVc {
     }
 
     pub(crate) fn connect(&self) {
-        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
+        let Some(task_id) = self.as_task_output() else {
             panic!("RawVc::connect() must only be called on a RawVc::TaskOutput");
         };
         let tt = turbo_tasks();
@@ -437,7 +455,7 @@ impl RawVc {
 /// This implementation of `CollectiblesSource` assumes that `self` is a `RawVc::TaskOutput`.
 impl CollectiblesSource for RawVc {
     fn peek_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
-        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
+        let Some(task_id) = self.as_task_output() else {
             panic!(
                 "<RawVc as CollectiblesSource>::peek_collectibles() must only be called on a \
                  RawVc::TaskOutput"
@@ -451,7 +469,7 @@ impl CollectiblesSource for RawVc {
     }
 
     fn take_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
-        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
+        let Some(task_id) = self.as_task_output() else {
             panic!(
                 "<RawVc as CollectiblesSource>::take_collectibles() must only be called on a \
                  RawVc::TaskOutput"
@@ -466,7 +484,7 @@ impl CollectiblesSource for RawVc {
     }
 
     fn drop_collectibles<T: VcValueTrait + ?Sized>(self) {
-        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
+        let Some(task_id) = self.as_task_output() else {
             panic!(
                 "<RawVc as CollectiblesSource>::drop_collectibles() must only be called on a \
                  RawVc::TaskOutput"
@@ -700,17 +718,17 @@ impl Future for ReadRawVcFuture {
             let strongly_consistent = resolve.strongly_consistent;
             match ready!(Pin::new(resolve).poll(cx)) {
                 Err(err) => return Poll::Ready(Err(err)),
-                Ok(resolved) => match resolved.unpack() {
-                    RawVcUnpacked::TaskCell(task, index) => {
-                        this.state = ReadRawVcState::Reading {
-                            task,
-                            index,
-                            strongly_consistent,
-                            listener: None,
-                        };
-                    }
-                    _ => unreachable!("ResolveRawVcFuture always resolves to a TaskCell"),
-                },
+                Ok(resolved) => {
+                    let Some((task, index)) = resolved.as_task_cell() else {
+                        unreachable!("ResolveRawVcFuture always resolves to a TaskCell")
+                    };
+                    this.state = ReadRawVcState::Reading {
+                        task,
+                        index,
+                        strongly_consistent,
+                        listener: None,
+                    };
+                }
             }
         }
 
@@ -822,6 +840,9 @@ mod tests {
             assert!(!vc.is_resolved() && !vc.is_local());
             assert_eq!(vc.is_transient(), task.is_transient());
             assert_eq!(vc.try_get_task_id(), Some(task));
+            // single-arm accessors
+            assert_eq!(vc.as_task_output(), Some(task));
+            assert_eq!(vc.as_task_cell(), None);
 
             // TaskCell, across CellId boundaries
             for cell in [
@@ -836,6 +857,9 @@ mod tests {
                 assert!(vc.is_resolved());
                 assert_eq!(vc.try_get_task_id(), Some(task));
                 assert_eq!(vc.try_get_type_id(), Some(cell.type_id()));
+                // single-arm accessors
+                assert_eq!(vc.as_task_cell(), Some((task, cell)));
+                assert_eq!(vc.as_task_output(), None);
             }
         }
 
@@ -852,6 +876,9 @@ mod tests {
                 assert!(vc.is_local());
                 assert_eq!(vc.is_transient(), persistence == TaskPersistence::Transient);
                 assert_eq!(vc.try_get_task_id(), None);
+                // single-arm accessors reject local outputs
+                assert_eq!(vc.as_task_output(), None);
+                assert_eq!(vc.as_task_cell(), None);
             }
         }
     }

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -246,6 +246,8 @@ impl RawVc {
     }
 
     /// Reads the `TaskId` from a `TaskOutput` / `TaskCell` word.
+    ///
+    /// Produces a garbage value if this is a `LocalOutput` word
     #[inline]
     fn read_task_id(self) -> TaskId {
         let id = ((self.bits() >> RAW_VC_TASK_SHIFT) & RAW_VC_TASK_MASK) as u32;
@@ -254,6 +256,8 @@ impl RawVc {
     }
 
     /// Reads the [`CellId`] from a `TaskCell` word.
+    ///
+    /// Produces a garbage value if this is a `LocalOutput` or `TaskOutput` word
     #[inline]
     fn read_cell(self) -> CellId {
         let raw = (self.bits() >> RAW_VC_CELL_SHIFT) as u32;
@@ -263,24 +267,12 @@ impl RawVc {
 
     /// Unpacks into the logical [`RawVcUnpacked`] enum for matching.
     pub fn unpack(self) -> RawVcUnpacked {
-        let bits = self.bits();
-        match bits & RAW_VC_TAG_MASK {
+        match self.tag() {
             RAW_VC_TAG_OUTPUT => RawVcUnpacked::TaskOutput(self.read_task_id()),
             RAW_VC_TAG_CELL => RawVcUnpacked::TaskCell(self.read_task_id(), self.read_cell()),
             RAW_VC_TAG_LOCAL => {
-                let persistence = if (bits >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1 {
-                    TaskPersistence::Transient
-                } else {
-                    TaskPersistence::Persistent
-                };
-                let execution_id = ((bits >> RAW_VC_LOCAL_EXECUTION_SHIFT) & 0xFFFF) as u16;
-                let local_task_id = ((bits >> RAW_VC_LOCAL_TASK_SHIFT) & 0xFFFF_FFFF) as u32;
-                // SAFETY: non-zero `ExecutionId`/`LocalTaskId` were packed in.
-                RawVcUnpacked::LocalOutput(
-                    unsafe { ExecutionId::new_unchecked(execution_id) },
-                    unsafe { LocalTaskId::new_unchecked(local_task_id) },
-                    persistence,
-                )
+                let (execution_id, local_task_id, persistence) = self.decode_local_output();
+                RawVcUnpacked::LocalOutput(execution_id, local_task_id, persistence)
             }
             _ => unreachable!("invalid RawVc tag"),
         }
@@ -302,6 +294,34 @@ impl RawVc {
     /// bits.
     pub fn as_task_cell(self) -> Option<(TaskId, CellId)> {
         (self.tag() == RAW_VC_TAG_CELL).then(|| (self.read_task_id(), self.read_cell()))
+    }
+
+    /// Returns the `(ExecutionId, LocalTaskId, TaskPersistence)` triple if this
+    /// is a `LocalOutput`, otherwise `None`.
+    ///
+    /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
+    /// the `LocalOutput` case.
+    pub fn as_local_output(self) -> Option<(ExecutionId, LocalTaskId, TaskPersistence)> {
+        (self.tag() == RAW_VC_TAG_LOCAL).then(|| self.decode_local_output())
+    }
+
+    /// Decodes the fields of a `LocalOutput` word. Only valid when the tag is
+    /// [`RAW_VC_TAG_LOCAL`].
+    fn decode_local_output(self) -> (ExecutionId, LocalTaskId, TaskPersistence) {
+        let bits = self.bits();
+        let persistence = if (bits >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1 {
+            TaskPersistence::Transient
+        } else {
+            TaskPersistence::Persistent
+        };
+        let execution_id = ((bits >> RAW_VC_LOCAL_EXECUTION_SHIFT) & 0xFFFF) as u16;
+        let local_task_id = ((bits >> RAW_VC_LOCAL_TASK_SHIFT) & 0xFFFF_FFFF) as u32;
+        // SAFETY: non-zero `ExecutionId`/`LocalTaskId` were packed in.
+        (
+            unsafe { ExecutionId::new_unchecked(execution_id) },
+            unsafe { LocalTaskId::new_unchecked(local_task_id) },
+            persistence,
+        )
     }
 }
 
@@ -377,18 +397,16 @@ impl RawVc {
     /// Convert a potentially local `RawVc` into a non-local `RawVc`. This is a subset of resolution
     /// resolution, because the returned `RawVc` can be a `TaskOutput`.
     pub async fn to_non_local(self) -> Result<RawVc> {
-        Ok(match self.unpack() {
-            RawVcUnpacked::LocalOutput(execution_id, local_task_id, ..) => {
-                let tt = turbo_tasks();
-                let local_output = read_local_output(&*tt, execution_id, local_task_id).await?;
-                debug_assert!(
-                    !local_output.is_local(),
-                    "a LocalOutput cannot point at other LocalOutputs"
-                );
-                local_output
-            }
-            _ => self,
-        })
+        let Some((execution_id, local_task_id, ..)) = self.as_local_output() else {
+            return Ok(self);
+        };
+        let tt = turbo_tasks();
+        let local_output = read_local_output(&*tt, execution_id, local_task_id).await?;
+        debug_assert!(
+            !local_output.is_local(),
+            "a LocalOutput cannot point at other LocalOutputs"
+        );
+        Ok(local_output)
     }
 
     /// Convert a potentially local `RawVc` into a non-local `RawVc`. This is a subset of resolution
@@ -397,20 +415,18 @@ impl RawVc {
     /// 'unchecked' because the caller must have already confirmed that the local tasks were already
     /// completed
     pub(crate) fn to_non_local_unchecked_sync(self, tt: &dyn TurboTasksApi) -> Result<RawVc> {
-        Ok(match self.unpack() {
-            RawVcUnpacked::LocalOutput(execution_id, local_task_id, ..) => {
-                let local_output = match tt.try_read_local_output(execution_id, local_task_id)? {
-                    Ok(raw_vc) => raw_vc,
-                    Err(_event_listener) => unreachable!("local output is not ready yet"),
-                };
-                debug_assert!(
-                    !local_output.is_local(),
-                    "a LocalOutput cannot point at other LocalOutputs"
-                );
-                local_output
-            }
-            _ => self,
-        })
+        let Some((execution_id, local_task_id, ..)) = self.as_local_output() else {
+            return Ok(self);
+        };
+        let local_output = match tt.try_read_local_output(execution_id, local_task_id)? {
+            Ok(raw_vc) => raw_vc,
+            Err(_event_listener) => unreachable!("local output is not ready yet"),
+        };
+        debug_assert!(
+            !local_output.is_local(),
+            "a LocalOutput cannot point at other LocalOutputs"
+        );
+        Ok(local_output)
     }
 
     pub(crate) fn connect(&self) {
@@ -843,6 +859,7 @@ mod tests {
             // single-arm accessors
             assert_eq!(vc.as_task_output(), Some(task));
             assert_eq!(vc.as_task_cell(), None);
+            assert_eq!(vc.as_local_output(), None);
 
             // TaskCell, across CellId boundaries
             for cell in [
@@ -860,6 +877,7 @@ mod tests {
                 // single-arm accessors
                 assert_eq!(vc.as_task_cell(), Some((task, cell)));
                 assert_eq!(vc.as_task_output(), None);
+                assert_eq!(vc.as_local_output(), None);
             }
         }
 
@@ -876,7 +894,8 @@ mod tests {
                 assert!(vc.is_local());
                 assert_eq!(vc.is_transient(), persistence == TaskPersistence::Transient);
                 assert_eq!(vc.try_get_task_id(), None);
-                // single-arm accessors reject local outputs
+                // single-arm accessors
+                assert_eq!(vc.as_local_output(), Some((exec, local, persistence)));
                 assert_eq!(vc.as_task_output(), None);
                 assert_eq!(vc.as_task_cell(), None);
             }

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -174,6 +174,9 @@ pub enum RawVcUnpacked {
 const RAW_VC_LOCAL_FLAG: u64 = 1 << 31;
 
 /// Mask of the `TaskId` value inside `TaskOutput` / `TaskCell` (bits `0..=30`).
+///
+/// This equals `TASK_ID_MAX` because a `TaskId` is `2^31 - 1`, so its max value
+/// is also the mask of its bits. TaskId is a u32 so this cast is safe.
 const RAW_VC_TASK_MASK: u64 = TASK_ID_MAX as u64;
 /// Shift of the packed `CellId` word inside `TaskCell`. A zero high word means
 /// `TaskOutput`; a non-zero one means `TaskCell`.
@@ -943,5 +946,41 @@ mod tests {
             TaskPersistence::Persistent,
         );
         assert!(local.is_local_output() && !local.is_task_cell() && !local.is_task_output());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "TaskId exceeds 31 bits")]
+    fn task_output_panics_on_out_of_range_task_id() {
+        // `TASK_ID_MAX + 1` is the first value that sets bit 31.
+        // SAFETY: non-zero.
+        let task = unsafe { TaskId::new_unchecked(TASK_ID_MAX + 1) };
+        let _ = RawVc::task_output(task);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "TaskId exceeds 31 bits")]
+    fn task_cell_panics_on_out_of_range_task_id() {
+        // SAFETY: non-zero.
+        let task = unsafe { TaskId::new_unchecked(TASK_ID_MAX + 1) };
+        let cell = CellId::new(unsafe { ValueTypeId::new_unchecked(1) }, 0);
+        let _ = RawVc::task_cell(task, cell);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "exceeds")]
+    fn cell_id_panics_on_out_of_range_type_id() {
+        // SAFETY: `MAX_VALUE_TYPE_ID + 1` is non-zero.
+        let type_id = unsafe { ValueTypeId::new_unchecked(CellId::MAX_VALUE_TYPE_ID + 1) };
+        let _ = CellId::new(type_id, 0);
+    }
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "exceeds")]
+    fn cell_id_panics_on_out_of_range_index() {
+        let type_id = unsafe { ValueTypeId::new_unchecked(1) };
+        let _ = CellId::new(type_id, CellId::MAX_CELL_INDEX + 1);
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -29,14 +29,12 @@ use crate::{
 /// Identifies a specific cell within a task: a [`ValueTypeId`] paired with a
 /// sequentially-allocated index within that type.
 ///
-/// Packed into a single [`NonZeroU32`] to keep [`RawVc`] small:
+/// Packed into a single [`NonZeroU32`]:
 /// ```text
-/// bits 31..=22 (10 bits): ValueTypeId logical value, 1..=1023
-/// bits 21..=0  (22 bits): cell index, 0..=4_194_303
+/// bits 31..=22 (10 bits): ValueTypeId logical value
+/// bits 21..=0  (22 bits): cell index
 /// ```
-/// Because the `ValueTypeId` is always `>= 1`, the packed word is always
-/// `>= (1 << CELL_INDEX_BITS)` and therefore never zero, which gives the type a
-/// niche (`Option<CellId>` is still 4 bytes).
+/// Because the `ValueTypeId` is always `>= 1`, the type is trivially non-zero
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub struct CellId(NonZeroU32);
 
@@ -52,10 +50,6 @@ impl CellId {
     pub const MAX_CELL_INDEX: u32 = CELL_INDEX_MASK;
 
     /// Packs a `type_id` and `index` into a single word.
-    ///
-    /// Panics in debug builds if `type_id` exceeds the 10-bit cap or `index`
-    /// exceeds the 22-bit cap. Those caps are enforced at the allocation sites
-    /// (`init_registry` for type ids, `find_cell_by_id` for indices).
     pub fn new(type_id: ValueTypeId, index: u32) -> Self {
         let type_id = *type_id;
         debug_assert!(
@@ -134,36 +128,24 @@ impl Display for CellId {
 /// # Representation
 ///
 /// `RawVc` is one of three logical variants (see [`RawVcUnpacked`]) bit-packed
-/// into a single [`NonZeroU64`] so that `RawVc` is 8 bytes (and `Option<RawVc>`
-/// stays 8 bytes via the niche).
+/// into a single [`NonZeroU64`].
 ///
 /// Bit 31 is the discriminator between a local output and a task variant; the
 /// two task variants are then told apart by whether the [`CellId`] field (the
 /// high 32 bits) is zero — which is unambiguous because every `CellId` is
-/// non-zero (its `ValueTypeId` is `>= 1`):
+/// non-zero.
 ///
 /// ```text
 /// bit31 = 1                  LocalOutput: 1<<31 | transient(1) | ExecutionId(16) << 1 | LocalTaskId(32) << 32
 /// bit31 = 0, bits32..63 == 0 TaskOutput:  TaskId(31)
 /// bit31 = 0, bits32..63 != 0 TaskCell:    TaskId(31) | CellId(32) << 32
 /// ```
-///
-/// The `TaskId` occupies bits `0..=30` (31 bits) unshifted, so a task variant's
-/// word equals its `TaskId` value (plus the cell field for `TaskCell`). The word
-/// is never zero: `TaskOutput`/`TaskCell` carry a `TaskId >= 1`, and
-/// `LocalOutput` always has bit 31 set.
-///
-/// Construct values with [`RawVc::task_output`], [`RawVc::task_cell`], and
-/// [`RawVc::local_output`]; read them back with [`RawVc::unpack`].
-///
 /// [`Vc`]: crate::Vc
 /// [monomorphization]: https://doc.rust-lang.org/book/ch10-01-syntax.html#performance-of-code-using-generics
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub struct RawVc(NonZeroU64);
 
-/// The unpacked form of [`RawVc`], produced by [`RawVc::unpack`]. This mirrors
-/// the logical variants for ergonomic matching; the in-memory form is the
-/// packed [`RawVc`].
+/// The unpacked form of [`RawVc`], produced by [`RawVc::unpack`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RawVcUnpacked {
     /// The synchronous return value of a task (after argument resolution). This is the
@@ -261,15 +243,15 @@ impl RawVc {
     /// True for `TaskCell`: a task variant (bit 31 clear) whose cell field is
     /// non-zero.
     #[inline]
-    fn is_cell(self) -> bool {
-        !self.is_local() && self.cell_word() != 0
+    fn is_task_cell(self) -> bool {
+        !self.is_local_output() && self.cell_word() != 0
     }
 
     /// True for `TaskOutput`: a task variant (bit 31 clear) whose cell field is
     /// zero.
     #[inline]
-    fn is_output(self) -> bool {
-        !self.is_local() && self.cell_word() == 0
+    fn is_task_output(self) -> bool {
+        !self.is_local_output() && self.cell_word() == 0
     }
 
     /// Reads the `TaskId` from a `TaskOutput` / `TaskCell` word.
@@ -293,13 +275,17 @@ impl RawVc {
 
     /// Unpacks into the logical [`RawVcUnpacked`] enum for matching.
     pub fn unpack(self) -> RawVcUnpacked {
-        if self.is_local() {
+        if self.is_local_output() {
             let (execution_id, local_task_id, persistence) = self.decode_local_output();
             RawVcUnpacked::LocalOutput(execution_id, local_task_id, persistence)
-        } else if self.cell_word() != 0 {
-            RawVcUnpacked::TaskCell(self.read_task_id(), self.read_cell())
         } else {
-            RawVcUnpacked::TaskOutput(self.read_task_id())
+            let task_id = self.read_task_id();
+            let cell_word = self.cell_word();
+            if cell_word != 0 {
+                RawVcUnpacked::TaskCell(task_id, unsafe { CellId::from_raw(self.cell_word()) })
+            } else {
+                RawVcUnpacked::TaskOutput(task_id)
+            }
         }
     }
 
@@ -308,7 +294,7 @@ impl RawVc {
     /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
     /// the `TaskOutput` case: it reads just the discriminator and the task bits.
     pub fn as_task_output(self) -> Option<TaskId> {
-        self.is_output().then(|| self.read_task_id())
+        self.is_task_output().then(|| self.read_task_id())
     }
 
     /// Returns the `(TaskId, CellId)` pair if this is a `TaskCell`, otherwise
@@ -318,7 +304,7 @@ impl RawVc {
     /// the `TaskCell` case: it reads just the discriminator, the task bits, and
     /// the cell bits.
     pub fn as_task_cell(self) -> Option<(TaskId, CellId)> {
-        self.is_cell()
+        self.is_task_cell()
             .then(|| (self.read_task_id(), self.read_cell()))
     }
 
@@ -328,7 +314,7 @@ impl RawVc {
     /// Prefer this over [`unpack`][Self::unpack] when a caller only cares about
     /// the `LocalOutput` case.
     pub fn as_local_output(self) -> Option<(ExecutionId, LocalTaskId, TaskPersistence)> {
-        self.is_local().then(|| self.decode_local_output())
+        self.is_local_output().then(|| self.decode_local_output())
     }
 
     /// Decodes the fields of a `LocalOutput` word. Only valid when
@@ -390,10 +376,10 @@ impl Display for RawVc {
 
 impl RawVc {
     pub fn is_resolved(&self) -> bool {
-        self.is_cell()
+        self.is_task_cell()
     }
 
-    pub fn is_local(&self) -> bool {
+    pub fn is_local_output(&self) -> bool {
         self.bits() & RAW_VC_LOCAL_FLAG != 0
     }
 
@@ -402,7 +388,7 @@ impl RawVc {
     ///
     /// See [`TaskPersistence`] for more details.
     pub fn is_transient(&self) -> bool {
-        if self.is_local() {
+        if self.is_local_output() {
             // LocalOutput: the transient flag is stored as a bit.
             (self.bits() >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1
         } else {
@@ -431,7 +417,7 @@ impl RawVc {
         let tt = turbo_tasks();
         let local_output = read_local_output(&*tt, execution_id, local_task_id).await?;
         debug_assert!(
-            !local_output.is_local(),
+            !local_output.is_local_output(),
             "a LocalOutput cannot point at other LocalOutputs"
         );
         Ok(local_output)
@@ -451,7 +437,7 @@ impl RawVc {
             Err(_event_listener) => unreachable!("local output is not ready yet"),
         };
         debug_assert!(
-            !local_output.is_local(),
+            !local_output.is_local_output(),
             "a LocalOutput cannot point at other LocalOutputs"
         );
         Ok(local_output)
@@ -466,18 +452,18 @@ impl RawVc {
     }
 
     pub fn try_get_task_id(&self) -> Option<TaskId> {
-        (!self.is_local()).then(|| self.read_task_id())
+        (!self.is_local_output()).then(|| self.read_task_id())
     }
 
     pub fn try_get_type_id(&self) -> Option<ValueTypeId> {
-        self.is_cell().then(|| self.read_cell().type_id())
+        self.is_task_cell().then(|| self.read_cell().type_id())
     }
 
     /// For a cell that's already resolved, synchronously check if it implements a trait using the
     /// type information in `RawVc::TaskCell` (we don't actually need to read the cell!).
     pub(crate) fn resolved_has_trait(&self, trait_id: TraitTypeId) -> bool {
         debug_assert!(
-            self.is_cell(),
+            self.is_task_cell(),
             "resolved_has_trait must be called with a RawVc::TaskCell"
         );
         get_value_type(self.read_cell().type_id()).has_trait(&trait_id)
@@ -487,7 +473,7 @@ impl RawVc {
     /// information in `RawVc::TaskCell` (we don't actually need to read the cell!).
     pub(crate) fn resolved_is_type(&self, type_id: ValueTypeId) -> bool {
         debug_assert!(
-            self.is_cell(),
+            self.is_task_cell(),
             "resolved_is_type must be called with a RawVc::TaskCell"
         );
         self.read_cell().type_id() == type_id
@@ -879,7 +865,7 @@ mod tests {
             // TaskOutput
             let vc = RawVc::task_output(task);
             assert_eq!(vc.unpack(), RawVcUnpacked::TaskOutput(task));
-            assert!(!vc.is_resolved() && !vc.is_local());
+            assert!(!vc.is_resolved() && !vc.is_local_output());
             assert_eq!(vc.is_transient(), task.is_transient());
             assert_eq!(vc.try_get_task_id(), Some(task));
             // single-arm accessors
@@ -917,7 +903,7 @@ mod tests {
                     vc.unpack(),
                     RawVcUnpacked::LocalOutput(exec, local, persistence)
                 );
-                assert!(vc.is_local());
+                assert!(vc.is_local_output());
                 assert_eq!(vc.is_transient(), persistence == TaskPersistence::Transient);
                 assert_eq!(vc.try_get_task_id(), None);
                 // single-arm accessors
@@ -941,8 +927,10 @@ mod tests {
 
         let output = RawVc::task_output(task);
         let task_cell = RawVc::task_cell(task, cell);
-        assert!(output.is_output() && !output.is_cell() && !output.is_local());
-        assert!(task_cell.is_cell() && !task_cell.is_output() && !task_cell.is_local());
+        assert!(output.is_task_output() && !output.is_task_cell() && !output.is_local_output());
+        assert!(
+            task_cell.is_task_cell() && !task_cell.is_task_output() && !task_cell.is_local_output()
+        );
         // Same TaskId, different variants, distinct words.
         assert_ne!(output, task_cell);
         assert_eq!(output.read_task_id(), task_cell.read_task_id());
@@ -954,6 +942,6 @@ mod tests {
             unsafe { LocalTaskId::new_unchecked(u32::MAX) },
             TaskPersistence::Persistent,
         );
-        assert!(local.is_local() && !local.is_cell() && !local.is_output());
+        assert!(local.is_local_output() && !local.is_task_cell() && !local.is_task_output());
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::{Debug, Display},
     future::Future,
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroU64},
     pin::Pin,
     sync::Arc,
     task::{Poll, ready},
@@ -17,7 +17,7 @@ use crate::{
     TaskPersistence, TraitTypeId, ValueTypeId, VcValueTrait,
     backend::TypedCellContent,
     event::EventListener,
-    id::{ExecutionId, LocalTaskId},
+    id::{ExecutionId, LocalTaskId, TASK_ID_MAX},
     manager::{
         ReadCellTracking, ReadTracking, SUPPRESS_EVENTUAL_CONSISTENCY_TOP_LEVEL_TASK_CHECK,
         TurboTasksApi, read_local_output, with_turbo_tasks,
@@ -84,6 +84,23 @@ impl CellId {
     pub fn index(self) -> u32 {
         self.0.get() & CELL_INDEX_MASK
     }
+
+    /// The raw packed word, used by [`RawVc`] to pack a `TaskCell` into its u64.
+    pub(crate) fn raw(self) -> u32 {
+        self.0.get()
+    }
+
+    /// Reconstructs a `CellId` from a raw packed word produced by [`Self::raw`].
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a value previously returned by [`Self::raw`] (in
+    /// particular, non-zero with a valid 10-bit type id in the high bits).
+    pub(crate) unsafe fn from_raw(raw: u32) -> Self {
+        debug_assert!(raw != 0);
+        // SAFETY: the caller guarantees `raw` came from a valid `CellId`.
+        CellId(unsafe { NonZeroU32::new_unchecked(raw) })
+    }
 }
 
 impl Debug for CellId {
@@ -114,10 +131,34 @@ impl Display for CellId {
 /// This type is heavily used within the [`Backend`][crate::backend::Backend] trait, but should
 /// otherwise be treated as an internal implementation detail of `turbo-tasks`.
 ///
+/// # Representation
+///
+/// `RawVc` is one of three logical variants (see [`RawVcUnpacked`]) bit-packed
+/// into a single [`NonZeroU64`] so that `RawVc` is 8 bytes (and `Option<RawVc>`
+/// stays 8 bytes via the niche). A 2-bit tag lives in the low bits:
+///
+/// ```text
+/// tag 0b00  TaskOutput:  tag | TaskId(30) << 2
+/// tag 0b01  TaskCell:    tag | TaskId(30) << 2 | CellId(32) << 32
+/// tag 0b10  LocalOutput: tag | transient(1) << 2 | ExecutionId(16) << 3 | LocalTaskId(32) << 19
+/// ```
+///
+/// The word is never zero: `TaskOutput`/`TaskCell` carry a `TaskId >= 1` shifted
+/// left by 2 (so `>= 4`), and `LocalOutput` always has the `0b10` tag bit set.
+///
+/// Construct values with [`RawVc::task_output`], [`RawVc::task_cell`], and
+/// [`RawVc::local_output`]; read them back with [`RawVc::unpack`].
+///
 /// [`Vc`]: crate::Vc
 /// [monomorphization]: https://doc.rust-lang.org/book/ch10-01-syntax.html#performance-of-code-using-generics
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
-pub enum RawVc {
+pub struct RawVc(NonZeroU64);
+
+/// The unpacked form of [`RawVc`], produced by [`RawVc::unpack`]. This mirrors
+/// the logical variants for ergonomic matching; the in-memory form is the
+/// packed [`RawVc`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RawVcUnpacked {
     /// The synchronous return value of a task (after argument resolution). This is the
     /// representation used by [`OperationVc`][crate::OperationVc].
     TaskOutput(TaskId),
@@ -138,23 +179,130 @@ pub enum RawVc {
     LocalOutput(ExecutionId, LocalTaskId, TaskPersistence),
 }
 
+/// 2-bit tag mask.
+const RAW_VC_TAG_MASK: u64 = 0b11;
+const RAW_VC_TAG_OUTPUT: u64 = 0b00;
+const RAW_VC_TAG_CELL: u64 = 0b01;
+const RAW_VC_TAG_LOCAL: u64 = 0b10;
+
+/// Bit width / shift of the `TaskId` value inside `TaskOutput` / `TaskCell`.
+const RAW_VC_TASK_SHIFT: u64 = 2;
+const RAW_VC_TASK_MASK: u64 = TASK_ID_MAX as u64;
+/// Shift of the packed `CellId` word inside `TaskCell`.
+const RAW_VC_CELL_SHIFT: u64 = 32;
+/// `LocalOutput` field shifts.
+const RAW_VC_LOCAL_TRANSIENT_SHIFT: u64 = 2;
+const RAW_VC_LOCAL_EXECUTION_SHIFT: u64 = 3;
+const RAW_VC_LOCAL_TASK_SHIFT: u64 = 19;
+
+impl RawVc {
+    /// Packs the synchronous return value of a task.
+    pub fn task_output(task: TaskId) -> Self {
+        let task = *task as u64;
+        debug_assert!(task <= RAW_VC_TASK_MASK, "TaskId exceeds 30 bits");
+        Self::from_bits(RAW_VC_TAG_OUTPUT | (task << RAW_VC_TASK_SHIFT))
+    }
+
+    /// Packs a pointer to a specific cell within a task.
+    pub fn task_cell(task: TaskId, cell: CellId) -> Self {
+        let task = *task as u64;
+        debug_assert!(task <= RAW_VC_TASK_MASK, "TaskId exceeds 30 bits");
+        let cell = cell.raw() as u64;
+        Self::from_bits(RAW_VC_TAG_CELL | (task << RAW_VC_TASK_SHIFT) | (cell << RAW_VC_CELL_SHIFT))
+    }
+
+    /// Packs the synchronous return value of a local task.
+    pub fn local_output(
+        execution_id: ExecutionId,
+        local_task_id: LocalTaskId,
+        persistence: TaskPersistence,
+    ) -> Self {
+        let transient = (persistence == TaskPersistence::Transient) as u64;
+        let execution_id = *execution_id as u64;
+        let local_task_id = *local_task_id as u64;
+        Self::from_bits(
+            RAW_VC_TAG_LOCAL
+                | (transient << RAW_VC_LOCAL_TRANSIENT_SHIFT)
+                | (execution_id << RAW_VC_LOCAL_EXECUTION_SHIFT)
+                | (local_task_id << RAW_VC_LOCAL_TASK_SHIFT),
+        )
+    }
+
+    #[inline]
+    fn from_bits(bits: u64) -> Self {
+        // SAFETY: every constructor sets a non-zero bit — `TaskId << 2 >= 4` for
+        // the task variants, and the `0b10` tag for local outputs.
+        RawVc(unsafe { NonZeroU64::new_unchecked(bits) })
+    }
+
+    #[inline]
+    fn bits(self) -> u64 {
+        self.0.get()
+    }
+
+    #[inline]
+    fn tag(self) -> u64 {
+        self.bits() & RAW_VC_TAG_MASK
+    }
+
+    /// Reads the `TaskId` from a `TaskOutput` / `TaskCell` word.
+    #[inline]
+    fn read_task_id(self) -> TaskId {
+        let id = ((self.bits() >> RAW_VC_TASK_SHIFT) & RAW_VC_TASK_MASK) as u32;
+        // SAFETY: a non-zero `TaskId` was packed in by construction.
+        unsafe { TaskId::new_unchecked(id) }
+    }
+
+    /// Reads the [`CellId`] from a `TaskCell` word.
+    #[inline]
+    fn read_cell(self) -> CellId {
+        let raw = (self.bits() >> RAW_VC_CELL_SHIFT) as u32;
+        // SAFETY: a valid packed `CellId` was stored in the high 32 bits.
+        unsafe { CellId::from_raw(raw) }
+    }
+
+    /// Unpacks into the logical [`RawVcUnpacked`] enum for matching.
+    pub fn unpack(self) -> RawVcUnpacked {
+        let bits = self.bits();
+        match bits & RAW_VC_TAG_MASK {
+            RAW_VC_TAG_OUTPUT => RawVcUnpacked::TaskOutput(self.read_task_id()),
+            RAW_VC_TAG_CELL => RawVcUnpacked::TaskCell(self.read_task_id(), self.read_cell()),
+            RAW_VC_TAG_LOCAL => {
+                let persistence = if (bits >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1 {
+                    TaskPersistence::Transient
+                } else {
+                    TaskPersistence::Persistent
+                };
+                let execution_id = ((bits >> RAW_VC_LOCAL_EXECUTION_SHIFT) & 0xFFFF) as u16;
+                let local_task_id = ((bits >> RAW_VC_LOCAL_TASK_SHIFT) & 0xFFFF_FFFF) as u32;
+                // SAFETY: non-zero `ExecutionId`/`LocalTaskId` were packed in.
+                RawVcUnpacked::LocalOutput(
+                    unsafe { ExecutionId::new_unchecked(execution_id) },
+                    unsafe { LocalTaskId::new_unchecked(local_task_id) },
+                    persistence,
+                )
+            }
+            _ => unreachable!("invalid RawVc tag"),
+        }
+    }
+}
+
 impl Debug for RawVc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RawVc::TaskOutput(task_id) => f
-                .debug_tuple("RawVc::TaskOutput")
-                .field(&**task_id)
-                .finish(),
-            RawVc::TaskCell(task_id, cell_id) => f
+        match self.unpack() {
+            RawVcUnpacked::TaskOutput(task_id) => {
+                f.debug_tuple("RawVc::TaskOutput").field(&*task_id).finish()
+            }
+            RawVcUnpacked::TaskCell(task_id, cell_id) => f
                 .debug_tuple("RawVc::TaskCell")
-                .field(&**task_id)
+                .field(&*task_id)
                 .field(&cell_id.to_string())
                 .finish(),
-            RawVc::LocalOutput(execution_id, local_task_id, task_persistence) => f
+            RawVcUnpacked::LocalOutput(execution_id, local_task_id, task_persistence) => f
                 .debug_tuple("RawVc::LocalOutput")
-                .field(&**execution_id)
-                .field(&**local_task_id)
-                .field(task_persistence)
+                .field(&*execution_id)
+                .field(&*local_task_id)
+                .field(&task_persistence)
                 .finish(),
         }
     }
@@ -162,15 +310,15 @@ impl Debug for RawVc {
 
 impl Display for RawVc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RawVc::TaskOutput(task_id) => write!(f, "output of task {}", **task_id),
-            RawVc::TaskCell(task_id, cell_id) => {
-                write!(f, "{} of task {}", cell_id, **task_id)
+        match self.unpack() {
+            RawVcUnpacked::TaskOutput(task_id) => write!(f, "output of task {}", *task_id),
+            RawVcUnpacked::TaskCell(task_id, cell_id) => {
+                write!(f, "{} of task {}", cell_id, *task_id)
             }
-            RawVc::LocalOutput(execution_id, local_task_id, task_persistence) => write!(
+            RawVcUnpacked::LocalOutput(execution_id, local_task_id, task_persistence) => write!(
                 f,
                 "output of local task {} ({}, {})",
-                **local_task_id, **execution_id, task_persistence
+                *local_task_id, *execution_id, task_persistence
             ),
         }
     }
@@ -178,19 +326,11 @@ impl Display for RawVc {
 
 impl RawVc {
     pub fn is_resolved(&self) -> bool {
-        match self {
-            RawVc::TaskOutput(..) => false,
-            RawVc::TaskCell(..) => true,
-            RawVc::LocalOutput(..) => false,
-        }
+        self.tag() == RAW_VC_TAG_CELL
     }
 
     pub fn is_local(&self) -> bool {
-        match self {
-            RawVc::TaskOutput(..) => false,
-            RawVc::TaskCell(..) => false,
-            RawVc::LocalOutput(..) => true,
-        }
+        self.tag() == RAW_VC_TAG_LOCAL
     }
 
     /// Returns `true` if the task this `RawVc` reads from cannot be serialized and will not be
@@ -198,9 +338,10 @@ impl RawVc {
     ///
     /// See [`TaskPersistence`] for more details.
     pub fn is_transient(&self) -> bool {
-        match self {
-            RawVc::TaskOutput(task) | RawVc::TaskCell(task, ..) => task.is_transient(),
-            RawVc::LocalOutput(_, _, persistence) => *persistence == TaskPersistence::Transient,
+        match self.tag() {
+            RAW_VC_TAG_OUTPUT | RAW_VC_TAG_CELL => self.read_task_id().is_transient(),
+            // LocalOutput: the transient flag is stored as a bit.
+            _ => (self.bits() >> RAW_VC_LOCAL_TRANSIENT_SHIFT) & 1 == 1,
         }
     }
 
@@ -218,17 +359,17 @@ impl RawVc {
     /// Convert a potentially local `RawVc` into a non-local `RawVc`. This is a subset of resolution
     /// resolution, because the returned `RawVc` can be a `TaskOutput`.
     pub async fn to_non_local(self) -> Result<RawVc> {
-        Ok(match self {
-            RawVc::LocalOutput(execution_id, local_task_id, ..) => {
+        Ok(match self.unpack() {
+            RawVcUnpacked::LocalOutput(execution_id, local_task_id, ..) => {
                 let tt = turbo_tasks();
                 let local_output = read_local_output(&*tt, execution_id, local_task_id).await?;
                 debug_assert!(
-                    !matches!(local_output, RawVc::LocalOutput(_, _, _)),
+                    !local_output.is_local(),
                     "a LocalOutput cannot point at other LocalOutputs"
                 );
                 local_output
             }
-            non_local => non_local,
+            _ => self,
         })
     }
 
@@ -238,69 +379,65 @@ impl RawVc {
     /// 'unchecked' because the caller must have already confirmed that the local tasks were already
     /// completed
     pub(crate) fn to_non_local_unchecked_sync(self, tt: &dyn TurboTasksApi) -> Result<RawVc> {
-        Ok(match self {
-            RawVc::LocalOutput(execution_id, local_task_id, ..) => {
+        Ok(match self.unpack() {
+            RawVcUnpacked::LocalOutput(execution_id, local_task_id, ..) => {
                 let local_output = match tt.try_read_local_output(execution_id, local_task_id)? {
                     Ok(raw_vc) => raw_vc,
                     Err(_event_listener) => unreachable!("local output is not ready yet"),
                 };
                 debug_assert!(
-                    !matches!(local_output, RawVc::LocalOutput(_, _, _)),
+                    !local_output.is_local(),
                     "a LocalOutput cannot point at other LocalOutputs"
                 );
                 local_output
             }
-            non_local => non_local,
+            _ => self,
         })
     }
 
     pub(crate) fn connect(&self) {
-        let RawVc::TaskOutput(task_id) = self else {
+        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
             panic!("RawVc::connect() must only be called on a RawVc::TaskOutput");
         };
         let tt = turbo_tasks();
-        tt.connect_task(*task_id);
+        tt.connect_task(task_id);
     }
 
     pub fn try_get_task_id(&self) -> Option<TaskId> {
-        match self {
-            RawVc::TaskOutput(t) | RawVc::TaskCell(t, ..) => Some(*t),
-            RawVc::LocalOutput(..) => None,
-        }
+        matches!(self.tag(), RAW_VC_TAG_OUTPUT | RAW_VC_TAG_CELL).then(|| self.read_task_id())
     }
 
     pub fn try_get_type_id(&self) -> Option<ValueTypeId> {
-        match self {
-            RawVc::TaskCell(_, cell_id) => Some(cell_id.type_id()),
-            RawVc::TaskOutput(..) | RawVc::LocalOutput(..) => None,
-        }
+        (self.tag() == RAW_VC_TAG_CELL).then(|| self.read_cell().type_id())
     }
 
     /// For a cell that's already resolved, synchronously check if it implements a trait using the
     /// type information in `RawVc::TaskCell` (we don't actually need to read the cell!).
     pub(crate) fn resolved_has_trait(&self, trait_id: TraitTypeId) -> bool {
-        match self {
-            RawVc::TaskCell(_task_id, cell_id) => {
-                get_value_type(cell_id.type_id()).has_trait(&trait_id)
-            }
-            _ => unreachable!("resolved_has_trait must be called with a RawVc::TaskCell"),
-        }
+        debug_assert_eq!(
+            self.tag(),
+            RAW_VC_TAG_CELL,
+            "resolved_has_trait must be called with a RawVc::TaskCell"
+        );
+        get_value_type(self.read_cell().type_id()).has_trait(&trait_id)
     }
 
     /// For a cell that's already resolved, synchronously check if it is a given type using the type
     /// information in `RawVc::TaskCell` (we don't actually need to read the cell!).
     pub(crate) fn resolved_is_type(&self, type_id: ValueTypeId) -> bool {
-        match self {
-            RawVc::TaskCell(_task_id, cell_id) => cell_id.type_id() == type_id,
-            _ => unreachable!("resolved_is_type must be called with a RawVc::TaskCell"),
-        }
+        debug_assert_eq!(
+            self.tag(),
+            RAW_VC_TAG_CELL,
+            "resolved_is_type must be called with a RawVc::TaskCell"
+        );
+        self.read_cell().type_id() == type_id
     }
 }
 
 /// This implementation of `CollectiblesSource` assumes that `self` is a `RawVc::TaskOutput`.
 impl CollectiblesSource for RawVc {
     fn peek_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
-        let RawVc::TaskOutput(task_id) = self else {
+        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
             panic!(
                 "<RawVc as CollectiblesSource>::peek_collectibles() must only be called on a \
                  RawVc::TaskOutput"
@@ -314,7 +451,7 @@ impl CollectiblesSource for RawVc {
     }
 
     fn take_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
-        let RawVc::TaskOutput(task_id) = self else {
+        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
             panic!(
                 "<RawVc as CollectiblesSource>::take_collectibles() must only be called on a \
                  RawVc::TaskOutput"
@@ -329,7 +466,7 @@ impl CollectiblesSource for RawVc {
     }
 
     fn drop_collectibles<T: VcValueTrait + ?Sized>(self) {
-        let RawVc::TaskOutput(task_id) = self else {
+        let RawVcUnpacked::TaskOutput(task_id) = self.unpack() else {
             panic!(
                 "<RawVc as CollectiblesSource>::drop_collectibles() must only be called on a \
                  RawVc::TaskOutput"
@@ -421,8 +558,8 @@ impl Future for ResolveRawVcFuture {
         let poll_fn = |tt: &Arc<dyn TurboTasksApi>| -> Poll<Self::Output> {
             'outer: loop {
                 ready!(poll_listener(&mut this.listener, cx));
-                let listener = match this.current {
-                    RawVc::TaskOutput(task) => {
+                let listener = match this.current.unpack() {
+                    RawVcUnpacked::TaskOutput(task) => {
                         let read_result = tt.try_read_task_output(task, this.read_output_options);
                         match read_result {
                             Ok(Ok(vc)) => {
@@ -442,8 +579,8 @@ impl Future for ResolveRawVcFuture {
                             Err(err) => return Poll::Ready(Err(err)),
                         }
                     }
-                    RawVc::TaskCell(_, _) => return Poll::Ready(Ok(this.current)),
-                    RawVc::LocalOutput(execution_id, local_task_id, ..) => {
+                    RawVcUnpacked::TaskCell(_, _) => return Poll::Ready(Ok(this.current)),
+                    RawVcUnpacked::LocalOutput(execution_id, local_task_id, ..) => {
                         debug_assert_eq!(
                             this.read_output_options.consistency,
                             ReadConsistency::Eventual
@@ -563,15 +700,17 @@ impl Future for ReadRawVcFuture {
             let strongly_consistent = resolve.strongly_consistent;
             match ready!(Pin::new(resolve).poll(cx)) {
                 Err(err) => return Poll::Ready(Err(err)),
-                Ok(RawVc::TaskCell(task, index)) => {
-                    this.state = ReadRawVcState::Reading {
-                        task,
-                        index,
-                        strongly_consistent,
-                        listener: None,
-                    };
-                }
-                Ok(_) => unreachable!("ResolveRawVcFuture always resolves to a TaskCell"),
+                Ok(resolved) => match resolved.unpack() {
+                    RawVcUnpacked::TaskCell(task, index) => {
+                        this.state = ReadRawVcState::Reading {
+                            task,
+                            index,
+                            strongly_consistent,
+                            listener: None,
+                        };
+                    }
+                    _ => unreachable!("ResolveRawVcFuture always resolves to a TaskCell"),
+                },
             }
         }
 
@@ -651,5 +790,69 @@ mod tests {
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(b, c);
+    }
+
+    /// `RawVc` must pack into 8 bytes and keep its niche.
+    #[test]
+    fn raw_vc_is_eight_bytes() {
+        assert_eq!(size_of::<RawVc>(), 8);
+        assert_eq!(size_of::<Option<RawVc>>(), 8);
+    }
+
+    /// Every variant must round-trip through pack → `unpack()` across the full
+    /// range of each packed field, including boundary values and both
+    /// persistence states. This is the core correctness property of the
+    /// bit-packing.
+    #[test]
+    fn raw_vc_pack_unpack_round_trip() {
+        // SAFETY: all ids below are >= 1 and within their bit budgets.
+        let tasks = [
+            1u32,
+            2,
+            crate::TRANSIENT_TASK_BIT - 1,
+            crate::TRANSIENT_TASK_BIT,
+            TASK_ID_MAX,
+        ];
+        for &t in &tasks {
+            let task = unsafe { TaskId::new_unchecked(t) };
+
+            // TaskOutput
+            let vc = RawVc::task_output(task);
+            assert_eq!(vc.unpack(), RawVcUnpacked::TaskOutput(task));
+            assert!(!vc.is_resolved() && !vc.is_local());
+            assert_eq!(vc.is_transient(), task.is_transient());
+            assert_eq!(vc.try_get_task_id(), Some(task));
+
+            // TaskCell, across CellId boundaries
+            for cell in [
+                CellId::new(unsafe { ValueTypeId::new_unchecked(1) }, 0),
+                CellId::new(
+                    unsafe { ValueTypeId::new_unchecked(CellId::MAX_VALUE_TYPE_ID) },
+                    CellId::MAX_CELL_INDEX,
+                ),
+            ] {
+                let vc = RawVc::task_cell(task, cell);
+                assert_eq!(vc.unpack(), RawVcUnpacked::TaskCell(task, cell));
+                assert!(vc.is_resolved());
+                assert_eq!(vc.try_get_task_id(), Some(task));
+                assert_eq!(vc.try_get_type_id(), Some(cell.type_id()));
+            }
+        }
+
+        // LocalOutput, both persistence states and boundary ids
+        for persistence in [TaskPersistence::Persistent, TaskPersistence::Transient] {
+            for (e, l) in [(1u16, 1u32), (u16::MAX, u32::MAX)] {
+                let exec = unsafe { ExecutionId::new_unchecked(e) };
+                let local = unsafe { LocalTaskId::new_unchecked(l) };
+                let vc = RawVc::local_output(exec, local, persistence);
+                assert_eq!(
+                    vc.unpack(),
+                    RawVcUnpacked::LocalOutput(exec, local, persistence)
+                );
+                assert!(vc.is_local());
+                assert_eq!(vc.is_transient(), persistence == TaskPersistence::Transient);
+                assert_eq!(vc.try_get_task_id(), None);
+            }
+        }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -15,8 +15,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(debug_assertions)]
 use crate::debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString};
 use crate::{
-    RawVc, RawVcUnpacked, Upcast, UpcastStrict, VcRead, VcTransparentRead, VcValueTrait,
-    VcValueType,
+    RawVc, Upcast, UpcastStrict, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
     trace::{TraceRawVcs, TraceRawVcsContext},
     vc::Vc,
 };
@@ -369,7 +368,7 @@ where
     type Error = anyhow::Error;
 
     fn try_from(raw: RawVc) -> Result<Self> {
-        if !matches!(raw.unpack(), RawVcUnpacked::TaskCell(..)) {
+        if raw.as_task_cell().is_none() {
             anyhow::bail!("Given RawVc {raw:?} is not a TaskCell");
         }
         Ok(Self {

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(debug_assertions)]
 use crate::debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString};
 use crate::{
-    RawVc, Upcast, UpcastStrict, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
+    RawVc, RawVcUnpacked, Upcast, UpcastStrict, VcRead, VcTransparentRead, VcValueTrait,
+    VcValueType,
     trace::{TraceRawVcs, TraceRawVcsContext},
     vc::Vc,
 };
@@ -368,7 +369,7 @@ where
     type Error = anyhow::Error;
 
     fn try_from(raw: RawVc) -> Result<Self> {
-        if !matches!(raw, RawVc::TaskCell(..)) {
+        if !matches!(raw.unpack(), RawVcUnpacked::TaskCell(..)) {
             anyhow::bail!("Given RawVc {raw:?} is not a TaskCell");
         }
         Ok(Self {


### PR DESCRIPTION
### What?

Shrink `RawVc` (16 → **8 bytes**) and `CellId` (6 → **4 bytes**), by hand-packing them into `NonZero` integers.

### Why?

`RawVc` is the type-erased representation behind every `Vc` / `ResolvedVc` / `OperationVc`, and `CellId` keys every task cell. They live in huge numbers in the cache keys and task storage to track cells. Cutting `RawVc` in half and `CellId` by a third removes hundreds of megabytes of peak RSS on a real, large app.

### How?

| Type      | Before   | After    | Representation |
|-----------|----------|----------|----------------|
| `CellId`  | 6 bytes  | **4 bytes** | `NonZeroU32`: `ValueTypeId` in the top 10 bits, cell index in the low 22 bits |
| `RawVc`   | 16 bytes | **8 bytes** | `NonZeroU64`; bit 31 flags `LocalOutput`, and the two task variants are split by whether the high-32-bit `CellId` field is zero |


Supporting changes:

- **`TaskId` constrained to 31 bits**
- **`ValueTypeId` capped at 1023** (10 bits) and **cell index capped at ~4.19M** (22 bits), enforced at the registry and cell-allocation sites.

Together those restrictions enable us to preserve a bit to use as a discreminent in RawVc and pack `CellId` into a u32

### Perf

Building vercel-site, 5 runs each. `maxRSS` and `user CPU` are means; `wall` is the median
| Condition | Branch | maxRSS | wall (s) | user CPU (s) |
|---|---|---|---|---|
| No persistence | canary | 13.64 GiB | 41.56 | 305.64 |
| No persistence | **this PR** | **13.04 GiB** | 40.72 | 299.52 |
| | | **−4.4%** | −2.0% | −2.0% |
| Persistence | canary | 17.19 GiB | 55.20 | 466.54 |
| Persistence | **this PR** | **16.30 GiB** | 55.12 | 462.33 |
| | | **−5.2%** | −0.1% | −0.9% |


<!-- NEXT_JS_LLM_PR -->




