### PR TITLE
fix(next-form): always fetch server content on SearchParamOnlyChange navigation

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -371,7 +371,8 @@ function updateCacheNodeOnNavigation(
       // route hasn't changed. Otherwise (no prior node) mint a fresh one.
       oldCacheNode !== undefined
         ? oldCacheNode.bfcacheId
-        : generateBFCacheId(freshness)
+        : generateBFCacheId(freshness),
+      segmentMatchKind === SegmentMatchKind.SearchParamOnlyChange
     )
     newCacheNode = result.cacheNode
     needsDynamicRequest = result.needsDynamicRequest
@@ -918,7 +919,11 @@ function createCacheNodeForSegment(
   seedHead: HeadData | null,
   freshness: FreshnessPolicy,
   dynamicStaleAt: number,
-  bfcacheId: number
+  bfcacheId: number,
+  // When true, search params changed and the segment cache may have a Fallback
+  // entry (keyed without search params) that does not reflect the new params.
+  // Always spawn a dynamic request so the correct content is fetched.
+  isSearchParamOnlyChange: boolean = false
 ): { cacheNode: CacheNode; needsDynamicRequest: boolean } {
   // Construct a new CacheNode using data from the BFCache, the client's
   // Segment Cache, or seeded from a server response.
@@ -1103,6 +1108,15 @@ function createCacheNodeForSegment(
         break
       }
     }
+  }
+
+  // When only search params changed, the segment cache may have returned a
+  // Fallback entry (one stored without search params, e.g. a PPR static shell)
+  // whose `isPartial` is false. That entry doesn't contain content specific to
+  // the new search params, so we must not treat it as a complete cache hit.
+  // Force a dynamic request to fetch the correct search-param-specific content.
+  if (isSearchParamOnlyChange) {
+    isCachedRscPartial = true
   }
 
   // Now combine the cached data with the seed data to determine what we can

--- a/test/e2e/next-form/default/app/search-with-form/loading.tsx
+++ b/test/e2e/next-form/default/app/search-with-form/loading.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react'
+
+export default function Loading() {
+  return <div id="loading">Loading...</div>
+}

--- a/test/e2e/next-form/default/app/search-with-form/page.tsx
+++ b/test/e2e/next-form/default/app/search-with-form/page.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+export default async function SearchWithFormPage({ searchParams }) {
+  const query = (await searchParams).query as string | undefined
+  await sleep(100)
+  return (
+    <div>
+      <Form action="/search-with-form" id="search-form">
+        <input name="query" defaultValue={query ?? ''} />
+        <button type="submit">Search</button>
+      </Form>
+      {query !== undefined && (
+        <div id="search-results">query: {JSON.stringify(query)}</div>
+      )}
+    </div>
+  )
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((res) => setTimeout(res, ms))
+}

--- a/test/e2e/next-form/default/shared-tests.util.ts
+++ b/test/e2e/next-form/default/shared-tests.util.ts
@@ -1,4 +1,5 @@
 import { isReact18, nextTestSetup, type Playwright } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 // These tests are defined here and used in `app-dir.test.ts` and
 // `pages-dir.test.ts` so that both test suites can be run in parallel.
@@ -285,6 +286,35 @@ export function runSharedTests(type: 'app' | 'pages') {
         ['file', 'hello.txt'],
       ])
     })
+
+    if (isAppDir) {
+      it('should show updated content when form is submitted with changed query params on the same page', async () => {
+        // Regression test: when a <Form> submits to the same pathname with
+        // different search params (a SearchParamOnlyChange navigation), the
+        // segment cache could return a stale Fallback entry with isPartial=false,
+        // suppressing the dynamic server request and showing old content.
+        const session = await next.browser('/search-with-form?query=first')
+
+        const result1 = await session
+          .waitForElementByCss('#search-results')
+          .text()
+        expect(result1).toMatch(/query: "first"/)
+
+        // Clear the input and submit a new query from the same page.
+        // This is a SearchParamOnlyChange navigation (/search-with-form?query=first
+        // → /search-with-form?query=second).
+        const searchInput = await session.elementByCss('input[name="query"]')
+        await searchInput.fill('second')
+
+        const submitButton = await session.elementByCss('[type="submit"]')
+        await submitButton.click()
+
+        await retry(async () => {
+          const result2 = await session.elementByCss('#search-results').text()
+          expect(result2).toMatch(/query: "second"/)
+        })
+      })
+    }
   })
 
   async function trackMpaNavs(session: Playwright) {


### PR DESCRIPTION
Fixes #94821

### What?

Fix `next/form` submitting with changed query params not showing updated server-rendered content.

### Why?

When a `<Form>` submits to the same pathname with different search params (a `SearchParamOnlyChange` navigation), `createCacheNodeForSegment` in `ppr-navigations.ts` looked up the segment cache using a Fallback key (keyed without search params). For PPR routes, a prior navigation would write a static shell to the cache at the Fallback key with `isPartial = false`. On a subsequent `SearchParamOnlyChange` navigation, that entry was treated as a complete cache hit — `needsDynamicRequest` was set to `false` — so no server request was made and the stale content was displayed.

### How?

Added an `isSearchParamOnlyChange` parameter to `createCacheNodeForSegment`. When `true`, `isCachedRscPartial` is forced to `true` after the segment cache lookup, ensuring a dynamic server request is always spawned regardless of what the cache returned. The call site in `updateCacheNodeOnNavigation` passes `segmentMatchKind === SegmentMatchKind.SearchParamOnlyChange`.

Added a regression test fixture (`/search-with-form`) and test case that navigates from `?query=first` to `?query=second` using form submission and asserts the rendered content updates.

### Verification

- `HEADLESS=true pnpm test-dev-turbo test/e2e/next-form/default/app-dir.test.ts` — 15/15 passed
- `HEADLESS=true pnpm test-dev-turbo test/e2e/next-form/default/` — 27/27 passed (2 suites)

<!-- NEXT_JS_LLM_PR -->