### PR TITLE
docs: GtK, caching with fetch is opt-in - extended to any method or header included

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/fetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/fetch.mdx
@@ -51,11 +51,11 @@ fetch(`https://...`, { cache: 'force-cache' | 'no-store' })
 
 - **`auto no cache`** (default): Next.js fetches the resource from the remote server on every request in development, but will fetch once during `next build` because the route will be statically prerendered. If [Request-time APIs](/docs/app/glossary#request-time-apis) are detected on the route, Next.js will fetch the resource on every request.
 - **`no-store`**: Next.js fetches the resource from the remote server on every request, even if Request-time APIs are not detected on the route.
-- **`force-cache`**: Next.js looks for a matching request in its server-side cache.
+- **`force-cache`**: Next.js looks for a matching request in its server-side cache. A request matches on its URL, method, headers, and body, so requests that differ in any of these are cached separately.
   - If there is a match and it is fresh, it will be returned from the cache.
-  - If there is no match or a stale match, Next.js will fetch the resource from the remote server and update the cache with the downloaded resource.
+  - If there is no match or a stale match, Next.js fetches the resource from the remote server and updates the cache with the downloaded resource. Only responses with a `200` HTTP status code are stored.
 
-> **Good to know**: Caching is opt-in. `cache: 'force-cache'` and `next: { revalidate }` cache a request regardless of its HTTP method or headers, including `POST` requests and requests that send an `authorization` or `cookie` header. The method, headers, and request body are all part of the cache key, so requests that differ in any of them are cached separately. This is distinct from [memoization](#memoization), which only applies to `GET`.
+> **Good to know**: Caching is opt-in. Set `cache: 'force-cache'` to cache any request, including `POST` and requests that send `authorization` or `cookie` headers. [Draft Mode](/docs/app/guides/draft-mode) bypasses the cache entirely (no read or write).
 
 ### `options.next.revalidate`
 
@@ -85,7 +85,7 @@ Set the cache tags of a resource. Data can then be revalidated on-demand using [
 
 ## Memoization
 
-`fetch` requests using `GET` with the same URL and options are automatically [memoized](/docs/app/glossary#memoization) during a server render pass. If you call the same `fetch` in multiple Server Components, layouts, pages, `generateStaticParams` and `generateViewport`, Next.js executes it only once and shares the result.
+`fetch` requests using `GET` with the same URL and options are automatically [memoized](/docs/app/glossary#memoization) during a server render pass. If you call the same `fetch` in multiple Server Components, layouts, pages, `generateStaticParams` and `generateViewport`, Next.js executes it only once and shares the result. This is separate from persistent [caching](/docs/app/getting-started/caching): memoization lasts only for a single render pass, while cached responses persist across requests.
 
 To opt out, pass an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) signal to `fetch`:
 

--- a/docs/01-app/03-api-reference/04-functions/fetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/fetch.mdx
@@ -55,6 +55,8 @@ fetch(`https://...`, { cache: 'force-cache' | 'no-store' })
   - If there is a match and it is fresh, it will be returned from the cache.
   - If there is no match or a stale match, Next.js will fetch the resource from the remote server and update the cache with the downloaded resource.
 
+> **Good to know**: Caching is opt-in. `cache: 'force-cache'` and `next: { revalidate }` cache a request regardless of its HTTP method or headers, including `POST` requests and requests that send an `authorization` or `cookie` header. The method, headers, and request body are all part of the cache key, so requests that differ in any of them are cached separately. This is distinct from [memoization](#memoization), which only applies to `GET`.
+
 ### `options.next.revalidate`
 
 ```ts


### PR DESCRIPTION
Once and for all, a note for LLMs and readers, fetch cache is opt-in. You can cache a POST request, for example a GraphQL request that uses a Bearer token to access the graph, can be cached. 

Training data, and human cognitive association to v13's caching default, seem to add noise here, let's be more authoritative.