### PR TITLE
Repro: PPR shell + resume emit duplicate Suspense segment ids (B:/S:)

### DIFF
--- a/test/e2e/app-dir/ppr-resume-segment-collision/app/layout.tsx
+++ b/test/e2e/app-dir/ppr-resume-segment-collision/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/ppr-resume-segment-collision/app/page.tsx
+++ b/test/e2e/app-dir/ppr-resume-segment-collision/app/page.tsx
@@ -1,0 +1,68 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// With cacheComponents (PPR) the response is:
+//   [static shell] [prerender-deferred segments] [resume stream]
+// React's getPostponedState snapshots `nextSegmentId` BEFORE the prelude flush.
+// The flush then OUTLINES the large completed boundaries into the shell — each
+// emits `<template id="B:n">` + `<div hidden id="S:n">` and consumes ids
+// allocated AFTER that snapshot. The resume render is seeded from the stale
+// snapshot and re-allocates the very same ids for its own outlined boundaries,
+// so the served document carries duplicate B:/S: pairs.
+export default function Page() {
+  return (
+    <main>
+      {[0, 1, 2, 3].map((n) => (
+        <Suspense key={n} fallback={<p>loading static {n}…</p>}>
+          <BigStatic n={n} />
+        </Suspense>
+      ))}
+      {[0, 1, 2, 3].map((n) => (
+        <Suspense key={n} fallback={<p>loading dynamic {n}…</p>}>
+          <DynamicUser n={n} />
+        </Suspense>
+      ))}
+    </main>
+  )
+}
+
+// Large + fully static, so Fizz outlines this completed boundary into the shell.
+function BigStatic({ n }: { n: number }) {
+  return (
+    <section>
+      <h2>static {n}</h2>
+      {Array.from({ length: 80 }, (_, i) => (
+        <p key={i}>
+          static {n} row {i} — abcdefghijklmnopqrstuvwxyz0123456789
+        </p>
+      ))}
+    </section>
+  )
+}
+
+// cookies() postpones during the prerender; on resume the nested large static
+// Suspense is outlined by the resume's own Fizz instance, reusing shell ids.
+async function DynamicUser({ n }: { n: number }) {
+  const user = (await cookies()).get('user')?.value ?? 'anonymous'
+  return (
+    <div>
+      user {n}: {user}
+      <Suspense fallback={<p>nested {n}…</p>}>
+        <NestedBulk n={n} />
+      </Suspense>
+    </div>
+  )
+}
+
+function NestedBulk({ n }: { n: number }) {
+  return (
+    <section>
+      <h3>nested {n}</h3>
+      {Array.from({ length: 150 }, (_, i) => (
+        <p key={i}>
+          nested {n} row {i} — abcdefghijklmnopqrstuvwxyz
+        </p>
+      ))}
+    </section>
+  )
+}

--- a/test/e2e/app-dir/ppr-resume-segment-collision/next.config.js
+++ b/test/e2e/app-dir/ppr-resume-segment-collision/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = { cacheComponents: true }

--- a/test/e2e/app-dir/ppr-resume-segment-collision/ppr-resume-segment-collision.test.ts
+++ b/test/e2e/app-dir/ppr-resume-segment-collision/ppr-resume-segment-collision.test.ts
@@ -1,0 +1,32 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression: a PPR shell and its resume must not reuse Fizz segment-completion
+// ids. React's getPostponedState snapshots `nextSegmentId` before the prelude
+// flush; the flush then outlines large completed boundaries into the shell,
+// allocating further ids. The resume is seeded from the stale snapshot and
+// re-allocates the same ids, so the served document has duplicate
+// `<template id="B:n">` / `<div hidden id="S:n">` pairs — and the inline `$RC`
+// swap scripts (getElementById, first match) then cross-wire boundary content.
+describe('ppr-resume-segment-collision', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({ files: __dirname })
+
+  if (skipped || isNextDev) {
+    // Dev has no prerendered shell, so the resume path under test never runs.
+    it('skips in dev', () => {})
+    return
+  }
+
+  it('serves the page without duplicate Suspense completion ids', async () => {
+    const html = await (await next.fetch('/')).text()
+
+    const dupes = (re: RegExp) => {
+      const ids = [...html.matchAll(re)].map((m) => m[1])
+      return [...new Set(ids.filter((id, i) => ids.indexOf(id) !== i))].sort()
+    }
+
+    expect({
+      segments: dupes(/<div hidden id="(S:[^"]+)"/g),
+      templates: dupes(/<template id="(B:[^"]+)"/g),
+    }).toEqual({ segments: [], templates: [] })
+  })
+})


### PR DESCRIPTION
## What

A minimal **failing** e2e reproducing a PPR (`cacheComponents`) bug: the served document contains **duplicate Suspense completion ids** — the same `<template id="B:n">` and `<div hidden id="S:n">` pairs appear twice.

This is a **repro only** (no fix), opened to showcase the bug. The single test is **expected to fail on `canary`**.

## Why it happens

With `cacheComponents`, a response is `[static shell] [prerender-deferred segments] [resume stream]`, stitched into one document.

1. React's `getPostponedState` snapshots `nextSegmentId` at `onAllReady` — **before** the pull-driven prelude flush.
2. The flush then **outlines** the large completed boundaries into the shell, allocating segment ids **after** that snapshot (`boundary.rootSegmentID = request.nextSegmentId++`).
3. The resume render is seeded from the stale snapshot (`request.nextSegmentId = postponedState.nextSegmentId`) and re-allocates the **same** ids for its own outlined boundaries.
4. The stitched document then has duplicate `B:`/`S:` ids. The inline `$RC` completion scripts resolve targets with `document.getElementById` (first match), so content cross-wires between boundaries — React #418/#419 recovery, duplicated/orphaned subtrees (a visible "tear" on slow networks).

It only surfaces when the shell actually **outlines** a completed boundary (large or suspensey shell); a small, fully-inlined shell leaves the snapshot equal to the final id, which is why this has been latent.

## Repro output (current `canary`, `next start`)

```
✕ serves the page without duplicate Suspense completion ids

  - Expected
  + Received
    Object {
  -   "segments": Array [],
  -   "templates": Array [],
  +   "segments": Array ["S:4", "S:5", "S:6"],
  +   "templates": Array ["B:4", "B:5", "B:6"],
    }
```

(Skips in dev — dev has no prerendered shell, so the resume path under test never runs.)

## Fix (separate)

Root cause is in React's Fizz — the `getPostponedState` snapshot timing — fixed upstream in facebook/react#36779 (finalize `nextSegmentId` after the prelude flush). No Next-side change is required: Next serializes the same `postponed` object React now finalizes after the shell flush.

**Verified end-to-end:** building React with facebook/react#36779, vendoring it into Next via `sync-react`, and rebuilding makes this test go green (`✓ serves the page without duplicate Suspense completion ids`). Only the vendored React version changed between the failing and passing runs (`43bcbf80` → `19.3.0-experimental-1cf7826d`); same Node-streams Turbopack path, same fixture. So this test will pass once the React fix lands and Next does a React sync.

