### PR TITLE
fix: ignore stray parent lockfiles in find-root (#94597)

### DIFF
--- a/packages/next/src/lib/find-root.test.ts
+++ b/packages/next/src/lib/find-root.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { findRootDirAndLockFiles } from './find-root'
+
+describe('findRootDirAndLockFiles()', () => {
+  it('ignores stray parent lockfiles without a package manifest', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'nextjs-find-root-'))
+
+    try {
+      const appDir = join(rootDir, 'app')
+      const parentLockfile = join(rootDir, 'package-lock.json')
+      const appLockfile = join(appDir, 'package-lock.json')
+
+      await mkdir(appDir)
+      await writeFile(parentLockfile, '{}')
+      await writeFile(join(appDir, 'package.json'), '{}')
+      await writeFile(appLockfile, '{}')
+
+      const result = findRootDirAndLockFiles(appDir)
+
+      expect(result.rootDir).toBe(appDir)
+      expect(result.lockFiles).toEqual([appLockfile])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores parent package roots that do not declare workspaces', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'nextjs-find-root-'))
+
+    try {
+      const appDir = join(rootDir, 'app')
+      const parentLockfile = join(rootDir, 'bun.lock')
+      const appLockfile = join(appDir, 'bun.lock')
+
+      await mkdir(appDir)
+      await writeFile(join(rootDir, 'package.json'), '{}')
+      await writeFile(parentLockfile, '')
+      await writeFile(join(appDir, 'package.json'), '{}')
+      await writeFile(appLockfile, '')
+
+      const result = findRootDirAndLockFiles(appDir)
+
+      expect(result.rootDir).toBe(appDir)
+      expect(result.lockFiles).toEqual([appLockfile])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps higher package roots when they declare workspaces', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'nextjs-find-root-'))
+
+    try {
+      const appDir = join(rootDir, 'apps', 'docs')
+      const parentLockfile = join(rootDir, 'package-lock.json')
+      const appLockfile = join(appDir, 'package-lock.json')
+
+      await mkdir(appDir, { recursive: true })
+      await writeFile(
+        join(rootDir, 'package.json'),
+        JSON.stringify({ workspaces: ['apps/*'] })
+      )
+      await writeFile(parentLockfile, '{}')
+      await writeFile(join(appDir, 'package.json'), '{}')
+      await writeFile(appLockfile, '{}')
+
+      const result = findRootDirAndLockFiles(appDir)
+
+      expect(result.rootDir).toBe(rootDir)
+      expect(result.lockFiles).toEqual([appLockfile, parentLockfile])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps higher pnpm workspace roots ahead of nested lockfiles', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'nextjs-find-root-'))
+
+    try {
+      const appDir = join(rootDir, 'apps', 'docs')
+      const workspaceFile = join(rootDir, 'pnpm-workspace.yaml')
+
+      await mkdir(appDir, { recursive: true })
+      await writeFile(workspaceFile, 'packages:\n  - apps/*\n')
+      await writeFile(join(appDir, 'package.json'), '{}')
+      await writeFile(join(appDir, 'pnpm-lock.yaml'), '')
+
+      const result = findRootDirAndLockFiles(appDir)
+
+      expect(result.rootDir).toBe(rootDir)
+      expect(result.lockFiles).toEqual([workspaceFile])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -1,34 +1,74 @@
-import { dirname } from 'path'
-import findUp from 'next/dist/compiled/find-up'
+import { existsSync, readFileSync } from 'fs'
+import { dirname, join } from 'path'
 import * as Log from '../build/output/log'
 
-function findWorkRoot(cwd: string) {
-  // Find-up evaluates the list of files at each level.
-  // For pnpm-workspace.yaml we first want to look up before searching for lockfiles as those can be included in the application directory by accident.
-  const pnpmWorkspaceFile = findUp.sync(
-    'pnpm-workspace.yaml',
+const lockFileNames = [
+  'pnpm-lock.yaml',
+  'package-lock.json',
+  'yarn.lock',
+  'bun.lock',
+  'bun.lockb',
+]
 
-    {
-      cwd,
+function findUpFile(
+  fileNames: string[],
+  cwd: string,
+  isCandidate = (_file: string) => true
+) {
+  let currentDir = cwd
+
+  while (true) {
+    for (const fileName of fileNames) {
+      const file = join(currentDir, fileName)
+      if (existsSync(file) && isCandidate(file)) {
+        return file
+      }
     }
-  )
+
+    const parentDir = dirname(currentDir)
+    if (parentDir === currentDir) {
+      return undefined
+    }
+    currentDir = parentDir
+  }
+}
+
+function hasPackageJson(dir: string) {
+  return existsSync(join(dir, 'package.json'))
+}
+
+function hasWorkspacePackageJson(dir: string) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    const workspaces = pkg?.workspaces
+    return Array.isArray(workspaces)
+      ? workspaces.length > 0
+      : Array.isArray(workspaces?.packages) && workspaces.packages.length > 0
+  } catch {
+    return false
+  }
+}
+
+function isLockFile(file: string) {
+  return lockFileNames.some((fileName) => file.endsWith(fileName))
+}
+
+function findWorkRoot(cwd: string, requireWorkspaceRoot = false) {
+  // pnpm-workspace.yaml is an explicit workspace root marker and should win
+  // before nested lockfiles are considered.
+  const pnpmWorkspaceFile = findUpFile(['pnpm-workspace.yaml'], cwd)
 
   if (pnpmWorkspaceFile) {
     return pnpmWorkspaceFile
   }
 
-  return findUp.sync(
-    [
-      'pnpm-lock.yaml',
-      'package-lock.json',
-      'yarn.lock',
-      'bun.lock',
-      'bun.lockb',
-    ],
-    {
-      cwd,
+  return findUpFile(lockFileNames, cwd, (file) => {
+    if (!isLockFile(file) || !hasPackageJson(dirname(file))) {
+      return false
     }
-  )
+
+    return !requireWorkspaceRoot || hasWorkspacePackageJson(dirname(file))
+  })
 }
 
 export function findRootDirAndLockFiles(cwd: string): {
@@ -51,7 +91,7 @@ export function findRootDirAndLockFiles(cwd: string): {
     // dirname('/')==='/' so if we happen to reach the FS root (as might happen in a container we need to quit to avoid looping forever
     if (parentDir === currentDir) break
 
-    const newLockFile = findWorkRoot(parentDir)
+    const newLockFile = findWorkRoot(parentDir, true)
 
     if (!newLockFile) break
 

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -7,8 +7,13 @@ describe('multiple-lockfiles - has-output-file-tracing-root', () => {
       app: new FileRef(join(__dirname, 'app')),
       // This will silence the multiple lockfiles warning.
       'next.config.js': `module.exports = { outputFileTracingRoot: __dirname }`,
-      // Write a package-lock.json file to the parent directory to simulate
-      // multiple lockfiles.
+      // Write workspace metadata and a package-lock.json file to the parent
+      // directory to simulate multiple valid lockfiles.
+      '../package.json': JSON.stringify({
+        name: 'parent-workspace',
+        private: true,
+        workspaces: ['test'],
+      }),
       '../package-lock.json': JSON.stringify({
         name: 'parent-workspace',
         version: '1.0.0',

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -7,8 +7,13 @@ describe('multiple-lockfiles - has-turbo-root', () => {
       app: new FileRef(join(__dirname, 'app')),
       // This will silence the multiple lockfiles warning.
       'next.config.js': `module.exports = { turbopack: { root: __dirname } }`,
-      // Write a package-lock.json file to the parent directory to simulate
-      // multiple lockfiles.
+      // Write workspace metadata and a package-lock.json file to the parent
+      // directory to simulate multiple valid lockfiles.
+      '../package.json': JSON.stringify({
+        name: 'parent-workspace',
+        private: true,
+        workspaces: ['test'],
+      }),
       '../package-lock.json': JSON.stringify({
         name: 'parent-workspace',
         version: '1.0.0',

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -6,8 +6,13 @@ describe('multiple-lockfiles', () => {
   const { next, skipped, isTurbopack } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
-      // Write a package-lock.json file to the parent directory to simulate
-      // multiple lockfiles.
+      // Write workspace metadata and a package-lock.json file to the parent
+      // directory to simulate multiple valid lockfiles.
+      '../package.json': JSON.stringify({
+        name: 'parent-workspace',
+        private: true,
+        workspaces: ['test'],
+      }),
       '../package-lock.json': JSON.stringify({
         name: 'parent-workspace',
         version: '1.0.0',


### PR DESCRIPTION
Refactors `findRootDirAndLockFiles()` to use a custom `findUpFile()` implementation instead of the `find-up` package, so that stray lockfiles in parent directories without a `package.json` (or without `workspaces` declared) are properly ignored.

Previously, any lockfile found walking up the directory tree was treated as a valid workspace root, causing incorrect root inference in monorepo setups where parent directories happened to contain a lockfile (e.g., from a different project or a container image).

Changes:
- Replace `find-up` with a lightweight `findUpFile()` that supports a candidate predicate
- Skip lockfiles in directories without `package.json`
- Skip parent directories that have `package.json` but no `workspaces` field
- Keep `pnpm-workspace.yaml` as an explicit, always-honored root marker
- Move lockfile name list to a module-level constant

Closes #94597

<!-- NEXT_JS_LLM_PR -->
