### PR TITLE
[turbopack] Add `experimental.turbopackChunkingPriorities` to `next.config.js` with validation

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -231,6 +231,7 @@ import {
 } from '../server/lib/router-utils/build-prefetch-segment-data-route'
 import { generateRoutesManifest } from './generate-routes-manifest'
 import { validateAppPaths } from './validate-app-paths'
+import { findInvalidChunkingPriorities } from './validate-chunking-priorities'
 
 type Fallback = null | boolean | string
 
@@ -1380,6 +1381,37 @@ export default async function build(
       // but is instead specifically focused on code that can be shared
       // eventually with the development code.
       validateAppPaths(appPaths)
+
+      // Validate that every `experimental.turbopackChunkingPriorities` key
+      // refers to a real route.
+      if (bundler === Bundler.Turbopack) {
+        const validChunkingPriorityRoutes = new Set([
+          ...pagesPageKeys,
+          ...appPaths,
+        ])
+
+        const invalidChunkingPriorities = findInvalidChunkingPriorities(
+          config.experimental.turbopackChunkingPriorities,
+          validChunkingPriorityRoutes
+        )
+        if (invalidChunkingPriorities.length > 0) {
+          Log.error(
+            `Invalid route ${
+              invalidChunkingPriorities.length > 1 ? 'keys' : 'key'
+            } in \`experimental.turbopackChunkingPriorities\`:`
+          )
+          for (const { key, suggestion } of invalidChunkingPriorities) {
+            Log.error(
+              `  - "${key}"${
+                suggestion ? ` (did you mean "${suggestion}"?)` : ''
+              }`
+            )
+          }
+          throw new Error(
+            'Invalid `experimental.turbopackChunkingPriorities` configuration.'
+          )
+        }
+      }
 
       // Interception routes are modelled as beforeFiles rewrites
       rewrites.beforeFiles.push(

--- a/packages/next/src/build/validate-chunking-priorities.ts
+++ b/packages/next/src/build/validate-chunking-priorities.ts
@@ -1,0 +1,92 @@
+/**
+ * An invalid `experimental.turbopackChunkingPriorities` key: a route that does
+ * not match any real route in the project, optionally with a "did you mean"
+ * suggestion for the closest known route.
+ */
+export interface InvalidChunkingPriority {
+  key: string
+  suggestion: string | undefined
+}
+
+/**
+ * Computes the Levenshtein edit distance between two strings. Used to suggest a
+ * "did you mean" route for a mistyped key in
+ * `experimental.turbopackChunkingPriorities`.
+ */
+function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  if (m === 0) return n
+  if (n === 0) return m
+
+  let prev = new Array<number>(n + 1)
+  for (let j = 0; j <= n; j++) prev[j] = j
+
+  for (let i = 1; i <= m; i++) {
+    const curr = new Array<number>(n + 1)
+    curr[0] = i
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+    }
+    prev = curr
+  }
+
+  return prev[n]
+}
+
+/**
+ * Returns the closest route to `key` from `validRoutes`, but only when it is
+ * close enough to plausibly be a typo.
+ */
+function findClosestRoute(
+  key: string,
+  validRoutes: Iterable<string>
+): string | undefined {
+  let best: string | undefined
+  let bestDistance = Infinity
+
+  for (const route of validRoutes) {
+    const distance = levenshtein(key, route)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = route
+    }
+  }
+
+  if (best === undefined) return undefined
+
+  // Only suggest when the edit distance is small relative to the key length.
+  const threshold = Math.max(2, Math.floor(key.length / 3))
+  return bestDistance <= threshold ? best : undefined
+}
+
+/**
+ * Validates the keys of `experimental.turbopackChunkingPriorities` against the
+ * set of real route pathnames in the project and returns the keys that don't
+ * match any route.
+ *
+ * @param priorities - The `experimental.turbopackChunkingPriorities` config value.
+ * @param validRoutes - Every valid route pathname in the project (app + pages).
+ * @returns The invalid keys, each with a "did you mean" suggestion when one is close.
+ */
+export function findInvalidChunkingPriorities(
+  priorities: Record<string, 'low' | 'medium' | 'high'> | undefined,
+  validRoutes: Iterable<string>
+): InvalidChunkingPriority[] {
+  if (!priorities) return []
+
+  const keys = Object.keys(priorities)
+  if (keys.length === 0) return []
+
+  const valid = new Set(validRoutes)
+
+  const invalid: InvalidChunkingPriority[] = []
+  for (const key of keys) {
+    if (!valid.has(key)) {
+      invalid.push({ key, suggestion: findClosestRoute(key, valid) })
+    }
+  }
+
+  return invalid
+}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -379,6 +379,9 @@ export const experimentalSchema = {
   turbopackRemoveUnusedImports: z.boolean().optional(),
   turbopackRemoveUnusedExports: z.boolean().optional(),
   turbopackScopeHoisting: z.boolean().optional(),
+  turbopackChunkingPriorities: z
+    .record(z.string(), z.enum(['low', 'medium', 'high']))
+    .optional(),
   turbopackWorkerAssetPrefix: z.string().optional(),
   turbopackClientSideNestedAsyncChunking: z.boolean().optional(),
   turbopackServerSideNestedAsyncChunking: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -750,7 +750,7 @@ export interface ExperimentalConfig {
    * paths (e.g. `/products/[id]`), values are `'low' | 'medium' | 'high'`.
    * Routes not listed default to `'medium'`. Turbopack will avoid
    * over-shipping code to `high` priority routes to reduce page-load times
-   * on them.
+   * on them, at the cost of making other pages slower to load.
    */
   turbopackChunkingPriorities?: Record<string, 'low' | 'medium' | 'high'>
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -746,6 +746,15 @@ export interface ExperimentalConfig {
   turbopackScopeHoisting?: boolean
 
   /**
+   * (`next --turbopack` only) Per-route traffic priorities. Keys are route
+   * paths (e.g. `/products/[id]`), values are `'low' | 'medium' | 'high'`.
+   * Routes not listed default to `'medium'`. Turbopack will avoid
+   * over-shipping code to `high` priority routes to reduce page-load times
+   * on them.
+   */
+  turbopackChunkingPriorities?: Record<string, 'low' | 'medium' | 'high'>
+
+  /**
    * (`next --turbopack` only) A custom URL prefix for Web Worker URLs
    * produced by `new Worker(new URL(..., import.meta.url))` — both the
    * entrypoint URL and the module chunks loaded inside the worker —


### PR DESCRIPTION
These priorities will be used up this PR stack to weight whether or not to over-ship code as part of chunking.