### PR TITLE
Release the instant navs lock without clearing the whole cookie jar

### DIFF
--- a/packages/next-playwright/src/index.ts
+++ b/packages/next-playwright/src/index.ts
@@ -14,14 +14,12 @@ interface PlaywrightBrowserContext {
       url?: string
       domain?: string
       path?: string
+      expires?: number
     }>
   ): Promise<void>
-  cookies(): Promise<Array<{ name: string; value: string }>>
-  clearCookies(options?: {
-    name?: string
-    domain?: string
-    path?: string
-  }): Promise<void>
+  cookies(): Promise<
+    Array<{ name: string; value: string; domain: string; path: string }>
+  >
 }
 
 interface PlaywrightPage {
@@ -86,13 +84,38 @@ export async function instant<T>(
   try {
     return await fn()
   } finally {
-    // Release the lock by clearing the cookie. Next.js may have updated the
-    // cookie value (e.g. from [0] to [1,null]) during the lock scope. We
-    // clear by name to remove the cookie regardless of its current value or
-    // which domain variant it was stored under.
-    await step('Release Instant Lock', () =>
-      page.context().clearCookies({ name: INSTANT_COOKIE })
-    )
+    // Release the lock by expiring the instant cookie, leaving every other
+    // cookie untouched.
+    //
+    // We must NOT use `context.clearCookies({ name: INSTANT_COOKIE })` here.
+    // Playwright implements a filtered `clearCookies` by clearing the ENTIRE
+    // cookie jar and then re-adding the cookies that don't match the filter.
+    // That briefly removes the application's own cookies too. Next.js reacts
+    // to the instant cookie's deletion by immediately re-rendering, and if
+    // that render's request races the empty window it observes none of the
+    // app's cookies (e.g. a navigated page renders as if no cookies were set).
+    //
+    // Instead we read the instant cookie's stored entries (Next.js may have
+    // updated the value, e.g. from [0] to [1,null], but preserves the domain
+    // and path) and re-add each with a past expiry, which deletes only those
+    // entries without disturbing the rest of the jar.
+    await step('Release Instant Lock', async () => {
+      const instantCookies = (await page.context().cookies()).filter(
+        (cookie) => cookie.name === INSTANT_COOKIE
+      )
+      if (instantCookies.length > 0) {
+        await page.context().addCookies(
+          instantCookies.map((cookie) => ({
+            name: cookie.name,
+            value: cookie.value,
+            domain: cookie.domain,
+            path: cookie.path,
+            // A past expiry (Unix epoch seconds) deletes the cookie.
+            expires: 1,
+          }))
+        )
+      }
+    })
   }
 }
 

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -93,8 +93,7 @@ describe('instant-navigation-testing-api', () => {
     )
   })
 
-  // TODO: This has been flaky in CI for weeks and needs further investigation.
-  it.skip('renders runtime-prefetched content instantly during navigation', async () => {
+  it('renders runtime-prefetched content instantly during navigation', async () => {
     const page = await openPage(next, '/')
 
     await instant(page, async () => {


### PR DESCRIPTION
The `instant()` helper in `@next/playwright` released the navigation lock by calling `page.context().clearCookies({ name: INSTANT_COOKIE })`. Playwright implements a filtered `clearCookies` non-atomically: it clears the entire cookie jar and then re-adds the cookies that don't match the filter, briefly removing the application's own cookies too. Because Next.js reacts to the instant cookie's deletion by immediately re-rendering (a soft refresh or a full reload), a render whose request raced that empty window observed none of the test's cookies, so a page reading `cookies()` rendered as if nothing was set, for example `testCookie: not set`. Resource contention widened the clear-then-re-add window, which is why the instant navigation suite failed intermittently in CI.

<img width="225" height="225" alt="empty cookie jar" src="https://github.com/user-attachments/assets/770b8817-e4c4-4b4b-8251-30353d892816" />

We now release the lock by reading the instant cookie's stored entries (Next.js may have updated the value, e.g. from `[0]` to `[1, null]`, but preserves the domain and path) and re-adding each with a past expiry, which deletes only those entries and leaves every other cookie untouched. This removes the transient empty-jar window while still firing the CookieStore deletion event that releases the lock.

To exercise the fix under the conditions that surfaced it, we want CI's flake-detection job to replay the instant navigation suite, which only happens when the suite's test file changes. We trigger that by un-skipping the `renders runtime-prefetched content instantly during navigation` test. That test had been skipped as flaky because of a real bug in the dev runtime-prefetch decode, which #94866 has since fixed, so it passes reliably now and no longer needs to be skipped.