### PR TITLE
fix(next): allow typegen without active bundler

### DIFF
--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -36,7 +36,9 @@ const nextTypegen = async (
     printAndExit(`> No such directory exists as the project root: ${baseDir}`)
   }
 
-  const nextConfig = await loadConfig(PHASE_PRODUCTION_BUILD, baseDir)
+  const nextConfig = await loadConfig(PHASE_PRODUCTION_BUILD, baseDir, {
+    isTypegen: true,
+  })
   await installBindings(nextConfig.experimental?.useWasmBinary)
   const distDir = join(baseDir, nextConfig.distDir)
   const { pagesDir, appDir } = findPagesDir(baseDir)

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -73,6 +73,44 @@ describe('loadConfig', () => {
     })
   })
 
+  describe('bundler-specific config validation', () => {
+    it('does not require an active bundler when loading config for typegen', async () => {
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: {
+              cssChunking: 'graph',
+              turbopackRustReactCompiler: true,
+            },
+            reactCompiler: true,
+          },
+          isTypegen: true,
+        })
+      ).resolves.toMatchObject({
+        experimental: {
+          cssChunking: 'graph',
+          turbopackRustReactCompiler: true,
+        },
+        reactCompiler: true,
+      })
+    })
+
+    it('still validates turbopack-only config outside of typegen', async () => {
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: {
+              turbopackRustReactCompiler: true,
+            },
+            reactCompiler: true,
+          },
+        })
+      ).rejects.toThrow(
+        /`experimental\.turbopackRustReactCompiler` is only supported with Turbopack/
+      )
+    })
+  })
+
   describe('canary-only features', () => {
     beforeAll(() => {
       process.env.__NEXT_VERSION = '14.2.0'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -296,7 +296,8 @@ function assignDefaultsAndValidate(
   dir: string,
   userConfig: NextConfig & { configFileName: string },
   silent: boolean,
-  phase: PHASE_TYPE
+  phase: PHASE_TYPE,
+  isTypegen: boolean
 ): NextConfigComplete {
   const configFileName = userConfig.configFileName
   if (typeof (userConfig as any).exportTrailingSlash !== 'undefined') {
@@ -487,9 +488,10 @@ function assignDefaultsAndValidate(
 
   // Validate experimental.cssChunking compatibility with the active bundler. Graph mode is
   // Turbopack-only; strict mode and `false` (single-chunk-per-module) are webpack-only.
-  // Only validate during build/dev — `next start` doesn't pick a bundler and would otherwise
-  // see `process.env.TURBOPACK` unset and reject a valid `cssChunking: "graph"` config.
-  if (phase !== PHASE_PRODUCTION_SERVER) {
+  // Only validate when the command picks a bundler. `next start` and `next typegen` would
+  // otherwise see `process.env.TURBOPACK` unset and reject valid bundler-specific configs.
+  const isBundlerPhase = phase !== PHASE_PRODUCTION_SERVER && !isTypegen
+  if (isBundlerPhase) {
     const cssChunkingValue = result.experimental.cssChunking
     const cssChunkingMode = resolveCssChunkingMode(cssChunkingValue)
     if (cssChunkingMode === 'graph' && !process.env.TURBOPACK) {
@@ -1718,6 +1720,7 @@ function getCacheKey(
   customConfig?: object | null,
   reactProductionProfiling?: boolean,
   debugPrerender?: boolean,
+  isTypegen?: boolean,
   pid?: number
 ): string {
   // The next.config.js is unique per project, so we can use the dir as the major key
@@ -1728,6 +1731,7 @@ function getCacheKey(
     hasCustomConfig: Boolean(customConfig),
     reactProductionProfiling: Boolean(reactProductionProfiling),
     debugPrerender: Boolean(debugPrerender),
+    isTypegen: Boolean(isTypegen),
     pid: pid || 0,
   })
 
@@ -1744,6 +1748,7 @@ type LoadConfigOptions = {
   reactProductionProfiling?: boolean
   debugPrerender?: boolean
   bundler?: Bundler
+  isTypegen?: boolean
 }
 
 export default async function loadConfig(
@@ -1773,6 +1778,7 @@ export default async function loadConfig(
     reactProductionProfiling,
     debugPrerender,
     bundler,
+    isTypegen = false,
   }: LoadConfigOptions = {}
 ): Promise<NextConfigComplete> {
   // Generate cache key based on parameters that affect config output
@@ -1783,6 +1789,7 @@ export default async function loadConfig(
     customConfig,
     reactProductionProfiling,
     debugPrerender,
+    isTypegen,
     process.pid
   )
 
@@ -1863,7 +1870,8 @@ export default async function loadConfig(
             ...customConfig,
           },
           silent,
-          phase
+          phase,
+          isTypegen
         ),
         phase,
         silent,
@@ -2067,7 +2075,8 @@ export default async function loadConfig(
         ...userConfig,
       },
       silent,
-      phase
+      phase,
+      isTypegen
     )
 
     const finalConfig = finalizeConfig(
@@ -2124,7 +2133,8 @@ export default async function loadConfig(
     dir,
     { ...clonedDefaultConfig, configFileName },
     silent,
-    phase
+    phase,
+    isTypegen
   )
 
   setHttpClientAndAgentOptions(completeConfig)

--- a/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/app/layout.tsx
+++ b/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/app/page.tsx
+++ b/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/next.config.js
+++ b/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/next.config.js
@@ -1,0 +1,14 @@
+const { PHASE_PRODUCTION_BUILD } = require('next/constants')
+
+module.exports = (phase) => {
+  if (phase !== PHASE_PRODUCTION_BUILD) {
+    throw new Error(`Unexpected phase: ${phase}`)
+  }
+
+  return {
+    experimental: {
+      turbopackRustReactCompiler: true,
+    },
+    reactCompiler: true,
+  }
+}

--- a/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/typegen-turbopack-rust-react-compiler.test.ts
+++ b/test/e2e/app-dir/typegen-turbopack-rust-react-compiler/typegen-turbopack-rust-react-compiler.test.ts
@@ -1,0 +1,27 @@
+import { nextTestSetup } from 'e2e-utils'
+import { runNextCommand } from 'next-test-utils'
+
+describe('typegen with turbopack rust react compiler', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('generates route types without requiring an active bundler', async () => {
+    const { code, stdout, stderr } = await runNextCommand(
+      ['typegen', next.testDir],
+      { stderr: true, stdout: true }
+    )
+
+    expect(code).toBe(0)
+    expect(stdout + stderr).not.toContain('turbopackRustReactCompiler')
+
+    const routeTypes = await next.readFile('.next/types/routes.d.ts')
+    expect(routeTypes).toContain('type AppRoutes = "/"')
+  })
+})


### PR DESCRIPTION
### What?

Allows `next typegen` to load config without requiring an active bundler when bundler-specific experimental options are present.

### Why?

`next typegen` does not run webpack or Turbopack, but it currently loads config through the production build phase. That makes `experimental.turbopackRustReactCompiler` fail unless `TURBOPACK` is set, even though type generation itself does not need a bundler.

### How?

- Marks the `loadConfig` call from `next typegen` as typegen-only while preserving the public `PHASE_PRODUCTION_BUILD` value passed to `next.config.js`.
- Skips only the bundler-availability validation for `next typegen`; normal build/dev validation still runs.
- Adds config unit coverage and an e2e regression fixture that verifies route types are generated.

Fixes #94950

### Tests

- `pnpm jest packages/next/src/server/config.test.ts --runInBand`
- `pnpm test-dev test/e2e/app-dir/typegen-turbopack-rust-react-compiler/typegen-turbopack-rust-react-compiler.test.ts`
- `pnpm test-dev test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts`
- `pnpm --filter=next build`