### PR TITLE
docs: fix capitalization of Server and Client Components

### DIFF
--- a/docs/01-app/01-getting-started/05-server-and-client-components.mdx
+++ b/docs/01-app/01-getting-started/05-server-and-client-components.mdx
@@ -14,7 +14,7 @@ This page explains how Server and Client Components work in Next.js and when to 
 
 ## When to use Server and Client Components?
 
-The client and server environments have different capabilities. Server and Client components allow you to run logic in each environment depending on your use case.
+The client and server environments have different capabilities. Server and Client Components allow you to run logic in each environment depending on your use case.
 
 Use **Client Components** when you need:
 


### PR DESCRIPTION
Fix minor capitalization inconsistency in documentation.

Changes:
- "Server and Client components" → "Server and Client Components"

No functional changes.

Docs-only change. No behavior impact.