### PR TITLE
Add robots Content Signals metadata

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/robots.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/robots.mdx
@@ -119,6 +119,109 @@ Disallow: /
 Sitemap: https://acme.com/sitemap.xml
 ```
 
+### Content Signals
+
+You can declare AI content usage preferences with [`Content Signals`](https://contentsignals.org/) by passing the `contentSignal` field on a rule.
+
+```ts filename="app/robots.ts" switcher
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      contentSignal: {
+        aiTrain: false,
+        search: true,
+        aiInput: false,
+      },
+    },
+  }
+}
+```
+
+```js filename="app/robots.js" switcher
+export default function robots() {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      contentSignal: {
+        aiTrain: false,
+        search: true,
+        aiInput: false,
+      },
+    },
+  }
+}
+```
+
+Output:
+
+```txt
+User-Agent: *
+Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=no
+```
+
+You can also scope signals to one or more paths:
+
+```ts filename="app/robots.ts" switcher
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      contentSignal: [
+        {
+          path: ['/blog', '/about'],
+          search: true,
+        },
+        {
+          path: '/projects',
+          aiTrain: false,
+          search: true,
+          aiInput: false,
+        },
+      ],
+    },
+  }
+}
+```
+
+```js filename="app/robots.js" switcher
+export default function robots() {
+  return {
+    rules: {
+      userAgent: '*',
+      contentSignal: [
+        {
+          path: ['/blog', '/about'],
+          search: true,
+        },
+        {
+          path: '/projects',
+          aiTrain: false,
+          search: true,
+          aiInput: false,
+        },
+      ],
+    },
+  }
+}
+```
+
+Output:
+
+```txt
+User-Agent: *
+Content-Signal: /blog search=yes
+Content-Signal: /about search=yes
+Content-Signal: /projects ai-train=no, search=yes, ai-input=no
+```
+
 ### Non-standard directives
 
 Some search engines support directives that aren't part of the [Robots Exclusion Standard](https://en.wikipedia.org/wiki/Robots.txt#Standard), such as `Request-Rate` (Seznam) or `Clean-param` (Yandex). Pass these through the `other` field on a rule. Keys preserve their casing and array values emit one line per entry, scoped to the rule's `User-Agent` block.
@@ -182,6 +285,19 @@ type Robots = {
         allow?: string | string[]
         disallow?: string | string[]
         crawlDelay?: number
+        contentSignal?:
+          | {
+              path?: string | string[]
+              aiTrain?: boolean
+              search?: boolean
+              aiInput?: boolean
+            }
+          | Array<{
+              path?: string | string[]
+              aiTrain?: boolean
+              search?: boolean
+              aiInput?: boolean
+            }>
         other?: Record<string, string | number | Array<string | number>>
       }
     | Array<{
@@ -189,6 +305,19 @@ type Robots = {
         allow?: string | string[]
         disallow?: string | string[]
         crawlDelay?: number
+        contentSignal?:
+          | {
+              path?: string | string[]
+              aiTrain?: boolean
+              search?: boolean
+              aiInput?: boolean
+            }
+          | Array<{
+              path?: string | string[]
+              aiTrain?: boolean
+              search?: boolean
+              aiInput?: boolean
+            }>
         other?: Record<string, string | number | Array<string | number>>
       }>
   sitemap?: string | string[]
@@ -200,5 +329,6 @@ type Robots = {
 
 | Version   | Changes                                                    |
 | --------- | ---------------------------------------------------------- |
+| `v16.3.0` | Added `contentSignal` field for Content Signals.           |
 | `v16.3.0` | Added `other` field for non-standard per-agent directives. |
 | `v13.3.0` | `robots` introduced.                                       |

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
@@ -116,6 +116,50 @@ describe('resolveRouteData', () => {
       `)
     })
 
+    it('should resolve content signals', () => {
+      const data: MetadataRoute.Robots = {
+        rules: [
+          {
+            userAgent: '*',
+            allow: '/',
+            contentSignal: {
+              aiTrain: true,
+              search: true,
+              aiInput: false,
+            },
+          },
+          {
+            userAgent: 'ExampleBot',
+            contentSignal: [
+              {
+                path: ['/blog', '/about'],
+                search: true,
+              },
+              {
+                path: '/projects',
+                aiTrain: false,
+                search: true,
+                aiInput: false,
+              },
+            ],
+          },
+        ],
+      }
+
+      expect(resolveRobots(data)).toMatchInlineSnapshot(`
+        "User-Agent: *
+        Allow: /
+        Content-Signal: ai-train=yes, search=yes, ai-input=no
+
+        User-Agent: ExampleBot
+        Content-Signal: /blog search=yes
+        Content-Signal: /about search=yes
+        Content-Signal: /projects ai-train=no, search=yes, ai-input=no
+
+        "
+      `)
+    })
+
     it('should skip null/undefined entries in `other`', () => {
       const data: MetadataRoute.Robots = {
         rules: {

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -1,6 +1,50 @@
 import type { MetadataRoute } from '../../../../lib/metadata/types/metadata-interface'
 import { resolveArray } from '../../../../lib/metadata/generate/utils'
 
+type RobotsContentSignal = NonNullable<
+  MetadataRoute.Robots['rules'] extends infer Rules
+    ? Rules extends Array<infer Rule>
+      ? Rule extends { contentSignal?: infer ContentSignal }
+        ? ContentSignal
+        : never
+      : Rules extends { contentSignal?: infer ContentSignal }
+        ? ContentSignal
+        : never
+    : never
+>
+
+function resolveContentSignal(
+  contentSignal: RobotsContentSignal | undefined
+): string {
+  if (!contentSignal) return ''
+
+  let content = ''
+  const signals = Array.isArray(contentSignal) ? contentSignal : [contentSignal]
+
+  for (const signal of signals) {
+    const values = [
+      typeof signal.aiTrain === 'boolean'
+        ? `ai-train=${signal.aiTrain ? 'yes' : 'no'}`
+        : null,
+      typeof signal.search === 'boolean'
+        ? `search=${signal.search ? 'yes' : 'no'}`
+        : null,
+      typeof signal.aiInput === 'boolean'
+        ? `ai-input=${signal.aiInput ? 'yes' : 'no'}`
+        : null,
+    ].filter(Boolean)
+
+    if (values.length === 0) continue
+
+    const paths = signal.path ? resolveArray(signal.path) : [null]
+    for (const path of paths) {
+      content += `Content-Signal: ${path ? `${path} ` : ''}${values.join(', ')}\n`
+    }
+  }
+
+  return content
+}
+
 // convert robots data to txt string
 export function resolveRobots(data: MetadataRoute.Robots): string {
   let content = ''
@@ -25,6 +69,7 @@ export function resolveRobots(data: MetadataRoute.Robots): string {
     if (rule.crawlDelay) {
       content += `Crawl-delay: ${rule.crawlDelay}\n`
     }
+    content += resolveContentSignal(rule.contentSignal)
     if (rule.other) {
       for (const key of Object.keys(rule.other)) {
         const value = rule.other[key]

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -679,6 +679,27 @@ type RobotsRuleBase = {
   disallow?: string | string[] | undefined
   crawlDelay?: number | undefined
   /**
+   * Content Signals directives for declaring preferences about automated
+   * content usage.
+   *
+   * @example
+   * ```ts
+   * contentSignal: {
+   *   aiTrain: false,
+   *   search: true,
+   *   aiInput: false,
+   * }
+   *
+   * contentSignal: {
+   *   path: '/blog',
+   *   aiTrain: false,
+   *   search: true,
+   *   aiInput: true,
+   * }
+   * ```
+   */
+  contentSignal?: RobotsContentSignal | RobotsContentSignal[] | undefined
+  /**
    * Non-standard per-user-agent directives passed through verbatim to the
    * generated `robots.txt`. Keys preserve their casing and array values emit
    * one line per entry.
@@ -694,6 +715,13 @@ type RobotsRuleBase = {
    * ```
    */
   other?: Record<string, string | number | Array<string | number>> | undefined
+}
+
+type RobotsContentSignal = {
+  path?: string | string[] | undefined
+  aiTrain?: boolean | undefined
+  search?: boolean | undefined
+  aiInput?: boolean | undefined
 }
 
 type RobotsFile = {


### PR DESCRIPTION
### What?

Adds first-class `contentSignal` support to `MetadataRoute.Robots` for emitting Content Signals directives in generated `robots.txt` files.

Example:

```ts
export default function robots(): MetadataRoute.Robots {
  return {
    rules: {
      userAgent: '*',
      contentSignal: {
        aiTrain: false,
        search: true,
        aiInput: false,
      },
    },
  }
}
```

emits:

```txt
Content-Signal: ai-train=no, search=yes, ai-input=no
```

Also supports path-scoped signals via `path`.

### Why?

Content Signals provide a standard way for publishers to declare preferences for automated content usage in `robots.txt`, including `ai-train`, `search`, and `ai-input`.

Related discussion: https://github.com/vercel/next.js/discussions/85382

### How?

- Adds a typed `contentSignal` field to `MetadataRoute.Robots` rules.
- Serializes boolean preferences to `yes` / `no` values for `Content-Signal` directives.
- Supports one or more path-scoped Content Signal directives.
- Adds unit coverage for generated `robots.txt` output.
- Documents the new field in the `robots.txt` file convention docs.

### Verification

- `pnpm prettier --write packages/next/src/lib/metadata/types/metadata-interface.ts packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts docs/01-app/03-api-reference/03-file-conventions/01-metadata/robots.mdx`
- `pnpm testonly packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts`
- `pnpm --filter next types`
- `pnpm --filter next build`

Closes #85382