### PR TITLE
feat(cache): configurable `cacheKeyExcludedHeaders` for fetch Data Cache key

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/fetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/fetch.mdx
@@ -83,6 +83,20 @@ fetch(`https://...`, { next: { tags: ['collection'] } })
 
 Set the cache tags of a resource. Data can then be revalidated on-demand using [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag). The max length for a custom tag is 256 characters and the max tag items is 128.
 
+### `options.next.cacheKeyExcludedHeaders`
+
+```ts
+fetch(`https://...`, {
+  next: { cacheKeyExcludedHeaders: ['x-request-id', 'sentry-trace'] },
+})
+```
+
+A list of request header names to exclude from the fetch [Data Cache](/docs/app/getting-started/caching) key for this individual request. Header names are matched case-insensitively. The excluded headers are still forwarded to the origin server — they only affect which responses are considered cache-equivalent.
+
+This is additive to the built-in exclusions (`traceparent`, `tracestate`) and to any headers configured globally via [`experimental.cacheKeyExcludedHeaders`](/docs/app/api-reference/config/next-config-js/cacheKeyExcludedHeaders).
+
+> **Warning:** Only exclude headers that do **not** affect the response body. Excluding a header that the origin uses to vary its response — such as `authorization`, `cookie`, `accept-language`, or `accept-encoding` — will cause **cross-context cache poisoning**: one user's response may be served to another user.
+
 ## Memoization
 
 `fetch` requests using `GET` with the same URL and options are automatically [memoized](/docs/app/glossary#memoization) during a server render pass. If you call the same `fetch` in multiple Server Components, layouts, pages, `generateStaticParams` and `generateViewport`, Next.js executes it only once and shares the result. This is separate from persistent [caching](/docs/app/getting-started/caching): memoization lasts only for a single render pass, while cached responses persist across requests.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheKeyExcludedHeaders.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheKeyExcludedHeaders.mdx
@@ -1,0 +1,54 @@
+---
+title: cacheKeyExcludedHeaders
+description: Configure request headers that are excluded from the fetch Data Cache key across all fetch requests in your application.
+version: experimental
+---
+
+`cacheKeyExcludedHeaders` is an experimental option that lets you declare request header names that should be ignored when computing the fetch [Data Cache](/docs/app/getting-started/caching) key. Use it for per-request-varying headers — such as trace or correlation IDs — that are forwarded on every request but have no effect on the response body.
+
+Excluded headers are still sent to the origin server. They are only removed from the string that Next.js hashes to identify a cached response.
+
+## Usage
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    cacheKeyExcludedHeaders: ['x-request-id', 'sentry-trace'],
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    cacheKeyExcludedHeaders: ['x-request-id', 'sentry-trace'],
+  },
+}
+
+module.exports = nextConfig
+```
+
+## Behavior
+
+- **Additive union.** The effective exclusion set is the union of the built-in exclusions (`traceparent`, `tracestate`), the headers listed here, and any per-request headers passed via [`fetch`'s `next.cacheKeyExcludedHeaders` option](/docs/app/api-reference/functions/fetch#optionsnextcachekeyexcludedheaders). You cannot remove built-in exclusions.
+- **Case-insensitive.** Header names are lowercased before matching, so `Sentry-Trace` and `sentry-trace` are treated identically.
+- **Exact names only.** Glob patterns and prefix matches are not supported. Each entry must be a full header name.
+
+> **Warning:** Only exclude headers that do **not** affect the response body. Excluding a header that the origin uses to vary its response — such as `authorization`, `cookie`, `accept-language`, or `accept-encoding` — will cause **cross-context cache poisoning**: one user's response may be served to another user.
+
+## Per-request exclusions
+
+To exclude headers for a single `fetch` call rather than globally, use the [`next.cacheKeyExcludedHeaders`](/docs/app/api-reference/functions/fetch#optionsnextcachekeyexcludedheaders) option on the individual request:
+
+```ts
+fetch('https://...', {
+  next: { cacheKeyExcludedHeaders: ['x-request-id'] },
+})
+```
+
+Per-request exclusions are additive to the global list configured here.

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -340,6 +340,8 @@ export function getDefineEnv({
       config.experimental.trustHostHeader ?? false,
     'process.env.__NEXT_ALLOWED_REVALIDATE_HEADERS':
       config.experimental.allowedRevalidateHeaderKeys ?? [],
+    'process.env.__NEXT_CACHE_KEY_EXCLUDED_HEADERS':
+      config.experimental.cacheKeyExcludedHeaders ?? [],
     ...(isNodeServer || isEdgeServer
       ? {
           'process.env.__NEXT_RELATIVE_DIST_DIR': config.distDir,

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -13,6 +13,7 @@ export async function createIncrementalCache({
   cacheHandler,
   cacheMaxMemorySize,
   fetchCacheKeyPrefix,
+  cacheKeyExcludedHeaders,
   distDir,
   dir,
   flushToDisk,
@@ -22,6 +23,7 @@ export async function createIncrementalCache({
   cacheHandler?: string
   cacheMaxMemorySize: number
   fetchCacheKeyPrefix?: string
+  cacheKeyExcludedHeaders?: string[]
   distDir: string
   dir: string
   flushToDisk?: boolean
@@ -59,6 +61,7 @@ export async function createIncrementalCache({
     flushToDisk,
     maxMemoryCacheSize: cacheMaxMemorySize,
     fetchCacheKeyPrefix,
+    cacheKeyExcludedHeaders,
     getPrerenderManifest: () => ({
       version: 4,
       routes: {},

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -381,6 +381,7 @@ export async function exportPages(
     cacheHandler,
     cacheMaxMemorySize,
     fetchCacheKeyPrefix,
+    cacheKeyExcludedHeaders: nextConfig.experimental.cacheKeyExcludedHeaders,
     distDir,
     dir,
     // skip writing to disk in minimal mode for now, pending some

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -196,6 +196,7 @@ export const experimentalSchema = {
   appNewScrollHandler: z.boolean().optional(),
   preloadEntriesOnStart: z.boolean().optional(),
   allowedRevalidateHeaderKeys: z.array(z.string()).optional(),
+  cacheKeyExcludedHeaders: z.array(z.string()).optional(),
   staleTimes: z
     .object({
       dynamic: z.number().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -535,6 +535,7 @@ export interface ExperimentalConfig {
   extensionAlias?: Record<string, any>
   allowedRevalidateHeaderKeys?: string[]
   fetchCacheKeyPrefix?: string
+  cacheKeyExcludedHeaders?: string[]
   imgOptConcurrency?: number | null
   imgOptOperationCache?: boolean | null
   imgOptTimeoutInSeconds?: number
@@ -2193,6 +2194,7 @@ export interface NextConfigRuntime {
     | 'clientParamParsingOrigins'
     | 'allowedRevalidateHeaderKeys'
     | 'fetchCacheKeyPrefix'
+    | 'cacheKeyExcludedHeaders'
     | 'isrFlushToDisk'
     | 'optimizeCss'
     | 'nextScriptWorkers'
@@ -2261,6 +2263,7 @@ export function getNextConfigRuntime(
     clientParamParsingOrigins: ex.clientParamParsingOrigins,
     allowedRevalidateHeaderKeys: ex.allowedRevalidateHeaderKeys,
     fetchCacheKeyPrefix: ex.fetchCacheKeyPrefix,
+    cacheKeyExcludedHeaders: ex.cacheKeyExcludedHeaders,
     isrFlushToDisk: ex.isrFlushToDisk,
     optimizeCss: ex.optimizeCss,
     nextScriptWorkers: ex.nextScriptWorkers,

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -90,6 +90,7 @@ export class IncrementalCache implements IncrementalCacheType {
   readonly allowedRevalidateHeaderKeys?: string[]
   readonly minimalMode?: boolean
   readonly fetchCacheKeyPrefix?: string
+  readonly cacheKeyExcludedHeaders?: string[]
   readonly isOnDemandRevalidate?: boolean
   readonly revalidatedTags?: readonly string[]
 
@@ -115,6 +116,7 @@ export class IncrementalCache implements IncrementalCacheType {
     fetchCacheKeyPrefix,
     CurCacheHandler,
     allowedRevalidateHeaderKeys,
+    cacheKeyExcludedHeaders,
   }: {
     fs?: CacheFs
     dev: boolean
@@ -126,6 +128,7 @@ export class IncrementalCache implements IncrementalCacheType {
     maxMemoryCacheSize?: number
     getPrerenderManifest: () => DeepReadonly<PrerenderManifest>
     fetchCacheKeyPrefix?: string
+    cacheKeyExcludedHeaders?: string[]
     CurCacheHandler?: typeof CacheHandler
   }) {
     this.hasCustomCacheHandler = Boolean(CurCacheHandler)
@@ -176,6 +179,9 @@ export class IncrementalCache implements IncrementalCacheType {
     this.prerenderManifest = getPrerenderManifest()
     this.cacheControls = new SharedCacheControls(this.prerenderManifest)
     this.fetchCacheKeyPrefix = fetchCacheKeyPrefix
+    this.cacheKeyExcludedHeaders = cacheKeyExcludedHeaders?.map((h) =>
+      h.toLowerCase()
+    )
     let revalidatedTags: string[] = []
 
     if (
@@ -378,15 +384,27 @@ export class IncrementalCache implements IncrementalCacheType {
       }
     }
 
-    const headers =
+    const headers: Record<string, string> =
       typeof (init.headers || {}).keys === 'function'
         ? Object.fromEntries(init.headers as Headers)
-        : Object.assign({}, init.headers)
+        : Object.assign({}, init.headers as Record<string, string>)
 
-    // w3c trace context headers can break request caching and deduplication
-    // so we remove them from the cache key
-    if ('traceparent' in headers) delete headers['traceparent']
-    if ('tracestate' in headers) delete headers['tracestate']
+    const fetchCacheKeyExcludedHeaders = (init as RequestInit).next
+      ?.cacheKeyExcludedHeaders
+
+    // Headers excluded from the cache key. The w3c trace context headers
+    // (traceparent/tracestate) are always excluded because they can break
+    // request caching and deduplication. The global
+    // (experimental.cacheKeyExcludedHeaders, pre-lowercased in the
+    // constructor) and per-fetch (next.cacheKeyExcludedHeaders) lists are
+    // additive on top of the built-ins.
+    const excluded = new Set<string>(['traceparent', 'tracestate'])
+    for (const h of this.cacheKeyExcludedHeaders ?? []) excluded.add(h)
+    for (const h of fetchCacheKeyExcludedHeaders ?? [])
+      excluded.add(h.toLowerCase())
+    for (const key of Object.keys(headers)) {
+      if (excluded.has(key.toLowerCase())) delete headers[key]
+    }
 
     const cacheString = JSON.stringify([
       MAIN_KEY_PREFIX,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -443,6 +443,8 @@ export default class NextNodeServer extends BaseServer<
       minimalMode: this.minimalMode,
       serverDistDir: this.serverDistDir,
       fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
+      cacheKeyExcludedHeaders:
+        this.nextConfig.experimental.cacheKeyExcludedHeaders,
       maxMemoryCacheSize: this.nextConfig.cacheMaxMemorySize,
       flushToDisk:
         !this.minimalMode && this.nextConfig.experimental.isrFlushToDisk,

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -515,6 +515,8 @@ export abstract class RouteModule<
         minimalMode: isMinimalMode,
         serverDistDir: `${projectDir}/${this.distDir}/server`,
         fetchCacheKeyPrefix: nextConfig.experimental.fetchCacheKeyPrefix,
+        cacheKeyExcludedHeaders:
+          nextConfig.experimental.cacheKeyExcludedHeaders,
         maxMemoryCacheSize: nextConfig.cacheMaxMemorySize,
         flushToDisk: !isMinimalMode && nextConfig.experimental.isrFlushToDisk,
         getPrerenderManifest: () => prerenderManifest,

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -223,6 +223,9 @@ export async function adapter(
       CurCacheHandler: params.incrementalCacheHandler,
       minimalMode: process.env.NODE_ENV !== 'development',
       fetchCacheKeyPrefix: process.env.__NEXT_FETCH_CACHE_KEY_PREFIX,
+      // define-env inlines this as a real array literal, not a string.
+      cacheKeyExcludedHeaders: process.env
+        .__NEXT_CACHE_KEY_EXCLUDED_HEADERS as unknown as string[] | undefined,
       dev: process.env.NODE_ENV === 'development',
       requestHeaders: params.request.headers as any,
 

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -149,6 +149,7 @@ interface Window {
 interface NextFetchRequestConfig {
   revalidate?: number | false
   tags?: string[]
+  cacheKeyExcludedHeaders?: string[]
 }
 
 interface RequestInit {

--- a/test/e2e/app-dir/cache-key-excluded-headers/app/global-excluded/page.tsx
+++ b/test/e2e/app-dir/cache-key-excluded-headers/app/global-excluded/page.tsx
@@ -1,0 +1,28 @@
+// Tests that a header listed in experimental.cacheKeyExcludedHeaders is
+// ignored when computing the fetch Data Cache key.  Two fetches to the same
+// URL with *different* x-request-id values should return the same cached
+// random value, proving a cache HIT.
+export default async function Page() {
+  const data1 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      headers: { 'x-request-id': 'req-aaa' },
+      next: { revalidate: 50 },
+    }
+  ).then((res) => res.text())
+
+  const data2 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      headers: { 'x-request-id': 'req-bbb' },
+      next: { revalidate: 50 },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="data1">{data1}</p>
+      <p id="data2">{data2}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-key-excluded-headers/app/layout.tsx
+++ b/test/e2e/app-dir/cache-key-excluded-headers/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-key-excluded-headers/app/non-excluded/page.tsx
+++ b/test/e2e/app-dir/cache-key-excluded-headers/app/non-excluded/page.tsx
@@ -1,0 +1,27 @@
+// Tests that a header NOT in cacheKeyExcludedHeaders still participates in
+// the cache key.  Two fetches to the same URL with different x-custom values
+// should produce *different* random values (cache MISS on the second fetch).
+export default async function Page() {
+  const data1 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      headers: { 'x-custom': 'val-aaa' },
+      next: { revalidate: 50 },
+    }
+  ).then((res) => res.text())
+
+  const data2 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      headers: { 'x-custom': 'val-bbb' },
+      next: { revalidate: 50 },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="data1">{data1}</p>
+      <p id="data2">{data2}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-key-excluded-headers/app/page.tsx
+++ b/test/e2e/app-dir/cache-key-excluded-headers/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/cache-key-excluded-headers/app/per-fetch-excluded/page.tsx
+++ b/test/e2e/app-dir/cache-key-excluded-headers/app/per-fetch-excluded/page.tsx
@@ -1,0 +1,34 @@
+// Tests that next.cacheKeyExcludedHeaders on a per-fetch basis causes the
+// specified header to be excluded from the cache key.  Two fetches with
+// different x-trace values and the same per-fetch exclusion list should
+// return the same cached random value (cache HIT).
+export default async function Page() {
+  const data1 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      headers: { 'x-trace': 'trace-aaa' },
+      next: {
+        revalidate: 50,
+        cacheKeyExcludedHeaders: ['x-trace'],
+      },
+    }
+  ).then((res) => res.text())
+
+  const data2 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      headers: { 'x-trace': 'trace-bbb' },
+      next: {
+        revalidate: 50,
+        cacheKeyExcludedHeaders: ['x-trace'],
+      },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="data1">{data1}</p>
+      <p id="data2">{data2}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-key-excluded-headers/cache-key-excluded-headers.test.ts
+++ b/test/e2e/app-dir/cache-key-excluded-headers/cache-key-excluded-headers.test.ts
@@ -1,0 +1,68 @@
+import cheerio from 'cheerio'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('cacheKeyExcludedHeaders', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe('global config — experimental.cacheKeyExcludedHeaders', () => {
+    it('excluded header: differing values → cache HIT (same response body)', async () => {
+      // The fixture at /global-excluded fetches the same URL twice, each time
+      // with a different x-request-id value.  Because x-request-id is listed
+      // in experimental.cacheKeyExcludedHeaders, both fetches should resolve
+      // to the same cached random value.
+      const res = await next.fetch('/global-excluded')
+      expect(res.status).toBe(200)
+
+      const $ = cheerio.load(await res.text())
+
+      await retry(async () => {
+        const data1 = $('#data1').text()
+        const data2 = $('#data2').text()
+        expect(data1).toBeTruthy()
+        expect(data1).toBe(data2)
+      })
+    })
+  })
+
+  describe('per-fetch — next.cacheKeyExcludedHeaders', () => {
+    it('excluded header: differing values → cache HIT (same response body)', async () => {
+      // The fixture at /per-fetch-excluded specifies cacheKeyExcludedHeaders
+      // inline on each fetch call.  Differing x-trace values should still
+      // resolve to the same cached random value.
+      const res = await next.fetch('/per-fetch-excluded')
+      expect(res.status).toBe(200)
+
+      const $ = cheerio.load(await res.text())
+
+      await retry(async () => {
+        const data1 = $('#data1').text()
+        const data2 = $('#data2').text()
+        expect(data1).toBeTruthy()
+        expect(data1).toBe(data2)
+      })
+    })
+  })
+
+  describe('non-excluded header', () => {
+    it('differing values → cache MISS (different response bodies)', async () => {
+      // The fixture at /non-excluded fetches the same URL twice with different
+      // x-custom values.  x-custom is NOT excluded so the two fetches land on
+      // different cache keys → different random values.
+      const res = await next.fetch('/non-excluded')
+      expect(res.status).toBe(200)
+
+      const $ = cheerio.load(await res.text())
+
+      await retry(async () => {
+        const data1 = $('#data1').text()
+        const data2 = $('#data2').text()
+        expect(data1).toBeTruthy()
+        expect(data2).toBeTruthy()
+        expect(data1).not.toBe(data2)
+      })
+    })
+  })
+})

--- a/test/e2e/app-dir/cache-key-excluded-headers/next.config.js
+++ b/test/e2e/app-dir/cache-key-excluded-headers/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    // Global cacheKeyExcludedHeaders: x-request-id should be ignored when
+    // computing the fetch Data Cache key so requests with different values
+    // still hit the same cached response.
+    cacheKeyExcludedHeaders: ['x-request-id'],
+  },
+}
+
+module.exports = nextConfig

--- a/test/unit/incremental-cache/cache-key-excluded-headers.test.ts
+++ b/test/unit/incremental-cache/cache-key-excluded-headers.test.ts
@@ -1,0 +1,171 @@
+import { IncrementalCache } from 'next/dist/server/lib/incremental-cache'
+
+const MINIMAL_PRERENDER_MANIFEST = {
+  version: 4 as const,
+  routes: {},
+  dynamicRoutes: {},
+  preview: {
+    previewModeEncryptionKey: '',
+    previewModeId: '',
+    previewModeSigningKey: '',
+  },
+  notFoundRoutes: [],
+}
+
+function makeCache(cacheKeyExcludedHeaders?: string[]): IncrementalCache {
+  return new IncrementalCache({
+    dev: false,
+    requestHeaders: {},
+    getPrerenderManifest: () => MINIMAL_PRERENDER_MANIFEST,
+    cacheKeyExcludedHeaders,
+  })
+}
+
+describe('generateCacheKey — cacheKeyExcludedHeaders', () => {
+  const url = 'https://api.example.com/data'
+
+  it('excluded header (global config): differing values → identical key', async () => {
+    const cache = makeCache(['x-request-id'])
+
+    const key1 = await cache.generateCacheKey(url, {
+      headers: { 'x-request-id': 'aaa', accept: 'application/json' },
+    })
+    const key2 = await cache.generateCacheKey(url, {
+      headers: { 'x-request-id': 'bbb', accept: 'application/json' },
+    })
+
+    expect(key1).toBe(key2)
+  })
+
+  it('non-excluded header: differing values → different key', async () => {
+    const cache = makeCache(['x-request-id'])
+
+    const key1 = await cache.generateCacheKey(url, {
+      headers: { 'x-custom': 'foo' },
+    })
+    const key2 = await cache.generateCacheKey(url, {
+      headers: { 'x-custom': 'bar' },
+    })
+
+    expect(key1).not.toBe(key2)
+  })
+
+  it('built-ins (traceparent/tracestate) are excluded with no config set', async () => {
+    const cache = makeCache()
+
+    const key1 = await cache.generateCacheKey(url, {
+      headers: { traceparent: '00-abc-def-01', tracestate: 'rojo=1' },
+    })
+    const key2 = await cache.generateCacheKey(url, {
+      headers: { traceparent: '00-xyz-uvw-02', tracestate: 'congo=2' },
+    })
+
+    expect(key1).toBe(key2)
+  })
+
+  it('case-insensitive: global config "Sentry-Trace" excludes "sentry-trace" header', async () => {
+    const cache = makeCache(['Sentry-Trace'])
+
+    const key1 = await cache.generateCacheKey(url, {
+      headers: { 'sentry-trace': 'value-a' },
+    })
+    const key2 = await cache.generateCacheKey(url, {
+      headers: { 'sentry-trace': 'value-b' },
+    })
+
+    expect(key1).toBe(key2)
+  })
+
+  it('per-fetch list is additive to the global list: both applied together', async () => {
+    const cache = makeCache(['x-global-exclude'])
+
+    // Both global and per-fetch headers are varied; key should be identical
+    // because both are excluded.
+    const key1 = await cache.generateCacheKey(url, {
+      headers: { 'x-global-exclude': 'g1', 'x-perfetch-exclude': 'p1' },
+      next: { cacheKeyExcludedHeaders: ['x-perfetch-exclude'] },
+    })
+    const key2 = await cache.generateCacheKey(url, {
+      headers: { 'x-global-exclude': 'g2', 'x-perfetch-exclude': 'p2' },
+      next: { cacheKeyExcludedHeaders: ['x-perfetch-exclude'] },
+    })
+
+    expect(key1).toBe(key2)
+
+    // Non-excluded header still differentiates keys
+    const key3 = await cache.generateCacheKey(url, {
+      headers: {
+        'x-global-exclude': 'g1',
+        'x-perfetch-exclude': 'p1',
+        'x-other': 'o1',
+      },
+      next: { cacheKeyExcludedHeaders: ['x-perfetch-exclude'] },
+    })
+    const key4 = await cache.generateCacheKey(url, {
+      headers: {
+        'x-global-exclude': 'g1',
+        'x-perfetch-exclude': 'p1',
+        'x-other': 'o2',
+      },
+      next: { cacheKeyExcludedHeaders: ['x-perfetch-exclude'] },
+    })
+
+    expect(key3).not.toBe(key4)
+  })
+
+  it('Request-input path: new Request(url, {next:{cacheKeyExcludedHeaders}}) respects exclusion', async () => {
+    const cache = makeCache()
+
+    // Pass a Request object rather than a plain RequestInit — the historically
+    // fragile branch (patch-fetch.ts isRequestInput === true).
+    const req1 = new Request(url, {
+      headers: { 'x-trace': 'val-a', accept: 'text/plain' },
+    })
+    ;(req1 as any).next = { cacheKeyExcludedHeaders: ['x-trace'] }
+
+    const req2 = new Request(url, {
+      headers: { 'x-trace': 'val-b', accept: 'text/plain' },
+    })
+    ;(req2 as any).next = { cacheKeyExcludedHeaders: ['x-trace'] }
+
+    const key1 = await cache.generateCacheKey(url, req1 as any)
+    const key2 = await cache.generateCacheKey(url, req2 as any)
+
+    expect(key1).toBe(key2)
+  })
+
+  it('built-in header in config (e.g. ["traceparent"]) is harmless — no error, still excluded', async () => {
+    // Passing a built-in in the config should not throw and the header should
+    // still be excluded (Set deduplication keeps exactly one entry).
+    const cache = makeCache(['traceparent'])
+
+    await expect(
+      cache.generateCacheKey(url, {
+        headers: { traceparent: '00-abc-def-01' },
+      })
+    ).resolves.toEqual(expect.any(String))
+
+    const key1 = await cache.generateCacheKey(url, {
+      headers: { traceparent: 'v1' },
+    })
+    const key2 = await cache.generateCacheKey(url, {
+      headers: { traceparent: 'v2' },
+    })
+
+    expect(key1).toBe(key2)
+  })
+
+  it('determinism: same inputs produce the same key across two calls', async () => {
+    const cache = makeCache(['x-request-id'])
+
+    const init = {
+      method: 'GET',
+      headers: { 'x-request-id': 'ignored', accept: 'application/json' },
+    }
+
+    const key1 = await cache.generateCacheKey(url, init)
+    const key2 = await cache.generateCacheKey(url, init)
+
+    expect(key1).toBe(key2)
+  })
+})


### PR DESCRIPTION
## What

Adds an experimental, additive API to exclude request headers from the **fetch Data Cache key**, generalizing the existing hard-coded `traceparent`/`tracestate` exclusion.

- Global: `experimental.cacheKeyExcludedHeaders: string[]` in `next.config`
- Per-fetch: `fetch(url, { next: { cacheKeyExcludedHeaders: ['x-request-id'] } })`

Effective exclusions = built-ins (`traceparent`, `tracestate`) ∪ global ∪ per-fetch — additive, case-insensitive, exact header names. Excluded headers are still sent to the origin; only the cache key ignores them.

## Why

Closes the request in #76875. Per-request-varying headers injected by instrumentation/middleware (Sentry `sentry-trace`/`baggage`, OpenTelemetry, Datadog, `x-request-id`, etc.) make the fetch Data Cache key unique on every request, silently turning cache hits into permanent misses. Today only the W3C trace headers are excluded, and that list is hard-coded. This makes it configurable.

## How

- `generateCacheKey()` (incremental-cache) now removes built-ins ∪ global (ctor-lowercased) ∪ per-fetch (`init.next.cacheKeyExcludedHeaders`, lowercased per-call), matched case-insensitively. Signature unchanged; `MAIN_KEY_PREFIX` unchanged (no cache invalidation — requests without excluded headers hash identically).
- Global value plumbed exactly like `fetchCacheKeyPrefix`/`allowedRevalidateHeaderKeys`: `ExperimentalConfig` type + zod schema + the `getNextConfigRuntime` runtime allowlist (so it survives into the production/standalone runtime config) + all `IncrementalCache` construction sites; the edge runtime reads it via a `define-env` array env (`__NEXT_CACHE_KEY_EXCLUDED_HEADERS`).
- Per-fetch type added to `NextFetchRequestConfig`.
- Note: unlike `fetchCacheKeyPrefix`, the define-env value is read straight off the full `config` object that `getDefineEnv` already receives, so no `NextBuildContext` threading is needed.

## Safety

Documented (docs-only) that this is only safe for headers that do **not** vary the response body; excluding `authorization`/`cookie`/`accept-language` would cause cross-context cache poisoning.

## Verification

- Unit (`test/unit/incremental-cache/cache-key-excluded-headers.test.ts`): excluded→same key, non-excluded→different key, built-ins regression, case-insensitive, per-fetch additive, `Request`-input path, built-in-in-config harmless, determinism.
- e2e (`test/e2e/app-dir/cache-key-excluded-headers/`): global→HIT, per-fetch→HIT, non-excluded→MISS. Passes under both `pnpm test-dev-turbo` and `pnpm test-start-turbo` (the start run confirms the value propagates to the production build runtime).

## Relationship to prior work

Supersedes the stalled #73502 (`next.disableHeaders`) with clearer naming and additive semantics (no "disable-all" boolean, which is a cache-poisoning footgun).

## Question for maintainers

Is `cacheKeyExcludedHeaders` under `experimental` (no `unstable_`, same name on both the global and per-fetch layers) the preferred API shape, or would you prefer a different name/gating?

<!-- NEXT_JS_LLM_PR -->
