### PR TITLE
docs: fix broken Node.js inspector URL in debugging guide

### DIFF
--- a/docs/01-app/02-guides/debugging.mdx
+++ b/docs/01-app/02-guides/debugging.mdx
@@ -137,7 +137,7 @@ Launching the Next.js server with the `--inspect` flag will look something like 
 
 ```bash filename="Terminal"
 Debugger listening on ws://127.0.0.1:9229/0cf90313-350d-4466-a748-cd60f4e47c95
-For help, see: https://nodejs.org/api/inspector.html
+For help, see: https://nodejs.org/learn/getting-started/debugging
 ready - started server on 0.0.0.0:3000, url: http://localhost:3000
 ```
 

--- a/docs/01-app/02-guides/debugging.mdx
+++ b/docs/01-app/02-guides/debugging.mdx
@@ -137,7 +137,7 @@ Launching the Next.js server with the `--inspect` flag will look something like 
 
 ```bash filename="Terminal"
 Debugger listening on ws://127.0.0.1:9229/0cf90313-350d-4466-a748-cd60f4e47c95
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/api/inspector.html
 ready - started server on 0.0.0.0:3000, url: http://localhost:3000
 ```
 


### PR DESCRIPTION
## What

Updates one broken URL in the debugging guide that returns 404.

```diff
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/api/inspector.html
```

The old path (`/en/docs/inspector`) no longer exists after Node.js restructured their documentation site. The replacement points to the current Node.js Inspector API docs which returns 200.

## Why

This URL appears inside a terminal output code block showing what the Node.js debugger prints when launched with `--inspect`. A reader who follows the link to learn more about the inspector gets a 404.

A related fix for the separate Debugging Guide link (`/en/docs/guides/debugging-getting-started`) is tracked in #93958. This PR addresses the second broken Node.js URL in the same file that #93958 did not cover.

## Checklist

- [x] Docs-only change. No behavior impact.
- [x] Replacement URL verified to return HTTP 200.

<!-- NEXT_JS_LLM_PR -->