### PR TITLE
[cd] reduce size of npm metadata on publish

### DIFF
--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -216,6 +216,13 @@ const publishRetryDelaySeconds = 15
     optionalDependencies['@next/swc-' + platform] = version
     nextPkg.optionalDependencies = optionalDependencies
   }
+  // These props are only needed for development and build so we strip
+  // before publishing to reduce the total metadata size. The max is
+  // 100 MB for all versions of a pkg and we are currently at 30MB. Run:
+  // curl -w '%{size_download}' -so /dev/null https://registry.npmjs.org/next | awk '{print $1/1000000 " MB"}'
+  for (const field of ['devDependencies', 'taskr', 'scripts']) {
+    delete nextPkg[field]
+  }
   await fs.writeFile(
     path.join(cwd, 'packages/next/package.json'),
     JSON.stringify(nextPkg, null, 2)


### PR DESCRIPTION
The maximum size of the npm package metadata for all versions of that package is 100 MB.

We are currently over 30MB as seen here:

```
curl -w '%{size_download}' -so /dev/null https://registry.npmjs.org/next | awk '{print $1/1000000 " MB"}'
```

In order to reduce our growth rate, we can omit certain properties (devDependencies, taskr, scripts) from package.json right before publishing since we know those are only needed for dev/build time and not at runtime.

See related:

https://x.com/andrii_sherman/status/2067246143348617226
https://x.com/andrii_sherman/status/2067495638489592156