### PR TITLE
Omit unused root params from App Shell cache key

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -3137,16 +3137,21 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   // incomplete and can't be trusted for the full response. Re-keying with an
   // untrustworthy set could replace concrete params with Fallback and let
   // unrelated URLs read each other's content from the cache.
-  //
-  // For RuntimeShell prefetches, always re-key to the precomputed shell vary
-  // path. A shell entry is spawned at a concrete param path but is reusable
-  // across all of them; tree.shellVaryPath (root-param values kept, every other
-  // param replaced with Fallback) is exactly the path that shell reads look it
-  // up under.
   let fulfilledVaryPath: SegmentVaryPath | null = null
   if (process.env.__NEXT_VARY_PARAMS) {
     if (fetchStrategy === FetchStrategy.RuntimeShell) {
-      fulfilledVaryPath = tree.shellVaryPath
+      // A shell is rendered with non-root params omitted, so the entry is
+      // reusable across all of their values. It can still vary on root params,
+      // but only on the ones it actually reads. So we narrow tree.shellVaryPath
+      // — which keeps every root param — by the server-reported vary params,
+      // replacing the root params the shell didn't read with Fallback so the
+      // entry is shared across those values too. (Without a reported set, use
+      // the shell vary path as-is: correct, but it over-keys on root params the
+      // shell may not read.)
+      fulfilledVaryPath =
+        segmentVaryParams !== null
+          ? getFulfilledSegmentVaryPath(tree.shellVaryPath, segmentVaryParams)
+          : tree.shellVaryPath
     } else if (
       fetchStrategy !== FetchStrategy.Full &&
       segmentVaryParams !== null

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/app-shell-root-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/app-shell-root-params.test.ts
@@ -1,0 +1,74 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+// The App Shell is keyed by root params so that a locale-aware (etc.) shell can
+// still be reused across navigations. But a shell should only vary on the root
+// params it actually reads — keying it on root params it never touches stores
+// redundant copies and misses cache hits.
+//
+// This fixture's root layout reads only `lang`; `region` is a root param that
+// is read only below the shell boundary. So the shell for
+// /[lang]/[region]/posts varies on `lang` but is identical across `region`.
+//
+// The app uses Partial Prefetching, so revealing a link prefetches only the
+// shared shell — no per-link Speculative prefetch. Each reveal is therefore
+// exactly one shell prefetch (when the shell isn't already cached) or no
+// requests at all. We pass `{ includeAppShellRequests: true }` so router-act
+// asserts on App Shell requests (next-router-prefetch: '3') instead of ignoring
+// them.
+describe('App Shell varies only on the root params it reads', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('is skipped in dev (prefetching is disabled)', () => {})
+    return
+  }
+
+  it('reuses the shell across an unread root param, but refetches across a read one', async () => {
+    let page: Playwright.Page
+    // Start on the one statically-generated route. The combos probed below are
+    // NOT statically generated, so their shells are rendered at runtime
+    // (FetchStrategy.RuntimeShell).
+    const browser = await next.browser('/en/us', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Prime the shared shell for /en/uk/posts. The shell render reads `lang`
+    // ('en') but not `region`.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/en/uk/posts/1"]')
+          .click()
+      },
+      { includes: 'App shell for posts' }
+    )
+
+    // Reveal /en/gb/posts/1 — SAME lang, DIFFERENT region. The shell does not
+    // read `region`, so the shell cached for /en/uk is reusable: this reveal
+    // should prefetch nothing.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/en/gb/posts/1"]')
+        .click()
+    }, 'no-requests')
+
+    // Reveal /fr/uk/posts/1 — DIFFERENT lang. The shell DOES read `lang`, so it
+    // must NOT be reused: a fresh shell prefetch fires. This guards against
+    // over-narrowing (dropping a root param the shell actually reads).
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/fr/uk/posts/1"]')
+          .click()
+      },
+      { includes: 'App shell for posts' }
+    )
+  })
+})

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/app-shell-root-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/app-shell-root-params.test.ts
@@ -29,9 +29,7 @@ describe('App Shell varies only on the root params it reads', () => {
 
   it('reuses the shell across an unread root param, but refetches across a read one', async () => {
     let page: Playwright.Page
-    // Start on the one statically-generated route. The combos probed below are
-    // NOT statically generated, so their shells are rendered at runtime
-    // (FetchStrategy.RuntimeShell).
+    // Start on the one statically-generated route.
     const browser = await next.browser('/en/us', {
       beforePageLoad(p: Playwright.Page) {
         page = p

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/layout.tsx
@@ -1,0 +1,35 @@
+import { lang } from 'next/root-params'
+import { ReactNode } from 'react'
+
+// This is the topmost layout in the route tree (there is no app/layout.tsx
+// above it), so both `lang` and `region` are "root params" (params at or above
+// the root layout), accessible via next/root-params.
+//
+// Crucially, the layout — which is part of the App Shell — reads ONLY `lang`,
+// never `region`. So the shell varies on `lang` but is identical across
+// `region` values.
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const currentLang = await lang()
+  return (
+    <html lang={currentLang}>
+      <body>
+        <div id="shell-lang">{`Shell lang: ${currentLang}`}</div>
+        {children}
+      </body>
+    </html>
+  )
+}
+
+// Only one combo is statically generated — just enough to give the app a
+// buildable start page (/en/us). The combos the test probes are deliberately
+// NOT listed here, so their shells are rendered at runtime (FetchStrategy.
+// RuntimeShell). A statically-prerendered shell would be cached via a different
+// code path that already narrows by the server-reported vary params, masking
+// the runtime-shell keying we're exercising here.
+export function generateStaticParams() {
+  return [{ lang: 'en', region: 'us' }]
+}

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/layout.tsx
@@ -25,11 +25,7 @@ export default async function RootLayout({
 }
 
 // Only one combo is statically generated — just enough to give the app a
-// buildable start page (/en/us). The combos the test probes are deliberately
-// NOT listed here, so their shells are rendered at runtime (FetchStrategy.
-// RuntimeShell). A statically-prerendered shell would be cached via a different
-// code path that already narrows by the server-reported vary params, masking
-// the runtime-shell keying we're exercising here.
+// buildable start page (/en/us).
 export function generateStaticParams() {
   return [{ lang: 'en', region: 'us' }]
 }

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/page.tsx
@@ -1,0 +1,23 @@
+import { LinkAccordion } from '../../../components/link-accordion'
+
+// Home page for a (lang, region) pair, e.g. /en/us. It renders accordion links
+// to the same posts route under several (lang, region) combinations so the test
+// can prime and probe the shell cache without navigating.
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/en/uk/posts/1">en/uk post 1</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/en/gb/posts/1">en/gb post 1</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/fr/uk/posts/1">fr/uk post 1</LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/posts/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/app/[lang]/[region]/posts/[id]/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { region } from 'next/root-params'
+
+type Params = { id: string }
+
+export default function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      {/* The fallback is the App Shell — the part of the page that doesn't
+          depend on the dynamic params. Nothing above this boundary reads the
+          `region` root param, so the shell does not vary on `region`. */}
+      <Suspense fallback={<p id="shell">App shell for posts</p>}>
+        <ParamsDependent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ParamsDependent({ params }: { params: Promise<Params> }) {
+  'use cache'
+
+  const { id } = await params
+  // `region` is a root param, but it's only read here — below the shell
+  // boundary, in the dynamic content — so it's not part of the shell.
+  const currentRegion = await region()
+  return <p id="dynamic-content">{`Post ${id} for region ${currentRegion}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/next.config.ts
@@ -1,0 +1,20 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  // Opt the whole app into Partial Prefetching (non-eager). Under App Shells
+  // this skips the per-link Speculative phase, so revealing a link prefetches
+  // ONLY the shared shell. That makes each reveal observable as exactly "one
+  // shell prefetch, or no requests at all" — which is what the assertions rely
+  // on.
+  partialPrefetching: true,
+  experimental: {
+    prefetchInlining: true,
+    optimisticRouting: true,
+    cachedNavigations: true,
+    appShells: true,
+    varyParams: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/app-shell-root-params/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/app-shell-root-params/next.config.ts
@@ -12,7 +12,6 @@ const nextConfig: NextConfig = {
     prefetchInlining: true,
     optimisticRouting: true,
     cachedNavigations: true,
-    appShells: true,
     varyParams: true,
   },
 }


### PR DESCRIPTION
Addresses an oversight from #94773. Not a bugfix, just a missed optimization.

We've decided to allow root params to be accessed in the App Shell. In a previous PR, I updated the client to include root params in the cache key. However, I missed an optimization: when writing shell entries to the cache, we should not assume that the shell varies on *all* root params — only the ones that the server reports as actually being accessed.

Note: When this PR was first opened, the server-side change to allow root params in the shell hadn't landed yet. It has since landed in #94738, so this optimization is observable end-to-end (the included e2e test exercises it).

<!-- NEXT_JS_LLM_PR -->
