### PR TITLE
docs(examples/with-magic): fix dead hapi.dev/family/iron link

### DIFF
--- a/examples/with-magic/README.md
+++ b/examples/with-magic/README.md
@@ -6,7 +6,7 @@ The example shows how to do a login and logout; and to get the user info using a
 
 A DB is not included. But you can add any DB you like!.
 
-The login cookie is `httpOnly`, meaning it can only be accessed by the API, and it's encrypted using [@hapi/iron](https://hapi.dev/family/iron) for more security.
+The login cookie is `httpOnly`, meaning it can only be accessed by the API, and it's encrypted using [@hapi/iron](https://github.com/hapijs/iron) for more security.
 
 ## Deploy your own
 


### PR DESCRIPTION
Replaces `https://hapi.dev/family/iron` (404 — `hapi.dev/family/*` retired) with `https://github.com/hapijs/iron` (200 — canonical iron repo).