### PR TITLE
examples: Remove server-only dependency from examples

### DIFF
--- a/examples/cms-sanity/package.json
+++ b/examples/cms-sanity/package.json
@@ -32,7 +32,6 @@
     "react-dom": "^19",
     "sanity": "^3.62.0",
     "sanity-plugin-asset-source-unsplash": "^3.0.1",
-    "server-only": "^0.0.1",
     "styled-components": "^6.1.13",
     "tailwindcss": "^3.4.14",
     "typescript": "5.6.3"

--- a/examples/i18n-routing/package.json
+++ b/examples/i18n-routing/package.json
@@ -10,7 +10,7 @@
     "negotiator": "1.0.0",
     "next": "latest",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/negotiator": "0.6.3",

--- a/examples/i18n-routing/package.json
+++ b/examples/i18n-routing/package.json
@@ -11,7 +11,6 @@
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "server-only": "0.0.1"
   },
   "devDependencies": {
     "@types/negotiator": "0.6.3",

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -11,7 +11,6 @@
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.1.5",

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "next": "latest",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.1.5",

--- a/examples/with-stripe-typescript/package.json
+++ b/examples/with-stripe-typescript/package.json
@@ -11,7 +11,6 @@
     "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "server-only": "0.0.1",
     "stripe": "14.8.0"
   },
   "devDependencies": {

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -10,7 +10,6 @@
     "next": "latest",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "next": "latest",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1",
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
Adding this package explicitly is unnecessary and is provided by next.js