### PR TITLE
fix: support custom page extensions in no-html-link-for-pages

### DIFF
--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -14,20 +14,21 @@ function parseUrlForPages(urlprefix: string, directory: string) {
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
-      }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
-    } else {
+    if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      return
+    }
+
+    const parsedName = path.parse(dirent.name)
+
+    // Treat any non-directory file in the pages directory as a page file.
+    // This keeps the rule aligned with custom page extensions such as .mdx.
+    if (parsedName.ext) {
+      if (parsedName.name === 'index') {
+        res.push(`${urlprefix}${parsedName.name.replace(/^index$/, '')}`)
       }
+      res.push(`${urlprefix}${parsedName.name}`)
     }
   })
   return res
@@ -52,8 +53,8 @@ function parseUrlForAppDir(urlprefix: string, directory: string) {
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(...parseUrlForAppDir(urlprefix + dirent.name + '/', dirPath))
       }
     }
   })

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -199,6 +199,20 @@ export class Blah extends Head {
   }
 }
 `
+const invalidMdxCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/markdown'>Markdown</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
 const secondInvalidDynamicCode = `
 import Link from 'next/link';
 
@@ -389,6 +403,18 @@ describe('no-html-link-for-pages', function () {
     assert.equal(
       thirdReport.message,
       'Do not use an `<a>` element to navigate to `/list/lorem-ipsum/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid custom extension page', function () {
+    const [report] = linters.withCustomPages.verify(
+      invalidMdxCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/markdown/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
   it('valid link element with appDir', function () {

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/markdown.mdx
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/markdown.mdx
@@ -1,0 +1,1 @@
+# Markdown Page


### PR DESCRIPTION
This expands the `no-html-link-for-pages` rule so it also recognizes non-JS/TS page files in the pages directory, which makes the rule work with custom `pageExtensions` setups.

The regression test covers an `.mdx` page and verifies the rule still reports internal anchor links for that page.

Checks:
- git diff --check