### PR TITLE
Fix stale next data API test URL

### DIFF
--- a/test/e2e/app-dir/app-static/app/prerendered-not-found/[slug]/page.tsx
+++ b/test/e2e/app-dir/app-static/app/prerendered-not-found/[slug]/page.tsx
@@ -16,7 +16,7 @@ export default async function Page(props: {
   params: Promise<{ slug: string }>
 }) {
   const params = await props.params
-  await fetch('https://next-data-api.vercel.app/api/random', {
+  await fetch('https://next-data-api-endpoint.vercel.app/api/random', {
     next: {
       tags: ['explicit-tag'],
     },

--- a/test/e2e/app-dir/app-static/app/prerendered-not-found/segment-revalidate/page.tsx
+++ b/test/e2e/app-dir/app-static/app/prerendered-not-found/segment-revalidate/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation'
 export const revalidate = 3
 
 export default async function Page() {
-  await fetch('https://next-data-api.vercel.app/api/random', {
+  await fetch('https://next-data-api-endpoint.vercel.app/api/random', {
     next: {
       tags: ['explicit-tag'],
     },


### PR DESCRIPTION
### Why?

Some app-static prerendered not-found fixtures still fetched `https://next-data-api.vercel.app/api/random`, which now points at a different static deployment and returns 404 for the API route. The rest of the test suite uses `https://next-data-api-endpoint.vercel.app` for this shared data API.

### How?

Updated the two stale fixture fetches to use `https://next-data-api-endpoint.vercel.app/api/random`.

### Verification

- `rg "next-data-api\.vercel\.app" test` returned no matches
- `git diff --check` passed for the changed files
- Not run: full e2e suite (URL-only fixture change)
- Not run: prettier/eslint (local `node_modules` is missing, so `prettier` and `eslint` were not available)

<!-- NEXT_JS_LLM_PR -->