### PR TITLE
docs(examples/with-nhost-auth-realtime-graphql): fix dead nhost console link

### DIFF
--- a/examples/with-nhost-auth-realtime-graphql/README.md
+++ b/examples/with-nhost-auth-realtime-graphql/README.md
@@ -30,7 +30,7 @@ pnpm create next-app --example with-nhost-auth-realtime-graphql nhost-app
 
 ### Step 1. Create an account and a project on Nhost
 
-[Create an account and project on Nhost](https://console.nhost.io).
+[Create an account and project on Nhost](https://app.nhost.io).
 
 ### Step 2. Create `items` database
 


### PR DESCRIPTION
Replaces `https://console.nhost.io` (404 — Nhost dashboard migrated) with `https://app.nhost.io` (200 — new Nhost dashboard).