### PR TITLE
docs(guides/testing/playwright): fix dead test-webserver trailing-slash link

### DIFF
--- a/docs/01-app/02-guides/testing/playwright.mdx
+++ b/docs/01-app/02-guides/testing/playwright.mdx
@@ -137,7 +137,7 @@ Playwright will simulate a user navigating your application using three browsers
 
 Run `npm run build` and `npm run start`, then run `npx playwright test` in another terminal window to run the Playwright tests.
 
-> **Good to know**: Alternatively, you can use the [`webServer`](https://playwright.dev/docs/test-webserver/) feature to let Playwright start the development server and wait until it's fully available.
+> **Good to know**: Alternatively, you can use the [`webServer`](https://playwright.dev/docs/test-webserver) feature to let Playwright start the development server and wait until it's fully available.
 
 ### Running Playwright on Continuous Integration (CI)
 


### PR DESCRIPTION
Replaces `https://playwright.dev/docs/test-webserver/` (404 — trailing slash 404s) with `https://playwright.dev/docs/test-webserver` (200 — canonical URL without trailing slash).