### PR TITLE
Sort multi-error Redbox snapshots to deflake the hydration-error ordering test

### DIFF
--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -676,19 +676,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
     })
 
     if (isReact18) {
-      await expect(browser).toDisplayRedbox(`
+      await expect(browser).toDisplayRedbox(
+        `
        [
-         {
-           "componentStack": "<Mismatch>
-       >   <div>
-             <Suspense>
-       >       <main>",
-           "description": "Expected server HTML to contain a matching <main> in <div>.",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": null,
-           "stack": [],
-         },
          {
            "componentStack": "<Mismatch>
        >   <div>
@@ -707,8 +697,23 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "source": null,
            "stack": [],
          },
+         {
+           "componentStack": "<Mismatch>
+       >   <div>
+             <Suspense>
+       >       <main>",
+           "description": "Expected server HTML to contain a matching <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
        ]
-      `)
+      `,
+        // React can report these hydration errors in a non-deterministic order
+        // (the thrown error races `onRecoverableError`), so sort for stability.
+        { sortErrors: true }
+      )
     } else {
       await expect(browser).toDisplayRedbox(`
        {

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -73,6 +73,16 @@ declare global {
 
 interface ErrorSnapshotOptions {
   label?: boolean
+  /**
+   * When a Redbox shows multiple errors, React can surface them in a
+   * non-deterministic order. For example, during hydration a thrown
+   * "Runtime Error" races the `onRecoverableError` callbacks, so the same set
+   * of errors can appear in a different order between runs and flake the
+   * snapshot. Set this to sort the collected errors into a stable order (by
+   * their serialized content) before snapshotting. Only affects multi-error
+   * snapshots; single-error snapshots are unaffected.
+   */
+  sortErrors?: boolean
 }
 
 interface SanitizedCauseEntry {
@@ -322,6 +332,18 @@ export async function createRedboxSnapshot(
         `[data-nextjs-dialog-error-index="${errorIndex + 1}"]`
       )
     }
+  }
+
+  if (opts?.sortErrors) {
+    // The Redbox can surface multiple errors in a non-deterministic order
+    // (e.g. a thrown error racing `onRecoverableError` during hydration), which
+    // flakes order-sensitive snapshots. Sort by serialized content so the
+    // snapshot is stable regardless of the order React reports the errors in.
+    errorSnapshots.sort((a, b) => {
+      const aKey = JSON.stringify(a)
+      const bKey = JSON.stringify(b)
+      return aKey < bKey ? -1 : aKey > bKey ? 1 : 0
+    })
   }
 
   return errorSnapshots.length === 1


### PR DESCRIPTION
The "extra node inside Suspense content" hydration test asserts the order of the three errors shown in the dev overlay, but React reports the thrown `Runtime Error` and the two `onRecoverableError` callbacks in a non-deterministic order during hydration, so the inline snapshot flakes on ordering. It's been flaky since 2024-09 (~11% failure rate) and most recently broke canary.

Add a `sortErrors` option to `toDisplayRedbox` that sorts a multi-error snapshot by serialized content before asserting, and enable it for this test (snapshot reordered to the resulting stable order). Single-error snapshots and tests that don't opt in are unaffected.

<!-- NEXT_JS_LLM_PR -->