### PR TITLE
docs(examples): fix 5 broken external links across 5 README files

### DIFF
--- a/examples/api-routes-apollo-server-and-client-auth/README.md
+++ b/examples/api-routes-apollo-server-and-client-auth/README.md
@@ -1,6 +1,6 @@
 # Apollo Server and Client Auth Example
 
-[Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run. The integration with Next and Apollo Server is implemented using the [apollo-server-integration-next](https://github.com/apollo-server-integrations/apollo-server-integration-next) community package.
+[Apollo Client for React](https://www.apollographql.com/docs/react) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run. The integration with Next and Apollo Server is implemented using the [apollo-server-integration-next](https://github.com/apollo-server-integrations/apollo-server-integration-next) community package.
 
 In this simple example, we integrate Apollo seamlessly with [Next.js data fetching methods](https://nextjs.org/docs/basic-features/data-fetching) to fetch queries in the server and hydrate them in the browser.
 

--- a/examples/api-routes-apollo-server-and-client/README.md
+++ b/examples/api-routes-apollo-server-and-client/README.md
@@ -1,6 +1,6 @@
 # Apollo Server and Client Example
 
-[Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run. The integration with Next and Apollo Server is implemented using the [apollo-server-integration-next](https://github.com/apollo-server-integrations/apollo-server-integration-next) community package.
+[Apollo Client for React](https://www.apollographql.com/docs/react) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run. The integration with Next and Apollo Server is implemented using the [apollo-server-integration-next](https://github.com/apollo-server-integrations/apollo-server-integration-next) community package.
 
 In this simple example, we integrate Apollo seamlessly with [Next.js data fetching methods](https://nextjs.org/docs/basic-features/data-fetching) to fetch queries in the server and hydrate them in the browser.
 

--- a/examples/auth0/README.md
+++ b/examples/auth0/README.md
@@ -10,7 +10,7 @@ This example shows how you can use `@auth0/nextjs-auth` to easily add authentica
 - Loading the user on the client side by accessing API (Serverless function) CSR pages ([`pages/advanced/api-profile.tsx`](pages/advanced/api-profile.tsx))
 - Creates route handlers under the hood that perform different parts of the authentication flow ([`pages/auth/[...auth0].tsx`](pages/auth/[...auth0].tsx))
 
-Read more: [https://auth0.com/blog/ultimate-guide-nextjs-authentication-auth0/](https://auth0.com/blog/ultimate-guide-nextjs-authentication-auth0/)
+Read more: [https://auth0.com/docs/quickstart/webapp/nextjs](https://auth0.com/docs/quickstart/webapp/nextjs) (the Auth0 blog post was retired; the official quickstart is the current canonical guide)
 
 ## How to use
 

--- a/examples/cache-handler-redis/README.md
+++ b/examples/cache-handler-redis/README.md
@@ -44,7 +44,7 @@ For detailed information on configuration and usage, please refer to our compreh
 
 - **Configure Redis Credentials:** Update the `cache-handler-redis*` files with your Redis credentials. Connection details can be found [here](https://redis.io/docs/connect/clients/nodejs/).
 
-- **Building Without Redis:** To build the app without connecting to Redis use conditions inside `onCreation` callback. Check the [documentation](https://caching-tools.github.io/next-shared-cache/configuration/opt-out-cache-on-build) for more details.
+- **Building Without Redis:** To build the app without connecting to Redis use conditions inside `onCreation` callback. Check the [documentation](https://caching-tools.github.io/next-shared-cache) for more details.
 
 ## Development and Production Considerations
 

--- a/examples/with-apollo/README.md
+++ b/examples/with-apollo/README.md
@@ -1,6 +1,6 @@
 # Apollo Example
 
-[Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run.
+[Apollo Client for React](https://www.apollographql.com/docs/react) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run.
 
 ## Deploy your own
 


### PR DESCRIPTION
## Summary
Five broken external links across 5 example READMEs:

**Apollo Client** (3 files, all reference `apollographql.com/client/` → 404):
- `examples/with-apollo/README.md`
- `examples/api-routes-apollo-server-and-client/README.md`
- `examples/api-routes-apollo-server-and-client-auth/README.md`

Replaced `apollographql.com/client/` with `apollographql.com/docs/react` (200) — the canonical home for the React client library after Apollo deprecated the `/client` landing page.

**Auth0 blog** (1 file):
- `examples/auth0/README.md` references `auth0.com/blog/ultimate-guide-nextjs-authentication-auth0/` (404)

Replaced with `auth0.com/docs/quickstart/webapp/nextjs` (200) — the official Auth0 Next.js quickstart in the Auth0 docs is the current canonical guide for the same topic.

**next-shared-cache** (1 file):
- `examples/cache-handler-redis/README.md` references `caching-tools.github.io/next-shared-cache/configuration/opt-out-cache-on-build` (404)

Replaced with `caching-tools.github.io/next-shared-cache` (200) — the opt-out pattern is documented on the root docs page.

## Diff
```
 examples/api-routes-apollo-server-and-client-auth/README.md | 2 +-
 examples/api-routes-apollo-server-and-client/README.md      | 2 +-
 examples/auth0/README.md                                    | 2 +-
 examples/cache-handler-redis/README.md                      | 2 +-
 examples/with-apollo/README.md                              | 2 +-
 5 files changed, 5 insertions(+), 5 deletions(-)
```

## Verification
- `apollographql.com/client/` → 404 (3 occurrences fixed)
- `auth0.com/blog/ultimate-guide-nextjs-authentication-auth0/` → 404
- `caching-tools.github.io/next-shared-cache/configuration/opt-out-cache-on-build` → 404
- All replacement URLs return HTTP 200