### PR TITLE
typegen: default to Turbopack

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -514,6 +514,7 @@ program
       'If no directory is provided, the current directory will be used.'
     )}`
   )
+  .option('--webpack', 'Use webpack when validating next.config.js')
   .action((directory: string, options: NextTypegenOptions) =>
     // ensure process exits after typegen completes so open handles/connections
     // don't cause process to hang

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -11,6 +11,7 @@ import { getProjectDir } from '../lib/get-project-dir'
 import { findPagesDir } from '../lib/find-pages-dir'
 import { verifyAndRunTypeScript } from '../lib/verify-typescript-setup'
 import { discoverRoutes } from '../build/route-discovery'
+import { parseBundlerArgs } from '../lib/bundler'
 
 import {
   createRouteTypesManifest,
@@ -23,12 +24,12 @@ import { installBindings } from '../build/swc/install-bindings'
 
 export type NextTypegenOptions = {
   dir?: string
+  webpack?: boolean
 }
 
-const nextTypegen = async (
-  _options: NextTypegenOptions,
-  directory?: string
-) => {
+const nextTypegen = async (options: NextTypegenOptions, directory?: string) => {
+  parseBundlerArgs(options)
+
   const baseDir = getProjectDir(directory)
 
   // Check if the provided directory exists

--- a/test/e2e/app-dir/typegen-bundler-env/app/page.tsx
+++ b/test/e2e/app-dir/typegen-bundler-env/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello</p>
+}

--- a/test/e2e/app-dir/typegen-bundler-env/next.config.js
+++ b/test/e2e/app-dir/typegen-bundler-env/next.config.js
@@ -1,0 +1,9 @@
+// cssChunking: "graph" is Turbopack-only. loadConfig throws when TURBOPACK is
+// not set, letting the test assert that typegen selects the right bundler.
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    cssChunking: 'graph',
+  },
+}
+module.exports = nextConfig

--- a/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
+++ b/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+import { runNextCommand } from 'next-test-utils'
+
+const baseEnv = {
+  IS_TURBOPACK_TEST: undefined,
+  TURBOPACK: undefined,
+  IS_WEBPACK_TEST: undefined,
+  NEXT_RSPACK: undefined,
+  NEXT_TEST_USE_RSPACK: undefined,
+}
+
+// cssChunking: "graph", is Turbopack-only, so we use this as to verify whether
+// typegen is selecting the right bundler
+describe('typegen bundler env', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('defaults to Turbopack, accepting Turbopack-only config', async () => {
+    const { code } = await runNextCommand(['typegen', next.testDir], {
+      stderr: true,
+      stdout: true,
+      env: baseEnv,
+    })
+    expect(code).toBe(0)
+  })
+
+  it('rejects Turbopack-only config when --webpack is passed', async () => {
+    const { code, stderr, stdout } = await runNextCommand(
+      ['typegen', next.testDir, '--webpack'],
+      {
+        stderr: true,
+        stdout: true,
+        env: baseEnv,
+      }
+    )
+    expect(code).not.toBe(0)
+    expect(stderr + stdout).toMatch(/cssChunking.*Turbopack/i)
+  })
+})


### PR DESCRIPTION
While the bundler isn't super relevant for typegen, we _do_ validate the config as part of the process, so some checks (like those added with the experimental rust react compiler) can fail if we're not consistent about
the default.

Test Plan: added an e2e test to verify the config is validated as turbopack by default
