### PR TITLE
[turbopack] Discover `ServiceWorkerEntryModule`s in `next-api` and compile + serve those service workers

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -87,6 +87,7 @@ use crate::{
         AppPageRoute, Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs, Route, Routes,
     },
     server_actions::{build_server_actions_loader, create_server_actions_manifest},
+    service_worker::service_worker_output_assets,
     sri_manifest::get_sri_manifest_asset,
 };
 
@@ -1418,6 +1419,15 @@ impl AppEndpoint {
         } else {
             None
         };
+
+        // Compile any service workers registered via `navigator.serviceWorker.register(new
+        // URL(...), { scope })` reachable from this endpoint.
+        client_assets.extend(
+            service_worker_output_assets(project, *module_graphs.base)
+                .await?
+                .iter()
+                .copied(),
+        );
 
         let client_assets: ResolvedVc<OutputAssets> =
             ResolvedVc::cell(client_assets.into_iter().collect::<Vec<_>>());

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -25,5 +25,6 @@ pub mod project_asset_hashes_manifest;
 pub mod route;
 pub mod routes_hashes_manifest;
 mod server_actions;
+mod service_worker;
 mod sri_manifest;
 mod versioned_content_map;

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -13,7 +13,10 @@ use next_core::{
     mode::NextMode,
     next_app::{AppPage, AppPath},
     next_client::{
-        ClientChunkingContextOptions, get_client_chunking_context, get_client_compile_time_info,
+        ClientChunkingContextOptions, ClientContextType, ServiceWorkerChunkingContextOptions,
+        get_client_chunking_context, get_client_compile_time_info,
+        get_client_module_options_context, get_client_resolve_options_context,
+        get_service_worker_chunking_context,
     },
     next_config::{
         DIST_PROFILES_DIR_NAME, ModuleIds as ModuleIdStrategyConfig, NextConfig, OutputType,
@@ -1624,6 +1627,52 @@ impl Project {
             chunk_loading_global: self.next_config().turbopack_chunk_loading_global(),
             style_groups_algorithm: self.next_config().css_chunking().owned().await?,
         }))
+    }
+
+    #[turbo_tasks::function]
+    pub(super) async fn service_worker_chunking_context(
+        self: Vc<Self>,
+    ) -> Result<Vc<Box<dyn ChunkingContext>>> {
+        Ok(get_service_worker_chunking_context(
+            ServiceWorkerChunkingContextOptions {
+                mode: self.next_mode(),
+                root_path: self.project_root_path().owned().await?,
+                output_root: self.node_root().owned().await?,
+                output_root_to_root_path: self.node_root_to_root_path().owned().await?,
+                environment: self.client_compile_time_info().environment(),
+                minify: self.next_config().turbo_minify(self.next_mode()),
+                source_maps: self.next_config().client_source_maps(self.next_mode()),
+                no_mangling: self.no_mangling(),
+                hash_salt: self.next_config().output_hash_salt().to_resolved().await?,
+            },
+        ))
+    }
+
+    #[turbo_tasks::function]
+    pub(super) async fn service_worker_asset_context(
+        self: Vc<Self>,
+    ) -> Result<Vc<Box<dyn AssetContext>>> {
+        Ok(Vc::upcast(ModuleAssetContext::new(
+            TransitionOptions::default().cell(),
+            self.client_compile_time_info(),
+            get_client_module_options_context(
+                self.project_path().owned().await?,
+                self.execution_context(),
+                self.client_compile_time_info().environment(),
+                ClientContextType::Other,
+                self.next_mode(),
+                self.next_config(),
+                self.encryption_key(),
+            ),
+            get_client_resolve_options_context(
+                self.project_path().owned().await?,
+                ClientContextType::Other,
+                self.next_mode(),
+                self.next_config(),
+                self.execution_context(),
+            ),
+            Layer::new_with_user_friendly_name(rcstr!("service-worker"), rcstr!("Service Worker")),
+        )))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/service_worker.rs
+++ b/crates/next-api/src/service_worker.rs
@@ -1,0 +1,179 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, Vc};
+use turbo_tasks_fs::FileSystemPath;
+use turbopack_core::{
+    chunk::{ChunkingContext, EntryChunkGroupResult, availability_info::AvailabilityInfo},
+    context::AssetContext,
+    file_source::FileSource,
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
+    module::Module,
+    module_graph::{
+        ModuleGraph, SingleModuleGraph,
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+    },
+    output::{OutputAsset, OutputAssets},
+    reference_type::{EntryReferenceSubType, ReferenceType},
+    source::Source,
+};
+use turbopack_ecmascript::references::service_worker::{
+    ServiceWorkerEntryModule, service_worker_chunk_filename,
+};
+
+use crate::project::Project;
+
+/// Discovers every `navigator.serviceWorker.register(new URL(...), { scope })` registration
+/// reachable from `module_graph` — via the [`ServiceWorkerEntryModule`] markers the analyzer leaves
+/// in the graph — and compiles each registered worker into a single self-contained bundle.
+///
+/// Each is emitted under `node_root/service-worker/<scope-derived name>` (e.g.
+/// `service-worker/sw.js`, `service-worker/sw-offline-mode.js`) and served at the matching
+/// origin-root URL (`/sw.js`, `/sw-offline-mode.js`).
+///
+/// Only one service worker is supported per scope.
+#[turbo_tasks::function]
+pub async fn service_worker_output_assets(
+    project: Vc<Project>,
+    module_graph: Vc<ModuleGraph>,
+) -> Result<Vc<OutputAssets>> {
+    let mut by_scope: FxIndexMap<RcStr, FxIndexSet<FileSystemPath>> = FxIndexMap::default();
+    for layer in module_graph.iter_graphs().await?.iter() {
+        let layer = layer.connect();
+        for module in layer.await?.iter_reachable_modules()? {
+            if let Some(marker) = ResolvedVc::try_downcast_type::<ServiceWorkerEntryModule>(module)
+            {
+                let marker = marker.await?;
+                let path = marker.inner.ident().await?.path.clone();
+                by_scope
+                    .entry(marker.scope.clone())
+                    .or_default()
+                    .insert(path);
+            }
+        }
+    }
+
+    let mut assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = vec![];
+    for (scope, sources) in by_scope {
+        match sources.len() {
+            0 => {}
+            1 => {
+                let source = sources.into_iter().next().unwrap();
+                assets.push(
+                    service_worker_chunk(project, scope, source)
+                        .to_resolved()
+                        .await?,
+                );
+            }
+            _ => {
+                let file_path = sources.iter().next().unwrap().clone();
+                let mut files = sources
+                    .iter()
+                    .map(|path| path.path.clone())
+                    .collect::<Vec<_>>();
+                files.sort();
+                ConflictingServiceWorkersIssue {
+                    scope,
+                    files,
+                    file_path,
+                }
+                .resolved_cell()
+                .emit();
+            }
+        }
+    }
+
+    Ok(Vc::cell(assets))
+}
+
+/// Compiles a single service worker `source_path` (registered at `scope`) into one self-contained
+/// chunk emitted at `node_root/service-worker/<scope-derived name>`.
+#[turbo_tasks::function]
+async fn service_worker_chunk(
+    project: Vc<Project>,
+    scope: RcStr,
+    source_path: FileSystemPath,
+) -> Result<Vc<Box<dyn OutputAsset>>> {
+    let asset_context = project.service_worker_asset_context();
+    let chunking_context = project.service_worker_chunking_context();
+    let node_root = project.node_root().owned().await?;
+    let is_production = project.next_mode().await?.is_production();
+    let filename = service_worker_chunk_filename(&scope);
+
+    let source: Vc<Box<dyn Source>> = Vc::upcast(FileSource::new(source_path));
+    let module = asset_context
+        .process(source, ReferenceType::Entry(EntryReferenceSubType::Web))
+        .module()
+        .to_resolved()
+        .await?;
+
+    let own_graph = ModuleGraph::from_graphs(
+        vec![SingleModuleGraph::new_with_entry(
+            ChunkGroupEntry::Entry(vec![module]),
+            /* include_traced */ *project.should_write_nft_manifests().await?,
+            /* include_binding_usage */ is_production,
+        )],
+        /* binding_usage */ None,
+    )
+    .connect();
+
+    let EntryChunkGroupResult { asset, .. } = *chunking_context
+        .entry_chunk_group(
+            node_root.join("service-worker")?.join(&filename)?,
+            ChunkGroup::Entry(vec![module]),
+            own_graph,
+            /* extra_chunks */ OutputAssets::empty(),
+            /* extra_referenced_chunks */ OutputAssets::empty(),
+            AvailabilityInfo::root(),
+        )
+        .await?;
+    Ok(*asset)
+}
+
+/// Emitted when more than one service worker, with differing source files, is registered for the
+/// same scope. Each scope can only serve a single service worker.
+#[turbo_tasks::value(shared)]
+struct ConflictingServiceWorkersIssue {
+    scope: RcStr,
+    files: Vec<RcStr>,
+    file_path: FileSystemPath,
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl Issue for ConflictingServiceWorkersIssue {
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Multiple service workers registered for the same scope."
+        )))
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Text(
+                format!(
+                    "Multiple service workers with different source files were registered for \
+                     scope '{}'. Each scope serves a single service worker.",
+                    self.scope
+                )
+                .into(),
+            ),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("Registered source files: ")),
+                StyledString::Code(self.files.join(", ").into()),
+            ]),
+        ])))
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Error
+    }
+
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
+    }
+
+    fn stage(&self) -> IssueStage {
+        IssueStage::ProcessModule
+    }
+}

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -55,6 +55,7 @@ export type FsOutput = {
     | 'publicFolder'
     | 'nextStaticFolder'
     | 'legacyStaticFolder'
+    | 'serviceWorker'
     | 'devVirtualFsItem'
 
   itemPath: string
@@ -131,6 +132,7 @@ export async function setupFsCheck(opts: {
   const publicFolderItems = new Set<string>()
   const nextStaticFolderItems = new Set<string>()
   const legacyStaticFolderItems = new Set<string>()
+  const serviceWorkerItems = new Set<string>()
 
   const appFiles = new Set<string>()
   const pageFiles = new Set<string>()
@@ -153,6 +155,7 @@ export async function setupFsCheck(opts: {
   const publicFolderPath = path.join(opts.dir, 'public')
   const nextStaticFolderPath = path.join(distDir, 'static')
   const legacyStaticFolderPath = path.join(opts.dir, 'static')
+  const serviceWorkerFolderPath = path.join(distDir, 'service-worker')
   let customRoutes: UnwrapPromise<ReturnType<typeof loadCustomRoutes>> = {
     redirects: [],
     rewrites: {
@@ -214,6 +217,16 @@ export async function setupFsCheck(opts: {
       }
     } catch (err) {
       if (opts.config.output !== 'standalone') throw err
+    }
+
+    try {
+      for (const file of await recursiveReadDir(serviceWorkerFolderPath)) {
+        serviceWorkerItems.add(encodeURIPath(normalizePathSep(file)))
+      }
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') {
+        throw err
+      }
     }
 
     const routesManifestPath = path.join(distDir, ROUTES_MANIFEST)
@@ -425,6 +438,7 @@ export async function setupFsCheck(opts: {
   debug('customRoutes', customRoutes)
   debug('publicFolderItems', publicFolderItems)
   debug('nextStaticFolderItems', nextStaticFolderItems)
+  debug('serviceWorkerItems', serviceWorkerItems)
   debug('pageFiles', pageFiles)
   debug('appFiles', appFiles)
 
@@ -526,6 +540,7 @@ export async function setupFsCheck(opts: {
 
       const itemsToCheck: Array<[Set<string>, FsOutput['type']]> = [
         [this.devVirtualFsItems, 'devVirtualFsItem'],
+        [serviceWorkerItems, 'serviceWorker'],
         [nextStaticFolderItems, 'nextStaticFolder'],
         [legacyStaticFolderItems, 'legacyStaticFolder'],
         [publicFolderItems, 'publicFolder'],
@@ -649,6 +664,10 @@ export async function setupFsCheck(opts: {
               itemsRoot = publicFolderPath
               break
             }
+            case 'serviceWorker': {
+              itemsRoot = serviceWorkerFolderPath
+              break
+            }
             case 'appFile':
             case 'pageFile':
             case 'nextImage':
@@ -672,6 +691,7 @@ export async function setupFsCheck(opts: {
                 'nextStaticFolder',
                 'publicFolder',
                 'legacyStaticFolder',
+                'serviceWorker',
               ] as (typeof type)[]
             ).includes(type)
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -16,6 +16,7 @@ pub mod node;
 pub mod pattern_mapping;
 pub mod raw;
 pub mod require_context;
+pub mod service_worker;
 pub mod type_issue;
 pub mod typescript;
 pub mod unreachable;

--- a/turbopack/crates/turbopack-ecmascript/src/references/service_worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/service_worker.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
+use turbopack_core::{
+    chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext},
+    ident::AssetIdent,
+    module::{Module, ModuleSideEffects},
+    module_graph::ModuleGraph,
+    reference::ModuleReferences,
+    source::OptionSource,
+};
+
+use crate::chunk::{
+    EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports, ecmascript_chunk_item,
+};
+
+/// The root-served file name for a service worker registered at `scope`. One worker is supported
+/// **per scope**; the scope is encoded into the (flat, root-served) file name so distinct scopes
+/// get distinct files.
+///
+/// The human-readable slug is lossy (e.g. `/foo/bar` and `/foo-bar` both slugify to `foo-bar`), so
+/// a hash of the original scope is appended to guarantee distinct scopes get distinct file names.
+pub fn service_worker_chunk_filename(scope: &str) -> RcStr {
+    let trimmed = scope.trim_matches('/');
+    if trimmed.is_empty() {
+        return rcstr!("sw.js");
+    }
+    let slug: String = trimmed
+        .chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => c,
+            _ => '-',
+        })
+        .collect();
+    let hash = encode_hex(hash_xxh3_hash64(trimmed));
+    RcStr::from(format!("sw-{slug}-{hash}.js"))
+}
+
+/// A marker module that wraps a service-worker entry source plus its registration `scope`. It
+/// carries the inner source so `next-api` can discover it in the module graph and compile it
+/// standalone.
+#[turbo_tasks::value(shared)]
+pub struct ServiceWorkerEntryModule {
+    pub inner: ResolvedVc<Box<dyn Module>>,
+    pub scope: RcStr,
+}
+
+#[turbo_tasks::value_impl]
+impl Module for ServiceWorkerEntryModule {
+    #[turbo_tasks::function]
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .inner
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(format!("service worker entry [{}]", self.scope).into())
+            .into_vc())
+    }
+
+    #[turbo_tasks::function]
+    fn source(&self) -> Vc<OptionSource> {
+        Vc::cell(None)
+    }
+
+    #[turbo_tasks::function]
+    fn references(&self) -> Vc<ModuleReferences> {
+        Vc::cell(vec![])
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::ModuleEvaluationIsSideEffectFree.cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModule for ServiceWorkerEntryModule {
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        ecmascript_chunk_item(ResolvedVc::upcast(self), module_graph, chunking_context)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for ServiceWorkerEntryModule {
+    #[turbo_tasks::function]
+    fn get_exports(&self) -> Vc<EcmascriptExports> {
+        EcmascriptExports::None.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn chunk_item_content(
+        &self,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _async_module_info: Option<Vc<AsyncModuleInfo>>,
+        _estimated: bool,
+    ) -> Vc<EcmascriptChunkItemContent> {
+        // Marker module: contributes no code to the page bundle.
+        EcmascriptChunkItemContent::default().cell()
+    }
+}


### PR DESCRIPTION
This is the big change in the `next-` part of the repo to support this. The code goes through the module graph to find any service workers that need compiling and then compiles them. It also has the code changes to `packages/next/src/server/lib/router-utils/filesystem.ts` that serve these files on their respective routes.