### PR TITLE
Fix sandbox timeout memory leak causing stepwise heap growth

### DIFF
--- a/packages/next/src/server/web/sandbox/resource-managers.test.ts
+++ b/packages/next/src/server/web/sandbox/resource-managers.test.ts
@@ -1,0 +1,70 @@
+import { timeoutsManager } from './resource-managers'
+
+describe('sandbox resource managers', () => {
+  afterEach(() => {
+    timeoutsManager.removeAll()
+  })
+
+  it('does not retain one-shot timeouts after they run', async () => {
+    const context = {}
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+
+    try {
+      await Promise.all(
+        [0, 1, 2].map(
+          () =>
+            new Promise<void>((resolve) => {
+              timeoutsManager.add([context, resolve, 0] as any)
+            })
+        )
+      )
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(3)
+
+      timeoutsManager.removeAll()
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(3)
+    } finally {
+      clearTimeoutSpy.mockRestore()
+    }
+  })
+
+  it('clears timeouts when they are removed explicitly', () => {
+    const context = {}
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+    const timeout = timeoutsManager.add([context, () => {}, 1000] as any)
+
+    try {
+      timeoutsManager.remove(timeout)
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timeout)
+    } finally {
+      clearTimeoutSpy.mockRestore()
+    }
+  })
+
+  it('preserves timeout callback arguments that are functions', async () => {
+    const context = {}
+    const callbackArg = () => 'value'
+    const callback = jest.fn(function (this: unknown, arg: () => string) {
+      expect(this).toBe(context)
+      expect(arg).toBe(callbackArg)
+      expect(arg()).toBe('value')
+    })
+
+    await new Promise<void>((resolve) => {
+      timeoutsManager.add([
+        context,
+        function (this: unknown, ...args: Parameters<typeof callback>) {
+          callback.apply(this, args)
+          resolve()
+        },
+        0,
+        callbackArg,
+      ] as any)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/next/src/server/web/sandbox/resource-managers.ts
+++ b/packages/next/src/server/web/sandbox/resource-managers.ts
@@ -1,23 +1,29 @@
 abstract class ResourceManager<T, Args> {
-  private resources: T[] = []
+  private resources = new Set<T>()
 
   abstract create(resourceArgs: Args): T
   abstract destroy(resource: T): void
 
   add(resourceArgs: Args) {
     const resource = this.create(resourceArgs)
-    this.resources.push(resource)
+    this.resources.add(resource)
     return resource
   }
 
   remove(resource: T) {
-    this.resources = this.resources.filter((r) => r !== resource)
+    this.release(resource)
     this.destroy(resource)
   }
 
   removeAll() {
-    this.resources.forEach(this.destroy)
-    this.resources = []
+    for (const resource of this.resources) {
+      this.destroy(resource)
+    }
+    this.resources.clear()
+  }
+
+  protected release(resource: T) {
+    this.resources.delete(resource)
   }
 }
 
@@ -40,8 +46,24 @@ class TimeoutsManager extends ResourceManager<
   Parameters<typeof webSetTimeoutPolyfill>
 > {
   create(args: Parameters<typeof webSetTimeoutPolyfill>) {
+    const [globalObject, callback, ms, ...timerArgs] = args
+    const manager = this
+    let timeout: number
+
     // TODO: use the edge runtime provided `setTimeout` instead
-    return webSetTimeoutPolyfill(...args)
+    timeout = webSetTimeoutPolyfill(
+      globalObject,
+      function (this: GlobalObject, ...callbackArgs) {
+        try {
+          return callback.apply(this, callbackArgs)
+        } finally {
+          manager.release(timeout)
+        }
+      },
+      ms,
+      ...timerArgs
+    )
+    return timeout
   }
 
   destroy(timeout: number) {


### PR DESCRIPTION
Fixes #95094

## What?

Fix a sandbox timer memory leak where naturally completed one-shot timeouts stay
tracked by Next.js after their callback runs.

In long-lived standalone/self-hosted processes, this can accumulate timeout ids
across middleware/proxy requests, producing step-like heap growth over time and
eventually contributing to OOM under sustained traffic.

Reproduction: https://github.com/berry95/next-timeout-resource-leak-repro

This changes the sandbox `ResourceManager` backing store from an array to a
`Set`, and makes `TimeoutsManager` remove a timeout from the tracked resource
set in a `finally` block after the timeout callback completes.

The existing `clearTimeout(timeout)` call inside `webSetTimeoutPolyfill` is kept.
That call works around the Node.js timer primitive leak described in
nodejs/node#53335. This PR fixes the separate Next.js resource-manager tracking
leak.

Background: the sandbox resource managers were introduced in #57235 to avoid
retaining old Edge runtime VM contexts during dev HMR by taking ownership of
timers and clearing them when a module context is invalidated. That covered
module-context teardown, but one-shot timeouts that complete naturally also need
to release themselves from the manager while the module context remains alive.

## Why?

Next.js installs sandbox-specific timer polyfills for middleware and edge
function execution:

1. `context.setTimeout` calls `timeoutsManager.add([context, ...args])`.
2. `ResourceManager.add()` stores the returned timeout id so it can be cleaned up
   when the sandbox module context is cleared.
3. A one-shot timeout may complete naturally without user code ever calling
   `clearTimeout(id)`.
4. Before this change, natural completion cleared the underlying Node timer but
   did not remove the timeout id from `TimeoutsManager`'s tracked resources.

In a long-lived sandbox module context, such as a self-hosted/standalone server
running middleware in a container, each naturally completed one-shot timeout
could leave its id behind until the module context was cleared or the process
restarted. Middleware code and its dependencies commonly treat `setTimeout` as a
fire-and-forget one-shot primitive, so they often do not keep the id or call
`clearTimeout()`.

Under sustained traffic this can make the tracked timeout resources grow
monotonically. The production symptom is step-like heap growth over time, and in
high-throughput long-lived processes this can contribute to an eventual OOM.

The affected path is the web sandbox used by middleware/proxy and edge function
execution. This was observed with Pages Router middleware in a standalone
self-hosted deployment, but the underlying issue is not Pages Router-specific:
any sandboxed runtime code that creates one-shot timeouts without explicitly
clearing them can hit the same tracking behavior.

## How?

- Use `Set<T>` for tracked resources because the manager tracks a live resource
  set, not an ordered list.
- Add `ResourceManager.release()` to remove a resource without destroying it.
- Wrap timeout callbacks in `TimeoutsManager.create()` so naturally completed
  one-shot timeouts release their id after callback execution.
- Preserve explicit `clearTimeout()` behavior through `TimeoutsManager.remove()`.
- Preserve timeout callback `this` binding and variadic callback arguments.

## Tests

- `pnpm prettier --check packages/next/src/server/web/sandbox/resource-managers.ts packages/next/src/server/web/sandbox/resource-managers.test.ts`
- `pnpm jest packages/next/src/server/web/sandbox/resource-managers.test.ts --runInBand`
- `pnpm --filter next typescript`
- `pnpm --filter next build`

The regression test verifies that completed one-shot timeouts are no longer
retained by checking that `removeAll()` does not clear already completed
timeouts again. This fails with the previous implementation because completed
timeout ids remain in the resource manager.

<!-- NEXT_JS_LLM_PR -->
