### PR TITLE
docs(guides/css-in-js): fix dead chakra-ui nextjs-app-guide link

### DIFF
--- a/docs/01-app/02-guides/css-in-js.mdx
+++ b/docs/01-app/02-guides/css-in-js.mdx
@@ -13,7 +13,7 @@ description: Use CSS-in-JS libraries with Next.js
 The following libraries are supported in Client Components in the `app` directory (alphabetical):
 
 - [`ant-design`](https://ant.design/docs/react/use-with-next#using-app-router)
-- [`chakra-ui`](https://chakra-ui.com/getting-started/nextjs-app-guide)
+- [`chakra-ui`](https://chakra-ui.com/docs/get-started/frameworks/next-app)
 - [`@fluentui/react-components`](https://react.fluentui.dev/?path=/docs/concepts-developer-server-side-rendering-next-js-appdir-setup--page)
 - [`kuma-ui`](https://kuma-ui.com)
 - [`@mui/material`](https://mui.com/material-ui/guides/next-js-app-router/)


### PR DESCRIPTION
Replaces `https://chakra-ui.com/getting-started/nextjs-app-guide` (404 — chakra-ui docs restructured to `/docs/get-started/*`) with `https://chakra-ui.com/docs/get-started/frameworks/next-app` (200 — canonical Next.js App framework guide).