### PR TITLE
fix(next-mdx): pin .mdx server pages to the rsc bundleLayer - metadata exports build under webpack

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -35,9 +35,23 @@ module.exports =
           '@mdx-js/react',
           require.resolve('./mdx-components.js'),
         ]
+        // App Router `.mdx` pages are Server Components, so pin the SWC pass to
+        // the 'rsc' bundle layer. `defaultLoaders.babel` is layer-agnostic, which
+        // leaves SWC's `isReactServerLayer` false and trips the RSC metadata guard.
+        const babelLoader =
+          options.isServer && options.defaultLoaders.babel
+            ? {
+                ...options.defaultLoaders.babel,
+                options: {
+                  ...options.defaultLoaders.babel.options,
+                  // WEBPACK_LAYERS.reactServerComponents
+                  bundleLayer: 'rsc',
+                },
+              }
+            : options.defaultLoaders.babel
         config.module.rules.push({
           test: extension,
-          use: [options.defaultLoaders.babel, loader],
+          use: [babelLoader, loader],
         })
 
         if (typeof inputConfig.webpack === 'function') {

--- a/test/e2e/app-dir/mdx/app/metadata/page.mdx
+++ b/test/e2e/app-dir/mdx/app/metadata/page.mdx
@@ -1,0 +1,8 @@
+export const metadata = {
+  title: 'MDX Metadata Title',
+  description: 'MDX metadata description',
+}
+
+# Metadata Page
+
+This page exports metadata.

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -65,6 +65,14 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
         )
       })
 
+      it('should support exporting metadata from an mdx page', async () => {
+        const $ = await next.render$('/metadata')
+        expect($('title').text()).toBe('MDX Metadata Title')
+        expect($('meta[name="description"]').attr('content')).toBe(
+          'MDX metadata description'
+        )
+      })
+
       if (type === 'without-mdx-rs') {
         it('should run recma plugins', async () => {
           const $ = await next.render$('/recma-plugin')


### PR DESCRIPTION
An App Router `.mdx` page that does `export const metadata = {…}` fails to build with **webpack**:

```console
You are attempting to export "metadata" from a component marked with "use client"
```

`@next/mdx` registers its `.mdx` rule with the layer-agnostic `options.defaultLoaders.babel`, so the SWC pass runs with `bundleLayer: undefined`. That makes `isReactServerLayer` false, and as of 16.2 the RSC metadata guard rejects any non-react-server module that exports `metadata`, even without an actual `"use client"` directive. A `.tsx` page in the same dir is unaffected because Next's core layered rules only match `/\.(tsx|ts|js|cjs|mjs|jsx)$/`, so `.mdx` never gets the `rsc` loader and falls through to the layer-less one. 

One possible fix is to pin the MDX SWC pass to the `rsc` bundle layer (App Router `.mdx` pages are Server Components), during the server compile step.

Also added `app/metadata/page.mdx` + an assertion in `test/e2e/app-dir/mdx/mdx.test.ts` (runs for both mdx-rs and non-rs) verifying the exported `metadata` renders.

Fixes https://github.com/vercel/next.js/issues/91735
