### PR TITLE
[CC] Remove invariant breaking output: export

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1365,5 +1365,6 @@
   "1364": "\\`experimental.turbopackRustReactCompiler\\` requires \\`reactCompiler\\` to be enabled. Please add \\`reactCompiler: true\\` in %s.",
   "1365": "Expected a dev tiered cache handler for kind \"%s\".",
   "1366": "Turbopack build failed with %s %s:\\n%s",
-  "1367": "createServerParamsForRoute should not be called in runtime prerenders."
+  "1367": "createServerParamsForRoute should not be called in runtime prerenders.",
+  "1368": "Route \"%s\" could not be statically exported because it uses dynamic or uncached data.\\n\"output: export\" requires every route to be fully prerendered at build time. Cache the data it reads with \"use cache\", or remove \"output: export\" if the route needs to be dynamic."
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3267,6 +3267,24 @@ export default async function build(
                 appConfig.revalidate
               )
 
+              // `output: export` has no server, so every route must fully
+              // prerender at build time. A dynamic bailout (revalidate === 0),
+              // a postponed shell, or an empty shell all mean the route still
+              // needs request-time work, so fail the build and name the route.
+              if (
+                config.output === 'export' &&
+                config.cacheComponents &&
+                (cacheControl.revalidate === 0 ||
+                  hasPostponed ||
+                  hasEmptyStaticShell)
+              ) {
+                throw new Error(
+                  `Route "${route.pathname}" could not be statically exported because it uses dynamic or uncached data.\n` +
+                    `"output: export" requires every route to be fully prerendered at build time. ` +
+                    `Cache the data it reads with "use cache", or remove "output: export" if the route needs to be dynamic.`
+                )
+              }
+
               // Generated concrete paths (for example `/blog/post-1`) inherit
               // the route-level classification from the dynamic page
               // (`/blog/[slug]`), but they also need their own export-time

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -879,12 +879,6 @@ async function exportAppImpl(
     }
   }
 
-  // Export mode provide static outputs that are not compatible with PPR mode.
-  if (!options.buildExport && nextConfig.experimental.ppr) {
-    // TODO: add message
-    throw new Error('Invariant: PPR cannot be enabled in export mode')
-  }
-
   // copy prerendered routes to outDir
   if (!options.buildExport && prerenderManifest) {
     await Promise.all(

--- a/test/e2e/app-dir/cache-components-output-export-error/app/dynamic-route/route.ts
+++ b/test/e2e/app-dir/cache-components-output-export-error/app/dynamic-route/route.ts
@@ -1,0 +1,12 @@
+import { setTimeout } from 'timers/promises'
+
+// Opts into static generation (generateStaticParams) but does uncached async
+// work that isn't wrapped in `use cache`, so it can't be fully prerendered.
+export function generateStaticParams() {
+  return [{}]
+}
+
+export async function GET() {
+  await setTimeout(50)
+  return new Response('dynamic')
+}

--- a/test/e2e/app-dir/cache-components-output-export-error/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-output-export-error/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-output-export-error/app/page.tsx
+++ b/test/e2e/app-dir/cache-components-output-export-error/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>static shell</p>
+}

--- a/test/e2e/app-dir/cache-components-output-export-error/cache-components-output-export-error.test.ts
+++ b/test/e2e/app-dir/cache-components-output-export-error/cache-components-output-export-error.test.ts
@@ -1,0 +1,23 @@
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+
+describe('cache-components-output-export-error', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  it('fails the build, naming the route, when a route cannot be fully prerendered', async () => {
+    if (!isNextStart) {
+      // The enforcement is a build-time concern; nothing to assert in dev.
+      return
+    }
+
+    const { exitCode, cliOutput } = await next.build()
+
+    expect(cliOutput).toContain(
+      'Route "/dynamic-route" could not be statically exported because it uses dynamic or uncached data.'
+    )
+    expect(exitCode).toBe(1)
+  })
+})

--- a/test/e2e/app-dir/cache-components-output-export-error/next.config.js
+++ b/test/e2e/app-dir/cache-components-output-export-error/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  output: 'export',
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/cache-components-output-export/app/feed/route.ts
+++ b/test/e2e/app-dir/cache-components-output-export/app/feed/route.ts
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{}]
+}
+
+async function getFeed() {
+  'use cache'
+  return 'feed-body'
+}
+
+export async function GET() {
+  return new Response(await getFeed())
+}

--- a/test/e2e/app-dir/cache-components-output-export/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-output-export/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-output-export/app/page.tsx
+++ b/test/e2e/app-dir/cache-components-output-export/app/page.tsx
@@ -1,0 +1,8 @@
+async function getMessage() {
+  'use cache'
+  return 'hello from cache'
+}
+
+export default async function Page() {
+  return <p>{await getMessage()}</p>
+}

--- a/test/e2e/app-dir/cache-components-output-export/cache-components-output-export.test.ts
+++ b/test/e2e/app-dir/cache-components-output-export/cache-components-output-export.test.ts
@@ -1,0 +1,27 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+import { existsSync, readFileSync } from 'fs'
+
+describe('cache-components-output-export', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  it('builds and statically exports a cached page and route handler', async () => {
+    if (!isNextStart) {
+      // output: export is a build-time concern; nothing to assert in dev.
+      return
+    }
+
+    const { exitCode } = await next.build()
+    expect(exitCode).toBe(0)
+
+    const out = join(next.testDir, 'out')
+    expect(readFileSync(join(out, 'index.html'), 'utf8')).toContain(
+      'hello from cache'
+    )
+    expect(existsSync(join(out, 'feed'))).toBe(true)
+  })
+})

--- a/test/e2e/app-dir/cache-components-output-export/next.config.js
+++ b/test/e2e/app-dir/cache-components-output-export/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  output: 'export',
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -10,12 +10,6 @@ describe('use-cache-output-export', () => {
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
 
-  if (process.env.__NEXT_CACHE_COMPONENTS === 'true') {
-    return it.skip('for PPR', () => {
-      // PPR is not compatible with `output: 'export'`.
-    })
-  }
-
   it('should work', async () => {
     let html: string
     let server: Server | undefined


### PR DESCRIPTION
This removes the invariant that caused `output: 'export'` to not work with `cacheComponents` at all.

The intention is to enable it for things that are actually fully static, or to err otherwise.

A similar patch got my blog running, though I haven't tried rebuilding Next from source.