### PR TITLE
Fix no-op PostCSS source labels in Turbopack errors

### DIFF
--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -47,7 +47,7 @@ describe('app dir - css', () => {
                ./app/global.scss.css [Client Component Browser]
                ./app/layout.js [Client Component Browser]
                ./app/layout.js [Server Component]"
-          `)
+           `)
         })
       }
     )

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -37,7 +37,7 @@ describe('app dir - css', () => {
 
            Pseudo-elements like '::before' or '::after' can't be followed by selectors like 'Ident("path")'
 
-           Generated code of PostCSS transform of loaders [next/dist/build/webpack/loaders/resolve-url-loader/index, next/dist/compiled/sass-loader] transform of file content of app/global.scss:
+           Generated code of loaders [next/dist/build/webpack/loaders/resolve-url-loader/index, next/dist/compiled/sass-loader] transform of file content of app/global.scss:
            ./app/global.scss.css:1:884
            > 1 | ...ate(-50%, 0px)}input.defaultCheckbox::before path{fill:currentColor}input:checked.defaul...
                |                                                ^

--- a/test/e2e/postcss-error-label/app/page.js
+++ b/test/e2e/postcss-error-label/app/page.js
@@ -1,0 +1,5 @@
+import styles from './styles.module.css'
+
+export default function Page() {
+  return <div className={styles.root}>PostCSS error</div>
+}

--- a/test/e2e/postcss-error-label/app/styles.module.css
+++ b/test/e2e/postcss-error-label/app/styles.module.css
@@ -1,0 +1,5 @@
+@media screen and (min-width: 700px), screen and (min-zoom: 120%) {
+  .root {
+    color: red;
+  }
+}

--- a/test/e2e/postcss-error-label/index.test.ts
+++ b/test/e2e/postcss-error-label/index.test.ts
@@ -1,0 +1,56 @@
+import { nextTestSetup } from 'e2e-utils'
+import { waitForRedbox, getRedboxSource } from 'next-test-utils'
+
+const postcssLabel =
+  'Generated code of PostCSS transform of file content of app/styles.module.css:'
+
+describe('postcss error labels (development)', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (!isNextDev) {
+    it('skipped in production mode', () => {})
+    return
+  }
+
+  beforeAll(() => next.start())
+
+  it('keeps the PostCSS label when a config applies', async () => {
+    const browser = await next.browser('/')
+
+    await waitForRedbox(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(source).toContain('Parsing CSS source code failed')
+    expect(source).toContain(postcssLabel)
+  })
+})
+
+describe('postcss error labels (production)', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (!isNextStart) {
+    it('skipped in development mode', () => {})
+    return
+  }
+
+  it('keeps the PostCSS label when a config applies', async () => {
+    await expect(next.start()).rejects.toThrow(
+      'next build failed with code/signal 1'
+    )
+
+    expect(next.cliOutput).toContain('Parsing CSS source code failed')
+    expect(next.cliOutput).toContain(postcssLabel)
+  })
+})

--- a/test/e2e/postcss-error-label/postcss.config.js
+++ b/test/e2e/postcss-error-label/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [],
+}

--- a/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
+++ b/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
@@ -177,7 +177,7 @@ describe('webpack-loader-parse-error (development)', () => {
 
        Unexpected token CurlyBracketBlock
 
-       Generated code of PostCSS transform of loaders [broken-css-loader.js] transform of file content of app/css-page/styles.broken.css:
+       Generated code of loaders [broken-css-loader.js] transform of file content of app/css-page/styles.broken.css:
        ./app/css-page/styles.broken.css:5:15
          3 |   color: red
          4 |   @@@ THIS IS NOT VALID CSS @@@;
@@ -260,7 +260,7 @@ describe('webpack-loader-parse-error (production)', () => {
 
        Unexpected token CurlyBracketBlock
 
-       Generated code of PostCSS transform of loaders [broken-css-loader.js] transform of file content of app/css-page/styles.broken.css:
+       Generated code of loaders [broken-css-loader.js] transform of file content of app/css-page/styles.broken.css:
        ./app/css-page/styles.broken.css:5:15
          3 |   color: red
          4 |   @@@ THIS IS NOT VALID CSS @@@;

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -176,6 +176,15 @@ impl Source for PostCssTransformedAsset {
 
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<RcStr>> {
+        let ExecutionContext { project_path, .. } = &*self.execution_context.await?;
+        // Keep the diagnostic label aligned with `process`, which returns the
+        // original source when no PostCSS config applies.
+        if find_config_in_location(project_path.clone(), self.config_location, *self.source)
+            .await?
+            .is_none()
+        {
+            return Ok(self.source.description());
+        }
         let inner = self.source.description().await?;
         Ok(Vc::cell(format!("PostCSS transform of {}", inner).into()))
     }


### PR DESCRIPTION
Fixes #94856.

### What
- Reuse the inner source description when a `PostCssTransformedAsset` has no matching PostCSS config.
- Keep the existing `PostCSS transform of ...` label when PostCSS actually applies.
- Update Turbopack error snapshots for loader and Sass-generated CSS.

### Why
Without a PostCSS config, `process()` already returns the original source content unchanged. The diagnostic label should match that behavior so CSS parse errors from loaders or Sass are not reported as generated by a PostCSS transform.

### Tests
- `cargo check -p turbopack-node`
- `pnpm exec prettier --check test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts test/development/sass-error/index.test.ts`
- `pnpm swc-build-native`
- `pnpm test-dev-turbo test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts`
- `pnpm test-dev-turbo test/development/sass-error/index.test.ts`