### PR TITLE
fix(typegen): skip turbopackRustReactCompiler Turbopack-only check during next typegen

### DIFF
--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -30,6 +30,11 @@ export type NextTypegenOptions = {
 const nextTypegen = async (options: NextTypegenOptions, directory?: string) => {
   parseBundlerArgs(options)
 
+  // Signal to config loading that we are running typegen so that
+  // Turbopack-only config checks (e.g. turbopackRustReactCompiler) are
+  // skipped – typegen does not involve a bundler at all.
+  process.env.NEXT_PRIVATE_TYPEGEN = '1'
+
   const baseDir = getProjectDir(directory)
 
   // Check if the provided directory exists

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -6,7 +6,7 @@ import { mkdir } from 'fs/promises'
 
 import loadConfig from '../server/config'
 import { printAndExit } from '../server/lib/utils'
-import { PHASE_PRODUCTION_BUILD } from '../shared/lib/constants'
+import { PHASE_INFO } from '../shared/lib/constants'
 import { getProjectDir } from '../lib/get-project-dir'
 import { findPagesDir } from '../lib/find-pages-dir'
 import { verifyAndRunTypeScript } from '../lib/verify-typescript-setup'
@@ -30,11 +30,6 @@ export type NextTypegenOptions = {
 const nextTypegen = async (options: NextTypegenOptions, directory?: string) => {
   parseBundlerArgs(options)
 
-  // Signal to config loading that we are running typegen so that
-  // Turbopack-only config checks (e.g. turbopackRustReactCompiler) are
-  // skipped – typegen does not involve a bundler at all.
-  process.env.NEXT_PRIVATE_TYPEGEN = '1'
-
   const baseDir = getProjectDir(directory)
 
   // Check if the provided directory exists
@@ -42,7 +37,10 @@ const nextTypegen = async (options: NextTypegenOptions, directory?: string) => {
     printAndExit(`> No such directory exists as the project root: ${baseDir}`)
   }
 
-  const nextConfig = await loadConfig(PHASE_PRODUCTION_BUILD, baseDir)
+  // Use PHASE_INFO: typegen is a read-only analysis step — no bundler runs,
+  // so bundler-specific config checks (e.g. turbopackRustReactCompiler) must
+  // not fire.  PHASE_INFO is already used by `next info` for the same reason.
+  const nextConfig = await loadConfig(PHASE_INFO, baseDir)
   await installBindings(nextConfig.experimental?.useWasmBinary)
   const distDir = join(baseDir, nextConfig.distDir)
   const { pagesDir, appDir } = findPagesDir(baseDir)

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -515,7 +515,8 @@ function assignDefaultsAndValidate(
 
     if (
       result.experimental.turbopackRustReactCompiler &&
-      !process.env.TURBOPACK
+      !process.env.TURBOPACK &&
+      !process.env.NEXT_PRIVATE_TYPEGEN
     ) {
       throw new Error(
         `\`experimental.turbopackRustReactCompiler\` is only supported with Turbopack. ` +

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -9,6 +9,7 @@ import {
   CONFIG_FILES,
   PHASE_DEVELOPMENT_SERVER,
   PHASE_EXPORT,
+  PHASE_INFO,
   PHASE_PRODUCTION_BUILD,
   PHASE_PRODUCTION_SERVER,
   type PHASE_TYPE,
@@ -487,9 +488,10 @@ function assignDefaultsAndValidate(
 
   // Validate experimental.cssChunking compatibility with the active bundler. Graph mode is
   // Turbopack-only; strict mode and `false` (single-chunk-per-module) are webpack-only.
-  // Only validate during build/dev — `next start` doesn't pick a bundler and would otherwise
-  // see `process.env.TURBOPACK` unset and reject a valid `cssChunking: "graph"` config.
-  if (phase !== PHASE_PRODUCTION_SERVER) {
+  // Only validate during build/dev — `next start` and informational commands (e.g. `next info`,
+  // `next typegen`) don't pick a bundler and would otherwise see `process.env.TURBOPACK`
+  // unset and reject valid bundler-specific config options.
+  if (phase !== PHASE_PRODUCTION_SERVER && phase !== PHASE_INFO) {
     const cssChunkingValue = result.experimental.cssChunking
     const cssChunkingMode = resolveCssChunkingMode(cssChunkingValue)
     if (cssChunkingMode === 'graph' && !process.env.TURBOPACK) {
@@ -515,8 +517,7 @@ function assignDefaultsAndValidate(
 
     if (
       result.experimental.turbopackRustReactCompiler &&
-      !process.env.TURBOPACK &&
-      !process.env.NEXT_PRIVATE_TYPEGEN
+      !process.env.TURBOPACK
     ) {
       throw new Error(
         `\`experimental.turbopackRustReactCompiler\` is only supported with Turbopack. ` +


### PR DESCRIPTION
## What?

Skip the `experimental.turbopackRustReactCompiler` Turbopack-only validation when running `next typegen`.

## Why?

`next typegen` does not involve a bundler at all — it only loads the project config to generate TypeScript route types. However, the check at `packages/next/src/server/config.ts` verifies that the `TURBOPACK` environment variable is set when `experimental.turbopackRustReactCompiler` is enabled, and since `typegen` never sets that variable the command throws:

```
Error: `experimental.turbopackRustReactCompiler` is only supported with Turbopack.
Please remove the option or run Next.js with Turbopack in next.config.ts.
```

## How?

1. At the start of the `nextTypegen` function in `next-typegen.ts`, set `process.env.NEXT_PRIVATE_TYPEGEN = '1'` before `loadConfig` is called.
2. In `config.ts`, add `!process.env.NEXT_PRIVATE_TYPEGEN` to the condition that throws the Turbopack-only error so typegen bypasses it.

The existing workaround of running `TURBOPACK=1 next typegen` continues to work unchanged.

Fixes #94950