### PR TITLE
[ci] Only install chromium-headless-shell and not chromium

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -327,7 +327,7 @@ jobs:
 
       - name: Install Playwright browsers
         if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' }}
-        run: pnpm playwright install --with-deps ${{ inputs.browser }}
+        run: pnpm playwright install --with-deps --only-shell ${{ inputs.browser }}
 
       - name: Download pre-built test timings
         if: ${{ inputs.testTimingsArtifact != '' }}


### PR DESCRIPTION
Because it's not sure which one you'll want, playwright installs TWO copies of Chromium by default. A full copy and a stripped down headless version.

Most of the install time is spent in `apt-get`/`dpkg`, but this at least buys us a few seconds back.

Before:

![Screenshot 2026-06-16 at 6.02.44 PM.png](https://app.graphite.com/user-attachments/assets/1cb05dca-c36d-472d-8ffd-1e177f77fc10.png)

After:

<img width="1700" height="552" alt="Screenshot 2026-06-16 at 6 24 50 PM" src="https://github.com/user-attachments/assets/d382cb8e-a875-4d67-92d6-32ff51c06488" />


Playwright also installs ffmpeg in case you want to perform a screen recording (we don't), but it's much smaller (2.3 MiB), and there doesn't appear to be a way to disable it.