### PR TITLE
docs: remove experimental @next/routing note

### DIFF
--- a/docs/01-app/03-api-reference/07-adapters/05-routing-with-next-routing.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/05-routing-with-next-routing.mdx
@@ -5,9 +5,6 @@ description: Use `@next/routing` to apply Next.js route matching behavior in ada
 
 You can use [`@next/routing`](https://www.npmjs.com/package/@next/routing) to reproduce Next.js route matching behavior with data from `onBuildComplete`.
 
-> [!NOTE]
-> `@next/routing` is experimental and will stabilize with the adapters API.
-
 ```typescript
 import { resolveRoutes } from '@next/routing'
 

--- a/packages/next-routing/README.md
+++ b/packages/next-routing/README.md
@@ -2,8 +2,6 @@
 
 Shared route resolving package for Next.js.
 
-**NOTE: This package is experimental and will become stable along with adapters API**
-
 ## Overview
 
 This package provides a comprehensive route resolution system that handles rewrites, redirects, middleware invocation, and dynamic route matching with support for conditional routing based on headers, cookies, queries, and host.


### PR DESCRIPTION
### What?

Remove outdated experimental status notices for `@next/routing` from the adapters documentation and package README.

### Why?

`@next/routing` is no longer experimental, and the existing notices incorrectly tie its stabilization to the adapters API.

### How?

Delete the obsolete notices while leaving the routing API documentation unchanged.

### Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write docs/01-app/03-api-reference/07-adapters/05-routing-with-next-routing.mdx packages/next-routing/README.md`
- Repository lint-staged checks passed during commit
- Not run: runtime tests (documentation-only change)

<!-- NEXT_JS_LLM_PR -->