### PR TITLE
fix(turbopack): allow #/* subpath imports

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3309,8 +3309,7 @@ async fn resolve_package_internal_with_imports_field(
     let Pattern::Constant(specifier) = pattern else {
         bail!("PackageInternal requests can only be Constant strings");
     };
-    // https://github.com/nodejs/node/blob/1b177932/lib/internal/modules/esm/resolve.js#L615-L619
-    if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with('/') {
+    if specifier == "#" || specifier.ends_with('/') {
         ResolvingIssue {
             severity: resolve_error_severity(resolve_options).await?,
             file_path: file_path.clone(),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/index.js
@@ -1,0 +1,5 @@
+import greeting from '#/greeting.js'
+
+it('should resolve #/* subpath imports', () => {
+  expect(greeting).toBe('hello')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "subpath-imports-slash",
+  "imports": {
+    "#/*": "./src/*"
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/src/greeting.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/subpath-imports-slash/input/src/greeting.js
@@ -1,0 +1,1 @@
+export default 'hello'


### PR DESCRIPTION
Removes the `specifier.starts_with("#/")` check from `resolve_package_internal_with_imports_field` so that subpath imports like `#/greeting.js` are correctly resolved.

According to the Node.js spec, `#/` is a valid prefix for subpath import patterns (e.g. `"#/*": "./src/*"`). The removed check was treating these as invalid.

Closes #94461

<!-- NEXT_JS_LLM_PR -->
