### PR TITLE
[backport] [test] Fix external rewrite target URL origin

### DIFF
--- a/test/e2e/skip-trailing-slash-redirect/app/middleware.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/middleware.js
@@ -35,11 +35,11 @@ export default function handler(req) {
     }
 
     console.log(
-      `rewriting to https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`
+      `rewriting to https://middleware-external-rewrite-target.vercel.app${pathname}`
     )
 
     return NextResponse.rewrite(
-      `https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`
+      `https://middleware-external-rewrite-target.vercel.app${pathname}`
     )
   }
 


### PR DESCRIPTION
### Why?

Backports https://github.com/vercel/next.js/pull/86863 to `14-2-1` so the skip-trailing-slash-redirect fixture rewrites to the assigned custom domain instead of the protected deployment-specific URL.

### How?

- Cherry-picked `551b32d8fc26f801a396391c002eea06ab963c31` with `-x`.
- Updates `test/e2e/skip-trailing-slash-redirect/app/middleware.js` to use `https://middleware-external-rewrite-target.vercel.app`.

### Verification

- `pnpm build` passed. (`pnpm build-all` is not available on `14-2-1`.)
- `pnpm test-start test/e2e/skip-trailing-slash-redirect/index.test.ts` failed locally: Playwright Chromium repeatedly exited/crashed with `SIGSEGV` during browser launch; 20 tests passed before browser-launch failures.
- `pnpm test-start-turbo test/e2e/skip-trailing-slash-redirect/index.test.ts` failed locally: fixture `next build` was killed with `SIGKILL`, causing the suite setup to time out.

<!-- NEXT_JS_LLM_PR -->