### PR TITLE
pass `--locked` to `cargo binstall`

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Install nextest
         if: ${{ inputs.needsNextest == 'yes' }}
-        run: cargo binstall --no-confirm cargo-nextest@0.9.133
+        run: cargo binstall --no-confirm --locked cargo-nextest@0.9.133
 
       - run: rustc --version
         if: ${{ (inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        run: cargo binstall --no-confirm cargo-codspeed@3.0.5
+        run: cargo binstall --locked --no-confirm cargo-codspeed@3.0.5
 
       - name: Start sccache
         uses: ./.github/actions/sccache
@@ -80,7 +80,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        run: cargo binstall --no-confirm cargo-codspeed@3.0.5
+        run: cargo binstall --locked --no-confirm cargo-codspeed@3.0.5
 
       - name: Start sccache
         uses: ./.github/actions/sccache
@@ -118,7 +118,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        run: cargo binstall --no-confirm cargo-codspeed@3.0.5
+        run: cargo binstall --locked --no-confirm cargo-codspeed@3.0.5
 
       - name: Start sccache
         uses: ./.github/actions/sccache


### PR DESCRIPTION
If `binstall` fails to download a precompiled artifact it falls back to `cargo install` and many tools (like `nextest`) require the `--locked` flag.  So pass the `--locked` flag.

