### PR TITLE
[ci] Allow "rerun failed jobs" to work up until 5 days for e2e deploy tests

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -104,7 +104,8 @@ jobs:
         with:
           name: test-timings
           path: test-timings.json
-          retention-days: 1
+          # Allows "rerun failed jobs" for N days
+          retention-days: 5
           if-no-files-found: error
 
   test-deploy-webpack:


### PR DESCRIPTION
Same as https://github.com/vercel/next.js/pull/91825 but for e2e deploy tests. Size is negligible compared to PNPM store and e2e deploy tests usually only run once a day (for nightlies).

All test timing artifacts are now retained for 5 days.