### PR TITLE
log config evaluation time

### DIFF
--- a/packages/next/src/build/duration-to-string.ts
+++ b/packages/next/src/build/duration-to-string.ts
@@ -22,7 +22,7 @@ const MILLISECONDS_THRESHOLD_NANOSECONDS = 2_000_000 // 2 milliseconds in nanose
  * - >= 2 seconds: show in seconds with 1 decimal place (e.g., "3.2s")
  * - < 2 seconds: show in whole milliseconds (e.g., "1500ms")
  *
- * @deprecated Use durationToStringWithNanoseconds instead, collect time in nanoseconds using process.hrtime.bigint().
+ * @deprecated Use hrtimeBigIntDurationToString instead, collect time in nanoseconds using process.hrtime.bigint().
  * @param compilerDuration - Duration in seconds as a number
  * @returns Formatted duration string with appropriate unit and precision
  */

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1747,6 +1747,12 @@ type LoadConfigOptions = {
   bundler?: Bundler
 }
 
+// If loading and evaluating the user's config (including any config plugins
+// such as `withMDX` or `withBundleAnalyzer`) takes longer than this, emit a
+// line reporting how long it took. Fast configs stay silent; slow plugin
+// chains get surfaced so they can be investigated.
+const SLOW_CONFIG_EVAL_THRESHOLD_MS = 500
+
 export default async function loadConfig(
   phase: typeof PHASE_DEVELOPMENT_SERVER,
   dir: string,
@@ -1766,6 +1772,36 @@ export default async function loadConfig(
 export default async function loadConfig(
   phase: PHASE_TYPE,
   dir: string,
+  opts: LoadConfigOptions = {}
+): Promise<NextConfigComplete> {
+  const start = performance.now()
+  // Intentionally not in a `finally`: if evaluation throws, the user already
+  // gets a "Failed to load" error, so reporting how long the failed attempt
+  // took on top of that is just noise.
+  const [config, meta] = await loadConfigImpl(phase, dir, opts)
+  const durationMs = performance.now() - start
+  // Skip the cache-hit fast path: it returns in ~0ms and doesn't re-evaluate
+  // the user's config, so its timing is meaningless noise.
+  if (
+    !meta.cacheHit &&
+    !opts.silent &&
+    durationMs > SLOW_CONFIG_EVAL_THRESHOLD_MS
+  ) {
+    Log.event(
+      `Evaluating ${meta.configFileName ?? 'next.config'} took ${Math.round(durationMs)}ms`
+    )
+  }
+  return config
+}
+
+// The resolved config plus metadata the timing wrapper in `loadConfig` needs:
+// `configFileName` names the actual file (e.g. `next.config.ts`) in the log
+// line, and `cacheHit` flags the fast path so its ~0ms timing is ignored.
+type LoadConfigMeta = { configFileName?: string; cacheHit?: boolean }
+
+async function loadConfigImpl(
+  phase: PHASE_TYPE,
+  dir: string,
   {
     customConfig,
     rawConfig,
@@ -1774,8 +1810,9 @@ export default async function loadConfig(
     reactProductionProfiling,
     debugPrerender,
     bundler,
-  }: LoadConfigOptions = {}
-): Promise<NextConfigComplete> {
+  }: LoadConfigOptions
+): Promise<[NextConfigComplete, LoadConfigMeta]> {
+  const meta: LoadConfigMeta = {}
   // Generate cache key based on parameters that affect config output
   // Include process.pid to invalidate cache on server restart
   const cacheKey = getCacheKey(
@@ -1790,6 +1827,8 @@ export default async function loadConfig(
   // Check if we have a cached result
   const cachedResult = configCache.get(cacheKey)
   if (cachedResult) {
+    meta.cacheHit = true
+
     // Call the experimental features callback if provided
     if (reportExperimentalFeatures) {
       reportExperimentalFeatures(cachedResult.configuredExperimentalFeatures)
@@ -1797,10 +1836,10 @@ export default async function loadConfig(
 
     // Return raw config if requested and available
     if (rawConfig && cachedResult.rawConfig) {
-      return cachedResult.rawConfig
+      return [cachedResult.rawConfig, meta]
     }
 
-    return cachedResult.config
+    return [cachedResult.config, meta]
   } else {
     // Reset next.config errors before loading config
     // This happens on every config load to ensure fresh validation
@@ -1834,7 +1873,7 @@ export default async function loadConfig(
       configuredExperimentalFeatures: [],
     })
 
-    return standaloneConfig
+    return [standaloneConfig, meta]
   }
 
   const curLog = silent
@@ -1881,7 +1920,7 @@ export default async function loadConfig(
 
     reportExperimentalFeatures?.(configuredExperimentalFeatures)
 
-    return config
+    return [config, meta]
   }
 
   const path = await findUp(CONFIG_FILES, { cwd: dir })
@@ -1889,6 +1928,7 @@ export default async function loadConfig(
   // If config file was found
   if (path?.length) {
     configFileName = basename(path)
+    meta.configFileName = configFileName
 
     let userConfigModule: any
     let loadedConfig: NextConfig
@@ -1930,7 +1970,7 @@ export default async function loadConfig(
 
         reportExperimentalFeatures?.(configuredExperimentalFeatures)
 
-        return userConfigModule
+        return [userConfigModule, meta]
       }
 
       // `normalizeConfig` invokes the user's exported config function (or
@@ -2086,7 +2126,7 @@ export default async function loadConfig(
       reportExperimentalFeatures(configuredExperimentalFeatures)
     }
 
-    return finalConfig
+    return [finalConfig, meta]
   } else {
     const configBaseName = basename(CONFIG_FILES[0], extname(CONFIG_FILES[0]))
     const unsupportedConfig = findUp.sync(
@@ -2145,7 +2185,7 @@ export default async function loadConfig(
     reportExperimentalFeatures(configuredExperimentalFeatures)
   }
 
-  return finalConfig
+  return [finalConfig, meta]
 }
 
 export type ConfiguredExperimentalFeature = {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1784,7 +1784,7 @@ export default async function loadConfig(
   // the user's config, so its timing is meaningless noise.
   if (
     !meta.cacheHit &&
-    !opts.silent &&
+    opts.silent === false &&
     durationMs > SLOW_CONFIG_EVAL_THRESHOLD_MS
   ) {
     Log.event(

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1775,9 +1775,9 @@ export default async function loadConfig(
   // took on top of that is just noise.
   const [config, meta] = await loadConfigImpl(phase, dir, opts)
 
-  const durationNanos = process.hrtime.bigint() - startTimeNanos
-  // Test for an explicit `silent == false` since the deffault in loadConfig is true
+  // Test for an explicit `silent == false` since the default in loadConfig is true
   if (!meta.cacheHit && opts.silent === false) {
+    const durationNanos = process.hrtime.bigint() - startTimeNanos
     Log.event(
       `Running ${meta.configFileName ?? 'next.config'} took ${hrtimeBigIntDurationToString(durationNanos)}`
     )

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1769,15 +1769,13 @@ export default async function loadConfig(
   dir: string,
   opts: LoadConfigOptions = {}
 ): Promise<NextConfigComplete> {
-  const startTimeNanos = process.hrtime.bigint()
-  // Intentionally not in a `finally`: if evaluation throws, the user already
-  // gets a "Failed to load" error, so reporting how long the failed attempt
-  // took on top of that is just noise.
+  // Test for an explicit `silent == false` since the default in loadConfig is true
+  const logTiming = opts.silent === false
+  const startTimeNanos = logTiming ? process.hrtime.bigint() : undefined
   const [config, meta] = await loadConfigImpl(phase, dir, opts)
 
-  // Test for an explicit `silent == false` since the default in loadConfig is true
-  if (!meta.cacheHit && opts.silent === false) {
-    const durationNanos = process.hrtime.bigint() - startTimeNanos
+  if (!meta.cacheHit && logTiming) {
+    const durationNanos = process.hrtime.bigint() - startTimeNanos!
     Log.event(
       `Running ${meta.configFileName ?? 'next.config'} took ${hrtimeBigIntDurationToString(durationNanos)}`
     )

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1779,7 +1779,7 @@ export default async function loadConfig(
   // Test for an explicit `silent == false` since the deffault in loadConfig is true
   if (!meta.cacheHit && opts.silent === false) {
     Log.event(
-      `Evaluating ${meta.configFileName ?? 'next.config'} took ${hrtimeBigIntDurationToString(durationNanos)}`
+      `Running ${meta.configFileName ?? 'next.config'} took ${hrtimeBigIntDurationToString(durationNanos)}`
     )
   }
   return config

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -53,7 +53,7 @@ import { HardDeprecatedConfigError } from '../shared/lib/errors/hard-deprecated-
 import { NextInstanceErrorState } from './mcp/tools/next-instance-error-state'
 import { Bundler } from '../lib/bundler'
 import type { MemoryEvictionMode } from '../build/swc/types'
-import { hrtimeBigIntDurationToString } from 'next/src/build/duration-to-string'
+import { hrtimeBigIntDurationToString } from '../build/duration-to-string'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1748,12 +1748,6 @@ type LoadConfigOptions = {
   bundler?: Bundler
 }
 
-// If loading and evaluating the user's config (including any config plugins
-// such as `withMDX` or `withBundleAnalyzer`) takes longer than this, emit a
-// line reporting how long it took. Fast configs stay silent; slow plugin
-// chains get surfaced so they can be investigated.
-const SLOW_CONFIG_EVAL_THRESHOLD_MS = 500
-
 export default async function loadConfig(
   phase: typeof PHASE_DEVELOPMENT_SERVER,
   dir: string,
@@ -1782,13 +1776,8 @@ export default async function loadConfig(
   const [config, meta] = await loadConfigImpl(phase, dir, opts)
 
   const durationNanos = process.hrtime.bigint() - startTimeNanos
-  // Skip the cache-hit fast path: it returns in ~0ms and doesn't re-evaluate
-  // the user's config, so its timing is meaningless noise.
-  if (
-    !meta.cacheHit &&
-    opts.silent === false &&
-    durationMs > SLOW_CONFIG_EVAL_THRESHOLD_MS
-  ) {
+  // Test for an explicit `silent == false` since the deffault in loadConfig is true
+  if (!meta.cacheHit && opts.silent === false) {
     Log.event(
       `Evaluating ${meta.configFileName ?? 'next.config'} took ${hrtimeBigIntDurationToString(durationNanos)}`
     )

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -53,6 +53,7 @@ import { HardDeprecatedConfigError } from '../shared/lib/errors/hard-deprecated-
 import { NextInstanceErrorState } from './mcp/tools/next-instance-error-state'
 import { Bundler } from '../lib/bundler'
 import type { MemoryEvictionMode } from '../build/swc/types'
+import { hrtimeBigIntDurationToString } from 'next/src/build/duration-to-string'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
@@ -1774,12 +1775,13 @@ export default async function loadConfig(
   dir: string,
   opts: LoadConfigOptions = {}
 ): Promise<NextConfigComplete> {
-  const start = performance.now()
+  const startTimeNanos = process.hrtime.bigint()
   // Intentionally not in a `finally`: if evaluation throws, the user already
   // gets a "Failed to load" error, so reporting how long the failed attempt
   // took on top of that is just noise.
   const [config, meta] = await loadConfigImpl(phase, dir, opts)
-  const durationMs = performance.now() - start
+
+  const durationNanos = process.hrtime.bigint() - startTimeNanos
   // Skip the cache-hit fast path: it returns in ~0ms and doesn't re-evaluate
   // the user's config, so its timing is meaningless noise.
   if (
@@ -1788,7 +1790,7 @@ export default async function loadConfig(
     durationMs > SLOW_CONFIG_EVAL_THRESHOLD_MS
   ) {
     Log.event(
-      `Evaluating ${meta.configFileName ?? 'next.config'} took ${Math.round(durationMs)}ms`
+      `Evaluating ${meta.configFileName ?? 'next.config'} took ${hrtimeBigIntDurationToString(durationNanos)}`
     )
   }
   return config

--- a/test/e2e/app-dir/cache-components-errors/utils.ts
+++ b/test/e2e/app-dir/cache-components-errors/utils.ts
@@ -5,6 +5,10 @@ const ignoredLines = [
   'Generating static pages',
   'Inlining static env',
   'Finalizing page optimization',
+  // The config evaluation timing line (e.g. "✓ Running next.config.js took
+  // 15ms") is non-deterministic boot/build noise that is irrelevant to these
+  // runtime-error snapshots.
+  'Running next.config',
 ]
 
 /**

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -18,7 +18,8 @@ describe('build-output-prerender', () => {
         if (cacheComponentsEnabled) {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Turbopack)
+             "✓ Running next.config.js took N
+             ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
@@ -26,7 +27,8 @@ describe('build-output-prerender', () => {
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Rspack)
+             "✓ Running next.config.js took N
+             ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
@@ -34,7 +36,8 @@ describe('build-output-prerender', () => {
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (webpack)
+             "✓ Running next.config.js took N
+             ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
@@ -44,21 +47,24 @@ describe('build-output-prerender', () => {
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Turbopack)
+             "✓ Running next.config.js took N
+             ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Rspack)
+             "✓ Running next.config.js took N
+             ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (webpack)
+             "✓ Running next.config.js took N
+             ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
@@ -133,6 +139,7 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config.js took N
              ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -146,6 +153,7 @@ describe('build-output-prerender', () => {
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config.js took N
              ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -159,6 +167,7 @@ describe('build-output-prerender', () => {
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config.js took N
              ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -174,6 +183,7 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config.js took N
              ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -186,6 +196,7 @@ describe('build-output-prerender', () => {
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config.js took N
              ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -198,6 +209,7 @@ describe('build-output-prerender', () => {
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config.js took N
              ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -328,7 +340,8 @@ describe('build-output-prerender', () => {
         if (cacheComponentsEnabled) {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Turbopack)
+             "✓ Running next.config took N
+             ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
@@ -336,7 +349,8 @@ describe('build-output-prerender', () => {
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Rspack)
+             "✓ Running next.config took N
+             ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
@@ -344,7 +358,8 @@ describe('build-output-prerender', () => {
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (webpack)
+             "✓ Running next.config took N
+             ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
@@ -354,19 +369,22 @@ describe('build-output-prerender', () => {
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Turbopack)
+             "✓ Running next.config took N
+             ▲ Next.js x.y.z (Turbopack)
              - Experiments (use with caution):
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Rspack)
+             "✓ Running next.config took N
+             ▲ Next.js x.y.z (Rspack)
              - Experiments (use with caution):
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (webpack)
+             "✓ Running next.config took N
+             ▲ Next.js x.y.z (webpack)
              - Experiments (use with caution):
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
@@ -389,6 +407,7 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config took N
              ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -402,6 +421,7 @@ describe('build-output-prerender', () => {
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config took N
              ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -415,6 +435,7 @@ describe('build-output-prerender', () => {
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config took N
              ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
@@ -430,6 +451,7 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config took N
              ▲ Next.js x.y.z (Turbopack)
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
@@ -441,6 +463,7 @@ describe('build-output-prerender', () => {
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config took N
              ▲ Next.js x.y.z (Rspack)
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
@@ -452,6 +475,7 @@ describe('build-output-prerender', () => {
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode with NODE_ENV='development'. This will affect performance and should not be used for production.
+             ✓ Running next.config took N
              ▲ Next.js x.y.z (webpack)
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
@@ -475,7 +499,13 @@ function getPreambleOutput(cliOutput: string): string {
       break
     }
 
-    lines.push(line.replace(nextVersion, 'x.y.z'))
+    lines.push(
+      line
+        .replace(nextVersion, 'x.y.z')
+        // The config evaluation timing varies between runs, so normalize it to
+        // keep the snapshot stable (e.g. "took 21ms" -> "took N").
+        .replace(/(Running .* took )[\d.]+(ms|s|min)/, '$1N')
+    )
   }
 
   return lines.join('\n').trim()


### PR DESCRIPTION
Log how long it takes to evaluate next.configs

Sometimes it is very slow this can help users understand at least that it is due to their config

Example dev log
```
running pnpm next --turbopack────────────────────────────────────────────────────────────────╯
▲ Next.js 16.3.0-canary.52 (Turbopack)
- Local:         http://localhost:61086
- Network:       http://10.103.12.203:61086
✓ Ready in 272ms
✓ Running next.config.js took 13ms
```

Example build log
```
✓ Running next.config.js took 10ms
▲ Next.js 16.3.0-canary.52 (Turbopack)
- Experiments (use with caution):
  ✓ mdxRs

⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.

  To migrate automatically, run:
  npx @next/codemod@canary middleware-to-proxy .

  Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
  Creating an optimized production build ...
```


