### PR TITLE
fix: add title attribute to RSS feed link for better accessibility

### DIFF
--- a/examples/cms-builder-io/components/meta.js
+++ b/examples/cms-builder-io/components/meta.js
@@ -31,7 +31,12 @@ export default function Meta() {
       <meta name="msapplication-TileColor" content="#000000" />
       <meta name="msapplication-config" content="/favicon/browserconfig.xml" />
       <meta name="theme-color" content="#000" />
-      <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        href="/feed.xml"
+        title="RSS Feed"
+      />
       <meta
         name="description"
         content={`A statically generated blog example using Next.js and ${CMS_NAME}.`}


### PR DESCRIPTION
## What?

Adds a `title` attribute to the RSS feed link in the `Meta` component.

```
- <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+ <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="RSS Feed"  />
```

## Why?

The `title` attribute helps improve accessibility and provides better context for feed readers and browser tools that display RSS metadata.

## Impact

* No functional changes
* Improves semantic metadata for RSS discovery
* Safe, non-breaking enhancement