### PR TITLE
docs(examples/with-passport): fix dead hapi.dev/family/iron link

### DIFF
--- a/examples/with-passport/README.md
+++ b/examples/with-passport/README.md
@@ -6,7 +6,7 @@ The example shows how to do a login, signup and logout; and to get the user info
 
 A database is not included. You can use any database you want and add it [in this file](lib/user.js).
 
-The login cookie is httpOnly, meaning it can only be accessed by the API, and it's encrypted using [@hapi/iron](https://hapi.dev/family/iron) for more security.
+The login cookie is httpOnly, meaning it can only be accessed by the API, and it's encrypted using [@hapi/iron](https://github.com/hapijs/iron) for more security.
 
 ## Deploy your own
 


### PR DESCRIPTION
Replaces `https://hapi.dev/family/iron` (404 — `hapi.dev/family/*` retired) with `https://github.com/hapijs/iron` (200 — canonical iron repo).