### PR TITLE
cache DelegatingImportTracer across use

### DIFF
--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -14,11 +14,12 @@ use auto_hash_map::AutoSet;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
+use turbo_frozenmap::FrozenSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    CollectiblesSource, NonLocalValue, OperationVc, RawVc, ReadRef, ResolvedVc, TryFlatJoinIterExt,
-    TryJoinIterExt, Upcast, ValueDefault, ValueToString, ValueToStringRef, Vc, emit,
-    trace::TraceRawVcs,
+    CollectiblesSource, NonLocalValue, OperationVc, OrdResolvedVc, RawVc, ReadRef, ResolvedVc,
+    TryFlatJoinIterExt, TryJoinIterExt, Upcast, ValueDefault, ValueToString, ValueToStringRef, Vc,
+    emit, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
     FileContent, FileLine, FileLinesContent, FileSystem, FileSystemPath, glob::Glob,
@@ -193,7 +194,15 @@ pub trait ImportTracer {
 #[turbo_tasks::value]
 #[derive(Debug)]
 pub struct DelegatingImportTracer {
-    delegates: AutoSet<ResolvedVc<Box<dyn ImportTracer>>>,
+    delegates: FrozenSet<OrdResolvedVc<Box<dyn ImportTracer>>>,
+}
+
+#[turbo_tasks::value_impl]
+impl DelegatingImportTracer {
+    #[turbo_tasks::function]
+    pub fn new(delegates: FrozenSet<OrdResolvedVc<Box<dyn ImportTracer>>>) -> Vc<Self> {
+        Self::cell(DelegatingImportTracer { delegates })
+    }
 }
 
 impl DelegatingImportTracer {
@@ -395,11 +404,10 @@ impl IssueFilter {
 }
 
 /// A list of issues captured with [`CollectibleIssuesExt::peek_issues`].
-#[turbo_tasks::value(shared)]
 #[derive(Debug)]
 pub struct CapturedIssues {
     issues: AutoSet<ResolvedVc<Box<dyn Issue>>>,
-    tracer: ResolvedVc<DelegatingImportTracer>,
+    tracer: Vc<DelegatingImportTracer>,
 }
 
 impl CapturedIssues {
@@ -416,7 +424,7 @@ impl CapturedIssues {
             .map(async |issue| {
                 if filter.matches(*issue).await? {
                     Ok(Some(
-                        PlainIssue::from_issue(**issue, Some(*self.tracer)).await?,
+                        PlainIssue::from_issue(**issue, Some(self.tracer)).await?,
                     ))
                 } else {
                     Ok(None)
@@ -1116,13 +1124,15 @@ where
     T: CollectiblesSource + Copy + Send,
 {
     fn peek_issues(self) -> CapturedIssues {
+        let collectibles = self
+            .peek_collectibles::<Box<dyn ImportTracer>>()
+            .into_iter()
+            .map(OrdResolvedVc::from)
+            .collect::<FrozenSet<_>>();
+
         CapturedIssues {
             issues: self.peek_collectibles(),
-
-            tracer: DelegatingImportTracer {
-                delegates: self.peek_collectibles(),
-            }
-            .resolved_cell(),
+            tracer: DelegatingImportTracer::new(collectibles),
         }
     }
 


### PR DESCRIPTION
Previously, we created new `DelegatingImportTracer`s even if the collectibles were the same. This stores the collectibles in a ~Vec~FrozenSet instead, ~sorted by cell id~ so the task input is cached.

Test Plan: Performance test tbd
