### PR TITLE
rust react compiler: detect and build for react 18

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -29,8 +29,10 @@ use turbopack_core::{
 };
 use turbopack_css::chunk::CssChunkType;
 use turbopack_ecmascript::{
-    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
-    transform::PresetEnvConfig,
+    AnalyzeMode, TypeofWindow,
+    chunk::EcmascriptChunkType,
+    references::esm::UrlRewriteBehavior,
+    transform::{PresetEnvConfig, ReactCompilerTarget},
 };
 use turbopack_node::{
     execution_context::ExecutionContext,
@@ -53,7 +55,10 @@ use crate::{
     },
     next_shared::{
         resolve::NextSharedRuntimeResolvePlugin,
-        webpack_rules::{WebpackLoaderBuiltinCondition, webpack_loader_options},
+        webpack_rules::{
+            WebpackLoaderBuiltinCondition, babel::detect_react_compiler_target,
+            webpack_loader_options,
+        },
     },
     transform_options::{
         get_decorators_transform_options, get_jsx_transform_options,
@@ -344,6 +349,14 @@ pub async fn get_client_module_options_context(
         });
 
     let enable_rust_react_compiler = *next_config.rust_react_compiler().await?;
+    let rust_react_compiler_target = if enable_rust_react_compiler.is_some() {
+        match detect_react_compiler_target(&project_path).await? {
+            Some(ReactCompilerTarget::React18) => ReactCompilerTarget::React18,
+            _ => ReactCompilerTarget::React19,
+        }
+    } else {
+        ReactCompilerTarget::React19
+    };
 
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
@@ -426,6 +439,7 @@ pub async fn get_client_module_options_context(
             enable_typescript_transform: Some(tsconfig),
             enable_decorators: Some(decorators_options.to_resolved().await?),
             enable_rust_react_compiler,
+            rust_react_compiler_target,
             ..module_options_context.ecmascript.clone()
         },
         enable_webpack_loaders,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -31,7 +31,9 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     OptionTreeShaking, TreeShakingMode,
-    transform::{OptionReactCompilerCompilationMode, ReactCompilerCompilationMode},
+    transform::{
+        OptionReactCompilerCompilationMode, ReactCompilerCompilationMode, ReactCompilerTarget,
+    },
 };
 use turbopack_ecmascript_plugins::transform::{
     emotion::EmotionTransformConfig, relay::RelayConfig,
@@ -938,13 +940,6 @@ pub enum ReactCompilerPanicThreshold {
     None,
     CriticalErrors,
     AllErrors,
-}
-
-#[turbo_tasks::value(shared, operation)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ReactCompilerTarget {
-    #[serde(rename = "18")]
-    React18,
 }
 
 /// Subset of react compiler options, we pass these options through to the webpack loader, so it

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
 use turbopack_css::chunk::CssChunkType;
 use turbopack_ecmascript::{
     AnalyzeMode, CustomTransformer, TransformPlugin, TypeofWindow, chunk::EcmascriptChunkType,
-    references::esm::UrlRewriteBehavior,
+    references::esm::UrlRewriteBehavior, transform::ReactCompilerTarget,
 };
 use turbopack_ecmascript_plugins::transform::directives::{
     client::ClientDirectiveTransformer, client_disallowed::ClientDisallowedDirectiveTransformer,
@@ -64,7 +64,10 @@ use crate::{
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
         },
-        webpack_rules::{WebpackLoaderBuiltinCondition, webpack_loader_options},
+        webpack_rules::{
+            WebpackLoaderBuiltinCondition, babel::detect_react_compiler_target,
+            webpack_loader_options,
+        },
     },
     transform_options::{
         get_decorators_transform_options, get_jsx_transform_options,
@@ -556,6 +559,14 @@ pub async fn get_server_module_options_context(
     .collect();
 
     let enable_rust_react_compiler = *next_config.rust_react_compiler().await?;
+    let rust_react_compiler_target = if enable_rust_react_compiler.is_some() {
+        match detect_react_compiler_target(&project_path).await? {
+            Some(ReactCompilerTarget::React18) => ReactCompilerTarget::React18,
+            _ => ReactCompilerTarget::React19,
+        }
+    } else {
+        ReactCompilerTarget::React19
+    };
 
     let source_maps = *next_config.server_source_maps().await?;
     let module_options_context = ModuleOptionsContext {
@@ -725,6 +736,7 @@ pub async fn get_server_module_options_context(
                     enable_typescript_transform: Some(tsconfig),
                     enable_decorators: Some(decorators_options.to_resolved().await?),
                     enable_rust_react_compiler,
+                    rust_react_compiler_target,
                     ..module_options_context.ecmascript
                 },
                 enable_webpack_loaders,

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -15,11 +15,11 @@ use turbopack_core::{
     resolve::{node::node_cjs_resolve_options, parse::Request, pattern::Pattern, resolve},
     source::Source,
 };
-use turbopack_ecmascript::transform::ReactCompilerCompilationMode;
+use turbopack_ecmascript::transform::{ReactCompilerCompilationMode, ReactCompilerTarget};
 use turbopack_node::transforms::webpack::WebpackLoaderItem;
 
 use crate::{
-    next_config::{NextConfig, ReactCompilerOptions, ReactCompilerTarget},
+    next_config::{NextConfig, ReactCompilerOptions},
     next_import_map::try_get_next_package,
     next_shared::webpack_rules::{
         ManuallyConfiguredBuiltinLoaderIssue, WebpackLoaderBuiltinCondition,
@@ -248,7 +248,7 @@ pub async fn get_babel_loader_rules(
     )])
 }
 
-async fn detect_react_compiler_target(
+pub async fn detect_react_compiler_target(
     project_path: &FileSystemPath,
 ) -> Result<Option<ReactCompilerTarget>> {
     #[derive(Deserialize)]

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -89,6 +89,7 @@ pub enum EcmascriptInputTransform {
     },
     ReactCompilerRust {
         compilation_mode: ReactCompilerCompilationMode,
+        target: ReactCompilerTarget,
     },
 }
 
@@ -114,6 +115,25 @@ impl ReactCompilerCompilationMode {
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionReactCompilerCompilationMode(Option<ReactCompilerCompilationMode>);
+
+#[turbo_tasks::value(shared, operation)]
+#[derive(Default, Debug, Clone, Copy, Hash, Serialize, Deserialize)]
+pub enum ReactCompilerTarget {
+    #[default]
+    #[serde(rename = "19")]
+    React19,
+    #[serde(rename = "18")]
+    React18,
+}
+
+impl ReactCompilerTarget {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReactCompilerTarget::React19 => "19",
+            ReactCompilerTarget::React18 => "18",
+        }
+    }
+}
 
 /// The CustomTransformer trait allows you to implement your own custom SWC
 /// transformer to run over all ECMAScript files imported in the graph.
@@ -377,8 +397,11 @@ impl EcmascriptInputTransform {
 
                 apply_transform(program, helpers, decorators(config))
             }
-            EcmascriptInputTransform::ReactCompilerRust { compilation_mode } => {
-                apply_rust_react_compiler(program, ctx, helpers, *compilation_mode).await?
+            EcmascriptInputTransform::ReactCompilerRust {
+                compilation_mode,
+                target,
+            } => {
+                apply_rust_react_compiler(program, ctx, helpers, *compilation_mode, *target).await?
             }
             EcmascriptInputTransform::Plugin(transform) => {
                 // We cannot pass helpers to plugins, so we return them as is
@@ -429,12 +452,13 @@ async fn apply_rust_react_compiler(
     ctx: &TransformContext<'_>,
     helpers: HelperData,
     compilation_mode: ReactCompilerCompilationMode,
+    target: ReactCompilerTarget,
 ) -> Result<HelperData> {
     let Program::Module(module) = program else {
         return Ok(helpers);
     };
 
-    let options = react_compiler_swc_options(ctx, compilation_mode);
+    let options = react_compiler_swc_options(ctx, compilation_mode, target);
     let result = react_compiler_swc::transform(module, ctx.source_text, options);
 
     for diag in &result.diagnostics {
@@ -475,6 +499,7 @@ async fn apply_rust_react_compiler(
 fn react_compiler_swc_options(
     ctx: &TransformContext<'_>,
     compilation_mode: ReactCompilerCompilationMode,
+    target: ReactCompilerTarget,
 ) -> react_compiler::entrypoint::plugin_options::PluginOptions {
     use react_compiler::entrypoint::plugin_options::{CompilerTarget, PluginOptions};
 
@@ -485,7 +510,7 @@ fn react_compiler_swc_options(
         filename: Some(ctx.file_name_str.to_string()),
         compilation_mode: compilation_mode.as_str().to_string(),
         panic_threshold: "none".to_string(),
-        target: CompilerTarget::Version("19".to_string()),
+        target: CompilerTarget::Version(target.as_str().to_string()),
         gating: None,
         dynamic_gating: None,
         no_emit: false,

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -233,6 +233,7 @@ impl ModuleOptions {
                 EcmascriptOptionsContext {
                     enable_jsx,
                     enable_rust_react_compiler,
+                    rust_react_compiler_target,
                     enable_types,
                     ref enable_typescript_transform,
                     ref enable_decorators,
@@ -305,7 +306,10 @@ impl ModuleOptions {
         // Runs first so it sees the original source text (text-bridge re-parses after
         // react_compiler_swc).
         if let Some(compilation_mode) = enable_rust_react_compiler {
-            ecma_preprocess.push(EcmascriptInputTransform::ReactCompilerRust { compilation_mode });
+            ecma_preprocess.push(EcmascriptInputTransform::ReactCompilerRust {
+                compilation_mode,
+                target: rust_react_compiler_target,
+            });
         }
 
         // Order of transforms is important. e.g. if the React transform occurs before

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
 use turbopack_ecmascript::{
     AnalyzeMode, TreeShakingMode, TypeofWindow,
     references::esm::UrlRewriteBehavior,
-    transform::{PresetEnvConfig, ReactCompilerCompilationMode},
+    transform::{PresetEnvConfig, ReactCompilerCompilationMode, ReactCompilerTarget},
 };
 pub use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::{
@@ -252,6 +252,7 @@ pub struct EcmascriptOptionsContext {
     pub enable_typeof_window_inlining: Option<TypeofWindow>,
     pub enable_jsx: Option<ResolvedVc<JsxTransformOptions>>,
     pub enable_rust_react_compiler: Option<ReactCompilerCompilationMode>,
+    pub rust_react_compiler_target: ReactCompilerTarget,
     /// Follow type references and resolve declaration files in additional to
     /// normal resolution.
     pub enable_types: bool,


### PR DESCRIPTION
Previously we just assumed all apps were react 19. This properly detects the version of react used by the app (using the same code as the babel version) and threads through the react version to the react compiler. React 17 is supported by the compiler but not by Next.js 16.

Test Plan: `HEADLESS=true pnpm test-start-turbo test/e2e/react-compiler/react-compiler.test.ts`
