### PR TITLE
docs(guides/authentication): fix dead stack-auth setup link

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1677,7 +1677,7 @@ Now that you've learned about authentication in Next.js, here are Next.js-compat
 - [Logto](https://docs.logto.io/quick-starts/next-app-router)
 - [NextAuth.js](https://authjs.dev/getting-started/installation?framework=next.js)
 - [Ory](https://www.ory.sh/docs/getting-started/integrate-auth/nextjs)
-- [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
+- [Stack Auth](https://docs.stack-auth.com/docs/getting-started/setup)
 - [Supabase](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs)
 - [Stytch](https://stytch.com/docs/guides/quickstarts/nextjs)
 - [WorkOS](https://workos.com/docs/user-management/nextjs)


### PR DESCRIPTION
Replaces `https://docs.stack-auth.com/getting-started/setup` (404 — unprefixed path retired) with `https://docs.stack-auth.com/docs/getting-started/setup` (200 — prefixed under /docs/).