### PR TITLE
Support vary params rewinding

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -44,6 +44,7 @@ export function createInitialRouterState({
     s: initialStaleTime,
     l: initialStaticStageByteLength,
     h: initialHeadVaryParams,
+    r: initialRootVaryParams,
     p: initialRuntimePrefetchStream,
     d: initialDynamicStaleTimeSeconds,
   } = initialRSCPayload
@@ -149,6 +150,7 @@ export function createInitialRouterState({
               staticStageResponse.f,
               undefined, // no build ID mismatch check for initial HTML
               staticStageResponse.h,
+              staticStageResponse.r ?? null,
               staleAt,
               initialTree,
               initialRenderedSearch,
@@ -175,6 +177,7 @@ export function createInitialRouterState({
               initialFlightData,
               undefined, // buildId — not applicable for initial HTML
               initialHeadVaryParams,
+              initialRootVaryParams ?? null,
               staleAt,
               initialTree,
               initialRenderedSearch,
@@ -214,6 +217,7 @@ export function createInitialRouterState({
               processed.buildId,
               processed.isResponsePartial,
               processed.headVaryParams,
+              processed.rootVaryParamsIterable,
               processed.staleAt,
               processed.navigationSeed,
               null

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1752,6 +1752,7 @@ async function fetchMissingDynamicData(
             staticStageResponse.f,
             buildId,
             staticStageResponse.h,
+            staticStageResponse.r ?? null,
             staleAt,
             dynamicRequestTree,
             result.renderedSearch,
@@ -1780,6 +1781,7 @@ async function fetchMissingDynamicData(
               processed.buildId,
               processed.isResponsePartial,
               processed.headVaryParams,
+              processed.rootVaryParamsIterable,
               processed.staleAt,
               processed.navigationSeed,
               null

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -12,7 +12,7 @@ import { PrefetchHint } from '../../../shared/lib/app-router-types'
 import {
   readVaryParams,
   type VaryParams,
-  type VaryParamsThenable,
+  type VaryParamsIterable,
 } from '../../../shared/lib/segment-cache/vary-params-decoding'
 import {
   NEXT_DID_POSTPONE_HEADER,
@@ -1861,13 +1861,11 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
 
-      // Read head vary params synchronously. Individual segments carry their
-      // own thenables in CacheNodeSeedData.
-      const headVaryParamsThenable = serverData.h
-      const headVaryParams =
-        headVaryParamsThenable !== null
-          ? readVaryParams(headVaryParamsThenable)
-          : null
+      // Read head vary params synchronously (unioning in the response-level
+      // root params). Individual segments carry their own iterables in
+      // CacheNodeSeedData; the root iterable is threaded down so each segment
+      // unions it too.
+      const headVaryParams = readVaryParams(serverData.h, serverData.r)
       writeDynamicTreeResponseIntoCache(
         Date.now(),
         // The non-PPR response format is what we'd get if we prefetched these segments
@@ -1880,6 +1878,7 @@ export async function fetchRouteOnCacheMiss(
         canonicalUrl,
         routeIsPPREnabled,
         headVaryParams,
+        serverData.r ?? null,
         pathname,
         search,
         nextUrl
@@ -2338,6 +2337,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
             serverData.f,
             buildId,
             serverData.h,
+            serverData.r ?? null,
             staleAt,
             dynamicRequestTree,
             renderedSearch,
@@ -2363,6 +2363,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
             shellStageData.f,
             buildId,
             shellStageData.h,
+            shellStageData.r ?? null,
             shellStaleAt,
             dynamicRequestTree,
             renderedSearch,
@@ -2372,13 +2373,16 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       }
     }
 
-    // Read head vary params synchronously. Individual segments carry their
-    // own thenables in CacheNodeSeedData.
-    const headVaryParamsThenable = serverDataThatSatisfiesSpawnedEntries.h
-    const headVaryParams =
-      headVaryParamsThenable !== null
-        ? readVaryParams(headVaryParamsThenable)
-        : null
+    // Read head vary params synchronously (unioning in the response-level root
+    // params). Individual segments carry their own iterables in
+    // CacheNodeSeedData; the root iterable is threaded down so each segment
+    // unions it too.
+    const rootVaryParamsIterable =
+      serverDataThatSatisfiesSpawnedEntries.r ?? null
+    const headVaryParams = readVaryParams(
+      serverDataThatSatisfiesSpawnedEntries.h,
+      rootVaryParamsIterable
+    )
 
     // PPRRuntime and RuntimeShell prefetches are partial when the server
     // marks the response as '~' (Partial). RuntimeShell additionally omits
@@ -2415,6 +2419,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       buildId,
       isResponsePartial,
       headVaryParams,
+      rootVaryParamsIterable,
       staleAtForSpawnedEntries,
       navigationSeed,
       spawnedEntries
@@ -2467,6 +2472,7 @@ function writeDynamicTreeResponseIntoCache(
   canonicalUrl: string,
   routeIsPPREnabled: boolean,
   headVaryParams: VaryParams | null,
+  rootVaryParamsIterable: VaryParamsIterable | null,
   originalPathname: string,
   originalSearch: NormalizedSearch,
   nextUrl: string | null
@@ -2549,6 +2555,7 @@ function writeDynamicTreeResponseIntoCache(
     buildId,
     isResponsePartial,
     headVaryParams,
+    rootVaryParamsIterable,
     getStaleAtFromHeader(now, response),
     navigationSeed,
     null
@@ -2582,6 +2589,7 @@ export function writeDynamicRenderResponseIntoCache(
   buildId: string | undefined,
   isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
+  rootVaryParamsIterable: VaryParamsIterable | null,
   staleAt: number,
   navigationSeed: NavigationSeed,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
@@ -2632,6 +2640,7 @@ export function writeDynamicRenderResponseIntoCache(
         staleAt,
         seedData,
         isResponsePartial,
+        rootVaryParamsIterable,
         spawnedEntries
       )
     }
@@ -2695,6 +2704,7 @@ function writeSeedDataIntoCache(
   staleAt: number,
   seedData: CacheNodeSeedData,
   isResponsePartial: boolean,
+  rootVaryParamsIterable: VaryParamsIterable | null,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -2704,12 +2714,11 @@ function writeSeedDataIntoCache(
   // (CacheNodeSeedData) into the prefetch cache.
   const rsc = seedData[0]
   const isPartial = rsc === null || isResponsePartial
-  const varyParamsThenable = seedData[4]
-  // Each segment carries its own vary params thenable in the seed data. The
-  // thenable resolves to the set of params the segment accessed during render.
-  // A null thenable means tracking was not enabled (not a prerender).
-  const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+  // Each segment carries its own vary params iterable in the seed data, which
+  // drains to the set of params the segment accessed during render. A null
+  // iterable means tracking was not enabled (not a prerender). readVaryParams
+  // unions in the response-level root params.
+  const varyParams = readVaryParams(seedData[4], rootVaryParamsIterable)
   fulfillEntrySpawnedByRuntimePrefetch(
     now,
     fetchStrategy,
@@ -2737,6 +2746,7 @@ function writeSeedDataIntoCache(
           staleAt,
           childSeedData,
           isResponsePartial,
+          rootVaryParamsIterable,
           entriesOwnedByCurrentTask
         )
       }
@@ -3119,16 +3129,19 @@ export function writePrerenderResponseIntoCache(
   fetchStrategy: FetchStrategy.PPR | FetchStrategy.RuntimeShell,
   flightData: FlightData,
   buildId: string | undefined,
-  headVaryParamsThenable: VaryParamsThenable | null,
+  headVaryParamsIterable: VaryParamsIterable | null,
+  rootVaryParamsIterable: VaryParamsIterable | null,
   staleAt: number,
   baseTree: FlightRouterState,
   renderedSearch: string,
   isResponsePartial: boolean
 ): void {
-  const headVaryParams =
-    headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
-      : null
+  // Root params are emitted once at the top level; readVaryParams unions them
+  // into the head, and they're threaded down to each segment below.
+  const headVaryParams = readVaryParams(
+    headVaryParamsIterable,
+    rootVaryParamsIterable
+  )
 
   const flightDatas = normalizeFlightData(flightData)
   if (typeof flightDatas === 'string') {
@@ -3148,6 +3161,7 @@ export function writePrerenderResponseIntoCache(
     buildId,
     isResponsePartial,
     headVaryParams,
+    rootVaryParamsIterable,
     staleAt,
     navigationSeed,
     null // spawnedEntries — no pre-created entries; will create or upsert
@@ -3171,6 +3185,7 @@ export async function processRuntimePrefetchStream(
   buildId: string | undefined
   isResponsePartial: boolean
   headVaryParams: VaryParams | null
+  rootVaryParamsIterable: VaryParamsIterable | null
   staleAt: number
 } | null> {
   const { stream, isPartial } = await stripIsPartialByte(runtimePrefetchStream)
@@ -3182,11 +3197,11 @@ export async function processRuntimePrefetchStream(
       { allowPartialStream: true }
     )
 
-  const headVaryParamsThenable = serverData.h
-  const headVaryParams =
-    headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
-      : null
+  // Root params are emitted once at the top level; readVaryParams unions them
+  // into the head, and we return the iterable so the caller can union it into
+  // each segment too.
+  const rootVaryParamsIterable = serverData.r ?? null
+  const headVaryParams = readVaryParams(serverData.h, rootVaryParamsIterable)
 
   const staleAt = await getStaleAt(now, serverData.s)
 
@@ -3208,6 +3223,7 @@ export async function processRuntimePrefetchStream(
     buildId: serverData.b,
     isResponsePartial: isPartial,
     headVaryParams,
+    rootVaryParamsIterable,
     staleAt,
   }
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -537,6 +537,7 @@ async function navigateToUnknownRoute(
             staticStageResponse.f,
             buildId,
             staticStageResponse.h,
+            staticStageResponse.r ?? null,
             staleAt,
             currentFlightRouterState,
             renderedSearch,
@@ -565,6 +566,7 @@ async function navigateToUnknownRoute(
               processed.buildId,
               processed.isResponsePartial,
               processed.headVaryParams,
+              processed.rootVaryParamsIterable,
               processed.staleAt,
               processed.navigationSeed,
               null

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -212,7 +212,8 @@ import { CacheSignal } from './cache-signal'
 import {
   createResponseVaryParamsAccumulator,
   finishAccumulatingVaryParams,
-  getMetadataVaryParamsThenable,
+  getMetadataVaryParamsAccumulator,
+  getRootParamsVaryParamsAccumulator,
 } from './vary-params'
 import { getTracedMetadata } from '../lib/trace/utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -739,7 +740,8 @@ async function generateDynamicRSCPayload(
       q: getRenderedSearch(query),
       i: !!couldBeIntercepted,
       S: workStore.isStaticGeneration,
-      h: getMetadataVaryParamsThenable(),
+      h: getMetadataVaryParamsAccumulator(),
+      r: getRootParamsVaryParamsAccumulator() ?? undefined,
     }
   )
 
@@ -1775,11 +1777,11 @@ async function finalRuntimeServerPrerender(
     // FIXME(NAR-810): If we're already aborted due to Sync IO, there should be no need to
     // finish the accumulators. However, it seems like in `--debug-prerender`
     // the stream will stay open if we don't close the iterable here.
-    if (
-      process.env.NODE_ENV === 'development' &&
-      staleTimeIterable !== undefined
-    ) {
-      staleTimeIterable.close()
+    if (process.env.NODE_ENV === 'development') {
+      if (staleTimeIterable !== undefined) {
+        staleTimeIterable.close()
+      }
+      finishAccumulatingVaryParams(varyParamsAccumulator)
     }
   }
 
@@ -2139,7 +2141,8 @@ async function getRSCPayload(
     // static pages do, because their per-segment prefetch responses are
     // generated during static generation (build or ISR).
     S: workStore.isStaticGeneration || ctx.renderOpts.cacheComponents,
-    h: getMetadataVaryParamsThenable(),
+    h: getMetadataVaryParamsAccumulator(),
+    r: getRootParamsVaryParamsAccumulator() ?? undefined,
     s: staleTimeIterable,
     a: shellByteLengthPromise,
     l: staticStageByteLengthPromise,
@@ -2298,7 +2301,8 @@ async function getErrorRSCPayload(
     // static pages do, because their per-segment prefetch responses are
     // generated during static generation (build or ISR).
     S: workStore.isStaticGeneration || ctx.renderOpts.cacheComponents,
-    h: getMetadataVaryParamsThenable(),
+    h: getMetadataVaryParamsAccumulator(),
+    r: getRootParamsVaryParamsAccumulator() ?? undefined,
   } satisfies InitialRSCPayload)
 }
 
@@ -7690,12 +7694,12 @@ async function prerenderToStream(
 
         // FIXME(NAR-810): If we're already aborted due to Sync IO, there should be no need to
         // finish the accumulators. However, it seems like in `--debug-prerender`
-        // the stream will stay open if we don't close the iterable here.
-        if (
-          process.env.NODE_ENV === 'development' &&
-          staleTimeIterable !== undefined
-        ) {
-          staleTimeIterable.close()
+        // the stream will stay open if we don't close the iterables here.
+        if (process.env.NODE_ENV === 'development') {
+          if (staleTimeIterable !== undefined) {
+            staleTimeIterable.close()
+          }
+          finishAccumulatingVaryParams(varyParamsAccumulator)
         }
       }
 
@@ -7781,10 +7785,10 @@ async function prerenderToStream(
           // into the stream. The timing here is important: both were
           // included in the Flight payload, but they can only be serialized
           // at the very end, after all the components have finished.
-          finishAccumulatingVaryParams(varyParamsAccumulator)
           if (staleTimeIterable !== undefined) {
             staleTimeIterable.close()
           }
+          finishAccumulatingVaryParams(varyParamsAccumulator)
 
           if (shellByteLengthDeferred && collectedChunksByStage) {
             shellByteLengthDeferred.resolve(

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -11,7 +11,10 @@ import {
   PrefetchHint,
   StaticPrefetchDisabled,
 } from '../../shared/lib/app-router-types'
-import { readVaryParams } from '../../shared/lib/segment-cache/vary-params-decoding'
+import {
+  readVaryParams,
+  type VaryParamsIterable,
+} from '../../shared/lib/segment-cache/vary-params-decoding'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -321,13 +324,17 @@ export async function collectPrefetchHints(
   }
   const { buildId, flightRouterState, seedData, head } = flightData
 
+  // Root params are emitted once at the top level; readVaryParams unions them
+  // into the head, and the iterable is threaded down so every segment below
+  // unions it too.
+  const rootVaryParamsIterable = initialRSCPayload.r ?? null
+
   // Measure the head (metadata/viewport) gzip size so the main traversal
   // can decide whether to inline it into a page's bundle.
-  const headVaryParamsThenable = initialRSCPayload.h
-  const headVaryParams =
-    headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
-      : null
+  const headVaryParams = readVaryParams(
+    initialRSCPayload.h,
+    rootVaryParamsIterable
+  )
 
   const [, headBuffer] = await renderSegmentPrefetch(
     buildId,
@@ -364,7 +371,8 @@ export async function collectPrefetchHints(
     maxBundleSize,
     headGzipSize,
     headInlineState,
-    subtreeHasRuntimePrefetch
+    subtreeHasRuntimePrefetch,
+    rootVaryParamsIterable
   )
 
   if (!headInlineState.inlined) {
@@ -417,7 +425,8 @@ async function collectPrefetchHintsImpl(
   maxBundleSize: number,
   headGzipSize: number,
   headInlineState: { inlined: boolean },
-  routeHasRuntimePrefetch: boolean
+  routeHasRuntimePrefetch: boolean,
+  rootVaryParamsIterable: VaryParamsIterable | null
 ): Promise<{
   node: PrefetchHints
   // Total inlined bytes accumulated along the deepest accepting path in this
@@ -438,9 +447,7 @@ async function collectPrefetchHintsImpl(
   // segments with static prefetching disabled since they contribute nothing.
   let currentGzipSize: number | null = null
   if (!isStaticPrefetchDisabled && seedData !== null) {
-    const varyParamsThenable = seedData[4]
-    const varyParams =
-      varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+    const varyParams = readVaryParams(seedData[4], rootVaryParamsIterable)
 
     const [, buffer] = await renderSegmentPrefetch(
       buildId,
@@ -519,7 +526,8 @@ async function collectPrefetchHintsImpl(
       maxBundleSize,
       headGzipSize,
       headInlineState,
-      routeHasRuntimePrefetch
+      routeHasRuntimePrefetch,
+      rootVaryParamsIterable
     )
 
     if (slots === null) {
@@ -695,14 +703,17 @@ async function PrefetchTreeData({
   }
   const { buildId, flightRouterState, seedData, head } = flightData
 
+  // Root params are emitted once at the top level; readVaryParams unions them
+  // into the head, and the iterable is threaded down so every segment below
+  // unions it too. The iterables should be drained to completion by now (the
+  // stream is buffered); a hanging one reads as the params yielded so far.
+  const rootVaryParamsIterable = initialRSCPayload.r ?? null
+
   // Extract the head vary params from the decoded response.
-  // The head vary params thenable should be fulfilled by now; if not, treat
-  // as unknown (null).
-  const headVaryParamsThenable = initialRSCPayload.h
-  const headVaryParams =
-    headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
-      : null
+  const headVaryParams = readVaryParams(
+    initialRSCPayload.h,
+    rootVaryParamsIterable
+  )
 
   // Only applies when prefetch inlining is enabled — the client doesn't
   // know to look for the head inside a page's response otherwise.
@@ -730,7 +741,8 @@ async function PrefetchTreeData({
     prefetchInlining,
     hints,
     null,
-    headBundle
+    headBundle,
+    rootVaryParamsIterable
   )
 
   // Spawn a task to produce a prefetch response for the "head" segment,
@@ -779,7 +791,8 @@ function collectSegmentDataImpl(
   prefetchInlining: boolean,
   hintTree: PrefetchHints | null,
   parentBundle: SegmentBundleNode | null,
-  headBundle: SegmentBundleNode | null
+  headBundle: SegmentBundleNode | null,
+  rootVaryParamsIterable: VaryParamsIterable | null
 ): TreePrefetch {
   // Union the hints already embedded in the FlightRouterState with the
   // separately-computed build-time hints. During the initial build, the
@@ -796,10 +809,12 @@ function collectSegmentDataImpl(
     ((route[4] ?? 0) | (hintTree !== null ? hintTree.hints : 0)) &
     ~PrefetchHint.InliningHintsStale
 
-  // Determine which params this segment varies on.
-  const varyParamsThenable = seedData !== null ? seedData[4] : null
-  const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+  // Determine which params this segment varies on, unioning in the
+  // response-level root params.
+  const varyParams = readVaryParams(
+    seedData !== null ? seedData[4] : null,
+    rootVaryParamsIterable
+  )
 
   // If static prefetching is disabled for this segment (runtime prefetch or
   // instant = false), it still participates in the bundle chain but with
@@ -897,7 +912,8 @@ function collectSegmentDataImpl(
       prefetchInlining,
       childHintTree,
       childBundle,
-      headBundle
+      headBundle,
+      rootVaryParamsIterable
     )
     if (slotMetadata === null) {
       slotMetadata = {}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -26,7 +26,6 @@ import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import {
   createVaryParamsAccumulator,
   emptyVaryParamsAccumulator,
-  getVaryParamsThenable,
   type VaryParamsAccumulator,
 } from './vary-params'
 import type {
@@ -1362,6 +1361,8 @@ function createSeedData(
     parallelRoutes,
     null,
     isPossiblyPartialResponse,
-    varyParamsAccumulator ? getVaryParamsThenable(varyParamsAccumulator) : null,
+    // The accumulator is itself the AsyncIterable<string> that Flight
+    // serializes into the segment's seed data.
+    varyParamsAccumulator,
   ]
 }

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -5,7 +5,7 @@ import type {
   InitialRSCPayload,
   Segment,
 } from '../../../shared/lib/app-router-types'
-import type { VaryParamsThenable } from '../../../shared/lib/segment-cache/vary-params-decoding'
+import type { VaryParamsIterable } from '../../../shared/lib/segment-cache/vary-params-decoding'
 import { InvariantError } from '../../../shared/lib/invariant-error'
 import { RenderStage } from '../staged-rendering'
 import { getServerModuleMap } from '../manifests-singleton'
@@ -706,7 +706,7 @@ function deserializeFromChunks<T>(
 type SegmentData = {
   node: React.ReactNode | null
   isPartial: boolean
-  varyParams: VaryParamsThenable | null
+  varyParams: VaryParamsIterable | null
 }
 
 function createSegmentData(seedData: CacheNodeSeedData): SegmentData {

--- a/packages/next/src/server/app-render/vary-params.ts
+++ b/packages/next/src/server/app-render/vary-params.ts
@@ -1,37 +1,87 @@
 import type { Params } from '../request/params'
 import type { SearchParams } from '../request/search-params'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
-import type {
-  VaryParamsThenable,
-  VaryParams,
-} from '../../shared/lib/segment-cache/vary-params-decoding'
+import {
+  getVaryParamsAccumulator,
+  workUnitAsyncStorage,
+} from './work-unit-async-storage.external'
 
 /**
  * Accumulates vary params for a single segment (or for metadata/rootParams).
  *
- * VaryParamsAccumulator is also a thenable that can be serialized by React
- * Flight. The accumulator starts as 'pending' and accumulates param accesses
- * during render. Call `finishTrackingVaryParams()` after rendering to resolve
- * all accumulators.
+ * A VaryParamsAccumulator is an `AsyncIterable<string>` that can be serialized
+ * by React Flight. As params are accessed during render, each newly-seen param
+ * name is `add`ed, which yields it into the Flight stream immediately. After
+ * rendering, call `close()` (via `finishAccumulatingVaryParams`) to end the
+ * iteration.
  *
- * The `status` and `value` fields follow the React Flight thenable protocol:
- * when `status === 'fulfilled'`, Flight can read `value` synchronously without
- * scheduling a microtask via `.then()`.
+ * Because each access is flushed into the stream as it happens, the set of
+ * accessed params is built up incrementally, with no step at the end of the
+ * render that has to run for the client to read anything. If the prerender is
+ * aborted by sync I/O, the params yielded before the abort are already in the
+ * stream — and they're exactly the params the partial response depends on.
+ * This mirrors how `StaleTimeIterable` works (see stale-time.ts).
+ *
+ * Each name is emitted at most once: `add` dedupes against the set of
+ * already-yielded names, so the stream never contains a duplicate.
+ *
+ * NOTE: like `StaleTimeIterable`, this supports a single concurrent iteration
+ * (Flight iterates it exactly once). The shared empty singleton below is the
+ * only instance referenced by more than one segment, and it only ever yields
+ * "done", so concurrent iteration of it is safe.
  */
-export type VaryParamsAccumulator = {
-  // Mutable during render - accumulates param access
-  varyParams: VaryParams
+export class VaryParamsAccumulator implements AsyncIterable<string> {
+  private _resolve: ((result: IteratorResult<string>) => void) | null = null
+  private _done = false
+  private _buffer: string[] = []
+  // The set of param names already yielded. Doubles as the dedupe guard so the
+  // same name is never emitted twice.
+  private _seen: Set<string> = new Set()
 
-  // React thenable protocol fields
-  status: 'pending' | 'fulfilled'
-  value: VaryParams
-  then(
-    onfulfilled?: ((value: Set<string>) => unknown) | null,
-    onrejected?: ((reason: unknown) => unknown) | null
-  ): void
+  /**
+   * Records that a param was accessed. Yields the name into the stream the
+   * first time it's seen; subsequent accesses of the same name are no-ops.
+   */
+  add(paramName: string): void {
+    if (this._done || this._seen.has(paramName)) {
+      return
+    }
+    this._seen.add(paramName)
+    if (this._resolve !== null) {
+      this._resolve({ value: paramName, done: false })
+      this._resolve = null
+    } else {
+      this._buffer.push(paramName)
+    }
+  }
 
-  // Internal - callbacks waiting for resolution
-  resolvers: Array<(value: Set<string>) => void>
+  /** Ends the iteration. Best-effort: if skipped (e.g. on a sync-I/O abort),
+   * the consumer simply reads the params yielded so far. */
+  close(): void {
+    if (this._done) {
+      return
+    }
+    this._done = true
+    if (this._resolve !== null) {
+      this._resolve({ value: undefined, done: true })
+      this._resolve = null
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<string> {
+    return {
+      next: () => {
+        if (this._buffer.length > 0) {
+          return Promise.resolve({ value: this._buffer.shift()!, done: false })
+        }
+        if (this._done) {
+          return Promise.resolve({ value: undefined, done: true })
+        }
+        return new Promise<IteratorResult<string>>((resolve) => {
+          this._resolve = resolve
+        })
+      },
+    }
+  }
 }
 
 /**
@@ -48,53 +98,28 @@ export type ResponseVaryParamsAccumulator = {
   segments: Set<VaryParamsAccumulator>
 }
 
-function createSegmentVaryParamsAccumulator(): VaryParamsAccumulator {
-  const accumulator: VaryParamsAccumulator = {
-    varyParams: new Set(),
-    status: 'pending',
-    value: new Set(),
-    then(onfulfilled: ((value: Set<string>) => unknown) | null | undefined) {
-      if (onfulfilled) {
-        if (accumulator.status === 'pending') {
-          accumulator.resolvers.push(onfulfilled)
-        } else {
-          onfulfilled(accumulator.value)
-        }
-      }
-    },
-    resolvers: [],
-  }
-  return accumulator
-}
-
 /**
- * A singleton accumulator that's already resolved to an empty Set. Use this for
+ * A singleton accumulator that's already closed with no params. Use this for
  * segments where we know upfront that no params will be accessed, such as
  * client components or segments without user code.
  *
  * Benefits:
- * - No need to accumulate or resolve later
- * - Resilient: resolves correctly even if other tracking fails
+ * - No need to accumulate or close later
+ * - Resilient: reads as an empty set even if other tracking fails
  * - Memory efficient: reuses the same object
+ *
+ * It's never added to `ResponseVaryParamsAccumulator.segments` (callers pass it
+ * directly), so `finishAccumulatingVaryParams` doesn't touch it.
  */
-const emptySet: VaryParams = new Set()
-export const emptyVaryParamsAccumulator: VaryParamsAccumulator = {
-  varyParams: emptySet,
-  status: 'fulfilled',
-  value: emptySet,
-  then(onfulfilled: ((value: Set<string>) => unknown) | null | undefined) {
-    if (onfulfilled) {
-      onfulfilled(emptySet)
-    }
-  },
-  resolvers: [],
-}
+export const emptyVaryParamsAccumulator: VaryParamsAccumulator =
+  new VaryParamsAccumulator()
+emptyVaryParamsAccumulator.close()
 
 export function createResponseVaryParamsAccumulator(): ResponseVaryParamsAccumulator {
   // Create the head and rootParams accumulators as top-level fields.
   // Segment accumulators are added to the segments set as they are created.
-  const head = createSegmentVaryParamsAccumulator()
-  const rootParams = createSegmentVaryParamsAccumulator()
+  const head = new VaryParamsAccumulator()
+  const rootParams = new VaryParamsAccumulator()
   const segments = new Set<VaryParamsAccumulator>()
 
   return {
@@ -108,82 +133,30 @@ export function createResponseVaryParamsAccumulator(): ResponseVaryParamsAccumul
  * Allocates a new VaryParamsAccumulator and adds it to the response accumulator
  * associated with the current WorkUnitStore.
  *
- * Returns a thenable that resolves to the segment's vary params once rendering
- * is complete. The thenable can be passed directly to React Flight for
+ * Returns an iterable that yields the segment's vary params as they're
+ * accessed. The iterable can be passed directly to React Flight for
  * serialization.
  */
 export function createVaryParamsAccumulator(): VaryParamsAccumulator | null {
   const workUnitStore = workUnitAsyncStorage.getStore()
-  if (workUnitStore) {
-    switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-runtime':
-      case 'request': {
-        const responseAccumulator = workUnitStore.varyParamsAccumulator
-        if (responseAccumulator) {
-          const accumulator = createSegmentVaryParamsAccumulator()
-          responseAccumulator.segments.add(accumulator)
-          return accumulator
-        }
-        return null
-      }
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'cache':
-      case 'private-cache':
-      case 'prerender-client':
-      case 'validation-client':
-      case 'unstable-cache':
-      case 'generate-static-params':
-        break
-      default:
-        workUnitStore satisfies never
-    }
+  if (!workUnitStore) {
+    return null
   }
-  return null
+  const responseAccumulator = getVaryParamsAccumulator(workUnitStore)
+  if (!responseAccumulator) {
+    return null
+  }
+  const accumulator = new VaryParamsAccumulator()
+  responseAccumulator.segments.add(accumulator)
+  return accumulator
 }
 
 export function getMetadataVaryParamsAccumulator(): VaryParamsAccumulator | null {
   const workUnitStore = workUnitAsyncStorage.getStore()
-  if (workUnitStore) {
-    switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-runtime':
-      case 'request': {
-        const responseAccumulator = workUnitStore.varyParamsAccumulator
-        if (responseAccumulator) {
-          return responseAccumulator.head
-        }
-        return null
-      }
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'cache':
-      case 'private-cache':
-      case 'prerender-client':
-      case 'validation-client':
-      case 'unstable-cache':
-      case 'generate-static-params':
-        return null
-      default:
-        workUnitStore satisfies never
-    }
+  if (!workUnitStore) {
+    return null
   }
-  return null
-}
-
-export function getVaryParamsThenable(
-  accumulator: VaryParamsAccumulator
-): VaryParamsThenable | null {
-  return accumulator as unknown as VaryParamsThenable | null
-}
-
-export function getMetadataVaryParamsThenable(): VaryParamsThenable | null {
-  const accumulator = getMetadataVaryParamsAccumulator()
-  if (accumulator !== null) {
-    return getVaryParamsThenable(accumulator)
-  }
-  return null
+  return getVaryParamsAccumulator(workUnitStore)?.head ?? null
 }
 
 // The metadata and viewport are always delivered in a single payload, so they
@@ -191,44 +164,27 @@ export function getMetadataVaryParamsThenable(): VaryParamsThenable | null {
 // now this is just an alias.
 export const getViewportVaryParamsAccumulator = getMetadataVaryParamsAccumulator
 
+/**
+ * Returns the response-level root params iterable for serialization. Root
+ * params are emitted once at the top level (not folded into every segment);
+ * the client unions them into each segment's set.
+ */
 export function getRootParamsVaryParamsAccumulator(): VaryParamsAccumulator | null {
   const workUnitStore = workUnitAsyncStorage.getStore()
-  if (workUnitStore) {
-    switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-runtime': {
-        const responseAccumulator = workUnitStore.varyParamsAccumulator
-        if (responseAccumulator !== null) {
-          return responseAccumulator.rootParams
-        }
-        return null
-      }
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'request':
-      case 'cache':
-      case 'private-cache':
-      case 'prerender-client':
-      case 'validation-client':
-      case 'unstable-cache':
-      case 'generate-static-params':
-        return null
-      default:
-        workUnitStore satisfies never
-    }
+  if (!workUnitStore) {
+    return null
   }
-  return null
+  return getVaryParamsAccumulator(workUnitStore)?.rootParams ?? null
 }
 
 /**
- * Records that a param was accessed. Adds the param name to the accumulator's
- * varyParams set.
+ * Records that a param was accessed. Adds the param name to the accumulator.
  */
 export function accumulateVaryParam(
   accumulator: VaryParamsAccumulator,
   paramName: string
 ): void {
-  accumulator.varyParams.add(paramName)
+  accumulator.add(paramName)
 }
 
 /**
@@ -328,46 +284,25 @@ export function createVaryingSearchParams(
 }
 
 /**
- * Resolves all segment accumulators in a ResponseVaryParamsAccumulator with
- * their final vary params. Call this after rendering is complete.
+ * Closes all accumulators in a ResponseVaryParamsAccumulator, ending their
+ * iterables. Call this after rendering is complete.
  *
- * Each segment's thenable is resolved with its vary params merged with the
- * root params. If we can't track vary params (e.g., legacy prerender), simply
- * don't call this function - the client treats unresolved thenables as
- * "unknown" vary params.
+ * This does NOT merge root params into each segment — root params are
+ * serialized separately (at the top level of the response) and unioned in by
+ * the client. And it's best-effort: if it's skipped because the render was
+ * aborted by sync I/O, the consumer just reads the params each iterable yielded
+ * before the abort.
  *
- * NOTE: This function does not wait for the resulting flight chunks to flush.
- * The appropriate wait time depends on whether we're using a prerender or a render.
+ * If we can't track vary params (e.g., legacy prerender), simply don't call
+ * this function - the client treats a missing iterable as "unknown" vary
+ * params.
  */
 export function finishAccumulatingVaryParams(
   responseAccumulator: ResponseVaryParamsAccumulator
 ): void {
-  const rootVaryParams = responseAccumulator.rootParams.varyParams
-
-  // Resolve head
-  finishSegmentAccumulator(responseAccumulator.head, rootVaryParams)
-
-  // Resolve each segment
+  responseAccumulator.head.close()
+  responseAccumulator.rootParams.close()
   for (const segmentAccumulator of responseAccumulator.segments) {
-    finishSegmentAccumulator(segmentAccumulator, rootVaryParams)
+    segmentAccumulator.close()
   }
-}
-
-function finishSegmentAccumulator(
-  accumulator: VaryParamsAccumulator,
-  rootVaryParams: VaryParams
-): void {
-  if (accumulator.status !== 'pending') {
-    return
-  }
-  const merged = new Set<string>(accumulator.varyParams)
-  for (const param of rootVaryParams) {
-    merged.add(param)
-  }
-  accumulator.value = merged
-  accumulator.status = 'fulfilled'
-  for (const resolver of accumulator.resolvers) {
-    resolver(merged)
-  }
-  accumulator.resolvers = []
 }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -617,3 +617,27 @@ export function getCacheSignal(
       return workUnitStore satisfies never
   }
 }
+
+export function getVaryParamsAccumulator(
+  workUnitStore: WorkUnitStore
+): ResponseVaryParamsAccumulator | null {
+  switch (workUnitStore.type) {
+    case 'prerender':
+    case 'prerender-runtime':
+    case 'request': {
+      return workUnitStore.varyParamsAccumulator ?? null
+    }
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'cache':
+    case 'private-cache':
+    case 'prerender-client':
+    case 'validation-client':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      return null
+    default:
+      workUnitStore satisfies never
+      return null
+  }
+}

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -11,7 +11,7 @@ export type LoadingModuleData =
   | [React.JSX.Element, React.ReactNode, React.ReactNode]
   | null
 
-import type { VaryParamsThenable } from './segment-cache/vary-params-decoding'
+import type { VaryParamsIterable } from './segment-cache/vary-params-decoding'
 
 /** viewport metadata node */
 export type HeadData = React.ReactNode
@@ -330,20 +330,23 @@ export type CacheNodeSeedData = [
   loading: null,
   isPartial: boolean,
   /**
-   * A thenable that resolves to the set of route params this segment accessed
-   * during server rendering. Used by the client router to determine cache key
-   * specificity - segments that only access certain params can be reused across
-   * navigations where unaccessed params change.
+   * An AsyncIterable that yields the route params this segment accessed during
+   * server rendering (one name per yield, deduped). Used by the client router
+   * to determine cache key specificity - segments that only access certain
+   * params can be reused across navigations where unaccessed params change.
    *
-   * - null thenable: tracking was not enabled for this render (e.g., not a
-   *   prerender). Treat conservatively - assume all params vary.
-   * - Thenable resolves to empty Set: segment accesses no params (e.g., client
-   *   components, or server components that don't read params). Can be shared
-   *   across all param values.
-   * - Thenable resolves to non-empty Set: segment depends on those params.
-   *   Can only reuse when those specific params match.
+   * Does NOT include root params; those are emitted once at the top level of
+   * the response (see `r` on the payload) and unioned in by the consumer.
+   *
+   * - null: tracking was not enabled for this render (e.g., not a prerender).
+   *   Treat conservatively - assume all params vary.
+   * - Drains to empty Set: segment accesses no params (e.g., client components,
+   *   or server components that don't read params). Can be shared across all
+   *   param values.
+   * - Drains to non-empty Set: segment depends on those params. Can only reuse
+   *   when those specific params match.
    */
-  varyParams: VaryParamsThenable | null,
+  varyParams: VaryParamsIterable | null,
 ]
 
 export type FlightDataSegment = [
@@ -407,8 +410,15 @@ export type InitialRSCPayload = {
   S: boolean
   /**
    * headVaryParams - vary params for the head (metadata) of the response.
+   * Does not include root params (see `r`).
    */
-  h: VaryParamsThenable | null
+  h: VaryParamsIterable | null
+  /**
+   * rootVaryParams - the root params accessed anywhere in the response, emitted
+   * once. The client unions these into the head and every segment's vary
+   * params, rather than the server folding them into each set.
+   */
+  r?: VaryParamsIterable
   /** staleTime in seconds - Only present when Cache Components is enabled. */
   s?: AsyncIterable<number>
   /** staticStageByteLength - Resolves when the static stage ends. */
@@ -470,8 +480,14 @@ export type NavigationFlightResponse = {
    * where we have a proper session shell.
    * */
   u?: Promise<boolean>
-  /** headVaryParams */
-  h: VaryParamsThenable | null
+  /** headVaryParams. Does not include root params (see `r`). */
+  h: VaryParamsIterable | null
+  /**
+   * rootVaryParams - the root params accessed anywhere in the response, emitted
+   * once. The client unions these into the head and every segment's vary
+   * params.
+   */
+  r?: VaryParamsIterable
   /** runtimePrefetchStream — Embedded runtime prefetch Flight stream. */
   p?: ReadableStream<Uint8Array>
   /**

--- a/packages/next/src/shared/lib/segment-cache/vary-params-decoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/vary-params-decoding.ts
@@ -6,50 +6,116 @@
 
 export type VaryParams = Set<string>
 
-type FulfilledVaryParamsThenable = {
-  status: 'fulfilled'
-  value: VaryParams
-} & PromiseLike<VaryParams>
-
-type PendingVaryParamsThenable = {
-  // 'resolved_model' is an internal React Flight state: the underlying model
-  // data has arrived but the thenable hasn't been "unwrapped" yet. Calling
-  // .then() triggers Flight to synchronously transition to 'fulfilled'.
-  status: 'pending' | 'resolved_model'
-  value: unknown
-} & PromiseLike<VaryParams>
-
-export type VaryParamsThenable =
-  | FulfilledVaryParamsThenable
-  | PendingVaryParamsThenable
+/**
+ * Vary params are serialized into the Flight stream as an
+ * `AsyncIterable<string>` that yields each accessed param name exactly once
+ * (the server dedupes before emitting). Because each access is flushed into the
+ * stream as it happens, there's no step at the end of the render that has to
+ * run for the client to read anything. If a prerender is aborted by sync I/O,
+ * the params yielded before the abort are already in the stream, and they're
+ * exactly the params the partial response actually depends on.
+ *
+ * Root params are NOT included in a segment's own iterable. They're emitted
+ * once at the top level of the response (as a separate iterable) and unioned in
+ * by `readVaryParams`, because root params can be accessed at any point during
+ * the render — folding them into every segment would otherwise require a merge
+ * once the whole render is complete.
+ */
+export type VaryParamsIterable = AsyncIterable<string>
 
 /**
- * Synchronously reads vary params from a thenable.
+ * A Flight "chunk": when an `AsyncIterable` arrives over a fully-buffered Flight
+ * stream, each `iterator.next()` returns one of these instead of a native
+ * Promise. It follows the React thenable protocol — once `status` is
+ * `'fulfilled'`, `value` (the `IteratorResult`) can be read synchronously.
+ */
+type IteratorResultChunk = PromiseLike<IteratorResult<string>> & {
+  status?: 'pending' | 'resolved_model' | 'fulfilled' | 'rejected' | string
+  value?: IteratorResult<string>
+}
+
+/**
+ * Synchronously drains a vary params `AsyncIterable`, adding each yielded name
+ * to `target`.
  *
- * By the time this is called (client-side or in collectSegmentData), the
- * thenable should already be fulfilled because the Flight stream has been
- * fully received. We check the status synchronously to avoid unnecessary
- * microtasks.
+ * By the time this runs (on the client, or in collectSegmentData), the Flight
+ * stream has been fully buffered, so every yielded value is already
+ * materialized and can be read without awaiting. We force each iterator result
+ * to resolve synchronously using the same `.then(noop)` trick React uses
+ * internally, then read its `status`/`value` directly.
  *
- * Returns null if the thenable is still pending (which shouldn't happen in
- * normal operation - it indicates the server failed to track vary params).
+ * We add "every param yielded up to the point the stream suspends": a
+ * normally-closed iterable drains fully, while one left hanging (a sync-I/O
+ * abort, or a `close()` whose row hasn't flushed yet) drains to the prefix
+ * already in the stream. Both are correct — a segment's param accesses are all
+ * flushed as they happen during its render, so the prefix is exactly the set
+ * the response depends on. We therefore never need the terminating `done` row
+ * to be present; it's only stream hygiene.
+ */
+function drainVaryParams(
+  iterable: VaryParamsIterable,
+  target: VaryParams
+): void {
+  const iterator = iterable[Symbol.asyncIterator]()
+  while (true) {
+    const chunk = iterator.next() as IteratorResultChunk
+    // Attach a no-op listener to force Flight to synchronously resolve the
+    // chunk. A freshly-arrived result may be in an intermediate
+    // 'resolved_model' state (data received but not unwrapped); calling
+    // .then() transitions it to 'fulfilled', making the value available
+    // synchronously. (A native Promise has no `status` and simply reads as
+    // not-fulfilled below, so this can never hang.)
+    chunk.then(noop, noop)
+    if (chunk.status !== 'fulfilled' || chunk.value === undefined) {
+      // The stream suspended here. Everything yielded before this point has
+      // already been added.
+      return
+    }
+    const step = chunk.value
+    if (step.done) {
+      return
+    }
+    target.add(step.value)
+  }
+}
+
+/**
+ * Reads a segment's (or the head's) vary params, unioning in the response-level
+ * root params.
+ *
+ * Root params are emitted once at the top level rather than folded into every
+ * segment by the server, so every read recombines them here — building the
+ * merge into the read means a caller can't forget it, and it's done in a single
+ * pass with no intermediate set.
+ *
+ * Returns null ("unknown", key on all params) unless BOTH iterables are
+ * present. A null/absent `iterable` means the segment's own tracking wasn't
+ * enabled (e.g. not a prerender). A null/absent `rootIterable` means root
+ * params weren't tracked — and since a segment's own iterable never includes
+ * root params (those are accessed in layouts above it), narrowing on the
+ * segment set alone would wrongly assume no root params were accessed. In
+ * either case we stay conservative.
+ *
+ * When both are present each is authoritative even when it drains to the empty
+ * set — a tracked segment that read no params, with no root params accessed,
+ * can be shared across all param values.
  */
 export function readVaryParams(
-  thenable: VaryParamsThenable
+  iterable: VaryParamsIterable | null | undefined,
+  rootIterable: VaryParamsIterable | null | undefined
 ): VaryParams | null {
-  // Attach a no-op listener to force Flight to synchronously resolve the
-  // thenable. When a thenable arrives from the Flight stream, it may be in an
-  // intermediate 'resolved_model' state (data received but not unwrapped).
-  // Calling .then() triggers Flight to transition it to 'fulfilled', making
-  // the value available synchronously. React uses this same optimization
-  // internally to avoid unnecessary microtasks.
-  thenable.then(noop)
-  // If the thenable is still not 'fulfilled' after calling .then(), the server
-  // failed to resolve it before the stream ended. Treat as unknown.
-  if (thenable.status !== 'fulfilled') {
+  if (
+    iterable === null ||
+    iterable === undefined ||
+    rootIterable === null ||
+    rootIterable === undefined
+  ) {
     return null
   }
-  return thenable.value
+  const varyParams: VaryParams = new Set()
+  drainVaryParams(iterable, varyParams)
+  drainVaryParams(rootIterable, varyParams)
+  return varyParams
 }
 
 const noop = () => {}


### PR DESCRIPTION
Refactors how vary params are serialized in the Flight stream so that it's compatible with stage rewinding.

The immediate motivation is preparation for allowing root params to be accessed in the App Shell, but this new approach will work more generally for any other kind of rewinding we add in the future.

The design is similar to how stale time is already serialized: each access of a param is written to an AsyncIterable that is embedded into the Flight stream. When decoding the params, the client first buffers the entire stream, then synchronously drains the iterable using the special `status` and `value` fields used by the React protocol, until it reaches a suspended entry.

This is compatible with rewinding because the stream can be cut off at any point and the client can still decode all the param accesses up to that point.

As of this PR, this is a pure refactor: it won't change any observable behavior until the server starts allowing root params in the shell.

<!-- NEXT_JS_LLM_PR -->
