### PR TITLE
docs(examples/with-xata): fix dead xata.io CLI getting-started link

### DIFF
--- a/examples/with-xata/README.md
+++ b/examples/with-xata/README.md
@@ -36,7 +36,7 @@ pnpm create next-app --example with-xata with-xata-app
 
 ### Link With Your Xata Workspace And Update Types
 
-> 💡 We recommend installing the [Xata CLI](https://xata.io/docs/cli/getting-started) globally, but you can also use `npx @xata.io/cli` instead of `xata` in the commands below.
+> 💡 We recommend installing the [Xata CLI](https://xata.io/docs/cli) globally, but you can also use `npx @xata.io/cli` instead of `xata` in the commands below.
 
 You can link your project with a Xata workspace by running the following command:
 


### PR DESCRIPTION
Replaces `https://xata.io/docs/cli/getting-started` (404 — page removed in xata docs restructure) with `https://xata.io/docs/cli` (200 — CLI docs root).