### PR TITLE
Avoid re-logging server-originated errors forwarded from the browser

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -37,6 +37,7 @@ import {
   type GlobalErrorState,
 } from '../../../components/app-router-instance'
 import { InvariantError } from '../../../../shared/lib/invariant-error'
+import { markErrorAsAlreadyLoggedOnServer } from '../../../../next-devtools/shared/forward-logs-shared'
 import { getOrCreateDebugChannelReadableWriterPair } from '../../debug-channel'
 // TODO: Explicitly import from client.browser (doesn't work with Webpack).
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -541,6 +542,10 @@ export function processMessage(
                 configurable: true,
               })
             }
+            // These errors originated on the server and were already logged
+            // there. Mark them so the browser-to-terminal log forwarding
+            // doesn't replay them back to the CLI as duplicates.
+            markErrorAsAlreadyLoggedOnServer(error)
             console.error(error)
           }
         },

--- a/packages/next/src/next-devtools/shared/forward-logs-shared.ts
+++ b/packages/next/src/next-devtools/shared/forward-logs-shared.ts
@@ -66,6 +66,31 @@ export type ServerLogEntry =
 
 export const UNDEFINED_MARKER = '__next_tagged_undefined'
 
+const alreadyLoggedOnServerSymbol = Symbol('nextAlreadyLoggedOnServer')
+
+/**
+ * Marks an error that originated on the server and was already logged there.
+ * Such errors are also sent to the browser, where they get logged to the
+ * browser console and shown in the dev overlay. This marker lets the
+ * browser-to-terminal log forwarding skip them, so they aren't replayed back to
+ * the CLI as duplicates.
+ */
+export function markErrorAsAlreadyLoggedOnServer(error: object): void {
+  Object.defineProperty(error, alreadyLoggedOnServerSymbol, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  })
+}
+
+export function wasErrorAlreadyLoggedOnServer(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[alreadyLoggedOnServerSymbol] === true
+  )
+}
+
 // Based on https://github.com/facebook/react/blob/28dc0776be2e1370fe217549d32aee2519f0cf05/packages/react-server/src/ReactFlightServer.js#L248
 export function patchConsoleMethod<T extends keyof Console>(
   methodName: T,

--- a/packages/next/src/next-devtools/userspace/app/forward-logs.ts
+++ b/packages/next/src/next-devtools/userspace/app/forward-logs.ts
@@ -7,6 +7,7 @@ import {
   type ClientLogEntry,
   type LogMethod,
   patchConsoleMethod,
+  wasErrorAlreadyLoggedOnServer,
 } from '../../shared/forward-logs-shared'
 import { preLogSerializationClone, logStringify } from './forward-logs-utils'
 import { getOwnerStack } from './errors/stitched-error'
@@ -218,6 +219,13 @@ export const forwardErrorLog = (args: any[]) => {
 
   const errorObjects = args.filter((arg) => arg instanceof Error)
   const first = errorObjects.at(0)
+  // Skip errors that originated on the server and were already logged there
+  // (e.g. Cache Components validation errors that are also sent to the browser
+  // to show in the dev overlay). Forwarding them back would duplicate them in
+  // the terminal.
+  if (first && wasErrorAlreadyLoggedOnServer(first)) {
+    return
+  }
   if (first) {
     const source = getErrorSource(first)
     if (source) {

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -212,7 +212,7 @@ describe(`Terminal Logging (${bundlerName})`, () => {
     // browser-to-terminal log forwarding would otherwise replay back to the
     // CLI, duplicating the error. Only applies with Cache Components enabled.
     if (isCacheComponentsEnabled) {
-      it('logs the validation error on the server and forwards a duplicate from the browser', async () => {
+      it('logs the validation error on the server without re-logging the forwarded browser copy', async () => {
         const outputIndex = logs.length
 
         const browser = await next.browser('/cache-components-error', {
@@ -249,13 +249,13 @@ describe(`Terminal Logging (${bundlerName})`, () => {
 
         const output = logs.slice(outputIndex).join('')
 
-        // FIXME: The validation error appears twice in the terminal: once
-        // logged directly by the dev server, and once replayed from the browser
-        // via log forwarding. The forwarded copy should be suppressed so it
-        // only appears once.
+        // The validation error is logged directly by the dev server. It is also
+        // sent to the browser, which logs it to its own console, but the
+        // browser-to-terminal log forwarding skips it since it already
+        // originated on the server. It should therefore appear exactly once.
         const validationError =
           'Route "/cache-components-error": Next.js encountered the unstable value'
-        expect(output).toIncludeRepeated(validationError, 2)
+        expect(output).toIncludeRepeated(validationError, 1)
 
         await browser.close()
       })

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -42,6 +42,8 @@ function setupLogCapture() {
   return { logs, restore, clearLogs }
 }
 
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
 describe(`Terminal Logging (${bundlerName})`, () => {
   describe('Pages Router', () => {
     let logs: string[] = []
@@ -203,6 +205,61 @@ describe(`Terminal Logging (${bundlerName})`, () => {
 
       await browser.close()
     })
+
+    // Cache Components validation errors are logged on the server during the
+    // dev render and are also sent to the browser to show in the dev overlay.
+    // The browser then logs them to its own console, which the
+    // browser-to-terminal log forwarding would otherwise replay back to the
+    // CLI, duplicating the error. Only applies with Cache Components enabled.
+    if (isCacheComponentsEnabled) {
+      it('logs the validation error on the server and forwards a duplicate from the browser', async () => {
+        const outputIndex = logs.length
+
+        const browser = await next.browser('/cache-components-error', {
+          // `disableBrowserLog` stops the test harness from echoing the browser
+          // console to the terminal, so the captured output reflects only the
+          // dev server's own logging.
+          disableBrowserLog: true,
+        })
+
+        // Wait until the browser has logged the validation error to its own
+        // console. This is the same console.error that schedules the log
+        // forwarding, so once it appears any forwarded copy has been queued.
+        await retry(async () => {
+          const browserLogs = await browser.log()
+          expect(browserLogs).toContainEqual(
+            expect.objectContaining({
+              source: 'error',
+              message: expect.stringContaining(
+                'Route "/cache-components-error": Next.js encountered the unstable value'
+              ),
+            })
+          )
+        })
+
+        // Emit a marker afterwards. The forwarding queue preserves order, so
+        // once the marker reaches the terminal we know a forwarded copy of the
+        // error would already be there too.
+        await browser.eval(`console.log('forward-flush-marker')`)
+        await retry(() => {
+          expect(logs.slice(outputIndex).join('')).toContain(
+            '[browser] forward-flush-marker'
+          )
+        })
+
+        const output = logs.slice(outputIndex).join('')
+
+        // FIXME: The validation error appears twice in the terminal: once
+        // logged directly by the dev server, and once replayed from the browser
+        // via log forwarding. The forwarded copy should be suppressed so it
+        // only appears once.
+        const validationError =
+          'Route "/cache-components-error": Next.js encountered the unstable value'
+        expect(output).toIncludeRepeated(validationError, 2)
+
+        await browser.close()
+      })
+    }
   })
 
   describe('App Router - Client Components', () => {

--- a/test/development/browser-logs/fixtures/app/cache-components-error/page.js
+++ b/test/development/browser-logs/fixtures/app/cache-components-error/page.js
@@ -1,0 +1,8 @@
+export default function CacheComponentsErrorPage() {
+  // Reading the current time during render is uncached sync IO. With Cache
+  // Components enabled, and without a parent Suspense boundary, this triggers a
+  // prerender validation error.
+  const now = new Date().toISOString()
+
+  return <p>{now}</p>
+}

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -269,6 +269,13 @@ export class Playwright<TCurrent = undefined> {
       disableCache?: boolean
       cpuThrottleRate?: number
       pushErrorAsConsoleLog?: boolean
+      /**
+       * Suppress the harness from echoing the browser's console output to the
+       * test's terminal (the `Browser Log:` lines). Browser logs are still
+       * collected and available via `browser.log()`. Useful when a test
+       * captures and asserts on terminal output, where the echo would be noise.
+       */
+      disableBrowserLog?: boolean
       beforePageLoad?: (page: Page) => void | Promise<void>
       /**
        * @see {@link https://playwright.dev/docs/api/class-page#page-set-extra-http-headers Playwright.Page.setExtraHTTPHeaders}
@@ -298,7 +305,9 @@ export class Playwright<TCurrent = undefined> {
     websocketFrames = []
 
     page.on('console', (msg) => {
-      debugPrint('Browser Log:', msg)
+      if (!opts?.disableBrowserLog) {
+        debugPrint('Browser Log:', msg)
+      }
 
       pageLogs.push(
         Promise.all(

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -93,6 +93,13 @@ export interface WebdriverOptions {
   pushErrorAsConsoleLog?: boolean
 
   /**
+   * Suppress the harness from echoing the browser's console output to the
+   * test's terminal (the `Browser Log:` lines). Browser logs are still
+   * collected and available via `browser.log()`.
+   */
+  disableBrowserLog?: boolean
+
+  /**
    * Override the user agent
    */
   userAgent?: string
@@ -134,6 +141,7 @@ export default async function webdriver(
     headless,
     cpuThrottleRate,
     pushErrorAsConsoleLog,
+    disableBrowserLog,
     userAgent,
     waitUntil,
     baseUrl,
@@ -173,6 +181,7 @@ export default async function webdriver(
     beforePageLoad,
     extraHTTPHeaders,
     pushErrorAsConsoleLog,
+    disableBrowserLog,
     waitUntil,
   })
   debugPrint(`Loaded browser with ${fullUrl}`)


### PR DESCRIPTION
During `next dev`, certain errors (such as Cache Components validation errors) are logged directly to the terminal by the dev server and are also sent to the browser so they can be shown in the dev overlay. The browser logs them to its own console, and the browser-to-terminal log forwarding would replay that copy back to the CLI, so the same error appeared in the terminal twice.

This change marks those errors when the browser receives them, in the `ERRORS_TO_SHOW_IN_BROWSER` handler, using a non-enumerable symbol. `forwardErrorLog`, the single function all forwarded error logs pass through, then skips any error carrying that marker, since it already originated on the server and was logged there. The marker has to be set browser-side because it wouldn't survive RSC serialization, which is the same reason the error code is sent through a side-channel map rather than on the error itself.

The error still shows in the browser console and the dev overlay; only the redundant terminal echo is suppressed. This applies to every error delivered over the errors RSC stream, all of which are logged on the server before being sent, so the forwarded copy is always a duplicate.

> [!TIP]
> Review the two commits individually to see the before/after change. 