### PR TITLE
docs(examples/with-chakra-ui): fix dead chakra-ui rtl-support link

### DIFF
--- a/examples/with-chakra-ui/README.md
+++ b/examples/with-chakra-ui/README.md
@@ -32,6 +32,6 @@ Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&ut
 
 ## Notes
 
-Chakra has supported Gradients and RTL in `v1.1`. To utilize RTL, [add RTL direction and swap](https://chakra-ui.com/docs/features/rtl-support).
+Chakra has supported Gradients and RTL in `v1.1`. To utilize RTL, [add RTL direction and swap](https://chakra-ui.com/docs/get-started/frameworks/next-app).
 
 If you don't have multi-direction app, you should make `<Html lang="ar" dir="rtl">` inside `_document.ts`.


### PR DESCRIPTION
Replaces `https://chakra-ui.com/docs/features/rtl-support` (404 — `/docs/features/*` section removed in docs restructure) with the canonical Next.js framework setup guide `https://chakra-ui.com/docs/get-started/frameworks/next-app` (200).