### PR TITLE
fix(next-mdx): report unresolved plugin paths

### DIFF
--- a/packages/next-mdx/mdx-js-loader.js
+++ b/packages/next-mdx/mdx-js-loader.js
@@ -6,7 +6,15 @@ function interopDefault(mod) {
 }
 
 async function importPluginForPath(pluginPath, projectRoot) {
-  const path = require.resolve(pluginPath, { paths: [projectRoot] })
+  let path
+
+  try {
+    path = require.resolve(pluginPath, { paths: [projectRoot] })
+  } catch (error) {
+    error.message = `Failed to resolve MDX plugin "${pluginPath}": ${error.message}`
+    throw error
+  }
+
   return interopDefault(
     // "use pathToFileUrl to make esm import()s work with absolute windows paths":
     // on windows import("C:\\path\\to\\file") is not valid, so we need to use file:// URLs
@@ -58,21 +66,30 @@ module.exports = function nextMdxLoader(...args) {
   const callback = this.async().bind(this)
   const loaderContext = this
 
-  getOptions(options, this.context).then((userProvidedMdxOptions) => {
-    const proxy = new Proxy(loaderContext, {
-      get(target, prop, receiver) {
-        if (prop === 'getOptions') {
-          return () => userProvidedMdxOptions
-        }
+  getOptions(options, this.context).then(
+    (userProvidedMdxOptions) => {
+      const proxy = new Proxy(loaderContext, {
+        get(target, prop, receiver) {
+          if (prop === 'getOptions') {
+            return () => userProvidedMdxOptions
+          }
 
-        if (prop === 'async') {
-          return () => callback
-        }
+          if (prop === 'async') {
+            return () => callback
+          }
 
-        return Reflect.get(target, prop, receiver)
-      },
-    })
+          return Reflect.get(target, prop, receiver)
+        },
+      })
 
-    mdxLoader.call(proxy, ...args)
-  })
+      try {
+        mdxLoader.call(proxy, ...args)
+      } catch (error) {
+        callback(error)
+      }
+    },
+    (error) => {
+      callback(error)
+    }
+  )
 }

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 
 for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
   describe(`mdx ${type}`, () => {
-    const { next } = nextTestSetup({
+    const { next, isNextStart } = nextTestSetup({
       files: __dirname,
       dependencies: {
         '@next/mdx': 'canary',
@@ -128,5 +128,39 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
         )
       })
     })
+
+    if (type === 'without-mdx-rs') {
+      it('should report unresolved string plugin paths during build', async () => {
+        if (!isNextStart) {
+          return
+        }
+
+        await next.stop()
+        await next.patchFile(
+          'next.config.ts',
+          `
+            import nextMDX from '@next/mdx'
+
+            const withMDX = nextMDX({
+              extension: /\\.mdx?$/,
+              options: {
+                remarkPlugins: ['remark-this-plugin-does-not-exist'],
+              },
+            })
+
+            export default withMDX({
+              pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+            })
+          `,
+          async () => {
+            const { exitCode, cliOutput } = await next.build()
+
+            expect(exitCode).toBe(1)
+            expect(cliOutput).toContain('remark-this-plugin-does-not-exist')
+            expect(cliOutput).not.toContain('UnhandledPromiseRejection')
+          }
+        )
+      })
+    }
   })
 }


### PR DESCRIPTION
## Summary

Closes #94118.

- forward MDX plugin resolution failures to the webpack loader callback
- include the unresolved plugin name in the surfaced build error
- add coverage for missing string plugin paths without changing the existing happy-path fixture

## Tests

- `pnpm build-all`
- `node --check packages/next-mdx/mdx-js-loader.js`
- `pnpm prettier --check packages/next-mdx/mdx-js-loader.js test/e2e/app-dir/mdx/mdx.test.ts`
- `pnpm --filter @next/mdx pack-for-isolated-tests`
- `git diff --check`
- `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/mdx/mdx.test.ts -t "should report unresolved string plugin paths during build"`
- `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/mdx/mdx.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir/mdx/mdx.test.ts`
