### PR TITLE
fix(router): preserve scroll:false across async PPR retry navigations (force-dynamic)

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -16,6 +16,7 @@ import type { NavigationLockState } from '../segment-cache/navigation-testing-lo
 import { createHrefFromUrl } from './create-href-from-url'
 import { fetchServerResponse } from './fetch-server-response'
 import { dispatchAppRouterAction } from '../use-action-queue'
+import type { ScrollBehavior } from './router-reducer-types'
 import {
   ACTION_SERVER_PATCH,
   type ServerPatchAction,
@@ -1417,6 +1418,9 @@ export function spawnDynamicRequests(
   // transition hasn't committed yet.
   navigateType: 'push' | 'replace',
   navigationLock: NavigationLock,
+  // The original navigation's scroll behavior. Threaded through to preserve
+  // scroll: false across async PPR retry navigations.
+  scrollBehavior: ScrollBehavior,
   signal: AbortSignal | undefined
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
@@ -1512,7 +1516,8 @@ export function spawnDynamicRequests(
     primaryRequestPromise,
     refreshRequestPromises,
     routeCacheEntry,
-    navigateType
+    navigateType,
+    scrollBehavior
   )
   // `finishNavigationTask` is responsible for error handling, so we can attach
   // noop callbacks to this promise.
@@ -1527,7 +1532,8 @@ async function finishNavigationTask(
     ReturnType<typeof fetchMissingDynamicData>
   > | null,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  scrollBehavior: ScrollBehavior
 ): Promise<void> {
   // Wait for all the requests to finish, or for the first one to fail.
   let exitStatus = await waitForRequestsToFinish(
@@ -1575,6 +1581,7 @@ async function finishNavigationTask(
         task.route,
         routeCacheEntry,
         navigateType,
+        scrollBehavior,
         FreshnessPolicy.RefreshAll
       )
       return
@@ -1594,6 +1601,7 @@ async function finishNavigationTask(
         task.route,
         routeCacheEntry,
         navigateType,
+        scrollBehavior,
         FreshnessPolicy.HistoryTraversal
       )
       return
@@ -1617,6 +1625,7 @@ async function finishNavigationTask(
         task.route,
         routeCacheEntry,
         navigateType,
+        scrollBehavior,
         FreshnessPolicy.RefreshAll
       )
       return
@@ -1688,6 +1697,9 @@ function dispatchRetryDueToTreeMismatch(
   routeCacheEntry: FulfilledRouteCacheEntry | null,
   // The original navigation's push/replace intent.
   originalNavigateType: 'push' | 'replace',
+  // The original navigation's scroll behavior. Threaded through to preserve
+  // scroll: false across async PPR retry navigations.
+  originalScrollBehavior: ScrollBehavior,
   // Freshness policy for the retry navigation. `RefreshAll` re-fetches the
   // tree's dynamic data (used for genuine tree mismatches). `HistoryTraversal`
   // reuses the data already in the tree (used when only the URL needs
@@ -1762,6 +1774,7 @@ function dispatchRetryDueToTreeMismatch(
     seed,
     mpa: isHardRetry,
     navigateType: retryNavigateType,
+    scrollBehavior: originalScrollBehavior,
     freshnessPolicy: retryFreshnessPolicy,
   }
   dispatchAppRouterAction(retryAction)

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -3,6 +3,7 @@ import type {
   ReducerState,
   RestoreAction,
 } from '../router-reducer-types'
+import { ScrollBehavior } from '../router-reducer-types'
 import { extractPathFromFlightRouterState } from '../compute-changed-path'
 import {
   FreshnessPolicy,
@@ -95,6 +96,8 @@ export function restoreReducer(
     // History traversal always uses 'replace'.
     'replace',
     navigationLock,
+    // History traversal preserves the current scroll position by default.
+    ScrollBehavior.Default,
     // Not an HMR refresh, so there's no request generation to cancel.
     undefined
   )

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -47,7 +47,13 @@ export function serverPatchReducer(
   // (`HistoryTraversal`), since the data we received is correct.
   const retryCanonicalUrl = createHrefFromUrl(retryUrl)
   const retryNextUrl = action.nextUrl
-  const scrollBehavior = ScrollBehavior.Default
+  // Preserve the original scroll behavior from the navigation that triggered
+  // the retry. This ensures that scroll: false is respected across async PPR
+  // retry navigations (e.g. force-dynamic pages).
+  const scrollBehavior =
+    action.scrollBehavior !== undefined
+      ? action.scrollBehavior
+      : ScrollBehavior.Default
   const navigationLock = getCurrentNavigationLock()
   const now = Date.now()
   return navigateToKnownRoute(

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -128,6 +128,11 @@ export interface ServerPatchAction {
   mpa: boolean
   navigateType: 'push' | 'replace'
   /**
+   * The original navigation's scroll behavior. Threaded through to preserve
+   * scroll: false across async PPR retry navigations.
+   */
+  scrollBehavior?: ScrollBehavior
+  /**
    * Freshness policy for the retry navigation. `RefreshAll` re-fetches the
    * tree's dynamic data (genuine tree mismatch). `HistoryTraversal` reuses the
    * data already in the tree (when only the URL needs correcting after a

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -354,6 +354,7 @@ export function navigateToKnownRoute(
         routeCacheEntry,
         navigateType,
         navigationLock,
+        scrollBehavior,
         signal
       )
     }


### PR DESCRIPTION
## What?

Thread `scrollBehavior` through the async PPR retry chain so that `scroll: false` passed to `router.replace()` (or `router.push()`) is preserved when a force-dynamic page triggers a tree mismatch and the navigation falls back to `ACTION_SERVER_PATCH`.

## Why?

On force-dynamic pages with PPR enabled, every navigation that hits an optimistic route cache entry ends up in a tree mismatch → `dispatchRetryDueToTreeMismatch` → `serverPatchReducer`. Before this fix, `serverPatchReducer` hardcoded `ScrollBehavior.Default` regardless of the original navigation's `scroll: false` option, causing the page to scroll back to the top on every navigation.

The bug only triggers in production (prefetching is disabled in dev) and only after the user has prefetched the root route (e.g. by hovering over a `<Link href="/">`), which is why it's subtle.

## How?

1. Add optional `scrollBehavior?: ScrollBehavior` to `ServerPatchAction` in `router-reducer-types.ts`.
2. Add `scrollBehavior` parameter to `spawnDynamicRequests()` (after `navigationLock`).
3. Thread it through: `spawnDynamicRequests` → `finishNavigationTask` → `dispatchRetryDueToTreeMismatch` → `ServerPatchAction.scrollBehavior`.
4. In `serverPatchReducer`, read `action.scrollBehavior ?? ScrollBehavior.Default` instead of always using `Default`.
5. Update `restore-reducer.ts` (the only other caller of `spawnDynamicRequests`) to pass `ScrollBehavior.Default` — history traversal already defaults to no-scroll behavior.

Fixes #94893

<!-- NEXT_JS_LLM_PR -->