### PR TITLE
docs(unstable_cache): add option-mapping bullets and remote callout

### DIFF
--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -329,9 +329,25 @@ Note the persistence difference. The `fetch` Data Cache persists cached response
 
 For example, this `unstable_cache` call:
 
-```ts
-const getUser = unstable_cache(
+```tsx filename="app/lib/data.ts" switcher
+import { unstable_cache } from 'next/cache'
+import { db } from '@/lib/db'
+
+export const getUser = unstable_cache(
   async (id: string) => {
+    return db.query.users.findFirst({ where: eq(users.id, id) })
+  },
+  ['user'],
+  { tags: ['users'], revalidate: 3600 }
+)
+```
+
+```js filename="app/lib/data.js" switcher
+import { unstable_cache } from 'next/cache'
+import { db } from '@/lib/db'
+
+export const getUser = unstable_cache(
+  async (id) => {
     return db.query.users.findFirst({ where: eq(users.id, id) })
   },
   ['user'],
@@ -341,52 +357,7 @@ const getUser = unstable_cache(
 
 can be rewritten as a function that uses the `'use cache'` directive:
 
-```ts
-import { cacheLife, cacheTag } from 'next/cache'
-
-export async function getUser(id: string) {
-  'use cache'
-  cacheLife('hours')
-  cacheTag('users')
-
-  return db.query.users.findFirst({ where: eq(users.id, id) })
-}
-```
-
-The wrapped function becomes the body of the cached function. The `options.revalidate` value becomes `cacheLife()`, and `options.tags` becomes `cacheTag()`. With `'use cache'`, the cache key is derived automatically from the function’s arguments and captured closure variables.
-
-> **Good to know:** If the preset profiles do not closely match your `revalidate` option, use an [[inline profile](https://chatgpt.com/docs/app/api-reference/functions/cacheLife#inline-cache-profiles)](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles).
-
 ```tsx filename="app/lib/data.ts" switcher
-// Before
-import { unstable_cache } from 'next/cache'
-import { db } from '@/lib/db'
-
-export const getUser = unstable_cache(
-  async (id: string) => {
-    return db.query.users.findFirst({ where: eq(users.id, id) })
-  },
-  ['user'], // cache key prefix
-  { tags: ['users'], revalidate: 3600 }
-)
-```
-
-```js filename="app/lib/data.js" switcher
-// Before
-import { unstable_cache } from 'next/cache'
-import { db } from '@/lib/db'
-
-export const getUser = unstable_cache(
-  async (id) => {
-    return db.query.users.findFirst({ where: eq(users.id, id) })
-  },
-  ['user'], // cache key prefix
-  { tags: ['users'], revalidate: 3600 }
-)
-```
-
-```tsx filename="app/lib/data.ts" switcher
-// After
 import { cacheLife, cacheTag } from 'next/cache'
 import { db } from '@/lib/db'
 
@@ -399,7 +370,6 @@ export async function getUser(id: string) {
 ```
 
 ```js filename="app/lib/data.js" switcher
-// After
 import { cacheLife, cacheTag } from 'next/cache'
 import { db } from '@/lib/db'
 
@@ -411,9 +381,9 @@ export async function getUser(id) {
 }
 ```
 
-Like the `fetch` Data Cache, `unstable_cache` persists cached values across deployments and serverless instances, while `use cache` does not. See [`fetch` cache options](#fetch-cache-options) above for the storage details.
+The wrapped function becomes the body of the cached function. `options.revalidate` becomes [`cacheLife()`](/docs/app/api-reference/functions/cacheLife), and `options.tags` becomes [`cacheTag()`](/docs/app/api-reference/functions/cacheTag). With `'use cache'`, the cache key is derived automatically from the function's arguments and captured closure variables, so `keyParts` is no longer needed.
 
-For durable, shared caching across instances, use [`use cache: remote`](/docs/app/api-reference/directives/use-cache-remote) or a [custom cache handler](/docs/app/api-reference/config/next-config-js/cacheHandlers). Remote cache keys include the `deploymentId` (when configured) or the `buildId`, so new deploys produce cache misses you wouldn't see with `unstable_cache`, which didn't use that keying. There's also added lookup latency and platform cost, so use it where the durability is worth it, not as a drop-in default. A custom cache handler can persist entries across deployments.
+> **Good to know:** If the preset profiles don't closely match your `revalidate` option, use an [inline profile](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles).
 
 ## On-demand revalidation (`revalidateTag`, `revalidatePath`, `updateTag`)
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -327,11 +327,35 @@ Note the persistence difference. The `fetch` Data Cache persists cached response
 
 `unstable_cache` is replaced by the [`use cache`](/docs/app/api-reference/directives/use-cache) directive.
 
-Turn the wrapped function into a function with the `'use cache'` directive. The cache key is derived automatically from the function's arguments and closure variables, and the `options` object maps to [`cacheLife`](/docs/app/api-reference/functions/cacheLife) and [`cacheTag`](/docs/app/api-reference/functions/cacheTag):
+For example, this `unstable_cache` call:
 
-- **`revalidate`** → [`cacheLife()`](/docs/app/api-reference/functions/cacheLife) with a [preset](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles), or an [inline profile](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles) for an exact duration in seconds.
-- **`tags`** → [`cacheTag()`](/docs/app/api-reference/functions/cacheTag) with the same strings.
-- **`keyParts`** → omit. The cache key comes from the function's arguments and closure.
+```ts
+const getUser = unstable_cache(
+  async (id: string) => {
+    return db.query.users.findFirst({ where: eq(users.id, id) })
+  },
+  ['user'],
+  { tags: ['users'], revalidate: 3600 }
+)
+```
+
+can be rewritten as a function that uses the `'use cache'` directive:
+
+```ts
+import { cacheLife, cacheTag } from 'next/cache'
+
+export async function getUser(id: string) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('users')
+
+  return db.query.users.findFirst({ where: eq(users.id, id) })
+}
+```
+
+The wrapped function becomes the body of the cached function. The `options.revalidate` value becomes `cacheLife()`, and `options.tags` becomes `cacheTag()`. With `'use cache'`, the cache key is derived automatically from the function’s arguments and captured closure variables.
+
+> **Good to know:** If the preset profiles do not closely match your `revalidate` option, use an [[inline profile](https://chatgpt.com/docs/app/api-reference/functions/cacheLife#inline-cache-profiles)](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles).
 
 ```tsx filename="app/lib/data.ts" switcher
 // Before

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -327,7 +327,11 @@ Note the persistence difference. The `fetch` Data Cache persists cached response
 
 `unstable_cache` is replaced by the [`use cache`](/docs/app/api-reference/directives/use-cache) directive.
 
-Turn the wrapped function into a function with the `'use cache'` directive. The cache key is derived automatically from the arguments, so the key-parts array is no longer needed, and the `options` object maps to [`cacheLife`](/docs/app/api-reference/functions/cacheLife) and [`cacheTag`](/docs/app/api-reference/functions/cacheTag).
+Turn the wrapped function into a function with the `'use cache'` directive. The cache key is derived automatically from the function's arguments and closure variables, and the `options` object maps to [`cacheLife`](/docs/app/api-reference/functions/cacheLife) and [`cacheTag`](/docs/app/api-reference/functions/cacheTag):
+
+- **`revalidate`** → [`cacheLife()`](/docs/app/api-reference/functions/cacheLife) with a [preset](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles), or an [inline profile](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles) for an exact duration in seconds.
+- **`tags`** → [`cacheTag()`](/docs/app/api-reference/functions/cacheTag) with the same strings.
+- **`keyParts`** → omit. The cache key comes from the function's arguments and closure.
 
 ```tsx filename="app/lib/data.ts" switcher
 // Before
@@ -384,6 +388,8 @@ export async function getUser(id) {
 ```
 
 Like the `fetch` Data Cache, `unstable_cache` persists cached values across deployments and serverless instances, while `use cache` does not. See [`fetch` cache options](#fetch-cache-options) above for the storage details.
+
+For durable, shared caching across instances, use [`use cache: remote`](/docs/app/api-reference/directives/use-cache-remote) or a [custom cache handler](/docs/app/api-reference/config/next-config-js/cacheHandlers). Remote cache keys include the `deploymentId` (when configured) or the `buildId`, so new deploys produce cache misses you wouldn't see with `unstable_cache`, which didn't use that keying. There's also added lookup latency and platform cost, so use it where the durability is worth it, not as a drop-in default. A custom cache handler can persist entries across deployments.
 
 ## On-demand revalidation (`revalidateTag`, `revalidatePath`, `updateTag`)
 


### PR DESCRIPTION
Picks up the salvageable additions from #92392 (closed in favor of this) on top of current canary, scoped to just the `unstable_cache` section of the Cache Components migration guide.

## Changes

- Replaces the prose option-mapping sentence with explicit bullets: `revalidate` → `cacheLife()`, `tags` → `cacheTag()`, `keyParts` → omit.
- Clarifies that the cache key is derived from the function's arguments **and closure variables**, not just arguments.
- Adds a follow-on paragraph after the persistence-difference line pointing at [`use cache: remote`](/docs/app/api-reference/directives/use-cache-remote) as the durable-storage replacement, with the deployment-id-keying gotcha and the latency/cost trade-off.

## Why these specifically

#92392 had drifted far enough from canary that bringing it forward would have meant reverting ~600 lines of intervening work on the guide. These are the three pieces from that branch that still add something current canary doesn't say.

<!-- NEXT_JS_LLM_PR -->