### PR TITLE
Turbopack: improve issue printing colors

### DIFF
--- a/crates/next-code-frame/benches/code_frame_bench.rs
+++ b/crates/next-code-frame/benches/code_frame_bench.rs
@@ -1,5 +1,7 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use next_code_frame::{CodeFrameLocation, CodeFrameOptions, Language, Location, render_code_frame};
+use next_code_frame::{
+    CodeFrameColorMode, CodeFrameLocation, CodeFrameOptions, Language, Location, render_code_frame,
+};
 
 /// Generate a realistic small TypeScript/React file (~300 lines).
 fn generate_small_file() -> String {
@@ -120,7 +122,7 @@ fn bench_small_file(c: &mut Criterion) {
 
     let options = CodeFrameOptions {
         highlight_code: true,
-        color: true,
+        color: CodeFrameColorMode::Error,
         max_width: 100,
         language: Language::JavaScript,
         ..Default::default()
@@ -149,7 +151,7 @@ fn bench_large_file(c: &mut Criterion) {
 
     let options = CodeFrameOptions {
         highlight_code: true,
-        color: true,
+        color: CodeFrameColorMode::Error,
         max_width: 100,
         language: Language::JavaScript,
         ..Default::default()
@@ -181,7 +183,7 @@ fn bench_minified_file(c: &mut Criterion) {
 
     let options = CodeFrameOptions {
         highlight_code: true,
-        color: true,
+        color: CodeFrameColorMode::Error,
         max_width: 100,
         language: Language::JavaScript,
         ..Default::default()

--- a/crates/next-code-frame/src/frame.rs
+++ b/crates/next-code-frame/src/frame.rs
@@ -4,7 +4,10 @@ use anyhow::{Result, bail};
 use serde::Deserialize;
 use unicode_width::UnicodeWidthChar;
 
-use crate::highlight::{ColorScheme, Language, Lines, apply_line_highlights, extract_highlights};
+use crate::highlight::{
+    ANSI_CODE_CYAN_BOLD, ANSI_CODE_RED_BOLD, ANSI_CODE_YELLOW_BOLD, ColorScheme, Language, Lines,
+    apply_line_highlights, extract_highlights,
+};
 
 /// Compute the display width of a string slice in terminal columns.
 ///
@@ -53,6 +56,15 @@ pub struct CodeFrameLocation {
     pub end: Option<Location>,
 }
 
+/// The severity of the message (default: "error"), influences the color mode.
+#[derive(Debug, Copy, Clone, Deserialize, PartialEq, Eq)]
+pub enum CodeFrameColorMode {
+    None,
+    Error,
+    Warning,
+    Info,
+}
+
 /// Options for rendering the code frame
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
@@ -62,7 +74,7 @@ pub struct CodeFrameOptions {
     /// Number of lines to show after the error
     pub lines_below: usize,
     /// Whether to use ANSI color output
-    pub color: bool,
+    pub color: CodeFrameColorMode,
     /// Whether to attempt syntax highlighting
     pub highlight_code: bool,
     /// Optional message to display with the error
@@ -81,7 +93,7 @@ impl Default for CodeFrameOptions {
         Self {
             lines_above: 2,
             lines_below: 3,
-            color: false,
+            color: CodeFrameColorMode::None,
             highlight_code: false,
             message: None,
             max_width: 100,
@@ -287,7 +299,7 @@ pub fn render_code_frame(
         available_code_width,
     );
 
-    let line_highlights = if options.color && options.highlight_code {
+    let line_highlights = if options.color != CodeFrameColorMode::None && options.highlight_code {
         Some(extract_highlights(
             &lines,
             first_line_idx..last_line_idx,
@@ -298,11 +310,13 @@ pub fn render_code_frame(
         None
     };
 
-    let color_scheme = if options.color {
-        ColorScheme::colored()
-    } else {
-        ColorScheme::plain()
+    let color_scheme = match options.color {
+        CodeFrameColorMode::None => ColorScheme::plain(),
+        CodeFrameColorMode::Error => ColorScheme::colored(ANSI_CODE_RED_BOLD),
+        CodeFrameColorMode::Warning => ColorScheme::colored(ANSI_CODE_YELLOW_BOLD),
+        CodeFrameColorMode::Info => ColorScheme::colored(ANSI_CODE_CYAN_BOLD),
     };
+
     let mut output = String::new();
     // Track whether we need a newline before the next section.
     // By prepending newlines instead of appending them we avoid a

--- a/crates/next-code-frame/src/highlight.rs
+++ b/crates/next-code-frame/src/highlight.rs
@@ -107,6 +107,16 @@ static JS_KEYWORDS: phf::Set<&'static str> = phf_set! {
     "yield",
 };
 
+pub(crate) const ANSI_CODE_RESET: &str = "\x1b[0m";
+pub(crate) const ANSI_CODE_CYAN: &str = "\x1b[36m";
+pub(crate) const ANSI_CODE_YELLOW: &str = "\x1b[33m";
+pub(crate) const ANSI_CODE_GREEN: &str = "\x1b[32m";
+pub(crate) const ANSI_CODE_MAGENTA: &str = "\x1b[35m";
+pub(crate) const ANSI_CODE_GRAY: &str = "\x1b[90m";
+pub(crate) const ANSI_CODE_RED_BOLD: &str = "\x1b[31m\x1b[1m";
+pub(crate) const ANSI_CODE_YELLOW_BOLD: &str = "\x1b[33m\x1b[1m";
+pub(crate) const ANSI_CODE_CYAN_BOLD: &str = "\x1b[36m\x1b[1m";
+
 /// ANSI color codes for token types
 #[derive(Debug, Clone, Copy)]
 pub struct ColorScheme {
@@ -124,18 +134,18 @@ pub struct ColorScheme {
 
 impl ColorScheme {
     /// Get a color scheme with ANSI colors (matching babel-code-frame)
-    pub const fn colored() -> Self {
+    pub const fn colored(marker_color: &'static str) -> Self {
         Self {
-            reset: "\x1b[0m",
-            keyword: "\x1b[36m",        // cyan
-            identifier: "\x1b[33m",     // yellow
-            string: "\x1b[32m",         // green
-            number: "\x1b[35m",         // magenta
-            regex: "\x1b[35m",          // magenta
-            comment: "\x1b[90m",        // gray
-            gutter: "\x1b[90m",         // gray
-            marker: "\x1b[31m\x1b[1m",  // red + bold
-            message: "\x1b[31m\x1b[1m", // red + bold (same as marker for now)
+            reset: ANSI_CODE_RESET,
+            keyword: ANSI_CODE_CYAN,
+            identifier: ANSI_CODE_YELLOW,
+            string: ANSI_CODE_GREEN,
+            number: ANSI_CODE_MAGENTA,
+            regex: ANSI_CODE_MAGENTA,
+            comment: ANSI_CODE_GRAY,
+            gutter: ANSI_CODE_GRAY,
+            marker: marker_color,
+            message: marker_color,
         }
     }
 
@@ -1059,7 +1069,7 @@ pub mod tests {
     fn test_apply_line_highlights_basic() {
         let source = "const Foo = 123";
         let highlights = extract_highlights(&Lines::new(source), 0..usize::MAX, JS, None);
-        let color_scheme = ColorScheme::colored();
+        let color_scheme = ColorScheme::colored(ANSI_CODE_RED_BOLD);
 
         let result = apply_line_highlights(source, &highlights[0], &color_scheme, 0, 0);
 
@@ -1112,7 +1122,7 @@ pub mod tests {
     fn test_apply_line_highlights_with_truncation() {
         let source = "const Foo = 123";
         let highlights = extract_highlights(&Lines::new(source), 0..usize::MAX, JS, None);
-        let color_scheme = ColorScheme::colored();
+        let color_scheme = ColorScheme::colored(ANSI_CODE_RED_BOLD);
 
         // Truncate to show "Foo = 123" (offset 6, length 9, no prefix)
         let visible = &source[6..];
@@ -1133,7 +1143,7 @@ pub mod tests {
         let source = r#"const x = "hello world";"#;
         let truncation_offset = 15;
         let highlights = extract_highlights(&Lines::new(source), 0..usize::MAX, JS, None);
-        let color_scheme = ColorScheme::colored();
+        let color_scheme = ColorScheme::colored(ANSI_CODE_RED_BOLD);
 
         let visible = &source[truncation_offset..];
         let result =

--- a/crates/next-code-frame/src/lib.rs
+++ b/crates/next-code-frame/src/lib.rs
@@ -3,7 +3,9 @@
 mod frame;
 mod highlight;
 
-pub use frame::{CodeFrameLocation, CodeFrameOptions, Location, render_code_frame};
+pub use frame::{
+    CodeFrameColorMode, CodeFrameLocation, CodeFrameOptions, Location, render_code_frame,
+};
 pub use highlight::Language;
 
 #[cfg(test)]

--- a/crates/next-code-frame/src/tests.rs
+++ b/crates/next-code-frame/src/tests.rs
@@ -1,8 +1,8 @@
 use insta::assert_snapshot;
 
 use crate::{
-    CodeFrameLocation, CodeFrameOptions, Location, highlight::tests::strip_ansi_codes,
-    render_code_frame,
+    CodeFrameColorMode, CodeFrameLocation, CodeFrameOptions, Location,
+    highlight::tests::strip_ansi_codes, render_code_frame,
 };
 
 /// Helper function to render code frame with highlighting enabled and ANSI codes stripped.
@@ -31,7 +31,6 @@ fn test_simple_single_line_error() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -56,7 +55,6 @@ fn test_empty_source() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -76,7 +74,6 @@ fn test_invalid_line_number() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -137,7 +134,6 @@ fn test_multiline_error() {
         }),
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -169,7 +165,6 @@ fn test_multiline_error_with_message() {
         }),
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         message: Some("Unexpected expression".to_string()),
         ..Default::default()
@@ -199,7 +194,6 @@ fn test_with_message() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         message: Some("Expected semicolon".to_string()),
         ..Default::default()
@@ -229,7 +223,6 @@ fn test_long_line_single_error() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         max_width: 100,
         ..Default::default()
@@ -261,7 +254,6 @@ fn test_long_line_at_start() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         max_width: 100,
         ..Default::default()
@@ -291,7 +283,6 @@ fn test_long_line_at_end() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         max_width: 100,
         ..Default::default()
@@ -323,7 +314,6 @@ fn test_long_line_multiline_aligned() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         max_width: 100,
         lines_above: 1,
@@ -353,7 +343,6 @@ fn test_context_lines() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         lines_above: 2,
         lines_below: 2,
@@ -387,7 +376,6 @@ fn test_gutter_width_alignment() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         lines_above: 2,
         lines_below: 1,
@@ -425,7 +413,6 @@ fn test_large_file() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         lines_above: 2,
         lines_below: 2,
@@ -463,7 +450,6 @@ fn test_long_error_span() {
         }), // 300 char span
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         max_width: 100,
         ..Default::default()
@@ -500,7 +486,6 @@ Another paragraph.
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -531,7 +516,6 @@ fn test_invalid_column_start_out_of_bounds() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -560,7 +544,6 @@ fn test_invalid_column_end_before_start() {
         }), // Before start - invalid
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -589,7 +572,6 @@ fn test_invalid_column_both_out_of_bounds() {
         }),
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -618,7 +600,6 @@ fn test_invalid_multiline_end_column_out_of_bounds() {
         }), // Way past end of "short"
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -653,7 +634,6 @@ fn test_column_semantics_explicit_end() {
         }), // Exclusive: marks [11, 12) = column 11 only
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -695,7 +675,6 @@ fn test_highlighting_doesnt_break_formatting() {
     // boundaries align correctly with char boundaries.
     fn assert_highlighting_roundtrips(source: &str, location: &CodeFrameLocation) {
         let options_plain = CodeFrameOptions {
-            color: false,
             highlight_code: false,
             ..Default::default()
         };
@@ -705,7 +684,6 @@ fn test_highlighting_doesnt_break_formatting() {
 
         // highlight_code=true with color=false should be identical to plain
         let options_highlighted = CodeFrameOptions {
-            color: false,
             highlight_code: true,
             ..Default::default()
         };
@@ -717,9 +695,9 @@ fn test_highlighting_doesnt_break_formatting() {
             "Highlighting with color=false should produce identical output"
         );
 
-        // color=true with ANSI stripped should also match plain
+        // color with ANSI stripped should also match plain
         let options_colored = CodeFrameOptions {
-            color: true,
+            color: CodeFrameColorMode::Error,
             highlight_code: true,
             ..Default::default()
         };
@@ -778,7 +756,6 @@ fn test_multibyte_cjk_no_truncation() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -809,7 +786,6 @@ fn test_multibyte_cjk_with_truncation() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         max_width: 80,
         ..Default::default()
@@ -840,7 +816,6 @@ fn test_multibyte_emoji() {
         }),
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         ..Default::default()
     };
@@ -872,7 +847,6 @@ fn test_multibyte_mixed_with_truncation() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: false,
         highlight_code: false,
         max_width: 80,
         ..Default::default()
@@ -902,7 +876,7 @@ fn test_multibyte_cjk_truncation_with_highlighting() {
         end: None,
     };
     let options = CodeFrameOptions {
-        color: true,
+        color: CodeFrameColorMode::Error,
         highlight_code: true,
         max_width: 80,
         ..Default::default()

--- a/crates/next-napi-bindings/src/code_frame.rs
+++ b/crates/next-napi-bindings/src/code_frame.rs
@@ -1,6 +1,8 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use next_code_frame::{CodeFrameLocation, CodeFrameOptions, Language, Location, render_code_frame};
+use next_code_frame::{
+    CodeFrameColorMode, CodeFrameLocation, CodeFrameOptions, Language, Location, render_code_frame,
+};
 
 /// Default max width when the caller doesn't provide one (e.g., no terminal).
 const DEFAULT_MAX_WIDTH: u32 = 100;
@@ -35,6 +37,14 @@ impl From<NapiCodeFrameLocation> for CodeFrameLocation {
     }
 }
 
+#[napi]
+#[derive(PartialEq, Eq)]
+pub enum NapiCodeFrameColorMode {
+    Error,
+    Warning,
+    Info,
+}
+
 #[napi(object)]
 #[derive(Default)]
 pub struct NapiCodeFrameOptions {
@@ -45,7 +55,7 @@ pub struct NapiCodeFrameOptions {
     /// Maximum width of the output in columns (default: 100)
     pub max_width: Option<u32>,
     /// Whether to use ANSI colors (default: false)
-    pub color: Option<bool>,
+    pub color: Option<Either<NapiCodeFrameColorMode, bool>>,
     /// Whether to highlight code syntax (default: follows color)
     ///
     /// This might be useful if syntax highlighting is very expensive or known to be useless for
@@ -67,12 +77,22 @@ fn parse_language(s: &Option<String>) -> Language {
 
 impl From<NapiCodeFrameOptions> for CodeFrameOptions {
     fn from(opts: NapiCodeFrameOptions) -> Self {
+        let color = match opts.color {
+            None | Some(Either::B(false)) => CodeFrameColorMode::None,
+            Some(Either::A(NapiCodeFrameColorMode::Error)) | Some(Either::B(true)) => {
+                CodeFrameColorMode::Error
+            }
+            Some(Either::A(NapiCodeFrameColorMode::Warning)) => CodeFrameColorMode::Warning,
+            Some(Either::A(NapiCodeFrameColorMode::Info)) => CodeFrameColorMode::Info,
+        };
         CodeFrameOptions {
             lines_above: opts.lines_above.unwrap_or(2) as usize,
             lines_below: opts.lines_below.unwrap_or(3) as usize,
             max_width: opts.max_width.unwrap_or(DEFAULT_MAX_WIDTH) as usize,
-            color: opts.color.unwrap_or(false),
-            highlight_code: opts.highlight_code.unwrap_or(opts.color.unwrap_or(false)),
+            color,
+            highlight_code: opts
+                .highlight_code
+                .unwrap_or(color != CodeFrameColorMode::None),
             message: opts.message,
             language: parse_language(&opts.language),
         }

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -12,7 +12,9 @@ use napi::{
     threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 use napi_derive::napi;
-use next_code_frame::{CodeFrameLocation, CodeFrameOptions, Location, render_code_frame};
+use next_code_frame::{
+    CodeFrameColorMode, CodeFrameLocation, CodeFrameOptions, Location, render_code_frame,
+};
 use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
@@ -149,7 +151,11 @@ fn is_internal(file_path: &str) -> bool {
 ///
 /// Because this accesses the terminal size, this function call should not be cached (e.g. in
 /// turbo-tasks).
-fn render_source_code_frame(source: &PlainIssueSource, file_path: &str) -> Result<Option<String>> {
+fn render_source_code_frame(
+    severity: IssueSeverity,
+    source: &PlainIssueSource,
+    file_path: &str,
+) -> Result<Option<String>> {
     let Some((start, end)) = source.range else {
         return Ok(None);
     };
@@ -184,7 +190,16 @@ fn render_source_code_frame(source: &PlainIssueSource, file_path: &str) -> Resul
         &content,
         &location,
         &CodeFrameOptions {
-            color: true,
+            color: match severity {
+                IssueSeverity::Bug | IssueSeverity::Fatal | IssueSeverity::Error => {
+                    CodeFrameColorMode::Error
+                }
+                IssueSeverity::Warning => CodeFrameColorMode::Warning,
+                IssueSeverity::Hint
+                | IssueSeverity::Note
+                | IssueSeverity::Suggestion
+                | IssueSeverity::Info => CodeFrameColorMode::Info,
+            },
             highlight_code: true,
             max_width: terminal_size::terminal_size()
                 .map(|(w, _)| w.0 as usize)
@@ -199,7 +214,7 @@ fn render_issue_code_frame(issue: &PlainIssue) -> Result<Option<String>> {
     let Some(source) = issue.source.as_ref() else {
         return Ok(None);
     };
-    render_source_code_frame(source, &issue.file_path)
+    render_source_code_frame(issue.severity, source, &issue.file_path)
 }
 
 #[napi(object)]
@@ -248,8 +263,12 @@ impl From<&PlainIssue> for NapiIssue {
                 .iter()
                 .map(|s| NapiAdditionalIssueSource {
                     description: s.description.clone(),
-                    code_frame: render_source_code_frame(&s.source, &s.source.asset.file_path)
-                        .unwrap_or_default(),
+                    code_frame: render_source_code_frame(
+                        issue.severity,
+                        &s.source,
+                        &s.source.asset.file_path,
+                    )
+                    .unwrap_or_default(),
                     source: (&s.source).into(),
                 })
                 .collect(),

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1363,5 +1363,6 @@
   "1362": "A <Link prefetch={true}> navigated to \"%s\", but Partial Prefetching is not enabled for that route, so its dynamic data was included in the prefetch. Enable Partial Prefetching app-wide by setting \\`partialPrefetching: true\\` in next.config, or per-route by exporting \\`const prefetch = 'partial'\\` from the page or layout.",
   "1363": "\\`experimental.turbopackRustReactCompiler\\` is only supported with Turbopack. Please remove the option or run Next.js with Turbopack in %s.",
   "1364": "\\`experimental.turbopackRustReactCompiler\\` requires \\`reactCompiler\\` to be enabled. Please add \\`reactCompiler: true\\` in %s.",
-  "1365": "Expected a dev tiered cache handler for kind \"%s\"."
+  "1365": "Expected a dev tiered cache handler for kind \"%s\".",
+  "1366": "Turbopack build failed with %s %s:\\n%s"
 }

--- a/packages/next/src/build/print-build-errors.ts
+++ b/packages/next/src/build/print-build-errors.ts
@@ -64,7 +64,7 @@ export function printBuildErrors(
     console.warn(
       `Turbopack build encountered ${
         topLevelWarnings.length
-      } warnings:\n${topLevelWarnings.join('\n')}`
+      } ${topLevelWarnings.length === 1 ? 'warning' : 'warnings'}:\n${topLevelWarnings.join('\n')}`
     )
   }
 
@@ -72,7 +72,7 @@ export function printBuildErrors(
     console.error(
       `Turbopack build encountered ${
         topLevelErrors.length
-      } errors:\n${topLevelErrors.join('\n')}`
+      } ${topLevelErrors.length === 1 ? 'error' : 'errors'}:\n${topLevelErrors.join('\n')}`
     )
   }
 
@@ -80,7 +80,7 @@ export function printBuildErrors(
     throw new Error(
       `Turbopack build failed with ${
         topLevelFatalIssues.length
-      } errors:\n${topLevelFatalIssues.join('\n')}`
+      } ${topLevelFatalIssues.length === 1 ? 'error' : 'errors'}:\n${topLevelFatalIssues.join('\n')}`
     )
   }
 }

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -67,6 +67,11 @@ export interface NapiCodeFrameLocation {
   start: NapiLocation
   end?: NapiLocation
 }
+export const enum NapiCodeFrameColorMode {
+  Error = 0,
+  Warning = 1,
+  Info = 2,
+}
 export interface NapiCodeFrameOptions {
   /** Number of lines to show above the error (default: 2) */
   linesAbove?: number
@@ -75,7 +80,7 @@ export interface NapiCodeFrameOptions {
   /** Maximum width of the output in columns (default: 100) */
   maxWidth?: number
   /** Whether to use ANSI colors (default: false) */
-  color?: boolean
+  color?: NapiCodeFrameColorMode | boolean
   /**
    * Whether to highlight code syntax (default: follows color)
    *

--- a/packages/next/src/shared/lib/turbopack/utils.test.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.test.ts
@@ -1,3 +1,4 @@
+import stripAnsi from 'next/dist/compiled/strip-ansi'
 import type {
   Issue,
   PlainTraceItem,
@@ -36,10 +37,10 @@ describe('formatIssue', () => {
       ...baseIssue,
       importTraces: [trace],
     }
-    const output = formatIssue(issue)
+    const output = stripAnsi(formatIssue(issue))
     expect(output).toBe(`\
 ./src/app/page.ts
-Module not found
+Error: Module not found
 Import trace:
   client:
     ./src/app/page.ts
@@ -63,10 +64,10 @@ https://nextjs.org/docs/messages/module-not-found
       ...baseIssue,
       importTraces: [trace1, trace2],
     }
-    const output = formatIssue(issue)
+    const output = stripAnsi(formatIssue(issue))
     expect(output).toBe(`\
 ./src/app/page.ts
-Module not found
+Error: Module not found
 Import traces:
   client:
     ./src/app/page.ts
@@ -94,10 +95,10 @@ https://nextjs.org/docs/messages/module-not-found
       ...baseIssue,
       importTraces: [trace1, trace2],
     }
-    const output = formatIssue(issue)
+    const output = stripAnsi(formatIssue(issue))
     expect(output).toBe(`\
 ./src/app/page.ts
-Module not found
+Error: Module not found
 Import traces:
   #1 [client]:
     ./src/app/page.ts
@@ -133,10 +134,10 @@ https://nextjs.org/docs/messages/module-not-found
       ...baseIssue,
       importTraces: [trace],
     }
-    const output = formatIssue(issue)
+    const output = stripAnsi(formatIssue(issue))
     expect(output).toBe(`\
 ./src/app/page.ts
-Module not found
+Error: Module not found
 Import trace:
   ./src/app/page.ts
   ./src/lib/foo.ts

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -115,11 +115,11 @@ export function formatIssue(issue: Issue) {
   )
 
   if (severity === 'bug' || severity === 'error' || severity === 'fatal') {
-    formattedTitle = bold(`${red('Error')}: ${bold(formattedTitle)}`)
+    formattedTitle = bold(`${red('Error')}: ${formattedTitle}`)
   } else if (severity === 'warning') {
-    formattedTitle = bold(`${yellow('Warning')}: ${bold(formattedTitle)}`)
+    formattedTitle = bold(`${yellow('Warning')}: ${formattedTitle}`)
   } else {
-    formattedTitle = bold(`Info: ${bold(formattedTitle)}`)
+    formattedTitle = bold(`Info: ${formattedTitle}`)
   }
 
   // TODO: Use error codes to identify these

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -5,7 +5,7 @@ import type {
   TurbopackResult,
 } from '../../../build/swc/types'
 
-import { bold, green, magenta, red } from '../../../lib/picocolors'
+import { bold, green, magenta, red, yellow } from '../../../lib/picocolors'
 import { deobfuscateText } from '../magic-identifier'
 import type { EntryKey } from './entry-key'
 import * as Log from '../../../build/output/log'
@@ -99,12 +99,28 @@ function formatFilePath(filePath: string): string {
 }
 
 export function formatIssue(issue: Issue) {
-  const { filePath, title, description, detail, source, importTraces } = issue
+  const {
+    filePath,
+    title,
+    description,
+    detail,
+    source,
+    importTraces,
+    severity,
+  } = issue
   let { documentationLink } = issue
-  const formattedTitle = renderStyledStringToErrorAnsi(title).replace(
+  let formattedTitle = renderStyledStringToErrorAnsi(title).replace(
     /\n/g,
     '\n    '
   )
+
+  if (severity === 'bug' || severity === 'error' || severity === 'fatal') {
+    formattedTitle = `Error: ${red(bold(formattedTitle))}`
+  } else if (severity === 'warning') {
+    formattedTitle = `Warning: ${yellow(bold(formattedTitle))}`
+  } else {
+    formattedTitle = `Info: ${bold(formattedTitle)}`
+  }
 
   // TODO: Use error codes to identify these
   // TODO: Generalize adapting Turbopack errors to Next.js errors

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -115,11 +115,11 @@ export function formatIssue(issue: Issue) {
   )
 
   if (severity === 'bug' || severity === 'error' || severity === 'fatal') {
-    formattedTitle = `Error: ${red(bold(formattedTitle))}`
+    formattedTitle = bold(`${red('Error')}: ${bold(formattedTitle)}`)
   } else if (severity === 'warning') {
-    formattedTitle = `Warning: ${yellow(bold(formattedTitle))}`
+    formattedTitle = bold(`${yellow('Warning')}: ${bold(formattedTitle)}`)
   } else {
-    formattedTitle = `Info: ${bold(formattedTitle)}`
+    formattedTitle = bold(`Info: ${bold(formattedTitle)}`)
   }
 
   // TODO: Use error codes to identify these

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -52,7 +52,7 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./node_modules/my-package/index.js (1:13)
-       Module not found: Can't resolve 'dns'
+       Error: Module not found: Can't resolve 'dns'
        > 1 | const dns = require('dns')
            |             ^^^^^^^^^^^^^^",
          "stack": [],
@@ -119,7 +119,7 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (1:1)
-       Module not found: Can't resolve 'b'
+       Error: Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
            | ^^^^^^^^^^^^^^^^^^^^",
          "stack": [],
@@ -188,7 +188,7 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js (2:1)
-       Module not found: Can't resolve 'b'
+       Error: Module not found: Can't resolve 'b'
        > 2 | import Comp from 'b'
            | ^^^^^^^^^^^^^^^^^^^^",
          "stack": [],
@@ -254,7 +254,7 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js (2:1)
-       Module not found: Can't resolve './non-existent.css'
+       Error: Module not found: Can't resolve './non-existent.css'
        > 2 | import './non-existent.css'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^",
          "stack": [],

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -538,7 +538,7 @@ describe('ReactRefreshLogBox app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.module.css
-       Transforming CSS failed
+       Error: Transforming CSS failed
        Selector "button" is not pure. Pure selectors must contain at least one local class or id.
        Import traces:
          Client Component Browser:

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -285,7 +285,7 @@ describe('ReactRefreshLogBox app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:1)
-       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+       Error: Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
        > 7 | }
            | ^",
          "stack": [],
@@ -485,7 +485,7 @@ describe('ReactRefreshLogBox app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.module.css (1:8)
-       Parsing CSS source code failed
+       Error: Parsing CSS source code failed
        > 1 | .button
            |        ^",
          "stack": [],
@@ -1436,7 +1436,7 @@ describe('ReactRefreshLogBox app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/module.js (1:1)
-       Module not found: Can't resolve 'non-existing-module'
+       Error: Module not found: Can't resolve 'non-existing-module'
        > 1 | import "non-existing-module"
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
          "stack": [],
@@ -1509,7 +1509,7 @@ describe('ReactRefreshLogBox app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/styles2.css (1:1)
-       Module not found: Can't resolve './boom.css'
+       Error: Module not found: Can't resolve './boom.css'
        > 1 | @import "./boom.css"
            | ^",
          "stack": [],

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -38,7 +38,7 @@ describe('ReactRefreshLogBox app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js (3:23)
-       "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+       Error: "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
        > 3 | export async function getStaticProps() {
            |                       ^^^^^^^^^^^^^^",
          "stack": [],

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -47,7 +47,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (1:27)
-       Expected '>', got '<eof>'
+       Error: Expected '>', got '<eof>'
        > 1 | export default () => <div/
            |                           ^",
          "stack": [],
@@ -140,7 +140,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/server/page.js (2:28)
-       Expected '}', got '<eof>'
+       Error: Expected '}', got '<eof>'
        > 2 |   return <p>Hello world</p>
            |                            ^",
          "stack": [],
@@ -224,7 +224,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/client/page.js (2:28)
-       Expected '}', got '<eof>'
+       Error: Expected '}', got '<eof>'
        > 2 |   return <p>Hello world</p>
            |                            ^",
          "stack": [],
@@ -659,7 +659,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (10:42)
-       Expected '}', got '<eof>'
+       Error: Expected '}', got '<eof>'
        > 10 | export default function FunctionNamed() {
             |                                          ^",
          "stack": [],
@@ -719,7 +719,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (10:42)
-       Expected '}', got '<eof>'
+       Error: Expected '}', got '<eof>'
        > 10 | export default function FunctionNamed() {
             |                                          ^",
          "stack": [],
@@ -911,7 +911,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Expected '{', got 'return'
+       Error: Expected '{', got 'return'
        > 5 |     return <h1>Default Export</h1>;
            |     ^^^^^^",
          "stack": [],
@@ -994,7 +994,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Expected '{', got 'throw'
+       Error: Expected '{', got 'throw'
        > 5 |     throw new Error('nooo');
            |     ^^^^^",
          "stack": [],
@@ -1120,7 +1120,7 @@ describe('Error recovery app', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js (1:4)
-       Expected '}', got '<eof>'
+       Error: Expected '}', got '<eof>'
        > 1 | {{{
            |    ^",
          "stack": [],

--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -67,7 +67,7 @@ describe('Error Overlay invalid imports', () => {
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/comp2.js
-       'styled-jsx' cannot be imported from a Server Component module
+       Error: 'styled-jsx' cannot be imported from a Server Component module
        It only works in a Client Component but none of its parents are marked with 'use client', so they're Server Components by default.
 
        Import trace:
@@ -136,7 +136,7 @@ describe('Error Overlay invalid imports', () => {
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/foo.js (1:1)
-       'client-only' cannot be imported from a Server Component module
+       Error: 'client-only' cannot be imported from a Server Component module
        > 1 | require("client-only")
            | ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -235,7 +235,7 @@ describe('Error Overlay invalid imports', () => {
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./node_modules/client-only-package/index.js (1:1)
-       'client-only' cannot be imported from a Server Component module
+       Error: 'client-only' cannot be imported from a Server Component module
        > 1 | require("client-only")
            | ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -336,7 +336,7 @@ describe('Error Overlay invalid imports', () => {
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./node_modules/server-only-package/index.js (1:1)
-       'server-only' cannot be imported from a Client Component module
+       Error: 'server-only' cannot be imported from a Client Component module
        > 1 | require("server-only")
            | ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -176,7 +176,7 @@ describe('Error overlay - RSC build errors', () => {
       // turbopack emits the resolve issue first instead of the transform issue.
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/server-with-errors/client-only-in-server/client-only-lib.js (1:1)
-       You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+       Error: You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
            Learn more: https://nextjs.org/docs/app/building-your-application/rendering
        > 1 | import 'client-only'
            | ^^^^^^^^^^^^^^^^^^^^
@@ -462,7 +462,7 @@ describe('Error overlay - RSC build errors', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./app/server-with-errors/error-file/error.js (1:1)
-       app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
+       Error: app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
            Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
        > 1 | export default function Error() {}
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -112,7 +112,7 @@ describe('ReactRefreshLogBox _app _document', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_app.js (2:10)
-       Expression expected
+       Error: Expression expected
        > 2 |   return <<Component {...pageProps} />;
            |          ^^",
          "stack": [],
@@ -231,7 +231,7 @@ describe('ReactRefreshLogBox _app _document', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_document.js (3:36)
-       Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
+       Error: Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
        > 3 | class MyDocument extends Document {{
            |                                    ^",
          "stack": [],

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -51,7 +51,7 @@ describe('ReactRefreshLogBox', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./node_modules/my-package/index.js (1:13)
-       Module not found: Can't resolve 'dns'
+       Error: Module not found: Can't resolve 'dns'
        > 1 | const dns = require('dns')
            |             ^^^^^^^^^^^^^^",
          "stack": [],
@@ -118,7 +118,7 @@ describe('ReactRefreshLogBox', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (1:1)
-       Module not found: Can't resolve 'b'
+       Error: Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
            | ^^^^^^^^^^^^^^^^^^^^",
          "stack": [],
@@ -187,7 +187,7 @@ describe('ReactRefreshLogBox', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/index.js (1:1)
-       Module not found: Can't resolve 'b'
+       Error: Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
            | ^^^^^^^^^^^^^^^^^^^^",
          "stack": [],
@@ -262,7 +262,7 @@ describe('ReactRefreshLogBox', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_app.js (1:1)
-       Module not found: Can't resolve './non-existent.css'
+       Error: Module not found: Can't resolve './non-existent.css'
        > 1 | import './non-existent.css'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^",
          "stack": [],

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -449,7 +449,7 @@ describe('ReactRefreshLogBox', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:1)
-       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+       Error: Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
        > 7 | }
            | ^",
          "stack": [],
@@ -716,7 +716,7 @@ describe('ReactRefreshLogBox', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.module.css (1:8)
-       Parsing CSS source code failed
+       Error: Parsing CSS source code failed
        > 1 | .button
            |        ^",
          "stack": [],

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -769,7 +769,7 @@ describe('ReactRefreshLogBox', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.module.css
-       Transforming CSS failed
+       Error: Transforming CSS failed
        Selector "button" is not pure. Pure selectors must contain at least one local class or id.
        Import traces:
          Browser:

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -47,7 +47,7 @@ describe('pages/ error recovery', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (1:27)
-       Expected '>', got '<eof>'
+       Error: Expected '>', got '<eof>'
        > 1 | export default () => <div/
            |                           ^",
          "stack": [],
@@ -405,7 +405,7 @@ describe('pages/ error recovery', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Expected '{', got 'return'
+       Error: Expected '{', got 'return'
        > 5 |     return <h1>Default Export</h1>;
            |     ^^^^^^",
          "stack": [],
@@ -823,7 +823,7 @@ describe('pages/ error recovery', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:42)
-       Expected '}', got '<eof>'
+       Error: Expected '}', got '<eof>'
        > 7 | export default function FunctionNamed() {
            |                                          ^",
          "stack": [],
@@ -888,7 +888,7 @@ describe('pages/ error recovery', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:42)
-       Expected '}', got '<eof>'
+       Error: Expected '}', got '<eof>'
        > 7 | export default function FunctionNamed() {
            |                                          ^",
          "stack": [],

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -489,7 +489,7 @@ describe('pages/ error recovery', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Expected '{', got 'throw'
+       Error: Expected '{', got 'throw'
        > 5 |     throw new Error('nooo');
            |     ^^^^^",
          "stack": [],

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -55,7 +55,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       You're importing a module that depends on "next/headers". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
+       Error: You're importing a module that depends on "next/headers". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
            Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import { cookies } from 'next/headers'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -141,7 +141,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       You're importing a module that depends on "server-only". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
+       Error: You're importing a module that depends on "server-only". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
            Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import 'server-only'
            | ^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:10)
-       You're importing a module that depends on "after". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
+       Error: You're importing a module that depends on "after". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
            Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import { after } from 'next/server'
            |          ^^^^^
@@ -319,7 +319,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       You're importing a module that depends on "next/root-params". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
+       Error: You're importing a module that depends on "next/root-params". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
            Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import { foo } from 'next/root-params'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -133,7 +133,7 @@ describe('Cache Components Dev Errors', () => {
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx (1:14)
-           Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+           Error: Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
            > 1 | export const revalidate = 10
                |              ^^^^^^^^^^",
              "stack": [],

--- a/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
+++ b/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
@@ -24,7 +24,7 @@ describe('app-dir - server-component-next-dynamic-ssr-false', () => {
       )
       expect(redbox.source).toMatchInlineSnapshot(`
        "./app/page.js (3:23)
-       \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a Client Component.
+       Error: \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a Client Component.
          1 | import dynamic from 'next/dynamic'
          2 |
        > 3 | const DynamicClient = dynamic(() => import('./client'), { ssr: false })

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -185,7 +185,7 @@ describe('react-dom/server in React Server environment', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
-       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+       Error: You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
            Learn more: https://nextjs.org/docs/app/building-your-application/rendering
        > 3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
@@ -327,7 +327,7 @@ describe('react-dom/server in React Server environment', () => {
        {
          "description": "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
          "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js (3:1)
-       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+       Error: You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
            Learn more: https://nextjs.org/docs/app/building-your-application/rendering
          1 | import * as ReactDOMServerNode from 'react-dom/server'
          2 | // Fine to drop once React is on ESM

--- a/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
@@ -164,7 +164,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
         if (process.env.IS_TURBOPACK_TEST) {
           expect(source).toMatchInlineSnapshot(`
                   "./pages/hmr/about2.js (7:1)
-                  Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+                  Error: Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
                     5 |     div
                     6 |   )
                   > 7 | }
@@ -434,7 +434,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
         if (process.env.IS_TURBOPACK_TEST) {
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
               "./components/parse-error.xyz
-              Unknown module type
+              Error: Unknown module type
               This module doesn't have an associated type. Use a known file extension, or register a loader for it.
 
               Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders"
@@ -514,7 +514,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
           expect(next.normalizeTestDirContent(redboxSource))
             .toMatchInlineSnapshot(`
                     "./components/parse-error.js (3:1)
-                    Expression expected
+                    Error: Expression expected
                       1 | This
                       2 | is
                     > 3 | }}}

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -505,7 +505,7 @@ describe('middleware - development errors', () => {
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./middleware.js (1:28)
-         Expected '{', got '}'
+         Error: Expected '{', got '}'
          > 1 | export default function () }
              |                            ^",
            "stack": [],
@@ -590,7 +590,7 @@ describe('middleware - development errors', () => {
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./middleware.js (1:28)
-         Expected '{', got '}'
+         Error: Expected '{', got '}'
          > 1 | export default function () }
              |                            ^",
            "stack": [],

--- a/test/development/next-font/font-loader-in-document-error.test.ts
+++ b/test/development/next-font/font-loader-in-document-error.test.ts
@@ -16,7 +16,7 @@ describe('font-loader-in-document-error', () => {
       // TODO: Turbopack doesn't include pages/
       expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
         "./_document.js
-        next/font: error:
+        Error: next/font: error:
         Cannot be used within _document.js"
       `)
     } else if (process.env.NEXT_RSPACK) {

--- a/test/development/report-system-env-var-inlining/report-system-env-var-inlining.test.ts
+++ b/test/development/report-system-env-var-inlining/report-system-env-var-inlining.test.ts
@@ -16,7 +16,7 @@ import { getRedboxSource, waitForRedbox } from 'next-test-utils'
       const error = await getRedboxSource(browser)
       expect(error).toMatchInlineSnapshot(`
        "./app/foo.tsx (2:14)
-       TP1202 The commit hash is being inlined.
+       Error: TP1202 The commit hash is being inlined.
          1 | export function Foo() {
        > 2 |   return <p>{process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA}</p>
            |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -26,7 +26,7 @@ describe('app dir - css', () => {
           // css-loader does not report an error for this case
           expect(source).toMatchInlineSnapshot(`
            "./app/global.scss.css (45:1)
-           Parsing CSS source code failed
+           Error: Parsing CSS source code failed
              43 | }
              44 |
            > 45 | input.defaultCheckbox::before path {

--- a/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
@@ -34,7 +34,7 @@ describe('app-dir edge SSR invalid reexport', () => {
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./app/export/inherit/page.tsx (1:28)
-         Next.js can't recognize the exported \`preferredRegion\` field in route. It mustn't be reexported.
+         Error: Next.js can't recognize the exported \`preferredRegion\` field in route. It mustn't be reexported.
          > 1 | export { default, runtime, preferredRegion } from '../basic/page'
              |                            ^^^^^^^^^^^^^^^",
            "stack": [],

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -52,7 +52,7 @@ function filterToErrorHeaders(output: string): string {
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./app/edge-with-layout/layout.tsx (1:14)
-         Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+         Error: Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
          > 1 | export const dynamic = 'force-dynamic'
              |              ^^^^^^^",
            "stack": [],

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -27,7 +27,7 @@ describe('app-dir - error-on-next-codemod-comment', () => {
       if (process.env.IS_TURBOPACK_TEST) {
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
            "./app/page.tsx (2:2)
-           You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
+           Error: You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
                After review, either remove the comment if you made the necessary changes or replace "@next-codemod-error" with "@next-codemod-ignore" to bypass the build error if no action at this line can be taken.
              1 | export default function Page() {
            > 2 |   // @next-codemod-error remove jsx of next line

--- a/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
+++ b/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
@@ -46,7 +46,7 @@ describe('proxy-missing-export', () => {
     // TODO: Investigate why in dev-turbo, the error is shown in the browser console, not CLI output.
     if (process.env.IS_TURBOPACK_TEST && !isNextDev) {
       expect(cliOutput).toContain(`./proxy.ts
-Proxy is missing expected function export name
+Error: Proxy is missing expected function export name
 ${errorMessage}`)
     } else {
       expect(cliOutput)
@@ -130,7 +130,7 @@ ${errorMessage}`)
     // TODO: Investigate why in dev-turbo, the error is shown in the browser console, not CLI output.
     if (process.env.IS_TURBOPACK_TEST && !isNextDev) {
       expect(cliOutput).toContain(`./proxy.ts
-Proxy is missing expected function export name
+Error: Proxy is missing expected function export name
 ${errorMessage}`)
     } else {
       expect(cliOutput)

--- a/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
+++ b/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
@@ -27,7 +27,7 @@ describe('proxy-runtime', () => {
     // TODO: Investigate why in dev-turbo, the error is shown in the browser console, not CLI output.
     if (process.env.IS_TURBOPACK_TEST && !isNextDev) {
       expect(stripAnsi(cliOutput)).toContain(`proxy.ts:3:14
-Next.js can't recognize the exported \`config\` field in route. Proxy does not support Edge runtime.
+Error: Next.js can't recognize the exported \`config\` field in route. Proxy does not support Edge runtime.
   1 | export default function () {}
   2 |
 > 3 | export const config = { runtime: 'edge' }

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -41,7 +41,7 @@ describe('Invalid Global CSS with Custom App', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./pages/index.js
-         Global CSS cannot be imported from files other than your Custom <App>.
+         Error: Global CSS cannot be imported from files other than your Custom <App>.
          Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
          Location: pages/index.js
          Import path: ../styles/global.scss

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -41,7 +41,7 @@ describe('Invalid Global CSS', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./pages/index.js
-         Global CSS cannot be imported from files other than your Custom <App>.
+         Error: Global CSS cannot be imported from files other than your Custom <App>.
          Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
          Location: pages/index.js
          Import path: ../styles/global.scss

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -38,7 +38,7 @@ describe('CSS Import from node_modules', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./styles/global.scss.css (1:9)
-         Module not found: Can't resolve 'nprogress/nprogress.css'
+         Error: Module not found: Can't resolve 'nprogress/nprogress.css'
          > 1 | @import 'nprogress/nprogress.css';
              |         ^
            2 |

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -41,7 +41,7 @@ describe('Valid and Invalid Global CSS with Custom App', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./pages/index.js
-         Global CSS cannot be imported from files other than your Custom <App>.
+         Error: Global CSS cannot be imported from files other than your Custom <App>.
          Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
          Location: pages/index.js
          Import path: ../styles/global.scss

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -78,9 +78,9 @@ describe('use-cache-segment-configs', () => {
 
       if (isTurbopack) {
         expect(buildOutput).toMatchInlineSnapshot(`
-         "Error: Turbopack build failed with 1 errors:
+         "Error: Turbopack build failed with 1 error:
          ./app/runtime/page.tsx:1:14
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Error: Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
          > 1 | export const runtime = 'edge'
              |              ^^^^^^^
            2 |

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -26,7 +26,7 @@ describe('use-cache-segment-configs', () => {
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./app/runtime/page.tsx (1:14)
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Error: Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
          > 1 | export const runtime = 'edge'
              |              ^^^^^^^",
            "stack": [],

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -127,7 +127,7 @@ describe('use-cache-unknown-cache-kind', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./app/page.tsx (1:1)
-         Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
+         Error: Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
          > 1 | 'use cache: custom'
              | ^^^^^^^^^^^^^^^^^^^
            2 |

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -30,7 +30,7 @@ describe('use-cache-unknown-cache-kind', () => {
 
       if (isTurbopack) {
         expect(buildOutput).toMatchInlineSnapshot(`
-         "Error: Turbopack build failed with 1 errors:
+         "Error: Turbopack build failed with 1 error:
          ./app/page.tsx:1:1
          Error: Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
          > 1 | 'use cache: custom'

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -32,7 +32,7 @@ describe('use-cache-unknown-cache-kind', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "Error: Turbopack build failed with 1 errors:
          ./app/page.tsx:1:1
-         Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
+         Error: Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
          > 1 | 'use cache: custom'
              | ^^^^^^^^^^^^^^^^^^^
            2 |

--- a/test/e2e/swc-plugins/index.test.ts
+++ b/test/e2e/swc-plugins/index.test.ts
@@ -37,7 +37,7 @@ describe('swcPlugins', () => {
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./app/layout.js
-         Failed to execute SWC plugin
+         Error: Failed to execute SWC plugin
          An unexpected error occurred when executing an SWC EcmaScript transform plugin.
          This might be due to a version mismatch between the plugin and Next.js. https://plugins.swc.rs/ can help you find the correct plugin version to use.
          Failed to execute @swc/plugin-react-remove-properties
@@ -81,7 +81,7 @@ module.exports = {
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./
-         Module not found: Can't resolve '@swc/plugin-nonexistent'
+         Error: Module not found: Can't resolve '@swc/plugin-nonexistent'
          https://nextjs.org/docs/messages/module-not-found",
            "stack": [],
          }

--- a/test/e2e/transpile-packages-typescript-foreign/index.test.ts
+++ b/test/e2e/transpile-packages-typescript-foreign/index.test.ts
@@ -23,7 +23,7 @@ describe('transpile-packages-typescript-foreign', () => {
 
       if (process.env.IS_TURBOPACK_TEST) {
         expect(next.cliOutput).toContain(`pkg/index.ts
-Unknown module type
+Error: Unknown module type
 This module doesn't have an associated type`)
         expect(
           next.cliOutput.match(/Unknown module type/g).length

--- a/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
+++ b/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
@@ -113,7 +113,7 @@ describe('webpack-loader-parse-error (development)', () => {
       )
       expect(errorBlock).toMatchInlineSnapshot(`
        "⨯ ./app/data.broken.js:3:1
-       Expected '</', got '{'
+       Error: Expected '</', got '{'
          1 | // This file will be processed by broken-js-loader
          2 | // The loader will return invalid JavaScript with a source map
        > 3 | export default function Data() {
@@ -167,7 +167,7 @@ describe('webpack-loader-parse-error (development)', () => {
       )
       expect(errorBlock).toMatchInlineSnapshot(`
        "⨯ ./app/css-page/styles.broken.css:2:3
-       Parsing CSS source code failed
+       Error: Parsing CSS source code failed
          1 | .page {
        > 2 |   color: blue;
            |   ^
@@ -218,7 +218,7 @@ describe('webpack-loader-parse-error (production)', () => {
       const jsError = extractErrorBlock(output, "Expected '</', got '{'")
       expect(jsError).toMatchInlineSnapshot(`
        "./app/data.broken.js:3:1
-       Expected '</', got '{'
+       Error: Expected '</', got '{'
          1 | // This file will be processed by broken-js-loader
          2 | // The loader will return invalid JavaScript with a source map
        > 3 | export default function Data() {
@@ -250,7 +250,7 @@ describe('webpack-loader-parse-error (production)', () => {
       )
       expect(cssError).toMatchInlineSnapshot(`
        "./app/css-page/styles.broken.css:5:15
-       Parsing CSS source code failed
+       Error: Parsing CSS source code failed
          3 |   color: red
          4 |   @@@ THIS IS NOT VALID CSS @@@;
        > 5 |   background: {{{ invalid

--- a/test/production/build-tracing-message/index.test.ts
+++ b/test/production/build-tracing-message/index.test.ts
@@ -22,9 +22,9 @@ import stripAnsi from 'strip-ansi'
         .trim()
 
       expect(stripAnsi(output)).toMatchInlineSnapshot(`
-       "Turbopack build encountered 1 warnings:
+       "Turbopack build encountered 1 warning:
        ./app/join-cwd.js:4:10
-       Dynamic filesystem access causes tracing of the whole project
+       Warning: Dynamic filesystem access causes tracing of the whole project
          2 |
          3 | export default function (f) {
        > 4 |   return path.join(process.cwd(), f)


### PR DESCRIPTION
1. Align the code highlight marker color with the issue severity
2. Make the issue title colored
3. Prefix issues with `Warning` or `Error`


<img width="1383" height="862" alt="Bildschirmfoto 2026-06-16 um 18 59 03" src="https://github.com/user-attachments/assets/f98c606d-4ea8-40c2-836d-e395f1df904c" />


<img width="1039" height="450" alt="Bildschirmfoto 2026-06-16 um 19 03 39" src="https://github.com/user-attachments/assets/2747f914-0587-4178-a87d-344f24715c96" />



<details>
<summary>Old</summary>

<img width="1267" height="745" alt="Bildschirmfoto 2026-06-16 um 17 04 35" src="https://github.com/user-attachments/assets/837739ff-82f7-4ea2-8767-ca7d866a8570" />

</details>


