### PR TITLE
Revert "Avoid a premature Suspense fallback flash in the streaming dev render"

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -89,15 +89,6 @@ type SpaFetchServerResponseResult = {
   runtimePrefetchStream: ReadableStream<Uint8Array> | null
   responseHeaders: Headers
   debugInfo: Array<any> | null
-  /**
-   * Dev only: resolves once the server has flushed the shell-stage content to
-   * the stream (or earlier, on a cache miss). The navigation defers revealing
-   * the response (resolving its deferred RSCs) until this settles, so React
-   * doesn't render a boundary's children before their row has been decoded and
-   * commit a premature Suspense fallback. `null` outside the streaming dev
-   * render.
-   */
-  revealAfter: Promise<void> | null
 }
 
 type MpaFetchServerResponseResult = string
@@ -310,7 +301,6 @@ export async function fetchServerResponse(
       runtimePrefetchStream: flightResponse.p ?? null,
       responseHeaders: res.headers,
       debugInfo: flightResponsePromise._debugInfo ?? null,
-      revealAfter: flightResponse._revealAfter ?? null,
     }
   } catch (err) {
     // If the fetch rejected due to a network error, wait for connectivity

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1802,8 +1802,7 @@ async function fetchMissingDynamicData(
       seed.data,
       seed.head,
       dynamicStaleAt,
-      result.debugInfo,
-      result.revealAfter
+      result.debugInfo
     )
 
     return {
@@ -1831,18 +1830,11 @@ function writeDynamicDataIntoNavigationTask(
   dynamicData: CacheNodeSeedData | null,
   dynamicHead: HeadData,
   dynamicStaleAt: number,
-  debugInfo: Array<any> | null,
-  revealAfter: Promise<void> | null
+  debugInfo: Array<any> | null
 ): boolean {
   if (task.status === NavigationTaskStatus.Pending && dynamicData !== null) {
     task.status = NavigationTaskStatus.Fulfilled
-    finishPendingCacheNode(
-      task.node,
-      dynamicData,
-      dynamicHead,
-      debugInfo,
-      revealAfter
-    )
+    finishPendingCacheNode(task.node, dynamicData, dynamicHead, debugInfo)
 
     // Update the BFCache entry's staleAt for this segment with the value
     // from the dynamic response. This applies the per-page
@@ -1901,8 +1893,7 @@ function writeDynamicDataIntoNavigationTask(
                 dynamicDataChild,
                 dynamicHead,
                 dynamicStaleAt,
-                debugInfo,
-                revealAfter
+                debugInfo
               )
             if (childDidReceiveUnknownParallelRoute) {
               didReceiveUnknownParallelRoute = true
@@ -1925,8 +1916,7 @@ function finishPendingCacheNode(
   cacheNode: CacheNode,
   dynamicData: CacheNodeSeedData,
   dynamicHead: HeadData,
-  debugInfo: Array<any> | null,
-  revealAfter: Promise<void> | null
+  debugInfo: Array<any> | null
 ): void {
   // Writes a dynamic response into an existing Cache Node tree. This does _not_
   // create a new tree, it updates the existing tree in-place. So it must follow
@@ -1959,21 +1949,7 @@ function finishPendingCacheNode(
     // This is a deferred RSC promise. We can fulfill it with the data we just
     // received from the server. If it was already resolved by a different
     // navigation, then this does nothing because we can't overwrite data.
-    //
-    // In the streaming dev render, defer the fill until `revealAfter` settles,
-    // so React doesn't render the boundary's children before their row has been
-    // decoded (otherwise it suspends on the still-pending children and commits
-    // a premature fallback). Outside that render `revealAfter` is null and we
-    // resolve immediately.
-    if (revealAfter !== null) {
-      const resolveRsc = () => rsc.resolve(dynamicSegmentData, debugInfo)
-      // Use the same callback for both outcomes: we don't expect `revealAfter`
-      // to reject, but if it ever did (e.g. a connection drop mid-stream) we'd
-      // still want to resolve the RSC.
-      revealAfter.then(resolveRsc, resolveRsc)
-    } else {
-      rsc.resolve(dynamicSegmentData, debugInfo)
-    }
+    rsc.resolve(dynamicSegmentData, debugInfo)
   } else {
     // This is not a deferred RSC promise, nor is it empty, so it must have
     // been populated by a different navigation. We must not overwrite it.

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -578,21 +578,6 @@ async function navigateToUnknownRoute(
     }
   }
 
-  // In the streaming dev render, this single response's seed content may still
-  // be streaming when we build the tree below. An unknown-route navigation
-  // places that content inline (it has no prior cache entry, so the server
-  // sends a full seed rather than the dynamic-only delta a known route gets),
-  // and that inline content is not gated like a known route's deferred RSCs. So
-  // React could read a still-pending chunk and flash a Suspense fallback
-  // (wanted on a cold cache, but not on a warm one). Wait for the shell to
-  // flush (`revealAfter`) first, so the inline seed content is decoded by the
-  // time React reads it, the same way the known-route path gates its deferred
-  // RSCs. `revealAfter` is null outside the streaming dev render. On a cache
-  // miss it resolves early, so the cold-cache fallback is still shown.
-  if (result.revealAfter !== null) {
-    await result.revealAfter
-  }
-
   return navigateToKnownRoute(
     now,
     state,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1341,27 +1341,23 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     // load: plain navigations, and HMR refreshes (a fresh render of the current
     // page, with no settled prefetch to draw on). Dynamic content always
     // streams in after the shell.
-    const revealAfterStage =
+    const streamReleaseStage =
       initialRequestStore.isHmrRefresh !== true &&
       (await anySegmentHasRuntimePrefetchEnabled(loaderTree))
         ? RenderStage.Runtime
         : RenderStage.Static
 
-    const result = await stagedRenderWithCachesInDev({
+    const result = await stagedRenderWithCachesInDev(
       ctx,
-      requestStore: initialRequestStore,
+      initialRequestStore,
       createRequestStore,
       getPayload,
       onError,
       shouldValidate,
-      fallbackRouteParams: fallbackParams,
-      getDevRenderDidError: () => didErrorObservably,
-      revealAfterStage,
-      // This stream goes to the browser, which gates revealing the response on
-      // the payload's `_revealAfter`, so release it live and let the browser
-      // process chunks as they arrive instead of holding it server-side.
-      holdStreamUntilRevealed: false,
-    })
+      fallbackParams,
+      () => didErrorObservably,
+      streamReleaseStage
+    )
     stream = result.stream
     debugChannel = result.debugChannel
   } else {
@@ -3369,24 +3365,19 @@ async function renderToStream(
           !isBypassingCachesInDev(requestStore, workStore)
         ) {
           const { stream: serverStream, debugChannel: returnedDebugChannel } =
-            await stagedRenderWithCachesInDev({
+            await stagedRenderWithCachesInDev(
               ctx,
               requestStore,
               createRequestStore,
               getPayload,
-              onError: serverComponentsErrorHandler,
-              shouldValidate: true,
-              fallbackRouteParams: fallbackParams,
-              getDevRenderDidError: () => didErrorObservably,
+              serverComponentsErrorHandler,
+              true,
+              fallbackParams,
+              () => didErrorObservably,
               // An initial HTML load serves the static shell; runtime and
               // dynamic content stream in afterward.
-              revealAfterStage: RenderStage.Static,
-              // Hold the stream until the shell content has flushed so the
-              // streamed HTML reflects the prerendered shell rather than a
-              // premature shell-stage Suspense fallback (see
-              // `holdStreamUntilRevealed`).
-              holdStreamUntilRevealed: true,
-            })
+              RenderStage.Static
+            )
 
           reactServerResult = new ReactServerResult(serverStream)
 
@@ -4541,24 +4532,6 @@ function getEnvironmentNameForStage(stage: RenderStage) {
   }
 }
 
-// The rendering context and reveal config that `stagedRenderWithCachesInDev`
-// forwards to `streamStagedRenderInDev`.
-interface StagedDevRenderOptions {
-  ctx: AppRenderContext
-  requestStore: RequestStore
-  onError: (error: unknown) => void
-  revealAfterStage: RenderStage.Static | RenderStage.Runtime
-  holdStreamUntilRevealed: boolean
-}
-
-interface StreamStagedRenderInDevOptions extends StagedDevRenderOptions {
-  rscPayload: RSCPayload
-  stageController: StagedRenderingController
-  cacheSignal: CacheSignal
-  environmentName: () => string
-  debugChannel: NodeDebugChannelPair | undefined
-}
-
 /**
  * Streams a staged dev render to completion without ever abandoning it, so it
  * streams progressively and fills caches as a side effect. Resolves as soon as
@@ -4572,55 +4545,42 @@ interface StreamStagedRenderInDevOptions extends StagedDevRenderOptions {
  * reading the whole stream anyway; the same accumulation feeds validation when
  * the render turns out to be prod-representative.
  */
-async function streamStagedRenderInDev({
-  ctx,
-  requestStore,
-  rscPayload,
-  stageController,
-  cacheSignal,
-  environmentName,
-  onError,
-  debugChannel,
-  revealAfterStage,
-  holdStreamUntilRevealed,
-}: StreamStagedRenderInDevOptions): Promise<{
+async function streamStagedRenderInDev(
+  ctx: AppRenderContext,
+  requestStore: RequestStore,
+  rscPayload: RSCPayload,
+  stageController: StagedRenderingController,
+  cacheSignal: CacheSignal,
+  environmentName: () => string,
+  onError: (error: unknown) => void,
+  debugChannel: NodeDebugChannelPair | undefined,
+  streamReleaseStage: RenderStage.Static | RenderStage.Runtime
+): Promise<{
   stream: Readable
   resultPromise: Promise<StagedDevRenderResult>
 }> {
   const { ComponentMod } = ctx.renderOpts
   const { clientModules } = getClientReferenceManifest()
 
-  // The first task creates the stream; `streamReady` carries it (and its chunk
-  // accumulation) out of that task into the function body below.
+  // The first task creates the stream; `streamReady` carries it out of that
+  // task. `streamReleased` resolves when the stream may be handed to the
+  // caller: once the render has buffered the `streamReleaseStage` content (the static
+  // shell, or the runtime-prefetchable shell for runtime-prefetch routes) so we
+  // don't flush a premature Suspense fallback into the shell - or earlier, on a
+  // cache miss, since then there's nothing prod-representative to wait for. We
+  // await both before returning.
   const streamReady = createPromiseWithResolvers<{
     stream: Readable
     accumulatedChunksPromise: Promise<AccumulatedStreamChunks>
   }>()
-
-  // `revealAfter` resolves once the `revealAfterStage` content has flushed (or
-  // earlier on a cache miss). When streaming live (a client navigation), it's
-  // surfaced through the Flight payload as `_revealAfter`: the client decodes
-  // it and defers resolving the response's deferred RSCs on it (see
-  // `ppr-navigations`), so a Suspense boundary's children aren't revealed
-  // before their row has been decoded, which would flush a premature fallback.
-  // React serializes the promise as a pending row whose resolution row is
-  // emitted only when we resolve it here, and that row follows the children's
-  // row in the payload, so the children are already decoded by the time the
-  // client unblocks. The HTML (Fizz) render can't gate like this, so we don't
-  // surface the promise on its payload and instead hold the whole stream on
-  // `revealAfter` for it (see `holdStreamUntilRevealed` below).
-  const revealAfter = createPromiseWithResolvers<void>()
-  if (!holdStreamUntilRevealed) {
-    ;(rscPayload as InitialRSCPayload | NavigationFlightResponse)._revealAfter =
-      revealAfter.promise
-  }
+  const streamReleased = createPromiseWithResolvers<void>()
 
   let startTime = -Infinity
 
   // Whether any stage boundary still had pending cache reads (or modules): i.e.
   // the caches weren't filled yet and the render streamed Suspense fallbacks
   // for content that would be cached in production. Returns the running verdict
-  // so each boundary can reveal the shell as soon as a miss is seen.
+  // so each boundary can release the stream as soon as a miss is seen.
   let hadCacheMiss = false
   const checkForCacheMiss = () => {
     if (cacheSignal.hasPendingReads()) {
@@ -4639,10 +4599,9 @@ async function streamStagedRenderInDev({
   // The render runs to completion; it never aborts. The first task starts the
   // render in the `ShellEarlyStatic` stage and creates the stream (one replay
   // for the response, one to accumulate the chunks). The later tasks advance
-  // the stages, settle `hadCacheMiss`, and reveal the shell – as soon as a
-  // cache miss is seen, or once the render reaches `revealAfterStage` – then
-  // advance into the dynamic stage a task later. The replayable stays local:
-  // the response is the only reader outside this function.
+  // the stages, settle `hadCacheMiss`, and release the stream – as soon as a
+  // cache miss is seen, or once the render reaches `streamReleaseStage`. The replayable
+  // stays local: the response is the only reader outside this function.
   const stagesAdvanced = runInSequentialTasks(
     () => {
       stageController.advanceStage(RenderStage.ShellEarlyStatic)
@@ -4676,69 +4635,69 @@ async function streamStagedRenderInDev({
     },
     () => {
       if (checkForCacheMiss()) {
-        revealAfter.resolve()
+        streamReleased.resolve()
       }
       stageController.advanceStage(RenderStage.ShellStatic)
     },
     () => {
       if (checkForCacheMiss()) {
-        revealAfter.resolve()
+        streamReleased.resolve()
       }
       stageController.advanceStage(RenderStage.EarlyStatic)
     },
     () => {
       if (checkForCacheMiss()) {
-        revealAfter.resolve()
+        streamReleased.resolve()
       }
       stageController.advanceStage(RenderStage.Static)
     },
     () => {
-      // Reveal on a cache miss, or at the static-shell boundary: the static
-      // stage's chunks flushed in the previous task, so the static shell is on
-      // the stream now. `checkForCacheMiss()` is the left operand so its side
-      // effect (tracking the miss / updating the dev overlay) always runs.
-      if (checkForCacheMiss() || revealAfterStage === RenderStage.Static) {
-        revealAfter.resolve()
+      if (checkForCacheMiss()) {
+        streamReleased.resolve()
+      }
+      // The static stage's chunks flushed in the previous task, so the static
+      // shell is buffered now. For a static shell, release the stream before
+      // advancing into the runtime stages.
+      if (streamReleaseStage === RenderStage.Static) {
+        streamReleased.resolve()
       }
       stageController.advanceStage(RenderStage.ShellEarlyRuntime)
     },
     () => {
       if (checkForCacheMiss()) {
-        revealAfter.resolve()
+        streamReleased.resolve()
       }
       stageController.advanceStage(RenderStage.ShellRuntime)
     },
     () => {
       if (checkForCacheMiss()) {
-        revealAfter.resolve()
+        streamReleased.resolve()
       }
       stageController.advanceStage(RenderStage.EarlyRuntime)
     },
     () => {
       if (checkForCacheMiss()) {
-        revealAfter.resolve()
+        streamReleased.resolve()
       }
       stageController.advanceStage(RenderStage.Runtime)
     },
     () => {
-      // Reveal on a cache miss, or at the runtime-shell boundary: the runtime
-      // stage's chunks flushed in the previous task, so the runtime shell is on
-      // the stream now. `checkForCacheMiss()` is the left operand so its side
-      // effect (tracking the miss / updating the dev overlay) always runs.
-      if (checkForCacheMiss() || revealAfterStage === RenderStage.Runtime) {
-        revealAfter.resolve()
+      if (checkForCacheMiss()) {
+        streamReleased.resolve()
       }
-    },
-    () => {
-      // Advance to the dynamic stage in the next task, after the `revealAfter`
-      // resolution row from the previous task has flushed: that way the row
-      // precedes any dynamic chunks, so the client unblocks as soon as the
-      // shell is ready, not only while the dynamic content streams.
-      //
-      // Advance as early as possible, even while caches are still filling, so
-      // dynamic content streams to the browser right away instead of being
-      // withheld until the slowest cache fill completes. Streaming that content
-      // promptly is the whole point of the streaming dev render.
+
+      // The runtime stage's chunks flushed in the previous task, so the runtime
+      // shell is buffered now. For a runtime-prefetch route, release the stream
+      // before advancing to the dynamic stage.
+      if (streamReleaseStage === RenderStage.Runtime) {
+        streamReleased.resolve()
+      }
+
+      // Always advance to the dynamic stage synchronously, even while caches
+      // are still filling, so dynamic content streams to the browser right away
+      // instead of being withheld until the slowest cache fill completes.
+      // Streaming that content promptly is the whole point of the streaming dev
+      // render.
       //
       // The tradeoff is that dev no longer detects a `'use cache'` deadlock: a
       // cache whose fill depends on Dynamic-stage IO used to be held here until
@@ -4752,30 +4711,19 @@ async function streamStagedRenderInDev({
     }
   )
 
-  // If a task throws before the stream is created, surface it to the awaiter
-  // below via `streamReady`. Resolve (not reject) `revealAfter` so the client
-  // consumers that gate on the payload's `_revealAfter` unblock rather than
-  // seeing a rejection; the actual error still surfaces through the stream.
+  // If a task throws before the stream is created or released, surface it to
+  // the awaiters below.
   stagesAdvanced.catch((err) => {
     streamReady.reject(err)
-    revealAfter.resolve()
+    streamReleased.reject(err)
   })
 
   const { stream, accumulatedChunksPromise } = await streamReady.promise
 
-  // For the HTML (Fizz) render, hold the stream until the shell-stage content
-  // has flushed (or until a cache miss reveals early) so the HTML reflects the
-  // prerendered shell that production streams rather than a premature fallback.
-  // The `_revealAfter` gate is client-side and doesn't apply to this render,
-  // which consumes the payload directly and would otherwise stream a boundary's
-  // fallback before its content arrived. A client navigation doesn't need the
-  // hold: it gates revealing the response on `_revealAfter` (whose resolution
-  // row follows the children's row in the stream), so we release the stream to
-  // it live and let the browser process chunks as they arrive instead of
-  // holding it server-side.
-  if (holdStreamUntilRevealed) {
-    await revealAfter.promise
-  }
+  // Don't hand the stream to the caller until it's been released: at the
+  // `streamReleaseStage` (so the shell content is buffered before the first flush), or
+  // earlier on a cache miss.
+  await streamReleased.promise
 
   // Advancing the stages only drives the pipeline forward; the render isn't
   // actually complete until its stream has fully finished. The accumulation
@@ -4890,14 +4838,6 @@ async function renderWithWarmCachesForValidationInDev(
   }
 }
 
-interface StagedRenderWithCachesInDevOptions extends StagedDevRenderOptions {
-  createRequestStore: () => RequestStore
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>
-  shouldValidate: boolean
-  fallbackRouteParams: OpaqueFallbackRouteParams | null
-  getDevRenderDidError: () => boolean
-}
-
 /**
  * Sets up and streams a dev Cache Components render. Streams immediately and
  * fills caches as a side effect, then runs a background follow-up once the
@@ -4906,18 +4846,17 @@ interface StagedRenderWithCachesInDevOptions extends StagedDevRenderOptions {
  * otherwise against a separate warm-cache render); otherwise it just forwards
  * any recorded invalid dynamic usage error to the dev overlay.
  */
-async function stagedRenderWithCachesInDev({
-  ctx,
-  requestStore,
-  createRequestStore,
-  getPayload,
-  onError,
-  shouldValidate,
-  fallbackRouteParams,
-  getDevRenderDidError,
-  revealAfterStage,
-  holdStreamUntilRevealed,
-}: StagedRenderWithCachesInDevOptions): Promise<{
+async function stagedRenderWithCachesInDev(
+  ctx: AppRenderContext,
+  requestStore: RequestStore,
+  createRequestStore: () => RequestStore,
+  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  onError: (error: unknown) => void,
+  shouldValidate: boolean,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null,
+  getDevRenderDidError: () => boolean,
+  streamReleaseStage: RenderStage.Static | RenderStage.Runtime
+): Promise<{
   stream: Readable
   debugChannel: NodeDebugChannelPair | undefined
 }> {
@@ -4944,7 +4883,7 @@ async function stagedRenderWithCachesInDev({
   // abort, so it's fine if it happens while creating the payload.
   const rscPayload = await getPayload(requestStore)
 
-  const { stream, resultPromise } = await streamStagedRenderInDev({
+  const { stream, resultPromise } = await streamStagedRenderInDev(
     ctx,
     requestStore,
     rscPayload,
@@ -4953,9 +4892,8 @@ async function stagedRenderWithCachesInDev({
     environmentName,
     onError,
     debugChannel,
-    revealAfterStage,
-    holdStreamUntilRevealed,
-  })
+    streamReleaseStage
+  )
 
   if (shouldValidate) {
     runDevValidationInBackground(

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -428,18 +428,6 @@ export type InitialRSCPayload = {
    * staleness.
    */
   d?: number
-  /**
-   * revealAfter (dev only). Resolves once the server has flushed the
-   * shell-stage content to the stream (static shell, or runtime-prefetchable
-   * shell for runtime-prefetch routes), or earlier on a cache miss. The client
-   * decodes this from the payload and defers resolving the response's deferred
-   * RSCs on it, so a boundary's children aren't revealed before their row has
-   * been decoded (which would flush a premature Suspense fallback). Its
-   * resolution row follows the children's row in the payload, so the children
-   * are decoded by the time the client unblocks. The HTML render gates on the
-   * same signal server-side instead of reading this field.
-   */
-  _revealAfter?: Promise<void>
 }
 
 // Response from `createFromFetch` for normal rendering
@@ -482,18 +470,6 @@ export type NavigationFlightResponse = {
    * staleness.
    */
   d?: number
-  /**
-   * revealAfter (dev only). Resolves once the server has flushed the
-   * shell-stage content to the stream (static shell, or runtime-prefetchable
-   * shell for runtime-prefetch routes), or earlier on a cache miss. The client
-   * decodes this from the payload and defers resolving the response's deferred
-   * RSCs on it, so a boundary's children aren't revealed before their row has
-   * been decoded (which would flush a premature Suspense fallback). Its
-   * resolution row follows the children's row in the payload, so the children
-   * are decoded by the time the client unblocks. The HTML render gates on the
-   * same signal server-side instead of reading this field.
-   */
-  _revealAfter?: Promise<void>
 }
 
 // Response from `createFromFetch` for server actions. Action's flight data can be null

--- a/test/development/app-dir/cache-components-dev-streaming/cache-components-dev-streaming.test.ts
+++ b/test/development/app-dir/cache-components-dev-streaming/cache-components-dev-streaming.test.ts
@@ -62,7 +62,7 @@ describe('cache-components-dev-streaming', () => {
     //
     // Use instant checks throughout: `elementByCss`/`elementById` also wait for
     // the page "load" event, which (with `waitUntil: 'commit'`) only fires once
-    // the slow cache has filled, which would advance past the very window this
+    // the slow cache has filled — that would advance past the very window this
     // test inspects.
     await retry(async () => {
       expect(await browser.elementByCssInstant('#dynamic').text()).toBe(
@@ -136,10 +136,9 @@ describe('cache-components-dev-streaming', () => {
   })
 
   it('shows the private-cache fallback on a cold client navigation but not on a warm one', async () => {
-    // Uses a runtime-prefetch route, whose cached content belongs to the
-    // runtime shell stage. On a warm navigation the client defers revealing
-    // the response (via `_revealAfter`) until the server has flushed the shell,
-    // so the content arrives with the shell and the fallback isn't shown.
+    // Uses a runtime-prefetch route, whose stream is held back until after the
+    // runtime stage, so a warm navigation reliably delivers the content with
+    // the shell and omits the fallback.
     const browser = await next.browser('/')
 
     // Cold navigation: the cache misses and fills in the background, so the
@@ -150,26 +149,22 @@ describe('cache-components-dev-streaming', () => {
     expect(await browser.elementByCss('#private-fallback').text()).toBe(
       'Loading...'
     )
-    expect(await browser.elementByCss('#private').text()).toBeDateString()
+    await retry(async () => {
+      expect(
+        await browser.elementByCssInstant('#private').text()
+      ).toBeDateString()
+    })
 
     // Wait for the background write to settle so the next navigation hits the
     // warm entry instead of racing a pending write.
     await waitFor(2000)
 
-    // Hard-reload home so the first navigation below is a fresh, unknown-route
-    // nav. An unknown route has no prior cache entry, so the server sends the
-    // content inline in the seed (rather than the dynamic-only delta a known
-    // route gets), and that inline reveal is gated on `_revealAfter` too, so
-    // even this first nav delivers the content with the shell. Later iterations
-    // navigate via back()/forward, exercising the known-route deferred-RSC
-    // path.
-    await browser.loadPage(new URL('/', next.url).href)
-
     // Warm navigation: record whether the fallback ever enters the DOM during
     // the navigation, even briefly. It shouldn't, since the warm content is
     // delivered with the shell.
+    await browser.loadPage(new URL('/', next.url).href)
     await browser.eval(() => {
-      ;(window as any).__privateFallbackSeen = 0
+      ;(window as any).__privateFallbackSeen = false
       new MutationObserver((records) => {
         records.forEach((record) =>
           record.addedNodes.forEach((node) => {
@@ -178,33 +173,24 @@ describe('cache-components-dev-streaming', () => {
               (node.id === 'private-fallback' ||
                 node.querySelector('#private-fallback'))
             ) {
-              ;(window as any).__privateFallbackSeen += 1
+              ;(window as any).__privateFallbackSeen = true
             }
           })
         )
       }).observe(document.body, { childList: true, subtree: true })
     })
 
-    // Regression test for a rare client-side race the `_revealAfter` gate
-    // fixes. The Flight client decodes the response incrementally, so before
-    // the gate React Fiber could occasionally commit the fallback before the
-    // children's row was processed, even though the warm content is delivered
-    // with the shell. Deferring the reveal until `_revealAfter` settles means
-    // the children are decoded by the time React reads them, so the fallback no
-    // longer appears. The race was timing-dependent, so a single navigation
-    // would catch a regression only by luck; we repeat the warm navigation many
-    // times and assert the fallback never enters the DOM.
-    for (let i = 0; i < 100; i++) {
-      await browser
-        .elementByCss('a[href="/use-cache-private-runtime-prefetch"]')
-        .click()
-      expect(await browser.elementByCss('#private').text()).toBeDateString()
-      await browser.back()
-    }
-
+    await browser
+      .elementByCss('a[href="/use-cache-private-runtime-prefetch"]')
+      .click()
+    await retry(async () => {
+      expect(
+        await browser.elementByCssInstant('#private').text()
+      ).toBeDateString()
+    })
     expect(
       await browser.eval(() => (window as any).__privateFallbackSeen)
-    ).toBe(0)
+    ).toBe(false)
   })
 
   // The following are smoke tests that Cache Components validation still


### PR DESCRIPTION
Reverts vercel/next.js#94783

Suspect this caused regressions in canary: https://github.com/vercel/next.js/actions/runs/27482922554/job/81247469526