### PR TITLE
Enforce route segment configs on metadata routes under Cache Components

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -902,7 +902,14 @@ impl ReactServerComponentValidator {
             return;
         }
         let ext_pattern = build_page_extensions_regex(&self.page_extensions);
-        let re = Regex::new(&format!(r"[\\/](page|layout|route)\.{ext_pattern}$")).unwrap();
+        // Metadata convention files (e.g. `icon`, `opengraph-image`, `sitemap`)
+        // compile to route handlers and accept the same route segment configs,
+        // so they're subject to the same `cacheComponents`/`useCache`
+        // restrictions as `page`/`layout`/`route` entries.
+        let re = Regex::new(&format!(
+            r"[\\/](page|layout|route|icon\d?|apple-icon\d?|opengraph-image\d?|twitter-image\d?|sitemap|robots|manifest)\.{ext_pattern}$",
+        ))
+        .unwrap();
         let is_app_entry = re.is_match(&self.filepath);
 
         if is_app_entry {

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -195,6 +195,7 @@
       "test/e2e/app-dir/logging/fetch-warning.test.ts",
       "test/e2e/app-dir/metadata-dynamic-routes/index.test.ts",
       "test/e2e/app-dir/metadata-edge/index.test.ts",
+      "test/e2e/app-dir/metadata-font/metadata-font.test.ts",
       "test/e2e/app-dir/metadata-icons/metadata-icons.test.ts",
       "test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts",
       "test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts",

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -64,6 +64,32 @@ describe('cache-components-segment-configs', () => {
       expect(next.cliOutput).toContain(
         '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
       )
+
+      // The remaining fixtures opt into `export const runtime = 'edge'` (the
+      // `runtime` page and the metadata convention files, which compile to
+      // route handlers and accept the same route segment configs). `next build`
+      // prints only the first five webpack errors and appends the edge
+      // compiler's errors last, so the five Node-runtime page errors above fill
+      // that limit and these edge-runtime errors are truncated from webpack's
+      // output. They're only asserted under Turbopack, which reports every
+      // build error.
+      if (isTurbopack) {
+        expect(next.cliOutput).toContain('./app/runtime/page.tsx')
+
+        expect(next.cliOutput).toContain('./app/metadata/icon.tsx')
+        expect(next.cliOutput).toContain('./app/metadata/apple-icon.tsx')
+        expect(next.cliOutput).toContain('./app/metadata/opengraph-image.tsx')
+        expect(next.cliOutput).toContain('./app/metadata/twitter-image.tsx')
+        expect(next.cliOutput).toContain('./app/metadata/sitemap.ts')
+
+        // Emitted once for each fixture that exports `runtime`:
+        // `runtime/page.tsx`, `multiple/page.tsx`, and the five `metadata/*`
+        // convention files.
+        expect(next.cliOutput).toIncludeRepeated(
+          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.',
+          7
+        )
+      }
     }
   })
 

--- a/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/apple-icon.tsx
+++ b/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/apple-icon.tsx
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function AppleIcon() {
+  return new Response('This metadata route uses `export const runtime`.')
+}

--- a/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/icon.tsx
+++ b/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/icon.tsx
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function Icon() {
+  return new Response('This metadata route uses `export const runtime`.')
+}

--- a/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/opengraph-image.tsx
+++ b/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/opengraph-image.tsx
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function OpengraphImage() {
+  return new Response('This metadata route uses `export const runtime`.')
+}

--- a/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/sitemap.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/sitemap.ts
@@ -1,0 +1,7 @@
+import type { MetadataRoute } from 'next'
+
+export const runtime = 'edge'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [{ url: 'https://example.com' }]
+}

--- a/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/twitter-image.tsx
+++ b/test/e2e/app-dir/cache-components-segment-configs/fixtures/default/app/metadata/twitter-image.tsx
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function TwitterImage() {
+  return new Response('This metadata route uses `export const runtime`.')
+}


### PR DESCRIPTION
The React Server Components transform validates route segment configs (rejecting `runtime`, `dynamic`, `revalidate`, and friends under Cache Components) only for `page`, `layout`, and `route` entries, so metadata convention files slipped past the check. Because these files compile to route handlers and accept the same configs, this change extends the match to `icon`, `apple-icon`, `opengraph-image`, `twitter-image`, `sitemap`, `robots`, and `manifest`. Exporting `runtime = 'edge'` (or any other unsupported config) from one of them is now a compile-time error that matches the behavior for regular routes, instead of surfacing later as a confusing bundling failure. The `metadata-font` suite, which intentionally builds edge-runtime image routes, joins the other edge metadata suites that are excluded from the Cache Components test run.