### PR TITLE
Let LLMs create less noisy and more focused PR descriptions

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -70,17 +70,7 @@ Use this skill when turning local work into a GitHub pull request.
 Use this PR body format:
 
 ```markdown
-### What?
-
-<what changed>
-
-### Why?
-
-<why this is needed>
-
-### How?
-
-<implementation approach>
+<what changed and why>
 
 ### Verification
 
@@ -89,6 +79,13 @@ Use this PR body format:
 
 <!-- NEXT_JS_LLM_PR -->
 ```
+
+The "what" should be explained from the end-user perspective or developer perspective. Only include implementation changes if they're not obvious from the diff.
+
+A "why" should be included if the change isn't self-explanatory, or if the motivation is not clear from the diff.
+Omitting the "why" should be used sparringly and only for small changes.
+
+Do not include trivial verification commands that CI already covers (e.g. `pnpm run build`), but do include any manual verification steps. If the PR changes a test, you don't need to repeat the command to run that test. But if you used an existing test to validate some behavior didn't change, include that test.
 
 Use `--body` with this filled content.
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -70,9 +70,11 @@ Use this skill when turning local work into a GitHub pull request.
 Use this PR body format:
 
 ```markdown
+## Summary
+
 <what changed and why>
 
-### Verification
+## Verification
 
 - `<command that passed>`
 - Not run: `<command>` (`<reason>`)


### PR DESCRIPTION
The default template is too noisy when used by LLMs. "what" and "how" are almost always duplicates. Verification most often includes trivial commands (e.g. static checking of .js files or running `pnpm build`). This information isn't relevant to review and can leave the important bits of a PR description unreviewed.

Oftentimes the "why" is the most important bit for maintainers. The "what" is most important for end users reading along (or for deriving docs or changelog entries from the PR).