### PR TITLE
Navigation inspector UI updates

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
@@ -1,155 +1,27 @@
 .instant-nav-panel {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: auto;
 }
 
 .instant-nav-content {
-  flex: 1;
-  padding: 16px 20px;
+  overflow: hidden;
 }
 
-/* Waiting state: preference-style sections */
-.instant-nav-section {
-  padding: 12px 20px;
-  border-bottom: 1px solid var(--color-gray-400);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 24px;
-}
-
-.instant-nav-section:last-child {
-  border-bottom: none;
-}
-
-.instant-nav-section-header {
-  flex: 1;
-}
-
-.instant-nav-section-header label {
-  font-size: var(--size-14);
-  font-weight: 500;
-  color: var(--color-gray-1000);
-  margin: 0;
-}
-
-.instant-nav-section-description {
-  color: var(--color-gray-900);
-  font-size: var(--size-14);
-  margin: 0;
-}
-
-.instant-nav-section-control {
-  flex-shrink: 0;
-}
-
-.instant-nav-section-control .action-button {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: var(--color-background-100);
-  border: 1px solid var(--color-gray-400);
-  border-radius: var(--rounded-lg);
-  font-weight: 400;
-  font-size: var(--size-14);
-  color: var(--color-gray-1000);
-  padding: 6px 8px;
-  cursor: pointer;
-  transition: border-color 150ms var(--timing-swift);
-}
-
-.instant-nav-section-control .action-button:hover {
-  border-color: var(--color-gray-500);
-}
-
-.instant-nav-section-control .action-button svg {
-  width: 14px;
-  height: 14px;
-  overflow: visible;
-}
-
-.instant-nav-helper-text {
-  font-size: var(--size-14);
-  color: var(--color-gray-900);
-  font-style: italic;
-  white-space: nowrap;
-}
-
-/* Result states (client-nav, initial-load) */
-.instant-nav-status-title {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-gray-900);
-}
-
-.instant-nav-urls {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 4px;
-}
-
-.instant-nav-url-row {
-  display: flex;
-  gap: 8px;
-  font-size: 13px;
-}
-
-.instant-nav-url-label {
-  color: var(--color-gray-700);
-  flex-shrink: 0;
-}
-
-.instant-nav-url-value {
-  color: var(--color-gray-900);
-  word-break: break-all;
-  font-family: var(--font-mono);
-}
-
-.instant-nav-actions {
-  margin-top: 8px;
-  display: flex;
-}
-
-.instant-nav-share-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 16px;
-  border-radius: 6px;
-  border: 1px solid var(--color-gray-alpha-400);
-  background: var(--color-background-200);
-  color: var(--color-gray-900);
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 150ms ease;
-}
-
-.instant-nav-share-button:hover {
-  background: var(--color-gray-alpha-200);
-}
-
-.instant-nav-helper-description {
-  color: var(--color-gray-900);
-  font-size: var(--size-14);
-  margin: 8px 0 0;
-}
-
-/* Initial pending (capture) state */
 .instant-nav-content-container {
   position: relative;
-  height: 83px;
-  /* overflow: hidden; */
-  margin-bottom: 24px;
-  transition: height var(--instant-nav-transition-duration, 200ms)
-    var(--instant-nav-transition-timing, var(--timing-swift));
+  height: 0;
+  overflow: hidden;
+  /*
+    TODO: Add this back when we can figure out a good answer for keeping the old
+    content around during the exit animation.
+  */
+  /* transition: height var(--instant-nav-transition-duration, 200ms)
+    cubic-bezier(0.36, 0.66, 0.04, 1); */
 }
 
 .instant-nav-content-container.is-expanded {
-  height: 140px;
+  height: 225px;
 }
 
 .instant-nav-transition-layer {
@@ -157,9 +29,9 @@
   inset: 0;
   opacity: var(--instant-nav-layer-opacity, 0);
   pointer-events: none;
-  transition: opacity var(--instant-nav-layer-transition-duration, 100ms)
+  /* transition: opacity var(--instant-nav-layer-transition-duration, 100ms)
     cubic-bezier(0.25, 0.8, 0.5, 1)
-    var(--instant-nav-layer-transition-delay, 0ms);
+    var(--instant-nav-layer-transition-delay, 0ms); */
 }
 
 .instant-nav-transition-layer.is-visible {
@@ -171,173 +43,238 @@
   transition: none;
 }
 
-.instant-nav-intro-description {
-  margin: 0;
-  color: var(--color-gray-1000);
-  font-size: var(--size-14);
-  line-height: 1.5;
+.instant-nav-state {
+  box-sizing: border-box;
+  height: 225px;
+  padding: 0;
 }
 
-.instant-nav-divider {
-  border: 0;
-  border-top: 1px solid var(--color-gray-400);
-  margin: 16px 0;
-}
-
-.instant-nav-capture-controls {
-  display: flex;
-  gap: 12px;
-}
-
-.instant-nav-capture-button {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  flex: 1;
-  padding: 8px 24px;
-  border-radius: 9999px;
-  border: 1px solid var(--color-gray-600);
-  background: var(--color-background-100);
-  color: var(--color-gray-1000);
-  font-size: var(--size-14);
-  font-weight: 400;
-  cursor: pointer;
-  transition:
-    background-color 150ms var(--timing-swift),
-    border-color 150ms var(--timing-swift);
-}
-
-.instant-nav-capture-button svg {
-  position: absolute;
-  left: 8px;
-}
-
-.instant-nav-capture-button--inline-icon {
-  /* gap: 8px; */
-}
-
-.instant-nav-capture-button--inline-icon svg {
-  position: static;
-  margin-right: 4px;
-}
-
-.instant-nav-capture-button:hover:not(:disabled) {
-  background: var(--color-gray-200);
-}
-
-.instant-nav-capture-button:focus-visible {
-  outline: var(--focus-ring);
-  outline-offset: 2px;
-}
-
-.instant-nav-capture-button:disabled {
-  border-color: var(--color-gray-400);
-  color: var(--color-gray-700);
-  cursor: not-allowed;
-}
-
-.instant-nav-capture-button--active {
-  background: var(--color-red-200);
-  border-color: var(--color-red-700);
-  color: var(--color-red-900);
-}
-
-.instant-nav-capture-button--active:hover:not(:disabled) {
-  background: var(--color-red-300);
-}
-
-.instant-nav-state-card {
-  padding: 16px;
-  border-radius: var(--rounded-lg);
-  background: var(--color-background-200);
-  border: 1px solid var(--color-gray-500);
+.instant-nav-state--pending {
   display: flex;
   flex-direction: column;
-  height: 140px;
-  box-sizing: border-box;
+}
+
+.instant-nav-state-details {
+  padding: 16px 20px 0;
 }
 
 .instant-nav-state-title {
   margin: 0;
-  font-size: var(--size-18);
+  font-size: var(--size-14);
   font-weight: 600;
+  line-height: 21px;
   color: var(--color-gray-1000);
 }
 
 .instant-nav-state-description {
-  margin: 4px 0 0;
+  margin: 0;
   font-size: var(--size-14);
+  line-height: 21px;
+  color: var(--color-gray-900);
+}
+
+.instant-nav-waiting-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  height: 42px;
+  padding: 0 20px;
+  background: #e0ebff;
+  box-sizing: border-box;
+}
+
+.instant-nav-waiting-status-dot {
+  position: relative;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #b8cffb;
+}
+
+.instant-nav-waiting-status-dot::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-blue-700);
+}
+
+.instant-nav-waiting-status-title {
+  margin: 0;
+  color: var(--color-gray-1000);
+  font-size: var(--size-13);
+  font-weight: 400;
+  line-height: 1;
+}
+
+.instant-nav-waiting-description {
+  margin: 16px 0 0;
+  padding: 0 20px;
+  color: var(--color-gray-1000);
+  font-size: var(--size-14);
+  line-height: 21px;
+}
+
+.instant-nav-state-url-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 21px;
+}
+
+.instant-nav-url-row {
+  display: flex;
+  flex-direction: column;
+  margin-top: 21px;
+  min-width: 0;
+  font-size: var(--size-14);
+  line-height: 21px;
   color: var(--color-gray-1000);
 }
 
-.instant-nav-state-card--awaiting .instant-nav-state-description {
-  margin-top: auto;
-  color: var(--color-gray-900);
+.instant-nav-state-url-list .instant-nav-url-row {
+  margin-top: 0;
 }
 
-.instant-nav-state-source-url {
-  margin: auto 0 0;
-  font-size: var(--size-14);
-  color: var(--color-gray-900);
+.instant-nav-url-label {
+  flex: 0 0 auto;
+  text-transform: uppercase;
+  font-size: var(--size-10);
+  color: var(--color-gray-700);
+  font-weight: 600;
+  letter-spacing: 5%;
+  line-height: 12px;
+}
+
+.instant-nav-url-value {
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  overflow: hidden;
+  /* font-family: monospace; */
+  font-weight: 500;
+  font-size: var(--size-12);
+  /* line-height: 1; */
 }
 
-/* Footer (pinned to bottom, matching segment-explorer-footer) */
-.instant-nav-footer {
-  display: flex;
-  gap: 8px;
-  padding: 8px;
-  border-top: 1px solid var(--color-gray-400);
-  user-select: none;
-}
-
-.instant-nav-footer-button {
+.instant-nav-debugger-paused {
   display: flex;
   align-items: center;
-  justify-content: center;
-  flex: 1;
+  gap: 12px;
+  width: 100%;
+  height: 42px;
+  padding: 0 20px;
+  border: 0;
+  background: #fef4ab;
+  color: var(--color-gray-1000);
+  font-size: var(--size-13);
+  font-weight: 400;
+  line-height: 1;
+}
+.instant-nav-debugger-paused-button {
+  margin-left: auto;
+  font-size: var(--size-12);
+  font-weight: 500;
+  color: var(--color-gray-1000);
+  padding: 7px 12px 7px 14px;
+  border-radius: 9999px;
+  background-color: white;
+  border: 1px solid #dfd587;
+  display: inline-flex;
   gap: 8px;
-  padding: 6px;
-  background: var(--color-background-100);
-  border: 1px solid var(--color-gray-400);
-  border-radius: 6px;
+  align-items: center;
+}
+
+.instant-nav-debugger-paused-button:hover {
+  background: #fafafa;
+}
+
+.instant-nav-debugger-paused-button:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.instant-nav-debugger-paused-button svg {
+  flex: 0 0 auto;
+}
+
+.instant-nav-debugger-paused-button span {
+  flex: 1;
+  text-align: left;
+}
+
+.instant-nav-pause-control {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border-top: 1px solid var(--color-gray-400);
+  margin-top: -1px;
+}
+
+.instant-nav-pause-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.instant-nav-pause-copy label {
+  margin: 0;
   color: var(--color-gray-1000);
   font-size: var(--size-14);
   font-weight: 500;
+  line-height: 21px;
+}
+
+.instant-nav-pause-copy p {
+  margin: 0px;
+  color: var(--color-gray-900);
+  font-size: var(--size-14);
+  line-height: 21px;
+}
+
+.instant-nav-pause-toggle {
+  position: relative;
+  flex: 0 0 auto;
+  width: 36px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: 9999px;
+  background: var(--color-gray-300);
+  box-shadow: inset 0 0 0 1px var(--color-gray-alpha-300);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition:
+    background-color 150ms var(--timing-swift),
+    box-shadow 150ms var(--timing-swift);
 }
 
-.instant-nav-footer-button:hover {
-  background: var(--color-gray-200);
+.instant-nav-pause-toggle[aria-checked='true'] {
+  background: var(--color-blue-700);
+  box-shadow: inset 0 0 0 1px var(--color-blue-700);
 }
 
-/* Shimmer skeleton for pending "to" route */
-@keyframes instant-nav-shimmer {
-  0% {
-    background-position: -400px 0;
-  }
-  100% {
-    background-position: 400px 0;
-  }
+.instant-nav-pause-toggle:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
 }
 
-.instant-nav-skeleton {
-  display: inline-block;
-  width: 120px;
-  height: 1em;
-  vertical-align: middle;
-  border-radius: 4px;
-  background: linear-gradient(
-    90deg,
-    var(--color-gray-300) 25%,
-    var(--color-blue-300) 50%,
-    var(--color-gray-300) 75%
-  );
-  background-size: 800px 100%;
-  animation: instant-nav-shimmer 1.5s ease-in-out infinite;
+.instant-nav-pause-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-background-100);
+  box-shadow: 0 1px 2px var(--color-gray-alpha-400);
+  transition: transform 150ms var(--timing-swift);
+}
+
+.instant-nav-pause-toggle[aria-checked='true'] .instant-nav-pause-toggle-thumb {
+  transform: translateX(16px);
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
@@ -10,18 +10,7 @@
 
 .instant-nav-content-container {
   position: relative;
-  height: 0;
   overflow: hidden;
-  /*
-    TODO: Add this back when we can figure out a good answer for keeping the old
-    content around during the exit animation.
-  */
-  /* transition: height var(--instant-nav-transition-duration, 200ms)
-    cubic-bezier(0.36, 0.66, 0.04, 1); */
-}
-
-.instant-nav-content-container.is-expanded {
-  height: 225px;
 }
 
 .instant-nav-transition-layer {
@@ -29,9 +18,9 @@
   inset: 0;
   opacity: var(--instant-nav-layer-opacity, 0);
   pointer-events: none;
-  /* transition: opacity var(--instant-nav-layer-transition-duration, 100ms)
+  transition: opacity var(--instant-nav-layer-transition-duration, 100ms)
     cubic-bezier(0.25, 0.8, 0.5, 1)
-    var(--instant-nav-layer-transition-delay, 0ms); */
+    var(--instant-nav-layer-transition-delay, 0ms);
 }
 
 .instant-nav-transition-layer.is-visible {
@@ -41,12 +30,6 @@
 
 .instant-nav-transition-layer--no-enter {
   transition: none;
-}
-
-.instant-nav-state {
-  box-sizing: border-box;
-  height: 225px;
-  padding: 0;
 }
 
 .instant-nav-state--pending {

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
@@ -47,13 +47,26 @@
   font-weight: 600;
   line-height: 21px;
   color: var(--color-gray-1000);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.instant-nav-state-title-type {
+  color: var(--color-gray-900);
+  font-size: var(--size-11);
+  font-weight: 500;
+  background-color: var(--color-gray-100);
+  padding: 4px 5px;
+  line-height: 1;
+  border-radius: 4px;
+  margin-left: 2px;
 }
 
 .instant-nav-state-description {
-  margin: 0;
+  margin-top: 4px;
   font-size: var(--size-14);
-  line-height: 21px;
-  color: var(--color-gray-900);
+  color: var(--color-gray-800);
 }
 
 .instant-nav-waiting-status {

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -87,7 +87,28 @@ function useInstantNavStatus(
   return getInstantNavStatus(cookieData, transientStatus)
 }
 
-const DURATION = 200
+const DURATION = 400
+
+function createPendingInstantNavCookie(): InstantCookie {
+  return [0, `p${Math.random()}`]
+}
+
+function setPendingInstantNavCookie(): void {
+  if (typeof cookieStore !== 'undefined') {
+    cookieStore.set({
+      name: COOKIE_NAME,
+      value: JSON.stringify(createPendingInstantNavCookie()),
+      path: '/',
+    })
+  }
+}
+
+function getCurrentLocationUrl(): string {
+  if (typeof window === 'undefined') {
+    return '/'
+  }
+  return window.location.pathname + window.location.search
+}
 
 function InstantNavContentTransition({
   status,
@@ -237,12 +258,11 @@ export function InstantNavsPanel() {
 
   // While we're waiting for a "Continue Rendering" -> restart to finish,
   // the cookie is briefly absent. Treat that window as pending so the
-  // panel keeps showing the "Awaiting navigation..." UI instead of
+  // panel keeps showing the "Waiting for navigation..." UI instead of
   // flickering back to idle.
   const status = useInstantNavStatus(cookieData)
   const contentStatus = getContentStatus(status)
   const isLocked = status !== 'idle'
-  const isPending = contentStatus === 'pending'
 
   const isClosing = panel !== 'instant-navs'
   const [displayStatus, setDisplayStatus] = useState(contentStatus)
@@ -251,57 +271,104 @@ export function InstantNavsPanel() {
     setDisplayStatus(contentStatus)
   }
 
-  const currentSpaSourceUrl =
+  const currentSpaFromUrl =
     cookieData?.state === 'spa' ? formatRoutePattern(cookieData.fromTree) : null
-  // Keep the most recent SPA source URL available while the outgoing card fades.
-  const [lastSpaSourceUrl, setLastSpaSourceUrl] = useState<string | null>(
-    currentSpaSourceUrl
+  const currentSpaToUrl =
+    cookieData?.state === 'spa' && cookieData.toTree !== null
+      ? formatRoutePattern(cookieData.toTree)
+      : null
+
+  // Keep the most recent SPA URLs available while the outgoing card fades.
+  const [lastSpaFromUrl, setLastSpaFromUrl] = useState<string | null>(
+    currentSpaFromUrl
+  )
+  const [lastSpaToUrl, setLastSpaToUrl] = useState<string | null>(
+    currentSpaToUrl
   )
 
-  if (
-    currentSpaSourceUrl !== null &&
-    currentSpaSourceUrl !== lastSpaSourceUrl
-  ) {
-    setLastSpaSourceUrl(currentSpaSourceUrl)
+  if (currentSpaFromUrl !== null && currentSpaFromUrl !== lastSpaFromUrl) {
+    setLastSpaFromUrl(currentSpaFromUrl)
   }
 
-  const spaSourceUrl = currentSpaSourceUrl ?? lastSpaSourceUrl
+  if (currentSpaToUrl !== null && currentSpaToUrl !== lastSpaToUrl) {
+    setLastSpaToUrl(currentSpaToUrl)
+  }
+
+  const spaFromUrl = currentSpaFromUrl ?? lastSpaFromUrl
+  const spaToUrl = currentSpaToUrl ?? lastSpaToUrl
+
+  async function continueRendering(): Promise<void> {
+    if (typeof cookieStore !== 'undefined') {
+      // Continue Rendering: delete the cookie (which releases the
+      // lock and triggers a soft refresh for real data via the lock
+      // listener), then restart capture for the next navigation by
+      // writing a fresh pending cookie. Chaining the writes keeps
+      // them as two ordered cookie events (delete -> refresh, then
+      // restart) rather than coalescing into one, so the refresh runs
+      // and snapshots the released lock before the restart re-acquires it.
+      setInstantNavTransientStatus('restarting')
+      const pendingCookie: InstantCookie = [0, `p${Math.random()}`]
+      await cookieStore.delete(COOKIE_NAME)
+      cookieStore.set({
+        name: COOKIE_NAME,
+        value: JSON.stringify(pendingCookie),
+        path: '/',
+      })
+    }
+  }
+
+  function togglePaused(): void {
+    if (isLocked) {
+      clearInstantNavCaptureCookie()
+    } else {
+      setPendingInstantNavCookie()
+    }
+  }
 
   const content: Record<InstantNavContentStatus, ReactNode> = {
-    idle: (
-      <p className="instant-nav-intro-description">
-        Inspect the UI that will show instantly to users as they navigate around
-        your app. Start capturing, then click any link or refresh the current
-        page.
-      </p>
-    ),
+    idle: null,
     pending: (
-      <div className="instant-nav-state-card instant-nav-state-card--awaiting">
-        <h3 className="instant-nav-state-title">Awaiting navigation...</h3>
-        <p className="instant-nav-state-description">
-          Click any link or refresh the page.
+      <div className="instant-nav-state instant-nav-state--pending">
+        <div className="instant-nav-waiting-status">
+          <span className="instant-nav-waiting-status-dot" />
+          <h3 className="instant-nav-waiting-status-title">
+            Waiting for navigation...
+          </h3>
+        </div>
+        <p className="instant-nav-waiting-description">
+          Click any link or refresh the page to inspect the shell.
         </p>
       </div>
     ),
     mpa: (
-      <div className="instant-nav-state-card">
-        <h3 className="instant-nav-state-title">Page load</h3>
-        <p className="instant-nav-state-description">
-          You're viewing the prerendered UI for the current page.
-        </p>
+      <div className="instant-nav-state">
+        <DebuggerPausedButton onClick={continueRendering} />
+        <div className="instant-nav-state-details">
+          <h3 className="instant-nav-state-title">Static shell</h3>
+          <p className="instant-nav-state-description">
+            You're viewing the shell for this page's initial load.
+          </p>
+          <UrlRow label="Target" value={getCurrentLocationUrl()} />
+        </div>
       </div>
     ),
     spa: (
-      <div className="instant-nav-state-card">
-        <h3 className="instant-nav-state-title">Navigation</h3>
-        <p className="instant-nav-state-description">
-          You're viewing the prefetched UI for the last navigation.
-        </p>
-        {spaSourceUrl !== null ? (
-          <p className="instant-nav-state-source-url" title={spaSourceUrl}>
-            Source URL: {spaSourceUrl}
+      <div className="instant-nav-state">
+        <DebuggerPausedButton onClick={continueRendering} />
+        <div className="instant-nav-state-details">
+          <h3 className="instant-nav-state-title">Client shell</h3>
+          <p className="instant-nav-state-description">
+            You're viewing the shell for the current navigation.
           </p>
-        ) : null}
+          <div className="instant-nav-state-url-list">
+            {spaFromUrl !== null ? (
+              <UrlRow label="Source" value={spaFromUrl} />
+            ) : null}
+            {spaToUrl !== null ? (
+              <UrlRow label="Target" value={spaToUrl} />
+            ) : null}
+          </div>
+        </div>
       </div>
     ),
   }
@@ -312,93 +379,87 @@ export function InstantNavsPanel() {
         <InstantNavContentTransition status={displayStatus}>
           {content}
         </InstantNavContentTransition>
-
-        <div className="instant-nav-capture-controls">
-          {isLocked ? (
-            <button
-              type="button"
-              className="instant-nav-capture-button instant-nav-capture-button--active"
-              onClick={() => {
-                // Delete the cookie to release the lock and end the capture session.
-                // The CookieStore change event triggers refreshOnInstantNavigationUnlock
-                // which does a soft refresh to fetch dynamic data.
-                clearInstantNavCaptureCookie()
-              }}
-            >
-              <StopIcon />
-              Stop Capturing
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="instant-nav-capture-button"
-              onClick={() => {
-                if (typeof cookieStore !== 'undefined') {
-                  const cookie: InstantCookie = [0, `p${Math.random()}`]
-                  cookieStore.set({
-                    name: COOKIE_NAME,
-                    value: JSON.stringify(cookie),
-                    path: '/',
-                  })
-                }
-              }}
-            >
-              <RecordIcon />
-              Start Capturing
-            </button>
-          )}
-          <button
-            type="button"
-            className="instant-nav-capture-button instant-nav-capture-button--inline-icon"
-            onClick={() => {
-              if (typeof cookieStore !== 'undefined') {
-                // Continue Rendering: delete the cookie (which releases the
-                // lock and triggers a soft refresh for real data via the lock
-                // listener), then restart capture for the next navigation by
-                // writing a fresh pending cookie. Chaining the writes keeps
-                // them as two ordered cookie events (delete -> refresh, then
-                // restart) rather than coalescing into one, so the refresh runs
-                // and snapshots the released lock before the restart re-acquires it.
-                setInstantNavTransientStatus('restarting')
-                const pendingCookie: InstantCookie = [0, `p${Math.random()}`]
-                cookieStore.delete(COOKIE_NAME).then(() => {
-                  cookieStore.set({
-                    name: COOKIE_NAME,
-                    value: JSON.stringify(pendingCookie),
-                    path: '/',
-                  })
-                })
-              }
-            }}
-            disabled={!isLocked || isPending}
-          >
-            <PlayIcon />
-            Continue Rendering
-          </button>
-        </div>
       </div>
+      <PauseControl checked={isLocked} onClick={togglePaused} />
     </div>
   )
 }
 
-function RecordIcon() {
+function DebuggerPausedButton({ onClick }: { onClick: () => void }) {
+  return (
+    <div className="instant-nav-debugger-paused">
+      <InfoIcon />
+      <span>Debugger paused</span>
+      <button
+        type="button"
+        className="instant-nav-debugger-paused-button"
+        onClick={onClick}
+        aria-label="Continue rendering"
+      >
+        Resume
+        <PlayIcon />
+      </button>
+    </div>
+  )
+}
+
+function PauseControl({
+  checked,
+  onClick,
+}: {
+  checked: boolean
+  onClick: () => void
+}) {
+  return (
+    <div className="instant-nav-pause-control">
+      <div className="instant-nav-pause-copy">
+        <label htmlFor="instant-nav-pause-toggle">Pause on navigations</label>
+        <p>
+          When enabled, every navigation will pause so you can inspect the shell
+          before resuming.
+        </p>
+      </div>
+      <button
+        id="instant-nav-pause-toggle"
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label="Pause on navigations"
+        className="instant-nav-pause-toggle"
+        onClick={onClick}
+      >
+        <span className="instant-nav-pause-toggle-thumb" />
+      </button>
+    </div>
+  )
+}
+
+function UrlRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="instant-nav-url-row">
+      <span className="instant-nav-url-label">{label}</span>
+      <span className="instant-nav-url-value" title={value}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function InfoIcon() {
   return (
     <svg
-      width="20"
-      height="20"
       viewBox="0 0 16 16"
-      fill="none"
+      height="16"
+      width="16"
       aria-hidden="true"
+      style={{ color: 'currentcolor' }}
     >
-      <circle
-        cx="8"
-        cy="8"
-        r="6.25"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        opacity="0.5"
-      />
-      <circle cx="8" cy="8" r="3.25" fill="currentColor" />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M8 14.5a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16M6.25 7h1.5a1 1 0 0 1 1 1v4.25h-1.5V8.5h-1zM8 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2"
+        clipRule="evenodd"
+      ></path>
     </svg>
   )
 }
@@ -409,32 +470,11 @@ function PlayIcon() {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      width="14"
-      height="14"
-    >
-      <path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.841Z" />
-    </svg>
-  )
-}
-
-function StopIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 16 16"
-      fill="none"
+      width="12"
+      height="12"
       aria-hidden="true"
     >
-      <circle
-        cx="8"
-        cy="8"
-        r="6.25"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        opacity="0.5"
-      />
-      <rect x="5.5" y="5.5" width="5" height="5" rx="1" fill="currentColor" />
+      <path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.841Z" />
     </svg>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -1,20 +1,19 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
+import type { InstantCookie } from '../../../../shared/lib/app-router-types'
+import type { InstantNavCookieData } from '../../../../shared/lib/instant-nav-cookie'
 import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { useDelayedRender } from '../../hooks/use-delayed-render'
 import { usePanelRouterContext } from '../../menu/context'
 import { ACTION_INSTANT_NAVS_RESET } from '../../shared'
 import {
-  useInstantNavCookieState,
   formatRoutePattern,
+  useInstantNavCookieState,
 } from './instant-nav-cookie'
 import './instant-navs-panel.css'
-import type { CSSProperties, ReactNode } from 'react'
-import type { InstantCookie } from '../../../../shared/lib/app-router-types'
-import type { InstantNavCookieData } from '../../../../shared/lib/instant-nav-cookie'
 
 const COOKIE_NAME = 'next-instant-navigation-testing'
 type InstantNavContentStatus = 'idle' | 'pending' | 'mpa' | 'spa'
-// During a "Continue Rendering" restart the cookie is briefly absent (it's
+// During a "Resume" restart the cookie is briefly absent (it's
 // deleted, then re-written as a new pending cookie). The transient "restarting"
 // status keeps the panel on "Awaiting navigation..." across that gap instead
 // of flickering back to idle until the new pending cookie lands.
@@ -88,6 +87,7 @@ function useInstantNavStatus(
 }
 
 const DURATION = 400
+const EXPANDED_HEIGHT = 225
 
 function createPendingInstantNavCookie(): InstantCookie {
   return [0, `p${Math.random()}`]
@@ -108,105 +108,6 @@ function getCurrentLocationUrl(): string {
     return '/'
   }
   return window.location.pathname + window.location.search
-}
-
-function InstantNavContentTransition({
-  status,
-  children,
-}: {
-  status: InstantNavContentStatus
-  children: Record<InstantNavContentStatus, ReactNode>
-}) {
-  const [initialStatus] = useState(status)
-  const [hasChangedStatus, setHasChangedStatus] = useState(false)
-
-  if (status !== initialStatus && !hasChangedStatus) {
-    setHasChangedStatus(true)
-  }
-
-  return (
-    <div
-      className={
-        'instant-nav-content-container' +
-        (status === 'idle' ? '' : ' is-expanded')
-      }
-      style={
-        {
-          '--instant-nav-transition-duration': `${DURATION}ms`,
-          '--instant-nav-transition-half-duration': `${DURATION / 2}ms`,
-          '--instant-nav-transition-timing': 'cubic-bezier(0.25, 0.8, 0.5, 1)',
-        } as CSSProperties
-      }
-    >
-      <InstantNavTransitionLayer
-        active={status === 'idle'}
-        enter={hasChangedStatus}
-      >
-        {children.idle}
-      </InstantNavTransitionLayer>
-      <InstantNavTransitionLayer
-        active={status === 'pending'}
-        enter={hasChangedStatus}
-      >
-        {children.pending}
-      </InstantNavTransitionLayer>
-      <InstantNavTransitionLayer
-        active={status === 'mpa'}
-        enter={hasChangedStatus}
-      >
-        {children.mpa}
-      </InstantNavTransitionLayer>
-      <InstantNavTransitionLayer
-        active={status === 'spa'}
-        enter={hasChangedStatus}
-      >
-        {children.spa}
-      </InstantNavTransitionLayer>
-    </div>
-  )
-}
-
-function InstantNavTransitionLayer({
-  active,
-  enter = true,
-  children,
-}: {
-  active: boolean
-  enter?: boolean
-  children: ReactNode
-}) {
-  const { mounted, rendered } = useDelayedRender(active, {
-    enterDelay: enter ? 1 : 0,
-    exitDelay: DURATION,
-  })
-
-  if (!mounted) return null
-
-  const visible = rendered || (active && !enter)
-  const entering = active && enter
-
-  return (
-    <div
-      className={
-        'instant-nav-transition-layer' +
-        (visible ? ' is-visible' : '') +
-        (active && !enter ? ' instant-nav-transition-layer--no-enter' : '')
-      }
-      aria-hidden={!active}
-      style={
-        {
-          '--instant-nav-layer-opacity': visible ? 1 : 0,
-          '--instant-nav-layer-transition-duration':
-            'var(--instant-nav-transition-half-duration, 100ms)',
-          '--instant-nav-layer-transition-delay': entering
-            ? 'var(--instant-nav-transition-half-duration, 100ms)'
-            : '0ms',
-        } as CSSProperties
-      }
-    >
-      {children}
-    </div>
-  )
 }
 
 // Ends the capture: deleting the cookie triggers the CookieStore handler in
@@ -256,7 +157,7 @@ export function InstantNavsPanel() {
     }
   }, [cookieData?.state])
 
-  // While we're waiting for a "Continue Rendering" -> restart to finish,
+  // While we're waiting for a "Resume" -> restart to finish,
   // the cookie is briefly absent. Treat that window as pending so the
   // panel keeps showing the "Waiting for navigation..." UI instead of
   // flickering back to idle.
@@ -297,9 +198,9 @@ export function InstantNavsPanel() {
   const spaFromUrl = currentSpaFromUrl ?? lastSpaFromUrl
   const spaToUrl = currentSpaToUrl ?? lastSpaToUrl
 
-  async function continueRendering(): Promise<void> {
+  async function resume(): Promise<void> {
     if (typeof cookieStore !== 'undefined') {
-      // Continue Rendering: delete the cookie (which releases the
+      // Resume: delete the cookie (which releases the
       // lock and triggers a soft refresh for real data via the lock
       // listener), then restart capture for the next navigation by
       // writing a fresh pending cookie. Chaining the writes keeps
@@ -325,60 +226,85 @@ export function InstantNavsPanel() {
     }
   }
 
-  const content: Record<InstantNavContentStatus, ReactNode> = {
-    idle: null,
-    pending: (
-      <div className="instant-nav-state instant-nav-state--pending">
-        <div className="instant-nav-waiting-status">
-          <span className="instant-nav-waiting-status-dot" />
-          <h3 className="instant-nav-waiting-status-title">
-            Waiting for navigation...
-          </h3>
-        </div>
-        <p className="instant-nav-waiting-description">
-          Click any link or refresh the page to inspect the shell.
-        </p>
-      </div>
-    ),
-    mpa: (
-      <div className="instant-nav-state">
-        <DebuggerPausedButton onClick={continueRendering} />
-        <div className="instant-nav-state-details">
-          <h3 className="instant-nav-state-title">Static shell</h3>
-          <p className="instant-nav-state-description">
-            You're viewing the shell for this page's initial load.
-          </p>
-          <UrlRow label="Target" value={getCurrentLocationUrl()} />
-        </div>
-      </div>
-    ),
-    spa: (
-      <div className="instant-nav-state">
-        <DebuggerPausedButton onClick={continueRendering} />
-        <div className="instant-nav-state-details">
-          <h3 className="instant-nav-state-title">Client shell</h3>
-          <p className="instant-nav-state-description">
-            You're viewing the shell for the current navigation.
-          </p>
-          <div className="instant-nav-state-url-list">
-            {spaFromUrl !== null ? (
-              <UrlRow label="Source" value={spaFromUrl} />
-            ) : null}
-            {spaToUrl !== null ? (
-              <UrlRow label="Target" value={spaToUrl} />
-            ) : null}
-          </div>
-        </div>
-      </div>
-    ),
+  // These two pieces of state are used to preserve the panel's contents
+  // during the collapsing animation.
+  const { mounted } = useDelayedRender(status !== 'idle', {
+    exitDelay: DURATION,
+  })
+  const [renderedStatus, setRenderedStatus] = useState(status)
+  if (status !== renderedStatus && ['pending', 'mpa', 'spa'].includes(status)) {
+    setRenderedStatus(status)
+  }
+
+  const containerHeight = status === 'idle' ? 0 : EXPANDED_HEIGHT
+
+  // This preserves whatever the last height of the expandable container was
+  // when the entire panel is dismissed (via ESC or by pressing X) so that
+  // its height doesn't change during the fade-out animation.
+  const [previousPanel, setPreviousPanel] = useState(panel)
+  const [exitingHeight, setExitingHeight] = useState<null | number>(null)
+  if (previousPanel !== panel) {
+    setPreviousPanel(panel)
+    setExitingHeight(containerHeight)
   }
 
   return (
     <div className="instant-nav-panel">
       <div className="instant-nav-content">
-        <InstantNavContentTransition status={displayStatus}>
-          {content}
-        </InstantNavContentTransition>
+        <div
+          className="instant-nav-content-container"
+          style={{
+            transition: `height ${DURATION}ms cubic-bezier(0.36, 0.66, 0.04, 1)`,
+            height: exitingHeight !== null ? exitingHeight : containerHeight,
+          }}
+        >
+          {mounted && (
+            <div style={{ height: EXPANDED_HEIGHT }}>
+              {renderedStatus === 'pending' ? (
+                <div className=" instant-nav-state--pending">
+                  <div className="instant-nav-waiting-status">
+                    <span className="instant-nav-waiting-status-dot" />
+                    <h3 className="instant-nav-waiting-status-title">
+                      Waiting for navigation...
+                    </h3>
+                  </div>
+                  <p className="instant-nav-waiting-description">
+                    Click any link or refresh the page to inspect the shell.
+                  </p>
+                </div>
+              ) : renderedStatus === 'mpa' ? (
+                <div className="">
+                  <DebuggerPausedButton onClick={resume} />
+                  <div className="instant-nav-state-details">
+                    <h3 className="instant-nav-state-title">Static shell</h3>
+                    <p className="instant-nav-state-description">
+                      You're viewing the shell for this page's initial load.
+                    </p>
+                    <UrlRow label="Target" value={getCurrentLocationUrl()} />
+                  </div>
+                </div>
+              ) : renderedStatus === 'spa' ? (
+                <div className="">
+                  <DebuggerPausedButton onClick={resume} />
+                  <div className="instant-nav-state-details">
+                    <h3 className="instant-nav-state-title">Client shell</h3>
+                    <p className="instant-nav-state-description">
+                      You're viewing the shell for the current navigation.
+                    </p>
+                    <div className="instant-nav-state-url-list">
+                      {spaFromUrl !== null ? (
+                        <UrlRow label="Source" value={spaFromUrl} />
+                      ) : null}
+                      {spaToUrl !== null ? (
+                        <UrlRow label="Target" value={spaToUrl} />
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
       </div>
       <PauseControl checked={isLocked} onClick={togglePaused} />
     </div>
@@ -394,7 +320,7 @@ function DebuggerPausedButton({ onClick }: { onClick: () => void }) {
         type="button"
         className="instant-nav-debugger-paused-button"
         onClick={onClick}
-        aria-label="Continue rendering"
+        aria-label="Resume"
       >
         Resume
         <PlayIcon />

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -292,7 +292,9 @@ export function InstantNavsPanel() {
                 <div className="">
                   <DebuggerPausedButton onClick={resume} />
                   <div className="instant-nav-state-details">
-                    <h3 className="instant-nav-state-title">Client shell</h3>
+                    <h3 className="instant-nav-state-title">
+                      Navigation shell
+                    </h3>
                     <p className="instant-nav-state-description">
                       You're viewing the shell for the current navigation.
                     </p>

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -240,12 +240,17 @@ export function InstantNavsPanel() {
 
   // This preserves whatever the last height of the expandable container was
   // when the entire panel is dismissed (via ESC or by pressing X) so that
-  // its height doesn't change during the fade-out animation.
+  // its height doesn't change during the fade-out animation. We only freeze
+  // the height while leaving the panel; re-entering it must reset back to
+  // null so the container can size to its content again. Otherwise, reopening
+  // the panel before it unmounts (it stays mounted briefly for the fade-out)
+  // would leave the height frozen at the dismissed value (e.g. 0), keeping
+  // the panel permanently collapsed.
   const [previousPanel, setPreviousPanel] = useState(panel)
   const [exitingHeight, setExitingHeight] = useState<null | number>(null)
   if (previousPanel !== panel) {
     setPreviousPanel(panel)
-    setExitingHeight(containerHeight)
+    setExitingHeight(panel === 'instant-navs' ? null : containerHeight)
   }
 
   return (

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -281,7 +281,12 @@ export function InstantNavsPanel() {
                 <div className="">
                   <DebuggerPausedButton onClick={resume} />
                   <div className="instant-nav-state-details">
-                    <h3 className="instant-nav-state-title">Static shell</h3>
+                    <h3 className="instant-nav-state-title">
+                      Loading shell
+                      <span className="instant-nav-state-title-type">
+                        Page load
+                      </span>
+                    </h3>
                     <p className="instant-nav-state-description">
                       You're viewing the shell for this page's initial load.
                     </p>
@@ -293,7 +298,10 @@ export function InstantNavsPanel() {
                   <DebuggerPausedButton onClick={resume} />
                   <div className="instant-nav-state-details">
                     <h3 className="instant-nav-state-title">
-                      Navigation shell
+                      Loading shell
+                      <span className="instant-nav-state-title-type">
+                        Client nav
+                      </span>
                     </h3>
                     <p className="instant-nav-state-description">
                       You're viewing the shell for the current navigation.
@@ -348,8 +356,8 @@ function PauseControl({
       <div className="instant-nav-pause-copy">
         <label htmlFor="instant-nav-pause-toggle">Pause on navigations</label>
         <p>
-          When enabled, every navigation will pause so you can inspect the shell
-          before resuming.
+          When enabled, every navigation will pause so you can inspect the
+          loading shell before resuming.
         </p>
       </div>
       <button

--- a/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.css
@@ -31,4 +31,7 @@
 .draggable-content {
   flex: 1;
   overflow: auto;
+  border-radius: inherit;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -232,7 +232,7 @@ describe('instant-nav-panel', () => {
       browser,
       'Debugger paused',
       'Resume',
-      'Client shell',
+      'Navigation shell',
       "You're viewing the shell for the current navigation.",
       'SOURCE',
       'TARGET'
@@ -696,7 +696,7 @@ describe('instant-nav-panel', () => {
 
       const initialPanelText = await getInstantNavPanelText(browser)
       expect(initialPanelText).toContain('Static shell')
-      expect(initialPanelText).not.toContain('Client shell')
+      expect(initialPanelText).not.toContain('Navigation shell')
 
       await expectMpaPanel(browser)
       await expectTargetPageMpaShell(browser)

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -46,16 +46,14 @@ describe('instant-nav-panel', () => {
   }
 
   async function clickStartCapturing(browser: Playwright) {
-    await browser
-      .locator('.instant-nav-capture-button', { hasText: 'Start Capturing' })
-      .click()
+    await browser.locator('#instant-nav-pause-toggle').click()
     await waitForInstantModeCookie(browser)
   }
 
   async function clickContinueRendering(browser: Playwright) {
     await browser
-      .locator('.instant-nav-capture-button', {
-        hasText: 'Continue Rendering',
+      .locator('.instant-nav-debugger-paused-button', {
+        hasText: 'Resume',
       })
       .click()
   }
@@ -204,38 +202,40 @@ describe('instant-nav-panel', () => {
   async function expectIdlePanel(browser: Playwright) {
     await expectInstantNavPanelText(
       browser,
-      'Inspect the UI',
-      'Start Capturing',
-      'Continue Rendering'
+      'Pause on navigations',
+      'When enabled, every navigation will pause so you can inspect the shell before resuming.'
     )
   }
 
   async function expectPendingPanel(browser: Playwright) {
     await expectInstantNavPanelText(
       browser,
-      'Awaiting navigation',
-      'Stop Capturing',
-      'Continue Rendering'
+      'Waiting for navigation',
+      'Click any link or refresh the page to inspect the shell.',
+      'Pause on navigations'
     )
   }
 
   async function expectMpaPanel(browser: Playwright) {
     await expectInstantNavPanelText(
       browser,
-      'Page load',
-      'prerendered UI',
-      'Stop Capturing',
-      'Continue Rendering'
+      'Debugger paused',
+      'Resume',
+      'Static shell',
+      "You're viewing the shell for this page's initial load.",
+      'TARGET'
     )
   }
 
   async function expectSpaPanel(browser: Playwright) {
     await expectInstantNavPanelText(
       browser,
-      'Navigation',
-      'prefetched UI',
-      'Stop Capturing',
-      'Continue Rendering'
+      'Debugger paused',
+      'Resume',
+      'Client shell',
+      "You're viewing the shell for the current navigation.",
+      'SOURCE',
+      'TARGET'
     )
   }
 
@@ -351,9 +351,10 @@ describe('instant-nav-panel', () => {
       // Panel should show the idle helper copy and capture controls.
       await retry(async () => {
         const text = await getInstantNavPanelText(browser)
-        expect(text).toContain('Inspect the UI')
-        expect(text).toContain('Start Capturing')
-        expect(text).toContain('Continue Rendering')
+        expect(text).toContain('Pause on navigations')
+        expect(text).toContain(
+          'When enabled, every navigation will pause so you can inspect the shell before resuming.'
+        )
       })
 
       // Cookie should NOT be set yet (only set when user starts capturing)
@@ -437,8 +438,10 @@ describe('instant-nav-panel', () => {
       await retry(async () => {
         await getInstantNavPanel(browser)
         const text = await getInstantNavPanelText(browser)
-        expect(text).toContain('Page load')
-        expect(text).toContain('prerendered UI')
+        expect(text).toContain('Static shell')
+        expect(text).toContain(
+          "You're viewing the shell for this page's initial load."
+        )
       })
 
       // Clean up
@@ -504,7 +507,7 @@ describe('instant-nav-panel', () => {
       ).toBe(0)
     })
 
-    it('should restart capture and return to awaiting navigation after Continue Rendering from MPA state', async () => {
+    it('should restart capture and return to awaiting navigation after resuming from MPA state', async () => {
       const browser = await next.browser('/target-page/my-post?search=foo')
       await clearInstantModeCookie(browser)
 
@@ -538,9 +541,11 @@ describe('instant-nav-panel', () => {
       // Panel should show the awaiting navigation state
       await retry(async () => {
         const text = await getInstantNavPanelText(browser)
-        expect(text).toContain('Awaiting navigation')
-        expect(text).toContain('Stop Capturing')
-        expect(text).toContain('Continue Rendering')
+        expect(text).toContain('Waiting for navigation')
+        expect(text).toContain(
+          'Click any link or refresh the page to inspect the shell.'
+        )
+        expect(text).toContain('Pause on navigations')
       })
 
       // Navigate to target page via SPA (use eval to bypass overlay pointer interception)
@@ -622,7 +627,7 @@ describe('instant-nav-panel', () => {
       await expectTargetPageSpaShellWithRuntimeData(browser)
     })
 
-    it('should restart capture and return to awaiting navigation after Continue Rendering from SPA state', async () => {
+    it('should restart capture and return to awaiting navigation after resuming from SPA state', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 
       await openInstantNavPanel(browser)
@@ -690,8 +695,8 @@ describe('instant-nav-panel', () => {
       await getInstantNavPanel(browser)
 
       const initialPanelText = await getInstantNavPanelText(browser)
-      expect(initialPanelText).toContain('Page load')
-      expect(initialPanelText).not.toContain('Navigation')
+      expect(initialPanelText).toContain('Static shell')
+      expect(initialPanelText).not.toContain('Client shell')
 
       await expectMpaPanel(browser)
       await expectTargetPageMpaShell(browser)

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -50,7 +50,7 @@ describe('instant-nav-panel', () => {
     await waitForInstantModeCookie(browser)
   }
 
-  async function clickContinueRendering(browser: Playwright) {
+  async function clickResume(browser: Playwright) {
     await browser
       .locator('.instant-nav-debugger-paused-button', {
         hasText: 'Resume',
@@ -519,7 +519,7 @@ describe('instant-nav-panel', () => {
       await expectTargetPageMpaShell(browser)
       await waitForAppHydration(browser)
 
-      await clickContinueRendering(browser)
+      await clickResume(browser)
       await expectPendingPanel(browser)
       await expectTargetPageRendered(browser)
       await waitForInstantModeCookie(browser)
@@ -635,13 +635,13 @@ describe('instant-nav-panel', () => {
       await clickLink(browser, '/target-page/my-post?search=foo')
       await expectSpaPanel(browser)
 
-      await clickContinueRendering(browser)
+      await clickResume(browser)
       await expectPendingPanel(browser)
       await expectTargetPageRendered(browser)
       await waitForInstantModeCookie(browser)
     })
 
-    it('should continue rendering a captured await connection navigation with loading.tsx', async () => {
+    it('should resume rendering a captured await connection navigation with loading.tsx', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 
       await openInstantNavPanel(browser)
@@ -650,7 +650,7 @@ describe('instant-nav-panel', () => {
       await expectSpaPanel(browser)
       await expectAwaitConnectionPageLoading(browser)
 
-      await clickContinueRendering(browser)
+      await clickResume(browser)
       await expectPendingPanel(browser)
       await expectTargetPageRendered(browser)
       await waitForInstantModeCookie(browser)

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -203,7 +203,7 @@ describe('instant-nav-panel', () => {
     await expectInstantNavPanelText(
       browser,
       'Pause on navigations',
-      'When enabled, every navigation will pause so you can inspect the shell before resuming.'
+      'When enabled, every navigation will pause so you can inspect the loading shell before resuming.'
     )
   }
 
@@ -221,7 +221,7 @@ describe('instant-nav-panel', () => {
       browser,
       'Debugger paused',
       'Resume',
-      'Static shell',
+      'Loading shell',
       "You're viewing the shell for this page's initial load.",
       'TARGET'
     )
@@ -232,7 +232,7 @@ describe('instant-nav-panel', () => {
       browser,
       'Debugger paused',
       'Resume',
-      'Navigation shell',
+      'Loading shell',
       "You're viewing the shell for the current navigation.",
       'SOURCE',
       'TARGET'
@@ -353,7 +353,7 @@ describe('instant-nav-panel', () => {
         const text = await getInstantNavPanelText(browser)
         expect(text).toContain('Pause on navigations')
         expect(text).toContain(
-          'When enabled, every navigation will pause so you can inspect the shell before resuming.'
+          'When enabled, every navigation will pause so you can inspect the loading shell before resuming.'
         )
       })
 
@@ -438,7 +438,7 @@ describe('instant-nav-panel', () => {
       await retry(async () => {
         await getInstantNavPanel(browser)
         const text = await getInstantNavPanelText(browser)
-        expect(text).toContain('Static shell')
+        expect(text).toContain('Loading shell')
         expect(text).toContain(
           "You're viewing the shell for this page's initial load."
         )
@@ -695,8 +695,8 @@ describe('instant-nav-panel', () => {
       await getInstantNavPanel(browser)
 
       const initialPanelText = await getInstantNavPanelText(browser)
-      expect(initialPanelText).toContain('Static shell')
-      expect(initialPanelText).not.toContain('Navigation shell')
+      expect(initialPanelText).toContain('Page load')
+      expect(initialPanelText).not.toContain('Client nav')
 
       await expectMpaPanel(browser)
       await expectTargetPageMpaShell(browser)


### PR DESCRIPTION
Updates the Navigation Inspector panel UI to match the new shell-inspection design.

- Reworks the idle, waiting, static shell, and client shell states around the new “Pause on navigations” toggle
- Adds full-width waiting/debugger banners, updated copy, URL labels, and the `Resume` action
- Simplifies the panel expansion animation so only the panel opens/closes, without fading the inner content

To try it out, run

```
pnpm next dev test/development/app-dir/instant-navs-devtools
```

https://github.com/user-attachments/assets/271d788e-87b9-4787-8d31-8008b9e693c0

