### PR TITLE
[turbopack] Discover service workers in the Turbopack analyzer

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/kinds.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/kinds.rs
@@ -36,6 +36,10 @@ pub enum WellKnownObjectKind {
     Generator,
     /// The `module.hot` object providing HMR API.
     ModuleHot,
+    /// The browser `navigator` global.
+    Navigator,
+    /// The `navigator.serviceWorker` container (`ServiceWorkerContainer`).
+    NavigatorServiceWorker,
 }
 
 impl WellKnownObjectKind {
@@ -137,6 +141,14 @@ impl WellKnownObjectKind {
             ),
             Self::ImportMeta => ("import.meta", "The import.meta object"),
             Self::ModuleHot => ("module.hot", "The module.hot HMR API"),
+            Self::Navigator => (
+                "navigator",
+                "The browser navigator global: https://developer.mozilla.org/en-US/docs/Web/API/Navigator",
+            ),
+            Self::NavigatorServiceWorker => (
+                "navigator.serviceWorker",
+                "The ServiceWorkerContainer: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer",
+            ),
         }
     }
 }
@@ -187,6 +199,8 @@ pub enum WellKnownFunctionKind<'a> {
     SharedWorkerConstructor,
     // The worker_threads Worker class
     NodeWorkerConstructor,
+    /// `navigator.serviceWorker.register(scriptURL, options?)`
+    ServiceWorkerRegister,
     URLConstructor,
     /// `module.hot.accept(deps, callback, errorHandler)` — accept HMR updates for dependencies.
     ModuleHotAccept,
@@ -357,6 +371,10 @@ impl WellKnownFunctionKind<'_> {
             Self::SharedWorkerConstructor => (
                 "SharedWorker".to_string(),
                 "The standard SharedWorker constructor: https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/SharedWorker",
+            ),
+            Self::ServiceWorkerRegister => (
+                "navigator.serviceWorker.register".to_string(),
+                "The ServiceWorkerContainer.register method: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register",
             ),
             Self::URLConstructor => (
                 "URL".to_string(),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/mod.rs
@@ -747,6 +747,28 @@ async fn well_known_object_member<'a>(
                 ));
             }
         },
+        WellKnownObjectKind::Navigator => match prop.as_str() {
+            Some("serviceWorker") => {
+                JsValue::WellKnownObject(WellKnownObjectKind::NavigatorServiceWorker)
+            }
+            _ => {
+                return Ok((
+                    JsValue::member(arena.get_or_default(), JsValue::WellKnownObject(kind), prop),
+                    false,
+                ));
+            }
+        },
+        WellKnownObjectKind::NavigatorServiceWorker => match prop.as_str() {
+            Some("register") => {
+                JsValue::WellKnownFunction(WellKnownFunctionKind::ServiceWorkerRegister)
+            }
+            _ => {
+                return Ok((
+                    JsValue::member(arena.get_or_default(), JsValue::WellKnownObject(kind), prop),
+                    false,
+                ));
+            }
+        },
         #[allow(unreachable_patterns)]
         _ => {
             return Ok((

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -38,6 +38,7 @@ use crate::{
         import_meta_glob::ImportMetaGlobAssetReferenceCodeGen,
         member::MemberReplacement,
         require_context::RequireContextAssetReferenceCodeGen,
+        service_worker::ServiceWorkerAssetReferenceCodeGen,
         unreachable::Unreachable,
         worker::{WorkerAssetReferenceCodeGen, WorkerGlobalsReplacementCodeGen},
     },
@@ -202,6 +203,7 @@ pub enum CodeGen {
     RequireContextAssetReferenceCodeGen(RequireContextAssetReferenceCodeGen),
     UrlAssetReferenceCodeGen(UrlAssetReferenceCodeGen),
     WorkerAssetReferenceCodeGen(WorkerAssetReferenceCodeGen),
+    ServiceWorkerAssetReferenceCodeGen(ServiceWorkerAssetReferenceCodeGen),
     ModuleHotReferenceCodeGen(ModuleHotReferenceCodeGen),
     WorkerGlobalsReplacementCodeGen(WorkerGlobalsReplacementCodeGen),
 }
@@ -237,6 +239,7 @@ impl CodeGen {
             Self::RequireContextAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
             Self::UrlAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
             Self::WorkerAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
+            Self::ServiceWorkerAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
             Self::ModuleHotReferenceCodeGen(v) => {
                 v.code_generation(ctx, scope_hoisting_context).await
             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -41,6 +41,7 @@ use num_traits::Zero;
 use parking_lot::Mutex;
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
+use service_worker::ServiceWorkerAssetReference;
 use swc_core::{
     atoms::{Atom, Wtf8Atom, atom},
     common::{
@@ -2990,6 +2991,85 @@ where
                 }
             }
         }
+        WellKnownFunctionKind::ServiceWorkerRegister => {
+            let args = linked_args().await?;
+            if let Some(url @ JsValue::Url(_, JsValueUrlKind::Relative)) = args.first() {
+                let pat = js_value_to_pattern(url);
+                if !pat.has_constant_parts() {
+                    let (args, hints) = explain_args(args);
+                    handler.span_warn_with_code(
+                        span,
+                        &format!(
+                            "navigator.serviceWorker.register({args}) is very dynamic{hints}",
+                        ),
+                        DiagnosticId::Lint(
+                            errors::failed_to_analyze::ecmascript::NEW_WORKER.to_string(),
+                        ),
+                    );
+                    if ignore_dynamic_requests {
+                        return Ok(());
+                    }
+                }
+
+                if *compile_time_info.environment().rendering().await? == Rendering::Client {
+                    let error_mode = if in_try {
+                        ResolveErrorMode::Warn
+                    } else {
+                        ResolveErrorMode::Error
+                    };
+                    // A static `scope` option selects the served file name (one worker per
+                    // scope). Defaults to "/" (served at /sw.js).
+                    let scope: RcStr = match args.get(1) {
+                        Some(JsValue::Object { parts, .. }) => {
+                            let scope_value = parts.iter().find_map(|part| match part {
+                                ObjectPart::KeyValue(
+                                    JsValue::Constant(JsConstantValue::Str(key)),
+                                    value,
+                                ) if key.as_str() == "scope" => Some(value),
+                                _ => None,
+                            });
+                            match scope_value {
+                                // No `scope` key: register at the default scope.
+                                None => rcstr!("/"),
+                                Some(JsValue::Constant(JsConstantValue::Str(value))) => {
+                                    value.as_str().into()
+                                }
+                                // A `scope` was provided but can't be analyzed statically;
+                                // don't silently register at the wrong scope.
+                                Some(_) => {
+                                    let (args, hints) = explain_args(args);
+                                    handler.span_warn_with_code(
+                                        span,
+                                        &format!(
+                                            "navigator.serviceWorker.register({args}) has a \
+                                             `scope` that is not statically analyze-able{hints}",
+                                        ),
+                                        DiagnosticId::Error(
+                                            errors::failed_to_analyze::ecmascript::NEW_WORKER
+                                                .to_string(),
+                                        ),
+                                    );
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        // No options argument: register at the default scope.
+                        _ => rcstr!("/"),
+                    };
+                    analysis.add_reference_code_gen(
+                        ServiceWorkerAssetReference::new(
+                            origin,
+                            Request::parse(pat).to_resolved().await?,
+                            scope,
+                            issue_source(source, span),
+                            error_mode,
+                        ),
+                        ast_path.to_vec().into(),
+                    );
+                }
+            }
+            return Ok(());
+        }
         _ => {}
     };
     Ok(())
@@ -3650,6 +3730,7 @@ async fn value_visitor_inner<'a>(
             "process" => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessModule),
             "Object" => JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject),
             "Buffer" => JsValue::WellKnownObject(WellKnownObjectKind::NodeBuffer),
+            "navigator" => JsValue::WellKnownObject(WellKnownObjectKind::Navigator),
             _ => return Ok((v, false)),
         },
         JsValue::Module(ref mv) => compile_time_info

--- a/turbopack/crates/turbopack-ecmascript/src/references/service_worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/service_worker.rs
@@ -1,18 +1,38 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
+use swc_core::{
+    ecma::ast::{Expr, ExprOrSpread, Lit},
+    quote_expr,
+};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{
+    NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    turbofmt,
+};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use turbopack_core::{
-    chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext},
+    chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType},
     ident::AssetIdent,
+    issue::IssueSource,
     module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
-    reference::ModuleReferences,
+    reference::{ModuleReference, ModuleReferences},
+    reference_type::{ReferenceType, WorkerReferenceSubType},
+    resolve::{
+        ModuleResolveResult, ModuleResolveResultItem, ResolveErrorMode, origin::ResolveOrigin,
+        parse::Request, url_resolve,
+    },
     source::OptionSource,
 };
 
-use crate::chunk::{
-    EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports, ecmascript_chunk_item,
+use crate::{
+    chunk::{
+        EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports,
+        ecmascript_chunk_item,
+    },
+    code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
+    create_visitor,
+    references::AstPath,
 };
 
 /// The root-served file name for a service worker registered at `scope`. One worker is supported
@@ -104,5 +124,165 @@ impl EcmascriptChunkPlaceable for ServiceWorkerEntryModule {
     ) -> Vc<EcmascriptChunkItemContent> {
         // Marker module: contributes no code to the page bundle.
         EcmascriptChunkItemContent::default().cell()
+    }
+}
+
+/// Reference created for `navigator.serviceWorker.register(new URL(...), { scope })`. It resolves
+/// the URL to the service-worker source and wraps it in a [`ServiceWorkerEntryModule`] (carrying
+/// the `scope`) so the source is discoverable in the page's module graph (but not bundled into it).
+#[turbo_tasks::value]
+#[derive(Hash, Debug)]
+pub struct ServiceWorkerAssetReference {
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    request: ResolvedVc<Request>,
+    scope: RcStr,
+    issue_source: IssueSource,
+    error_mode: ResolveErrorMode,
+}
+
+impl ServiceWorkerAssetReference {
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        scope: RcStr,
+        issue_source: IssueSource,
+        error_mode: ResolveErrorMode,
+    ) -> Self {
+        ServiceWorkerAssetReference {
+            origin,
+            request,
+            scope,
+            issue_source,
+            error_mode,
+        }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ModuleReference for ServiceWorkerAssetReference {
+    #[turbo_tasks::function]
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        let result = url_resolve(
+            *self.origin,
+            *self.request,
+            ReferenceType::Worker(WorkerReferenceSubType::ServiceWorker),
+            Some(self.issue_source),
+            self.error_mode,
+        );
+
+        let result_ref = result.await?;
+        let mut primary = Vec::with_capacity(result_ref.primary.len());
+        for (request_key, item) in result_ref.primary.iter() {
+            match item {
+                ModuleResolveResultItem::Module(module) => {
+                    let marker = ServiceWorkerEntryModule {
+                        inner: *module,
+                        scope: self.scope.clone(),
+                    }
+                    .resolved_cell();
+                    primary.push((
+                        request_key.clone(),
+                        ModuleResolveResultItem::Module(ResolvedVc::upcast(marker)),
+                    ));
+                }
+                _ => primary.push((request_key.clone(), item.clone())),
+            }
+        }
+
+        Ok(ModuleResolveResult {
+            primary: primary.into_boxed_slice(),
+            affecting_sources: result_ref.affecting_sources.clone(),
+        }
+        .cell())
+    }
+
+    fn chunking_type(&self) -> Option<ChunkingType> {
+        // Keep the marker in the page graph (so it is discoverable) without making it
+        // an async/isolated boundary. It emits no code, so it adds nothing to the bundle.
+        Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        })
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.issue_source)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for ServiceWorkerAssetReference {
+    #[turbo_tasks::function]
+    async fn to_string(&self) -> Result<Vc<RcStr>> {
+        let request = self.request.to_string();
+        Ok(Vc::cell(turbofmt!("service worker {request}").await?))
+    }
+}
+
+impl IntoCodeGenReference for ServiceWorkerAssetReference {
+    fn into_code_gen_reference(
+        self,
+        path: AstPath,
+    ) -> (ResolvedVc<Box<dyn ModuleReference>>, CodeGen) {
+        let scope = self.scope.clone();
+        let reference = self.resolved_cell();
+        (
+            ResolvedVc::upcast(reference),
+            CodeGen::ServiceWorkerAssetReferenceCodeGen(ServiceWorkerAssetReferenceCodeGen {
+                scope,
+                path,
+            }),
+        )
+    }
+}
+
+#[derive(
+    PartialEq, Eq, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug, Encode, Decode,
+)]
+pub struct ServiceWorkerAssetReferenceCodeGen {
+    scope: RcStr,
+    path: AstPath,
+}
+
+impl ServiceWorkerAssetReferenceCodeGen {
+    pub async fn code_generation(
+        &self,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Result<CodeGeneration> {
+        // The worker is served at a fixed, root-scoped URL derived from its `scope`. Rewrite the
+        // `new URL(...)` script argument to that URL string.
+        let url = format!("/{}", service_worker_chunk_filename(&self.scope));
+
+        let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
+            let message = if let Expr::Call(call_expr) = expr {
+                match call_expr.args.first_mut() {
+                    Some(ExprOrSpread {
+                        spread: None,
+                        expr: url_expr,
+                    }) => {
+                        **url_expr = Expr::Lit(Lit::Str(url.as_str().into()));
+                        return;
+                    }
+                    Some(ExprOrSpread {
+                        spread: Some(_), ..
+                    }) => "spread operator is illegal in navigator.serviceWorker.register().",
+                    None => "navigator.serviceWorker.register() requires at least 1 argument",
+                }
+            } else {
+                "visitor must be executed on a CallExpr"
+            };
+            *expr = *quote_expr!(
+                "(() => { throw new Error($message); })()",
+                message: Expr = Expr::Lit(Lit::Str(message.into()))
+            );
+        });
+
+        Ok(CodeGeneration::visitors(vec![visitor]))
+    }
+}
+
+impl From<ServiceWorkerAssetReferenceCodeGen> for CodeGen {
+    fn from(val: ServiceWorkerAssetReferenceCodeGen) -> Self {
+        CodeGen::ServiceWorkerAssetReferenceCodeGen(val)
     }
 }


### PR DESCRIPTION
This PR is the PR that "turns on" the service worker feature, this is because in the analyzer we are now looking for code like:

```
await navigator.serviceWorker.register(new URL('../lib/service-workers/1.js', import.meta.url), ...)
```

And transforms it into registering the URL that Next.js will now serve based on scope.

URL scheme is:

```
scope: "/" -> `sw.js`
scope: "/offline/mode" -> `sw-offline-mode.js`
```

etc.

It also inserts the `ServiceWorkerEntryModule`s so they can be discovered by `next-api` (see https://github.com/vercel/next.js/pull/94922).