### PR TITLE
fix(eslint-plugin-next): detect async client components in named exports

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
@@ -24,6 +24,90 @@ export default defineRule({
       Program(node) {
         let isClientComponent: boolean = false
 
+        // Reports when an inline declaration is an async, capitalized
+        // function/arrow, e.g. `export [default] async function MyComponent() {}`
+        // or `export const MyComponent = async () => {}`.
+        function checkInlineDeclaration(declaration, reportNode) {
+          if (
+            declaration?.type === 'FunctionDeclaration' &&
+            declaration.async &&
+            isCapitalized(declaration.id.name)
+          ) {
+            context.report({ node: reportNode, message })
+            return
+          }
+
+          if (declaration?.type === 'VariableDeclaration') {
+            for (const varDeclarator of declaration.declarations) {
+              if (
+                varDeclarator.id?.type === 'Identifier' &&
+                isCapitalized(varDeclarator.id.name) &&
+                varDeclarator.init?.type === 'ArrowFunctionExpression' &&
+                varDeclarator.init.async
+              ) {
+                context.report({ node: reportNode, message })
+              }
+            }
+          }
+        }
+
+        // Resolves an exported identifier (e.g. `export default MyComponent` or
+        // `export { MyComponent }`) to its top-level declaration and reports
+        // when it is an async, capitalized function/arrow.
+        function checkExportedIdentifier(targetName: string) {
+          if (!isCapitalized(targetName)) {
+            return
+          }
+
+          const functionDeclaration = node.body.find((localBlock) => {
+            if (
+              localBlock.type === 'FunctionDeclaration' &&
+              localBlock.id.name === targetName
+            )
+              return true
+
+            if (
+              localBlock.type === 'VariableDeclaration' &&
+              localBlock.declarations.find(
+                (declaration) =>
+                  declaration.id?.type === 'Identifier' &&
+                  declaration.id.name === targetName
+              )
+            )
+              return true
+
+            return false
+          })
+
+          if (
+            functionDeclaration?.type === 'FunctionDeclaration' &&
+            functionDeclaration.async
+          ) {
+            context.report({
+              node: functionDeclaration,
+              message,
+            })
+          }
+
+          if (functionDeclaration?.type === 'VariableDeclaration') {
+            const varDeclarator = functionDeclaration.declarations.find(
+              (declaration) =>
+                declaration.id?.type === 'Identifier' &&
+                declaration.id.name === targetName
+            )
+
+            if (
+              varDeclarator?.init?.type === 'ArrowFunctionExpression' &&
+              varDeclarator.init.async
+            ) {
+              context.report({
+                node: functionDeclaration,
+                message,
+              })
+            }
+          }
+        }
+
         for (const block of node.body) {
           if (
             block.type === 'ExpressionStatement' &&
@@ -33,72 +117,31 @@ export default defineRule({
             isClientComponent = true
           }
 
-          if (block.type === 'ExportDefaultDeclaration' && isClientComponent) {
+          if (!isClientComponent) {
+            continue
+          }
+
+          if (block.type === 'ExportDefaultDeclaration') {
             // export default async function MyComponent() {...}
-            if (
-              block.declaration?.type === 'FunctionDeclaration' &&
-              block.declaration.async &&
-              isCapitalized(block.declaration.id.name)
-            ) {
-              context.report({
-                node: block,
-                message,
-              })
-            }
+            checkInlineDeclaration(block.declaration, block)
 
             // async function MyComponent() {...}; export default MyComponent;
-            if (
-              block.declaration.type === 'Identifier' &&
-              isCapitalized(block.declaration.name)
-            ) {
-              const targetName = block.declaration.name
+            if (block.declaration.type === 'Identifier') {
+              checkExportedIdentifier(block.declaration.name)
+            }
+          }
 
-              const functionDeclaration = node.body.find((localBlock) => {
-                if (
-                  localBlock.type === 'FunctionDeclaration' &&
-                  localBlock.id.name === targetName
-                )
-                  return true
+          if (block.type === 'ExportNamedDeclaration') {
+            // export async function MyComponent() {...}
+            // export const MyComponent = async () => {...}
+            if (block.declaration) {
+              checkInlineDeclaration(block.declaration, block)
+            }
 
-                if (
-                  localBlock.type === 'VariableDeclaration' &&
-                  localBlock.declarations.find(
-                    (declaration) =>
-                      declaration.id?.type === 'Identifier' &&
-                      declaration.id.name === targetName
-                  )
-                )
-                  return true
-
-                return false
-              })
-
-              if (
-                functionDeclaration?.type === 'FunctionDeclaration' &&
-                functionDeclaration.async
-              ) {
-                context.report({
-                  node: functionDeclaration,
-                  message,
-                })
-              }
-
-              if (functionDeclaration?.type === 'VariableDeclaration') {
-                const varDeclarator = functionDeclaration.declarations.find(
-                  (declaration) =>
-                    declaration.id?.type === 'Identifier' &&
-                    declaration.id.name === targetName
-                )
-
-                if (
-                  varDeclarator?.init?.type === 'ArrowFunctionExpression' &&
-                  varDeclarator.init.async
-                ) {
-                  context.report({
-                    node: functionDeclaration,
-                    message,
-                  })
-                }
+            // async function MyComponent() {...}; export { MyComponent };
+            for (const specifier of block.specifiers) {
+              if (specifier.local.type === 'Identifier') {
+                checkExportedIdentifier(specifier.local.name)
               }
             }
           }

--- a/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
@@ -31,7 +31,9 @@ export default defineRule({
           if (
             declaration?.type === 'FunctionDeclaration' &&
             declaration.async &&
-            isCapitalized(declaration.id.name)
+            // `id` is null for anonymous default exports
+            // (`export default async function () {}`), which we skip.
+            isCapitalized(declaration.id?.name)
           ) {
             context.report({ node: reportNode, message })
             return
@@ -54,15 +56,23 @@ export default defineRule({
         // Resolves an exported identifier (e.g. `export default MyComponent` or
         // `export { MyComponent }`) to its top-level declaration and reports
         // when it is an async, capitalized function/arrow.
-        function checkExportedIdentifier(targetName: string) {
-          if (!isCapitalized(targetName)) {
+        //
+        // `localName` is the name the declaration is resolved by; `exportedName`
+        // is the (possibly aliased) name it is exported as. Either being
+        // capitalized marks it as a component, so aliased exports such as
+        // `export { foo as MyComponent }` are not missed.
+        function checkExportedIdentifier(
+          localName: string,
+          exportedName: string = localName
+        ) {
+          if (!isCapitalized(localName) && !isCapitalized(exportedName)) {
             return
           }
 
           const functionDeclaration = node.body.find((localBlock) => {
             if (
               localBlock.type === 'FunctionDeclaration' &&
-              localBlock.id.name === targetName
+              localBlock.id.name === localName
             )
               return true
 
@@ -71,7 +81,7 @@ export default defineRule({
               localBlock.declarations.find(
                 (declaration) =>
                   declaration.id?.type === 'Identifier' &&
-                  declaration.id.name === targetName
+                  declaration.id.name === localName
               )
             )
               return true
@@ -93,7 +103,7 @@ export default defineRule({
             const varDeclarator = functionDeclaration.declarations.find(
               (declaration) =>
                 declaration.id?.type === 'Identifier' &&
-                declaration.id.name === targetName
+                declaration.id.name === localName
             )
 
             if (
@@ -139,9 +149,15 @@ export default defineRule({
             }
 
             // async function MyComponent() {...}; export { MyComponent };
+            // also handles aliases, e.g. `export { foo as MyComponent }`.
             for (const specifier of block.specifiers) {
               if (specifier.local.type === 'Identifier') {
-                checkExportedIdentifier(specifier.local.name)
+                checkExportedIdentifier(
+                  specifier.local.name,
+                  specifier.exported.type === 'Identifier'
+                    ? specifier.exported.name
+                    : undefined
+                )
               }
             }
           }

--- a/test/unit/eslint-plugin-next/no-async-client-component.test.ts
+++ b/test/unit/eslint-plugin-next/no-async-client-component.test.ts
@@ -51,7 +51,7 @@ const tests = {
     export default myFunction
     `,
     `
-    // named export inline capitalization
+    // named export inline, lowercase name is not a component
     "use client"
 
     export async function myFunction() {
@@ -59,7 +59,7 @@ const tests = {
     }
     `,
     `
-    // named export specifier capitalization
+    // named export specifier, lowercase name is not a component
     "use client"
 
     async function myFunction() {
@@ -73,6 +73,14 @@ const tests = {
     "use client"
 
     export function MyComponent() {
+      return <></>
+    }
+    `,
+    `
+    // anonymous default async export (no name to flag, must not crash)
+    "use client"
+
+    export default async function () {
       return <></>
     }
     `,
@@ -184,6 +192,19 @@ const tests = {
       }
 
       export { MyComponent }
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      // named export specifier aliased to a capitalized component name
+      "use client"
+
+      async function foo() {
+        return <></>
+      }
+
+      export { foo as MyComponent }
       `,
       errors: [{ message }],
     },

--- a/test/unit/eslint-plugin-next/no-async-client-component.test.ts
+++ b/test/unit/eslint-plugin-next/no-async-client-component.test.ts
@@ -50,6 +50,32 @@ const tests = {
 
     export default myFunction
     `,
+    `
+    // named export inline capitalization
+    "use client"
+
+    export async function myFunction() {
+      return ''
+    }
+    `,
+    `
+    // named export specifier capitalization
+    "use client"
+
+    async function myFunction() {
+      return ''
+    }
+
+    export { myFunction }
+    `,
+    `
+    // named export non-async function
+    "use client"
+
+    export function MyComponent() {
+      return <></>
+    }
+    `,
   ],
   invalid: [
     {
@@ -110,6 +136,54 @@ const tests = {
       }
 
       export default MyFunction
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      // named export inline async function
+      "use client"
+
+      export async function MyComponent() {
+        return <></>
+      }
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      // named export inline async arrow function
+      "use client"
+
+      export const MyComponent = async () => {
+        return <></>
+      }
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      // named export specifier async function
+      "use client"
+
+      async function MyComponent() {
+        return <></>
+      }
+
+      export { MyComponent }
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      // named export specifier async arrow function
+      "use client"
+
+      const MyComponent = async () => {
+        return <></>
+      }
+
+      export { MyComponent }
       `,
       errors: [{ message }],
     },


### PR DESCRIPTION
## What

The [`no-async-client-component`](https://nextjs.org/docs/messages/no-async-client-component) ESLint rule only inspected `ExportDefaultDeclaration` nodes. As a result, async Client Components exported as **named exports** were never flagged, even though they hit the same runtime pitfall:

```jsx
"use client"

// all three were silently missed before this change:
export async function MyComponent() { return <></> }
export const MyComponent = async () => { return <></> }

async function MyComponent() { return <></> }
export { MyComponent }
```

Closes #77243.

## How

- Extracted the existing identifier-resolution logic and the inline async/capitalized check into two shared helpers (`checkExportedIdentifier`, `checkInlineDeclaration`).
- Applied them to `ExportNamedDeclaration` as well — covering inline declarations (`export async function` / `export const = async () =>`) and specifiers (`export { MyComponent }`).
- The existing capitalization guard is preserved, so lowercase helpers (e.g. `export async function useData()`) are still not flagged, and non-async components are untouched.

No public API or config changes; this only broadens detection of an existing recommended rule.

## Testing

Extended `test/unit/eslint-plugin-next/no-async-client-component.test.ts`:
- **invalid** (now reported): named inline async function, named inline async arrow, and both specifier forms.
- **valid** (still not reported): lowercase named export, and a non-async named function export.

Verified against the built rule with ESLint's `RuleTester` (all 8 valid + 9 invalid cases pass). As a regression control, the four new named-export `invalid` cases fail against the pre-change rule and pass after it. `eslint-plugin-next` `index.test.ts`, `tsc`, and `prettier` all pass.