### PR TITLE
fix(next-mdx): preserve MDX metadata in webpack

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -35,9 +35,29 @@ module.exports =
           '@mdx-js/react',
           require.resolve('./mdx-components.js'),
         ]
+        const rscMdxLoader =
+          options.defaultLoaders.babel &&
+          typeof options.defaultLoaders.babel === 'object' &&
+          options.defaultLoaders.babel.loader?.includes('next-swc-loader')
+            ? {
+                ...options.defaultLoaders.babel,
+                options: {
+                  ...options.defaultLoaders.babel.options,
+                  bundleLayer: 'rsc',
+                },
+              }
+            : options.defaultLoaders.babel
         config.module.rules.push({
           test: extension,
-          use: [options.defaultLoaders.babel, loader],
+          oneOf: [
+            {
+              issuerLayer: 'rsc',
+              use: [rscMdxLoader, loader],
+            },
+            {
+              use: [options.defaultLoaders.babel, loader],
+            },
+          ],
         })
 
         if (typeof inputConfig.webpack === 'function') {

--- a/test/e2e/app-dir/mdx/app/page.mdx
+++ b/test/e2e/app-dir/mdx/app/page.mdx
@@ -1,5 +1,9 @@
 # Hello World
 
+export const metadata = {
+  title: 'MDX metadata',
+}
+
 This is MDX!
 
 import { Client } from './client'

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -22,6 +22,7 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
     describe('app directory', () => {
       it('should work in initial html', async () => {
         const $ = await next.render$('/')
+        expect($('title').text()).toBe('MDX metadata')
         expect($('h1').text()).toBe('Hello World')
         expect($('p').text()).toBe('This is MDX!')
       })
@@ -97,7 +98,8 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
       it('should work in initial html', async () => {
         const $ = await next.render$('/pages')
         expect($('h1').text()).toBe('Hello World')
-        expect($('p').text()).toBe('This is MDX!')
+        expect($('p').first().text()).toBe('This is MDX!')
+        expect($('#pages-router-counter').text()).toBe('Count: 0')
       })
 
       // Recommended for tests that need a full browser

--- a/test/e2e/app-dir/mdx/pages/pages/index.mdx
+++ b/test/e2e/app-dir/mdx/pages/pages/index.mdx
@@ -1,3 +1,13 @@
 # Hello World
 
 This is MDX!
+
+import { useState } from 'react'
+
+export function Counter() {
+  const [count] = useState(0)
+
+return <p id="pages-router-counter">Count: {count}</p>
+}
+
+<Counter />


### PR DESCRIPTION
### What

Teach `@next/mdx` to pass app-router MDX files through `next-swc-loader` with the React Server Components bundle layer when webpack is used.

This keeps MDX pages that export `metadata` classified as Server Components instead of being rejected as Client Components.

### Why

The documented app-router MDX pattern supports `export const metadata`, but under webpack the custom MDX rule reused the default SWC loader without the RSC bundle layer. That made `app/page.mdx` fail during `next build --webpack` with:

> You are attempting to export "metadata" from a component marked with "use client"

### How

- Clone the default SWC loader used by `@next/mdx` webpack rules.
- Add `bundleLayer: "rsc"` only when that loader is `next-swc-loader`.
- Extend the existing MDX e2e fixture with a `metadata` export and assert the rendered `<title>`.

Fixes #91735

### Testing

- `pnpm build-all`
- `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/mdx/mdx.test.ts -t "should work in initial html"`
- `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/mdx/mdx.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir/mdx/mdx.test.ts`
- `node --check packages/next-mdx/index.js`
- `pnpm prettier --check packages/next-mdx/index.js test/e2e/app-dir/mdx/mdx.test.ts test/e2e/app-dir/mdx/app/page.mdx`
- `pnpm --filter @next/mdx pack-for-isolated-tests`
- `git diff --check`
