### PR TITLE
docs(examples/with-rbx-bulma-pro): fix dead bulma-pro homepage link

### DIFF
--- a/examples/with-rbx-bulma-pro/README.md
+++ b/examples/with-rbx-bulma-pro/README.md
@@ -1,6 +1,6 @@
 # rbx & bulma-pro example
 
-This example shows how to use Next.js along with [rbx](https://github.com/dfee/rbx)(Bulma UI Framework for react) and [Bulma Pro](https://mubaidr.js.org/bulma-pro/).
+This example shows how to use Next.js along with [rbx](https://github.com/dfee/rbx)(Bulma UI Framework for react) and [Bulma Pro](https://github.com/mubaidr/bulma-pro).
 
 ## Deploy your own
 


### PR DESCRIPTION
Replaces `https://mubaidr.js.org/bulma-pro/` (404 — mubaidr.js.org site retired) with `https://github.com/mubaidr/bulma-pro` (200 — canonical GitHub repo).