### PR TITLE
docs: clarify caching behavior for `fetch` with `POST`

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/fetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/fetch.mdx
@@ -94,6 +94,17 @@ fetch(url, { signal })
 
 > **Good to know**: Memoization does not apply in [Route Handlers](/docs/app/api-reference/file-conventions/route), since they are not part of the React component tree.
 
+## Caching `POST` requests
+
+A `POST` request can also be cached, but only when you explicitly opt in. A fetch response is stored in the Data Cache only if **all** of the following conditions are met:
+
+- It runs on the server (Server Component, Route Handler, or Server Action)
+- [Draft Mode](/docs/app/guides/draft-mode) is not enabled
+- You explicitly opt in with `cache: 'force-cache'`, with `next: { revalidate: N }` where `N > 0` (or `false` for indefinite caching) or `next: { tags: [tags] }`
+- The response status is `200`
+
+The cache key includes the URL, method, headers, mode, redirect, credentials, referrer, referrerPolicy, integrity, `cache`, and the request **body**. Two `POST` requests with different payloads are stored as separate entries.
+
 ## Troubleshooting
 
 ### Fetch default `auto no store` and `cache: 'no-store'` not showing fresh data in development


### PR DESCRIPTION
### What

Clarify in the [fetch](https://nextjs.org/docs/app/api-reference/functions/fetch) documentation that `POST` requests can be stored in the Data Cache when caching is explicitly enabled.

Related:
https://github.com/vercel/next.js/discussions/94888

### Why

The current documentation does not make this behavior obvious, which can lead to confusion about whether `POST` requests are cacheable.

### How

Add a note and example demonstrating that `POST` requests can be written to the Data Cache when all caching requirements are met.

@icyJoseph 
If any changes are needed, please let me know and I'll be happy to update the PR.