### PR TITLE
Statically prerender metadata image routes under Cache Components

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1371,5 +1371,6 @@
   "1370": "Route %s used \\`headers()\\` inside \\`after()\\` while rendering. This is not supported. If you need this data inside an \\`after()\\` callback, use \\`headers()\\` outside of the callback. See more info here: https://nextjs.org/docs/app/api-reference/functions/after",
   "1371": "Route %s used \\`io()\\` inside \\`after()\\`. The \\`io()\\` function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after",
   "1372": "Route %s used \\`io()\\` inside \\`after()\\` while rendering. The \\`io()\\` function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after",
-  "1373": "Route %s used \\`cookies()\\` inside \\`after()\\` while rendering. This is not supported. If you need this data inside an \\`after()\\` callback, use \\`cookies()\\` outside of the callback. See more info here: https://nextjs.org/docs/app/api-reference/functions/after"
+  "1373": "Route %s used \\`cookies()\\` inside \\`after()\\` while rendering. This is not supported. If you need this data inside an \\`after()\\` callback, use \\`cookies()\\` outside of the callback. See more info here: https://nextjs.org/docs/app/api-reference/functions/after",
+  "1374": "Expected a work store while caching an `ImageResponse` during prerendering."
 }

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -26,6 +26,7 @@ import type {
   PrerenderStoreLegacy,
   PrerenderStoreModern,
   ValidationStoreClient,
+  PrerenderStoreModernServer,
 } from '../app-render/work-unit-async-storage.external'
 
 // Once postpone is in stable we should switch to importing the postpone export directly
@@ -554,6 +555,12 @@ export function createRenderInBrowserAbortSignal(): AbortSignal {
  * stalling on connection() or because they're loading dynamic data. In that
  * case we need to abort the encoding of arguments since they'll never complete.
  */
+export function createHangingInputAbortSignal(
+  workUnitStore: PrerenderStoreModernServer
+): AbortSignal
+export function createHangingInputAbortSignal(
+  workUnitStore: WorkUnitStore
+): AbortSignal | undefined
 export function createHangingInputAbortSignal(
   workUnitStore: WorkUnitStore
 ): AbortSignal | undefined {

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -77,6 +77,7 @@ describe('getDynamicHTMLPostponedState', () => {
          "decryptedBoundArgs": Map {},
          "encryptedBoundArgs": Map {},
          "fetch": Map {},
+         "imageResponses": Map {},
          "mutable": false,
        },
        "type": 2,
@@ -125,6 +126,7 @@ describe('getDynamicHTMLPostponedState', () => {
         fetch: new Map(),
         encryptedBoundArgs: new Map(),
         decryptedBoundArgs: new Map(),
+        imageResponses: new Map(),
         mutable: false,
       },
     })
@@ -161,6 +163,7 @@ describe('parsePostponedState', () => {
         fetch: new Map(),
         encryptedBoundArgs: new Map(),
         decryptedBoundArgs: new Map(),
+        imageResponses: new Map(),
         mutable: false,
       },
     })
@@ -183,6 +186,7 @@ describe('parsePostponedState', () => {
         fetch: new Map(),
         encryptedBoundArgs: new Map(),
         decryptedBoundArgs: new Map(),
+        imageResponses: new Map(),
         mutable: false,
       },
     })
@@ -200,6 +204,7 @@ describe('parsePostponedState', () => {
         fetch: new Map(),
         encryptedBoundArgs: new Map(),
         decryptedBoundArgs: new Map(),
+        imageResponses: new Map(),
         mutable: false,
       },
     })

--- a/packages/next/src/server/og/cache-image-response.ts
+++ b/packages/next/src/server/og/cache-image-response.ts
@@ -1,0 +1,169 @@
+import { PassThrough, Writable } from 'node:stream'
+
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { renderToPipeableStream } from 'react-server-dom-webpack/server'
+import { getClientReferenceManifest } from '../app-render/manifests-singleton'
+
+type OgModule = typeof import('next/dist/compiled/@vercel/og')
+
+function importOgModule(): Promise<OgModule> {
+  // Cache Components is Node-only (rejected for the edge runtime at compile
+  // time), so we always load the Node build. Loading it dynamically keeps the
+  // heavy `@vercel/og` renderer (satori + WASM) off the module-load path, so
+  // it's pulled in only when an image is actually rendered.
+  return import('next/dist/compiled/@vercel/og/index.node.js')
+}
+
+/**
+ * Builds the body for a Cache Components `ImageResponse`. The rendered image is
+ * cached in the Resume Data Cache during a prerender, so the prospective
+ * prerender renders it once and the final prerender retrieves it from memory
+ * within microtasks. This lets metadata image routes be statically prerendered
+ * under Cache Components instead of being treated as dynamic.
+ *
+ * The cache boundary is drawn around only the deterministic JSX -> image
+ * rasterization. The handler that constructs the `ImageResponse` still re-runs
+ * on every prerender pass, so any user-space I/O remains subject to the normal
+ * Cache Components rules (it must be wrapped in `use cache` by the user). If
+ * the inputs don't reproduce across the prospective and final passes, the cache
+ * keys diverge, the final render re-renders, and the route falls back to
+ * dynamic.
+ *
+ * Outside of a prerender (normal requests) this just renders.
+ */
+export function getCachedImageResponseBody(
+  args: ConstructorParameters<OgModule['ImageResponse']>
+): ReadableStream {
+  return new ReadableStream({
+    async start(controller) {
+      const arrayBuffer = await getCachedImageResponseArrayBuffer(args)
+      if (arrayBuffer.byteLength > 0) {
+        controller.enqueue(new Uint8Array(arrayBuffer))
+      }
+      controller.close()
+    },
+  })
+}
+
+async function getCachedImageResponseArrayBuffer(
+  args: ConstructorParameters<OgModule['ImageResponse']>
+): Promise<ArrayBuffer> {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  switch (workUnitStore?.type) {
+    case 'prerender':
+      // We only cache during a prerender. Metadata image routes compile to
+      // route handlers, which use the `prerender` store.
+      break
+    case undefined:
+    case 'request':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'prerender-runtime':
+    case 'prerender-client':
+    case 'validation-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'generate-static-params':
+      return renderImageResponseArrayBuffer(args)
+    default:
+      return workUnitStore satisfies never
+  }
+
+  const { cacheSignal, resumeDataCache } = workUnitStore
+
+  if (!resumeDataCache) {
+    return renderImageResponseArrayBuffer(args)
+  }
+
+  // Begin a cache read synchronously, before any await, so the prospective
+  // prerender's `cacheReady()` doesn't resolve until the image is rendered and
+  // stored. The final prerender has no cache signal, so this is a no-op there.
+  cacheSignal?.beginRead()
+
+  try {
+    const cacheKey = await serializeImageResponseArgs(args)
+    const cached = resumeDataCache.imageResponses.get(cacheKey)
+
+    if (cached) {
+      return await cached
+    }
+
+    // Render outside the prerender work-unit store. The renderer does uncached
+    // `fetch` calls (e.g. loading a font or a remote image), and inside a Cache
+    // Components prerender an uncached `fetch` outside a cache scope is turned
+    // into a hanging promise, since Cache Components skips I/O that wouldn't be
+    // cached anyway. That would stall the render forever during the prospective
+    // pass, so we run it with no store, letting those fetches resolve normally.
+    //
+    // Running it in a cache scope would also avoid the hang, but it would route
+    // those fetches through the serialized `cache` / `fetch` resume data stores
+    // and bloat the resume data that ships with the prerender. The only
+    // artifact we intentionally cache is the rendered image, in the
+    // in-memory-only `imageResponses` store.
+    const arrayBufferPromise = workUnitAsyncStorage.exit(() =>
+      renderImageResponseArrayBuffer(args)
+    )
+
+    if (resumeDataCache.mutable) {
+      resumeDataCache.imageResponses.set(cacheKey, arrayBufferPromise)
+    }
+
+    return await arrayBufferPromise
+  } finally {
+    cacheSignal?.endRead()
+  }
+}
+
+async function renderImageResponseArrayBuffer(
+  args: ConstructorParameters<OgModule['ImageResponse']>
+): Promise<ArrayBuffer> {
+  const OGImageResponse = (await importOgModule()).ImageResponse
+  const imageResponse = new OGImageResponse(...args) as Response
+
+  if (!imageResponse.body) {
+    return new ArrayBuffer(0)
+  }
+
+  return imageResponse.arrayBuffer()
+}
+
+/**
+ * Builds a stable cache key from the `ImageResponse` constructor args by
+ * serializing them with React Flight, the same mechanism
+ * `encryptActionBoundArgs` uses for server action bound args. This handles
+ * arbitrary component trees and client references, not just intrinsic-element
+ * JSX.
+ */
+async function serializeImageResponseArgs(
+  args: ConstructorParameters<OgModule['ImageResponse']>
+): Promise<string> {
+  const { clientModules } = getClientReferenceManifest()
+
+  const { pipe } = renderToPipeableStream(args, clientModules, {
+    // Only affects error-stack formatting and I/O tracking, which is irrelevant
+    // for a cache key.
+    filterStackFrame: undefined,
+    // Debug info embeds per-call timing that would destabilize the key, so
+    // discard it via a throwaway writable. It is only emitted in development;
+    // production never includes it.
+    debugChannel:
+      process.env.NODE_ENV === 'development'
+        ? new Writable({ write: (_chunk, _encoding, callback) => callback() })
+        : undefined,
+  })
+
+  const passThrough = new PassThrough()
+  pipe(passThrough)
+
+  const decoder = new TextDecoder('utf-8', { fatal: true })
+  let serialized = ''
+  for await (const chunk of passThrough) {
+    serialized += decoder.decode(chunk, { stream: true })
+  }
+  serialized += decoder.decode()
+
+  return serialized
+}

--- a/packages/next/src/server/og/cache-image-response.ts
+++ b/packages/next/src/server/og/cache-image-response.ts
@@ -158,12 +158,16 @@ async function serializeImageResponseArgs(
   const passThrough = new PassThrough()
   pipe(passThrough)
 
-  const decoder = new TextDecoder('utf-8', { fatal: true })
-  let serialized = ''
+  // The Flight stream can contain raw binary bytes. Most notably, binary
+  // `ImageResponse` args such as a custom font (`fonts: [{ data: ArrayBuffer }]`)
+  // are serialized as verbatim typed-array bytes, which are not valid UTF-8.
+  // Decoding those bytes with a fatal UTF-8 decoder would throw, so we collect
+  // the raw bytes and build the key with a lossless binary-safe encoding
+  // (Node's `latin1`, i.e. ISO-8859-1, maps each byte to a distinct code point).
+  const chunks: Buffer[] = []
   for await (const chunk of passThrough) {
-    serialized += decoder.decode(chunk, { stream: true })
+    chunks.push(chunk)
   }
-  serialized += decoder.decode()
 
-  return serialized
+  return Buffer.concat(chunks).toString('latin1')
 }

--- a/packages/next/src/server/og/cache-image-response.ts
+++ b/packages/next/src/server/og/cache-image-response.ts
@@ -172,17 +172,9 @@ async function getCachedImageResponseArrayBuffer(
           serializationError = error
         }
       },
-    }).then((result) => {
-      prerenderCompleted = true
-      // The serialization finished before any dynamic input was needed, so we
-      // will render and cache the image. Hold the cache read now, before the
-      // stream is buffered and deserialized below, so that the prospective
-      // prerender's `cacheReady()` waits for the image to be stored.
-      if (!resultIsPartial) {
-        beginReadOnce()
-      }
-      return result
     })
+
+    prerenderCompleted = true
 
     if (serializationError !== undefined) {
       throw serializationError
@@ -199,6 +191,12 @@ async function getCachedImageResponseArrayBuffer(
         'dynamic `ImageResponse`'
       )
     }
+
+    // The serialization finished before any dynamic input was needed, so we
+    // will render and cache the image. Hold the cache read now, before the
+    // stream is buffered and deserialized below, so that the prospective
+    // prerender's `cacheReady()` waits for the image to be stored.
+    beginReadOnce()
 
     const chunks: Buffer[] = []
     for await (const chunk of prelude) {

--- a/packages/next/src/server/og/cache-image-response.ts
+++ b/packages/next/src/server/og/cache-image-response.ts
@@ -140,11 +140,11 @@ async function getCachedImageResponseArrayBuffer(
   // time. But route handler prerendering doesn't use that scheme, so here the
   // deferred immediates would race the abort.
   //
-  // We can't pass the abort signal directly because the prerender then halts
-  // silently, leaving unfulfilled references without telling us. Instead we
-  // pass a derived signal that we only abort when the serialization didn't
-  // complete in time, recording that fact so we can fall back to dynamic.
-  const abortController = new AbortController()
+  // The prerender halts silently on abort, leaving unfulfilled references in
+  // place rather than reporting through `onError`. So to tell a halt (the tree
+  // needed dynamic input) apart from a normal completion, we record whether the
+  // abort fired before the serialization finished. `abort()` runs this listener
+  // synchronously, well before we read `resultIsPartial` below.
   let prerenderCompleted = false
   let resultIsPartial = false
   let serializationError: unknown
@@ -154,7 +154,6 @@ async function getCachedImageResponseArrayBuffer(
     () => {
       if (!prerenderCompleted) {
         resultIsPartial = true
-        abortController.abort(hangingInputAbortSignal.reason)
       }
     },
     { once: true }
@@ -164,7 +163,7 @@ async function getCachedImageResponseArrayBuffer(
 
   try {
     const { prelude } = await prerenderToNodeStream(args, clientModules, {
-      signal: abortController.signal,
+      signal: hangingInputAbortSignal,
       filterStackFrame: undefined,
       onError(error) {
         // A halt (our deliberate abort) emits nothing, so this is only called

--- a/packages/next/src/server/og/cache-image-response.ts
+++ b/packages/next/src/server/og/cache-image-response.ts
@@ -1,11 +1,22 @@
-import { PassThrough, Writable } from 'node:stream'
+import { Readable } from 'node:stream'
 
+import { InvariantError } from '../../shared/lib/invariant-error'
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { createHangingInputAbortSignal } from '../app-render/dynamic-rendering'
+import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  getClientReferenceManifest,
+  getServerModuleMap,
+} from '../app-render/manifests-singleton'
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { renderToPipeableStream } from 'react-server-dom-webpack/server'
-import { getClientReferenceManifest } from '../app-render/manifests-singleton'
+import { prerenderToNodeStream } from 'react-server-dom-webpack/static'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createFromNodeStream } from 'react-server-dom-webpack/client'
 
 type OgModule = typeof import('next/dist/compiled/@vercel/og')
+
+type ImageResponseArgs = ConstructorParameters<OgModule['ImageResponse']>
 
 function importOgModule(): Promise<OgModule> {
   // Cache Components is Node-only (rejected for the edge runtime at compile
@@ -22,20 +33,21 @@ function importOgModule(): Promise<OgModule> {
  * within microtasks. This lets metadata image routes be statically prerendered
  * under Cache Components instead of being treated as dynamic.
  *
- * The cache boundary is drawn around only the deterministic JSX -> image
- * rasterization. The handler that constructs the `ImageResponse` still re-runs
- * on every prerender pass, so any user-space I/O remains subject to the normal
- * Cache Components rules (it must be wrapped in `use cache` by the user). If
- * the inputs don't reproduce across the prospective and final passes, the cache
- * keys diverge, the final render re-renders, and the route falls back to
- * dynamic.
+ * The cache boundary is drawn around only the deterministic rasterization of
+ * the element tree into an image. The `ImageResponse` element tree is rendered
+ * with React Flight once, inside the prerender work-unit store, so any
+ * user-space I/O (e.g. `cookies()` or an uncached `fetch`) runs in the correct
+ * scope and is subject to the normal Cache Components rules. If that tree
+ * needs dynamic input the serialization can't complete, and the route falls
+ * back to dynamic. Otherwise the fully resolved tree is handed to satori,
+ * which never re-runs the user's components.
  *
  * Outside of a prerender (normal requests) this just renders.
  */
 export function getCachedImageResponseBody(
-  args: ConstructorParameters<OgModule['ImageResponse']>
-): ReadableStream {
-  return new ReadableStream({
+  args: ImageResponseArgs
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
     async start(controller) {
       const arrayBuffer = await getCachedImageResponseArrayBuffer(args)
       if (arrayBuffer.byteLength > 0) {
@@ -47,7 +59,7 @@ export function getCachedImageResponseBody(
 }
 
 async function getCachedImageResponseArrayBuffer(
-  args: ConstructorParameters<OgModule['ImageResponse']>
+  args: ImageResponseArgs
 ): Promise<ArrayBuffer> {
   const workUnitStore = workUnitAsyncStorage.getStore()
 
@@ -72,39 +84,169 @@ async function getCachedImageResponseArrayBuffer(
       return workUnitStore satisfies never
   }
 
-  const { cacheSignal, resumeDataCache } = workUnitStore
+  const { cacheSignal, resumeDataCache, renderSignal } = workUnitStore
 
   if (!resumeDataCache) {
     return renderImageResponseArrayBuffer(args)
   }
 
-  // Begin a cache read synchronously, before any await, so the prospective
-  // prerender's `cacheReady()` doesn't resolve until the image is rendered and
-  // stored. The final prerender has no cache signal, so this is a no-op there.
-  cacheSignal?.beginRead()
+  const workStore = workAsyncStorage.getStore()
+
+  if (!workStore) {
+    throw new InvariantError(
+      'Expected a work store while caching an `ImageResponse` during prerendering.'
+    )
+  }
+
+  // `createHangingInputAbortSignal` aborts once the prerender's cache-sourced
+  // input is ready, so anything the serialization below is still awaiting past
+  // that point can be treated as dynamic (non-cache) input. In the prospective
+  // pass it aborts when `cacheSignal.inputReady()` resolves (no cache reads
+  // in progress); in the final pass the caches are already filled, so it just
+  // aborts on the next tick.
+  const hangingInputAbortSignal = createHangingInputAbortSignal(workUnitStore)
+
+  // We open the cache read lazily, once we know the serialization completed and
+  // we're about to render and store the image. Opening it before serializing
+  // would keep `cacheSignal.inputReady()` from resolving and thus prevent the
+  // abort signal from ever firing, deadlocking the prospective prerender.
+  let readState: 'ready' | 'pending' | 'done' = 'ready'
+
+  function beginReadOnce() {
+    if (readState === 'ready') {
+      readState = 'pending'
+      cacheSignal?.beginRead()
+    }
+  }
+
+  function endReadIfStarted() {
+    if (readState === 'pending') {
+      cacheSignal?.endRead()
+    }
+    readState = 'done'
+  }
+
+  // We serialize the element tree with `prerenderToNodeStream` rather than
+  // `renderToPipeableStream`. It's the right fit for prerendering, and it
+  // schedules work deferred for size (`deferTask`) on microtasks, so a fully
+  // static tree finishes flushing before the abort signal fires; a tree still
+  // pending at abort time is then genuinely waiting on dynamic input rather
+  // than just deferred.
+  //
+  // `renderToPipeableStream` would schedule that deferred work on
+  // `setImmediate` instead, which isn't necessarily a deal-breaker: the
+  // sequential-task scheme page rendering uses (`runInSequentialTasks`) drains
+  // pending immediates at each task boundary, so deferred work still runs in
+  // time. But route handler prerendering doesn't use that scheme, so here the
+  // deferred immediates would race the abort.
+  //
+  // We can't pass the abort signal directly because the prerender then halts
+  // silently, leaving unfulfilled references without telling us. Instead we
+  // pass a derived signal that we only abort when the serialization didn't
+  // complete in time, recording that fact so we can fall back to dynamic.
+  const abortController = new AbortController()
+  let prerenderCompleted = false
+  let resultIsPartial = false
+  let serializationError: unknown
+
+  hangingInputAbortSignal.addEventListener(
+    'abort',
+    () => {
+      if (!prerenderCompleted) {
+        resultIsPartial = true
+        abortController.abort(hangingInputAbortSignal.reason)
+      }
+    },
+    { once: true }
+  )
+
+  const { clientModules, rscModuleMapping } = getClientReferenceManifest()
 
   try {
-    const cacheKey = await serializeImageResponseArgs(args)
+    const { prelude } = await prerenderToNodeStream(args, clientModules, {
+      signal: abortController.signal,
+      filterStackFrame: undefined,
+      onError(error) {
+        // A halt (our deliberate abort) emits nothing, so this is only called
+        // for genuine serialization errors. We surface the first one.
+        if (serializationError === undefined && !resultIsPartial) {
+          serializationError = error
+        }
+      },
+    }).then((result) => {
+      prerenderCompleted = true
+      // The serialization finished before any dynamic input was needed, so we
+      // will render and cache the image. Hold the cache read now, before the
+      // stream is buffered and deserialized below, so that the prospective
+      // prerender's `cacheReady()` waits for the image to be stored.
+      if (!resultIsPartial) {
+        beginReadOnce()
+      }
+      return result
+    })
+
+    if (serializationError !== undefined) {
+      throw serializationError
+    }
+
+    if (resultIsPartial) {
+      // The element tree needed dynamic input (e.g. `cookies()` or an uncached
+      // `fetch`), so the image can't be produced statically. Return a hanging
+      // promise: the body never resolves, and the final prerender's macrotask
+      // budget then classifies the route as dynamic.
+      return makeHangingPromise<ArrayBuffer>(
+        renderSignal,
+        workStore.route,
+        'dynamic `ImageResponse`'
+      )
+    }
+
+    const chunks: Buffer[] = []
+    for await (const chunk of prelude) {
+      chunks.push(chunk)
+    }
+
+    const buffer = Buffer.concat(chunks)
+    // Base64-encode the serialized output to use it as a stable string key
+    // (the Flight stream is binary, so it isn't safe to treat as UTF-8 text).
+    const cacheKey = buffer.toString('base64')
+
     const cached = resumeDataCache.imageResponses.get(cacheKey)
 
     if (cached) {
       return await cached
     }
 
-    // Render outside the prerender work-unit store. The renderer does uncached
-    // `fetch` calls (e.g. loading a font or a remote image), and inside a Cache
-    // Components prerender an uncached `fetch` outside a cache scope is turned
-    // into a hanging promise, since Cache Components skips I/O that wouldn't be
-    // cached anyway. That would stall the render forever during the prospective
-    // pass, so we run it with no store, letting those fetches resolve normally.
+    // Deserialize the resolved tree and hand it to satori. Because the user's
+    // components already ran during serialization, satori only walks resolved
+    // host elements and never re-runs them, confining user-space I/O to the
+    // in-store serialization above.
     //
-    // Running it in a cache scope would also avoid the hang, but it would route
-    // those fetches through the serialized `cache` / `fetch` resume data stores
-    // and bloat the resume data that ships with the prerender. The only
-    // artifact we intentionally cache is the rendered image, in the
-    // in-memory-only `imageResponses` store.
+    // The Flight client hands back the output of an async Server Component as
+    // a `React.lazy` (sync components and plain host elements are inlined).
+    // satori can't unwrap lazies, so we resolve them into plain elements first.
+    // We only reach here once the serialization completed, so every lazy is
+    // already resolved and `_init` returns synchronously.
+    const resolvedArgs = resolveFlightLazies(
+      await createFromNodeStream(
+        Readable.from([buffer]),
+        {
+          // We don't want to trigger preloads of client references here.
+          moduleLoading: null,
+          moduleMap: rscModuleMapping,
+          serverModuleMap: getServerModuleMap(),
+        },
+        { findSourceMapURL: undefined }
+      )
+    ) as ImageResponseArgs
+
+    // Render satori outside the prerender work-unit store. It does uncached
+    // `fetch` calls (e.g. loading a font), and inside a Cache Components
+    // prerender an uncached `fetch` outside a cache scope becomes a hanging
+    // promise. Those are framework fetches, not user I/O, so we let them
+    // resolve normally with no store.
     const arrayBufferPromise = workUnitAsyncStorage.exit(() =>
-      renderImageResponseArrayBuffer(args)
+      renderImageResponseArrayBuffer(resolvedArgs)
     )
 
     if (resumeDataCache.mutable) {
@@ -113,15 +255,15 @@ async function getCachedImageResponseArrayBuffer(
 
     return await arrayBufferPromise
   } finally {
-    cacheSignal?.endRead()
+    endReadIfStarted()
   }
 }
 
 async function renderImageResponseArrayBuffer(
-  args: ConstructorParameters<OgModule['ImageResponse']>
+  args: ImageResponseArgs
 ): Promise<ArrayBuffer> {
   const OGImageResponse = (await importOgModule()).ImageResponse
-  const imageResponse = new OGImageResponse(...args) as Response
+  const imageResponse = new OGImageResponse(...args)
 
   if (!imageResponse.body) {
     return new ArrayBuffer(0)
@@ -130,44 +272,42 @@ async function renderImageResponseArrayBuffer(
   return imageResponse.arrayBuffer()
 }
 
+const REACT_LAZY_TYPE = Symbol.for('react.lazy')
+
 /**
- * Builds a stable cache key from the `ImageResponse` constructor args by
- * serializing them with React Flight, the same mechanism
- * `encryptActionBoundArgs` uses for server action bound args. This handles
- * arbitrary component trees and client references, not just intrinsic-element
- * JSX.
+ * Recursively replaces the `React.lazy` references that Flight emits for
+ * resolved async Server Components with the elements they resolve to, so that
+ * satori (which doesn't understand lazy nodes) can walk the tree. This must
+ * only be called on a fully resolved (completed) Flight result, where each
+ * lazy's `_init` returns synchronously rather than suspending.
  */
-async function serializeImageResponseArgs(
-  args: ConstructorParameters<OgModule['ImageResponse']>
-): Promise<string> {
-  const { clientModules } = getClientReferenceManifest()
-
-  const { pipe } = renderToPipeableStream(args, clientModules, {
-    // Only affects error-stack formatting and I/O tracking, which is irrelevant
-    // for a cache key.
-    filterStackFrame: undefined,
-    // Debug info embeds per-call timing that would destabilize the key, so
-    // discard it via a throwaway writable. It is only emitted in development;
-    // production never includes it.
-    debugChannel:
-      process.env.NODE_ENV === 'development'
-        ? new Writable({ write: (_chunk, _encoding, callback) => callback() })
-        : undefined,
-  })
-
-  const passThrough = new PassThrough()
-  pipe(passThrough)
-
-  // The Flight stream can contain raw binary bytes. Most notably, binary
-  // `ImageResponse` args such as a custom font (`fonts: [{ data: ArrayBuffer }]`)
-  // are serialized as verbatim typed-array bytes, which are not valid UTF-8.
-  // Decoding those bytes with a fatal UTF-8 decoder would throw, so we collect
-  // the raw bytes and build the key with a lossless binary-safe encoding
-  // (Node's `latin1`, i.e. ISO-8859-1, maps each byte to a distinct code point).
-  const chunks: Buffer[] = []
-  for await (const chunk of passThrough) {
-    chunks.push(chunk)
+function resolveFlightLazies(node: unknown): unknown {
+  if (node === null || typeof node !== 'object') {
+    return node
   }
 
-  return Buffer.concat(chunks).toString('latin1')
+  if ((node as { $$typeof?: symbol }).$$typeof === REACT_LAZY_TYPE) {
+    const lazy = node as {
+      _init: (payload: unknown) => unknown
+      _payload: unknown
+    }
+    return resolveFlightLazies(lazy._init(lazy._payload))
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(resolveFlightLazies)
+  }
+
+  const element = node as { props?: { children?: unknown } }
+  if (element.props && 'children' in element.props) {
+    return {
+      ...element,
+      props: {
+        ...element.props,
+        children: resolveFlightLazies(element.props.children),
+      },
+    }
+  }
+
+  return node
 }

--- a/packages/next/src/server/og/image-response.ts
+++ b/packages/next/src/server/og/image-response.ts
@@ -10,6 +10,21 @@ function importModule(): Promise<
   )
 }
 
+// The Cache Components-specific caching path (and its React Flight dependency)
+// lives in a separate module that is only loaded for Cache Components builds.
+// Cache Components is rejected for the edge runtime at compile time, so a build
+// with it enabled is always Node.js. When it's disabled this flag folds to
+// `false` and the `require` is eliminated as dead code, so apps without Cache
+// Components stream the image directly and never load that module.
+let getCachedImageResponseBody:
+  | typeof import('./cache-image-response').getCachedImageResponseBody
+  | undefined
+if (process.env.__NEXT_CACHE_COMPONENTS) {
+  getCachedImageResponseBody = (
+    require('./cache-image-response') as typeof import('./cache-image-response')
+  ).getCachedImageResponseBody
+}
+
 /**
  * The ImageResponse class allows you to generate dynamic images using JSX and CSS.
  * This is useful for generating social media images such as Open Graph images, Twitter cards, and more.
@@ -19,28 +34,33 @@ function importModule(): Promise<
 export class ImageResponse extends Response {
   public static displayName = 'ImageResponse'
   constructor(...args: ConstructorParameters<OgModule['ImageResponse']>) {
-    const readable = new ReadableStream({
-      async start(controller) {
-        const OGImageResponse: typeof import('next/dist/compiled/@vercel/og').ImageResponse =
-          // So far we have to manually determine which build to use,
-          // as the auto resolving is not working
-          (await importModule()).ImageResponse
-        const imageResponse = new OGImageResponse(...args) as Response
+    // Under Cache Components, route the render through the cache so metadata
+    // image routes can be statically prerendered. Otherwise stream the rendered
+    // image directly from the underlying `@vercel/og` response.
+    const readable = getCachedImageResponseBody
+      ? getCachedImageResponseBody(args)
+      : new ReadableStream({
+          async start(controller) {
+            const OGImageResponse: typeof import('next/dist/compiled/@vercel/og').ImageResponse =
+              // So far we have to manually determine which build to use, as the
+              // auto resolving is not working
+              (await importModule()).ImageResponse
+            const imageResponse = new OGImageResponse(...args) as Response
 
-        if (!imageResponse.body) {
-          return controller.close()
-        }
+            if (!imageResponse.body) {
+              return controller.close()
+            }
 
-        const reader = imageResponse.body!.getReader()
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) {
-            return controller.close()
-          }
-          controller.enqueue(value)
-        }
-      },
-    })
+            const reader = imageResponse.body.getReader()
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) {
+                return controller.close()
+              }
+              controller.enqueue(value)
+            }
+          },
+        })
 
     const options = args[1] || {}
 

--- a/packages/next/src/server/og/image-response.ts
+++ b/packages/next/src/server/og/image-response.ts
@@ -10,16 +10,25 @@ function importModule(): Promise<
   )
 }
 
-// The Cache Components-specific caching path (and its React Flight dependency)
-// lives in a separate module that is only loaded for Cache Components builds.
-// Cache Components is rejected for the edge runtime at compile time, so a build
-// with it enabled is always Node.js. When it's disabled this flag folds to
-// `false` and the `require` is eliminated as dead code, so apps without Cache
-// Components stream the image directly and never load that module.
+// The Cache Components-specific caching path (and its React Flight and Node
+// stream dependencies) lives in a separate module that is only required for
+// Node.js Cache Components builds. The `NEXT_RUNTIME` guard matters because
+// `__NEXT_CACHE_COMPONENTS` is derived from config, not the per-route runtime,
+// so it stays `true` in edge bundles too. A Pages Router edge route that
+// renders an `ImageResponse` is valid under Cache Components, and without the
+// guard this node-only module would be pulled into that edge bundle and fail to
+// compile. (App Router edge routes, including metadata routes, are
+// independently rejected at compile time under Cache Components.) Both checks
+// fold to constants at build time, so the `require` is eliminated as dead code
+// for edge builds and for apps without Cache Components, which keep
+// ImageResponse's original streaming behavior.
 let getCachedImageResponseBody:
   | typeof import('./cache-image-response').getCachedImageResponseBody
   | undefined
-if (process.env.__NEXT_CACHE_COMPONENTS) {
+if (
+  process.env.NEXT_RUNTIME !== 'edge' &&
+  process.env.__NEXT_CACHE_COMPONENTS
+) {
   getCachedImageResponseBody = (
     require('./cache-image-response') as typeof import('./cache-image-response')
   ).getCachedImageResponseBody

--- a/packages/next/src/server/resume-data-cache/cache-store.ts
+++ b/packages/next/src/server/resume-data-cache/cache-store.ts
@@ -31,6 +31,16 @@ export type EncryptedBoundArgsCacheStore = CacheStore<string>
 export type DecryptedBoundArgsCacheStore = CacheStore<string>
 
 /**
+ * An in-memory-only cache store for rendered `ImageResponse` array buffers,
+ * keyed by a serialization of the `ImageResponse` constructor args. This lets
+ * the prospective prerender render the image once and hand the array buffer to
+ * the final prerender within microtasks, so that metadata image routes can be
+ * statically prerendered under Cache Components. Never serialized into the
+ * resume store.
+ */
+export type ImageResponseCacheStore = CacheStore<Promise<ArrayBuffer>>
+
+/**
  * Serialized format for "use cache" entries
  */
 export interface UseCacheCacheStoreSerialized {

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.ts
@@ -6,6 +6,7 @@ import {
   serializeUseCacheCacheStore,
   parseUseCacheCacheStore,
   type DecryptedBoundArgsCacheStore,
+  type ImageResponseCacheStore,
   type UseCacheCacheStoreSerialized,
 } from './cache-store'
 
@@ -47,6 +48,14 @@ export interface RenderResumeDataCache {
    * enforce immutability.
    */
   readonly decryptedBoundArgs: Omit<DecryptedBoundArgsCacheStore, 'set'>
+
+  /**
+   * A read-only in-memory Map store for rendered `ImageResponse` array buffers.
+   * This is only intended for in-memory usage during pre-rendering, and must
+   * not be persisted in the resume store. The 'set' operation is omitted to
+   * enforce immutability.
+   */
+  readonly imageResponses: Omit<ImageResponseCacheStore, 'set'>
 
   /**
    * Serialized cache keys that were intentionally skipped during the
@@ -100,6 +109,13 @@ export interface PrerenderResumeDataCache {
    * operations to build the cache during pre-rendering.
    */
   readonly decryptedBoundArgs: DecryptedBoundArgsCacheStore
+
+  /**
+   * A mutable in-memory Map store for rendered `ImageResponse` array buffers.
+   * Filled during the prospective prerender and read during the final
+   * prerender. Never persisted in the resume store.
+   */
+  readonly imageResponses: ImageResponseCacheStore
 
   /**
    * Tracks serialized cache keys that were intentionally skipped during the
@@ -204,6 +220,7 @@ export function createPrerenderResumeDataCache(
       fetch: new Map(source.fetch),
       encryptedBoundArgs: new Map(source.encryptedBoundArgs),
       decryptedBoundArgs: new Map(source.decryptedBoundArgs),
+      imageResponses: new Map(source.imageResponses),
       dynamicCacheKeys: source.dynamicCacheKeys
         ? new Set(source.dynamicCacheKeys)
         : new Set(),
@@ -215,6 +232,7 @@ export function createPrerenderResumeDataCache(
       fetch: new Map(),
       encryptedBoundArgs: new Map(),
       decryptedBoundArgs: new Map(),
+      imageResponses: new Map(),
       dynamicCacheKeys: new Set(),
     }
   }
@@ -265,6 +283,7 @@ export function createRenderResumeDataCache(
         fetch: new Map(),
         encryptedBoundArgs: new Map(),
         decryptedBoundArgs: new Map(),
+        imageResponses: new Map(),
       }
     }
 
@@ -308,6 +327,7 @@ export function createRenderResumeDataCache(
         Object.entries(json.store.encryptedBoundArgs)
       ),
       decryptedBoundArgs: new Map(),
+      imageResponses: new Map(),
     }
   }
 }

--- a/test/e2e/app-dir/cache-components-errors/cache-components-client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-client-hook-abort-reasons.test.ts
@@ -321,13 +321,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSearchParams (webpack:///<next-src>)
                      at UseSearchParams (webpack:///app/client-hook-abort-reasons/client.tsx:27:18)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-search-params/[id]/page.tsx:8:7)
-                   708 |       return
-                   709 |     case 'prerender-client': {
-                 > 710 |       React.use(
+                   715 |       return
+                   716 |     case 'prerender-client': {
+                 > 717 |       React.use(
                        |             ^
-                   711 |         makeClientHookHangingPromise(
-                   712 |           workUnitStore.renderSignal,
-                   713 |           new ClientHookDynamicError(workStore.route, expression) {
+                   718 |         makeClientHookHangingPromise(
+                   719 |           workUnitStore.renderSignal,
+                   720 |           new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-search-params/[id]" in your browser to investigate the error.
@@ -623,13 +623,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at usePathname (webpack:///<next-src>)
                      at UsePathname (webpack:///app/client-hook-abort-reasons/client.tsx:22:14)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-pathname/[id]/page.tsx:7:7)
-                   637 |           // hang here and never resolve. This will cause the currently
-                   638 |           // rendering component to effectively be a dynamic hole.
-                 > 639 |           React.use(
+                   644 |           // hang here and never resolve. This will cause the currently
+                   645 |           // rendering component to effectively be a dynamic hole.
+                 > 646 |           React.use(
                        |                 ^
-                   640 |             makeClientHookHangingPromise(
-                   641 |               workUnitStore.renderSignal,
-                   642 |               new ParamClientHookDynamicError(workStore.route, expression) {
+                   647 |             makeClientHookHangingPromise(
+                   648 |               workUnitStore.renderSignal,
+                   649 |               new ParamClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-pathname/[id]" in your browser to investigate the error.
@@ -927,13 +927,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-params/[id]/page.tsx:8:7)
-                   637 |           // hang here and never resolve. This will cause the currently
-                   638 |           // rendering component to effectively be a dynamic hole.
-                 > 639 |           React.use(
+                   644 |           // hang here and never resolve. This will cause the currently
+                   645 |           // rendering component to effectively be a dynamic hole.
+                 > 646 |           React.use(
                        |                 ^
-                   640 |             makeClientHookHangingPromise(
-                   641 |               workUnitStore.renderSignal,
-                   642 |               new ParamClientHookDynamicError(workStore.route, expression) {
+                   647 |             makeClientHookHangingPromise(
+                   648 |               workUnitStore.renderSignal,
+                   649 |               new ParamClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-params/[id]" in your browser to investigate the error.
@@ -1235,13 +1235,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegments (webpack:///<next-src>)
                      at UseSelectedLayoutSegments (webpack:///app/client-hook-abort-reasons/client.tsx:37:28)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]/page.tsx:7:7)
-                   637 |           // hang here and never resolve. This will cause the currently
-                   638 |           // rendering component to effectively be a dynamic hole.
-                 > 639 |           React.use(
+                   644 |           // hang here and never resolve. This will cause the currently
+                   645 |           // rendering component to effectively be a dynamic hole.
+                 > 646 |           React.use(
                        |                 ^
-                   640 |             makeClientHookHangingPromise(
-                   641 |               workUnitStore.renderSignal,
-                   642 |               new ParamClientHookDynamicError(workStore.route, expression) {
+                   647 |             makeClientHookHangingPromise(
+                   648 |               workUnitStore.renderSignal,
+                   649 |               new ParamClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]" in your browser to investigate the error.
@@ -1537,13 +1537,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   637 |           // hang here and never resolve. This will cause the currently
-                   638 |           // rendering component to effectively be a dynamic hole.
-                 > 639 |           React.use(
+                   644 |           // hang here and never resolve. This will cause the currently
+                   645 |           // rendering component to effectively be a dynamic hole.
+                 > 646 |           React.use(
                        |                 ^
-                   640 |             makeClientHookHangingPromise(
-                   641 |               workUnitStore.renderSignal,
-                   642 |               new ParamClientHookDynamicError(workStore.route, expression) {
+                   647 |             makeClientHookHangingPromise(
+                   648 |               workUnitStore.renderSignal,
+                   649 |               new ParamClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]" in your browser to investigate the error.
@@ -2277,13 +2277,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-params/[id]/page.tsx:7:7)
-                   637 |           // hang here and never resolve. This will cause the currently
-                   638 |           // rendering component to effectively be a dynamic hole.
-                 > 639 |           React.use(
+                   644 |           // hang here and never resolve. This will cause the currently
+                   645 |           // rendering component to effectively be a dynamic hole.
+                 > 646 |           React.use(
                        |                 ^
-                   640 |             makeClientHookHangingPromise(
-                   641 |               workUnitStore.renderSignal,
-                   642 |               new ParamClientHookDynamicError(workStore.route, expression) {
+                   647 |             makeClientHookHangingPromise(
+                   648 |               workUnitStore.renderSignal,
+                   649 |               new ParamClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-params/[id]" in your browser to investigate the error.
@@ -2805,13 +2805,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   637 |           // hang here and never resolve. This will cause the currently
-                   638 |           // rendering component to effectively be a dynamic hole.
-                 > 639 |           React.use(
+                   644 |           // hang here and never resolve. This will cause the currently
+                   645 |           // rendering component to effectively be a dynamic hole.
+                 > 646 |           React.use(
                        |                 ^
-                   640 |             makeClientHookHangingPromise(
-                   641 |               workUnitStore.renderSignal,
-                   642 |               new ParamClientHookDynamicError(workStore.route, expression) {
+                   647 |             makeClientHookHangingPromise(
+                   648 |               workUnitStore.renderSignal,
+                   649 |               new ParamClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]" in your browser to investigate the error.

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/app/apple-icon.tsx
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/app/apple-icon.tsx
@@ -1,0 +1,33 @@
+import { ImageResponse } from 'next/og'
+
+export const contentType = 'image/png'
+export const size = { width: 180, height: 180 }
+
+export default function appleIcon() {
+  return new ImageResponse(<AsyncAppleIcon />)
+}
+
+async function AsyncAppleIcon() {
+  'use cache'
+
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  ).then((res) => res.text())
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 88,
+        background: '#fff',
+        color: '#000',
+      }}
+    >
+      {data}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/app/twitter-image.tsx
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/app/twitter-image.tsx
@@ -1,0 +1,35 @@
+import { cookies } from 'next/headers'
+import { ImageResponse } from 'next/og'
+
+export const contentType = 'image/png'
+export const alt = 'Twitter'
+export const size = { width: 1600, height: 900 }
+
+export default function twitterImage() {
+  return new ImageResponse(<AsyncTwitterImage />, size)
+}
+
+async function AsyncTwitterImage() {
+  const cookieStore = await cookies()
+  const numCookies = cookieStore.getAll().length
+
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  ).then((res) => res.text())
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 128,
+        background: 'lavender',
+      }}
+    >
+      {data} {numCookies}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
@@ -29,6 +29,30 @@ describe('use-cache-metadata-route-handler', () => {
     }
   })
 
+  it('should statically prerender an image whose component uses "use cache" directly', async () => {
+    const res = await next.fetch('/apple-icon')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+
+    if (isNextStart) {
+      const [buildStatus] = next.cliOutput.match(/. \/apple-icon/)
+
+      expect(buildStatus).toBe('○ /apple-icon')
+    }
+  })
+
+  it('should treat a twitter image that reads request data as dynamic', async () => {
+    const res = await next.fetch('/twitter-image')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+
+    if (isNextStart) {
+      const [buildStatus] = next.cliOutput.match(/. \/twitter-image/)
+
+      expect(buildStatus).toBe('ƒ /twitter-image')
+    }
+  })
+
   it('should generate sitemaps with a metadata route handler that uses "use cache"', async () => {
     const res = await next.fetch('/sitemap.xml')
     expect(res.status).toBe(200)

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
@@ -13,11 +13,7 @@ describe('use-cache-metadata-route-handler', () => {
     if (isNextStart) {
       const [buildStatus] = next.cliOutput.match(/. \/opengraph-image/)
 
-      // TODO: Should always be `○ /opengraph-image`.
-      expect(buildStatus).toBeOneOf([
-        '○ /opengraph-image',
-        'ƒ /opengraph-image',
-      ])
+      expect(buildStatus).toBe('○ /opengraph-image')
     }
   })
 
@@ -29,8 +25,7 @@ describe('use-cache-metadata-route-handler', () => {
     if (isNextStart) {
       const [buildStatus] = next.cliOutput.match(/. \/icon/)
 
-      // TODO: Should always be `○ /icon`.
-      expect(buildStatus).toBeOneOf(['○ /icon', 'ƒ /icon'])
+      expect(buildStatus).toBe('○ /icon')
     }
   })
 


### PR DESCRIPTION
Under Cache Components, metadata image routes such as `opengraph-image` and `icon` that return an `ImageResponse` were always rendered on demand (`ƒ`) rather than prerendered. `ImageResponse` defers rasterizing its element tree into the response body stream, and the route-handler prerender unwraps that body within a single task; the rasterization never finishes within that budget, so the route was classified as dynamic. This change renders and caches the image during the prerender so these routes become static (`○`).

During the prerender we serialize the `ImageResponse` arguments with React Flight's `prerenderToNodeStream` inside the prerender work-unit store, which runs the user's component tree once in the correct scope. This brings any user-space I/O inside that tree, such as `cookies()` or an uncached `fetch`, under the same Cache Components rules that already governed I/O elsewhere in the handler. The hanging-input abort signal bounds the serialization and decides static versus dynamic: if the tree is still waiting on dynamic input once the prerender's cache-sourced input is ready, the serialization can't complete and we return a hanging promise, so the final prerender's macrotask budget classifies the route as dynamic; a tree that resolves entirely from static data or `use cache` finishes serializing and is rendered to an image. This mirrors `encryptActionBoundArgs`, which serializes server action bound args with React Flight under the same hanging-input abort signal during a prerender.

The fully resolved element tree is then handed to satori. Because React Flight encodes an async Server Component's output as a `React.lazy` that satori can't walk, those references are resolved into plain elements first; this lets an async server component, including one that uses `use cache`, be passed as the `ImageResponse` element. Rasterization runs outside the prerender work-unit store: inside a Cache Components prerender an uncached `fetch`, such as the renderer loading a font, is turned into a hanging promise (Cache Components skips I/O that would not be cached anyway), so running satori with no store lets those framework fetches resolve normally. Crucially, because satori only walks the already-resolved tree, no user component runs in that storeless scope, so uncached user-space I/O can't be wrongly allowed there and let a route that should be dynamic render as static.

The rendered image is stored as an `ArrayBuffer` in a new in-memory `imageResponses` store on the Resume Data Cache, keyed by a base64 encoding of its serialized arguments, and the cache signal is held open until it is stored so the prospective prerender waits for it. The final prerender retrieves the array buffer from memory within microtasks. The store is in-memory only and is never serialized, so the image array buffers never enter the resume data that ships with the prerender.

The caching path lives in a separate `cache-image-response` module that is loaded only for Cache Components builds, gated behind `process.env.__NEXT_CACHE_COMPONENTS` so the `require` and its React Flight dependencies are eliminated as dead code otherwise; apps without Cache Components keep `ImageResponse`'s original streaming behavior unchanged.