### PR TITLE
docs(examples/with-firebase-hosting): fix dead nextjs.org learn typescript link

### DIFF
--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -49,7 +49,7 @@ yarn deploy
 
 ## TypeScript
 
-To use TypeScript, simply follow [TypeScript setup](https://nextjs.org/learn/excel/typescript/setup) as normal (package.json scripts are already set).
+To use TypeScript, simply follow [TypeScript setup](https://nextjs.org/learn) as normal (package.json scripts are already set).
 
 i.e: `npm install --save-dev typescript @types/react @types/node`
 


### PR DESCRIPTION
Replaces `https://nextjs.org/learn/excel/typescript/setup` (404 — `/learn/excel/*` walkthrough removed) with `https://nextjs.org/learn` (200 — canonical learn landing).