### PR TITLE
Turbopack: Add an OrdResolvedVc wrapper type

### DIFF
--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -122,12 +122,12 @@ pub use crate::{
     value::{TransientInstance, TransientValue},
     value_type::{Evictability, TraitMethod, TraitType, ValueType, ValueTypePersistence},
     vc::{
-        CellId, Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, RawVc,
-        RawVcUnpacked, ReadRawVcFuture, ReadVcFuture, ResolveOperationVcFuture, ResolveRawVcFuture,
-        ResolveVcFuture, ResolvedVc, ToResolvedVcFuture, Upcast, UpcastStrict, ValueDefault, Vc,
-        VcCast, VcCellCompareMode, VcCellHashedCompareMode, VcCellKeyedCompareMode, VcCellNewMode,
-        VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
-        VcValueTypeCast,
+        CellId, Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, OrdResolvedVc,
+        RawVc, RawVcUnpacked, ReadRawVcFuture, ReadVcFuture, ResolveOperationVcFuture,
+        ResolveRawVcFuture, ResolveVcFuture, ResolvedVc, ToResolvedVcFuture, Upcast, UpcastStrict,
+        ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellHashedCompareMode,
+        VcCellKeyedCompareMode, VcCellNewMode, VcDefaultRead, VcRead, VcTransparentRead,
+        VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
     },
 };
 

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -24,7 +24,7 @@ use turbo_tasks_hash::HashAlgorithm;
 
 // This import is necessary for derive macros to work, as their expansion refers to the crate
 // name directly.
-use crate::{self as turbo_tasks, ReadRef};
+use crate::{self as turbo_tasks, OrdResolvedVc, ReadRef};
 use crate::{
     DynTaskInputs, ResolvedVc, TaskId, TransientInstance, TransientValue, ValueTypeId, Vc,
     trace::TraceRawVcs,
@@ -294,6 +294,19 @@ where
 // `TaskInput` isn't needed/used for a bare `ResolvedVc`, as we'll expose `ResolvedVc` arguments as
 // `Vc`, but it is useful for structs that contain `ResolvedVc` and want to derive `TaskInput`.
 impl<T> TaskInput for ResolvedVc<T>
+where
+    T: Send + Sync + ?Sized,
+{
+    fn is_resolved(&self) -> bool {
+        true
+    }
+
+    fn is_transient(&self) -> bool {
+        self.node.is_transient()
+    }
+}
+
+impl<T> TaskInput for OrdResolvedVc<T>
 where
     T: Send + Sync + ?Sized,
 {

--- a/turbopack/crates/turbo-tasks/src/vc/local.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/local.rs
@@ -1,4 +1,4 @@
-use crate::{OperationVc, ResolvedVc, marker_trait::impl_auto_marker_trait};
+use crate::{OperationVc, OrdResolvedVc, ResolvedVc, marker_trait::impl_auto_marker_trait};
 
 /// Marker trait indicating that a type does not contain any instances of [`Vc`] or references to
 /// [`Vc`]. It may contain [`ResolvedVc`] or [`OperationVc`].
@@ -35,6 +35,7 @@ pub unsafe trait NonLocalValue {}
 
 unsafe impl<T: NonLocalValue + ?Sized> NonLocalValue for OperationVc<T> {}
 unsafe impl<T: NonLocalValue + ?Sized> NonLocalValue for ResolvedVc<T> {}
+unsafe impl<T: NonLocalValue + ?Sized> NonLocalValue for OrdResolvedVc<T> {}
 
 impl_auto_marker_trait!(NonLocalValue);
 

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -3,6 +3,7 @@ mod cell_mode;
 pub(crate) mod default;
 mod local;
 pub(crate) mod operation;
+mod ord;
 mod raw;
 mod read;
 pub(crate) mod resolved;
@@ -11,7 +12,7 @@ mod traits;
 use std::{
     any::Any,
     fmt::Debug,
-    future::{Future, IntoFuture},
+    future::Future,
     hash::{Hash, Hasher},
     marker::PhantomData,
     ops::Deref,
@@ -24,7 +25,9 @@ use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use shrink_to_fit::ShrinkToFit;
 
-pub use self::{
+#[cfg(debug_assertions)]
+use crate::debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString};
+pub use crate::vc::{
     cast::{VcCast, VcValueTraitCast, VcValueTypeCast},
     cell_mode::{
         VcCellCompareMode, VcCellHashedCompareMode, VcCellKeyedCompareMode, VcCellMode,
@@ -33,13 +36,12 @@ pub use self::{
     default::ValueDefault,
     local::NonLocalValue,
     operation::{OperationValue, OperationVc, ResolveOperationVcFuture},
+    ord::OrdResolvedVc,
     raw::{CellId, RawVc, RawVcUnpacked, ReadRawVcFuture, ResolveRawVcFuture},
     read::{ReadOwnedVcFuture, ReadVcFuture, VcDefaultRead, VcRead, VcTransparentRead},
     resolved::ResolvedVc,
     traits::{Dynamic, Upcast, UpcastStrict, VcValueTrait, VcValueType},
 };
-#[cfg(debug_assertions)]
-use crate::debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString};
 use crate::{
     keyed::{KeyedAccess, KeyedEq},
     registry,
@@ -496,23 +498,25 @@ where
 }
 
 macro_rules! into_future {
-    ($ty:ty) => {
-        impl<T> IntoFuture for $ty
+    ($ty:ty, |$this:ident| $into_future:expr $(,)?) => {
+        impl<T> ::std::future::IntoFuture for $ty
         where
-            T: VcValueType,
+            T: $crate::VcValueType,
         {
-            type Output = <ReadVcFuture<T> as Future>::Output;
-            type IntoFuture = ReadVcFuture<T>;
+            type Output = <$crate::ReadVcFuture<T> as ::std::future::Future>::Output;
+            type IntoFuture = $crate::ReadVcFuture<T>;
             fn into_future(self) -> Self::IntoFuture {
-                self.node.into_read().into()
+                let $this = self;
+                $into_future
             }
         }
     };
 }
+pub(crate) use into_future;
 
-into_future!(Vc<T>);
-into_future!(&Vc<T>);
-into_future!(&mut Vc<T>);
+into_future!(Vc<T>, |this| this.node.into_read().into());
+into_future!(&Vc<T>, |this| this.node.into_read().into());
+into_future!(&mut Vc<T>, |this| this.node.into_read().into());
 
 impl<T> Vc<T>
 where

--- a/turbopack/crates/turbo-tasks/src/vc/ord.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/ord.rs
@@ -1,0 +1,171 @@
+use std::{
+    cmp::Ordering,
+    fmt::{self, Debug},
+    hash::{Hash, Hasher},
+    ops::Deref,
+    slice,
+};
+
+use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ResolvedVc, Vc,
+    trace::{TraceRawVcs, TraceRawVcsContext},
+    vc::into_future,
+};
+#[cfg(debug_assertions)]
+use crate::{
+    UpcastStrict,
+    debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
+};
+
+/// A thin wrapper on [`ResolvedVc`] that implements [`Ord`]. You must not depend on this to provide
+/// deterministic execution (i.e. to produce externally-visible outputs, like when performing
+/// chunking) as task ids are non-deterministic across cold executions.
+///
+/// This can be useful to provide a cache key. Given a single instance of `turbo-tasks`, this will
+/// give stable results.
+#[derive(Serialize, Deserialize, Encode, Decode)]
+#[serde(transparent, bound = "")]
+#[bincode(bounds = "T: ?Sized")]
+#[repr(transparent)]
+pub struct OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    node: ResolvedVc<T>,
+}
+
+impl<T> OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    /// Wraps a [`ResolvedVc`] so that it can be ordered. See the type-level documentation for the
+    /// caveats around determinism.
+    pub fn new(node: ResolvedVc<T>) -> Self {
+        Self { node }
+    }
+
+    /// Cheaply converts a [`Vec`] of ordered [`ResolvedVc`]s to a [`Vec`] of [`ResolvedVc`]s.
+    pub fn deref_vec(vec: Vec<OrdResolvedVc<T>>) -> Vec<ResolvedVc<T>> {
+        debug_assert!(size_of::<OrdResolvedVc<T>>() == size_of::<ResolvedVc<T>>());
+        let (ptr, len, capacity) = vec.into_raw_parts();
+        // Safety: The memory layout of `OrdResolvedVc<T>` and `ResolvedVc<T>` is
+        // the same.
+        unsafe { Vec::from_raw_parts(ptr as *mut ResolvedVc<T>, len, capacity) }
+    }
+
+    /// Cheaply converts a slice of [`OrdResolvedVc`]s to a slice of
+    /// [`ResolvedVc`]s.
+    pub fn deref_slice(s: &[OrdResolvedVc<T>]) -> &[ResolvedVc<T>] {
+        debug_assert!(size_of::<OrdResolvedVc<T>>() == size_of::<ResolvedVc<T>>());
+        // Safety: The memory layout of `OrdResolvedVc<T>` and `ResolvedVc<T>` is
+        // the same.
+        unsafe { slice::from_raw_parts(s.as_ptr() as *const ResolvedVc<T>, s.len()) }
+    }
+}
+
+impl<T> From<ResolvedVc<T>> for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn from(node: ResolvedVc<T>) -> Self {
+        Self::new(node)
+    }
+}
+
+impl<T> PartialEq<OrdResolvedVc<T>> for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.node == other.node
+    }
+}
+
+impl<T> Eq for OrdResolvedVc<T> where T: ?Sized {}
+
+impl<T> Hash for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.node.hash(state);
+    }
+}
+
+impl<T> PartialOrd for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<T> Ord for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        Vc::into_raw(*self.node)
+            .bits()
+            .cmp(&Vc::into_raw(*other.node).bits())
+    }
+}
+
+impl<T> Copy for OrdResolvedVc<T> where T: ?Sized {}
+
+impl<T> Clone for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Debug for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OrdResolvedVc")
+            .field(&self.node.node.node)
+            .finish()
+    }
+}
+
+impl<T> TraceRawVcs for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        TraceRawVcs::trace_raw_vcs(&self.node, trace_context);
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<T> ValueDebugFormat for OrdResolvedVc<T>
+where
+    T: UpcastStrict<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
+{
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
+        self.node.value_debug_format(depth)
+    }
+}
+
+impl<T> Deref for OrdResolvedVc<T>
+where
+    T: ?Sized,
+{
+    type Target = ResolvedVc<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+into_future!(OrdResolvedVc<T>, |this| (*this).into_future());
+into_future!(&OrdResolvedVc<T>, |this| (*this).into_future());
+into_future!(&mut OrdResolvedVc<T>, |this| (*this).into_future());

--- a/turbopack/crates/turbo-tasks/src/vc/raw.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/raw.rs
@@ -232,7 +232,7 @@ impl RawVc {
     }
 
     #[inline]
-    fn bits(self) -> u64 {
+    pub(crate) fn bits(self) -> u64 {
         self.0.get()
     }
 

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -1,7 +1,6 @@
 use std::{
     any::Any,
     fmt::Debug,
-    future::IntoFuture,
     hash::{Hash, Hasher},
     marker::PhantomData,
     ops::Deref,
@@ -17,7 +16,7 @@ use crate::debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString};
 use crate::{
     RawVc, Upcast, UpcastStrict, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
     trace::{TraceRawVcs, TraceRawVcsContext},
-    vc::Vc,
+    vc::{Vc, into_future},
 };
 
 /// A "subtype" (via [`Deref`]) of [`Vc`] that represents a specific [`Vc::cell`]/`.cell()` or
@@ -152,24 +151,9 @@ where
     }
 }
 
-macro_rules! into_future {
-    ($ty:ty) => {
-        impl<T> IntoFuture for $ty
-        where
-            T: VcValueType,
-        {
-            type Output = <Vc<T> as IntoFuture>::Output;
-            type IntoFuture = <Vc<T> as IntoFuture>::IntoFuture;
-            fn into_future(self) -> Self::IntoFuture {
-                (*self).into_future()
-            }
-        }
-    };
-}
-
-into_future!(ResolvedVc<T>);
-into_future!(&ResolvedVc<T>);
-into_future!(&mut ResolvedVc<T>);
+into_future!(ResolvedVc<T>, |this| (*this).into_future());
+into_future!(&ResolvedVc<T>, |this| (*this).into_future());
+into_future!(&mut ResolvedVc<T>, |this| (*this).into_future());
 
 impl<T> ResolvedVc<T>
 where


### PR DESCRIPTION
Based on our office hours discussion, we don't want to add `Ord` to `ResolvedVc`, but we think this wrapper type adds enough friction to prevent misuse.

```
/// A thin wrapper on [`ResolvedVc`] that implements [`Ord`]. You must not depend on this to provide
/// deterministic execution (i.e. to produce externally-visible outputs, like when performing
/// chunking) as task ids are non-deterministic across cold executions.
///
/// This can be useful to provide a cache key. Given a single instance of `turbo-tasks`, this will
/// give stable results.
```