### PR TITLE
docs(guides/ci-build-caching): fix dead circleci docs/2.0 caching link

### DIFF
--- a/docs/01-app/02-guides/ci-build-caching.mdx
+++ b/docs/01-app/02-guides/ci-build-caching.mdx
@@ -29,7 +29,7 @@ steps:
         - ./.next/cache
 ```
 
-If you do not have a `save_cache` key, please follow CircleCI's [documentation on setting up build caching](https://circleci.com/docs/2.0/caching/).
+If you do not have a `save_cache` key, please follow CircleCI's [documentation on setting up build caching](https://circleci.com/docs/caching/).
 
 ## Travis CI
 


### PR DESCRIPTION
Replaces `https://circleci.com/docs/2.0/caching/` (404 — version-prefixed URL pattern retired) with `https://circleci.com/docs/caching/` (200 — canonical unversioned URL).