### PR TITLE
fix(next-mdx): resolve import-only ESM plugins via string syntax (#73757)

### DIFF
--- a/packages/next-mdx/mdx-js-loader.js
+++ b/packages/next-mdx/mdx-js-loader.js
@@ -2,30 +2,60 @@ const mdxLoader = require('@mdx-js/loader')
 const { pathToFileURL } = require('node:url')
 
 function interopDefault(mod) {
-  return mod.default || mod
+  // Prefer the default export when present (covers CommonJS modules and ESM
+  // packages whose plugin is the default export).
+  if (mod.default) {
+    return mod.default
+  }
+  // For ESM packages that expose the plugin as a named export rather than a
+  // default export (https://github.com/vercel/next.js/issues/73757), fall back
+  // to the first function-valued named export on the namespace object. Without
+  // this the namespace object was returned and the plugin was silently dropped.
+  for (const key of Object.keys(mod)) {
+    if (key !== 'default' && typeof mod[key] === 'function') {
+      return mod[key]
+    }
+  }
+  return mod
 }
 
-async function importPluginForPath(pluginPath, projectRoot) {
-  const path = require.resolve(pluginPath, { paths: [projectRoot] })
+async function importPluginForPath(pluginPath, projectRoot, resolve) {
+  let resolvedPath
+  try {
+    resolvedPath = require.resolve(pluginPath, { paths: [projectRoot] })
+  } catch (err) {
+    // ESM-only packages whose "exports" map has no "require"/"default" condition
+    // cannot be resolved by require.resolve() (it throws
+    // ERR_PACKAGE_PATH_NOT_EXPORTED). Re-resolve through webpack's resolver,
+    // which honours the "import" condition, scoped to the importing file's
+    // directory. See https://github.com/vercel/next.js/issues/73757.
+    if (err.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' && resolve) {
+      resolvedPath = await resolve(projectRoot, pluginPath)
+    } else {
+      throw err
+    }
+  }
   return interopDefault(
     // "use pathToFileUrl to make esm import()s work with absolute windows paths":
     // on windows import("C:\\path\\to\\file") is not valid, so we need to use file:// URLs
     // https://github.com/vercel/next.js/commit/fbf9e12de095e0237d4ba4aa6139d9757bd20be9
-    await import(process.platform === 'win32' ? pathToFileURL(path) : path)
+    await import(
+      process.platform === 'win32' ? pathToFileURL(resolvedPath) : resolvedPath
+    )
   )
 }
 
-async function importPlugin(plugin, projectRoot) {
+async function importPlugin(plugin, projectRoot, resolve) {
   if (Array.isArray(plugin) && typeof plugin[0] === 'string') {
-    plugin[0] = await importPluginForPath(plugin[0], projectRoot)
+    plugin[0] = await importPluginForPath(plugin[0], projectRoot, resolve)
   }
   if (typeof plugin === 'string') {
-    plugin = await importPluginForPath(plugin, projectRoot)
+    plugin = await importPluginForPath(plugin, projectRoot, resolve)
   }
   return plugin
 }
 
-async function getOptions(options, projectRoot) {
+async function getOptions(options, projectRoot, resolve) {
   const {
     recmaPlugins = [],
     rehypePlugins = [],
@@ -35,13 +65,13 @@ async function getOptions(options, projectRoot) {
 
   const [updatedRecma, updatedRehype, updatedRemark] = await Promise.all([
     Promise.all(
-      recmaPlugins.map((plugin) => importPlugin(plugin, projectRoot))
+      recmaPlugins.map((plugin) => importPlugin(plugin, projectRoot, resolve))
     ),
     Promise.all(
-      rehypePlugins.map((plugin) => importPlugin(plugin, projectRoot))
+      rehypePlugins.map((plugin) => importPlugin(plugin, projectRoot, resolve))
     ),
     Promise.all(
-      remarkPlugins.map((plugin) => importPlugin(plugin, projectRoot))
+      remarkPlugins.map((plugin) => importPlugin(plugin, projectRoot, resolve))
     ),
   ])
 
@@ -58,7 +88,14 @@ module.exports = function nextMdxLoader(...args) {
   const callback = this.async().bind(this)
   const loaderContext = this
 
-  getOptions(options, this.context).then((userProvidedMdxOptions) => {
+  // webpack resolver scoped to the importing file's directory, honouring the
+  // ESM "import" condition so import-only ESM plugin packages can be resolved.
+  const resolve = this.getResolve({
+    conditionNames: ['import', 'node', 'require', 'default'],
+    extensions: ['.js', '.mjs', '.cjs'],
+  })
+
+  getOptions(options, this.context, resolve).then((userProvidedMdxOptions) => {
     const proxy = new Proxy(loaderContext, {
       get(target, prop, receiver) {
         if (prop === 'getOptions') {
@@ -76,3 +113,9 @@ module.exports = function nextMdxLoader(...args) {
     mdxLoader.call(proxy, ...args)
   })
 }
+
+// Exported for unit testing of plugin resolution (see
+// test/unit/next-mdx-plugin-resolution.test.ts). Webpack only invokes the
+// default callable export, so attaching these is side-effect free.
+module.exports.interopDefault = interopDefault
+module.exports.importPluginForPath = importPluginForPath

--- a/test/unit/fixtures/mdx-esm-only-plugin/node_modules/esm-only-plugin/index.js
+++ b/test/unit/fixtures/mdx-esm-only-plugin/node_modules/esm-only-plugin/index.js
@@ -1,0 +1,6 @@
+// A remark/rehype-style plugin exposed as a NAMED export with no default export,
+// inside a package whose "exports" map only declares the "import" condition.
+// This reproduces https://github.com/vercel/next.js/issues/73757.
+export function esmOnlyPlugin() {
+  return (tree) => tree
+}

--- a/test/unit/fixtures/mdx-esm-only-plugin/node_modules/esm-only-plugin/package.json
+++ b/test/unit/fixtures/mdx-esm-only-plugin/node_modules/esm-only-plugin/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "esm-only-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.js"
+    }
+  }
+}

--- a/test/unit/fixtures/mdx-esm-only-plugin/resolve-check.js
+++ b/test/unit/fixtures/mdx-esm-only-plugin/resolve-check.js
@@ -1,0 +1,62 @@
+// Helper for next-mdx-plugin-resolution.test.ts.
+//
+// Runs in a real Node process (not jest) so that Node's own module resolver is
+// used. jest's resolver shims `require.resolve` and reports MODULE_NOT_FOUND
+// instead of Node's ERR_PACKAGE_PATH_NOT_EXPORTED, which would mask the exact
+// failure this fixture reproduces (https://github.com/vercel/next.js/issues/73757).
+//
+// Exercises the real mdx-js-loader against an import-only ESM package whose
+// plugin is exposed as a named export, and prints a JSON result line.
+const path = require('path')
+
+const { importPluginForPath } = require(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'packages',
+    'next-mdx',
+    'mdx-js-loader.js'
+  )
+)
+
+const fixtureRoot = __dirname
+const pluginEntry = path.join(
+  fixtureRoot,
+  'node_modules',
+  'esm-only-plugin',
+  'index.js'
+)
+
+// Stub for webpack's `this.getResolve(...)`: returns the ESM entry path,
+// honouring the "import" condition like the real resolver does.
+const resolve = async () => pluginEntry
+
+;(async () => {
+  const result = {
+    withResolver: null,
+    withResolverName: null,
+    withoutResolverCode: null,
+  }
+
+  const plugin = await importPluginForPath(
+    'esm-only-plugin',
+    fixtureRoot,
+    resolve
+  )
+  result.withResolver = typeof plugin
+  result.withResolverName = typeof plugin === 'function' ? plugin.name : null
+
+  try {
+    await importPluginForPath('esm-only-plugin', fixtureRoot, undefined)
+  } catch (err) {
+    result.withoutResolverCode = err.code
+  }
+
+  process.stdout.write('RESULT:' + JSON.stringify(result))
+})().catch((err) => {
+  process.stdout.write('ERROR:' + (err && err.stack ? err.stack : String(err)))
+  process.exit(1)
+})

--- a/test/unit/next-mdx-plugin-resolution.test.ts
+++ b/test/unit/next-mdx-plugin-resolution.test.ts
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+// Regression tests for https://github.com/vercel/next.js/issues/73757
+//
+// `@next/mdx`'s string-form plugin syntax (e.g. `remarkPlugins: ['plugin']`)
+// failed for ESM plugin packages in two ways:
+//   1. Packages whose "exports" map only declares the "import" condition could
+//      not be resolved by `require.resolve` (ERR_PACKAGE_PATH_NOT_EXPORTED), so
+//      the build crashed.
+//   2. Packages exposing the plugin as a *named* export (no default) resolved
+//      to the module namespace object instead of the plugin function, so the
+//      plugin was silently dropped.
+
+import path from 'path'
+import { execFileSync } from 'child_process'
+
+const { interopDefault } = require('../../packages/next-mdx/mdx-js-loader')
+
+describe('next-mdx interopDefault', () => {
+  it('returns the default export when present', () => {
+    const plugin = () => {}
+    expect(interopDefault({ default: plugin })).toBe(plugin)
+  })
+
+  it('prefers the default export over named exports', () => {
+    const defaultPlugin = () => {}
+    const namedPlugin = () => {}
+    expect(interopDefault({ default: defaultPlugin, namedPlugin })).toBe(
+      defaultPlugin
+    )
+  })
+
+  it('falls back to a function-valued named export when there is no default (issue #73757)', () => {
+    const remarkPlugin = () => {}
+    expect(interopDefault({ remarkPlugin })).toBe(remarkPlugin)
+  })
+
+  it('skips non-function named exports and returns the first function export', () => {
+    const remarkPlugin = () => {}
+    expect(interopDefault({ version: '1.0.0', meta: {}, remarkPlugin })).toBe(
+      remarkPlugin
+    )
+  })
+
+  it('returns the module itself when it is the plugin function (CJS interop)', () => {
+    const plugin = () => {}
+    expect(interopDefault(plugin)).toBe(plugin)
+  })
+})
+
+describe('next-mdx importPluginForPath (import-only ESM packages, issue #73757)', () => {
+  // Runs in a child Node process: jest's resolver shims require.resolve and
+  // reports MODULE_NOT_FOUND, which would mask the real Node
+  // ERR_PACKAGE_PATH_NOT_EXPORTED this fixture reproduces.
+  const runner = path.join(
+    __dirname,
+    'fixtures',
+    'mdx-esm-only-plugin',
+    'resolve-check.js'
+  )
+
+  it('resolves an import-only ESM named-export plugin via the resolver, and fails without it', () => {
+    const stdout = execFileSync('node', [runner], { encoding: 'utf8' })
+    const line = stdout.split('\n').find((l) => l.startsWith('RESULT:'))
+    expect(line).toBeTruthy()
+    const result = JSON.parse(line!.slice('RESULT:'.length))
+
+    // With the resolver fallback (the fix): the named export is returned.
+    expect(result.withResolver).toBe('function')
+    expect(result.withResolverName).toBe('esmOnlyPlugin')
+
+    // Without it: Node throws the exact error reported in the issue.
+    expect(result.withoutResolverCode).toBe('ERR_PACKAGE_PATH_NOT_EXPORTED')
+  })
+})


### PR DESCRIPTION
### What

`@next/mdx`'s string-form plugin syntax (e.g. `rehypePlugins: [['plugin']]`) failed for ESM plugin packages in two ways:

1. **Build crash** — packages whose `exports` map only declares the `"import"` condition could not be resolved by `require.resolve()`, which threw `ERR_PACKAGE_PATH_NOT_EXPORTED`. This is the error in the linked reproduction (`@stefanprobst/rehype-extract-toc`).
2. **Silently dropped plugin** — packages exposing the plugin as a *named* export (no default export) resolved to the module namespace object instead of the plugin function, so the plugin was applied as `undefined`/dropped.

### How

- `importPluginForPath` now catches `ERR_PACKAGE_PATH_NOT_EXPORTED` and re-resolves the package through **webpack's resolver** (`this.getResolve`, honouring the `import` condition and scoped to the importing file's directory), then imports the resolved path. This avoids reimplementing Node's `exports` resolution and keeps resolution correctly scoped (matters for monorepos/Turborepo, which the reporter uses).
- `interopDefault` falls back to the first function-valued named export when the module has no default export.

### Tests

`test/unit/next-mdx-plugin-resolution.test.ts`:
- Unit tests for `interopDefault` (default / named-only / mixed / non-function / CJS-interop).
- A fixture-based test (`test/unit/fixtures/mdx-esm-only-plugin`) that runs the loader in a real Node process — jest's resolver shims `require.resolve` and masks the Node error code — verifying an import-only ESM named-export plugin resolves **with** the fix and that `require.resolve` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` **without** it.

All pass under `pnpm jest test/unit/next-mdx-plugin-resolution.test.ts`.

Fixes #73757
