### PR TITLE
Replicate production prefetch shells for instant navigations in dev

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -797,8 +797,10 @@ export async function handler(
       postponed,
       fallbackRouteParams,
       forceStaticRender,
+      allowEmptyStaticShell,
     }: {
       span?: Span
+      allowEmptyStaticShell?: boolean
 
       /**
        * The postponed data for this render. This is only provided when resuming
@@ -845,6 +847,7 @@ export async function handler(
           routeModule,
           page: srcPage,
           postponed,
+          allowEmptyStaticShell,
           shouldWaitOnAllReady,
           serveStreamingMetadata,
           supportsDynamicResponse:
@@ -1171,22 +1174,33 @@ export async function handler(
                 fallbackRouteParams = null
               }
             } else {
-              // In dev, the prerender manifest isn't populated for ad-hoc
-              // prefetches. The outer `!isPrerendered` guard means every URL
-              // reaching this block has params not covered by
-              // `generateStaticParams`, so the worst-case fallback set —
-              // every dynamic segment from the loader tree — matches what a
-              // static prerender would use. This keeps the prefetch response
-              // from baking resolved param values into the shell.
-              //
-              // `isDebugStaticShell` covers the `?__nextppronly=1` query and
-              // the Instant Navigation testing cookie; `isDebugFallbackShell`
-              // is the explicit fallback-shell debug flow.
-              if (isDebugStaticShell || isDebugFallbackShell) {
+              // In dev the prerender manifest isn't populated for ad-hoc
+              // prefetches (`fallbackMode` is undefined for not-fully-generated
+              // routes, so the on-demand manifest write is skipped, and
+              // `getPrerenderManifest` is cached regardless). So
+              // `prerenderInfo` is unavailable here. Instead base-server
+              // derives the per-URL fallback set from the dev `getStaticPaths`
+              // result and threads it via the `fallbackParams` request meta —
+              // the most-specific prerendered route matching this URL, so
+              // `generateStaticParams`-covered params resolve in the shell and
+              // only the uncovered ones are deferred, matching what a
+              // production build serves. `isDebugFallbackShell` (the explicit
+              // fallback-shell debug flow) still forces the worst case.
+              if (isDebugFallbackShell) {
                 fallbackRouteParams = getFallbackRouteParams(
                   normalizedSrcPage,
                   routeModule
                 )
+              } else if (isDebugStaticShell) {
+                // base-server threads the per-URL fallback set via the
+                // `fallbackParams` meta for every dev Cache Components dynamic
+                // request, so reuse it as the fallback route params for this
+                // shell render. It only sets the meta for routes that still
+                // have uncovered params, so an absent meta means this URL is
+                // fully covered by `generateStaticParams` and there is nothing
+                // to defer (`null`).
+                fallbackRouteParams =
+                  getRequestMeta(req, 'fallbackParams') ?? null
               } else {
                 fallbackRouteParams = null
               }
@@ -1221,6 +1235,7 @@ export async function handler(
                   // more specific cache entry for later requests.
                   fallbackRouteParams,
                   forceStaticRender: true,
+                  allowEmptyStaticShell: isInstantNavigationTest || undefined,
                 }),
               waitUntil: ctx.waitUntil,
               isMinimalMode,
@@ -1499,6 +1514,7 @@ export async function handler(
           postponed,
           fallbackRouteParams,
           forceStaticRender,
+          allowEmptyStaticShell: isInstantNavigationTest || undefined,
         })
       } catch (err) {
         // if this is a background revalidate we need to report

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/app/blocking-cookies/[id]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/app/blocking-cookies/[id]/page.tsx
@@ -1,0 +1,35 @@
+import { cookies } from 'next/headers'
+
+// A blocking route with a `generateStaticParams`-covered param. The page awaits
+// `params` BEFORE reading `cookies()`. In the app-shell prefetch ('3') all
+// params are withheld (app shells carry session data like cookies, but no
+// params — not even static ones), so `await params` suspends here and the
+// `cookies()` read is never reached — keeping the cookie value OUT of the app
+// shell. (A cookie-only route with no preceding param access would instead
+// include the cookie in the app shell, since cookies are allowed there — that
+// would not be the blocking behavior we want to assert.)
+//
+// `cookies()` is still read outside any <Suspense>, so the route has no static
+// shell and remains request-time blocking. It fails `next build`'s static-shell
+// validation, which is why it lives in this dev-only fixture. Under instant()
+// the cookie value must NOT commit while the lock is held; it only streams in
+// after the lock releases.
+export function generateStaticParams() {
+  return [{ id: 'x' }]
+}
+
+export default async function BlockingCookiesPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  await params
+  const cookieStore = await cookies()
+  const testCookie = cookieStore.get('testCookie')
+
+  return (
+    <div data-testid="blocking-cookie-value">
+      testCookie: {testCookie?.value ?? 'not set'}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/app/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/app/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1 data-testid="home-title">Instant Navigation API Test (blocking)</h1>
+      <ul>
+        <li>
+          <Link href="/blocking-cookies/x" id="link-to-blocking-cookies">
+            Go to blocking cookies page
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/blocking/next.config.js
@@ -1,0 +1,17 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    // Matches the `default` fixture: App Shells is implicit via
+    // `cacheComponents`, `prefetchInlining` stays `false`. This fixture holds
+    // routes with no static shell (a dynamic read outside any `<Suspense>`),
+    // which fail `next build`'s static-shell validation, so its suite runs in
+    // dev only and is never production-built.
+    exposeTestingApiInProductionBuild: true,
+    prefetchInlining: false,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/[scope]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/[scope]/page.tsx
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers'
+
+// The deeper, blocking segment of the fallback route: reads request-time
+// `cookies()` and has no <Suspense> of its own, so it has no static shell.
+// Under instant() the navigation here must stay parked on the committed parent;
+// the cookie value must not commit while the lock is held.
+export default function ScopePage() {
+  return (
+    <div>
+      <h1 data-testid="blocking-scope-title">Scope</h1>
+      <Secret />
+    </div>
+  )
+}
+
+async function Secret() {
+  const cookieStore = await cookies()
+  return (
+    <div data-testid="blocking-secret">
+      testCookie: {cookieStore.get('testCookie')?.value ?? 'not set'}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/layout.tsx
@@ -1,0 +1,21 @@
+import { ReactNode, Suspense } from 'react'
+
+// `[lang]` is covered by generateStaticParams, so `/blocking-fallback/en` is a
+// committed landing route. `[scope]` is not covered, so
+// `/blocking-fallback/en/s1` is an on-demand fallback route. This layout owns
+// the only <Suspense> boundary above that deeper segment, so its request-time
+// work is held here rather than bailing the whole route.
+export function generateStaticParams() {
+  return [{ lang: 'en' }]
+}
+
+export default function LangLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <p data-testid="blocking-parent">parent</p>
+      <Suspense fallback={<p data-testid="blocking-shell">shell</p>}>
+        {children}
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function LangHome() {
+  return (
+    <div>
+      <h1 data-testid="blocking-landing">Landing</h1>
+      <Link href="/blocking-fallback/en/s1" id="to-blocking-scope">
+        Go deeper
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/cookies-with-param/[id]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/cookies-with-param/[id]/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// Same shape as `cookies-page` (cookies read inside a <Suspense>), but the
+// component awaits a `generateStaticParams`-covered `params` BEFORE reading
+// `cookies()`. The app-shell prefetch withholds all params, so it suspends at
+// `await params` and never reaches the cookie read — keeping the cookie value
+// OUT of the instant shell. Contrast with `cookies-page`, where the cookie (a
+// session value carried by the app shell) appears in the instant shell because
+// nothing gates it.
+export function generateStaticParams() {
+  return [{ id: 'x' }]
+}
+
+export default function CookiesWithParamPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  return (
+    <div>
+      <h1 data-testid="cookies-param-title">Cookies With Param Page</h1>
+      <Suspense
+        fallback={
+          <div data-testid="cookies-param-fallback">Loading cookies...</div>
+        }
+      >
+        <CookieContent params={params} />
+      </Suspense>
+    </div>
+  )
+}
+
+async function CookieContent({ params }: { params: Promise<{ id: string }> }) {
+  await params
+  const cookieStore = await cookies()
+  const testCookie = cookieStore.get('testCookie')
+
+  return (
+    <div data-testid="cookies-param-value">
+      testCookie: {testCookie?.value ?? 'not set'}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params-runtime/[lang]/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params-runtime/[lang]/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// A route that mixes a `generateStaticParams`-covered param (`lang`, resolved
+// in the static shell by the parent layout) with an uncovered one (`slug`).
+// The route opts into runtime prefetching, so `slug` is resolved by the runtime
+// prefetch rather than the static shell. Under instant() we expect both to
+// surface — `lang` from the static shell, `slug` from the runtime prefetch —
+// while the genuinely request-time `connection()` sibling stays deferred until
+// the lock releases.
+export const instant: {
+  unstable_samples: Array<{ params: { lang: string; slug: string } }>
+} = {
+  unstable_samples: [{ params: { lang: 'en', slug: 'anything' } }],
+}
+export const prefetch = 'allow-runtime'
+
+export default function MixedParamsRuntimePage({
+  params,
+}: {
+  params: Promise<{ lang: string; slug: string }>
+}) {
+  return (
+    <div>
+      <h1 data-testid="mixed-params-runtime-title">
+        Mixed Params Runtime Page
+      </h1>
+      <Suspense
+        fallback={<div data-testid="mixed-slug-fallback">Loading slug...</div>}
+      >
+        <SlugContent params={params} />
+      </Suspense>
+      <Suspense
+        fallback={
+          <div data-testid="mixed-dynamic-fallback">Loading dynamic...</div>
+        }
+      >
+        <DynamicContent />
+      </Suspense>
+    </div>
+  )
+}
+
+async function SlugContent({
+  params,
+}: {
+  params: Promise<{ lang: string; slug: string }>
+}) {
+  const { slug } = await params
+
+  return <div data-testid="mixed-slug-value">slug: {slug}</div>
+}
+
+async function DynamicContent() {
+  await connection()
+
+  return <div data-testid="mixed-dynamic-value">dynamic content</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params-runtime/[lang]/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params-runtime/[lang]/layout.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react'
+
+// `lang` IS covered by `generateStaticParams`, so it is part of the static
+// shell. The layout awaits it OUTSIDE <Suspense>; under instant() the per-URL
+// shell must resolve the covered `lang` here (not defer it), exactly like the
+// build's prebuilt `en/[slug]` shell.
+export function generateStaticParams() {
+  return [{ lang: 'en' }]
+}
+
+export default async function MixedLangLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ lang: string }>
+}) {
+  const { lang } = await params
+  return (
+    <>
+      <p data-testid="mixed-lang">lang: {lang}</p>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params/[lang]/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params/[lang]/[slug]/page.tsx
@@ -1,0 +1,48 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// A route mixing a `generateStaticParams`-covered param (`lang`, resolved in
+// the static shell by the parent layout) with an uncovered one (`slug`). Unlike
+// `mixed-params-runtime`, this route does NOT opt into runtime prefetching, so
+// a normal (no `prefetch` prop) navigation carries only the covered `lang` in
+// the shell; the uncovered `slug` and the request-time `connection()` sibling
+// stay deferred behind their Suspense fallbacks until the navigation completes.
+export default function MixedParamsPage({
+  params,
+}: {
+  params: Promise<{ lang: string; slug: string }>
+}) {
+  return (
+    <div>
+      <h1 data-testid="mixed-params-title">Mixed Params Page</h1>
+      <Suspense
+        fallback={<div data-testid="mixed-slug-fallback">Loading slug...</div>}
+      >
+        <SlugContent params={params} />
+      </Suspense>
+      <Suspense
+        fallback={
+          <div data-testid="mixed-dynamic-fallback">Loading dynamic...</div>
+        }
+      >
+        <DynamicContent />
+      </Suspense>
+    </div>
+  )
+}
+
+async function SlugContent({
+  params,
+}: {
+  params: Promise<{ lang: string; slug: string }>
+}) {
+  const { slug } = await params
+
+  return <div data-testid="mixed-slug-value">slug: {slug}</div>
+}
+
+async function DynamicContent() {
+  await connection()
+
+  return <div data-testid="mixed-dynamic-value">dynamic content</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params/[lang]/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/mixed-params/[lang]/layout.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react'
+
+// `lang` IS covered by `generateStaticParams`, so it is part of the static
+// shell. The layout awaits it OUTSIDE <Suspense>; under instant() the per-URL
+// shell resolves the covered `lang` here (not deferred), exactly like the
+// build's prebuilt `en/[slug]` shell.
+export function generateStaticParams() {
+  return [{ lang: 'en' }]
+}
+
+export default async function MixedLangLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ lang: string }>
+}) {
+  const { lang } = await params
+  return (
+    <>
+      <p data-testid="mixed-lang">lang: {lang}</p>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
@@ -75,11 +75,8 @@ export default function HomePage() {
           </Link>
         </li>
         <li>
-          <Link
-            href="/mixed-params-runtime/en/anything"
-            id="link-to-mixed-params-runtime-no-prefetch"
-          >
-            Go to mixed params runtime page (no prefetch)
+          <Link href="/mixed-params/en/anything" id="link-to-mixed-params">
+            Go to mixed params page (no runtime)
           </Link>
         </li>
         <li>

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
@@ -4,71 +4,142 @@ export default function HomePage() {
   return (
     <div>
       <h1 data-testid="home-title">Instant Navigation API Test</h1>
-      <Link href="/target-page" id="link-to-target">
-        Go to target page
-      </Link>
-      <Link
-        href="/runtime-prefetch-target?myParam=testValue"
-        id="link-to-runtime-prefetch"
-      >
-        Go to runtime prefetch target
-      </Link>
-      <Link
-        href="/full-prefetch-target"
-        prefetch={true}
-        id="link-to-full-prefetch"
-      >
-        Go to full prefetch target
-      </Link>
-      <Link href="/cookies-page" id="link-to-cookies-page">
-        Go to cookies page
-      </Link>
-      <Link href="/dynamic-params/unknown" id="link-to-dynamic-params">
-        Go to dynamic params page
-      </Link>
-      <Link href="/dynamic-params/hello" id="link-to-static-dynamic-params">
-        Go to static dynamic params page
-      </Link>
-      <Link href="/ungenerated-params/anything" id="link-to-ungenerated-params">
-        Go to ungenerated params page
-      </Link>
-      <Link
-        href="/ungenerated-params-runtime/anything"
-        id="link-to-ungenerated-params-runtime"
-      >
-        Go to ungenerated params runtime page
-      </Link>
-      <Link href="/search-params-page?foo=bar" id="link-to-search-params">
-        Go to search params page
-      </Link>
-      {/* Plain anchor for MPA navigation testing (bypasses client-side routing) */}
-      <a href="/target-page" id="plain-link-to-target">
-        Go to target page (MPA)
-      </a>
-      <a href="/cookies-page" id="plain-link-to-cookies-page">
-        Go to cookies page (MPA)
-      </a>
-      <a href="/dynamic-params/unknown" id="plain-link-to-dynamic-params">
-        Go to dynamic params page (MPA)
-      </a>
-      <a href="/dynamic-params/hello" id="plain-link-to-static-dynamic-params">
-        Go to static dynamic params page (MPA)
-      </a>
-      <a href="/search-params-page?foo=bar" id="plain-link-to-search-params">
-        Go to search params page (MPA)
-      </a>
-      <Link href="/client-fetch-page" id="link-to-client-fetch">
-        Go to client fetch page
-      </Link>
-      <a href="/client-fetch-page" id="plain-link-to-client-fetch">
-        Go to client fetch page (MPA)
-      </a>
-      <Link href="/root-blocking-page" id="link-to-root-blocking">
-        Go to blocking route (no static shell)
-      </Link>
-      <a href="/root-blocking-page" id="plain-link-to-root-blocking">
-        Go to blocking route (no static shell) (MPA)
-      </a>
+      <ul>
+        <li>
+          <Link href="/target-page" id="link-to-target">
+            Go to target page
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/runtime-prefetch-target?myParam=testValue"
+            id="link-to-runtime-prefetch"
+            prefetch
+          >
+            Go to runtime prefetch target
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/full-prefetch-target"
+            prefetch={true}
+            id="link-to-full-prefetch"
+          >
+            Go to full prefetch target
+          </Link>
+        </li>
+        <li>
+          <Link href="/cookies-page" id="link-to-cookies-page">
+            Go to cookies page
+          </Link>
+        </li>
+        <li>
+          <Link href="/cookies-with-param/x" id="link-to-cookies-with-param">
+            Go to cookies-with-param page
+          </Link>
+        </li>
+        <li>
+          <Link href="/dynamic-params/unknown" id="link-to-dynamic-params">
+            Go to dynamic params page
+          </Link>
+        </li>
+        <li>
+          <Link href="/dynamic-params/hello" id="link-to-static-dynamic-params">
+            Go to static dynamic params page
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/ungenerated-params/anything"
+            id="link-to-ungenerated-params"
+          >
+            Go to ungenerated params page
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/ungenerated-params-runtime/anything"
+            id="link-to-ungenerated-params-runtime"
+            prefetch
+          >
+            Go to ungenerated params runtime page
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/mixed-params-runtime/en/anything"
+            id="link-to-mixed-params-runtime"
+            prefetch
+          >
+            Go to mixed params runtime page
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/mixed-params-runtime/en/anything"
+            id="link-to-mixed-params-runtime-no-prefetch"
+          >
+            Go to mixed params runtime page (no prefetch)
+          </Link>
+        </li>
+        <li>
+          <Link href="/search-params-page?foo=bar" id="link-to-search-params">
+            Go to search params page
+          </Link>
+        </li>
+        {/* Plain anchor for MPA navigation testing (bypasses client-side routing) */}
+        <li>
+          <a href="/target-page" id="plain-link-to-target">
+            Go to target page (MPA)
+          </a>
+        </li>
+        <li>
+          <a href="/cookies-page" id="plain-link-to-cookies-page">
+            Go to cookies page (MPA)
+          </a>
+        </li>
+        <li>
+          <a href="/dynamic-params/unknown" id="plain-link-to-dynamic-params">
+            Go to dynamic params page (MPA)
+          </a>
+        </li>
+        <li>
+          <a
+            href="/dynamic-params/hello"
+            id="plain-link-to-static-dynamic-params"
+          >
+            Go to static dynamic params page (MPA)
+          </a>
+        </li>
+        <li>
+          <a
+            href="/search-params-page?foo=bar"
+            id="plain-link-to-search-params"
+          >
+            Go to search params page (MPA)
+          </a>
+        </li>
+        <li>
+          <Link href="/client-fetch-page" id="link-to-client-fetch">
+            Go to client fetch page
+          </Link>
+        </li>
+        <li>
+          <a href="/client-fetch-page" id="plain-link-to-client-fetch">
+            Go to client fetch page (MPA)
+          </a>
+        </li>
+        <li>
+          <Link href="/root-blocking-page" id="link-to-root-blocking">
+            Go to blocking route (no static shell)
+          </Link>
+        </li>
+        <li>
+          <a href="/root-blocking-page" id="plain-link-to-root-blocking">
+            Go to blocking route (no static shell) (MPA)
+          </a>
+        </li>
+      </ul>
     </div>
   )
 }

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
@@ -4,9 +4,9 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    // TODO(appShells): migrate this test to the two-phase (app shell +
-    // per-page data) prefetch behavior, then remove this override. See #94516.
-    appShells: false,
+    // App Shells is enabled implicitly by `cacheComponents`. `prefetchInlining`
+    // is kept `false` so the non-inlined (speculative per-segment) static
+    // prefetch path is exercised alongside the app-shell prefetch.
     // Enable the testing API in production builds for these tests
     exposeTestingApiInProductionBuild: true,
     prefetchInlining: false,

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
@@ -3,6 +3,10 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  // The Instant Navigation devtools panel defaults to the dev tools position
+  // (bottom-left). This suite's links are a left-aligned vertical list, so a
+  // bottom-left panel overlaps them and intercepts clicks; move it aside.
+  devIndicators: { position: 'bottom-right' },
   experimental: {
     // App Shells is enabled implicitly by `cacheComponents`. `prefetchInlining`
     // is kept `false` so the non-inlined (speculative per-segment) static

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -641,18 +641,21 @@ describe('instant-navigation-testing-api', () => {
     })
   })
 
-  // A route mixing a `generateStaticParams`-covered param (`lang`) with an
-  // uncovered one (`slug`), `prefetch='allow-runtime'`. The two tests below
-  // differ only in whether the link opts into prefetching.
+  // Two routes mix a `generateStaticParams`-covered param (`lang`) with an
+  // uncovered one (`slug`); they differ in prefetch capability, which is what
+  // each test exercises.
   //
-  // Normal navigation (no runtime prefetch): the static prefetch carries only
-  // the covered `lang`, so inside the instant scope `lang` is shown and the
-  // uncovered `slug` stays deferred behind its Suspense fallback.
+  // `mixed-params` does NOT opt into runtime prefetching, so a normal (no
+  // `prefetch` prop) navigation carries only the covered `lang` in the static
+  // shell. Inside the instant scope `lang` is shown while the uncovered `slug`
+  // and the request-time `connection()` sibling both stay deferred behind their
+  // Suspense fallbacks. Because the route can never runtime-prefetch, `slug` is
+  // deferred here.
   it('shows only the static param in the instant shell on a normal navigation to a mixed route', async () => {
     const page = await openPage(next, '/')
 
     await instant(page, async () => {
-      await page.click('#link-to-mixed-params-runtime-no-prefetch')
+      await page.click('#link-to-mixed-params')
 
       // The covered `lang` comes from the static shell.
       const lang = page.locator('[data-testid="mixed-lang"]')
@@ -667,18 +670,31 @@ describe('instant-navigation-testing-api', () => {
       expect(
         await page.locator('[data-testid="mixed-slug-value"]').count()
       ).toBe(0)
+
+      // The request-time `connection()` sibling likewise stays on its fallback
+      // and must not leak into the instant scope.
+      await page
+        .locator('[data-testid="mixed-dynamic-fallback"]')
+        .waitFor({ state: 'visible' })
+      expect(
+        await page.locator('[data-testid="mixed-dynamic-value"]').count()
+      ).toBe(0)
     })
 
-    // After the lock releases, the uncovered `slug` streams in.
+    // After the lock releases, the uncovered `slug` and the request-time
+    // content stream in.
     const slug = page.locator('[data-testid="mixed-slug-value"]')
     await slug.waitFor({ state: 'visible' })
     expect(await slug.textContent()).toContain('slug: anything')
+    await page
+      .locator('[data-testid="mixed-dynamic-value"]')
+      .waitFor({ state: 'visible' })
   })
 
-  // With `prefetch` on the link, the runtime prefetch ('2') resolves ALL params,
-  // so inside the instant scope both `lang` (static shell) and `slug` (runtime
-  // prefetch) are shown, while the genuinely request-time `connection()` sibling
-  // stays deferred until the lock releases.
+  // With `prefetch` on the link, the runtime prefetch ('2') resolves ALL
+  // params, so inside the instant scope both `lang` (static shell) and `slug`
+  // (runtime prefetch) are shown, while the genuinely request-time
+  // `connection()` sibling stays deferred until the lock releases.
   it('resolves the covered param from the static shell and the uncovered param from the runtime prefetch in a mixed route', async () => {
     const page = await openPage(next, '/')
 

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -22,7 +22,7 @@
  * API in production mode for testing purposes.
  */
 
-import { NextInstance, nextTestSetup } from 'e2e-utils'
+import { NextInstance, nextTestSetup, isNextDev } from 'e2e-utils'
 import { instant } from '@next/playwright'
 import type * as Playwright from 'playwright'
 import { join } from 'node:path'
@@ -131,6 +131,55 @@ describe('instant-navigation-testing-api', () => {
     // Search param content remains visible
     const searchParamValue = page.locator('[data-testid="search-param-value"]')
     expect(await searchParamValue.textContent()).toContain('myParam: testValue')
+  })
+
+  // Navigate deeper under the lock. Loading `/blocking-fallback/en` commits the
+  // parent layout (which owns the only <Suspense> boundary) and the landing
+  // page. `/blocking-fallback/en/s1` is a fallback route (`[scope]` has no
+  // generateStaticParams) whose deeper page blocks on `cookies()`. Navigating
+  // into it must stay parked: the committed parent and landing page stay on
+  // screen, the deeper page and its cookie value must not commit while the lock
+  // is held, and they stream in only after release.
+  it('keeps the committed layout and defers a deeper blocking segment under instant()', async () => {
+    const page = await openPage(next, '/blocking-fallback/en', {
+      cookies: [{ name: 'testCookie', value: 'hello' }],
+    })
+    await page
+      .locator('[data-testid="blocking-landing"]')
+      .waitFor({ state: 'visible' })
+
+    await instant(page, async () => {
+      await page.click('#to-blocking-scope')
+
+      const secret = page.locator('[data-testid="blocking-secret"]')
+      // Poll past the point where the navigation previously committed,
+      // breaking early if the destination leaks so a regression fails fast.
+      for (let i = 0; i < 8; i++) {
+        await page.waitForTimeout(1000)
+        if (await secret.count()) break
+      }
+
+      // The parent layout's Suspense already resolved on the landing page, so
+      // navigating deeper does NOT re-show its fallback; React keeps the
+      // previous page on screen until the blocking destination resolves. So
+      // under the lock the committed parent and landing page stay put, and the
+      // deeper blocking page (and its cookie read) must not commit.
+      expect(
+        await page.locator('[data-testid="blocking-parent"]').count()
+      ).toBe(1)
+      expect(
+        await page.locator('[data-testid="blocking-landing"]').count()
+      ).toBe(1)
+      expect(
+        await page.locator('[data-testid="blocking-scope-title"]').count()
+      ).toBe(0)
+      expect(await secret.count()).toBe(0)
+    })
+
+    // After the lock releases, the deeper page and cookie value stream in.
+    const secret = page.locator('[data-testid="blocking-secret"]')
+    await secret.waitFor({ state: 'visible' })
+    expect(await secret.textContent()).toContain('testCookie: hello')
   })
 
   it('renders full prefetch content instantly when prefetch={true}', async () => {
@@ -294,18 +343,13 @@ describe('instant-navigation-testing-api', () => {
     )
   })
 
-  // Verifies that runtime params (cookies, dynamic route params, search
-  // params) are excluded from the instant navigation shell. The shell should
-  // only contain static content — runtime param values should be blocked
-  // behind a Suspense boundary until the instant lock is released.
-  //
-  // Each test route reads a different runtime param inside a <Suspense>
-  // boundary without opting into `instant: { prefetch: 'runtime' }`.
-  // During the instant scope, the static page title should be visible and the
-  // Suspense fallback should be shown, but the resolved param value should
-  // NOT be present.
-  describe('runtime params are excluded from instant shell', () => {
-    it('does not include cookie values in instant shell during client navigation', async () => {
+  // Cookies are session data carried by the app shell, so on a client
+  // navigation they ARE available in the instant shell — unless a param is read
+  // before the cookie, which makes the app-shell render suspend at the
+  // (withheld) param before it reaches the cookie. On a full page load the
+  // document render defers the cookie regardless.
+  describe('cookies in the instant shell', () => {
+    it('includes app-shell cookie values in the instant shell during client navigation', async () => {
       const page = await openPage(next, '/', {
         cookies: [{ name: 'testCookie', value: 'hello' }],
       })
@@ -313,25 +357,81 @@ describe('instant-navigation-testing-api', () => {
       await instant(page, async () => {
         await page.click('#link-to-cookies-page')
 
-        // Static page title is visible
         const title = page.locator('[data-testid="cookies-page-title"]')
         await title.waitFor({ state: 'visible' })
 
-        // Suspense fallback is visible
+        // Cookies are session data in the app shell, and nothing gates them,
+        // so the value is available inside the instant scope.
+        const cookieValue = page.locator('[data-testid="cookie-value"]')
+        await cookieValue.waitFor({ state: 'visible' })
+        expect(await cookieValue.textContent()).toContain('testCookie: hello')
+      })
+    })
+
+    it('excludes a cookie read after a param access from the instant shell during client navigation', async () => {
+      const page = await openPage(next, '/', {
+        cookies: [{ name: 'testCookie', value: 'hello' }],
+      })
+
+      await instant(page, async () => {
+        await page.click('#link-to-cookies-with-param')
+
+        const title = page.locator('[data-testid="cookies-param-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // The component awaits `params` before `cookies()`. The app shell
+        // withholds params, so it suspends before the cookie read — the cookie
+        // value is NOT in the instant shell; its Suspense fallback is shown.
+        const fallback = page.locator('[data-testid="cookies-param-fallback"]')
+        await fallback.waitFor({ state: 'visible' })
+        expect(
+          await page.locator('[data-testid="cookies-param-value"]').count()
+        ).toBe(0)
+      })
+
+      // After exiting the instant scope, the cookie value streams in.
+      const cookieValue = page.locator('[data-testid="cookies-param-value"]')
+      await cookieValue.waitFor({ state: 'visible' })
+      expect(await cookieValue.textContent()).toContain('testCookie: hello')
+    })
+
+    it('does not include cookie values in instant shell during page load', async () => {
+      const page = await openPage(next, '/', {
+        cookies: [{ name: 'testCookie', value: 'hello' }],
+      })
+
+      await instant(page, async () => {
+        await page.click('#plain-link-to-cookies-page')
+
+        const title = page.locator('[data-testid="cookies-page-title"]')
+        await title.waitFor({ state: 'visible' })
+
         const fallback = page.locator('[data-testid="cookies-fallback"]')
         await fallback.waitFor({ state: 'visible' })
 
-        // Cookie value is NOT in the shell
         const cookieValue = page.locator('[data-testid="cookie-value"]')
         expect(await cookieValue.count()).toBe(0)
       })
 
       // After exiting instant scope, cookie value streams in
       const cookieValue = page.locator('[data-testid="cookie-value"]')
-      await cookieValue.waitFor({ state: 'visible' })
+      await cookieValue.waitFor({ state: 'visible', timeout: 10000 })
       expect(await cookieValue.textContent()).toContain('testCookie: hello')
     })
+  })
 
+  // Verifies that dynamic route params and search params are excluded from the
+  // instant navigation shell. The shell should only contain static content —
+  // these runtime values should be blocked behind a Suspense boundary until the
+  // instant lock is released. (Cookies are session data carried by the app
+  // shell and are covered separately below.)
+  //
+  // Each test route reads a different runtime param inside a <Suspense>
+  // boundary without opting into `instant: { prefetch: 'runtime' }`.
+  // During the instant scope, the static page title should be visible and the
+  // Suspense fallback should be shown, but the resolved param value should
+  // NOT be present.
+  describe('runtime params are excluded from instant shell', () => {
     it('does not include dynamic param values in instant shell during client navigation', async () => {
       const page = await openPage(next, '/')
 
@@ -384,33 +484,6 @@ describe('instant-navigation-testing-api', () => {
       )
       await searchParamContent.waitFor({ state: 'visible' })
       expect(await searchParamContent.textContent()).toContain('foo: bar')
-    })
-
-    it('does not include cookie values in instant shell during page load', async () => {
-      const page = await openPage(next, '/', {
-        cookies: [{ name: 'testCookie', value: 'hello' }],
-      })
-
-      await instant(page, async () => {
-        await page.click('#plain-link-to-cookies-page')
-
-        // Static page title is visible
-        const title = page.locator('[data-testid="cookies-page-title"]')
-        await title.waitFor({ state: 'visible' })
-
-        // Suspense fallback is visible
-        const fallback = page.locator('[data-testid="cookies-fallback"]')
-        await fallback.waitFor({ state: 'visible' })
-
-        // Cookie value is NOT in the shell
-        const cookieValue = page.locator('[data-testid="cookie-value"]')
-        expect(await cookieValue.count()).toBe(0)
-      })
-
-      // After exiting instant scope, cookie value streams in
-      const cookieValue = page.locator('[data-testid="cookie-value"]')
-      await cookieValue.waitFor({ state: 'visible', timeout: 10000 })
-      expect(await cookieValue.textContent()).toContain('testCookie: hello')
     })
 
     it('does not include dynamic param values in instant shell during page load', async () => {
@@ -556,6 +629,83 @@ describe('instant-navigation-testing-api', () => {
       )
       expect(await fallback.count()).toBe(0)
     })
+  })
+
+  // A route mixing a `generateStaticParams`-covered param (`lang`) with an
+  // uncovered one (`slug`), `prefetch='allow-runtime'`. The two tests below
+  // differ only in whether the link opts into prefetching.
+  //
+  // Normal navigation (no runtime prefetch): the static prefetch carries only
+  // the covered `lang`, so inside the instant scope `lang` is shown and the
+  // uncovered `slug` stays deferred behind its Suspense fallback.
+  it('shows only the static param in the instant shell on a normal navigation to a mixed route', async () => {
+    const page = await openPage(next, '/')
+
+    await instant(page, async () => {
+      await page.click('#link-to-mixed-params-runtime-no-prefetch')
+
+      // The covered `lang` comes from the static shell.
+      const lang = page.locator('[data-testid="mixed-lang"]')
+      await lang.waitFor({ state: 'visible' })
+      expect(await lang.textContent()).toContain('lang: en')
+
+      // The uncovered `slug` is a fallback param and there is no runtime
+      // prefetch, so it stays on its Suspense fallback and its value is absent.
+      await page
+        .locator('[data-testid="mixed-slug-fallback"]')
+        .waitFor({ state: 'visible' })
+      expect(
+        await page.locator('[data-testid="mixed-slug-value"]').count()
+      ).toBe(0)
+    })
+
+    // After the lock releases, the uncovered `slug` streams in.
+    const slug = page.locator('[data-testid="mixed-slug-value"]')
+    await slug.waitFor({ state: 'visible' })
+    expect(await slug.textContent()).toContain('slug: anything')
+  })
+
+  // With `prefetch` on the link, the runtime prefetch ('2') resolves ALL params,
+  // so inside the instant scope both `lang` (static shell) and `slug` (runtime
+  // prefetch) are shown, while the genuinely request-time `connection()` sibling
+  // stays deferred until the lock releases.
+  it('resolves the covered param from the static shell and the uncovered param from the runtime prefetch in a mixed route', async () => {
+    const page = await openPage(next, '/')
+
+    await instant(page, async () => {
+      await page.click('#link-to-mixed-params-runtime')
+
+      // The generateStaticParams-covered `lang` comes from the static shell.
+      const lang = page.locator('[data-testid="mixed-lang"]')
+      await lang.waitFor({ state: 'visible' })
+      expect(await lang.textContent()).toContain('lang: en')
+
+      // The uncovered `slug` is resolved by the runtime prefetch and surfaces
+      // inside the instant scope.
+      const slug = page.locator('[data-testid="mixed-slug-value"]')
+      await slug.waitFor({ state: 'visible' })
+      expect(await slug.textContent()).toContain('slug: anything')
+
+      // The request-time dynamic sibling stays on its fallback under the lock.
+      await page
+        .locator('[data-testid="mixed-dynamic-fallback"]')
+        .waitFor({ state: 'visible' })
+      expect(
+        await page.locator('[data-testid="mixed-dynamic-value"]').count()
+      ).toBe(0)
+    })
+
+    // After the lock releases, the request-time content streams in while both
+    // params remain visible.
+    await page
+      .locator('[data-testid="mixed-dynamic-value"]')
+      .waitFor({ state: 'visible' })
+    expect(
+      await page.locator('[data-testid="mixed-lang"]').textContent()
+    ).toContain('lang: en')
+    expect(
+      await page.locator('[data-testid="mixed-slug-value"]').textContent()
+    ).toContain('slug: anything')
   })
 
   // In dev mode, hover/intent-based prefetches should not send requests
@@ -932,5 +1082,53 @@ describe('instant-navigation-testing-api - partial prefetching (App Shells)', ()
       const fallback = page.locator('[data-testid="params-fallback"]')
       expect(await fallback.count()).toBe(0)
     })
+  })
+})
+
+// A route with no static shell — `cookies()` read outside any <Suspense>, no
+// `instant = false` — is a hard `next build` error (it can't be prerendered),
+// so it can't live in a fixture that gets production-built. The Instant
+// Navigation behavior it exercises (the destination must not commit under the
+// lock) is a dev-time concern, so this suite uses a dedicated fixture and runs
+// in dev only; `next start`/deploy register a single placeholder so the build
+// is never attempted.
+describe('instant-navigation-testing-api - blocking routes (dev only)', () => {
+  if (!isNextDev) {
+    it('skips blocking route tests outside dev (route cannot be production-built)', () => {})
+    return
+  }
+
+  const { next } = nextTestSetup({
+    files: join(__dirname, 'fixtures', 'blocking'),
+    skipDeployment: true,
+  })
+
+  // The cookie value must not commit while the instant lock is held; it only
+  // streams in after the lock releases.
+  it('does not include blocking cookies read outside a Suspense in the instant shell', async () => {
+    const page = await openPage(next, '/', {
+      cookies: [{ name: 'testCookie', value: 'hello' }],
+    })
+    await page
+      .locator('[data-testid="home-title"]')
+      .waitFor({ state: 'visible' })
+
+    await instant(page, async () => {
+      await page.click('#link-to-blocking-cookies')
+
+      const cookieValue = page.locator('[data-testid="blocking-cookie-value"]')
+      // Poll past the point where a leak previously committed (~10s), breaking
+      // early so a regression fails fast.
+      for (let i = 0; i < 8; i++) {
+        await page.waitForTimeout(1000)
+        if (await cookieValue.count()) break
+      }
+      expect(await cookieValue.count()).toBe(0)
+    })
+
+    // After exiting the instant scope, the cookie value streams in.
+    const cookieValue = page.locator('[data-testid="blocking-cookie-value"]')
+    await cookieValue.waitFor({ state: 'visible' })
+    expect(await cookieValue.textContent()).toContain('testCookie: hello')
   })
 })

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -349,34 +349,46 @@ describe('instant-navigation-testing-api', () => {
   // (withheld) param before it reaches the cookie. On a full page load the
   // document render defers the cookie regardless.
   describe('cookies in the instant shell', () => {
-    // Skipped: this asserts the app shell's cookie value survives into the
-    // captured instant shell, but the current App Shells implementation can
-    // regress it. A route's app shell carries session data such as cookies,
-    // while a speculative static prefetch for the same URL keeps the cookie
-    // behind its <Suspense> boundary; the captured shell therefore includes the
-    // cookie only when it settles on the app shell rather than the static one,
-    // which is racy in production. The planned fix is to detect a `cookies()`
-    // access while generating the app shell and opt the route into runtime
-    // prefetching, so the cookie is carried regardless of which prefetch
-    // settles first. Re-enable this test once that detection lands.
-    it.skip('includes app-shell cookie values in the instant shell during client navigation', async () => {
-      const page = await openPage(next, '/', {
-        cookies: [{ name: 'testCookie', value: 'hello' }],
-      })
+    // Marked failing: `/cookies-page` is a non-partial route (it opts into
+    // neither `partialPrefetching` nor a per-route `prefetch`/`instant`
+    // config), so its speculative static prefetch is fuller than the app-shell
+    // render and supersedes it in the segment cache. The cookie that only the
+    // app shell carries is dropped before it reaches the instant shell, and
+    // #95150's shell handling only engages under partial prefetching, so it
+    // does not cover this case.
+    //
+    // If we later detect that a route reads cookies during app-shell
+    // generation, we should opt it into either partial prefetching, so that
+    // only the app shell is fetched on the client, or runtime prefetching, so
+    // that a speculative prefetch can never regress the content an app shell
+    // initially showed, and cookie-dependent content is not removed once a
+    // speculative prefetch (for a link whose instant app shell we already
+    // displayed) has settled.
+    it.failing(
+      'includes app-shell cookie values in the instant shell during client navigation',
+      async () => {
+        const page = await openPage(next, '/', {
+          cookies: [{ name: 'testCookie', value: 'hello' }],
+        })
 
-      await instant(page, async () => {
-        await page.click('#link-to-cookies-page')
+        await instant(page, async () => {
+          await page.click('#link-to-cookies-page')
 
-        const title = page.locator('[data-testid="cookies-page-title"]')
-        await title.waitFor({ state: 'visible' })
+          const title = page.locator('[data-testid="cookies-page-title"]')
+          await title.waitFor({ state: 'visible' })
 
-        // Cookies are session data in the app shell, and nothing gates them,
-        // so the value is available inside the instant scope.
-        const cookieValue = page.locator('[data-testid="cookie-value"]')
-        await cookieValue.waitFor({ state: 'visible' })
-        expect(await cookieValue.textContent()).toContain('testCookie: hello')
-      })
-    })
+          // Cookies are session data in the app shell, and nothing gates them,
+          // so the value should be available inside the instant scope.
+          const cookieValue = page.locator('[data-testid="cookie-value"]')
+          // Expected-failing today (see the note above): the cookie never reaches
+          // the shell, so cap the wait rather than spend the default 60s on a
+          // known timeout. A real fix puts the cookie in the same captured shell
+          // as the title above, so it surfaces well within this.
+          await cookieValue.waitFor({ state: 'visible', timeout: 3000 })
+          expect(await cookieValue.textContent()).toContain('testCookie: hello')
+        })
+      }
+    )
 
     it('excludes a cookie read after a param access from the instant shell during client navigation', async () => {
       const page = await openPage(next, '/', {

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -349,7 +349,17 @@ describe('instant-navigation-testing-api', () => {
   // (withheld) param before it reaches the cookie. On a full page load the
   // document render defers the cookie regardless.
   describe('cookies in the instant shell', () => {
-    it('includes app-shell cookie values in the instant shell during client navigation', async () => {
+    // Skipped: this asserts the app shell's cookie value survives into the
+    // captured instant shell, but the current App Shells implementation can
+    // regress it. A route's app shell carries session data such as cookies,
+    // while a speculative static prefetch for the same URL keeps the cookie
+    // behind its <Suspense> boundary; the captured shell therefore includes the
+    // cookie only when it settles on the app shell rather than the static one,
+    // which is racy in production. The planned fix is to detect a `cookies()`
+    // access while generating the app shell and opt the route into runtime
+    // prefetching, so the cookie is carried regardless of which prefetch
+    // settles first. Re-enable this test once that detection lands.
+    it.skip('includes app-shell cookie values in the instant shell during client navigation', async () => {
       const page = await openPage(next, '/', {
         cookies: [{ name: 'testCookie', value: 'hello' }],
       })


### PR DESCRIPTION
The Instant Navigation lock makes a development render reflect the route's prefetched state: while the lock is held, a navigation shows only what was prefetched and keeps navigation-time data deferred. Both the `instant()` testing API from `@next/playwright` and the Instant Navigation devtools rely on it. The client side of that behavior, restricting the navigation read to the prefetched shell unless the link opts into a runtime prefetch and ignoring cache entries acquired before the lock, landed separately in #95150, which this change builds on. What remained were two ways the development app render diverged from what a production build serves, both in `app-page.ts`, so this PR contains no client-side router changes.

While the lock is held, the app render now permits an empty static shell. A route that reads dynamic data such as `cookies()` outside any `<Suspense>` boundary has no static shell, so the on-demand render previously threw a static generation bailout, served an error page, and entered a `/_tree` redirect loop that committed the blocked data. Permitting an empty shell lets the render emit the shell instead. The override is scoped to the prefetch render made while the lock is held, a document request or a `'1'` static prefetch; a regular dynamic navigation, including the one that commits once the lock releases, runs without it. So the validation that flags a blocking route is not weakened: production validation runs at build time, and the development validation still runs and is shown in the dev overlay.

The development fallback-shell render now reads the per-URL `fallbackParams` request meta that base-server derives for the requested URL, so the instant shell defers exactly the params a production prefetch would: `generateStaticParams`-covered params resolve in the shell and only the uncovered ones are deferred. When the URL is fully covered the meta is absent and nothing is deferred. That per-URL computation landed in #95066, which this change depends on.

This suite now runs with App Shells enabled, which is the default under Cache Components. #94516 had temporarily forced it back to `false` here while the prefetch behavior settled and left the migration as a follow-up; re-enabling it is what lets these tests exercise the app-shell prefetch path the changes above target.

New end-to-end coverage exercises the cases this render path affects. A deeper-segment blocking navigation must stay parked on the committed parent while the lock is held. Two mixed routes pair a `generateStaticParams`-covered param with an uncovered one: a plain route where a normal navigation surfaces only the covered param while the uncovered param and a request-time `connection()` sibling stay deferred, and an `allow-runtime` route where a `prefetch={true}` link additionally surfaces the uncovered param from the runtime prefetch. A blocking route that reads request data outside any `<Suspense>` boundary cannot be built for production, so it lives in a development-only fixture, guarded so the production job registers only a placeholder. The default fixture moves the dev-tools indicator to `bottom-right` so the Instant Navigation panel does not overlap the left-aligned test links during a navigation.

One client-navigation cookie case is marked `it.failing`: on a non-partial route the speculative static prefetch is fuller than the app-shell render and supersedes it in the segment cache, so the cookie that only the app shell carries never reaches the instant shell. #95150's shell handling only engages under partial prefetching. Closing this needs a separate server-side change so that a route reading `cookies()` during app-shell generation opts into either partial prefetching, where only the app shell is fetched and nothing fuller can supersede it, or a runtime prefetch, where the speculative prefetch carries the cookie and no longer regresses what the app shell initially showed.