### PR TITLE
fix(lru-cache): include URL key length in getItemsLru size accounting

### DIFF
--- a/packages/next/src/server/lib/lru-cache.ts
+++ b/packages/next/src/server/lib/lru-cache.ts
@@ -49,12 +49,14 @@ export class LRUCache<T> {
   private readonly tail: SentinelNode<T>
   private totalSize: number = 0
   private readonly maxSize: number
-  private readonly calculateSize: ((value: T) => number) | undefined
+  private readonly calculateSize:
+    | ((value: T, key: string) => number)
+    | undefined
   private readonly onEvict: ((key: string, value: T) => void) | undefined
 
   constructor(
     maxSize: number,
-    calculateSize?: (value: T) => number,
+    calculateSize?: (value: T, key: string) => number,
     onEvict?: (key: string, value: T) => void
   ) {
     this.maxSize = maxSize
@@ -124,7 +126,7 @@ export class LRUCache<T> {
    * - O(k) where k is the number of items evicted (can be O(N) for variable sizes)
    */
   public set(key: string, value: T): boolean {
-    const size = this.calculateSize?.(value) ?? 1
+    const size = this.calculateSize?.(value, key) ?? 1
     if (size <= 0) {
       throw new Error(
         `LRUCache: calculateSize returned ${size}, but size must be > 0. ` +

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -113,12 +113,14 @@ export async function setupFsCheck(opts: {
   config: NextConfigRuntime
 }) {
   const getItemsLru = !opts.dev
-    ? new LRUCache<FsOutput | null>(1024 * 1024, function length(value) {
+    ? new LRUCache<FsOutput | null>(1024 * 1024, function length(value, key) {
         if (!value) {
-          // Null entries (negative cache) still need a non-zero size for LRU eviction
-          return 1
+          // Null entries (negative cache) still need a non-zero size for LRU eviction.
+          // Include the URL key length to accurately account for heap usage.
+          return 1 + key.length
         }
         return (
+          key.length +
           (value.fsPath || '').length +
           value.itemPath.length +
           value.type.length


### PR DESCRIPTION
## What?

The `calculateSize` callback in `LRUCache` only received the cached value, omitting the key (URL string). In the filesystem router, the URL key – which can be long in path-heavy apps – was never counted toward the cache's memory budget.

## Why?

This causes under-eviction: the LRU cache believes entries are smaller than they really are, so it evicts too infrequently, leading to excessive heap retention in long-lived servers handling many unique URLs.

## How?

1. **`lru-cache.ts`** — Extend the `calculateSize` callback signature to pass `key` as a second argument. This is fully backward-compatible: all existing callers that only use `value` continue to work unchanged (TypeScript allows functions with fewer parameters to satisfy a type requiring more).

2. **`filesystem.ts`** — Update the `getItemsLru` size function to include `key.length` for both positive cache entries and negative (null) entries, so the full URL string is counted toward the cache budget.

Fixes #94890