### PR TITLE
Record size metrics to our compaction and persistence spans

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     collections::HashSet,
+    fmt::Display,
     fs::{self, File, OpenOptions, ReadDir},
     io::{BufWriter, Write},
     mem::take,
@@ -276,14 +277,27 @@ struct DeletedFile {
     size: u64,
 }
 
-/// Physical byte volume of a single commit, measured from on-disk file sizes (post-compression,
-/// including `.sst`, `.blob`, and `.meta` files).
+/// Physical byte volume of a single commit/compaction cycle, measured from on-disk file sizes
+/// (post-compression, including `.sst`, `.blob`, and `.meta` files).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct CommitStats {
     /// Total bytes of new files created by this commit.
     pub bytes_written: u64,
     /// Total bytes of files removed/superseded by this commit.
     pub bytes_deleted: u64,
+}
+
+impl Display for CommitStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let CommitStats {
+            bytes_written,
+            bytes_deleted,
+        } = self;
+        write!(
+            f,
+            "bytes_written={bytes_written} bytes_deleted={bytes_deleted}"
+        )
+    }
 }
 
 struct OpenOpts<S: ParallelScheduler, const FAMILIES: usize> {
@@ -799,14 +813,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
         new_meta_files.sort_unstable_by_key(|f| f.seq);
 
-        // Sum the on-disk size of every new file (post-compression). The sizes were captured at
-        // each file's creation site (no stat), so this is a plain in-memory sum.
-        let bytes_written = new_meta_files
-            .iter()
-            .chain(new_sst_files.iter())
-            .chain(new_blob_files.iter())
-            .map(|f| f.size)
-            .sum::<u64>();
+        let mut stats = CommitStats::default();
 
         let sync_span = tracing::trace_span!("sync new files").entered();
 
@@ -823,13 +830,16 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
         let mut sync_items: Vec<SyncItem> =
             Vec::with_capacity(new_meta_files.len() + new_sst_files.len() + new_blob_files.len());
-        for NewFile { seq, file, .. } in new_meta_files {
+        for NewFile { seq, file, size } in new_meta_files {
+            stats.bytes_written += size;
             sync_items.push(SyncItem::Meta(seq, file));
         }
-        for NewFile { file, .. } in new_sst_files {
+        for NewFile { file, size, .. } in new_sst_files {
+            stats.bytes_written += size;
             sync_items.push(SyncItem::Sst(file));
         }
-        for NewFile { seq, file, .. } in new_blob_files {
+        for NewFile { seq, file, size } in new_blob_files {
+            stats.bytes_written += size;
             sync_items.push(SyncItem::Blob(seq, file));
         }
 
@@ -906,11 +916,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let has_delete_file;
         let mut meta_seq_numbers_to_delete = Vec::new();
         let entries_to_remove;
-        // On-disk bytes of deleted SST files. The caller knows each deleted SST's size when it
-        // decides to delete it, so it's carried on `DeletedFile` — just sum it (no scan, no stat).
-        let sst_bytes_deleted = sst_files_to_delete.iter().map(|f| f.size).sum::<u64>();
-        // On-disk bytes of deleted meta files, read from each `MetaFile`'s mmap length (no stat).
-        let mut meta_bytes_deleted = 0u64;
+        // Deleted SST bytes: the caller knows each deleted SST's size when it decides to delete it,
+        // so it's carried on `DeletedFile` and summed here (no scan, no stat).
+        stats.bytes_deleted += sst_files_to_delete.iter().map(|f| f.size).sum::<u64>();
         // The rest of the commit only needs the sequence numbers of the deleted SSTs.
         let mut sst_seq_numbers_to_delete = sst_files_to_delete
             .iter()
@@ -948,7 +956,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             for i in (0..inner.meta_files.len()).rev() {
                 if sst_filter.apply_and_get_remove(&inner.meta_files[i]) {
                     meta_seq_numbers_to_delete.push(inner.meta_files[i].sequence_number());
-                    meta_bytes_deleted += inner.meta_files[i].byte_size();
+                    // Deleted meta bytes, read from the `MetaFile`'s mmap length (no stat).
+                    stats.bytes_deleted += inner.meta_files[i].byte_size();
                 }
             }
 
@@ -960,12 +969,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 || !meta_seq_numbers_to_delete.is_empty();
         }
 
-        // Bytes deleted by this commit. SST sizes came from `DeletedFile` and meta sizes from each
-        // `MetaFile`'s mmap length (both in-memory, no stat). Blob sizes aren't tracked in memory,
-        // so stat them by sequence number before Phase C unlinks them — best-effort: a file already
-        // gone reports 0 rather than failing the commit (these stats are reported, not
-        // load-bearing). Blob deletions are rare.
-        let blob_bytes_deleted = blob_seq_numbers_to_delete
+        // Deleted blob bytes. Unlike SST/meta sizes (both already in memory), blob sizes aren't
+        // tracked, so we stat them by sequence number before Phase C unlinks them. Best-effort: a
+        // file already gone reports 0 rather than failing the commit (these stats are reported, not
+        // load-bearing). Left serial rather than dispatched to the scheduler: blob deletions are
+        // rare and few, so the fan-out overhead would outweigh a handful of `stat` calls.
+        stats.bytes_deleted += blob_seq_numbers_to_delete
             .iter()
             .map(|seq| {
                 fs::metadata(self.path.join(format!("{seq:08}.blob")))
@@ -973,7 +982,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     .unwrap_or(0)
             })
             .sum::<u64>();
-        let bytes_deleted = sst_bytes_deleted + meta_bytes_deleted + blob_bytes_deleted;
 
         if has_delete_file {
             seq += 1;
@@ -1188,10 +1196,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             })();
         }
 
-        Ok(CommitStats {
-            bytes_written,
-            bytes_deleted,
-        })
+        Ok(stats)
     }
 
     /// Runs a full compaction on the database. This will rewrite all SST files, removing all
@@ -1213,7 +1218,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// files is above the given threshold. The coverage is the average number of SST files that
     /// need to be read to find a key. It also limits the maximum number of SST files that are
     /// merged at once, which is the main factor for the runtime of the compaction.
-    pub fn compact(&self, compact_config: &CompactConfig) -> Result<bool> {
+    ///
+    /// Returns `Some(stats)` describing the bytes written/deleted if a compaction commit happened,
+    /// or `None` if there was nothing to compact.
+    pub fn compact(&self, compact_config: &CompactConfig) -> Result<Option<CommitStats>> {
         let mut guard = self.acquire_write_operation("compaction")?;
 
         // Free block caches and SST mmaps before compaction. The block caches
@@ -1246,13 +1254,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
 
         let has_changes = !new_meta_files.is_empty();
-        if has_changes {
-            let span = tracing::info_span!(
-                "compact",
-                bytes_written = tracing::field::Empty,
-                bytes_deleted = tracing::field::Empty,
-            )
-            .entered();
+        let stats = if has_changes {
             let stats = self
                 .commit(CommitOptions {
                     new_meta_files,
@@ -1264,12 +1266,13 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     keys_written,
                 })
                 .context("Failed to commit the database compaction")?;
-            span.record("bytes_written", stats.bytes_written);
-            span.record("bytes_deleted", stats.bytes_deleted);
-        }
+            Some(stats)
+        } else {
+            None
+        };
 
         guard.success();
-        Ok(has_changes)
+        Ok(stats)
     }
 
     /// Internal function to perform a compaction.

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -43,7 +43,7 @@ use crate::{
     sst_filter::SstFilter,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFileIter},
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, StreamingSstWriter},
-    write_batch::{FinishResult, WriteBatch},
+    write_batch::{FinishResult, NewFile, WriteBatch},
 };
 
 #[cfg(feature = "stats")]
@@ -258,13 +258,32 @@ struct Inner<const FAMILIES: usize> {
 }
 
 pub struct CommitOptions {
-    new_meta_files: Vec<(u32, File)>,
-    new_sst_files: Vec<(u32, File)>,
-    new_blob_files: Vec<(u32, File)>,
-    sst_seq_numbers_to_delete: Vec<u32>,
+    new_meta_files: Vec<NewFile>,
+    new_sst_files: Vec<NewFile>,
+    new_blob_files: Vec<NewFile>,
+    sst_files_to_delete: Vec<DeletedFile>,
     blob_seq_numbers_to_delete: Vec<u32>,
     sequence_number: u32,
     keys_written: u64,
+}
+
+/// An SST file superseded by a commit, carrying its on-disk size (known when the deletion is
+/// decided) so `commit` can sum deleted bytes without scanning meta entries or stat'ing the file.
+#[derive(Clone, Copy)]
+struct DeletedFile {
+    seq: u32,
+    /// On-disk size in bytes
+    size: u64,
+}
+
+/// Physical byte volume of a single commit, measured from on-disk file sizes (post-compression,
+/// including `.sst`, `.blob`, and `.meta` files).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CommitStats {
+    /// Total bytes of new files created by this commit.
+    pub bytes_written: u64,
+    /// Total bytes of files removed/superseded by this commit.
+    pub bytes_deleted: u64,
 }
 
 struct OpenOpts<S: ParallelScheduler, const FAMILIES: usize> {
@@ -712,7 +731,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     pub fn commit_write_batch<K: StoreKey + Send + Sync>(
         &self,
         mut write_batch: WriteBatch<'_, K, S, FAMILIES>,
-    ) -> Result<()> {
+    ) -> Result<CommitStats> {
         if self.read_only {
             unreachable!("It's not possible to create a write batch for a read-only database");
         }
@@ -748,18 +767,18 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             });
             amqf
         })?;
-        self.commit(CommitOptions {
+        let stats = self.commit(CommitOptions {
             new_meta_files,
             new_sst_files,
             new_blob_files,
-            sst_seq_numbers_to_delete: vec![],
+            sst_files_to_delete: vec![],
             blob_seq_numbers_to_delete: vec![],
             sequence_number,
             keys_written,
         })?;
         // Mark the guard inside the write batch as succeeded so it skips the rollback on drop.
         write_batch.mark_succeeded();
-        Ok(())
+        Ok(stats)
     }
 
     /// fsyncs the new files and updates the CURRENT file. Updates the database state to include the
@@ -770,15 +789,24 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             mut new_meta_files,
             new_sst_files,
             new_blob_files,
-            mut sst_seq_numbers_to_delete,
+            sst_files_to_delete,
             mut blob_seq_numbers_to_delete,
             sequence_number: mut seq,
             keys_written,
         }: CommitOptions,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<CommitStats, anyhow::Error> {
         let time = Timestamp::now();
 
-        new_meta_files.sort_unstable_by_key(|(seq, _)| *seq);
+        new_meta_files.sort_unstable_by_key(|f| f.seq);
+
+        // Sum the on-disk size of every new file (post-compression). The sizes were captured at
+        // each file's creation site (no stat), so this is a plain in-memory sum.
+        let bytes_written = new_meta_files
+            .iter()
+            .chain(new_sst_files.iter())
+            .chain(new_blob_files.iter())
+            .map(|f| f.size)
+            .sum::<u64>();
 
         let sync_span = tracing::trace_span!("sync new files").entered();
 
@@ -795,13 +823,13 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
         let mut sync_items: Vec<SyncItem> =
             Vec::with_capacity(new_meta_files.len() + new_sst_files.len() + new_blob_files.len());
-        for (seq, file) in new_meta_files {
+        for NewFile { seq, file, .. } in new_meta_files {
             sync_items.push(SyncItem::Meta(seq, file));
         }
-        for (_, file) in new_sst_files {
+        for NewFile { file, .. } in new_sst_files {
             sync_items.push(SyncItem::Sst(file));
         }
-        for (seq, file) in new_blob_files {
+        for NewFile { seq, file, .. } in new_blob_files {
             sync_items.push(SyncItem::Blob(seq, file));
         }
 
@@ -878,6 +906,16 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let has_delete_file;
         let mut meta_seq_numbers_to_delete = Vec::new();
         let entries_to_remove;
+        // On-disk bytes of deleted SST files. The caller knows each deleted SST's size when it
+        // decides to delete it, so it's carried on `DeletedFile` — just sum it (no scan, no stat).
+        let sst_bytes_deleted = sst_files_to_delete.iter().map(|f| f.size).sum::<u64>();
+        // On-disk bytes of deleted meta files, read from each `MetaFile`'s mmap length (no stat).
+        let mut meta_bytes_deleted = 0u64;
+        // The rest of the commit only needs the sequence numbers of the deleted SSTs.
+        let mut sst_seq_numbers_to_delete = sst_files_to_delete
+            .iter()
+            .map(|f| f.seq)
+            .collect::<Vec<_>>();
 
         {
             let inner = self.inner.read();
@@ -910,16 +948,33 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             for i in (0..inner.meta_files.len()).rev() {
                 if sst_filter.apply_and_get_remove(&inner.meta_files[i]) {
                     meta_seq_numbers_to_delete.push(inner.meta_files[i].sequence_number());
+                    meta_bytes_deleted += inner.meta_files[i].byte_size();
                 }
             }
 
             // (A3) Compute the final sequence number that will be written to
             // CURRENT. A .del file is created only when there are files to
             // delete, which consumes one extra sequence number.
-            has_delete_file = !sst_seq_numbers_to_delete.is_empty()
+            has_delete_file = !sst_files_to_delete.is_empty()
                 || !blob_seq_numbers_to_delete.is_empty()
                 || !meta_seq_numbers_to_delete.is_empty();
         }
+
+        // Bytes deleted by this commit. SST sizes came from `DeletedFile` and meta sizes from each
+        // `MetaFile`'s mmap length (both in-memory, no stat). Blob sizes aren't tracked in memory,
+        // so stat them by sequence number before Phase C unlinks them — best-effort: a file already
+        // gone reports 0 rather than failing the commit (these stats are reported, not
+        // load-bearing). Blob deletions are rare.
+        let blob_bytes_deleted = blob_seq_numbers_to_delete
+            .iter()
+            .map(|seq| {
+                fs::metadata(self.path.join(format!("{seq:08}.blob")))
+                    .map(|m| m.len())
+                    .unwrap_or(0)
+            })
+            .sum::<u64>();
+        let bytes_deleted = sst_bytes_deleted + meta_bytes_deleted + blob_bytes_deleted;
+
         if has_delete_file {
             seq += 1;
         }
@@ -1133,7 +1188,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             })();
         }
 
-        Ok(())
+        Ok(CommitStats {
+            bytes_written,
+            bytes_deleted,
+        })
     }
 
     /// Runs a full compaction on the database. This will rewrite all SST files, removing all
@@ -1167,7 +1225,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut sequence_number;
         let mut new_meta_files = Vec::new();
         let mut new_sst_files = Vec::new();
-        let mut sst_seq_numbers_to_delete = Vec::new();
+        let mut sst_files_to_delete = Vec::new();
         let mut blob_seq_numbers_to_delete = Vec::new();
         let mut keys_written = 0;
 
@@ -1179,7 +1237,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 &sequence_number,
                 &mut new_meta_files,
                 &mut new_sst_files,
-                &mut sst_seq_numbers_to_delete,
+                &mut sst_files_to_delete,
                 &mut blob_seq_numbers_to_delete,
                 &mut keys_written,
                 compact_config,
@@ -1189,16 +1247,25 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
         let has_changes = !new_meta_files.is_empty();
         if has_changes {
-            self.commit(CommitOptions {
-                new_meta_files,
-                new_sst_files,
-                new_blob_files: Vec::new(),
-                sst_seq_numbers_to_delete,
-                blob_seq_numbers_to_delete,
-                sequence_number: *sequence_number.get_mut(),
-                keys_written,
-            })
-            .context("Failed to commit the database compaction")?;
+            let span = tracing::info_span!(
+                "compact",
+                bytes_written = tracing::field::Empty,
+                bytes_deleted = tracing::field::Empty,
+            )
+            .entered();
+            let stats = self
+                .commit(CommitOptions {
+                    new_meta_files,
+                    new_sst_files,
+                    new_blob_files: Vec::new(),
+                    sst_files_to_delete,
+                    blob_seq_numbers_to_delete,
+                    sequence_number: *sequence_number.get_mut(),
+                    keys_written,
+                })
+                .context("Failed to commit the database compaction")?;
+            span.record("bytes_written", stats.bytes_written);
+            span.record("bytes_deleted", stats.bytes_deleted);
         }
 
         guard.success();
@@ -1210,9 +1277,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         &self,
         meta_files: &[MetaFile],
         sequence_number: &AtomicU32,
-        new_meta_files: &mut Vec<(u32, File)>,
-        new_sst_files: &mut Vec<(u32, File)>,
-        sst_seq_numbers_to_delete: &mut Vec<u32>,
+        new_meta_files: &mut Vec<NewFile>,
+        new_sst_files: &mut Vec<NewFile>,
+        sst_files_to_delete: &mut Vec<DeletedFile>,
         blob_seq_numbers_to_delete: &mut Vec<u32>,
         keys_written: &mut u64,
         compact_config: &CompactConfig,
@@ -1275,9 +1342,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let log_mutex = Mutex::new(());
 
         struct PartialResultPerFamily {
-            new_meta_file: Option<(u32, File)>,
-            new_sst_files: Vec<(u32, File)>,
-            sst_seq_numbers_to_delete: Vec<u32>,
+            new_meta_file: Option<NewFile>,
+            new_sst_files: Vec<NewFile>,
+            sst_files_to_delete: Vec<DeletedFile>,
             blob_seq_numbers_to_delete: Vec<u32>,
             keys_written: u64,
         }
@@ -1308,7 +1375,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         return Ok(PartialResultPerFamily {
                             new_meta_file: None,
                             new_sst_files: Vec::new(),
-                            sst_seq_numbers_to_delete: Vec::new(),
+                            sst_files_to_delete: Vec::new(),
                             blob_seq_numbers_to_delete: Vec::new(),
                             keys_written: 0,
                         });
@@ -1351,12 +1418,16 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         }
                     };
 
-                    // Later we will remove the merged files
-                    let sst_seq_numbers_to_delete = merge_jobs
+                    // Later we will remove the merged files. Capture each one's size now (we know
+                    // exactly which SST it is) so `commit` can report deleted bytes without a scan.
+                    let sst_files_to_delete = merge_jobs
                         .iter()
                         .filter(|l| l.len() > 1)
                         .flat_map(|l| l.iter().copied())
-                        .map(|index| ssts_with_ranges[index].seq)
+                        .map(|index| DeletedFile {
+                            seq: ssts_with_ranges[index].seq,
+                            size: ssts_with_ranges[index].size,
+                        })
                         .collect::<Vec<_>>();
 
                     // Merge SST files
@@ -1660,8 +1731,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             meta.flags
                                         )?;
 
+                                        let size = meta.size;
                                         meta_file_builder.add(seq, meta);
-                                        new_sst_files.push((seq, file));
+                                        new_sst_files.push(NewFile { seq, file, size });
                                     }
                                     blob_seq_numbers_to_delete
                                         .extend(merged_blob_seq_numbers_to_delete);
@@ -1686,20 +1758,26 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         anyhow::Ok(())
                     })?;
 
-                    for &seq in sst_seq_numbers_to_delete.iter() {
-                        meta_file_builder.add_obsolete_sst_file(seq);
+                    for f in sst_files_to_delete.iter() {
+                        meta_file_builder.add_obsolete_sst_file(f.seq);
                     }
 
-                    let meta_file = {
+                    let new_meta_file = {
                         let _span = tracing::trace_span!("write meta file").entered();
-                        self.parallel_scheduler
-                            .block_in_place(|| meta_file_builder.write(&self.path, meta_seq))?
+                        let (file, size) = self
+                            .parallel_scheduler
+                            .block_in_place(|| meta_file_builder.write(&self.path, meta_seq))?;
+                        NewFile {
+                            seq: meta_seq,
+                            file,
+                            size,
+                        }
                     };
 
                     Ok(PartialResultPerFamily {
-                        new_meta_file: Some((meta_seq, meta_file)),
+                        new_meta_file: Some(new_meta_file),
                         new_sst_files,
-                        sst_seq_numbers_to_delete,
+                        sst_files_to_delete,
                         blob_seq_numbers_to_delete,
                         keys_written,
                     })
@@ -1709,14 +1787,14 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         for PartialResultPerFamily {
             new_meta_file: inner_new_meta_file,
             new_sst_files: mut inner_new_sst_files,
-            sst_seq_numbers_to_delete: mut inner_sst_seq_numbers_to_delete,
+            sst_files_to_delete: mut inner_sst_files_to_delete,
             blob_seq_numbers_to_delete: mut inner_blob_seq_numbers_to_delete,
             keys_written: inner_keys_written,
         } in result
         {
             new_meta_files.extend(inner_new_meta_file);
             new_sst_files.append(&mut inner_new_sst_files);
-            sst_seq_numbers_to_delete.append(&mut inner_sst_seq_numbers_to_delete);
+            sst_files_to_delete.append(&mut inner_sst_files_to_delete);
             blob_seq_numbers_to_delete.append(&mut inner_blob_seq_numbers_to_delete);
             *keys_written += inner_keys_written;
         }

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -30,7 +30,7 @@ mod tests;
 
 pub use arc_bytes::ArcBytes;
 pub use compression::checksum_block;
-pub use db::{CompactConfig, MetaFileEntryInfo, MetaFileInfo, TurboPersistence};
+pub use db::{CommitStats, CompactConfig, MetaFileEntryInfo, MetaFileInfo, TurboPersistence};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FamilyKind {

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -379,6 +379,11 @@ impl MetaFile {
         self.family
     }
 
+    /// The on-disk size of this meta file in bytes (the length of its memory map).
+    pub fn byte_size(&self) -> u64 {
+        self.mmap.len() as u64
+    }
+
     pub fn entries(&self) -> &[MetaEntry] {
         &self.entries
     }

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -43,8 +43,6 @@ impl<'a> MetaFileBuilder<'a> {
         self.used_key_hashes_amqf = Some(amqf);
     }
 
-    /// Writes the meta file and returns the file handle along with the number of bytes written to
-    /// disk.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn write(self, db_path: &Path, seq: u32) -> Result<(File, u64)> {
         let file = db_path.join(format!("{seq:08}.meta"));

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -43,15 +43,19 @@ impl<'a> MetaFileBuilder<'a> {
         self.used_key_hashes_amqf = Some(amqf);
     }
 
+    /// Writes the meta file and returns the file handle along with the number of bytes written to
+    /// disk.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub fn write(self, db_path: &Path, seq: u32) -> Result<File> {
+    pub fn write(self, db_path: &Path, seq: u32) -> Result<(File, u64)> {
         let file = db_path.join(format!("{seq:08}.meta"));
         self.write_internal(&file)
             .with_context(|| format!("Unable to write meta file {seq:08}.meta"))
     }
 
-    fn write_internal(mut self, file: &Path) -> io::Result<File> {
-        let mut file = BufWriter::new(File::create(file)?);
+    fn write_internal(mut self, file: &Path) -> io::Result<(File, u64)> {
+        // Wrap the writer to count the bytes written, so callers can accumulate written-byte totals
+        // without stat'ing the file afterwards.
+        let mut file = CountingWriter::new(BufWriter::new(File::create(file)?));
         file.write_u32::<BE>(0xFE4ADA4A)?; // Magic number
         file.write_u32::<BE>(self.family)?;
 
@@ -93,6 +97,44 @@ impl<'a> MetaFileBuilder<'a> {
         if let Some(bytes) = &serialized_used_key_hashes {
             file.write_all(bytes)?;
         }
-        Ok(file.into_inner()?)
+        let bytes_written = file.bytes_written();
+        let file = file.into_inner().into_inner()?;
+        Ok((file, bytes_written))
+    }
+}
+
+/// A [`Write`] adapter that counts the total number of bytes written through it, so writers can
+/// report their on-disk size without an extra `stat`/`stream_position` syscall.
+struct CountingWriter<W> {
+    inner: W,
+    bytes_written: u64,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            bytes_written: 0,
+        }
+    }
+
+    fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+
+    fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.bytes_written += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
     }
 }

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -33,7 +33,7 @@ use crate::{
 pub(crate) struct NewFile {
     pub(crate) seq: u32,
     pub(crate) file: File,
-    /// On-disk size in bytes (post-compression).
+    /// On-disk size in bytes.
     pub(crate) size: u64,
 }
 

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -28,6 +28,15 @@ use crate::{
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
 };
 
+/// A newly created database file (meta, SST, or blob), carrying its on-disk size so commit can sum
+/// written bytes without stat'ing the files afterwards.
+pub(crate) struct NewFile {
+    pub(crate) seq: u32,
+    pub(crate) file: File,
+    /// On-disk size in bytes (post-compression).
+    pub(crate) size: u64,
+}
+
 /// The thread local state of a `WriteBatch`. `FAMILIES` should fit within a `u32`.
 //
 // NOTE: This type *must* use `usize`, even though the real type used in storage is `u32` because
@@ -37,8 +46,7 @@ struct ThreadLocalState<K: StoreKey + Send, const FAMILIES: usize> {
     /// The collectors for each family.
     collectors: [Option<Collector<K, THREAD_LOCAL_SIZE_SHIFT>>; FAMILIES],
     /// The list of new blob files that have been created.
-    /// Tuple of (sequence number, file).
-    new_blob_files: Vec<(u32, File)>,
+    new_blob_files: Vec<NewFile>,
 }
 
 const COLLECTOR_SHARDS: usize = 4;
@@ -48,12 +56,9 @@ const COLLECTOR_SHARD_SHIFT: usize =
 /// The result of a `WriteBatch::finish` operation.
 pub(crate) struct FinishResult {
     pub(crate) sequence_number: u32,
-    /// Tuple of (sequence number, file).
-    pub(crate) new_meta_files: Vec<(u32, File)>,
-    /// Tuple of (sequence number, file).
-    pub(crate) new_sst_files: Vec<(u32, File)>,
-    /// Tuple of (sequence number, file).
-    pub(crate) new_blob_files: Vec<(u32, File)>,
+    pub(crate) new_meta_files: Vec<NewFile>,
+    pub(crate) new_sst_files: Vec<NewFile>,
+    pub(crate) new_blob_files: Vec<NewFile>,
     /// Number of keys written in this batch.
     pub(crate) keys_written: u64,
 }
@@ -86,8 +91,7 @@ pub struct WriteBatch<'db, K: StoreKey + Send, S: ParallelScheduler, const FAMIL
     /// Meta file builders for each family.
     meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMeta<'static>)>>; FAMILIES],
     /// The list of new SST files that have been created.
-    /// Tuple of (sequence number, file).
-    new_sst_files: Mutex<Vec<(u32, File)>>,
+    new_sst_files: Mutex<Vec<NewFile>>,
 }
 
 impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
@@ -234,9 +238,9 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         if value.len() <= MAX_MEDIUM_VALUE_SIZE {
             collector.put(key, value);
         } else {
-            let (blob, file) = self.create_blob(&value)?;
-            collector.put_blob(key, blob);
-            state.new_blob_files.push((blob, file));
+            let blob = self.create_blob(&value)?;
+            collector.put_blob(key, blob.seq);
+            state.new_blob_files.push(blob);
         }
         Ok(())
     }
@@ -425,8 +429,8 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                     let accessed_key_hashes = get_accessed_key_hashes(family);
                     builder.set_used_key_hashes_amqf(accessed_key_hashes);
                     let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
-                    let file = builder.write(&self.db_path, seq)?;
-                    Ok((seq, file))
+                    let (file, size) = builder.write(&self.db_path, seq)?;
+                    Ok(NewFile { seq, file, size })
                 },
             )?;
 
@@ -442,9 +446,8 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
     }
 
     /// Creates a new blob file with the given value.
-    /// Returns a tuple of (sequence number, file).
     #[tracing::instrument(level = "trace", skip(self, value), fields(value_len = value.len()))]
-    fn create_blob(&self, value: &[u8]) -> Result<(u32, File)> {
+    fn create_blob(&self, value: &[u8]) -> Result<NewFile> {
         let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
         let mut compressed = Vec::new();
         compress_into_buffer(value, &mut compressed)
@@ -455,22 +458,22 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         buffer.write_u32::<BE>(checksum_block(&compressed))?;
         buffer.extend_from_slice(&compressed);
 
+        let size = buffer.len() as u64;
         let file = self.db_path.join(format!("{seq:08}.blob"));
         let mut file = File::create(&file).context("Unable to create blob file")?;
         file.write_all(&buffer)
             .context("Unable to write blob file")?;
         file.flush().context("Unable to flush blob file")?;
-        Ok((seq, file))
+        Ok(NewFile { seq, file, size })
     }
 
     /// Creates a new SST file with the given collector data.
-    /// Returns a tuple of (sequence number, file).
     #[tracing::instrument(level = "trace", skip(self, collector_data), fields(family_name = self.family_configs[usize_from_u32(family)].name))]
     fn create_sst_file(
         &self,
         family: u32,
         collector_data: (&[CollectorEntry<K>], usize),
-    ) -> Result<(u32, File)> {
+    ) -> Result<NewFile> {
         let (entries, _total_key_size) = collector_data;
         let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
 
@@ -568,11 +571,12 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
             }
         }
 
+        let size = meta.size;
         self.meta_collectors[usize_from_u32(family)]
             .lock()
             .push((seq, meta));
 
-        Ok((seq, file))
+        Ok(NewFile { seq, file, size })
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1259,87 +1259,85 @@ impl TurboTasksBackend {
             snapshot_meta = tracing::field::Empty,
         )
         .entered();
+        // Tasks were already consumed by take_snapshot, so a future snapshot
+        // would not re-persist them — returning an error signals to the caller
+        // that further persist attempts would corrupt the task graph in storage.
+        let snapshot_meta = self
+            .backing_storage
+            .save_snapshot(suspended_operations, task_snapshots)?;
+        span.record("snapshot_meta", display(snapshot_meta));
+
+        #[cfg(feature = "print_cache_item_size")]
         {
-            // Tasks were already consumed by take_snapshot, so a future snapshot
-            // would not re-persist them — returning an error signals to the caller
-            // that further persist attempts would corrupt the task graph in storage.
-            let snapshot_meta = self
-                .backing_storage
-                .save_snapshot(suspended_operations, task_snapshots)?;
-            span.record("snapshot_meta", display(snapshot_meta));
+            let mut task_cache_stats = task_cache_stats
+                .into_inner()
+                .into_iter()
+                .collect::<Vec<_>>();
+            if !task_cache_stats.is_empty() {
+                use turbo_tasks::util::FormatBytes;
 
-            #[cfg(feature = "print_cache_item_size")]
-            {
-                let mut task_cache_stats = task_cache_stats
-                    .into_inner()
-                    .into_iter()
-                    .collect::<Vec<_>>();
-                if !task_cache_stats.is_empty() {
-                    use turbo_tasks::util::FormatBytes;
+                use crate::utils::markdown_table::print_markdown_table;
 
-                    use crate::utils::markdown_table::print_markdown_table;
+                task_cache_stats.sort_unstable_by(|(key_a, stats_a), (key_b, stats_b)| {
+                    (stats_b.sort_key(), key_b).cmp(&(stats_a.sort_key(), key_a))
+                });
 
-                    task_cache_stats.sort_unstable_by(|(key_a, stats_a), (key_b, stats_b)| {
-                        (stats_b.sort_key(), key_b).cmp(&(stats_a.sort_key(), key_a))
-                    });
+                println!(
+                    "Task cache stats: {}",
+                    FormatSizes {
+                        size: task_cache_stats
+                            .iter()
+                            .map(|(_, s)| s.data + s.meta)
+                            .sum::<usize>(),
+                        #[cfg(feature = "print_cache_item_size_with_compressed")]
+                        compressed_size: task_cache_stats
+                            .iter()
+                            .map(|(_, s)| s.data_compressed + s.meta_compressed)
+                            .sum::<usize>()
+                    },
+                );
 
-                    println!(
-                        "Task cache stats: {}",
-                        FormatSizes {
-                            size: task_cache_stats
-                                .iter()
-                                .map(|(_, s)| s.data + s.meta)
-                                .sum::<usize>(),
-                            #[cfg(feature = "print_cache_item_size_with_compressed")]
-                            compressed_size: task_cache_stats
-                                .iter()
-                                .map(|(_, s)| s.data_compressed + s.meta_compressed)
-                                .sum::<usize>()
-                        },
-                    );
-
-                    print_markdown_table(
+                print_markdown_table(
+                    [
+                        "Task",
+                        " Total Size",
+                        " Data Size",
+                        " Data Count x Avg",
+                        " Data Count x Avg",
+                        " Meta Size",
+                        " Meta Count x Avg",
+                        " Meta Count x Avg",
+                        " Uppers",
+                        " Coll",
+                        " Agg Coll",
+                        " Children",
+                        " Followers",
+                        " Coll Deps",
+                        " Agg Dirty",
+                        " Output Size",
+                    ],
+                    task_cache_stats.iter(),
+                    |(task_desc, stats)| {
                         [
-                            "Task",
-                            " Total Size",
-                            " Data Size",
-                            " Data Count x Avg",
-                            " Data Count x Avg",
-                            " Meta Size",
-                            " Meta Count x Avg",
-                            " Meta Count x Avg",
-                            " Uppers",
-                            " Coll",
-                            " Agg Coll",
-                            " Children",
-                            " Followers",
-                            " Coll Deps",
-                            " Agg Dirty",
-                            " Output Size",
-                        ],
-                        task_cache_stats.iter(),
-                        |(task_desc, stats)| {
-                            [
-                                task_desc.to_string(),
-                                format!(" {}", stats.format_total()),
-                                format!(" {}", stats.format_data()),
-                                format!(" {} x", stats.data_count),
-                                format!("{}", stats.format_avg_data()),
-                                format!(" {}", stats.format_meta()),
-                                format!(" {} x", stats.meta_count),
-                                format!("{}", stats.format_avg_meta()),
-                                format!(" {}", stats.upper_count),
-                                format!(" {}", stats.collectibles_count),
-                                format!(" {}", stats.aggregated_collectibles_count),
-                                format!(" {}", stats.children_count),
-                                format!(" {}", stats.followers_count),
-                                format!(" {}", stats.collectibles_dependents_count),
-                                format!(" {}", stats.aggregated_dirty_containers_count),
-                                format!(" {}", FormatBytes(stats.output_size)),
-                            ]
-                        },
-                    );
-                }
+                            task_desc.to_string(),
+                            format!(" {}", stats.format_total()),
+                            format!(" {}", stats.format_data()),
+                            format!(" {} x", stats.data_count),
+                            format!("{}", stats.format_avg_data()),
+                            format!(" {}", stats.format_meta()),
+                            format!(" {} x", stats.meta_count),
+                            format!("{}", stats.format_avg_meta()),
+                            format!(" {}", stats.upper_count),
+                            format!(" {}", stats.collectibles_count),
+                            format!(" {}", stats.aggregated_collectibles_count),
+                            format!(" {}", stats.children_count),
+                            format!(" {}", stats.followers_count),
+                            format!(" {}", stats.collectibles_dependents_count),
+                            format!(" {}", stats.aggregated_dirty_containers_count),
+                            format!(" {}", FormatBytes(stats.output_size)),
+                        ]
+                    },
+                );
             }
         }
 
@@ -1375,6 +1373,14 @@ impl TurboTasksBackend {
                     serde_json::Value::from(persist_duration.as_secs_f64() * 1000.0),
                 ),
                 ("task_count", serde_json::Value::from(task_count)),
+                (
+                    "bytes_written",
+                    serde_json::Value::from(snapshot_meta.bytes_written),
+                ),
+                (
+                    "bytes_deleted",
+                    serde_json::Value::from(snapshot_meta.bytes_deleted),
+                ),
             ],
         )));
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -26,7 +26,7 @@ use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use smallvec::{SmallVec, smallvec};
 use tokio::time::{Duration, Instant};
-use tracing::{Span, trace_span};
+use tracing::{Span, field::display, trace_span};
 use turbo_bincode::{TurboBincodeBuffer, new_turbo_bincode_decoder, new_turbo_bincode_encoder};
 use turbo_tasks::{
     CellId, DynTaskInputsStorage, RawVc, RawVcUnpacked, ReadCellOptions, ReadCellTracking,
@@ -1266,7 +1266,7 @@ impl TurboTasksBackend {
             let snapshot_meta = self
                 .backing_storage
                 .save_snapshot(suspended_operations, task_snapshots)?;
-            span.record("snapshot_meta", tracing::field::display(snapshot_meta));
+            span.record("snapshot_meta", display(snapshot_meta));
 
             #[cfg(feature = "print_cache_item_size")]
             {
@@ -2950,16 +2950,18 @@ impl TurboTasksBackend {
                                     // Enter the span only around the synchronous
                                     // compact() call so we never hold an
                                     // `EnteredSpan` across an await point.
-                                    let _compact_span = tracing::info_span!(
+                                    let compact_span = tracing::info_span!(
                                         parent: background_span.id(),
-                                        "compact database"
+                                        "compact database",
+                                        stats = tracing::field::Empty,
                                     )
                                     .entered();
                                     match self.backing_storage.compact() {
-                                        Ok(true) => {
+                                        Ok(Some(stats)) => {
+                                            compact_span.record("stats", display(stats));
                                             ran_compaction = true;
                                         }
-                                        Ok(false) => break,
+                                        Ok(None) => break,
                                         Err(err) => {
                                             eprintln!("Compaction failed: {err:?}");
                                             if self.backing_storage.has_unrecoverable_write_error()

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -68,7 +68,7 @@ use crate::{
         storage::Storage,
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    backing_storage::{SnapshotItem, SnapshotMeta, compute_task_type_hash},
+    backing_storage::{SnapshotItem, compute_task_type_hash},
     data::{
         ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
         InProgressState, InProgressStateInner, OutputValue, TransientTask,
@@ -1256,27 +1256,17 @@ impl TurboTasksBackend {
             parent: parent_span,
             "persist",
             reason = reason.as_str(),
-            data_items= tracing::field::Empty,
-            meta_items= tracing::field::Empty,
-            task_cache_items= tracing::field::Empty,
-            next_task_id= tracing::field::Empty,)
+            snapshot_meta = tracing::field::Empty,
+        )
         .entered();
         {
             // Tasks were already consumed by take_snapshot, so a future snapshot
             // would not re-persist them — returning an error signals to the caller
             // that further persist attempts would corrupt the task graph in storage.
-            let SnapshotMeta {
-                task_cache_items,
-                data_items,
-                meta_items,
-                max_next_task_id,
-            } = self
+            let snapshot_meta = self
                 .backing_storage
                 .save_snapshot(suspended_operations, task_snapshots)?;
-            span.record("data_items", data_items);
-            span.record("meta_items", meta_items);
-            span.record("task_cache_items", task_cache_items);
-            span.record("next_task_id", max_next_task_id);
+            span.record("snapshot_meta", tracing::field::display(snapshot_meta));
 
             #[cfg(feature = "print_cache_item_size")]
             {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1362,26 +1362,20 @@ impl TurboTasksBackend {
             "turbopack-persistence",
             wall_start_ms,
             wall_end_ms,
-            vec![
-                ("reason", serde_json::Value::from(reason.as_str())),
-                (
+            serde_json::json!([
+                ["reason", reason.as_str()],
+                [
                     "snapshot_duration_ms",
-                    serde_json::Value::from(snapshot_duration.as_secs_f64() * 1000.0),
-                ),
-                (
+                    snapshot_duration.as_secs_f64() * 1000.0,
+                ],
+                [
                     "persist_duration_ms",
-                    serde_json::Value::from(persist_duration.as_secs_f64() * 1000.0),
-                ),
-                ("task_count", serde_json::Value::from(task_count)),
-                (
-                    "bytes_written",
-                    serde_json::Value::from(snapshot_meta.bytes_written),
-                ),
-                (
-                    "bytes_deleted",
-                    serde_json::Value::from(snapshot_meta.bytes_deleted),
-                ),
-            ],
+                    persist_duration.as_secs_f64() * 1000.0,
+                ],
+                ["task_count", task_count],
+                ["bytes_written", snapshot_meta.bytes_written,],
+                ["bytes_deleted", snapshot_meta.bytes_deleted,]
+            ]),
         )));
 
         Ok((snapshot_time, true))

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -59,11 +59,10 @@ pub struct SnapshotMeta {
     pub data_items: usize,
     pub meta_items: usize,
     pub task_cache_items: usize,
-    /// Physical on-disk bytes (post-compression, including `.sst`/`.blob`/`.meta` files) written
-    /// by the commit.
-    pub bytes_written: usize,
-    /// Physical on-disk bytes of files removed/superseded by the commit.
-    pub bytes_deleted: usize,
+    /// Physical on-disk bytes written by the commit.
+    pub bytes_written: u64,
+    /// Physical on-disk bytes of files removed by the commit.
+    pub bytes_deleted: u64,
     pub max_next_task_id: u32,
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -59,6 +59,11 @@ pub struct SnapshotMeta {
     pub data_items: usize,
     pub meta_items: usize,
     pub task_cache_items: usize,
+    /// Physical on-disk bytes (post-compression, including `.sst`/`.blob`/`.meta` files) written
+    /// by the commit.
+    pub bytes_written: usize,
+    /// Physical on-disk bytes of files removed/superseded by the commit.
+    pub bytes_deleted: usize,
     pub max_next_task_id: u32,
 }
 
@@ -69,7 +74,28 @@ impl SnapshotMeta {
             data_items: self.data_items + rhs.data_items,
             meta_items: self.meta_items + rhs.meta_items,
             task_cache_items: self.task_cache_items + rhs.task_cache_items,
+            bytes_written: self.bytes_written + rhs.bytes_written,
+            bytes_deleted: self.bytes_deleted + rhs.bytes_deleted,
             max_next_task_id: max(self.max_next_task_id, rhs.max_next_task_id),
         }
+    }
+}
+
+impl std::fmt::Display for SnapshotMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let SnapshotMeta {
+            data_items,
+            meta_items,
+            task_cache_items,
+            bytes_written,
+            bytes_deleted,
+            max_next_task_id,
+        } = self;
+        write!(
+            f,
+            "data_items={data_items} meta_items={meta_items} task_cache_items={task_cache_items} \
+             bytes_written={bytes_written} bytes_deleted={bytes_deleted} \
+             next_task_id={max_next_task_id}"
+        )
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -8,7 +8,8 @@ use std::{
 use anyhow::{Ok, Result};
 use smallvec::SmallVec;
 use turbo_persistence::{
-    ArcBytes, CompactConfig, DbConfig, KeyBase, StoreKey, TurboPersistence, ValueBuffer,
+    ArcBytes, CommitStats, CompactConfig, DbConfig, KeyBase, StoreKey, TurboPersistence,
+    ValueBuffer,
 };
 use turbo_tasks::{
     message_queue::{TimingEvent, TraceEvent},
@@ -216,9 +217,8 @@ impl<'a> TurboWriteBatch<'a> {
         self.db.get(key_space as usize, &key)
     }
 
-    pub fn commit(self) -> Result<()> {
-        self.db.commit_write_batch(self.batch)?;
-        Ok(())
+    pub fn commit(self) -> Result<CommitStats> {
+        self.db.commit_write_batch(self.batch)
     }
 
     pub fn put(

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -179,7 +179,7 @@ fn do_compact(
         max_merge_segment_count,
         ..COMPACT_CONFIG
     })?;
-    if stats.is_some() {
+    if let Some(stats) = stats {
         let elapsed = start.elapsed();
         // avoid spamming the event queue with information about fast operations
         if elapsed > Duration::from_secs(10) {
@@ -196,7 +196,16 @@ fn do_compact(
             "turbopack-compaction",
             wall_start_ms,
             wall_end_ms,
-            vec![],
+            vec![
+                (
+                    "bytes_written",
+                    serde_json::Value::from(stats.bytes_written),
+                ),
+                (
+                    "bytes_deleted",
+                    serde_json::Value::from(stats.bytes_deleted),
+                ),
+            ],
         )));
     }
     Ok(stats)

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -126,11 +126,11 @@ impl TurboKeyValueDatabase {
 
     /// Triggers compaction of the database.
     ///
-    /// Returns `Ok(true)` if compaction actually merged files, `Ok(false)` if there was nothing
-    /// to compact.
-    pub fn compact(&self) -> Result<bool> {
+    /// Returns `Ok(Some(stats))` with the bytes written/deleted if compaction actually merged
+    /// files, `Ok(None)` if there was nothing to compact.
+    pub fn compact(&self) -> Result<Option<CommitStats>> {
         if self.is_short_session || self.db.is_empty() {
-            return Ok(false);
+            return Ok(None);
         }
         do_compact(
             &self.db,
@@ -170,16 +170,16 @@ fn do_compact(
     db: &TurboPersistence<TurboTasksParallelScheduler, FAMILIES>,
     message: &'static str,
     max_merge_segment_count: usize,
-) -> Result<bool> {
+) -> Result<Option<CommitStats>> {
     let start = Instant::now();
     // SystemTime for wall-clock timestamps in trace events (Instant has no
     // defined epoch so it can't be used for cross-process trace correlation).
     let wall_start = SystemTime::now();
-    let ran = db.compact(&CompactConfig {
+    let stats = db.compact(&CompactConfig {
         max_merge_segment_count,
         ..COMPACT_CONFIG
     })?;
-    if ran {
+    if stats.is_some() {
         let elapsed = start.elapsed();
         // avoid spamming the event queue with information about fast operations
         if elapsed > Duration::from_secs(10) {
@@ -199,7 +199,7 @@ fn do_compact(
             vec![],
         )));
     }
-    Ok(ran)
+    Ok(stats)
 }
 
 pub struct TurboWriteBatch<'a> {

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -196,16 +196,10 @@ fn do_compact(
             "turbopack-compaction",
             wall_start_ms,
             wall_end_ms,
-            vec![
-                (
-                    "bytes_written",
-                    serde_json::Value::from(stats.bytes_written),
-                ),
-                (
-                    "bytes_deleted",
-                    serde_json::Value::from(stats.bytes_deleted),
-                ),
-            ],
+            serde_json::json!([
+                ["bytes_written", stats.bytes_written],
+                ["bytes_deleted", stats.bytes_deleted],
+            ]),
         )));
     }
     Ok(stats)

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -236,7 +236,7 @@ impl TurboBackingStorage {
 
         {
             let _span = tracing::trace_span!("update task data").entered();
-            let snapshot_meta =
+            let mut snapshot_meta =
                 parallel::map_collect_owned::<_, _, Result<Vec<_>>>(snapshots, |shard: I| {
                     let mut max_new_task_id = 0;
                     let mut data_items = 0;
@@ -282,6 +282,9 @@ impl TurboBackingStorage {
                         data_items,
                         meta_items,
                         task_cache_items,
+                        // we don't know yet
+                        bytes_written: 0,
+                        bytes_deleted: 0,
                         max_next_task_id: max_new_task_id,
                     })
                 })?
@@ -306,7 +309,11 @@ impl TurboBackingStorage {
             save_infra(&batch, next_task_id, operations)?;
             {
                 let _span = tracing::trace_span!("commit").entered();
-                batch.commit().context("Unable to commit operations")?;
+                // Byte totals are the physical on-disk bytes (post-compression, including .sst /
+                // .blob / .meta files) produced and removed by the commit.
+                let stats = batch.commit().context("Unable to commit operations")?;
+                snapshot_meta.bytes_written = stats.bytes_written as usize;
+                snapshot_meta.bytes_deleted = stats.bytes_deleted as usize;
             }
             Ok(snapshot_meta)
         }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -314,8 +314,8 @@ impl TurboBackingStorage {
                 // Byte totals are the physical on-disk bytes (post-compression, including .sst /
                 // .blob / .meta files) produced and removed by the commit.
                 let stats = batch.commit().context("Unable to commit operations")?;
-                snapshot_meta.bytes_written = stats.bytes_written as usize;
-                snapshot_meta.bytes_deleted = stats.bytes_deleted as usize;
+                snapshot_meta.bytes_written = stats.bytes_written;
+                snapshot_meta.bytes_deleted = stats.bytes_deleted;
             }
             Ok(snapshot_meta)
         }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -8,6 +8,7 @@ use std::{
 use anyhow::{Context, Result};
 use smallvec::SmallVec;
 use turbo_bincode::{new_turbo_bincode_decoder, turbo_bincode_decode, turbo_bincode_encode};
+use turbo_persistence::CommitStats;
 use turbo_tasks::{
     DynTaskInputs, RawVc, TaskId,
     macro_helpers::NativeFunction,
@@ -282,7 +283,8 @@ impl TurboBackingStorage {
                         data_items,
                         meta_items,
                         task_cache_items,
-                        // we don't know yet
+                        // The on-disk byte totals aren't known until the batch is committed below;
+                        // they're filled in from `CommitStats` after `batch.commit()`.
                         bytes_written: 0,
                         bytes_deleted: 0,
                         max_next_task_id: max_new_task_id,
@@ -402,7 +404,7 @@ impl TurboBackingStorage {
             .collect::<Result<Vec<_>>>()
     }
 
-    pub(crate) fn compact(&self) -> Result<bool> {
+    pub(crate) fn compact(&self) -> Result<Option<CommitStats>> {
         self.inner.database.compact()
     }
 

--- a/turbopack/crates/turbo-tasks/src/message_queue.rs
+++ b/turbopack/crates/turbo-tasks/src/message_queue.rs
@@ -244,7 +244,8 @@ pub struct TraceEvent {
     pub name: &'static str,
     pub start_time_ms: f64,
     pub end_time_ms: f64,
-    pub attributes: Vec<(&'static str, serde_json::Value)>,
+    /// Should be an array of key value pairs
+    pub attributes: serde_json::Value,
 }
 
 impl TraceEvent {
@@ -252,8 +253,10 @@ impl TraceEvent {
         name: &'static str,
         start_time_ms: f64,
         end_time_ms: f64,
-        attributes: Vec<(&'static str, serde_json::Value)>,
+        attributes: serde_json::Value,
     ) -> Self {
+        // basic sanity test
+        debug_assert!(matches!(attributes, serde_json::Value::Array(_)));
         Self {
             name,
             start_time_ms,


### PR DESCRIPTION
Add data about persistence and compaction size to our spans

This will show up in trace data collected by `NEXT_TURBOPACK_TRACING` and in the default trace spans collected by next.js