### PR TITLE
docs: fix preview message typo

### DIFF
--- a/examples/cms-builder-io/components/alert.js
+++ b/examples/cms-builder-io/components/alert.js
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"


### PR DESCRIPTION
## What?

Fixes a typo in the preview message.

- This is page is a preview.
+ This page is a preview.

## Why?

The current text contains a grammatical error that is shown when preview mode is enabled.

## Testing

* Verified the updated text renders correctly.
* No functional changes.
