### PR TITLE
Format submillisecond durations as milliseconds

### DIFF
--- a/packages/next/src/build/duration-to-string.test.ts
+++ b/packages/next/src/build/duration-to-string.test.ts
@@ -22,17 +22,17 @@ describe('durationToString', () => {
 
 describe('hrtimeBigIntDurationToString', () => {
   it.each([
-    [0n, '0.0ms'],
-    [500_000n, '0.5ms'],
-    [1_500_000n, '1.5ms'],
-    [2_000_000n, '2ms'],
-    [1_500_000_000n, '1500ms'],
-    [2_000_000_000n, '2.0s'],
-    [2_500_000_000n, '2.5s'],
-    [40_000_000_000n, '40s'],
-    [45_400_000_000n, '45s'],
-    [120_000_000_000n, '2.0min'],
-    [150_000_000_000n, '2.5min'],
+    [BigInt(0), '0.0ms'],
+    [BigInt(500_000), '0.5ms'],
+    [BigInt(1_500_000), '1.5ms'],
+    [BigInt(2_000_000), '2ms'],
+    [BigInt(1_500_000_000), '1500ms'],
+    [BigInt(2_000_000_000), '2.0s'],
+    [BigInt(2_500_000_000), '2.5s'],
+    [BigInt(40_000_000_000), '40s'],
+    [BigInt(45_400_000_000), '45s'],
+    [BigInt(120_000_000_000), '2.0min'],
+    [BigInt(150_000_000_000), '2.5min'],
   ])('formats %s nanoseconds as %s', (duration, expected) => {
     expect(hrtimeBigIntDurationToString(duration)).toBe(expected)
   })

--- a/packages/next/src/build/duration-to-string.test.ts
+++ b/packages/next/src/build/duration-to-string.test.ts
@@ -1,0 +1,66 @@
+import {
+  durationToString,
+  hrtimeBigIntDurationToString,
+  hrtimeDurationToString,
+  hrtimeToSeconds,
+} from './duration-to-string'
+
+describe('durationToString', () => {
+  it.each([
+    [0, '0ms'],
+    [0.5, '500ms'],
+    [2, '2000ms'],
+    [2.5, '2.5s'],
+    [40, '40.0s'],
+    [45.4, '45s'],
+    [120, '120s'],
+    [150, '2.5min'],
+  ])('formats %s seconds as %s', (duration, expected) => {
+    expect(durationToString(duration)).toBe(expected)
+  })
+})
+
+describe('hrtimeBigIntDurationToString', () => {
+  it.each([
+    [0n, '0.0ms'],
+    [500_000n, '0.5ms'],
+    [1_500_000n, '1.5ms'],
+    [2_000_000n, '2ms'],
+    [1_500_000_000n, '1500ms'],
+    [2_000_000_000n, '2.0s'],
+    [2_500_000_000n, '2.5s'],
+    [40_000_000_000n, '40s'],
+    [45_400_000_000n, '45s'],
+    [120_000_000_000n, '2.0min'],
+    [150_000_000_000n, '2.5min'],
+  ])('formats %s nanoseconds as %s', (duration, expected) => {
+    expect(hrtimeBigIntDurationToString(duration)).toBe(expected)
+  })
+})
+
+describe('hrtimeToSeconds', () => {
+  it.each([
+    [[0, 0], 0],
+    [[1, 500_000_000], 1.5],
+    [[2, 1], 2.000000001],
+  ] as Array<[[number, number], number]>)(
+    'converts %j to %s seconds',
+    (hrtime, expected) => {
+      expect(hrtimeToSeconds(hrtime)).toBe(expected)
+    }
+  )
+})
+
+describe('hrtimeDurationToString', () => {
+  it.each([
+    [[0, 500_000_000], '500ms'],
+    [[2, 500_000_000], '2.5s'],
+    [[45, 400_000_000], '45s'],
+    [[150, 0], '2.5min'],
+  ] as Array<[[number, number], string]>)(
+    'formats %j as %s',
+    (hrtime, expected) => {
+      expect(hrtimeDurationToString(hrtime)).toBe(expected)
+    }
+  )
+})

--- a/packages/next/src/build/duration-to-string.ts
+++ b/packages/next/src/build/duration-to-string.ts
@@ -8,7 +8,6 @@ const MILLISECONDS_PER_SECOND = 1000
 // Time thresholds and conversion factors for nanoseconds
 const NANOSECONDS_PER_SECOND = 1_000_000_000
 const NANOSECONDS_PER_MILLISECOND = 1_000_000
-const NANOSECONDS_PER_MICROSECOND = 1_000
 const NANOSECONDS_IN_MINUTE = 60_000_000_000 // 60 * 1_000_000_000
 const MINUTES_THRESHOLD_NANOSECONDS = 120_000_000_000 // 2 minutes in nanoseconds
 const SECONDS_THRESHOLD_HIGH_NANOSECONDS = 40_000_000_000 // 40 seconds in nanoseconds
@@ -46,7 +45,7 @@ export function durationToString(compilerDuration: number) {
  * - >= 40 seconds: show in whole seconds (e.g., "45s")
  * - >= 2 seconds: show in seconds with 1 decimal place (e.g., "3.2s")
  * - >= 2 milliseconds: show in whole milliseconds (e.g., "250ms")
- * - < 2 milliseconds: show in whole microseconds (e.g., "500µs")
+ * - < 2 milliseconds: show in milliseconds with 1 decimal place (e.g., "0.5ms")
  *
  * @param durationBigInt - Duration in nanoseconds as a BigInt
  * @returns Formatted duration string with appropriate unit and precision
@@ -62,7 +61,7 @@ function durationToStringWithNanoseconds(durationBigInt: bigint): string {
   } else if (duration >= MILLISECONDS_THRESHOLD_NANOSECONDS) {
     return `${(duration / NANOSECONDS_PER_MILLISECOND).toFixed(0)}ms`
   } else {
-    return `${(duration / NANOSECONDS_PER_MICROSECOND).toFixed(0)}µs`
+    return `${(duration / NANOSECONDS_PER_MILLISECOND).toFixed(1)}ms`
   }
 }
 


### PR DESCRIPTION
### What?

Format high-resolution durations below 2 milliseconds using fractional milliseconds instead of microseconds. For example, 500 microseconds is now logged as `0.5ms`.

Add colocated unit coverage for all duration formatting branches, thresholds, and exported conversion helpers.

### Why?

Development request timing details such as `next.js` and `application-code` should use a consistent millisecond unit, including for submillisecond durations.

### How?

Convert nanosecond durations below the 2 millisecond threshold to milliseconds with one decimal place. Durations at or above the threshold retain the existing whole-millisecond formatting.

### Verification

- `pnpm exec jest packages/next/src/build/duration-to-string.test.ts --runInBand` (26 tests passed)
- `pnpm prettier --with-node-modules --ignore-path .prettierignore --check packages/next/src/build/duration-to-string.ts packages/next/src/build/duration-to-string.test.ts`
- `pnpm exec eslint --config eslint.config.mjs packages/next/src/build/duration-to-string.ts packages/next/src/build/duration-to-string.test.ts`
- `pnpm --filter=next types`
- Broad `pnpm test-unit` invocation surfaced four unrelated/environment-dependent failing suites, including a network-dependent test.

<!-- NEXT_JS_LLM_PR -->