### PR TITLE
[backport] [test] Fix external rewrite target URL origin

### DIFF
--- a/test/e2e/skip-trailing-slash-redirect/app/middleware.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/middleware.js
@@ -35,11 +35,11 @@ export default function handler(req) {
     }
 
     console.log(
-      `rewriting to https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`
+      `rewriting to https://middleware-external-rewrite-target.vercel.app${pathname}`
     )
 
     return NextResponse.rewrite(
-      `https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`
+      `https://middleware-external-rewrite-target.vercel.app${pathname}`
     )
   }
 


### PR DESCRIPTION
### Why?

Backports https://github.com/vercel/next.js/pull/86863 to `next-15-5` so the skip-trailing-slash-redirect fixture rewrites to the assigned custom domain instead of the protected deployment-specific URL.

### How?

- Cherry-picked `551b32d8fc26f801a396391c002eea06ab963c31` with `-x`.
- Updates `test/e2e/skip-trailing-slash-redirect/app/middleware.js` to use `https://middleware-external-rewrite-target.vercel.app`.

### Verification

- `pnpm build` passed. (`pnpm build-all` is not available on `next-15-5`.)
- Not run: `pnpm test-start test/e2e/skip-trailing-slash-redirect/index.test.ts` (stopped per follow-up request to just cherry-pick and open PR).
- Not run: `pnpm test-start-turbo test/e2e/skip-trailing-slash-redirect/index.test.ts` (stopped per follow-up request to just cherry-pick and open PR).

<!-- NEXT_JS_LLM_PR -->