### PR TITLE
[test] Enable `metadata-streaming-config` for Cache Components

### DIFF
--- a/test/production/app-dir/metadata-streaming-config/app/dynamic/page.tsx
+++ b/test/production/app-dir/metadata-streaming-config/app/dynamic/page.tsx
@@ -1,6 +1,0 @@
-import { connection } from 'next/server'
-
-export default async function Page() {
-  await connection()
-  return <p>dynamic</p>
-}

--- a/test/production/app-dir/metadata-streaming-config/app/ppr/layout.tsx
+++ b/test/production/app-dir/metadata-streaming-config/app/ppr/layout.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
 
-export default function Root({ children }) {
+export default function Root({ children }: { children: React.ReactNode }) {
   return <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
 }

--- a/test/production/app-dir/metadata-streaming-config/app/ppr/page.tsx
+++ b/test/production/app-dir/metadata-streaming-config/app/ppr/page.tsx
@@ -1,8 +1,8 @@
 import { connection } from 'next/server'
 
+export const instant = false
+
 export default async function Page() {
   await connection()
   return <p>ppr</p>
 }
-
-export const experimental_ppr = true

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO: the incremental option has been removed, update to use cacheComponents
-describe.skip('app-dir - metadata-streaming-config-customized', () => {
+describe('app-dir - metadata-streaming-config-customized', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     overrideFiles: {
       'next.config.js': `
         module.exports = {
           htmlLimitedBots: /MyBot/i,
-            experimental: {
-            ppr: 'incremental',
-          }
+          cacheComponents: true,
         }
       `,
     },
@@ -32,6 +29,21 @@ describe.skip('app-dir - metadata-streaming-config-customized', () => {
 
     expect(bypassConfigs).toMatchInlineSnapshot(`
      {
+       "/": {
+         "key": "user-agent",
+         "type": "header",
+         "value": "MyBot",
+       },
+       "/_global-error": {
+         "key": "user-agent",
+         "type": "header",
+         "value": "MyBot",
+       },
+       "/_not-found": {
+         "key": "user-agent",
+         "type": "header",
+         "value": "MyBot",
+       },
        "/ppr": {
          "key": "user-agent",
          "type": "header",

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config.test.ts
@@ -1,7 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO: the incremental option has been removed, update to use cacheComponents
-describe.skip('app-dir - metadata-streaming-config', () => {
+describe('app-dir - metadata-streaming-config', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
@@ -36,6 +35,21 @@ describe.skip('app-dir - metadata-streaming-config', () => {
 
     expect(bypassConfigs).toMatchInlineSnapshot(`
      {
+       "/": {
+         "key": "user-agent",
+         "type": "header",
+         "value": "[\\w-]+-Google|Google-[\\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight",
+       },
+       "/_global-error": {
+         "key": "user-agent",
+         "type": "header",
+         "value": "[\\w-]+-Google|Google-[\\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight",
+       },
+       "/_not-found": {
+         "key": "user-agent",
+         "type": "header",
+         "value": "[\\w-]+-Google|Google-[\\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight",
+       },
        "/ppr": {
          "key": "user-agent",
          "type": "header",

--- a/test/production/app-dir/metadata-streaming-config/next.config.js
+++ b/test/production/app-dir/metadata-streaming-config/next.config.js
@@ -2,9 +2,7 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  experimental: {
-    ppr: 'incremental',
-  },
+  cacheComponents: true,
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Less coverage than before we disabled the tests.
But better than not testing at all.

Last mention of `experimental_ppr` in our tests.