### PR TITLE
docs(create-next-app/templates): fix dead learn-pages-router link

### DIFF
--- a/packages/create-next-app/templates/default-tw-empty/js/README-template.md
+++ b/packages/create-next-app/templates/default-tw-empty/js/README-template.md
@@ -23,7 +23,7 @@ You can start editing the page by modifying `pages/index.js`. The page auto-upda
 To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn-pages-router) - an interactive Next.js tutorial.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 

--- a/packages/create-next-app/templates/default-tw-empty/ts/README-template.md
+++ b/packages/create-next-app/templates/default-tw-empty/ts/README-template.md
@@ -23,7 +23,7 @@ You can start editing the page by modifying `pages/index.tsx`. The page auto-upd
 To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn-pages-router) - an interactive Next.js tutorial.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 

--- a/packages/create-next-app/templates/default/js/README-template.md
+++ b/packages/create-next-app/templates/default/js/README-template.md
@@ -29,7 +29,7 @@ This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-appl
 To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn-pages-router) - an interactive Next.js tutorial.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 


### PR DESCRIPTION
Replaces `https://nextjs.org/learn-pages-router` (404 — renamed in learn hub restructure) with `https://nextjs.org/learn` (200 — canonical learn landing). Affects 3 templates: default-tw-empty/js, default-tw-empty/ts, default/js.