### PR TITLE
docs(examples/with-formspree): fix dead formspree nextjs guide link

### DIFF
--- a/examples/with-formspree/README.md
+++ b/examples/with-formspree/README.md
@@ -1,6 +1,6 @@
 # Formspree & Next.js example
 
-**An example of using [Formspree](https://formspree.io) with [Next.js](https://nextjs.org). For more information on how to use Formspree check out [our official integration guide](https://formspree.io/guides/nextjs/).**
+**An example of using [Formspree](https://formspree.io) with [Next.js](https://nextjs.org). For more information on how to use Formspree check out [our official integration guide](https://formspree.io/forms/integration/nextjs/).**
 
 ## Get the code
 


### PR DESCRIPTION
Replaces `https://formspree.io/guides/nextjs/` (404 — `/guides/` section retired) with `https://formspree.io/forms/integration/nextjs/` (200 — Next.js integration page).