### PR TITLE
docs(examples/i18n-routing-pages): fix dead i18n-routing-pages docs link

### DIFF
--- a/examples/i18n-routing-pages/README.md
+++ b/examples/i18n-routing-pages/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to create internationalized pages using Next.js and the i18n routing feature. It shows a normal page, a non-dynamic `getStaticProps` page, a dynamic `getStaticProps` page, and a `getServerSideProps` page.
 
-For further documentation on this feature see the [Internationalized Routing docs](https://nextjs.org/docs/advanced-features/i18n-routing-pages).
+For further documentation on this feature see the [Internationalized Routing docs](https://nextjs.org/docs/app/building-your-application/routing/internationalization).
 
 ## Deploy your own
 


### PR DESCRIPTION
Replaces `https://nextjs.org/docs/advanced-features/i18n-routing-pages` (404 — pages-router docs section retired) with the App Router canonical location `https://nextjs.org/docs/app/building-your-application/routing/internationalization` (200).