### PR TITLE
Scope the Cold cache indicator in dev to shell cache misses

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4655,19 +4655,41 @@ async function streamStagedRenderInDev({
 
   // Whether any stage boundary still had pending cache reads (or modules): i.e.
   // the caches weren't filled yet and the render streamed Suspense fallbacks
-  // for content that would be cached in production. Returns the running verdict
-  // so each boundary can reveal the shell as soon as a miss is seen.
+  // for content that would be cached in production.
   let hadCacheMiss = false
+
+  // Whether the cold-cache status has already been reported for this render. It
+  // is reported at most once, and only for a read that's still pending while a
+  // shell stage is flushing (see `checkForCacheMiss`).
+  let reportedColdCache = false
+
+  // Runs at each stage boundary. Latches the running cache-miss verdict and
+  // returns it, so a boundary can reveal the shell as soon as a miss is seen
+  // (and so dev validation can later tell whether the streamed render is
+  // prod-representative). The first miss seen while a shell stage is still
+  // flushing also reports the cold-cache status.
   const checkForCacheMiss = () => {
     if (cacheSignal.hasPendingReads()) {
-      if (!hadCacheMiss) {
-        // First detected cache miss this render: tell the dev overlay the load
-        // is streaming with a cold cache now, while it's still in progress, so
-        // the indicator can combine with the rendering status on client navs.
-        // The per-load `'ready'` reset clears it again on the next load.
-        ctx.renderOpts.setCacheStatus?.('cold', ctx.htmlRequestId)
-      }
       hadCacheMiss = true
+
+      // The cold-cache indicator reflects the shell only. A cache read still
+      // pending while a shell stage flushes (`currentStage <=
+      // revealAfterStage`, using the ordered `RenderStage` values) is part of
+      // the shell that production serves instantly, so a cold cache there is
+      // worth surfacing and we show the indicator. A cache miss after the shell
+      // stage is runtime or dynamic content that production reads/fills during
+      // the resume at runtime, so a cold cache there is expected and must not
+      // show the indicator.
+      if (
+        !reportedColdCache &&
+        stageController.currentStage <= revealAfterStage
+      ) {
+        // First in-shell cache miss this render: tell the dev overlay we're
+        // streaming with a cold cache now. The per-load `'ready'` reset clears
+        // it again on the next load.
+        ctx.renderOpts.setCacheStatus?.('cold', ctx.htmlRequestId)
+        reportedColdCache = true
+      }
     }
     return hadCacheMiss
   }

--- a/test/development/app-dir/cache-indicator-partial-prefetching/app/layout.tsx
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/app/layout.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <nav>
+          <Link href="/">/index</Link> |{' '}
+          <Link href="/params/some-id" prefetch={true}>
+            /params/some-id
+          </Link>{' '}
+          |{' '}
+          <Link href="/private" prefetch={true}>
+            /private
+          </Link>
+        </nav>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/development/app-dir/cache-indicator-partial-prefetching/app/page.tsx
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">Hello, initial load!</p>
+}

--- a/test/development/app-dir/cache-indicator-partial-prefetching/app/params/[id]/page.tsx
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/app/params/[id]/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { setTimeout } from 'timers/promises'
+
+// Runtime-prefetchable: a client navigation reveals the runtime shell.
+export const prefetch = 'allow-runtime'
+
+async function getCachedValue() {
+  'use cache'
+  await setTimeout(1500)
+  return new Date().toISOString()
+}
+
+async function ParamsData({ params }: { params: Promise<{ id: string }> }) {
+  // Awaiting params (without generateStaticParams) is what defers the cache
+  // read past the static shell.
+  await params
+  const value = await getCachedValue()
+  return <p id="params">{value}</p>
+}
+
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <Suspense fallback={<p id="params-fallback">Loading...</p>}>
+      <ParamsData params={params} />
+    </Suspense>
+  )
+}

--- a/test/development/app-dir/cache-indicator-partial-prefetching/app/private/page.tsx
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/app/private/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { setTimeout } from 'timers/promises'
+
+// Runtime-prefetchable: a client navigation reveals the runtime shell, and a
+// private cache resolves in the session-data (runtime) stage, so it's part of
+// the runtime shell for a dev client navigation.
+export const prefetch = 'allow-runtime'
+
+async function PrivateData() {
+  'use cache: private'
+  await setTimeout(1500)
+  return <p id="private">{new Date().toISOString()}</p>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="private-fallback">Loading...</p>}>
+      <PrivateData />
+    </Suspense>
+  )
+}

--- a/test/development/app-dir/cache-indicator-partial-prefetching/cache-indicator-partial-prefetching.test.ts
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/cache-indicator-partial-prefetching.test.ts
@@ -1,0 +1,84 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+// Partial prefetching is enabled here (and Cache Components), so a client
+// navigation to a route with `export const prefetch = 'allow-runtime'` reveals
+// the runtime shell. Caches that resolve in the runtime stage (a `'use cache'`
+// read after `await params`, or a private cache) are therefore part of the
+// shell for that navigation, so a cold cache must show the Cold cache badge,
+// unlike on an initial (static-shell) load, where those same caches sit after
+// the shell. (The static-shell behavior is covered in the `cache-indicator`
+// suite.)
+describe('cache-indicator-partial-prefetching', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('shows the Cold cache badge on a cold runtime-prefetch navigation to a route whose cache read follows await params, not on a warm one', async () => {
+    const browser = await next.browser('/')
+
+    // Cold navigation: the cache read sits after `await params`, so it resolves
+    // in the runtime stage, part of the runtime shell for this navigation, so a
+    // cold cache there shows the badge.
+    await browser.elementByCss('a[href="/params/some-id"]').click()
+    await browser.elementById('params')
+    await retry(async () => {
+      expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
+        true
+      )
+    })
+
+    // Navigate to the static home (a fresh render clears the badge), then wait
+    // for the background fill to settle so the next navigation is a warm hit.
+    await browser.elementByCss('a[href="/"]').click()
+    await retry(async () => {
+      expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
+        false
+      )
+    })
+    await waitFor(2000)
+
+    // Warm navigation: the runtime shell is a cache hit, so no badge. An absence
+    // can't be retried on, so wait out the replay window, then assert it never
+    // appeared.
+    await browser.elementByCss('a[href="/params/some-id"]').click()
+    await browser.elementById('params')
+    await waitFor(500)
+    expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(false)
+  })
+
+  it('shows the Cold cache badge on a cold runtime-prefetch navigation to a private-cache route, not on a warm one', async () => {
+    const browser = await next.browser('/')
+
+    // Cold navigation: the private cache resolves in the runtime shell, so a
+    // cold cache there shows the badge.
+    await browser.elementByCss('a[href="/private"]').click()
+    await browser.elementById('private')
+    await retry(async () => {
+      expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
+        true
+      )
+    })
+
+    // Navigate to the static home (a fresh render clears the badge), then wait
+    // for the background fill to settle.
+    await browser.elementByCss('a[href="/"]').click()
+    await retry(async () => {
+      expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
+        false
+      )
+    })
+    await waitFor(2000)
+
+    // Warm navigation: the private entry is served from the dev store, so no
+    // badge.
+    await browser.elementByCss('a[href="/private"]').click()
+    await browser.elementById('private')
+    await waitFor(500)
+    expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(false)
+  })
+})

--- a/test/development/app-dir/cache-indicator-partial-prefetching/next.config.js
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/cache-indicator/app/dynamic/[id]/page.tsx
+++ b/test/development/app-dir/cache-indicator/app/dynamic/[id]/page.tsx
@@ -1,0 +1,20 @@
+// A blocking route (`instant = false`) with a dynamic param and no
+// `generateStaticParams`. The `'use cache'` read sits after `await params`, so
+// it can only run once the param resolves, in the runtime stage.
+export const instant = false
+
+async function getCachedValue() {
+  'use cache'
+  await new Promise((resolve) => setTimeout(resolve, 1500))
+  return new Date().toISOString()
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  await params
+  const value = await getCachedValue()
+  return <p id="dynamic">{value}</p>
+}

--- a/test/development/app-dir/cache-indicator/cache-indicator.test.ts
+++ b/test/development/app-dir/cache-indicator/cache-indicator.test.ts
@@ -271,24 +271,37 @@ describe('cache-indicator', () => {
       )
     })
 
-    it('shows the Cold cache badge on an initial cold load and not on a warm reload for a private cache', async () => {
+    it('does not show the Cold cache badge for a private cache on an initial load', async () => {
       const browser = await next.browser('/private')
 
-      // Cold load: the private cache misses and fills while streaming, so the
-      // cold verdict is replayed after load.
+      // A private cache is deferred to the session-data (runtime) stage, after
+      // the static shell. On an initial load the relevant shell is the static
+      // shell, so a private miss is a runtime-resumed hole rather than part of
+      // the shell, and must not show the badge, even on this first, generating
+      // load, when the read is pending at the post-shell boundary. (A private
+      // cache does show the badge on a runtime-prefetch navigation, where
+      // session data is part of the runtime shell; see the
+      // cache-indicator-partial-prefetching suite.) An absence can't be retried
+      // on, so wait out the replay-on-connect window and then assert it never
+      // showed.
       await browser.elementById('private')
-      await retry(async () => {
-        expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
-          true
-        )
-      })
+      await waitFor(500)
+      expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
+        false
+      )
+    })
 
-      // Warm reload: the private entry is now persisted in dev and served as a
-      // stale-while-revalidate hit, so it does not register as a cache miss and
-      // no badge appears. An absence can't be retried on, so wait out the
+    it('does not show the Cold cache badge for a cache read that follows await params on an initial load', async () => {
+      const browser = await next.browser('/dynamic/some-id')
+
+      // The cache read sits after `await params`, so it resolves in the runtime
+      // stage, after the static shell. On an initial load the relevant shell is
+      // the static shell, so this is a runtime-resumed hole rather than part of
+      // the shell, and must not show the badge, even while the value generates
+      // on this first load, when the read is pending at the post-shell
+      // boundary. An absence can't be retried on, so wait out the
       // replay-on-connect window and then assert it never showed.
-      await browser.refresh()
-      await browser.elementById('private')
+      await browser.elementById('dynamic')
       await waitFor(500)
       expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(
         false


### PR DESCRIPTION
In #94611 we added a Cold cache indicator that `next dev` shows when a page or navigation was not served in a production-representative way. In production the shell is served instantly, so a cache miss within the shell means the loading sequence differs from production, which is what the indicator flags.

The indicator counted a cache miss up to the runtime stage, regardless of which shell the request served. That is right for a runtime-prefetch navigation, where the runtime shell is served, but on an initial load only the static shell is served up front, so a read that runs after it, such as one after `await params` on a dynamic route, or a private cache, was counted even though it is not part of the served shell. Whether such a read hits or misses does not affect how the shell loaded, so it should not affect the indicator, yet a page loaded from a warm cache hit could still show the badge.

We now consider only caches still missing up to the shell the request serves: the static shell on an initial load, or the runtime shell on a runtime-prefetch navigation. Reads that resolve after the shell no longer count, so the indicator reflects only whether the shell loaded as it would in production. New development tests cover both the static-shell and runtime-prefetch cases.