### PR TITLE
pre-cache idents

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -890,6 +890,12 @@ impl AppProject {
             let next_mode_ref = next_mode.await?;
             let should_trace = *self.project.should_write_nft_manifests().await?;
             let should_read_binding_usage = next_mode_ref.is_production();
+            let remove_unused_imports = *self
+                .project
+                .next_config()
+                .turbopack_remove_unused_imports(next_mode)
+                .await?;
+            let graph_options = self.project.module_graph_options().await?;
 
             // Implements layout segment optimization to compute a graph "chain" for each layout
             // segment
@@ -935,8 +941,7 @@ impl AppProject {
                             ),
                         ]),
                         visited_modules,
-                        should_trace,
-                        should_read_binding_usage,
+                        graph_options,
                     );
                     graphs.push(graph);
                     visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -954,8 +959,7 @@ impl AppProject {
                                 ResolvedVc::upcast(*module),
                             )]),
                             visited_modules,
-                            should_trace,
-                            should_read_binding_usage,
+                            graph_options,
                         );
                         graphs.push(graph);
                         let is_layout = module.server_path().await?.file_stem() == Some("layout");
@@ -977,8 +981,7 @@ impl AppProject {
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
                     GraphEntries::from_chunk_groups(vec![rsc_entry_chunk_group]),
                     visited_modules,
-                    should_trace,
-                    should_read_binding_usage,
+                    graph_options,
                 );
                 graphs.push(graph);
                 visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -988,8 +991,7 @@ impl AppProject {
                 let additional_module_graph = SingleModuleGraph::new_with_entries_visited_intern(
                     additional_entries.owned().await?,
                     visited_modules,
-                    should_trace,
-                    should_read_binding_usage,
+                    graph_options,
                 );
                 graphs.push(additional_module_graph);
 
@@ -1000,12 +1002,6 @@ impl AppProject {
                     }
                     span.record("modules", module_count);
                 }
-
-                let remove_unused_imports = *self
-                    .project
-                    .next_config()
-                    .turbopack_remove_unused_imports(next_mode)
-                    .await?;
 
                 let (full, binding_usage_info) = if remove_unused_imports {
                     let full_with_unused_references =

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -892,6 +892,12 @@ impl AppProject {
             let next_mode_ref = next_mode.await?;
             let should_trace = *self.project.should_write_nft_manifests().await?;
             let should_read_binding_usage = next_mode_ref.is_production();
+            let remove_unused_imports = *self
+                .project
+                .next_config()
+                .turbopack_remove_unused_imports(next_mode)
+                .await?;
+            let graph_options = self.project.module_graph_options().await?;
 
             // Implements layout segment optimization to compute a graph "chain" for each layout
             // segment
@@ -937,8 +943,7 @@ impl AppProject {
                             ),
                         ]),
                         visited_modules,
-                        should_trace,
-                        should_read_binding_usage,
+                        graph_options,
                     );
                     graphs.push(graph);
                     visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -956,8 +961,7 @@ impl AppProject {
                                 ResolvedVc::upcast(*module),
                             )]),
                             visited_modules,
-                            should_trace,
-                            should_read_binding_usage,
+                            graph_options,
                         );
                         graphs.push(graph);
                         let is_layout = module.server_path().await?.file_stem() == Some("layout");
@@ -979,8 +983,7 @@ impl AppProject {
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
                     GraphEntries::from_chunk_groups(vec![rsc_entry_chunk_group]),
                     visited_modules,
-                    should_trace,
-                    should_read_binding_usage,
+                    graph_options,
                 );
                 graphs.push(graph);
                 visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -990,8 +993,7 @@ impl AppProject {
                 let additional_module_graph = SingleModuleGraph::new_with_entries_visited_intern(
                     additional_entries.owned().await?,
                     visited_modules,
-                    should_trace,
-                    should_read_binding_usage,
+                    graph_options,
                 );
                 graphs.push(additional_module_graph);
 
@@ -1002,12 +1004,6 @@ impl AppProject {
                     }
                     span.record("modules", module_count);
                 }
-
-                let remove_unused_imports = *self
-                    .project
-                    .next_config()
-                    .turbopack_remove_unused_imports(next_mode)
-                    .await?;
 
                 let (full, binding_usage_info) = if remove_unused_imports {
                     let full_with_unused_references =

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -14,7 +14,7 @@ use turbopack::externals_tracing_module_context;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     module::{Module, Modules},
-    module_graph::{GraphEntries, ModuleGraph, SingleModuleGraph},
+    module_graph::{GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph},
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
     reference_type::CommonJsReferenceSubType,
     resolve::{ResolveErrorMode, origin::PlainResolveOrigin, parse::Request},
@@ -108,8 +108,13 @@ impl Asset for ServerNftJsonAsset {
         let module_graph = ModuleGraph::from_graphs(
             vec![SingleModuleGraph::new_with_entries(
                 GraphEntries::new(vec![], self.entries().owned().await?).resolved_cell(),
-                true,
-                false,
+                ModuleGraphOptions {
+                    include_ident_strings: false,
+                    include_side_effects: false,
+                    include_mergeable: false,
+                    include_traced: true,
+                    include_binding_usage: false,
+                },
             )],
             None,
         )

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -14,7 +14,7 @@ use turbopack::externals_tracing_module_context;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     module::{Module, Modules},
-    module_graph::{GraphEntries, ModuleGraph, SingleModuleGraph},
+    module_graph::{GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph},
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
     reference_type::CommonJsReferenceSubType,
     resolve::{ResolveErrorMode, origin::PlainResolveOrigin, parse::Request},
@@ -193,8 +193,13 @@ impl Asset for ServerNftJsonAsset {
         let module_graph = ModuleGraph::from_graphs(
             vec![SingleModuleGraph::new_with_entries(
                 GraphEntries::new(vec![], self.entries().owned().await?).resolved_cell(),
-                true,
-                false,
+                ModuleGraphOptions {
+                    include_ident_strings: false,
+                    include_side_effects: false,
+                    include_mergeable: false,
+                    include_traced: true,
+                    include_binding_usage: false,
+                },
             )],
             None,
         )

--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -415,8 +415,9 @@ pub async fn traced_module_data_for_graph(
     let (idents, hashes): (FxHashMap<_, _>, FxHashMap<_, _>) = traced_modules
         .into_iter()
         .map(async |module| {
+            let ident = module_graph.module_ident_resolved(module)?.await?;
             Ok((
-                (module, module.ident().await?),
+                (module, ident),
                 (
                     module,
                     module

--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -433,7 +433,7 @@ async fn traced_module_idents_for_graph(
     Ok(Vc::cell(
         traced_modules
             .into_iter()
-            .map(async |module| Ok((module, module.ident().await?)))
+            .map(async |module| Ok((module, module_graph.module_ident_resolved(module)?.await?)))
             .try_join()
             .await?
             .into_iter()

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -725,9 +725,11 @@ impl PageEndpoint {
 
         if *project.per_page_module_graph().await? {
             let next_mode = project.next_mode();
-            let next_mode_ref = next_mode.await?;
-            let should_trace = *project.should_write_nft_manifests().await?;
-            let should_read_binding_usage = next_mode_ref.is_production();
+            let remove_unused_imports = *project
+                .next_config()
+                .turbopack_remove_unused_imports(next_mode)
+                .await?;
+            let graph_options = project.module_graph_options().await?;
 
             let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
             // Implements layout segment optimization to compute a graph "chain" for document, app,
@@ -744,8 +746,7 @@ impl PageEndpoint {
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
                     GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Shared(module)]),
                     visited_modules,
-                    should_trace,
-                    should_read_binding_usage,
+                    graph_options,
                 );
                 graphs.push(graph);
                 visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -757,15 +758,9 @@ impl PageEndpoint {
                     heuristics: EntryHeuristics::default(),
                 }]),
                 visited_modules,
-                should_trace,
-                should_read_binding_usage,
+                graph_options,
             );
             graphs.push(graph);
-
-            let remove_unused_imports = *project
-                .next_config()
-                .turbopack_remove_unused_imports(next_mode)
-                .await?;
 
             let graph = if remove_unused_imports {
                 let graph = ModuleGraph::from_graphs(graphs.clone(), None);

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -740,9 +740,11 @@ impl PageEndpoint {
 
         if *project.per_page_module_graph().await? {
             let next_mode = project.next_mode();
-            let next_mode_ref = next_mode.await?;
-            let should_trace = *project.should_write_nft_manifests().await?;
-            let should_read_binding_usage = next_mode_ref.is_production();
+            let remove_unused_imports = *project
+                .next_config()
+                .turbopack_remove_unused_imports(next_mode)
+                .await?;
+            let graph_options = project.module_graph_options().await?;
 
             let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
             // Implements layout segment optimization to compute a graph "chain" for document, app,
@@ -759,8 +761,7 @@ impl PageEndpoint {
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
                     GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Shared(module)]),
                     visited_modules,
-                    should_trace,
-                    should_read_binding_usage,
+                    graph_options,
                 );
                 graphs.push(graph);
                 visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -772,15 +773,9 @@ impl PageEndpoint {
                     heuristics: EntryHeuristics::default(),
                 }]),
                 visited_modules,
-                should_trace,
-                should_read_binding_usage,
+                graph_options,
             );
             graphs.push(graph);
-
-            let remove_unused_imports = *project
-                .next_config()
-                .turbopack_remove_unused_imports(next_mode)
-                .await?;
 
             let graph = if remove_unused_imports {
                 let graph = ModuleGraph::from_graphs(graphs.clone(), None);

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -70,7 +70,7 @@ use turbopack_core::{
     },
     module::{Module, Modules},
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph, VisitedModules,
         binding_usage_info::{
             BindingUsageInfo, OptionBindingUsageInfo, compute_binding_usage_info,
         },
@@ -1039,6 +1039,43 @@ impl Issue for ConflictIssue {
     }
 }
 
+impl Project {
+    /// Whether the project uses the deterministic module-id strategy, i.e. whether
+    /// `get_global_module_id_strategy` runs (and therefore whether the module graph needs each
+    /// module's stringified ident). `Named` (the dev default, and an opt-in build config) does not.
+    ///
+    /// The strategy only ever runs on the whole-app graph, which is only built when *not* using
+    /// per-page graphs — so this also requires `!per_page_module_graph`. Encoding that here means
+    /// every graph (per-page or whole-app) can derive `include_ident_strings` from this single
+    /// query without the caller having to know which graph it's building.
+    pub(super) async fn uses_deterministic_module_ids(self: Vc<Self>) -> Result<bool> {
+        Ok(!*self.per_page_module_graph().await?
+            && matches!(
+                *self.next_config().module_ids(self.next_mode()).await?,
+                ModuleIdStrategyConfig::Deterministic
+            ))
+    }
+
+    /// Builds the [`ModuleGraphOptions`] shared by all project-config-derived module graphs, so the
+    /// per-page and whole-app graphs can't drift. Every field is derived from project config;
+    /// `include_ident_strings` follows [`Self::uses_deterministic_module_ids`] (the only consumer
+    /// of the stringified idents is `get_global_module_id_strategy`, which runs only on the
+    /// whole-app graph).
+    pub(super) async fn module_graph_options(self: Vc<Self>) -> Result<ModuleGraphOptions> {
+        let next_mode = self.next_mode();
+        Ok(ModuleGraphOptions {
+            include_ident_strings: self.uses_deterministic_module_ids().await?,
+            include_side_effects: *self
+                .next_config()
+                .turbopack_remove_unused_imports(next_mode)
+                .await?,
+            include_mergeable: *self.next_config().turbo_scope_hoisting(next_mode).await?,
+            include_traced: *self.should_write_nft_manifests().await?,
+            include_binding_usage: self.next_mode().await?.is_production(),
+        })
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl Project {
     #[turbo_tasks::function]
@@ -1472,8 +1509,7 @@ impl Project {
                         modules: vec![entry],
                         heuristics: EntryHeuristics::default(),
                     },
-                    /* include_traced */ *self.should_write_nft_manifests().await?,
-                    /* include_binding_usage */ self.next_mode().await?.is_production(),
+                    self.module_graph_options().await?,
                 )],
                 None,
             )
@@ -1502,8 +1538,7 @@ impl Project {
                         heuristics: EntryHeuristics::default(),
                     }])
                     .resolved_cell(),
-                    /* include_traced */ *self.should_write_nft_manifests().await?,
-                    /* include_binding_usage */ self.next_mode().await?.is_production(),
+                    self.module_graph_options().await?,
                 )],
                 None,
             )
@@ -1804,16 +1839,16 @@ impl Project {
         // appears in the module graph, but the synthesized `target.css` module's path suffix does.
         // `ident.path.path` does not include the query string (that lives on `ident.query`), so
         // `ends_with` is the correct matcher here.
-        static FEATURE_MODULE_PATH_SUFFIXES: &[(&str, &str)] = &[
-            ("next/image", "/next/image.js"),
-            ("next/future/image", "/next/future/image.js"),
-            ("next/legacy/image", "/next/legacy/image.js"),
-            ("next/script", "/next/script.js"),
-            ("next/dynamic", "/next/dynamic.js"),
-            ("next/font/google", "/next/font/google/target.css"),
-            ("next/font/local", "/next/font/local/target.css"),
-            ("@next/font/google", "/@next/font/google/target.css"),
-            ("@next/font/local", "/@next/font/local/target.css"),
+        static FEATURE_MODULE_PATH_SUFFIXES: &[(RcStr, &str)] = &[
+            (rcstr!("next/image"), "/next/image.js"),
+            (rcstr!("next/future/image"), "/next/future/image.js"),
+            (rcstr!("next/legacy/image"), "/next/legacy/image.js"),
+            (rcstr!("next/script"), "/next/script.js"),
+            (rcstr!("next/dynamic"), "/next/dynamic.js"),
+            (rcstr!("next/font/google"), "/next/font/google/target.css"),
+            (rcstr!("next/font/local"), "/next/font/local/target.css"),
+            (rcstr!("@next/font/google"), "/@next/font/google/target.css"),
+            (rcstr!("@next/font/local"), "/@next/font/local/target.css"),
         ];
 
         // TODO: useSwcLoader is not being reported as it is not directly corresponds (it checks
@@ -1880,12 +1915,12 @@ impl Project {
         //     to that feature's unique-importer set.
         let module_graph = self.whole_app_module_graphs().await?.full.await?;
 
-        let matching: FxHashMap<ResolvedVc<Box<dyn Module>>, &'static str> = module_graph
+        let matching: FxHashMap<ResolvedVc<Box<dyn Module>>, &'static RcStr> = module_graph
             .iter_nodes()
             .map(async |node| {
-                let ident = node.ident().await?;
+                let ident = module_graph.module_ident_resolved(node)?.await?;
                 let path = &ident.path.path;
-                for &(feature, suffix) in FEATURE_MODULE_PATH_SUFFIXES {
+                for (feature, suffix) in FEATURE_MODULE_PATH_SUFFIXES {
                     if path.ends_with(suffix) {
                         return Ok(Some((node, feature)));
                     }
@@ -1904,13 +1939,13 @@ impl Project {
         // We could filter via `BindingUsageInfo` to only count edges that survive tree-shaking,
         // but staying parallel to webpack lets dashboards compare counts across the two bundlers
         // directly.
-        let mut pairs: FxHashSet<(&'static str, ResolvedVc<Box<dyn Module>>)> =
-            FxHashSet::default();
+        let mut pairs: Vec<(&'static RcStr, ResolvedVc<Box<dyn Module>>)> =
+            Vec::with_capacity(matching.len() * 2);
         module_graph.traverse_edges_unordered(|parent, node| {
             if let Some((parent_node, _)) = parent
                 && let Some(&feature) = matching.get(&node)
             {
-                pairs.insert((feature, parent_node));
+                pairs.push((feature, parent_node));
             }
             Ok(())
         })?;
@@ -1922,7 +1957,7 @@ impl Project {
         let parent_source_keys = pairs
             .into_iter()
             .map(async |(feature, parent)| {
-                let ident = parent.ident().await?;
+                let ident = module_graph.module_ident_resolved(parent)?.await?;
                 let key = (
                     ident.path.path.clone(),
                     ident.query.clone(),
@@ -1933,13 +1968,13 @@ impl Project {
             .try_join()
             .await?;
 
-        let mut importers: FxHashMap<&'static str, FxHashSet<(RcStr, RcStr, RcStr)>> =
+        let mut importers: FxHashMap<&'static RcStr, FxHashSet<(RcStr, RcStr, RcStr)>> =
             FxHashMap::default();
         for (feature, key) in parent_source_keys {
             importers.entry(feature).or_default().insert(key);
         }
         for (feature, unique_sources) in importers {
-            features.push((RcStr::from(feature), unique_sources.len() as u32));
+            features.push((feature.clone(), unique_sources.len() as u32));
         }
 
         features.sort_by(|a, b| a.0.cmp(&b.0));
@@ -2714,21 +2749,18 @@ async fn whole_app_module_graph_operation(
     let span_clone = span.clone();
     async move {
         let next_mode = project.next_mode();
-        let should_trace = *project.should_write_nft_manifests().await?;
-        let should_read_binding_usage = next_mode.await?.is_production();
-        let base_single_module_graph = SingleModuleGraph::new_with_entries(
-            project.get_all_entries().to_resolved().await?,
-            should_trace,
-            should_read_binding_usage,
-        );
-        let base_visited_modules = VisitedModules::from_graph(base_single_module_graph);
-
-        let base = ModuleGraph::from_graphs(vec![base_single_module_graph], None);
-
         let turbopack_remove_unused_imports = *project
             .next_config()
             .turbopack_remove_unused_imports(next_mode)
             .await?;
+        let graph_options = project.module_graph_options().await?;
+        let base_single_module_graph = SingleModuleGraph::new_with_entries(
+            project.get_all_entries().to_resolved().await?,
+            graph_options,
+        );
+        let base_visited_modules = VisitedModules::from_graph(base_single_module_graph);
+
+        let base = ModuleGraph::from_graphs(vec![base_single_module_graph], None);
 
         let base = if turbopack_remove_unused_imports {
             // TODO suboptimal that we do compute_binding_usage_info twice (once for the base
@@ -2747,8 +2779,7 @@ async fn whole_app_module_graph_operation(
         let additional_module_graph = SingleModuleGraph::new_with_entries_visited(
             additional_entries,
             base_visited_modules,
-            should_trace,
-            should_read_binding_usage,
+            graph_options,
         );
 
         if !span.is_disabled() {

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -70,7 +70,7 @@ use turbopack_core::{
     },
     module::{Module, Modules},
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph, VisitedModules,
         binding_usage_info::{
             BindingUsageInfo, OptionBindingUsageInfo, compute_binding_usage_info,
         },
@@ -1018,6 +1018,43 @@ impl Issue for ConflictIssue {
     }
 }
 
+impl Project {
+    /// Whether the project uses the deterministic module-id strategy, i.e. whether
+    /// `get_global_module_id_strategy` runs (and therefore whether the module graph needs each
+    /// module's stringified ident). `Named` (the dev default, and an opt-in build config) does not.
+    ///
+    /// The strategy only ever runs on the whole-app graph, which is only built when *not* using
+    /// per-page graphs — so this also requires `!per_page_module_graph`. Encoding that here means
+    /// every graph (per-page or whole-app) can derive `include_ident_strings` from this single
+    /// query without the caller having to know which graph it's building.
+    pub(super) async fn uses_deterministic_module_ids(self: Vc<Self>) -> Result<bool> {
+        Ok(!*self.per_page_module_graph().await?
+            && matches!(
+                *self.next_config().module_ids(self.next_mode()).await?,
+                ModuleIdStrategyConfig::Deterministic
+            ))
+    }
+
+    /// Builds the [`ModuleGraphOptions`] shared by all project-config-derived module graphs, so the
+    /// per-page and whole-app graphs can't drift. Every field is derived from project config;
+    /// `include_ident_strings` follows [`Self::uses_deterministic_module_ids`] (the only consumer
+    /// of the stringified idents is `get_global_module_id_strategy`, which runs only on the
+    /// whole-app graph).
+    pub(super) async fn module_graph_options(self: Vc<Self>) -> Result<ModuleGraphOptions> {
+        let next_mode = self.next_mode();
+        Ok(ModuleGraphOptions {
+            include_ident_strings: self.uses_deterministic_module_ids().await?,
+            include_side_effects: *self
+                .next_config()
+                .turbopack_remove_unused_imports(next_mode)
+                .await?,
+            include_mergeable: *self.next_config().turbo_scope_hoisting(next_mode).await?,
+            include_traced: *self.should_write_nft_manifests().await?,
+            include_binding_usage: self.next_mode().await?.is_production(),
+        })
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl Project {
     #[turbo_tasks::function]
@@ -1470,8 +1507,7 @@ impl Project {
                         modules: vec![entry],
                         heuristics: EntryHeuristics::default(),
                     },
-                    /* include_traced */ *self.should_write_nft_manifests().await?,
-                    /* include_binding_usage */ self.next_mode().await?.is_production(),
+                    self.module_graph_options().await?,
                 )],
                 None,
             )
@@ -1500,8 +1536,7 @@ impl Project {
                         heuristics: EntryHeuristics::default(),
                     }])
                     .resolved_cell(),
-                    /* include_traced */ *self.should_write_nft_manifests().await?,
-                    /* include_binding_usage */ self.next_mode().await?.is_production(),
+                    self.module_graph_options().await?,
                 )],
                 None,
             )
@@ -1810,16 +1845,16 @@ impl Project {
         // appears in the module graph, but the synthesized `target.css` module's path suffix does.
         // `ident.path.path` does not include the query string (that lives on `ident.query`), so
         // `ends_with` is the correct matcher here.
-        static FEATURE_MODULE_PATH_SUFFIXES: &[(&str, &str)] = &[
-            ("next/image", "/next/image.js"),
-            ("next/future/image", "/next/future/image.js"),
-            ("next/legacy/image", "/next/legacy/image.js"),
-            ("next/script", "/next/script.js"),
-            ("next/dynamic", "/next/dynamic.js"),
-            ("next/font/google", "/next/font/google/target.css"),
-            ("next/font/local", "/next/font/local/target.css"),
-            ("@next/font/google", "/@next/font/google/target.css"),
-            ("@next/font/local", "/@next/font/local/target.css"),
+        static FEATURE_MODULE_PATH_SUFFIXES: &[(RcStr, &str)] = &[
+            (rcstr!("next/image"), "/next/image.js"),
+            (rcstr!("next/future/image"), "/next/future/image.js"),
+            (rcstr!("next/legacy/image"), "/next/legacy/image.js"),
+            (rcstr!("next/script"), "/next/script.js"),
+            (rcstr!("next/dynamic"), "/next/dynamic.js"),
+            (rcstr!("next/font/google"), "/next/font/google/target.css"),
+            (rcstr!("next/font/local"), "/next/font/local/target.css"),
+            (rcstr!("@next/font/google"), "/@next/font/google/target.css"),
+            (rcstr!("@next/font/local"), "/@next/font/local/target.css"),
         ];
 
         // TODO: useSwcLoader is not being reported as it is not directly corresponds (it checks
@@ -1886,12 +1921,12 @@ impl Project {
         //     to that feature's unique-importer set.
         let module_graph = self.whole_app_module_graphs().await?.full.await?;
 
-        let matching: FxHashMap<ResolvedVc<Box<dyn Module>>, &'static str> = module_graph
+        let matching: FxHashMap<ResolvedVc<Box<dyn Module>>, &'static RcStr> = module_graph
             .iter_nodes()
             .map(async |node| {
-                let ident = node.ident().await?;
+                let ident = module_graph.module_ident_resolved(node)?.await?;
                 let path = &ident.path.path;
-                for &(feature, suffix) in FEATURE_MODULE_PATH_SUFFIXES {
+                for (feature, suffix) in FEATURE_MODULE_PATH_SUFFIXES {
                     if path.ends_with(suffix) {
                         return Ok(Some((node, feature)));
                     }
@@ -1910,13 +1945,13 @@ impl Project {
         // We could filter via `BindingUsageInfo` to only count edges that survive tree-shaking,
         // but staying parallel to webpack lets dashboards compare counts across the two bundlers
         // directly.
-        let mut pairs: FxHashSet<(&'static str, ResolvedVc<Box<dyn Module>>)> =
-            FxHashSet::default();
+        let mut pairs: Vec<(&'static RcStr, ResolvedVc<Box<dyn Module>>)> =
+            Vec::with_capacity(matching.len() * 2);
         module_graph.traverse_edges_unordered(|parent, node| {
             if let Some((parent_node, _)) = parent
                 && let Some(&feature) = matching.get(&node)
             {
-                pairs.insert((feature, parent_node));
+                pairs.push((feature, parent_node));
             }
             Ok(())
         })?;
@@ -1928,7 +1963,7 @@ impl Project {
         let parent_source_keys = pairs
             .into_iter()
             .map(async |(feature, parent)| {
-                let ident = parent.ident().await?;
+                let ident = module_graph.module_ident_resolved(parent)?.await?;
                 let key = (
                     ident.path.path.clone(),
                     ident.query.clone(),
@@ -1939,13 +1974,13 @@ impl Project {
             .try_join()
             .await?;
 
-        let mut importers: FxHashMap<&'static str, FxHashSet<(RcStr, RcStr, RcStr)>> =
+        let mut importers: FxHashMap<&'static RcStr, FxHashSet<(RcStr, RcStr, RcStr)>> =
             FxHashMap::default();
         for (feature, key) in parent_source_keys {
             importers.entry(feature).or_default().insert(key);
         }
         for (feature, unique_sources) in importers {
-            features.push((RcStr::from(feature), unique_sources.len() as u32));
+            features.push((feature.clone(), unique_sources.len() as u32));
         }
 
         features.sort_by(|a, b| a.0.cmp(&b.0));
@@ -2822,21 +2857,18 @@ async fn whole_app_module_graph_operation(
     let span_clone = span.clone();
     async move {
         let next_mode = project.next_mode();
-        let should_trace = *project.should_write_nft_manifests().await?;
-        let should_read_binding_usage = next_mode.await?.is_production();
-        let base_single_module_graph = SingleModuleGraph::new_with_entries(
-            project.get_all_entries().to_resolved().await?,
-            should_trace,
-            should_read_binding_usage,
-        );
-        let base_visited_modules = VisitedModules::from_graph(base_single_module_graph);
-
-        let base = ModuleGraph::from_graphs(vec![base_single_module_graph], None);
-
         let turbopack_remove_unused_imports = *project
             .next_config()
             .turbopack_remove_unused_imports(next_mode)
             .await?;
+        let graph_options = project.module_graph_options().await?;
+        let base_single_module_graph = SingleModuleGraph::new_with_entries(
+            project.get_all_entries().to_resolved().await?,
+            graph_options,
+        );
+        let base_visited_modules = VisitedModules::from_graph(base_single_module_graph);
+
+        let base = ModuleGraph::from_graphs(vec![base_single_module_graph], None);
 
         let base = if turbopack_remove_unused_imports {
             // TODO suboptimal that we do compute_binding_usage_info twice (once for the base
@@ -2855,8 +2887,7 @@ async fn whole_app_module_graph_operation(
         let additional_module_graph = SingleModuleGraph::new_with_entries_visited(
             additional_entries,
             base_visited_modules,
-            should_trace,
-            should_read_binding_usage,
+            graph_options,
         );
 
         if !span.is_disabled() {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -38,7 +38,8 @@ use turbopack_core::{
     ident::AssetIdent,
     module::Module,
     module_graph::{
-        GraphTraversalAction, ModuleGraph, ModuleGraphLayer, async_module_info::AsyncModulesInfo,
+        GraphTraversalAction, ModuleGraph, ModuleGraphLayer, SingleModuleGraphNode,
+        async_module_info::AsyncModulesInfo,
     },
     output::{OutputAsset, OutputAssetsReference},
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
@@ -780,10 +781,15 @@ pub async fn map_server_actions(
     let graph = graph.connect();
     let actions = graph
         .await?
-        .iter_reachable_modules()?
-        .map(async |module| {
+        .iter_reachable_nodes()?
+        .map(async |node| {
+            let SingleModuleGraphNode::Module { module, ident, .. } = node else {
+                // VisitedModule nodes were handled in their owning graph.
+                return Ok(None);
+            };
             // TODO: compare module contexts instead?
-            let layer = match module.ident().await?.layer.as_ref() {
+            let ident = ident.await?;
+            let layer = match ident.layer.as_ref() {
                 Some(layer) if layer.name() == "app-rsc" || layer.name() == "app-edge-rsc" => {
                     ActionLayer::Rsc
                 }
@@ -793,9 +799,9 @@ pub async fn map_server_actions(
             };
             // TODO the old implementation did parse_actions(to_rsc_context(module))
             // is that really necessary?
-            Ok(parse_actions(*module)
+            Ok(parse_actions(**module)
                 .await?
-                .map(|action_map| (module, (layer, action_map))))
+                .map(|action_map| (*module, (layer, action_map))))
         })
         .try_flat_join()
         .await?;

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -40,7 +40,8 @@ use turbopack_core::{
     ident::AssetIdent,
     module::{Module, Modules},
     module_graph::{
-        GraphTraversalAction, ModuleGraph, ModuleGraphLayer, async_module_info::AsyncModulesInfo,
+        GraphTraversalAction, ModuleGraph, ModuleGraphLayer, SingleModuleGraphNode,
+        async_module_info::AsyncModulesInfo,
     },
     output::{OutputAsset, OutputAssetsReference},
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
@@ -911,10 +912,15 @@ pub async fn map_server_actions(
     let graph = graph.connect();
     let actions = graph
         .await?
-        .iter_reachable_modules()?
-        .map(async |module| {
+        .iter_reachable_nodes()?
+        .map(async |node| {
+            let SingleModuleGraphNode::Module { module, ident, .. } = node else {
+                // VisitedModule nodes were handled in their owning graph.
+                return Ok(None);
+            };
             // TODO: compare module contexts instead?
-            let layer = match module.ident().await?.layer.as_ref() {
+            let ident = ident.await?;
+            let layer = match ident.layer.as_ref() {
                 Some(layer)
                     if layer.name() == "app-rsc"
                         || layer.name() == "app-edge-rsc"
@@ -929,9 +935,9 @@ pub async fn map_server_actions(
             };
             // TODO the old implementation did parse_actions(to_rsc_context(module))
             // is that really necessary?
-            Ok(parse_actions(*module)
+            Ok(parse_actions(**module)
                 .await?
-                .map(|action_map| (module, (layer, action_map))))
+                .map(|action_map| (*module, (layer, action_map))))
         })
         .try_flat_join()
         .await?;

--- a/crates/next-api/src/service_worker.rs
+++ b/crates/next-api/src/service_worker.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     module::Module,
     module_graph::{
-        ModuleGraph, SingleModuleGraph,
+        ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry, EntryHeuristics},
     },
     output::{OutputAsset, OutputAssets},
@@ -113,8 +113,16 @@ async fn service_worker_chunk(
                 modules: vec![module],
                 heuristics: EntryHeuristics::default(),
             },
-            /* include_traced */ *project.should_write_nft_manifests().await?,
-            /* include_binding_usage */ is_production,
+            ModuleGraphOptions {
+                // The module-id strategy isn't computed on this isolated service-worker graph.
+                include_ident_strings: false,
+                include_side_effects: is_production,
+                // The service-worker chunking context doesn't enable module merging (scope
+                // hoisting), so `compute_merged_modules` never runs on this graph.
+                include_mergeable: false,
+                include_traced: *project.should_write_nft_manifests().await?,
+                include_binding_usage: is_production,
+            },
         )],
         /* binding_usage */ None,
     )

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -20,8 +20,8 @@ use turbopack_core::{
     asset::AssetContent,
     context::AssetContext,
     ident::Layer,
-    issue::{IssueExt, IssueSeverity},
-    module_graph::{ModuleGraph, SingleModuleGraph},
+    issue::{IssueExt, IssueSeverity, StyledString},
+    module_graph::{ModuleGraph, ModuleGraphOptions, SingleModuleGraph},
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
         ResolveResult,
@@ -737,8 +737,7 @@ async fn get_mock_stylesheet(
     let module_graph = ModuleGraph::from_graphs(
         vec![SingleModuleGraph::new_with_entries(
             entries.graph_entries().to_resolved().await?,
-            false,
-            false,
+            ModuleGraphOptions::default(),
         )],
         None,
     );

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -21,7 +21,7 @@ use turbopack_core::{
     context::AssetContext,
     ident::Layer,
     issue::{IssueExt, IssueSeverity},
-    module_graph::{ModuleGraph, SingleModuleGraph},
+    module_graph::{ModuleGraph, ModuleGraphOptions, SingleModuleGraph},
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
         ResolveResult,
@@ -737,8 +737,7 @@ async fn get_mock_stylesheet(
     let module_graph = ModuleGraph::from_graphs(
         vec![SingleModuleGraph::new_with_entries(
             entries.graph_entries().to_resolved().await?,
-            false,
-            false,
+            ModuleGraphOptions::default(),
         )],
         None,
     );

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_rcstr::rcstr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -60,11 +60,13 @@ impl NextServerComponentModule {
     }
 }
 
+const NEXT_JS_SERVER_COMPONENT: RcStr = rcstr!("Next.js Server Component");
+
 impl NextServerComponentModule {
     fn module_reference(&self) -> Vc<Box<dyn ModuleReference>> {
         Vc::upcast(SingleChunkableModuleReference::new(
             Vc::upcast(*self.module),
-            rcstr!("Next.js Server Component"),
+            NEXT_JS_SERVER_COMPONENT,
             ExportUsage::all(),
         ))
     }
@@ -79,7 +81,7 @@ impl Module for NextServerComponentModule {
             .ident()
             .owned()
             .await?
-            .with_modifier(rcstr!("Next.js Server Component"))
+            .with_modifier(NEXT_JS_SERVER_COMPONENT)
             .into_vc())
     }
 

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -34,7 +34,7 @@ use turbopack_core::{
     issue::{IssueReporter, IssueSeverity, handle_issues},
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry, EntryHeuristics},
     },
@@ -321,8 +321,20 @@ async fn build_internal(
             heuristics: EntryHeuristics::default(),
         }])
         .resolved_cell(),
-        false,
-        true,
+        ModuleGraphOptions {
+            include_binding_usage: true,
+            // `compute_binding_usage_info(_, true)` below runs
+            // `compute_side_effect_free_module_info`, which reads `side_effects` from
+            // the graph node.
+            include_side_effects: true,
+            // Module merging (driven by `scope_hoist` in the chunking context below) reads
+            // `is_mergeable` from the graph node and bails if absent.
+            include_mergeable: scope_hoist,
+            // `get_global_module_id_strategy` below reads each module's `ident_string` from the
+            // graph node; collect it so it doesn't fan out a `to_string()` per module.
+            include_ident_strings: true,
+            ..Default::default()
+        },
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
     let binding_usage = compute_binding_usage_info(module_graph, true);

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -34,7 +34,7 @@ use turbopack_core::{
     issue::{IssueReporter, IssueSeverity, handle_issues},
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry, EntryHeuristics},
     },
@@ -316,8 +316,20 @@ async fn build_internal(
             heuristics: EntryHeuristics::default(),
         }])
         .resolved_cell(),
-        false,
-        true,
+        ModuleGraphOptions {
+            include_binding_usage: true,
+            // `compute_binding_usage_info(_, true)` below runs
+            // `compute_side_effect_free_module_info`, which reads `side_effects` from
+            // the graph node.
+            include_side_effects: true,
+            // Module merging (driven by `scope_hoist` in the chunking context below) reads
+            // `is_mergeable` from the graph node and bails if absent.
+            include_mergeable: scope_hoist,
+            // `get_global_module_id_strategy` below reads each module's `ident_string` from the
+            // graph node; collect it so it doesn't fan out a `to_string()` per module.
+            include_ident_strings: true,
+            ..Default::default()
+        },
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
     let binding_usage = compute_binding_usage_info(module_graph, true);

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
     file_source::FileSource,
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         chunk_group_info::{ChunkGroupEntry, EntryHeuristics},
     },
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -169,14 +169,25 @@ pub async fn create_web_entry_source(
         .collect::<Vec<ResolvedVc<Box<dyn Module>>>>();
     let module_graph = ModuleGraph::from_graphs(
         vec![SingleModuleGraph::new_with_entries(
-            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
-                modules: all_modules,
-                heuristics: EntryHeuristics::default(),
-            }])
-            .resolved_cell(),
-            false,
-            false,
-        )],
+        <<<<<<< HEAD
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                        modules: all_modules,
+                        heuristics: EntryHeuristics::default(),
+                    }])
+                    .resolved_cell(),
+                    false,
+                    false,
+        ||||||| parent of 5f2ce7aa024 (pre-cache idents)
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(all_modules)])
+                        .resolved_cell(),
+                    false,
+                    false,
+        =======
+                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(all_modules)])
+                        .resolved_cell(),
+                    ModuleGraphOptions::default(),
+        >>>>>>> 5f2ce7aa024 (pre-cache idents)
+                )],
         None,
     );
     let module_graph = module_graph.connect().to_resolved().await?;

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -169,25 +169,13 @@ pub async fn create_web_entry_source(
         .collect::<Vec<ResolvedVc<Box<dyn Module>>>>();
     let module_graph = ModuleGraph::from_graphs(
         vec![SingleModuleGraph::new_with_entries(
-        <<<<<<< HEAD
-                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
-                        modules: all_modules,
-                        heuristics: EntryHeuristics::default(),
-                    }])
-                    .resolved_cell(),
-                    false,
-                    false,
-        ||||||| parent of 5f2ce7aa024 (pre-cache idents)
-                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(all_modules)])
-                        .resolved_cell(),
-                    false,
-                    false,
-        =======
-                    GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry(all_modules)])
-                        .resolved_cell(),
-                    ModuleGraphOptions::default(),
-        >>>>>>> 5f2ce7aa024 (pre-cache idents)
-                )],
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Entry {
+                modules: all_modules,
+                heuristics: EntryHeuristics::default(),
+            }])
+            .resolved_cell(),
+            ModuleGraphOptions::default(),
+        )],
         None,
     );
     let module_graph = module_graph.connect().to_resolved().await?;

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
     file_source::FileSource,
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         chunk_group_info::{ChunkGroupEntry, EntryHeuristics},
     },
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -174,8 +174,7 @@ pub async fn create_web_entry_source(
                 heuristics: EntryHeuristics::default(),
             }])
             .resolved_cell(),
-            false,
-            false,
+            ModuleGraphOptions::default(),
         )],
         None,
     );

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{FxIndexMap, FxIndexSet, MappedReadRef, ReadRef, ResolvedVc, Tr
 use crate::{
     chunk::{
         ChunkItemBatchGroup, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo,
-        ChunkingConfig,
+        ChunkingConfig, ChunkingContext,
         chunking::{ChunkItemOrBatchWithInfo, ComponentChunkItems, SplitContext, make_chunk},
     },
     module_graph::{
@@ -42,7 +42,19 @@ pub async fn make_production_chunks(
         let module_chunk_groups = module_graph.chunk_group_info().module_chunk_groups();
         let chunk_group_info = module_graph.chunk_group_info().await?;
         let heuristics = &chunk_group_info.chunking_heuristics;
-        let merged_modules = module_graph.merged_modules().await?;
+        // Merged modules only exist when module merging is enabled; computing `merged_modules()`
+        // otherwise would force the (potentially expensive) merge analysis — and the module graph
+        // isn't even built to support it (it only collects `is_mergeable` when merging is on). So
+        // only resolve it when merging is enabled; the lookup below is only reached for modules
+        // that were merged away, which can't happen when merging is off.
+        let merged_modules = if *(*split_context.chunking_context)
+            .is_module_merging_enabled()
+            .await?
+        {
+            Some(module_graph.merged_modules().await?)
+        } else {
+            None
+        };
 
         #[derive(Default)]
         struct GroupedChunkItems<'l> {
@@ -78,8 +90,16 @@ pub async fn make_production_chunks(
                             module_chunk_groups
                         } else {
                             // Merged modules don't have a chunk group in chunk_group_info, so
-                            // lookup using the original module.
+                            // lookup using the original module. A module can only be missing here
+                            // if it was merged away, which only happens
+                            // when merging is enabled (so
+                            // `merged_modules` is `Some`).
                             let original_module = merged_modules
+                                .as_ref()
+                                .context(
+                                    "module has no chunk group and module merging is disabled, so \
+                                     it cannot have been merged away",
+                                )?
                                 .get_original_module(ResolvedVc::upcast(module))
                                 .await?
                                 .context("every module should have a chunk group")?;

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -11,7 +11,7 @@ use turbo_tasks::{FxIndexMap, FxIndexSet, MappedReadRef, ReadRef, ResolvedVc, Tr
 use crate::{
     chunk::{
         ChunkItemBatchGroup, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo,
-        ChunkingConfig,
+        ChunkingConfig, ChunkingContext,
         chunking::{ChunkItemOrBatchWithInfo, ComponentChunkItems, SplitContext, make_chunk},
     },
     module_graph::{
@@ -46,7 +46,19 @@ pub async fn make_production_chunks(
         let module_chunk_groups = module_graph.chunk_group_info().module_chunk_groups();
         let chunk_group_info = module_graph.chunk_group_info().await?;
         let heuristics = &chunk_group_info.chunking_heuristics;
-        let merged_modules = module_graph.merged_modules().await?;
+        // Merged modules only exist when module merging is enabled; computing `merged_modules()`
+        // otherwise would force the (potentially expensive) merge analysis — and the module graph
+        // isn't even built to support it (it only collects `is_mergeable` when merging is on). So
+        // only resolve it when merging is enabled; the lookup below is only reached for modules
+        // that were merged away, which can't happen when merging is off.
+        let merged_modules = if *(*split_context.chunking_context)
+            .is_module_merging_enabled()
+            .await?
+        {
+            Some(module_graph.merged_modules().await?)
+        } else {
+            None
+        };
 
         #[derive(Default)]
         struct GroupedChunkItems<'l> {
@@ -80,8 +92,16 @@ pub async fn make_production_chunks(
                             module_chunk_groups
                         } else {
                             // Merged modules don't have a chunk group in chunk_group_info, so
-                            // lookup using the original module.
+                            // lookup using the original module. A module can only be missing here
+                            // if it was merged away, which only happens
+                            // when merging is enabled (so
+                            // `merged_modules` is `Some`).
                             let original_module = merged_modules
+                                .as_ref()
+                                .context(
+                                    "module has no chunk group and module merging is disabled, so \
+                                     it cannot have been merged away",
+                                )?
                                 .get_original_module(module)
                                 .await?
                                 .context("every module should have a chunk group")?;

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -47,7 +47,11 @@ async fn compute_async_module_info_single(
         .iter_reachable_nodes()?
         .map(async |node| {
             Ok(match node {
-                SingleModuleGraphNode::Module(node) => node.is_self_async().await?.then_some(*node),
+                SingleModuleGraphNode::Module {
+                    module: node,
+                    is_self_async,
+                    ..
+                } => is_self_async.await?.then_some(*node),
                 SingleModuleGraphNode::VisitedModule { idx: _, module } => {
                     // If a module is async in the parent then we need to mark reverse dependencies
                     // async in this graph as well.

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -12,7 +12,8 @@ use crate::{
     },
     module::Module,
     module_graph::{
-        GraphTraversalAction, ModuleGraph, RefData, chunk_group_info::RoaringBitmapWrapper,
+        GraphTraversalAction, ModuleGraph, RefData, SingleModuleGraphNode,
+        chunk_group_info::RoaringBitmapWrapper,
     },
     resolve::ExportUsage,
 };
@@ -132,15 +133,27 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
 
         let inner_span = tracing::info_span!("collect mergeable modules");
         let mergeable = module_graph
-            .iter_reachable_modules()?
-            .map(async |module| {
-                if let Some(mergeable) =
-                    ResolvedVc::try_downcast::<Box<dyn MergeableModule>>(module)
-                    && *mergeable.is_mergeable().await?
-                {
-                    return Ok(Some(module));
+            .iter_reachable_nodes()?
+            .map(async |node| {
+                match node {
+                    SingleModuleGraphNode::Module { module, .. } => {
+                        // Read the eagerly-resolved `is_mergeable` from the node. The graph must be
+                        // built with `ModuleGraphOptions::include_mergeable` (we enable it wherever
+                        // the chunking context merges modules), so a missing value is a
+                        // misconfigured graph; bail rather than silently
+                        // treating everything as non-mergeable.
+                        // Tracked read: the producing task was resolved at graph construction, so
+                        // this is cheap while still depending on the value correctly.
+                        let is_mergeable = node.is_mergeable_resolved().context(
+                            "compute_merged_modules requires the module graph to be built with \
+                             `ModuleGraphOptions::include_mergeable`",
+                        )?;
+                        Ok(is_mergeable.await?.then_some(*module))
+                    }
+                    // VisitedModule nodes belong to a parent graph; their mergeability was already
+                    // accounted for there.
+                    SingleModuleGraphNode::VisitedModule { .. } => Ok(None),
                 }
-                Ok(None)
             })
             .try_flat_join()
             .instrument(inner_span)

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BinaryHeap, VecDeque},
     future::Future,
+    hash::{Hash, Hasher},
     iter::FusedIterator,
     ops::Deref,
 };
@@ -26,9 +27,10 @@ use turbo_tasks::{
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
-    chunk::{AsyncModuleInfo, ChunkingContext, ChunkingType, TracedMode},
+    chunk::{AsyncModuleInfo, ChunkingContext, ChunkingType, MergeableModule, TracedMode},
+    ident::AssetIdent,
     issue::{ImportTracer, ImportTraces, Issue},
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::{
         async_module_info::{AsyncModulesInfo, compute_async_module_info},
         binding_usage_info::BindingUsageInfo,
@@ -151,7 +153,7 @@ impl VisitedModules {
                 .await?
                 .enumerate_nodes()
                 .flat_map(|(node_idx, module)| match module {
-                    SingleModuleGraphNode::Module(module) => Some((
+                    SingleModuleGraphNode::Module { module, .. } => Some((
                         *module,
                         GraphNodeIndex {
                             graph_idx: 0,
@@ -191,7 +193,7 @@ impl VisitedModules {
                 graph
                     .enumerate_nodes()
                     .flat_map(|(node_idx, module)| match module {
-                        SingleModuleGraphNode::Module(module) => Some((
+                        SingleModuleGraphNode::Module { module, .. } => Some((
                             *module,
                             GraphNodeIndex {
                                 graph_idx: this.next_graph_idx,
@@ -289,6 +291,48 @@ impl GraphEntries {
     }
 }
 
+/// Options controlling what data [`SingleModuleGraph`] collects while walking module references.
+/// Passed by value to the graph constructors.
+#[turbo_tasks::task_input]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash, TraceRawVcs, Encode, Decode)]
+pub struct ModuleGraphOptions {
+    /// Eagerly resolve and store each module's `ident_string()` `Vc` in its graph node, so the
+    /// module-id strategy reads it from the in-memory graph instead of fanning out a
+    /// `module.ident_string()` (i.e. `ident().to_string()`) turbo-task launch per module. Only the
+    /// whole-app/CLI-build graphs that run [`get_global_module_id_strategy`] need it; other graphs
+    /// leave it off to avoid the per-module `to_string` resolve.
+    ///
+    /// (`ident()` itself is always collected — see [`SingleModuleGraphNode::Module::ident`].)
+    ///
+    /// [`get_global_module_id_strategy`]: (crate `turbopack`) `global_module_ids`
+    pub include_ident_strings: bool,
+    /// Eagerly resolve and store each module's `side_effects()` `Vc` in its graph node, so the
+    /// side-effect-free aggregation reads it from the in-memory graph instead of fanning out a
+    /// `module.side_effects()` turbo-task launch per module. Required by
+    /// [`compute_side_effect_free_module_info`]: that pass `bail!`s on graphs built without this.
+    ///
+    /// [`compute_side_effect_free_module_info`]:
+    /// crate::module_graph::side_effect_module_info::compute_side_effect_free_module_info
+    pub include_side_effects: bool,
+    /// Eagerly resolve and store each module's `MergeableModule::is_mergeable()` `Vc` in its graph
+    /// node, so module merging (scope hoisting) reads it from the in-memory graph instead of
+    /// fanning out a `module.is_mergeable()` turbo-task launch per module. Required by
+    /// [`compute_merged_modules`]: that pass `bail!`s on graphs built without this. Should be
+    /// enabled wherever the chunking context has module merging enabled (`turbo_scope_hoisting`).
+    ///
+    /// When set, every `Module` node stores `Some`: the module's real `is_mergeable()` for types
+    /// that implement [`MergeableModule`], or a resolved `false` for types that don't (so `None`
+    /// unambiguously means "this graph wasn't built with `include_mergeable`").
+    ///
+    /// [`compute_merged_modules`]: crate::module_graph::merged_modules::compute_merged_modules
+    /// [`MergeableModule`]: crate::chunk::MergeableModule
+    pub include_mergeable: bool,
+    /// Whether to walk `ChunkingType::Traced` references.
+    pub include_traced: bool,
+    /// Whether to read `ModuleReference::binding_usage()`.
+    pub include_binding_usage: bool,
+}
+
 #[turbo_tasks::value(cell = "new", eq = "manual")]
 #[derive(Clone, Default)]
 pub struct SingleModuleGraph {
@@ -336,14 +380,20 @@ impl SingleModuleGraph {
     async fn new_inner(
         entries: &GraphEntries,
         visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
         let emit_spans = tracing::enabled!(Level::INFO);
         let root_nodes = entries
             .all_modules_with_is_traced()
             .map(|(e, is_traced)| {
-                SingleModuleGraphBuilderNode::new_module(emit_spans, e, is_traced)
+                SingleModuleGraphBuilderNode::new_module(
+                    emit_spans,
+                    options.include_ident_strings,
+                    options.include_side_effects,
+                    options.include_mergeable,
+                    e,
+                    is_traced,
+                )
             })
             .try_join()
             .await?;
@@ -354,13 +404,43 @@ impl SingleModuleGraph {
                 SingleModuleGraphBuilder {
                     visited_modules,
                     emit_spans,
-                    include_traced,
-                    include_binding_usage,
+                    options,
                 },
             )
             .await
             .completed()?;
         let node_count = children_nodes_iter.len();
+
+        // Materialize the breadth-first edges into an owned `Vec`. This drops the `AdjacencyMap`
+        // iterator (and lets us `.await` below without holding it across a suspension point — the
+        // build loop itself must stay synchronous, see the `node_data` read note below).
+        let edges = children_nodes_iter
+            .into_breadth_first_edges()
+            .collect::<Vec<_>>();
+
+        // Read each unique module's `node_data` cell exactly once, off the synchronous build loop.
+        // `new_module` resolved (but didn't read) the cell, distributing the data-dependency edges
+        // onto per-module tasks; reading here once per module (rather than once per incoming edge)
+        // lets us pass `final_read_hint` so the backend can drop the now-unneeded cell content.
+        let node_data = {
+            let mut seen = FxHashSet::default();
+            edges
+                .iter()
+                .filter_map(|(_, current)| match current {
+                    SingleModuleGraphBuilderNode::Module {
+                        module, node_data, ..
+                    } => seen.insert(*module).then_some((*module, *node_data)),
+                    SingleModuleGraphBuilderNode::VisitedModule { .. } => None,
+                })
+                .map(async |(module, node_data)| Ok((module, node_data.final_read_hint().await?)))
+                .try_join()
+                // `.instrument(...)` rather than an entered guard: an `Entered` span guard is
+                // `!Send` and would poison this future when held across the `.await`.
+                .instrument(tracing::info_span!("read module graph node data"))
+                .await?
+                .into_iter()
+                .collect::<FxHashMap<_, _>>()
+        };
 
         let mut graph: DiGraph<SingleModuleGraphNode, RefData> = DiGraph::with_capacity(
             node_count,
@@ -374,24 +454,33 @@ impl SingleModuleGraph {
             FxHashMap::with_capacity_and_hasher(node_count, Default::default());
         {
             let _span = tracing::info_span!("build module graph").entered();
-            for (parent, current) in children_nodes_iter.into_breadth_first_edges() {
-                let (module, graph_node, count) = match current {
-                    SingleModuleGraphBuilderNode::Module {
-                        module,
-                        is_traced: _,
-                        ident: _,
-                    } => (module, SingleModuleGraphNode::Module(module), 1),
-                    SingleModuleGraphBuilderNode::VisitedModule { module, idx } => (
-                        module,
-                        SingleModuleGraphNode::VisitedModule { idx, module },
-                        0,
-                    ),
-                };
-
-                // Find the current node, if it was already added
+            // Synchronous: no `.await` here (the loop holds the `tracing` span guard and many
+            // mutable locals across iterations; the per-module `node_data` was already read above).
+            for (parent, current) in edges {
+                let module = current.module();
+                // Find the current node, if it was already added.
                 let current_idx = if let Some(current_idx) = modules.get(&module) {
                     *current_idx
                 } else {
+                    let (graph_node, count) = match current {
+                        SingleModuleGraphBuilderNode::Module { module, .. } => {
+                            let data = &node_data[&module];
+                            (
+                                SingleModuleGraphNode::Module {
+                                    module,
+                                    ident: data.ident,
+                                    ident_string: data.ident_string,
+                                    is_self_async: data.is_self_async,
+                                    side_effects: data.side_effects,
+                                    is_mergeable: data.is_mergeable,
+                                },
+                                1,
+                            )
+                        }
+                        SingleModuleGraphBuilderNode::VisitedModule { module, idx } => {
+                            (SingleModuleGraphNode::VisitedModule { idx, module }, 0)
+                        }
+                    };
                     let idx = graph.add_node(graph_node);
                     number_of_modules += count;
                     modules.insert(module, idx);
@@ -445,7 +534,9 @@ impl SingleModuleGraph {
                                 let parent_modules: Vec<_> = graph
                                     .edges_directed(idx, petgraph::Direction::Incoming)
                                     .filter_map(|edge| match graph.node_weight(edge.source()) {
-                                        Some(SingleModuleGraphNode::Module(m)) => Some(*m),
+                                        Some(SingleModuleGraphNode::Module {
+                                            module: m, ..
+                                        }) => Some(*m),
                                         Some(SingleModuleGraphNode::VisitedModule {
                                             module,
                                             ..
@@ -511,7 +602,7 @@ impl SingleModuleGraph {
     /// Use iter_reachable_modules or one of the .traverse_* functions instead.
     pub fn iter_nodes(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
         self.graph.node_weights().filter_map(|n| match n {
-            SingleModuleGraphNode::Module(node) => Some(*node),
+            SingleModuleGraphNode::Module { module, .. } => Some(*module),
             SingleModuleGraphNode::VisitedModule { .. } => None,
         })
     }
@@ -636,7 +727,7 @@ impl SingleModuleGraph {
                                 let poppped = stack.pop().unwrap();
                                 let popped_state = node_states[poppped.index()].as_mut().unwrap();
                                 popped_state.on_stack = false;
-                                if let SingleModuleGraphNode::Module(module) =
+                                if let SingleModuleGraphNode::Module { module, .. } =
                                     self.graph.node_weight(poppped).unwrap()
                                 {
                                     scc.push(module);
@@ -681,9 +772,17 @@ impl ModuleGraphImportTracer {
         let path_and_modules = self
             .graph
             .await?
-            .modules
-            .iter()
-            .map(|(&module, _)| async move { Ok((module.ident().await?.path.clone(), module)) })
+            .graph
+            .node_weights()
+            .map(|n| async move {
+                let (module, ident) = match n {
+                    SingleModuleGraphNode::Module { module, ident, .. } => (*module, *ident),
+                    SingleModuleGraphNode::VisitedModule { module, .. } => {
+                        (*module, module.ident().to_resolved().await?)
+                    }
+                };
+                Ok((ident.await?.path.clone(), module))
+            })
             .try_join()
             .await?;
         let mut map: FxHashMap<FileSystemPath, Vec<ResolvedVc<Box<dyn Module>>>> =
@@ -1125,6 +1224,36 @@ impl ModuleGraphSnapshot {
             .await?
             .into_iter()
             .collect::<FxHashMap<_, _>>())
+    }
+
+    /// Returns a module's eagerly-resolved `AssetIdent` `Vc`, read from its graph node. Idents are
+    /// always collected for `Module` nodes, and `get_entry` only resolves a module to its `Module`
+    /// node, so this always finds an ident. The returned `ResolvedVc` is read tracked by callers.
+    pub fn module_ident_resolved(
+        &self,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Result<ResolvedVc<AssetIdent>> {
+        let idx = self.get_entry(module)?;
+        self.get_node(idx)?
+            .ident_resolved()
+            .context("a Module node always carries its eagerly-resolved ident")
+    }
+
+    /// Returns a module's eagerly-resolved `ident_string()` `Vc`, read from its graph node.
+    ///
+    /// Requires the graph to have been built with [`ModuleGraphOptions::include_ident_strings`];
+    /// `bail!`s otherwise. Asking a graph for an ident string it never collected is a programming
+    /// error — only the whole-app/CLI-build graphs that run the module-id strategy set the bit, and
+    /// those are exactly the graphs this is called on.
+    pub fn module_ident_string_resolved(
+        &self,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Result<ResolvedVc<RcStr>> {
+        let idx = self.get_entry(module)?;
+        self.get_node(idx)?.ident_string_resolved().context(
+            "module_ident_string_resolved() requires the module graph to be built with \
+             `ModuleGraphOptions::include_ident_strings`",
+        )
     }
 
     /// Traverses all reachable nodes exactly once and calls the visitor.
@@ -1570,7 +1699,7 @@ impl ModuleGraphSnapshot {
         &self,
     ) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn Module>>>> {
         Ok(self.iter_reachable_nodes()?.filter_map(|n| match n {
-            SingleModuleGraphNode::Module(m) => Some(*m),
+            SingleModuleGraphNode::Module { module: m, .. } => Some(*m),
             SingleModuleGraphNode::VisitedModule { .. } => None,
         }))
     }
@@ -1640,14 +1769,12 @@ impl SingleModuleGraph {
     #[turbo_tasks::function(operation)]
     pub async fn new_with_entry(
         entry: ChunkGroupEntry,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &GraphEntries::from_chunk_groups(vec![entry]),
             &Default::default(),
-            include_traced,
-            include_binding_usage,
+            options,
         )
         .await
     }
@@ -1655,30 +1782,21 @@ impl SingleModuleGraph {
     #[turbo_tasks::function(operation)]
     pub async fn new_with_entries(
         entries: ResolvedVc<GraphEntries>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(
-            &*entries.await?,
-            &Default::default(),
-            include_traced,
-            include_binding_usage,
-        )
-        .await
+        SingleModuleGraph::new_inner(&*entries.await?, &Default::default(), options).await
     }
 
     #[turbo_tasks::function(operation)]
     pub async fn new_with_entries_visited(
         entries: ResolvedVc<GraphEntries>,
         visited_modules: OperationVc<VisitedModules>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &*entries.await?,
             &visited_modules.connect().await?.modules,
-            include_traced,
-            include_binding_usage,
+            options,
         )
         .await
     }
@@ -1688,16 +1806,10 @@ impl SingleModuleGraph {
         // This must not be a Vc<Vec<_>> to ensure layout segment optimization hits the cache
         entries: GraphEntries,
         visited_modules: OperationVc<VisitedModules>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(
-            &entries,
-            &visited_modules.connect().await?.modules,
-            include_traced,
-            include_binding_usage,
-        )
-        .await
+        SingleModuleGraph::new_inner(&entries, &visited_modules.connect().await?.modules, options)
+            .await
     }
 
     #[turbo_tasks::function]
@@ -1713,28 +1825,130 @@ impl SingleModuleGraph {
 
 #[derive(Clone, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
 pub enum SingleModuleGraphNode {
-    Module(ResolvedVc<Box<dyn Module>>),
+    Module {
+        module: ResolvedVc<Box<dyn Module>>,
+        /// The module's resolved identifier, eagerly resolved at graph construction for every
+        /// `Module` node. Lets consumers that need idents for many modules read them from the
+        /// in-memory graph instead of each fanning out a `module.ident()` turbo-task launch per
+        /// module.
+        ///
+        /// Stored as a `ResolvedVc`, which serializes to just a cell id (so it survives a
+        /// persistent-cache hit, unlike the previous `ReadRef`) and is `Copy`. Consumers read it
+        /// with a *tracked* `.await?`: the producing task is already resolved by construction
+        /// time, so the read is cheap, while the consumer still correctly depends on the
+        /// value.
+        ident: ResolvedVc<AssetIdent>,
+        /// The module's resolved `ident_string()` (`ident().to_string()`) `Vc`, eagerly resolved
+        /// when the graph was built with `include_ident_strings`. The module-id strategy reads it
+        /// tracked and only runs on graphs built with the bit; `None` otherwise. Separate from
+        /// `ident` because the string is real work (recursive stringify) and only that one
+        /// consumer needs it.
+        ident_string: Option<ResolvedVc<RcStr>>,
+        /// The module's resolved `is_self_async()` `Vc`. Always present: `async_module_info()`
+        /// runs during chunking for every module graph, so this is unconditionally
+        /// collected (it is cheap — the trait default is `Vc::cell(false)` and the ecma
+        /// impl reads already-cached `references()`). Read tracked at consumption, like
+        /// `ident`.
+        is_self_async: ResolvedVc<bool>,
+        /// The module's resolved `side_effects()` `Vc`, eagerly resolved when the graph was built
+        /// with `include_side_effects`. `compute_side_effect_free_module_info` reads it tracked
+        /// and `bail!`s when it is `None`; that pass only runs under
+        /// `turbopack_remove_unused_imports`, where we set the bit.
+        side_effects: Option<ResolvedVc<ModuleSideEffects>>,
+        /// The module's resolved `MergeableModule::is_mergeable()` `Vc`, eagerly resolved when the
+        /// graph was built with `include_mergeable`. When the bit is set this is `Some` for
+        /// *every* `Module` node — the real `is_mergeable()` for types implementing
+        /// `MergeableModule`, or a resolved `false` for types that don't — so `None`
+        /// unambiguously means the graph wasn't built with `include_mergeable`.
+        /// `compute_merged_modules` reads it tracked and `bail!`s on `None`; that pass
+        /// only runs when the chunking context enables module merging.
+        is_mergeable: Option<ResolvedVc<bool>>,
+    },
     // Models a module that is referenced but has already been visited by an earlier graph.
     VisitedModule {
         idx: GraphNodeIndex,
         module: ResolvedVc<Box<dyn Module>>,
     },
 }
+#[cfg(test)]
+mod size_test {
+    use crate::module_graph::SingleModuleGraphNode;
+
+    /// Guards the per-module node size — there is one of these per module in the graph, so growth
+    /// here is multiplied across the whole app. The cached `ident_string` (`Option<ResolvedVc>`,
+    /// +8 bytes) is the cost of removing the per-module `ident().to_string()` fan-out from the
+    /// module-id strategy; bump deliberately if you add another field.
+    #[test]
+    pub fn test_size() {
+        assert_eq!(48, size_of::<SingleModuleGraphNode>());
+    }
+}
 
 impl SingleModuleGraphNode {
     pub fn module(&self) -> ResolvedVc<Box<dyn Module>> {
         match self {
-            SingleModuleGraphNode::Module(module) => *module,
+            SingleModuleGraphNode::Module { module, .. } => *module,
             SingleModuleGraphNode::VisitedModule { module, .. } => *module,
         }
     }
+
+    /// The eagerly-resolved ident for `Module` nodes (always collected). `Copy`. Returns `None`
+    /// only for `VisitedModule` nodes (whose ident lives on their owning graph's node); callers
+    /// handling those should fall back to `module().ident()`.
+    pub fn ident_resolved(&self) -> Option<ResolvedVc<AssetIdent>> {
+        match self {
+            SingleModuleGraphNode::Module { ident, .. } => Some(*ident),
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `ident_string()` `Vc`, if this is a `Module` node from a graph built
+    /// with `include_ident_strings`. `Copy`. `None` for `VisitedModule` nodes and for graphs built
+    /// without ident-string storage.
+    pub fn ident_string_resolved(&self) -> Option<ResolvedVc<RcStr>> {
+        match self {
+            SingleModuleGraphNode::Module { ident_string, .. } => *ident_string,
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `is_self_async()` `Vc` for `Module` nodes (always collected). `Copy`.
+    /// Returns `None` for `VisitedModule` nodes (their async-ness comes from the parent graph).
+    pub fn is_self_async_resolved(&self) -> Option<ResolvedVc<bool>> {
+        match self {
+            SingleModuleGraphNode::Module { is_self_async, .. } => Some(*is_self_async),
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `side_effects()` `Vc`, if this is a `Module` node from a graph built
+    /// with `include_side_effects`. `Copy`. `None` for `VisitedModule` nodes and for graphs built
+    /// without side-effect storage.
+    pub fn side_effects_resolved(&self) -> Option<ResolvedVc<ModuleSideEffects>> {
+        match self {
+            SingleModuleGraphNode::Module { side_effects, .. } => *side_effects,
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `is_mergeable()` `Vc`, if this is a `Module` node from a graph built
+    /// with `include_mergeable`. `Copy`. When the graph collected mergeability this is `Some` for
+    /// every `Module` node (a resolved `false` for non-`MergeableModule` types). `None` for
+    /// `VisitedModule` nodes and for graphs built without mergeable storage.
+    pub fn is_mergeable_resolved(&self) -> Option<ResolvedVc<bool>> {
+        match self {
+            SingleModuleGraphNode::Module { is_mergeable, .. } => *is_mergeable,
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
     pub fn target_idx(&self, direction: Direction) -> Option<GraphNodeIndex> {
         match self {
             SingleModuleGraphNode::VisitedModule { idx, .. } => match direction {
                 Direction::Outgoing => Some(*idx),
                 Direction::Incoming => None,
             },
-            SingleModuleGraphNode::Module(_) => None,
+            SingleModuleGraphNode::Module { .. } => None,
         }
     }
 }
@@ -1751,13 +1965,23 @@ pub enum GraphTraversalAction {
 
 // These nodes are created while walking the Turbopack modules references, and are used to then
 // afterwards build the SingleModuleGraph.
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Clone)]
 enum SingleModuleGraphBuilderNode {
     /// A regular module
     Module {
         module: ResolvedVc<Box<dyn Module>>,
-        /// module.ident().to_string(), eagerly computed for tracing, otherwise None
-        ident: Option<ReadRef<RcStr>>,
+        /// The module's resolved `module_graph_node_data` cell — *resolved* (pointer only, not
+        /// read) in `new_module`, so the per-module task owns the data-dependency edges. The cell
+        /// content is read exactly once, at dedup time in `new_inner` (with `final_read_hint`),
+        /// since `new_module` runs once per incoming edge. Excluded from `Hash`/`Eq` (see below)
+        /// since it is fully determined by `module`.
+        node_data: ResolvedVc<ModuleGraphNodeData>,
+        /// The module's `ident().to_string()`, read (untracked) only when `emit_spans` so [`span`]
+        /// can use it as the span name synchronously. Transient (never reaches the graph node) and
+        /// excluded from `Hash`/`Eq`.
+        ///
+        /// [`span`]: SingleModuleGraphBuilder::span
+        span_name: Option<ReadRef<RcStr>>,
         /// whether this module is a tracing context
         is_traced: bool,
     },
@@ -1768,17 +1992,163 @@ enum SingleModuleGraphBuilderNode {
     },
 }
 
+// `Hash`/`Eq` are implemented manually over the identity-determining fields only (`module` +
+// `is_traced` / `idx`), deliberately excluding `ident`. This node is the `AdjacencyMap` visit dedup
+// key; `ident` is fully determined by `module`, so including it would only waste cycles hashing a
+// full `AssetIdent` per insert.
+impl PartialEq for SingleModuleGraphBuilderNode {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                SingleModuleGraphBuilderNode::Module {
+                    module: l_module,
+                    is_traced: l_is_traced,
+                    ..
+                },
+                SingleModuleGraphBuilderNode::Module {
+                    module: r_module,
+                    is_traced: r_is_traced,
+                    ..
+                },
+            ) => l_module == r_module && l_is_traced == r_is_traced,
+            (
+                SingleModuleGraphBuilderNode::VisitedModule {
+                    module: l_module,
+                    idx: l_idx,
+                },
+                SingleModuleGraphBuilderNode::VisitedModule {
+                    module: r_module,
+                    idx: r_idx,
+                },
+            ) => l_module == r_module && l_idx == r_idx,
+            _ => false,
+        }
+    }
+}
+impl Eq for SingleModuleGraphBuilderNode {}
+impl Hash for SingleModuleGraphBuilderNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        match self {
+            SingleModuleGraphBuilderNode::Module {
+                module, is_traced, ..
+            } => {
+                module.hash(state);
+                is_traced.hash(state);
+            }
+            SingleModuleGraphBuilderNode::VisitedModule { module, idx } => {
+                module.hash(state);
+                idx.hash(state);
+            }
+        }
+    }
+}
+
+/// The eagerly-resolved per-module data stored on a [`SingleModuleGraphNode::Module`]. Computed by
+/// [`module_graph_node_data`] so the `to_resolved()` dependency edges are owned by a per-module
+/// task instead of the single graph-construction task.
+#[turbo_tasks::value]
+struct ModuleGraphNodeData {
+    ident: ResolvedVc<AssetIdent>,
+    ident_string: Option<ResolvedVc<RcStr>>,
+    is_self_async: ResolvedVc<bool>,
+    side_effects: Option<ResolvedVc<ModuleSideEffects>>,
+    is_mergeable: Option<ResolvedVc<bool>>,
+}
+
+/// Resolves a module's graph-node data. Each `to_resolved()` (resolving the pointer chain,
+/// executing the producing task — the same work `references()` already triggers via `analyze()`,
+/// without reading the cell content) installs its dependency edge on *this* per-module task, which
+/// is cached and shared across graphs built with the same options. The graph builder *resolves*
+/// (but does not read) this cell in `new_module`, then reads it exactly once at dedup time in
+/// `new_inner` with `final_read_hint`, so the backend can drop the content afterward. The
+/// `include_*` flags are part of the task key but are constant within a graph build.
+#[turbo_tasks::function]
+async fn module_graph_node_data(
+    module: Vc<Box<dyn Module>>,
+    include_ident_strings: bool,
+    include_side_effects: bool,
+    include_mergeable: bool,
+) -> Result<Vc<ModuleGraphNodeData>> {
+    let ident = module.ident().to_resolved().await?;
+    Ok(ModuleGraphNodeData {
+        // Always collected: idents have many consumers (NFT, feature usage, module-id strategy,
+        // import tracer).
+        ident,
+        // Only the module-id strategy needs the stringified ident, and only on the graphs that set
+        // this bit. `ident_string()` is real work (recursive stringify), so it's gated.
+        ident_string: if include_ident_strings {
+            Some(ident.to_string().to_resolved().await?)
+        } else {
+            None
+        },
+        // Always collected: `async_module_info()` runs during chunking for every graph. Cheap to
+        // resolve (trait default `Vc::cell(false)`; ecma reads already-cached `references()`).
+        is_self_async: module.is_self_async().to_resolved().await?,
+        side_effects: if include_side_effects {
+            Some(module.side_effects().to_resolved().await?)
+        } else {
+            None
+        },
+        // When collecting mergeability, store `Some` for *every* module so that `None` at the node
+        // level unambiguously means "graph not built with `include_mergeable`". Types that
+        // implement `MergeableModule` get their real `is_mergeable()`; others get a
+        // resolved `false` (the interned `false` cell, so this is cheap and deduped).
+        is_mergeable: if include_mergeable {
+            Some(
+                match ResolvedVc::try_downcast::<Box<dyn MergeableModule>>(
+                    module.to_resolved().await?,
+                ) {
+                    Some(mergeable) => mergeable.is_mergeable().to_resolved().await?,
+                    None => Vc::<bool>::default().to_resolved().await?,
+                },
+            )
+        } else {
+            None
+        },
+    }
+    .cell())
+}
+
 impl SingleModuleGraphBuilderNode {
+    fn module(&self) -> ResolvedVc<Box<dyn Module>> {
+        match self {
+            SingleModuleGraphBuilderNode::Module { module, .. } => *module,
+            SingleModuleGraphBuilderNode::VisitedModule { module, .. } => *module,
+        }
+    }
+
     async fn new_module(
         emit_spans: bool,
+        include_ident_strings: bool,
+        include_side_effects: bool,
+        include_mergeable: bool,
         module: ResolvedVc<Box<dyn Module>>,
         is_traced: bool,
     ) -> Result<Self> {
+        // The per-module `to_resolved()` calls happen inside `module_graph_node_data`, a
+        // `#[turbo_tasks::function]` keyed on the module — so those data-dependency edges are owned
+        // by that per-module task (and shared/cached across graphs) rather than concentrated in the
+        // single graph-construction task. We only *resolve* the cell here (pointer only, no content
+        // read); it is read once at dedup time in `new_inner`. `new_module` runs once per incoming
+        // edge, so reading here would read the same cell once per importer — deferring the read to
+        // the single dedup point lets that read use `final_read_hint`.
+        let node_data = module_graph_node_data(
+            *module,
+            include_ident_strings,
+            include_side_effects,
+            include_mergeable,
+        )
+        .to_resolved()
+        .await?;
         Ok(Self::Module {
             module,
-            ident: if emit_spans {
-                // INVALIDATION: we don't need to invalidate when the span name changes
-                Some(module.ident_string().untracked().await?)
+            node_data,
+            // The span name needs the ident string synchronously. Read it (untracked — its value is
+            // non-load-bearing for correctness) only when spans are enabled. Stays on the builder
+            // node; never reaches the graph node.
+            span_name: if emit_spans {
+                Some(module.ident().to_string().untracked().await?)
             } else {
                 None
             },
@@ -1795,11 +2165,7 @@ struct SingleModuleGraphBuilder<'a> {
 
     emit_spans: bool,
 
-    /// Whether to walk ChunkingType::Traced references
-    include_traced: bool,
-
-    /// Whether to read ModuleReference::binding_usage()
-    include_binding_usage: bool,
+    options: ModuleGraphOptions,
 }
 impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'_> {
     type EdgesIntoIter = Vec<(SingleModuleGraphBuilderNode, RefData)>;
@@ -1828,8 +2194,13 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
         };
         let visited_modules = self.visited_modules;
         let emit_spans = self.emit_spans;
-        let include_traced = self.include_traced;
-        let include_binding_usage = self.include_binding_usage;
+        let ModuleGraphOptions {
+            include_ident_strings,
+            include_side_effects,
+            include_mergeable,
+            include_traced,
+            include_binding_usage,
+        } = self.options;
         async move {
             let refs_cell = if !is_traced {
                 primary_chunkable_referenced_modules(*module, include_traced, include_binding_usage)
@@ -1877,6 +2248,9 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
                     } else {
                         SingleModuleGraphBuilderNode::new_module(
                             emit_spans,
+                            include_ident_strings,
+                            include_side_effects,
+                            include_mergeable,
                             target,
                             is_traced || ty.is_traced(),
                         )
@@ -1907,14 +2281,22 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
 
         let mut span = match node {
             SingleModuleGraphBuilderNode::Module {
-                ident: Some(ident), ..
+                span_name: Some(span_name),
+                ..
             } => {
-                tracing::info_span!("module", name = display(ident))
+                // Use the precomputed `ident().to_string()` (read untracked in `new_module`).
+                // `span_name` is populated whenever `emit_spans`, so this arm is taken for every
+                // `Module` node here.
+                tracing::info_span!("module", name = display(span_name))
+            }
+            SingleModuleGraphBuilderNode::Module {
+                span_name: None, ..
+            } => {
+                tracing::info_span!("module")
             }
             SingleModuleGraphBuilderNode::VisitedModule { .. } => {
                 tracing::info_span!("visited module")
             }
-            _ => unreachable!(),
         };
 
         if let Some(edge) = edge {
@@ -2294,8 +2676,7 @@ pub mod tests {
                         heuristics: EntryHeuristics::default(),
                     }])
                     .resolved_cell(),
-                    false,
-                    false,
+                    ModuleGraphOptions::default(),
                 );
 
                 let module_graph = ModuleGraph::from_graphs(
@@ -2308,8 +2689,7 @@ pub mod tests {
                             }])
                             .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
-                            false,
-                            false,
+                            ModuleGraphOptions::default(),
                         ),
                     ],
                     None,
@@ -2346,7 +2726,9 @@ pub mod tests {
                     .enumerate_nodes()
                     .map(|(_index, module)| async move {
                         Ok(match module {
-                            crate::module_graph::SingleModuleGraphNode::Module(module) => {
+                            crate::module_graph::SingleModuleGraphNode::Module {
+                                module, ..
+                            } => {
                                 if module.ident().to_string().owned().await? == "[test]/d.js" {
                                     Some(*module)
                                 } else {
@@ -2475,8 +2857,10 @@ pub mod tests {
                         heuristics: EntryHeuristics::default(),
                     }])
                     .resolved_cell(),
-                    true,
-                    false,
+                    ModuleGraphOptions {
+                        include_traced: true,
+                        ..Default::default()
+                    },
                 );
 
                 let module_graph = ModuleGraph::from_graphs(
@@ -2489,8 +2873,10 @@ pub mod tests {
                             }])
                             .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
-                            true,
-                            false,
+                            ModuleGraphOptions {
+                                include_traced: true,
+                                ..Default::default()
+                            },
                         ),
                     ],
                     None,
@@ -2504,7 +2890,7 @@ pub mod tests {
                         .iter_reachable_nodes()?
                         .map(async |node| {
                             Ok(match node {
-                                SingleModuleGraphNode::Module(module) => {
+                                SingleModuleGraphNode::Module { module, .. } => {
                                     module.ident_string().owned().await?
                                 }
                                 SingleModuleGraphNode::VisitedModule { module, .. } => {
@@ -2530,7 +2916,7 @@ pub mod tests {
                                 .iter_reachable_nodes()?
                                 .map(async |node| {
                                     Ok(match node {
-                                        SingleModuleGraphNode::Module(module) => {
+                                        SingleModuleGraphNode::Module { module, .. } => {
                                             module.ident_string().owned().await?
                                         }
                                         SingleModuleGraphNode::VisitedModule { module, .. } => {
@@ -2842,8 +3228,7 @@ pub mod tests {
                     }],
                     vec![],
                 )),
-                false,
-                false,
+                ModuleGraphOptions::default(),
             );
 
             // Create a simple name mapping to make analyzing the visitors easier.

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BinaryHeap, VecDeque},
     future::Future,
+    hash::{Hash, Hasher},
     iter::FusedIterator,
     ops::Deref,
 };
@@ -26,9 +27,10 @@ use turbo_tasks::{
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
-    chunk::{AsyncModuleInfo, ChunkingContext, ChunkingType, TracedMode},
+    chunk::{AsyncModuleInfo, ChunkingContext, ChunkingType, MergeableModule, TracedMode},
+    ident::AssetIdent,
     issue::{ImportTracer, ImportTraces, Issue},
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::{
         async_module_info::{AsyncModulesInfo, compute_async_module_info},
         binding_usage_info::BindingUsageInfo,
@@ -153,7 +155,7 @@ impl VisitedModules {
                 .await?
                 .enumerate_nodes()
                 .flat_map(|(node_idx, module)| match module {
-                    SingleModuleGraphNode::Module(module) => Some((
+                    SingleModuleGraphNode::Module { module, .. } => Some((
                         *module,
                         GraphNodeIndex {
                             graph_idx: 0,
@@ -193,7 +195,7 @@ impl VisitedModules {
                 graph
                     .enumerate_nodes()
                     .flat_map(|(node_idx, module)| match module {
-                        SingleModuleGraphNode::Module(module) => Some((
+                        SingleModuleGraphNode::Module { module, .. } => Some((
                             *module,
                             GraphNodeIndex {
                                 graph_idx: this.next_graph_idx,
@@ -291,6 +293,48 @@ impl GraphEntries {
     }
 }
 
+/// Options controlling what data [`SingleModuleGraph`] collects while walking module references.
+/// Passed by value to the graph constructors.
+#[turbo_tasks::task_input]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash, TraceRawVcs, Encode, Decode)]
+pub struct ModuleGraphOptions {
+    /// Eagerly resolve and store each module's `ident_string()` `Vc` in its graph node, so the
+    /// module-id strategy reads it from the in-memory graph instead of fanning out a
+    /// `module.ident_string()` (i.e. `ident().to_string()`) turbo-task launch per module. Only the
+    /// whole-app/CLI-build graphs that run [`get_global_module_id_strategy`] need it; other graphs
+    /// leave it off to avoid the per-module `to_string` resolve.
+    ///
+    /// (`ident()` itself is always collected — see [`SingleModuleGraphNode::Module::ident`].)
+    ///
+    /// [`get_global_module_id_strategy`]: (crate `turbopack`) `global_module_ids`
+    pub include_ident_strings: bool,
+    /// Eagerly resolve and store each module's `side_effects()` `Vc` in its graph node, so the
+    /// side-effect-free aggregation reads it from the in-memory graph instead of fanning out a
+    /// `module.side_effects()` turbo-task launch per module. Required by
+    /// [`compute_side_effect_free_module_info`]: that pass `bail!`s on graphs built without this.
+    ///
+    /// [`compute_side_effect_free_module_info`]:
+    /// crate::module_graph::side_effect_module_info::compute_side_effect_free_module_info
+    pub include_side_effects: bool,
+    /// Eagerly resolve and store each module's `MergeableModule::is_mergeable()` `Vc` in its graph
+    /// node, so module merging (scope hoisting) reads it from the in-memory graph instead of
+    /// fanning out a `module.is_mergeable()` turbo-task launch per module. Required by
+    /// [`compute_merged_modules`]: that pass `bail!`s on graphs built without this. Should be
+    /// enabled wherever the chunking context has module merging enabled (`turbo_scope_hoisting`).
+    ///
+    /// When set, every `Module` node stores `Some`: the module's real `is_mergeable()` for types
+    /// that implement [`MergeableModule`], or a resolved `false` for types that don't (so `None`
+    /// unambiguously means "this graph wasn't built with `include_mergeable`").
+    ///
+    /// [`compute_merged_modules`]: crate::module_graph::merged_modules::compute_merged_modules
+    /// [`MergeableModule`]: crate::chunk::MergeableModule
+    pub include_mergeable: bool,
+    /// Whether to walk `ChunkingType::Traced` references.
+    pub include_traced: bool,
+    /// Whether to read `ModuleReference::binding_usage()`.
+    pub include_binding_usage: bool,
+}
+
 #[turbo_tasks::value(cell = "new", eq = "manual")]
 #[derive(Clone, Default)]
 pub struct SingleModuleGraph {
@@ -340,14 +384,20 @@ impl SingleModuleGraph {
     async fn new_inner(
         entries: &GraphEntries,
         visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
         let emit_spans = tracing::enabled!(Level::INFO);
         let root_nodes = entries
             .all_modules_with_is_traced()
             .map(|(e, is_traced)| {
-                SingleModuleGraphBuilderNode::new_module(emit_spans, e, is_traced)
+                SingleModuleGraphBuilderNode::new_module(
+                    emit_spans,
+                    options.include_ident_strings,
+                    options.include_side_effects,
+                    options.include_mergeable,
+                    e,
+                    is_traced,
+                )
             })
             .try_join()
             .await?;
@@ -358,13 +408,43 @@ impl SingleModuleGraph {
                 SingleModuleGraphBuilder {
                     visited_modules,
                     emit_spans,
-                    include_traced,
-                    include_binding_usage,
+                    options,
                 },
             )
             .await
             .completed()?;
         let node_count = children_nodes_iter.len();
+
+        // Materialize the breadth-first edges into an owned `Vec`. This drops the `AdjacencyMap`
+        // iterator (and lets us `.await` below without holding it across a suspension point — the
+        // build loop itself must stay synchronous, see the `node_data` read note below).
+        let edges = children_nodes_iter
+            .into_breadth_first_edges()
+            .collect::<Vec<_>>();
+
+        // Read each unique module's `node_data` cell exactly once, off the synchronous build loop.
+        // `new_module` resolved (but didn't read) the cell, distributing the data-dependency edges
+        // onto per-module tasks; reading here once per module (rather than once per incoming edge)
+        // lets us pass `final_read_hint` so the backend can drop the now-unneeded cell content.
+        let node_data = {
+            let mut seen = FxHashSet::default();
+            edges
+                .iter()
+                .filter_map(|(_, current)| match current {
+                    SingleModuleGraphBuilderNode::Module {
+                        module, node_data, ..
+                    } => seen.insert(*module).then_some((*module, *node_data)),
+                    SingleModuleGraphBuilderNode::VisitedModule { .. } => None,
+                })
+                .map(async |(module, node_data)| Ok((module, node_data.final_read_hint().await?)))
+                .try_join()
+                // `.instrument(...)` rather than an entered guard: an `Entered` span guard is
+                // `!Send` and would poison this future when held across the `.await`.
+                .instrument(tracing::info_span!("read module graph node data"))
+                .await?
+                .into_iter()
+                .collect::<FxHashMap<_, _>>()
+        };
 
         let mut graph: DiGraph<SingleModuleGraphNode, RefData> = DiGraph::with_capacity(
             node_count,
@@ -378,24 +458,33 @@ impl SingleModuleGraph {
             FxHashMap::with_capacity_and_hasher(node_count, Default::default());
         {
             let _span = tracing::info_span!("build module graph").entered();
-            for (parent, current) in children_nodes_iter.into_breadth_first_edges() {
-                let (module, graph_node, count) = match current {
-                    SingleModuleGraphBuilderNode::Module {
-                        module,
-                        is_traced: _,
-                        ident: _,
-                    } => (module, SingleModuleGraphNode::Module(module), 1),
-                    SingleModuleGraphBuilderNode::VisitedModule { module, idx } => (
-                        module,
-                        SingleModuleGraphNode::VisitedModule { idx, module },
-                        0,
-                    ),
-                };
-
-                // Find the current node, if it was already added
+            // Synchronous: no `.await` here (the loop holds the `tracing` span guard and many
+            // mutable locals across iterations; the per-module `node_data` was already read above).
+            for (parent, current) in edges {
+                let module = current.module();
+                // Find the current node, if it was already added.
                 let current_idx = if let Some(current_idx) = modules.get(&module) {
                     *current_idx
                 } else {
+                    let (graph_node, count) = match current {
+                        SingleModuleGraphBuilderNode::Module { module, .. } => {
+                            let data = &node_data[&module];
+                            (
+                                SingleModuleGraphNode::Module {
+                                    module,
+                                    ident: data.ident,
+                                    ident_string: data.ident_string,
+                                    is_self_async: data.is_self_async,
+                                    side_effects: data.side_effects,
+                                    is_mergeable: data.is_mergeable,
+                                },
+                                1,
+                            )
+                        }
+                        SingleModuleGraphBuilderNode::VisitedModule { module, idx } => {
+                            (SingleModuleGraphNode::VisitedModule { idx, module }, 0)
+                        }
+                    };
                     let idx = graph.add_node(graph_node);
                     number_of_modules += count;
                     modules.insert(module, idx);
@@ -449,7 +538,9 @@ impl SingleModuleGraph {
                                 let parent_modules: Vec<_> = graph
                                     .edges_directed(idx, petgraph::Direction::Incoming)
                                     .filter_map(|edge| match graph.node_weight(edge.source()) {
-                                        Some(SingleModuleGraphNode::Module(m)) => Some(*m),
+                                        Some(SingleModuleGraphNode::Module {
+                                            module: m, ..
+                                        }) => Some(*m),
                                         Some(SingleModuleGraphNode::VisitedModule {
                                             module,
                                             ..
@@ -515,7 +606,7 @@ impl SingleModuleGraph {
     /// Use iter_reachable_modules or one of the .traverse_* functions instead.
     pub fn iter_nodes(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
         self.graph.node_weights().filter_map(|n| match n {
-            SingleModuleGraphNode::Module(node) => Some(*node),
+            SingleModuleGraphNode::Module { module, .. } => Some(*module),
             SingleModuleGraphNode::VisitedModule { .. } => None,
         })
     }
@@ -640,7 +731,7 @@ impl SingleModuleGraph {
                                 let poppped = stack.pop().unwrap();
                                 let popped_state = node_states[poppped.index()].as_mut().unwrap();
                                 popped_state.on_stack = false;
-                                if let SingleModuleGraphNode::Module(module) =
+                                if let SingleModuleGraphNode::Module { module, .. } =
                                     self.graph.node_weight(poppped).unwrap()
                                 {
                                     scc.push(module);
@@ -685,9 +776,17 @@ impl ModuleGraphImportTracer {
         let path_and_modules = self
             .graph
             .await?
-            .modules
-            .iter()
-            .map(async |(&module, _)| Ok((module.ident().await?.path.clone(), module)))
+            .graph
+            .node_weights()
+            .map(async |n| {
+                let (module, ident) = match n {
+                    SingleModuleGraphNode::Module { module, ident, .. } => (*module, *ident),
+                    SingleModuleGraphNode::VisitedModule { module, .. } => {
+                        (*module, module.ident().to_resolved().await?)
+                    }
+                };
+                Ok((ident.await?.path.clone(), module))
+            })
             .try_join()
             .await?;
         let mut map: FxHashMap<FileSystemPath, Vec<ResolvedVc<Box<dyn Module>>>> =
@@ -1134,6 +1233,36 @@ impl ModuleGraphSnapshot {
             .await?
             .into_iter()
             .collect::<FxHashMap<_, _>>())
+    }
+
+    /// Returns a module's eagerly-resolved `AssetIdent` `Vc`, read from its graph node. Idents are
+    /// always collected for `Module` nodes, and `get_entry` only resolves a module to its `Module`
+    /// node, so this always finds an ident. The returned `ResolvedVc` is read tracked by callers.
+    pub fn module_ident_resolved(
+        &self,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Result<ResolvedVc<AssetIdent>> {
+        let idx = self.get_entry(module)?;
+        self.get_node(idx)?
+            .ident_resolved()
+            .context("a Module node always carries its eagerly-resolved ident")
+    }
+
+    /// Returns a module's eagerly-resolved `ident_string()` `Vc`, read from its graph node.
+    ///
+    /// Requires the graph to have been built with [`ModuleGraphOptions::include_ident_strings`];
+    /// `bail!`s otherwise. Asking a graph for an ident string it never collected is a programming
+    /// error — only the whole-app/CLI-build graphs that run the module-id strategy set the bit, and
+    /// those are exactly the graphs this is called on.
+    pub fn module_ident_string_resolved(
+        &self,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Result<ResolvedVc<RcStr>> {
+        let idx = self.get_entry(module)?;
+        self.get_node(idx)?.ident_string_resolved().context(
+            "module_ident_string_resolved() requires the module graph to be built with \
+             `ModuleGraphOptions::include_ident_strings`",
+        )
     }
 
     /// Traverses all reachable nodes exactly once and calls the visitor.
@@ -1586,7 +1715,7 @@ impl ModuleGraphSnapshot {
         &self,
     ) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn Module>>>> {
         Ok(self.iter_reachable_nodes()?.filter_map(|n| match n {
-            SingleModuleGraphNode::Module(m) => Some(*m),
+            SingleModuleGraphNode::Module { module: m, .. } => Some(*m),
             SingleModuleGraphNode::VisitedModule { .. } => None,
         }))
     }
@@ -1656,14 +1785,12 @@ impl SingleModuleGraph {
     #[turbo_tasks::function(operation)]
     pub async fn new_with_entry(
         entry: ChunkGroupEntry,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &GraphEntries::from_chunk_groups(vec![entry]),
             &Default::default(),
-            include_traced,
-            include_binding_usage,
+            options,
         )
         .await
     }
@@ -1671,30 +1798,21 @@ impl SingleModuleGraph {
     #[turbo_tasks::function(operation)]
     pub async fn new_with_entries(
         entries: ResolvedVc<GraphEntries>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(
-            &*entries.await?,
-            &Default::default(),
-            include_traced,
-            include_binding_usage,
-        )
-        .await
+        SingleModuleGraph::new_inner(&*entries.await?, &Default::default(), options).await
     }
 
     #[turbo_tasks::function(operation)]
     pub async fn new_with_entries_visited(
         entries: ResolvedVc<GraphEntries>,
         visited_modules: OperationVc<VisitedModules>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &*entries.await?,
             &visited_modules.connect().await?.modules,
-            include_traced,
-            include_binding_usage,
+            options,
         )
         .await
     }
@@ -1704,16 +1822,10 @@ impl SingleModuleGraph {
         // This must not be a Vc<Vec<_>> to ensure layout segment optimization hits the cache
         entries: GraphEntries,
         visited_modules: OperationVc<VisitedModules>,
-        include_traced: bool,
-        include_binding_usage: bool,
+        options: ModuleGraphOptions,
     ) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(
-            &entries,
-            &visited_modules.connect().await?.modules,
-            include_traced,
-            include_binding_usage,
-        )
-        .await
+        SingleModuleGraph::new_inner(&entries, &visited_modules.connect().await?.modules, options)
+            .await
     }
 
     #[turbo_tasks::function]
@@ -1729,28 +1841,130 @@ impl SingleModuleGraph {
 
 #[derive(Clone, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
 pub enum SingleModuleGraphNode {
-    Module(ResolvedVc<Box<dyn Module>>),
+    Module {
+        module: ResolvedVc<Box<dyn Module>>,
+        /// The module's resolved identifier, eagerly resolved at graph construction for every
+        /// `Module` node. Lets consumers that need idents for many modules read them from the
+        /// in-memory graph instead of each fanning out a `module.ident()` turbo-task launch per
+        /// module.
+        ///
+        /// Stored as a `ResolvedVc`, which serializes to just a cell id (so it survives a
+        /// persistent-cache hit, unlike the previous `ReadRef`) and is `Copy`. Consumers read it
+        /// with a *tracked* `.await?`: the producing task is already resolved by construction
+        /// time, so the read is cheap, while the consumer still correctly depends on the
+        /// value.
+        ident: ResolvedVc<AssetIdent>,
+        /// The module's resolved `ident_string()` (`ident().to_string()`) `Vc`, eagerly resolved
+        /// when the graph was built with `include_ident_strings`. The module-id strategy reads it
+        /// tracked and only runs on graphs built with the bit; `None` otherwise. Separate from
+        /// `ident` because the string is real work (recursive stringify) and only that one
+        /// consumer needs it.
+        ident_string: Option<ResolvedVc<RcStr>>,
+        /// The module's resolved `is_self_async()` `Vc`. Always present: `async_module_info()`
+        /// runs during chunking for every module graph, so this is unconditionally
+        /// collected (it is cheap — the trait default is `Vc::cell(false)` and the ecma
+        /// impl reads already-cached `references()`). Read tracked at consumption, like
+        /// `ident`.
+        is_self_async: ResolvedVc<bool>,
+        /// The module's resolved `side_effects()` `Vc`, eagerly resolved when the graph was built
+        /// with `include_side_effects`. `compute_side_effect_free_module_info` reads it tracked
+        /// and `bail!`s when it is `None`; that pass only runs under
+        /// `turbopack_remove_unused_imports`, where we set the bit.
+        side_effects: Option<ResolvedVc<ModuleSideEffects>>,
+        /// The module's resolved `MergeableModule::is_mergeable()` `Vc`, eagerly resolved when the
+        /// graph was built with `include_mergeable`. When the bit is set this is `Some` for
+        /// *every* `Module` node — the real `is_mergeable()` for types implementing
+        /// `MergeableModule`, or a resolved `false` for types that don't — so `None`
+        /// unambiguously means the graph wasn't built with `include_mergeable`.
+        /// `compute_merged_modules` reads it tracked and `bail!`s on `None`; that pass
+        /// only runs when the chunking context enables module merging.
+        is_mergeable: Option<ResolvedVc<bool>>,
+    },
     // Models a module that is referenced but has already been visited by an earlier graph.
     VisitedModule {
         idx: GraphNodeIndex,
         module: ResolvedVc<Box<dyn Module>>,
     },
 }
+#[cfg(test)]
+mod size_test {
+    use crate::module_graph::SingleModuleGraphNode;
+
+    /// Guards the per-module node size — there is one of these per module in the graph, so growth
+    /// here is multiplied across the whole app. The cached `ident_string` (`Option<ResolvedVc>`,
+    /// +8 bytes) is the cost of removing the per-module `ident().to_string()` fan-out from the
+    /// module-id strategy; bump deliberately if you add another field.
+    #[test]
+    pub fn test_size() {
+        assert_eq!(48, size_of::<SingleModuleGraphNode>());
+    }
+}
 
 impl SingleModuleGraphNode {
     pub fn module(&self) -> ResolvedVc<Box<dyn Module>> {
         match self {
-            SingleModuleGraphNode::Module(module) => *module,
+            SingleModuleGraphNode::Module { module, .. } => *module,
             SingleModuleGraphNode::VisitedModule { module, .. } => *module,
         }
     }
+
+    /// The eagerly-resolved ident for `Module` nodes (always collected). `Copy`. Returns `None`
+    /// only for `VisitedModule` nodes (whose ident lives on their owning graph's node); callers
+    /// handling those should fall back to `module().ident()`.
+    pub fn ident_resolved(&self) -> Option<ResolvedVc<AssetIdent>> {
+        match self {
+            SingleModuleGraphNode::Module { ident, .. } => Some(*ident),
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `ident_string()` `Vc`, if this is a `Module` node from a graph built
+    /// with `include_ident_strings`. `Copy`. `None` for `VisitedModule` nodes and for graphs built
+    /// without ident-string storage.
+    pub fn ident_string_resolved(&self) -> Option<ResolvedVc<RcStr>> {
+        match self {
+            SingleModuleGraphNode::Module { ident_string, .. } => *ident_string,
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `is_self_async()` `Vc` for `Module` nodes (always collected). `Copy`.
+    /// Returns `None` for `VisitedModule` nodes (their async-ness comes from the parent graph).
+    pub fn is_self_async_resolved(&self) -> Option<ResolvedVc<bool>> {
+        match self {
+            SingleModuleGraphNode::Module { is_self_async, .. } => Some(*is_self_async),
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `side_effects()` `Vc`, if this is a `Module` node from a graph built
+    /// with `include_side_effects`. `Copy`. `None` for `VisitedModule` nodes and for graphs built
+    /// without side-effect storage.
+    pub fn side_effects_resolved(&self) -> Option<ResolvedVc<ModuleSideEffects>> {
+        match self {
+            SingleModuleGraphNode::Module { side_effects, .. } => *side_effects,
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
+    /// The eagerly-resolved `is_mergeable()` `Vc`, if this is a `Module` node from a graph built
+    /// with `include_mergeable`. `Copy`. When the graph collected mergeability this is `Some` for
+    /// every `Module` node (a resolved `false` for non-`MergeableModule` types). `None` for
+    /// `VisitedModule` nodes and for graphs built without mergeable storage.
+    pub fn is_mergeable_resolved(&self) -> Option<ResolvedVc<bool>> {
+        match self {
+            SingleModuleGraphNode::Module { is_mergeable, .. } => *is_mergeable,
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }
+    }
+
     pub fn target_idx(&self, direction: Direction) -> Option<GraphNodeIndex> {
         match self {
             SingleModuleGraphNode::VisitedModule { idx, .. } => match direction {
                 Direction::Outgoing => Some(*idx),
                 Direction::Incoming => None,
             },
-            SingleModuleGraphNode::Module(_) => None,
+            SingleModuleGraphNode::Module { .. } => None,
         }
     }
 }
@@ -1767,13 +1981,23 @@ pub enum GraphTraversalAction {
 
 // These nodes are created while walking the Turbopack modules references, and are used to then
 // afterwards build the SingleModuleGraph.
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Clone)]
 enum SingleModuleGraphBuilderNode {
     /// A regular module
     Module {
         module: ResolvedVc<Box<dyn Module>>,
-        /// module.ident().to_string(), eagerly computed for tracing, otherwise None
-        ident: Option<ReadRef<RcStr>>,
+        /// The module's resolved `module_graph_node_data` cell — *resolved* (pointer only, not
+        /// read) in `new_module`, so the per-module task owns the data-dependency edges. The cell
+        /// content is read exactly once, at dedup time in `new_inner` (with `final_read_hint`),
+        /// since `new_module` runs once per incoming edge. Excluded from `Hash`/`Eq` (see below)
+        /// since it is fully determined by `module`.
+        node_data: ResolvedVc<ModuleGraphNodeData>,
+        /// The module's `ident().to_string()`, read (untracked) only when `emit_spans` so [`span`]
+        /// can use it as the span name synchronously. Transient (never reaches the graph node) and
+        /// excluded from `Hash`/`Eq`.
+        ///
+        /// [`span`]: SingleModuleGraphBuilder::span
+        span_name: Option<ReadRef<RcStr>>,
         /// whether this module is a tracing context
         is_traced: bool,
     },
@@ -1784,17 +2008,163 @@ enum SingleModuleGraphBuilderNode {
     },
 }
 
+// `Hash`/`Eq` are implemented manually over the identity-determining fields only (`module` +
+// `is_traced` / `idx`), deliberately excluding `ident`. This node is the `AdjacencyMap` visit dedup
+// key; `ident` is fully determined by `module`, so including it would only waste cycles hashing a
+// full `AssetIdent` per insert.
+impl PartialEq for SingleModuleGraphBuilderNode {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                SingleModuleGraphBuilderNode::Module {
+                    module: l_module,
+                    is_traced: l_is_traced,
+                    ..
+                },
+                SingleModuleGraphBuilderNode::Module {
+                    module: r_module,
+                    is_traced: r_is_traced,
+                    ..
+                },
+            ) => l_module == r_module && l_is_traced == r_is_traced,
+            (
+                SingleModuleGraphBuilderNode::VisitedModule {
+                    module: l_module,
+                    idx: l_idx,
+                },
+                SingleModuleGraphBuilderNode::VisitedModule {
+                    module: r_module,
+                    idx: r_idx,
+                },
+            ) => l_module == r_module && l_idx == r_idx,
+            _ => false,
+        }
+    }
+}
+impl Eq for SingleModuleGraphBuilderNode {}
+impl Hash for SingleModuleGraphBuilderNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        match self {
+            SingleModuleGraphBuilderNode::Module {
+                module, is_traced, ..
+            } => {
+                module.hash(state);
+                is_traced.hash(state);
+            }
+            SingleModuleGraphBuilderNode::VisitedModule { module, idx } => {
+                module.hash(state);
+                idx.hash(state);
+            }
+        }
+    }
+}
+
+/// The eagerly-resolved per-module data stored on a [`SingleModuleGraphNode::Module`]. Computed by
+/// [`module_graph_node_data`] so the `to_resolved()` dependency edges are owned by a per-module
+/// task instead of the single graph-construction task.
+#[turbo_tasks::value]
+struct ModuleGraphNodeData {
+    ident: ResolvedVc<AssetIdent>,
+    ident_string: Option<ResolvedVc<RcStr>>,
+    is_self_async: ResolvedVc<bool>,
+    side_effects: Option<ResolvedVc<ModuleSideEffects>>,
+    is_mergeable: Option<ResolvedVc<bool>>,
+}
+
+/// Resolves a module's graph-node data. Each `to_resolved()` (resolving the pointer chain,
+/// executing the producing task — the same work `references()` already triggers via `analyze()`,
+/// without reading the cell content) installs its dependency edge on *this* per-module task, which
+/// is cached and shared across graphs built with the same options. The graph builder *resolves*
+/// (but does not read) this cell in `new_module`, then reads it exactly once at dedup time in
+/// `new_inner` with `final_read_hint`, so the backend can drop the content afterward. The
+/// `include_*` flags are part of the task key but are constant within a graph build.
+#[turbo_tasks::function]
+async fn module_graph_node_data(
+    module: Vc<Box<dyn Module>>,
+    include_ident_strings: bool,
+    include_side_effects: bool,
+    include_mergeable: bool,
+) -> Result<Vc<ModuleGraphNodeData>> {
+    let ident = module.ident().to_resolved().await?;
+    Ok(ModuleGraphNodeData {
+        // Always collected: idents have many consumers (NFT, feature usage, module-id strategy,
+        // import tracer).
+        ident,
+        // Only the module-id strategy needs the stringified ident, and only on the graphs that set
+        // this bit. `ident_string()` is real work (recursive stringify), so it's gated.
+        ident_string: if include_ident_strings {
+            Some(ident.to_string().to_resolved().await?)
+        } else {
+            None
+        },
+        // Always collected: `async_module_info()` runs during chunking for every graph. Cheap to
+        // resolve (trait default `Vc::cell(false)`; ecma reads already-cached `references()`).
+        is_self_async: module.is_self_async().to_resolved().await?,
+        side_effects: if include_side_effects {
+            Some(module.side_effects().to_resolved().await?)
+        } else {
+            None
+        },
+        // When collecting mergeability, store `Some` for *every* module so that `None` at the node
+        // level unambiguously means "graph not built with `include_mergeable`". Types that
+        // implement `MergeableModule` get their real `is_mergeable()`; others get a
+        // resolved `false` (the interned `false` cell, so this is cheap and deduped).
+        is_mergeable: if include_mergeable {
+            Some(
+                match ResolvedVc::try_downcast::<Box<dyn MergeableModule>>(
+                    module.to_resolved().await?,
+                ) {
+                    Some(mergeable) => mergeable.is_mergeable().to_resolved().await?,
+                    None => Vc::<bool>::default().to_resolved().await?,
+                },
+            )
+        } else {
+            None
+        },
+    }
+    .cell())
+}
+
 impl SingleModuleGraphBuilderNode {
+    fn module(&self) -> ResolvedVc<Box<dyn Module>> {
+        match self {
+            SingleModuleGraphBuilderNode::Module { module, .. } => *module,
+            SingleModuleGraphBuilderNode::VisitedModule { module, .. } => *module,
+        }
+    }
+
     async fn new_module(
         emit_spans: bool,
+        include_ident_strings: bool,
+        include_side_effects: bool,
+        include_mergeable: bool,
         module: ResolvedVc<Box<dyn Module>>,
         is_traced: bool,
     ) -> Result<Self> {
+        // The per-module `to_resolved()` calls happen inside `module_graph_node_data`, a
+        // `#[turbo_tasks::function]` keyed on the module — so those data-dependency edges are owned
+        // by that per-module task (and shared/cached across graphs) rather than concentrated in the
+        // single graph-construction task. We only *resolve* the cell here (pointer only, no content
+        // read); it is read once at dedup time in `new_inner`. `new_module` runs once per incoming
+        // edge, so reading here would read the same cell once per importer — deferring the read to
+        // the single dedup point lets that read use `final_read_hint`.
+        let node_data = module_graph_node_data(
+            *module,
+            include_ident_strings,
+            include_side_effects,
+            include_mergeable,
+        )
+        .to_resolved()
+        .await?;
         Ok(Self::Module {
             module,
-            ident: if emit_spans {
-                // INVALIDATION: we don't need to invalidate when the span name changes
-                Some(module.ident_string().untracked().await?)
+            node_data,
+            // The span name needs the ident string synchronously. Read it (untracked — its value is
+            // non-load-bearing for correctness) only when spans are enabled. Stays on the builder
+            // node; never reaches the graph node.
+            span_name: if emit_spans {
+                Some(module.ident().to_string().untracked().await?)
             } else {
                 None
             },
@@ -1811,11 +2181,7 @@ struct SingleModuleGraphBuilder<'a> {
 
     emit_spans: bool,
 
-    /// Whether to walk ChunkingType::Traced references
-    include_traced: bool,
-
-    /// Whether to read ModuleReference::binding_usage()
-    include_binding_usage: bool,
+    options: ModuleGraphOptions,
 }
 impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'_> {
     type EdgesIntoIter = Vec<(SingleModuleGraphBuilderNode, RefData)>;
@@ -1844,8 +2210,13 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
         };
         let visited_modules = self.visited_modules;
         let emit_spans = self.emit_spans;
-        let include_traced = self.include_traced;
-        let include_binding_usage = self.include_binding_usage;
+        let ModuleGraphOptions {
+            include_ident_strings,
+            include_side_effects,
+            include_mergeable,
+            include_traced,
+            include_binding_usage,
+        } = self.options;
         async move {
             let refs_cell = if !is_traced {
                 primary_chunkable_referenced_modules(*module, include_traced, include_binding_usage)
@@ -1893,6 +2264,9 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
                     } else {
                         SingleModuleGraphBuilderNode::new_module(
                             emit_spans,
+                            include_ident_strings,
+                            include_side_effects,
+                            include_mergeable,
                             target,
                             is_traced || ty.is_traced(),
                         )
@@ -1923,14 +2297,22 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
 
         let mut span = match node {
             SingleModuleGraphBuilderNode::Module {
-                ident: Some(ident), ..
+                span_name: Some(span_name),
+                ..
             } => {
-                tracing::info_span!("module", name = display(ident))
+                // Use the precomputed `ident().to_string()` (read untracked in `new_module`).
+                // `span_name` is populated whenever `emit_spans`, so this arm is taken for every
+                // `Module` node here.
+                tracing::info_span!("module", name = display(span_name))
+            }
+            SingleModuleGraphBuilderNode::Module {
+                span_name: None, ..
+            } => {
+                tracing::info_span!("module")
             }
             SingleModuleGraphBuilderNode::VisitedModule { .. } => {
                 tracing::info_span!("visited module")
             }
-            _ => unreachable!(),
         };
 
         if let Some(edge) = edge {
@@ -2323,8 +2705,7 @@ pub mod tests {
                         heuristics: EntryHeuristics::default(),
                     }])
                     .resolved_cell(),
-                    false,
-                    false,
+                    ModuleGraphOptions::default(),
                 );
 
                 let module_graph = ModuleGraph::from_graphs(
@@ -2337,8 +2718,7 @@ pub mod tests {
                             }])
                             .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
-                            false,
-                            false,
+                            ModuleGraphOptions::default(),
                         ),
                     ],
                     None,
@@ -2375,7 +2755,9 @@ pub mod tests {
                     .enumerate_nodes()
                     .map(async |(_index, module)| {
                         Ok(match module {
-                            crate::module_graph::SingleModuleGraphNode::Module(module) => {
+                            crate::module_graph::SingleModuleGraphNode::Module {
+                                module, ..
+                            } => {
                                 if module.ident().to_string().owned().await? == "[test]/d.js" {
                                     Some(*module)
                                 } else {
@@ -2504,8 +2886,10 @@ pub mod tests {
                         heuristics: EntryHeuristics::default(),
                     }])
                     .resolved_cell(),
-                    true,
-                    false,
+                    ModuleGraphOptions {
+                        include_traced: true,
+                        ..Default::default()
+                    },
                 );
 
                 let module_graph = ModuleGraph::from_graphs(
@@ -2518,8 +2902,10 @@ pub mod tests {
                             }])
                             .resolved_cell(),
                             VisitedModules::from_graph(parent_graph),
-                            true,
-                            false,
+                            ModuleGraphOptions {
+                                include_traced: true,
+                                ..Default::default()
+                            },
                         ),
                     ],
                     None,
@@ -2533,7 +2919,7 @@ pub mod tests {
                         .iter_reachable_nodes()?
                         .map(async |node| {
                             Ok(match node {
-                                SingleModuleGraphNode::Module(module) => {
+                                SingleModuleGraphNode::Module { module, .. } => {
                                     module.ident_string().owned().await?
                                 }
                                 SingleModuleGraphNode::VisitedModule { module, .. } => {
@@ -2559,7 +2945,7 @@ pub mod tests {
                                 .iter_reachable_nodes()?
                                 .map(async |node| {
                                     Ok(match node {
-                                        SingleModuleGraphNode::Module(module) => {
+                                        SingleModuleGraphNode::Module { module, .. } => {
                                             module.ident_string().owned().await?
                                         }
                                         SingleModuleGraphNode::VisitedModule { module, .. } => {
@@ -2871,8 +3257,7 @@ pub mod tests {
                     }],
                     vec![],
                 )),
-                false,
-                false,
+                ModuleGraphOptions::default(),
             );
 
             // Create a simple name mapping to make analyzing the visitors easier.

--- a/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 
@@ -46,11 +46,21 @@ async fn compute_side_effect_free_module_info_single(
         .iter_reachable_nodes()?
         .map(async |node| {
             Ok(match node {
-                SingleModuleGraphNode::Module(module) => {
-                    // This turbo task always has a cache hit since it is called when building the
-                    // module graph. we could consider moving this information
-                    // into to the module graph, but then changes would invalidate the whole graph.
-                    (*module, *module.side_effects().await?)
+                SingleModuleGraphNode::Module {
+                    module,
+                    side_effects,
+                    ..
+                } => {
+                    // Read the eagerly-resolved `side_effects` from the node. This pass only runs
+                    // under `turbopack_remove_unused_imports`, and we build those graphs with
+                    // `ModuleGraphOptions::include_side_effects`, so the value is always present;
+                    // bail otherwise. Tracked read: the producing task was resolved at graph
+                    // construction, so this is cheap while still depending on the value correctly.
+                    let side_effects = (*side_effects).context(
+                        "compute_side_effect_free_module_info requires the module graph to be \
+                         built with `ModuleGraphOptions::include_side_effects`",
+                    )?;
+                    (*module, *side_effects.await?)
                 }
                 SingleModuleGraphNode::VisitedModule { idx: _, module } => (
                     *module,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -822,7 +822,7 @@ impl Module for EcmascriptModuleAsset {
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
         // We need to respect package.json configuration over any static analysis we might do.
         Ok((match *get_side_effect_free_declaration(
-            self.ident().await?.path.clone(),
+            this.source.ident().await?.path.clone(),
             this.side_effect_free_packages.map(|g| *g),
         )
         .await?

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -901,7 +901,7 @@ impl Module for EcmascriptModuleAsset {
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
         // We need to respect package.json configuration over any static analysis we might do.
         Ok((match *get_side_effect_free_declaration(
-            self.ident().await?.path.clone(),
+            this.source.ident().await?.path.clone(),
             this.side_effect_free_packages.map(|g| *g),
         )
         .await?

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/part/module.rs
@@ -335,7 +335,7 @@ impl Module for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
-    async fn side_effects(&self) -> Vc<ModuleSideEffects> {
+    fn side_effects(&self) -> Vc<ModuleSideEffects> {
         match self.part {
             ModulePart::Exports | ModulePart::Export(..) => {
                 ModuleSideEffects::SideEffectFree.cell()

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/part/module.rs
@@ -340,7 +340,7 @@ impl Module for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
-    async fn side_effects(&self) -> Vc<ModuleSideEffects> {
+    fn side_effects(&self) -> Vc<ModuleSideEffects> {
         match self.part {
             ModulePart::Exports | ModulePart::Export(..) => {
                 ModuleSideEffects::SideEffectFree.cell()

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
     context::{AssetContext, ProcessResult},
     file_source::FileSource,
     ident::AssetIdent,
-    module_graph::{ModuleGraph, SingleModuleGraph},
+    module_graph::{ModuleGraph, ModuleGraphOptions, SingleModuleGraph},
     reference_type::{EntryReferenceSubType, InnerAssets, ReferenceType},
     resolve::{FindContextFileResult, find_context_file_or_package_key, options::ImportMapping},
     source::Source,
@@ -531,8 +531,7 @@ impl PostCssTransformedAsset {
         let module_graph = ModuleGraph::from_graphs(
             vec![SingleModuleGraph::new_with_entries(
                 entries.graph_entries().to_resolved().await?,
-                false,
-                false,
+                ModuleGraphOptions::default(),
             )],
             None,
         )

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -31,7 +31,7 @@ use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     module::Module,
     module_graph::{
-        ModuleGraph, SingleModuleGraph,
+        ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry, EntryHeuristics},
     },
     output::{ExpandOutputAssetsInput, OutputAsset, OutputAssets, expand_output_assets},
@@ -283,8 +283,7 @@ impl WebpackLoadersProcessedAsset {
             let module_graph = ModuleGraph::from_graphs(
                 vec![SingleModuleGraph::new_with_entries(
                     entries.graph_entries().to_resolved().await?,
-                    false,
-                    false,
+                    ModuleGraphOptions::default(),
                 )],
                 None,
             )
@@ -757,8 +756,7 @@ impl EvaluateContext for WebpackLoaderContext {
                         modules: vec![module],
                         heuristics: EntryHeuristics::default(),
                     },
-                    false,
-                    false,
+                    ModuleGraphOptions::default(),
                 );
                 let import_module_graph = ModuleGraph::from_graphs(vec![single_graph], None)
                     .connect()

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -39,7 +39,8 @@ use turbopack_core::{
     ident::Layer,
     issue::{CollectibleIssuesExt, IssueFilter},
     module_graph::{
-        ModuleGraph, SingleModuleGraph, binding_usage_info::compute_binding_usage_info,
+        ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
+        binding_usage_info::compute_binding_usage_info,
     },
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
@@ -517,8 +518,16 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
 
     let single_graph = SingleModuleGraph::new_with_entries(
         entries.graph_entries().to_resolved().await?,
-        false,
-        true,
+        ModuleGraphOptions {
+            include_binding_usage: true,
+            // `compute_side_effect_free_module_info` (run below via `compute_binding_usage_info`
+            // when removing unused imports) reads `side_effects` from the graph node.
+            include_side_effects: options.remove_unused_imports,
+            // Module merging (driven by `scope_hoisting` in the chunking context below) reads
+            // `is_mergeable` from the graph node and bails if absent.
+            include_mergeable: options.scope_hoisting,
+            ..Default::default()
+        },
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -42,7 +42,8 @@ use turbopack_core::{
     ident::Layer,
     issue::{CollectibleIssuesExt, IssueFilter},
     module_graph::{
-        ModuleGraph, SingleModuleGraph, binding_usage_info::compute_binding_usage_info,
+        ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
+        binding_usage_info::compute_binding_usage_info,
     },
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
@@ -561,8 +562,16 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
 
     let single_graph = SingleModuleGraph::new_with_entries(
         entries.graph_entries().to_resolved().await?,
-        false,
-        true,
+        ModuleGraphOptions {
+            include_binding_usage: true,
+            // `compute_side_effect_free_module_info` (run below via `compute_binding_usage_info`
+            // when removing unused imports) reads `side_effects` from the graph node.
+            include_side_effects: options.remove_unused_imports,
+            // Module merging (driven by `scope_hoisting` in the chunking context below) reads
+            // `is_mergeable` from the graph node and bails if absent.
+            include_mergeable: options.scope_hoisting,
+            ..Default::default()
+        },
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -47,7 +47,7 @@ use turbopack_core::{
     issue::{CollectibleIssuesExt, IssueFilter, IssueSeverity},
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry, EntryHeuristics},
     },
@@ -484,8 +484,16 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             heuristics: EntryHeuristics::default(),
         }])
         .resolved_cell(),
-        false,
-        true,
+        ModuleGraphOptions {
+            include_binding_usage: true,
+            // `compute_side_effect_free_module_info` (run below via `compute_binding_usage_info`
+            // when removing unused imports) reads `side_effects` from the graph node.
+            include_side_effects: options.remove_unused_imports,
+            // Module merging (driven by `scope_hoisting` in the chunking context below) reads
+            // `is_mergeable` from the graph node and bails if absent.
+            include_mergeable: options.scope_hoisting,
+            ..Default::default()
+        },
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -47,7 +47,7 @@ use turbopack_core::{
     issue::{CollectibleIssuesExt, IssueFilter, IssueSeverity},
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph,
+        GraphEntries, ModuleGraph, ModuleGraphOptions, SingleModuleGraph,
         binding_usage_info::compute_binding_usage_info,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry, EntryHeuristics},
     },
@@ -496,8 +496,16 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             heuristics: EntryHeuristics::default(),
         }])
         .resolved_cell(),
-        false,
-        true,
+        ModuleGraphOptions {
+            include_binding_usage: true,
+            // `compute_side_effect_free_module_info` (run below via `compute_binding_usage_info`
+            // when removing unused imports) reads `side_effects` from the graph node.
+            include_side_effects: options.remove_unused_imports,
+            // Module merging (driven by `scope_hoisting` in the chunking context below) reads
+            // `is_mergeable` from the graph node and bails if absent.
+            include_mergeable: options.scope_hoisting,
+            ..Default::default()
+        },
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
 

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -11,7 +11,6 @@ use turbopack_core::{
         chunk_id_strategy::{ModuleIdFallback, ModuleIdStrategy},
     },
     ident::AssetIdent,
-    module::Module,
     module_graph::{ModuleGraph, RefData},
 };
 use turbopack_ecmascript::async_chunk::module::AsyncLoaderModule;
@@ -25,11 +24,17 @@ pub async fn get_global_module_id_strategy(
         let module_graph = module_graph.await?;
 
         // All modules in the graph and additionally, all the modules that are inserted by chunking
-        // (i.e. async loaders)
+        // (i.e. async loaders). For graph modules we read the eagerly-resolved ident AND its
+        // pre-resolved `ident_string` from the node, so we don't fan out a `to_string()` task per
+        // module here (the production/CLI-build graphs that run this are built with
+        // `include_ident_strings`). Async-loader idents are synthesized and not in the graph, so
+        // their strings are still computed via `to_string()`.
         let mut modules = FxHashSet::default();
         let mut async_idents = vec![];
         module_graph.traverse_edges_unordered(|parent, current| {
-            modules.insert(current);
+            let ident = module_graph.module_ident_resolved(current)?;
+            let ident_string = module_graph.module_ident_string_resolved(current)?;
+            modules.insert((ident, ident_string));
             if let Some((
                 _,
                 &RefData {
@@ -45,10 +50,21 @@ pub async fn get_global_module_id_strategy(
             Ok(())
         })?;
 
-        let mut module_id_map = modules
+        // Resolve graph-module idents to `(ident, (ident_str, hash))`, reading the pre-resolved
+        // `ident_string` from the node (the graph is built with `include_ident_strings`, else
+        // `module_ident_string_resolved` bails — no silent per-module `to_string()` fallback).
+        let graph_entries = modules
             .into_iter()
-            .map(|m| m.ident())
-            .chain(async_idents.into_iter())
+            .map(|(ident, ident_string)| async move {
+                let ident_str = ident_string.await?;
+                let hash = hash_xxh3_hash64(&ident_str);
+                Ok((ident, (ident_str, hash)))
+            })
+            .try_join()
+            .await?;
+        // Async-loader idents are synthesized (not in the graph); compute their strings directly.
+        let async_entries = async_idents
+            .into_iter()
             .map(|ident| async move {
                 let ident = ident.to_resolved().await?;
                 let ident_str = ident.to_string().await?;
@@ -56,8 +72,11 @@ pub async fn get_global_module_id_strategy(
                 Ok((ident, (ident_str, hash)))
             })
             .try_join()
-            .await?
+            .await?;
+
+        let mut module_id_map = graph_entries
             .into_iter()
+            .chain(async_entries)
             .collect::<FxHashMap<_, _>>();
 
         finalize_module_ids(&mut module_id_map);

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -11,7 +11,6 @@ use turbopack_core::{
         chunk_id_strategy::{ModuleIdFallback, ModuleIdStrategy},
     },
     ident::AssetIdent,
-    module::Module,
     module_graph::{ModuleGraph, RefData},
 };
 use turbopack_ecmascript::async_chunk::module::AsyncLoaderModule;
@@ -25,11 +24,17 @@ pub async fn get_global_module_id_strategy(
         let module_graph = module_graph.await?;
 
         // All modules in the graph and additionally, all the modules that are inserted by chunking
-        // (i.e. async loaders)
+        // (i.e. async loaders). For graph modules we read the eagerly-resolved ident AND its
+        // pre-resolved `ident_string` from the node, so we don't fan out a `to_string()` task per
+        // module here (the production/CLI-build graphs that run this are built with
+        // `include_ident_strings`). Async-loader idents are synthesized and not in the graph, so
+        // their strings are still computed via `to_string()`.
         let mut modules = FxHashSet::default();
         let mut async_idents = vec![];
         module_graph.traverse_edges_unordered(|parent, current| {
-            modules.insert(current);
+            let ident = module_graph.module_ident_resolved(current)?;
+            let ident_string = module_graph.module_ident_string_resolved(current)?;
+            modules.insert((ident, ident_string));
             if let Some((
                 _,
                 &RefData {
@@ -45,10 +50,21 @@ pub async fn get_global_module_id_strategy(
             Ok(())
         })?;
 
-        let mut module_id_map = modules
+        // Resolve graph-module idents to `(ident, (ident_str, hash))`, reading the pre-resolved
+        // `ident_string` from the node (the graph is built with `include_ident_strings`, else
+        // `module_ident_string_resolved` bails — no silent per-module `to_string()` fallback).
+        let graph_entries = modules
             .into_iter()
-            .map(|m| m.ident())
-            .chain(async_idents.into_iter())
+            .map(|(ident, ident_string)| async move {
+                let ident_str = ident_string.await?;
+                let hash = hash_xxh3_hash64(&ident_str);
+                Ok((ident, (ident_str, hash)))
+            })
+            .try_join()
+            .await?;
+        // Async-loader idents are synthesized (not in the graph); compute their strings directly.
+        let async_entries = async_idents
+            .into_iter()
             .map(async |ident| {
                 let ident = ident.to_resolved().await?;
                 let ident_str = ident.to_string().await?;
@@ -56,8 +72,11 @@ pub async fn get_global_module_id_strategy(
                 Ok((ident, (ident_str, hash)))
             })
             .try_join()
-            .await?
+            .await?;
+
+        let mut module_id_map = graph_entries
             .into_iter()
+            .chain(async_entries)
             .collect::<FxHashMap<_, _>>();
 
         finalize_module_ids(&mut module_id_map);


### PR DESCRIPTION
### What

`SingleModuleGraph` nodes now carry the per-module data that the "late" graph traversals previously re-derived by reading per-module turbo-tasks cells (`Module::ident`, `ident_string`, `is_self_async`, `side_effects`, `MergeableModule::is_mergeable`).

On `canary`, `SingleModuleGraphNode::Module` was a bare tuple — `Module(ResolvedVc<Box<dyn Module>>)` — and every consuming pass re-read the module's properties on demand, fanning out a turbo-task per module per pass. This PR turns it into a struct that stores the resolved data:

```rust
Module {
    module: ResolvedVc<Box<dyn Module>>,
    ident: ResolvedVc<AssetIdent>,
    ident_string: Option<ResolvedVc<RcStr>>,
    is_self_async: ResolvedVc<bool>,
    side_effects: Option<ResolvedVc<ModuleSideEffects>>,
    is_mergeable: Option<ResolvedVc<bool>>,
}
```

- `ident` / `is_self_async` are always collected (`async_module_info()` runs on every graph during chunking; idents are broadly needed).
- `ident_string` / `side_effects` / `is_mergeable` are gated by new `ModuleGraphOptions` bits (`include_ident_strings`, `include_side_effects`, `include_mergeable`), collected only when the consuming pass actually runs — `include_side_effects` ↔ `turbopackRemoveUnusedImports`, `include_mergeable` ↔ scope hoisting, `include_ident_strings` ↔ the deterministic module-id strategy. `None` on a gated field unambiguously means "the graph wasn't built with that bit," and consumers `bail!` rather than silently fall back to a per-module read.

### How

Resolution happens in a single per-module turbo-tasks function, `module_graph_node_data(module, …)`, rather than inline in the graph-construction task. The builder node holds the resolved (pointer-only, unread) `ModuleGraphNodeData` cell; its content is read **exactly once**, at the dedup point in `new_inner`, with `final_read_hint` so the backend can drop the cell afterward (no intermediary copy retained in the task cache).

This keeps the per-module dependency edges distributed across many small per-module tasks rather than concentrating them on the single construction task, while still tracking those reads in the ultimate consumer.

Consumers updated to read from the node instead of re-reading the module: `compute_async_module_info`, `compute_side_effect_free_module_info`, `compute_merged_modules` (gated on the chunking context's `is_module_merging_enabled()`), `get_global_module_id_strategy`, and `server_actions.rs`.

`ModuleGraphOptions` construction is also consolidated: `Project::module_graph_options()` builds the options for every project-derived graph in one place, with `include_ident_strings` derived from `Project::uses_deterministic_module_ids()` (which now also accounts for per-page graphs) so the per-page and whole-app graphs can't drift.

### Performance

Measured on a large internal Next.js production build (full `next build`). Wall time is within run-to-run noise; the win is in distributed/serial CPU — the per-module reads move out of the late, serial-leaning traversals into the highly-parallel graph-construction phase.

**Single-threaded (serial) CPU time, from Xcode Instruments traces** — `canary` vs. this change (two independent captures of this change):

| metric                                       | canary | this — run 1 | this — run 2 |
| -------------------------------------------- | ------ | ------------ | ------------ |
| single-threaded wall                         | ~5.3s  | ~3.1s        | ~3.5s        |
| single-threaded CPU                          | ~5.25s | ~2.98s       | ~3.44s       |
| `aggregation_update` — in serial windows     | 101ms  | 26ms         | 5ms          |
| `aggregation_update` — total CPU             | 3438ms | 3213ms       | 3236ms       |
| `module_graph_node_data` — in serial windows | n/a    | 0ms          | 0ms          |
| `module_graph_node_data` — total CPU         | n/a    | ~29ms        | ~28ms        |

Relocating the per-module child-edge aggregation into the parallel construction phase **reduces single-threaded time by ~1.8–2.2s** and cuts serial `aggregation_update` by 4–20×. The new `module_graph_node_data` task contributes **0ms** to serial windows (fully parallel) despite adding one child per module to the construction task.

**Selected late-traversal task times** (whole-build, illustrative — these reads are now satisfied from the node):

| task                        | canary | this   |
| --------------------------- | ------ | ------ |
| `get_project_feature_usage` | ~2.5s  | ~80ms  |
| collect mergeable modules   | ~391ms | ~36ms  |

`SingleModuleGraphNode` grows from 8 bytes (the bare `ResolvedVc` tuple) to 48 bytes (the added resolved fields); a `size_test` pins this. Peak RSS is up ~0.6%.

<!-- NEXT_JS_LLM_PR -->
