### PR TITLE
[ci] Migrate build_and_test and pull_request_stats to use arm64 runners

### DIFF
--- a/.github/actions/setup-datadog-ci/action.yml
+++ b/.github/actions/setup-datadog-ci/action.yml
@@ -17,8 +17,20 @@ runs:
             DATADOG_CI_ASSET=datadog-ci_win-x64
             ;;
           *)
-            DATADOG_CI_SHA256=86fcf24d5211f5ae714e947354ccb621e74e2bba4162247890454c6461e74ca5
-            DATADOG_CI_ASSET=datadog-ci_linux-x64
+            case "$(uname -m)" in
+              aarch64)
+                DATADOG_CI_SHA256=a192622b4aba3e040f12dadb73e8cf7158a11027c3aab5a16404b152940991d6
+                DATADOG_CI_ASSET=datadog-ci_linux-arm64
+                ;;
+              x86_64)
+                DATADOG_CI_SHA256=86fcf24d5211f5ae714e947354ccb621e74e2bba4162247890454c6461e74ca5
+                DATADOG_CI_ASSET=datadog-ci_linux-x64
+                ;;
+              *)
+                echo "::error::Unsupported architecture: $(uname -m)"
+                exit 1
+                ;;
+            esac
             ;;
         esac
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -336,7 +336,7 @@ jobs:
     with:
       afterBuild: |
         ./node_modules/.bin/devlow-bench ./scripts/devlow-bench.mjs \
-          --datadog=ubuntu-latest-16-core \
+          --datadog=ubuntu-latest-16-core-arm-oss \
           ${{ matrix.mode }} \
           ${{ matrix.selector }}
       stepName: 'devlow-bench-${{ matrix.mode }}-${{ matrix.selector }}'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -265,6 +265,13 @@ jobs:
       skipInstallBuild: 'yes'
       afterBuild: pnpm dlx turbo@${TURBO_VERSION} run test-cargo-unit ${TURBO_ARGS}
       stepName: 'test-cargo-unit'
+      # Run on x86-64 instead of arm64/aarch64. The pnpm workspace in
+      # turbopack/crates/turbopack-tracing/tests/node-file-trace pulls in a ton
+      # of old native dependencies that do not support arm64. We can't easily
+      # update these, because the goal of the NFT tests is to ensure we can
+      # trace unusual packages, who may have since changed how they package
+      # themselves.
+      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-bench:

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -335,11 +335,7 @@ jobs:
       - name: Install node-file-trace test dependencies
         if: ${{ inputs.needsNextest == 'yes' }}
         working-directory: turbopack/crates/turbopack-tracing/tests/node-file-trace
-        # there are no arm64 binaries for the phamtomjs-prebuilt or canvas
-        # packages, but we can install the x64 versions, we don't actually run
-        # the binary. npm_config_target_arch is read by node-pre-gyp, which
-        # canvas uses.
-        run: PHANTOMJS_ARCH=x64 npm_config_target_arch=x64 pnpm install --recursive
+        run: pnpm install --recursive
 
       - run: ANALYZE=1 pnpm build
         if: ${{ inputs.skipInstallBuild != 'yes' }}

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -62,12 +62,12 @@ on:
         description: 'List of runner labels'
         required: false
         type: string
-        default: '["ubuntu-latest-16-core-oss"]'
+        default: '["ubuntu-latest-16-core-arm-oss"]'
       buildNativeTarget:
         description: 'Target for build-native step'
         required: false
         type: string
-        default: 'x86_64-unknown-linux-gnu'
+        default: 'aarch64-unknown-linux-gnu'
       overrideProxyAddress:
         description: Override the proxy address to use for the test
         required: false
@@ -188,8 +188,21 @@ jobs:
             Linux)
               # The asset names and sha256 are available on the GH releases page
               # https://github.com/Schniz/fnm/releases
-              FNM_ASSET=fnm-linux.zip
-              FNM_SHA256=7807664f39d39fc518da1c35ba0181e4b3267603c4b1dedeb4b5fc6ae440a224
+              ARCH="$(uname -m)"
+              case "$ARCH" in
+                aarch64)
+                  FNM_ASSET=fnm-arm64.zip
+                  FNM_SHA256=4eaff58b2c5bf30d0934027572dd0b5bbb60d2a1af309230b53662d4b1d45599
+                  ;;
+                x86_64)
+                  FNM_ASSET=fnm-linux.zip
+                  FNM_SHA256=7807664f39d39fc518da1c35ba0181e4b3267603c4b1dedeb4b5fc6ae440a224
+                  ;;
+                *)
+                  echo "::error::Unsupported architecture: $ARCH"
+                  exit 1
+                  ;;
+              esac
               FNM_EXE=fnm
               ;;
             Windows)
@@ -295,8 +308,8 @@ jobs:
         if: ${{ inputs.uploadSwcArtifact == 'yes' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: next-swc-binary
-          path: packages/next-swc/native/next-swc.linux-x64-gnu.node
+          name: next-swc-binary-${{ runner.os }}-${{ runner.arch }}
+          path: packages/next-swc/native/next-swc.*.node
 
       # undo normalize version changes for install/build
       - run: git checkout .
@@ -322,7 +335,11 @@ jobs:
       - name: Install node-file-trace test dependencies
         if: ${{ inputs.needsNextest == 'yes' }}
         working-directory: turbopack/crates/turbopack-tracing/tests/node-file-trace
-        run: pnpm install -r --side-effects-cache false
+        # there are no arm64 binaries for the phamtomjs-prebuilt or canvas
+        # packages, but we can install the x64 versions, we don't actually run
+        # the binary. npm_config_target_arch is read by node-pre-gyp, which
+        # canvas uses.
+        run: PHANTOMJS_ARCH=x64 npm_config_target_arch=x64 pnpm install --recursive
 
       - run: ANALYZE=1 pnpm build
         if: ${{ inputs.skipInstallBuild != 'yes' }}

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         bundler: [webpack, turbopack]
-    runs-on: ubuntu-latest-16-core-oss
+    runs-on: ubuntu-latest-16-core-arm-oss
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
-          name: next-swc-binary
+          name: next-swc-binary-${{ runner.os }}-${{ runner.arch }}
           path: packages/next-swc/native
 
       - run: cp -r packages/next-swc/native .github/actions/next-stats-action/native


### PR DESCRIPTION
A 16 core x86-64 runner is $0.042/minute. A 16 core arm64 runner is $0.026/minute.
https://docs.github.com/en/billing/reference/actions-runner-pricing

It also looks like they're faster! After factoring the performance improvement, this appears to be a ~50% cost reduction for migrated jobs.

Datadog SQL:

```
SELECT
  REGEXP_REPLACE(ci_job_name, '\s*\([0-9]+/[0-9]+\)', '') AS ci_job_name,
  labels,
  branch,
  commit_date,
  SUM(duration) / 1000 / 1000 / 1000 / 60 as minutes,
  ci_pipeline_id
FROM dd.ci_pipelines(
    columns => ARRAY ['@git.commit.committer.date', '@ci.pipeline.id', '@duration', '@git.branch', '@ci.node.labels', '@ci.job.name'],
    event_type => 'job',
    filter => '@git.repository.id_v2:github.com/vercel/next.js @ci.pipeline.name:build-and-test @ci.provider.instance:github-actions @ci.pipeline.id:(28266192824-1 OR 28266190122-2) -@ci.job.name:*changed*',
    from_timestamp => now() - INTERVAL '30 days',
    to_timestamp => now()
  ) AS (
    commit_date VARCHAR,
    ci_pipeline_id VARCHAR,
    duration BIGINT,
    branch VARCHAR,
    labels VARCHAR,
    ci_job_name VARCHAR
  )
GROUP BY
  REGEXP_REPLACE(ci_job_name, '\s*\([0-9]+/[0-9]+\)', ''),
  labels,
  commit_date,
  branch, 
  ci_pipeline_id
ORDER BY 
  REGEXP_REPLACE(ci_job_name, '\s*\([0-9]+/[0-9]+\)', ''),
  branch,
  commit_date,
  minutes;
```

https://app.datadoghq.com/ddsql/editor?ddsql_dataset_id=34de66b9-30f4-48dd-ac98-354dc7e67fdf

Full Data: https://docs.google.com/spreadsheets/d/1SszR3RsPeJ13nVW5ggMakwy87fkQMqWMHbZDehHH8IA/edit?usp=sharing

Here's the abbreviated data for jobs longer than 5 minutes:
<img width="1187" height="656" alt="Screenshot 2026-06-26 at 4 38 00 PM" src="https://github.com/user-attachments/assets/9341039e-c4ea-405c-8d24-cdbc5ed1ba24" />

It seems like for the jobs switched over to arm64, they run in about ~73-82% of the time as arm.