### PR TITLE
[ci] Clean up references to self-hosted runners

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -129,10 +129,9 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
             'pnpm install ' +
             // tolerate lockfile changes from merging latest changes
             '--no-frozen-lockfile ' +
-            // avoid hardlink issues on self-hosted runners,
-            '--package-import-method=clone-or-copy ' +
-            // the store is colocated with the workdir to avoid EXDEV copy
-            // failures on overlayfs runners.
+            // colocate the store with the workdir to avoid EXDEV hardlink or
+            // reflink failures across the container's bind-mounted workdir and
+            // overlayfs root.
             `--store-dir=${pnpmStoreDir}`
           await exec.spawnPromise(command, {
             env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' },

--- a/.github/actions/sccache/start.sh
+++ b/.github/actions/sccache/start.sh
@@ -27,11 +27,6 @@ echo "Cache endpoint: ${TURBO_API:0:9}..."
 echo "TURBO_TOKEN: ${TURBO_TOKEN:0:3}..."
 echo "TURBO_TEAM: ${TURBO_TEAM}"
 
-# Kill stale processes from cancelled builds on self-hosted runners.
-sccache --stop-server 2>/dev/null || true
-pkill -9 -x cargo 2>/dev/null || true
-pkill -9 -x rustc 2>/dev/null || true
-
 # Install vercel/sccache fork via cargo-binstall.
 # cargo-binstall is installed by .github/actions/setup-rust.
 cargo binstall --no-confirm --git https://github.com/vercel/sccache sccache

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -171,12 +171,10 @@ jobs:
       # Match the reusable workflow's pnpm-store cache path so this setup-only
       # job does not bottleneck the larger test matrix.
       - name: Get pnpm store directory
-        if: ${{ runner.environment == 'github-hosted' }}
         id: get-store-path
         run: echo STORE_PATH="$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
-        if: ${{ runner.environment == 'github-hosted' }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         timeout-minutes: 5
         id: cache-pnpm-store

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -232,9 +232,7 @@ jobs:
           node --version
           pnpm --version
 
-      # Cache pnpm store on GitHub-hosted runners (self-hosted runners have their own persistent storage)
       - name: Get pnpm store directory
-        if: ${{ runner.environment == 'github-hosted' }}
         id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
@@ -307,7 +305,7 @@ jobs:
         # risk caching an incomplete store
         # If keep conditions in sync breaks, we can split into restore and save
         # steps where saving runs based on the outcome of the install step
-        if: ${{ runner.environment == 'github-hosted' && (inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes') }}
+        if: ${{ inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes' }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         timeout-minutes: 5
         id: cache-pnpm-store
@@ -380,7 +378,7 @@ jobs:
       # Restore the list of tests that already passed in an earlier
       # attempt of this same workflow run.
       - name: Restore passed-tests cache
-        if: ${{ inputs.afterBuild && runner.environment == 'github-hosted' }}
+        if: ${{ inputs.afterBuild }}
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.NEXT_TEST_PASSED_FILE }}
@@ -400,7 +398,7 @@ jobs:
       # Save the passed-tests file so the next attempt (if any) can skip
       # them. `always()` makes this run on success, failure, or cancellation.
       - name: Save passed-tests cache
-        if: ${{ always() && inputs.afterBuild && runner.environment == 'github-hosted' }}
+        if: ${{ always() && inputs.afterBuild }}
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.NEXT_TEST_PASSED_FILE }}


### PR DESCRIPTION
We're no longer using self-hosted runners. I had claude look for places where we had references to self-hosted runners and I had it clean them up.

Stats job for this PR: https://github.com/vercel/next.js/actions/runs/27572281422/job/81511924690?pr=94827