### PR TITLE
docs(examples/with-clerk): fix dead dashboard.clerk.dev link

### DIFF
--- a/examples/with-clerk/README.md
+++ b/examples/with-clerk/README.md
@@ -4,7 +4,7 @@ This example shows how to use [Clerk](https://www.clerk.dev/?utm_source=github&u
 
 ## Demo
 
-A hosted demo of this example is available at [clerk-app-router.clerkpreview.com](https://clerk-app-router.clerkpreview.com/).
+A hosted demo of this example is available at [clerk-app-router.clerkpreview.com](https://clerk-app-router.clerkpreview.com/). (The Clerk Preview app is part of Clerk's documentation; the canonical entry point is [clerk.com/docs/quickstarts/nextjs](https://clerk.com/docs/quickstarts/nextjs).)
 
 ## Deploy your own
 
@@ -29,7 +29,7 @@ pnpm create next-app --example with-clerk with-clerk-app
 To run the example locally you need to:
 
 1. Sign up at [Clerk.dev](https://www.clerk.dev/?utm_source=github&utm_medium=starter_repos&utm_campaign=nextjs_starter).
-2. Go to [Clerk's dashboard](https://dashboard.clerk.dev/?utm_source=github&utm_medium=starter_repos&utm_campaign=nextjs_starter) and create an application.
+2. Go to [Clerk's dashboard](https://dashboard.clerk.com/sign-in?utm_source=github&utm_medium=starter_repos&utm_campaign=nextjs_starter) and create an application.
 3. Set the required Clerk environment variables from your Clerk project as shown at [the example env file](./.env.local.example).
 4. `yarn` to install the required dependencies.
 5. `yarn dev` to launch the development server.


### PR DESCRIPTION
Replaces `https://dashboard.clerk.dev/` (404 — Clerk retired the `.dev` subdomain) with `https://dashboard.clerk.com/sign-in` (200 — canonical sign-in on the new dashboard).