### PR TITLE
[turbopack] Thread priorities for chunking through to `ChunkGroupInfo`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -60,7 +60,7 @@ use turbopack_core::{
     module_graph::{
         GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
         binding_usage_info::compute_binding_usage_info,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     reference::all_assets_from_entries,
@@ -886,7 +886,10 @@ impl AppProject {
             let span = tracing::info_span!("module graph for endpoint", modules = Empty);
             let span_clone = span.clone();
             async move {
-                let rsc_entry_chunk_group = ChunkGroupEntry::Entry(vec![rsc_entry]);
+                let rsc_entry_chunk_group = ChunkGroupEntry::Entry {
+                    modules: vec![rsc_entry],
+                    priority: ChunkGroupPriority::default(),
+                };
 
                 let mut graphs = vec![];
                 let mut visited_modules = VisitedModules::empty();
@@ -909,7 +912,10 @@ impl AppProject {
                     // and the page
                     let graph = SingleModuleGraph::new_with_entries_visited_intern(
                         GraphEntries::from_chunk_groups(vec![
-                            ChunkGroupEntry::Entry(client_shared_entries),
+                            ChunkGroupEntry::Entry {
+                                modules: client_shared_entries,
+                                priority: ChunkGroupPriority::default(),
+                            },
                             ChunkGroupEntry::SharedMultiple(
                                 server_utils
                                     .iter()
@@ -2128,17 +2134,35 @@ impl Endpoint for AppEndpoint {
     #[turbo_tasks::function]
     async fn entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
         let this = self.await?;
+        let app_entry = self.app_endpoint_entry().await?;
+        // The route's traffic priority from `experimental.turbopackChunkingPriorities`. The
+        // client chunk group of the route is an IsolatedMerged chunk group below this entry
+        // chunk group and inherits its priority.
+        let priority = this
+            .app_project
+            .project()
+            .next_config()
+            .turbopack_chunking_priorities()
+            .await?
+            .get(&app_entry.pathname)
+            .copied()
+            .unwrap_or_default();
         Ok(GraphEntries::from_chunk_groups(vec![
-            ChunkGroupEntry::Entry(vec![self.app_endpoint_entry().await?.rsc_entry]),
-            ChunkGroupEntry::Entry(
-                this.app_project
+            ChunkGroupEntry::Entry {
+                modules: vec![app_entry.rsc_entry],
+                priority,
+            },
+            ChunkGroupEntry::Entry {
+                modules: this
+                    .app_project
                     .client_runtime_entries()
                     .await?
                     .iter()
                     .copied()
                     .map(ResolvedVc::upcast)
                     .collect(),
-            ),
+                priority: ChunkGroupPriority::default(),
+            },
         ])
         .cell())
     }

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{
         GraphEntries,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -257,8 +257,11 @@ impl Endpoint for InstrumentationEndpoint {
     async fn entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
         let entry_module = self.entry_module().to_resolved().await?;
         Ok(
-            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![entry_module])])
-                .cell(),
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                modules: vec![entry_module],
+                priority: ChunkGroupPriority::default(),
+            }])
+            .cell(),
         )
     }
 

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{
         GraphEntries,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -407,9 +407,10 @@ impl Endpoint for MiddlewareEndpoint {
     #[turbo_tasks::function]
     async fn entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
         Ok(
-            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
-                self.entry_module().to_resolved().await?,
-            ])])
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                modules: vec![self.entry_module().to_resolved().await?],
+                priority: ChunkGroupPriority::default(),
+            }])
             .cell(),
         )
     }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -56,7 +56,7 @@ use turbopack_core::{
     module_graph::{
         GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
         binding_usage_info::compute_binding_usage_info,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{OptionOutputAsset, OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
@@ -745,9 +745,10 @@ impl PageEndpoint {
             }
 
             let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
-                    ssr_chunk_module.ssr_module,
-                ])]),
+                GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                    modules: vec![ssr_chunk_module.ssr_module],
+                    priority: ChunkGroupPriority::default(),
+                }]),
                 visited_modules,
                 should_trace,
                 should_read_binding_usage,
@@ -1708,6 +1709,17 @@ impl Endpoint for PageEndpoint {
 
         let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
 
+        // The route's traffic priority from `experimental.turbopackChunkingPriorities`.
+        let priority = this
+            .pages_project
+            .project()
+            .next_config()
+            .turbopack_chunking_priorities()
+            .await?
+            .get(&this.pathname)
+            .copied()
+            .unwrap_or_default();
+
         let shared_entries = [
             ssr_chunk_module.document_module,
             ssr_chunk_module.app_module,
@@ -1717,17 +1729,20 @@ impl Endpoint for PageEndpoint {
             .into_iter()
             .flatten()
             .map(ChunkGroupEntry::Shared)
-            .chain(std::iter::once(ChunkGroupEntry::Entry(vec![
-                ssr_chunk_module.ssr_module,
-            ])))
+            .chain(std::iter::once(ChunkGroupEntry::Entry {
+                modules: vec![ssr_chunk_module.ssr_module],
+                priority,
+            }))
             .chain(if this.ty == PageEndpointType::Html {
-                Some(ChunkGroupEntry::Entry(
-                    self.client_evaluatable_assets()
+                Some(ChunkGroupEntry::Entry {
+                    modules: self
+                        .client_evaluatable_assets()
                         .await?
                         .iter()
                         .map(|m| ResolvedVc::upcast(*m))
                         .collect(),
-                ))
+                    priority,
+                })
                 .into_iter()
             } else {
                 None.into_iter()

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -70,7 +70,7 @@ use turbopack_core::{
         binding_usage_info::{
             BindingUsageInfo, OptionBindingUsageInfo, compute_binding_usage_info,
         },
-        chunk_group_info::ChunkGroupEntry,
+        chunk_group_info::{ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{
         ExpandOutputAssetsInput, ExpandedOutputAssets, OutputAsset, OutputAssets,
@@ -1474,7 +1474,10 @@ impl Project {
             let is_production = self.next_mode().await?.is_production();
             ModuleGraph::from_graphs(
                 vec![SingleModuleGraph::new_with_entry(
-                    ChunkGroupEntry::Entry(vec![entry]),
+                    ChunkGroupEntry::Entry {
+                        modules: vec![entry],
+                        priority: ChunkGroupPriority::default(),
+                    },
                     is_production,
                     is_production,
                 )],
@@ -1501,8 +1504,11 @@ impl Project {
                 .collect();
             ModuleGraph::from_graphs(
                 vec![SingleModuleGraph::new_with_entries(
-                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(entries)])
-                        .resolved_cell(),
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                        modules: entries,
+                        priority: ChunkGroupPriority::default(),
+                    }])
+                    .resolved_cell(),
                     is_production,
                     is_production,
                 )],
@@ -2518,14 +2524,16 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn client_main_modules(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
         let pages_project = self.pages_project();
-        let mut chunk_groups = vec![ChunkGroupEntry::Entry(vec![
-            pages_project.client_main_module().to_resolved().await?,
-        ])];
+        let mut chunk_groups = vec![ChunkGroupEntry::Entry {
+            modules: vec![pages_project.client_main_module().to_resolved().await?],
+            priority: ChunkGroupPriority::default(),
+        }];
 
         if let Some(app_project) = *self.app_project().await? {
-            chunk_groups.push(ChunkGroupEntry::Entry(vec![
-                app_project.client_main_module().to_resolved().await?,
-            ]));
+            chunk_groups.push(ChunkGroupEntry::Entry {
+                modules: vec![app_project.client_main_module().to_resolved().await?],
+                priority: ChunkGroupPriority::default(),
+            });
         }
 
         Ok(GraphEntries::from_chunk_groups(chunk_groups).cell())

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -26,7 +26,7 @@ use turbopack_core::{
     issue::{
         IgnoreIssue, IgnoreIssuePattern, Issue, IssueExt, IssueSeverity, IssueStage, StyledString,
     },
-    module_graph::style_groups::StyleGroupsAlgorithm,
+    module_graph::{chunk_group_info::ChunkGroupPriority, style_groups::StyleGroupsAlgorithm},
     resolve::ResolveAliasMap,
 };
 use turbopack_ecmascript::{
@@ -82,6 +82,13 @@ impl Default for CacheKinds {
 
 #[turbo_tasks::value(transparent)]
 pub struct CacheHandlersMap(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, RcStr>);
+
+/// Map of route path → [`ChunkGroupPriority`] from
+/// `experimental.turbopackChunkingPriorities`.
+#[turbo_tasks::value(transparent)]
+pub struct ChunkingPriorities(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, ChunkGroupPriority>,
+);
 
 #[turbo_tasks::value(eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
@@ -1284,6 +1291,10 @@ pub struct ExperimentalConfig {
     webpack_build_worker: Option<bool>,
     worker_threads: Option<bool>,
 
+    /// Per-route traffic priorities. Keys are route paths (e.g.
+    /// `/products/[id]`); unlisted routes default to `medium`.
+    #[bincode(with_serde)]
+    turbopack_chunking_priorities: Option<FxIndexMap<RcStr, ChunkGroupPriority>>,
     turbopack_minify: Option<bool>,
     turbopack_module_ids: Option<ModuleIds>,
     turbopack_plugin_runtime_strategy: Option<TurbopackPluginRuntimeStrategy>,
@@ -2011,6 +2022,18 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn css_chunking(&self) -> Result<Vc<StyleGroupsAlgorithm>> {
         Ok(resolve_css_chunking_algorithm(self.experimental.css_chunking.as_ref())?.cell())
+    }
+
+    /// `experimental.turbopackChunkingPriorities`: per-route traffic priorities. Keys are
+    /// route paths; unlisted routes default to [`ChunkGroupPriority::Medium`].
+    #[turbo_tasks::function]
+    pub fn turbopack_chunking_priorities(&self) -> Vc<ChunkingPriorities> {
+        Vc::cell(
+            self.experimental
+                .turbopack_chunking_priorities
+                .clone()
+                .unwrap_or_default(),
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -36,7 +36,7 @@ use turbopack_core::{
     module_graph::{
         GraphEntries, ModuleGraph, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -316,8 +316,11 @@ async fn build_internal(
     .await?;
 
     let single_graph = SingleModuleGraph::new_with_entries(
-        GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(entries.clone())])
-            .resolved_cell(),
+        GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+            modules: entries.clone(),
+            priority: ChunkGroupPriority::default(),
+        }])
+        .resolved_cell(),
         false,
         true,
     );

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -14,7 +14,8 @@ use turbopack_core::{
     file_source::FileSource,
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph, chunk_group_info::ChunkGroupEntry,
+        GraphEntries, ModuleGraph, SingleModuleGraph,
+        chunk_group_info::{ChunkGroupEntry, ChunkGroupPriority},
     },
     reference_type::{EntryReferenceSubType, ReferenceType},
     resolve::{
@@ -168,8 +169,11 @@ pub async fn create_web_entry_source(
         .collect::<Vec<ResolvedVc<Box<dyn Module>>>>();
     let module_graph = ModuleGraph::from_graphs(
         vec![SingleModuleGraph::new_with_entries(
-            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(all_modules)])
-                .resolved_cell(),
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                modules: all_modules,
+                priority: ChunkGroupPriority::default(),
+            }])
+            .resolved_cell(),
             false,
             false,
         )],

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -8,12 +8,13 @@ use bincode::{Decode, Encode};
 use either::Either;
 use indexmap::map::Entry;
 use roaring::RoaringBitmap;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString,
-    Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbofmt,
+    FxIndexMap, FxIndexSet, NonLocalValue, OperationValue, ResolvedVc, TaskInput, TryJoinIterExt,
+    ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbofmt,
 };
 
 use crate::{
@@ -94,6 +95,10 @@ pub struct ChunkGroupInfo {
     #[turbo_tasks(trace_ignore)]
     #[bincode(with = "turbo_bincode::indexset")]
     pub chunk_group_keys: FxIndexSet<ChunkGroupKey>,
+    /// Traffic priority of each chunk group, parallel to `chunk_groups`. Entry chunk groups
+    /// carry the priority of their [`ChunkGroupEntry::Entry`]; all other chunk groups default
+    /// to [`ChunkGroupPriority::Medium`].
+    pub chunk_group_priorities: Vec<ChunkGroupPriority>,
 }
 
 #[turbo_tasks::value_impl]
@@ -126,11 +131,48 @@ impl ChunkGroupInfo {
     }
 }
 
+/// Relative traffic priority of a chunk group, configured per entry (e.g. via
+/// `experimental.turbopackChunkingPriorities`). Currently informational only —
+/// it does not affect chunking behavior.
+///
+/// The variant order defines the priority order (`Low < Medium < High`).
+#[turbo_tasks::task_input]
+#[derive(
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum ChunkGroupPriority {
+    Low,
+    #[default]
+    Medium,
+    High,
+}
+
 /// See [ChunkGroup] for documentation
 #[turbo_tasks::task_input]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, TraceRawVcs, Encode, Decode)]
 pub enum ChunkGroupEntry {
-    Entry(Vec<ResolvedVc<Box<dyn Module>>>),
+    /// An entry chunk group with an explicit traffic priority (e.g. from
+    /// `experimental.turbopackChunkingPriorities`). The priority does not affect chunk group
+    /// identity — it is dropped when building the [`ChunkGroupKey`].
+    Entry {
+        modules: Vec<ResolvedVc<Box<dyn Module>>>,
+        priority: ChunkGroupPriority,
+    },
     Async(ResolvedVc<Box<dyn Module>>),
     Isolated(ResolvedVc<Box<dyn Module>>),
     IsolatedMerged {
@@ -152,7 +194,9 @@ impl ChunkGroupEntry {
             Self::Async(e) | Self::Isolated(e) | Self::Shared(e) => {
                 Either::Left(std::iter::once(*e))
             }
-            Self::Entry(entries)
+            Self::Entry {
+                modules: entries, ..
+            }
             | Self::IsolatedMerged { entries, .. }
             | Self::SharedMultiple(entries)
             | Self::SharedMerged { entries, .. } => Either::Right(entries.iter().copied()),
@@ -465,7 +509,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
             >,
         ) -> ChunkGroupKey {
             match entry {
-                ChunkGroupEntry::Entry(entries) => ChunkGroupKey::Entry(entries),
+                ChunkGroupEntry::Entry { modules, .. } => ChunkGroupKey::Entry(modules),
                 ChunkGroupEntry::Async(entry) => ChunkGroupKey::Async(entry),
                 ChunkGroupEntry::Isolated(entry) => ChunkGroupKey::Isolated(entry),
                 ChunkGroupEntry::Shared(entry) => ChunkGroupKey::Shared(entry),
@@ -507,11 +551,27 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
             }
         }
 
+        // Traffic priorities of entry chunk groups, keyed by their chunk group key. Only
+        // non-default priorities are recorded; every other chunk group (including derived
+        // Async/Isolated/Shared groups) defaults to `Medium`.
+        let mut entry_priorities: FxHashMap<ChunkGroupKey, ChunkGroupPriority> =
+            FxHashMap::default();
         let entry_chunk_group_keys = entries
             .iter()
             .flat_map(|&chunk_group| {
                 let chunk_group_key =
                     entry_to_chunk_group_id(chunk_group.clone(), &mut chunk_groups_map);
+                if let ChunkGroupEntry::Entry { priority, .. } = chunk_group
+                    && *priority != ChunkGroupPriority::default()
+                {
+                    // If the same module set is used by multiple entries, the highest
+                    // priority wins (the key is deduplicated by modules only; `max` keeps
+                    // this independent of entry iteration order).
+                    entry_priorities
+                        .entry(chunk_group_key.clone())
+                        .and_modify(|p| *p = (*p).max(*priority))
+                        .or_insert(*priority);
+                }
                 chunk_group
                     .entries()
                     .map(move |e| (e, chunk_group_key.clone()))
@@ -757,9 +817,99 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
             }
         }
 
+        // Compute per-chunk-group priorities. Entry chunk groups carry the priority of their
+        // [`ChunkGroupEntry::Entry`]; derived chunk groups inherit the maximum priority of
+        // the chunk groups that create them.
+        let chunk_group_priorities: Vec<ChunkGroupPriority> = if entry_priorities.is_empty() {
+            vec![ChunkGroupPriority::default(); chunk_groups_map.len()]
+        } else {
+            // `None` means "no information yet"; unconfigured entry chunk groups explicitly
+            // start at the default priority so that e.g. a chunk group shared between a
+            // `low` route and an unconfigured route resolves to `Medium`.
+            let mut priorities: Vec<Option<ChunkGroupPriority>> = chunk_groups_map
+                .keys()
+                .map(|k| {
+                    entry_priorities.get(k).copied().or(match k {
+                        ChunkGroupKey::Entry(..) => Some(ChunkGroupPriority::default()),
+                        _ => None,
+                    })
+                })
+                .collect();
+
+            // For priority, inheritance happens as follows:
+            //   - merged groups (IsolatedMerged/SharedMerged) inherit from their parent group, and
+            //   - groups created by non-parallel edges (Async/Isolated/Shared) inherit from the
+            //     chunk groups of the referencing module.
+            let mut inherits_from: Vec<Vec<usize>> = vec![Vec::new(); chunk_groups_map.len()];
+            let mut seen_edges: FxHashSet<(usize, usize)> = FxHashSet::default();
+
+            for (index, key) in chunk_groups_map.keys().enumerate() {
+                if let ChunkGroupKey::IsolatedMerged { parent, .. }
+                | ChunkGroupKey::SharedMerged { parent, .. } = key
+                {
+                    let parent = parent.0 as usize;
+                    if parent != index && seen_edges.insert((parent, index)) {
+                        inherits_from[parent].push(index);
+                    }
+                }
+            }
+
+            graph.traverse_edges_unordered(|parent, target| {
+                let Some((parent_module, ref_data)) = parent else {
+                    return Ok(());
+                };
+                let target_key = match &ref_data.chunking_type {
+                    ChunkingType::Async => ChunkGroupKey::Async(target),
+                    ChunkingType::Isolated {
+                        merge_tag: None, ..
+                    } => ChunkGroupKey::Isolated(target),
+                    ChunkingType::Shared {
+                        merge_tag: None, ..
+                    } => ChunkGroupKey::Shared(target),
+                    _ => return Ok(()),
+                };
+                let Some(target_index) = chunk_groups_map.get_index_of(&target_key) else {
+                    return Ok(());
+                };
+                if let Some(parent_groups) = module_chunk_groups.get(&parent_module) {
+                    for group in parent_groups.iter() {
+                        let group = group as usize;
+                        if group != target_index && seen_edges.insert((group, target_index)) {
+                            inherits_from[group].push(target_index);
+                        }
+                    }
+                }
+                Ok(())
+            })?;
+
+            // Propagate along the inheritance graph. Priorities only ever increase and `High` is
+            // the maximum, so a group that has reached `High` is final.
+            let mut worklist: Vec<usize> = (0..chunk_groups_map.len())
+                .filter(|&index| priorities[index].is_some())
+                .collect();
+            while let Some(source_index) = worklist.pop() {
+                let source = priorities[source_index];
+                for &target_index in &inherits_from[source_index] {
+                    if priorities[target_index] == Some(ChunkGroupPriority::High) {
+                        continue;
+                    }
+                    if source > priorities[target_index] {
+                        priorities[target_index] = source;
+                        worklist.push(target_index);
+                    }
+                }
+            }
+
+            priorities
+                .into_iter()
+                .map(|p| p.unwrap_or_default())
+                .collect()
+        };
+
         Ok(ChunkGroupInfo {
             module_chunk_groups: ResolvedVc::cell(module_chunk_groups),
             chunk_group_keys: chunk_groups_map.keys().cloned().collect(),
+            chunk_group_priorities,
             chunk_groups: chunk_groups_map
                 .into_iter()
                 .map(|(k, (_, merged_entries))| match k {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1967,6 +1967,7 @@ pub mod tests {
         asset::{Asset, AssetContent},
         ident::AssetIdent,
         module::{Module, ModuleSideEffects},
+        module_graph::chunk_group_info::ChunkGroupPriority,
         reference::{ModuleReference, ModuleReferences},
         resolve::ModuleResolveResult,
     };
@@ -2288,8 +2289,11 @@ pub mod tests {
                 let b_module = make_module("b.js").await?;
 
                 let parent_graph = SingleModuleGraph::new_with_entries(
-                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![b_module])])
-                        .resolved_cell(),
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                        modules: vec![b_module],
+                        priority: ChunkGroupPriority::default(),
+                    }])
+                    .resolved_cell(),
                     false,
                     false,
                 );
@@ -2298,9 +2302,10 @@ pub mod tests {
                     vec![
                         parent_graph,
                         SingleModuleGraph::new_with_entries_visited(
-                            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
-                                a_module,
-                            ])])
+                            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                                modules: vec![a_module],
+                                priority: ChunkGroupPriority::default(),
+                            }])
                             .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
                             false,
@@ -2465,8 +2470,11 @@ pub mod tests {
                 let a_module = make_module("a.js").await?;
 
                 let parent_graph = SingleModuleGraph::new_with_entries(
-                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![x_module])])
-                        .resolved_cell(),
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                        modules: vec![x_module],
+                        priority: ChunkGroupPriority::default(),
+                    }])
+                    .resolved_cell(),
                     true,
                     false,
                 );
@@ -2475,9 +2483,10 @@ pub mod tests {
                     vec![
                         parent_graph,
                         SingleModuleGraph::new_with_entries_visited(
-                            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(vec![
-                                a_module,
-                            ])])
+                            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                                modules: vec![a_module],
+                                priority: ChunkGroupPriority::default(),
+                            }])
                             .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
                             true,
@@ -2827,7 +2836,10 @@ pub mod tests {
                 .await?;
             let graph = SingleModuleGraph::new_with_entries(
                 GraphEntries::resolved_cell(GraphEntries::new(
-                    vec![ChunkGroupEntry::Entry(entry_modules.clone())],
+                    vec![ChunkGroupEntry::Entry {
+                        modules: entry_modules.clone(),
+                        priority: ChunkGroupPriority::default(),
+                    }],
                     vec![],
                 )),
                 false,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -26,7 +26,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{
         GraphEntries, ModuleGraph,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{OutputAsset, OutputAssets},
     reference_type::{InnerAssets, ReferenceType},
@@ -422,15 +422,19 @@ pub struct EvaluateEntries {
 impl EvaluateEntries {
     #[turbo_tasks::function]
     pub async fn graph_entries(self: Vc<Self>) -> Result<Vc<GraphEntries>> {
-        Ok(GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(
-            self.await?
-                .entries
-                .iter()
-                .cloned()
-                .map(ResolvedVc::upcast)
-                .collect(),
-        )])
-        .cell())
+        Ok(
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                modules: self
+                    .await?
+                    .entries
+                    .iter()
+                    .cloned()
+                    .map(ResolvedVc::upcast)
+                    .collect(),
+                priority: ChunkGroupPriority::default(),
+            }])
+            .cell(),
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -32,7 +32,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{
         ModuleGraph, SingleModuleGraph,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{ExpandOutputAssetsInput, OutputAsset, OutputAssets, expand_output_assets},
     reference_type::{EcmaScriptModulesReferenceSubType, InnerAssets, ReferenceType},
@@ -753,7 +753,10 @@ impl EvaluateContext for WebpackLoaderContext {
                 // Build a module graph from the resolved module and its
                 // transitive dependencies
                 let single_graph = SingleModuleGraph::new_with_entry(
-                    ChunkGroupEntry::Entry(vec![module]),
+                    ChunkGroupEntry::Entry {
+                        modules: vec![module],
+                        priority: ChunkGroupPriority::default(),
+                    },
                     false,
                     false,
                 );

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -50,7 +50,7 @@ use turbopack_core::{
     module_graph::{
         GraphEntries, ModuleGraph, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry, ChunkGroupPriority},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType, ReferenceTypeCondition},
@@ -465,8 +465,11 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .collect();
 
     let single_graph = SingleModuleGraph::new_with_entries(
-        GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(entry_modules.clone())])
-            .resolved_cell(),
+        GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+            modules: entry_modules.clone(),
+            priority: ChunkGroupPriority::default(),
+        }])
+        .resolved_cell(),
         false,
         true,
     );


### PR DESCRIPTION
This PR takes the information from https://github.com/vercel/next.js/pull/94830 and threads it through to `ChunkGroupInfo`, which is then used in https://github.com/vercel/next.js/pull/94832. 

Probably the most important part of the PR to review is the part where it inherits the priority from its parent chunk group or the highest priority chunk group that references it. Is there a better place to put this traversal? I've tried to limit the time this takes by doing one traversal to pick up on the relationships and then just do the priority changes with those already known relationships. Maybe I can put this into an already existing traversal? Or maybe its best left separate whilst this is experimental. 