### PR TITLE
docs: clarify sequential data fetching example

### DIFF
--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -374,7 +374,7 @@ export default function BlogPage() {
 
 Sequential data fetching happens when one request depends on data from another.
 
-For example, `<Playlists>` can only fetch data after `<Artist>` completes because it needs the `artistID`:
+For example, `<Playlists>` can only fetch data after `getArtist()` resolves because it needs the `artistID`:
 
 ```tsx filename="app/artist/[username]/page.tsx" switcher
 export default async function Page({


### PR DESCRIPTION
Replace the incorrect `<Artist>` reference with `getArtist()` to clarify the dependency in the sequential fetching example.

### What?
Replace the incorrect <Artist> reference with getArtist().

### Why?
To accurately describe the sequential data dependency.

### How?
Update the wording in the data-fetching documentation.

