### PR TITLE
Fix app-relative open-in-editor paths

### DIFF
--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -12,6 +12,7 @@ import {
 import { middlewareResponse } from '../../next-devtools/server/middleware-response'
 import path from 'path'
 import { openFileInEditor } from '../../next-devtools/server/launch-editor'
+import { getAppRelativeEditorPath } from './open-editor-path'
 import {
   SourceMapConsumer,
   type NullableMappedPosition,
@@ -401,11 +402,7 @@ export function getOverlayMiddleware({
       let openEditorResult
       if (isAppRelativePath) {
         const relativeFilePath = searchParams.get('file') || ''
-        const appPath = path.join(
-          'app',
-          isSrcDir ? 'src' : '',
-          relativeFilePath
-        )
+        const appPath = getAppRelativeEditorPath(relativeFilePath, isSrcDir)
         openEditorResult = await openFileInEditor(appPath, 1, 1, projectPath)
       } else {
         const frame = createStackFrame(searchParams)

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -11,6 +11,7 @@ import {
   type ModernSourceMapPayload,
 } from '../lib/source-maps'
 import { openFileInEditor } from '../../next-devtools/server/launch-editor'
+import { getAppRelativeEditorPath } from './open-editor-path'
 import {
   DEVTOOLS_CODE_FRAME_MAX_WIDTH,
   getOriginalCodeFrame,
@@ -646,11 +647,7 @@ export function getOverlayMiddleware(options: {
       const isAppRelativePath = searchParams.get('isAppRelativePath') === '1'
       if (isAppRelativePath) {
         const relativeFilePath = searchParams.get('file') || ''
-        const appPath = path.join(
-          'app',
-          isSrcDir ? 'src' : '',
-          relativeFilePath
-        )
+        const appPath = getAppRelativeEditorPath(relativeFilePath, isSrcDir)
         openEditorResult = await openFileInEditor(appPath, 1, 1, rootDirectory)
       } else {
         // TODO: How do we differentiate layers and actual file paths with round brackets?

--- a/packages/next/src/server/dev/open-editor-path.test.ts
+++ b/packages/next/src/server/dev/open-editor-path.test.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+
+import { getAppRelativeEditorPath } from './open-editor-path'
+
+describe('getAppRelativeEditorPath', () => {
+  it('puts src before app when the app directory lives under src', () => {
+    expect(getAppRelativeEditorPath('layout.tsx', true)).toBe(
+      path.join('src', 'app', 'layout.tsx')
+    )
+  })
+
+  it('keeps the original app path when src is not used', () => {
+    expect(getAppRelativeEditorPath('layout.tsx', false)).toBe(
+      path.join('app', 'layout.tsx')
+    )
+  })
+})

--- a/packages/next/src/server/dev/open-editor-path.ts
+++ b/packages/next/src/server/dev/open-editor-path.ts
@@ -1,0 +1,8 @@
+import path from 'path'
+
+export function getAppRelativeEditorPath(
+  relativeFilePath: string,
+  isSrcDir: boolean
+) {
+  return path.join(isSrcDir ? 'src' : '', 'app', relativeFilePath)
+}


### PR DESCRIPTION
What?
Fix the dev overlay's `__nextjs_launch-editor` app-relative path resolution so projects with a `src/` directory resolve `src/app/...` instead of `app/src/...`.

Why?
The DevTools segment explorer uses `isAppRelativePath=1`, and in `src/` projects the current path order leads to a 404 from the open-in-editor endpoint.

How?
Extract the app-relative path construction into a small helper and use it from both webpack and turbopack middleware.
Add a unit test for the path helper to cover both `src` and non-`src` layouts.

Fixes #94776

Tests:
- `corepack pnpm --filter @next/polyfill-module build`
- `corepack pnpm --filter @next/polyfill-nomodule build`
- `PATH=/private/tmp/pnpm-shim:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/markusstark/.codex/tmp/arg0/codex-arg0MisBSE:/Users/markusstark/opt/anaconda3/bin:/Applications/Codex.app/Contents/Resources corepack pnpm --filter @next/env build`
- `PATH=/private/tmp/pnpm-shim:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/markusstark/.codex/tmp/arg0/codex-arg0MisBSE:/Users/markusstark/opt/anaconda3/bin:/Applications/Codex.app/Contents/Resources corepack pnpm --filter next build`
- `PATH=/private/tmp/pnpm-shim:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/markusstark/.codex/tmp/arg0/codex-arg0MisBSE:/Users/markusstark/opt/anaconda3/bin:/Applications/Codex.app/Contents/Resources corepack pnpm exec jest packages/next/src/server/dev/open-editor-path.test.ts --runInBand`