### PR TITLE
fix(eslint-plugin-next): support custom pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -24,11 +24,14 @@ const fsExistsSyncCache = {}
 const memoize = <T = any>(fn: (...args: any[]) => T) => {
   const cache = {}
   return (...args: any[]): T => {
-    const key = JSON.stringify(args)
-    if (cache[key] === undefined) {
-      cache[key] = fn(...args)
+    // Include pageExtensions in cache key
+    const cacheKey = JSON.stringify(args.map((arg) => 
+      Array.isArray(arg) ? arg.sort() : arg
+    ))
+    if (cache[cacheKey] === undefined) {
+      cache[cacheKey] = fn(...args)
     }
-    return cache[key]
+    return cache[cacheKey]
   }
 }
 
@@ -49,18 +52,31 @@ export default defineRule({
     type: 'problem',
     schema: [
       {
-        oneOf: [
-          {
-            type: 'string',
+        type: 'object',
+        properties: {
+          pages: {
+            oneOf: [
+              {
+                type: 'string',
+              },
+              {
+                type: 'array',
+                uniqueItems: true,
+                items: {
+                  type: 'string',
+                },
+              },
+            ],
           },
-          {
+          pageExtensions: {
             type: 'array',
             uniqueItems: true,
             items: {
               type: 'string',
             },
           },
-        ],
+        },
+        additionalProperties: false,
       },
     ],
   },
@@ -69,8 +85,9 @@ export default defineRule({
    * Creates an ESLint rule listener.
    */
   create(context) {
-    const ruleOptions: (string | string[])[] = context.options
-    const [customPagesDirectory] = ruleOptions
+    const ruleOptions: any = context.options[0] || {}
+    const customPagesDirectory = ruleOptions.pages || ruleOptions
+    const pageExtensions: string[] | undefined = ruleOptions.pageExtensions
 
     const rootDirs = getRootDirs(context)
 
@@ -107,8 +124,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -8,25 +8,38 @@ const fsReadDirSyncCache = {}
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['.js', '.jsx', '.ts', '.tsx']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    // Support custom pageExtensions
+    const extensionsPattern = pageExtensions
+      .map((ext) => ext.replace(/\./g, '\\.'))
+      .join('|')
+    const extensionRegex = new RegExp(`(${extensionsPattern})$`)
+
+    if (extensionRegex.test(dirent.name)) {
+      const indexPattern = new RegExp(`^index(${extensionsPattern})$`)
+      if (indexPattern.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexPattern, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +49,41 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['.js', '.jsx', '.ts', '.tsx']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    // Support custom pageExtensions
+    const extensionsPattern = pageExtensions
+      .map((ext) => ext.replace(/\./g, '\\.'))
+      .join('|')
+    const extensionRegex = new RegExp(`(${extensionsPattern})$`)
+
+    if (extensionRegex.test(dirent.name)) {
+      const pagePattern = new RegExp(`^page(${extensionsPattern})$`)
+      const layoutPattern = new RegExp(`^layout(${extensionsPattern})$`)
+
+      if (pagePattern.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pagePattern, '')}`)
+      } else if (!layoutPattern.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForAppDir(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,33 +166,39 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
         )
     )
   ).map((urlReg) => {
-    urlReg = urlReg.replace(/\[.*\]/g, '((?!.+?\\..+?).*?)')
+    urlReg = urlReg.replace(/\\[.*\\]/g, '((?!.+?\\\\..+?).*?)')
     return new RegExp(urlReg)
   })
 }
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
@@ -170,7 +206,7 @@ export function getUrlFromAppDirectory(
         )
     )
   ).map((urlReg) => {
-    urlReg = urlReg.replace(/\[.*\]/g, '((?!.+?\\..+?).*?)')
+    urlReg = urlReg.replace(/\\[.*\\]/g, '((?!.+?\\\\..+?).*?)')
     return new RegExp(urlReg)
   })
 }


### PR DESCRIPTION
## Overview

Fixes #53473

The `no-html-link-for-pages` ESLint rule now supports custom `pageExtensions` configuration.

## Changes

- **url.ts**: Update `parseUrlForPages` and `parseUrlForAppDir` to accept and use custom pageExtensions parameter
- **url.ts**: Update `getUrlFromPagesDirectories` and `getUrlFromAppDirectory` export signatures to accept pageExtensions
- **no-html-link-for-pages.ts**: Update schema to accept object with `pages` and `pageExtensions` properties
- **no-html-link-for-pages.ts**: Pass pageExtensions to URL parsing functions
- **no-html-link-for-pages.ts**: Update memoization cache key to sort arrays for proper caching

## Usage

```javascript
// next.config.js
module.exports = {
  pageExtensions: ['mdx', 'md', 'tsx']
}

// .eslintrc.js
module.exports = {
  rules: {
    '@next/next/no-html-link-for-pages': ['error', { pageExtensions: ['mdx', 'md', 'tsx'] }]
  }
}
```

Closes #53473