### PR TITLE
[skills] Mark insight-error-page and next-rspack as internal

### DIFF
--- a/.agents/skills/insight-error-page/SKILL.md
+++ b/.agents/skills/insight-error-page/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: insight-error-page
 description: Write or audit an insight-kind error page for the Next.js dev overlay. Use when creating a new `errors/<slug>.mdx` page, auditing an existing one, or checking that a page matches the framework fix cards. Covers page structure, title alignment, FixOption cards with Copy AI prompt button, code snippets, terminology verification against canonical docs, and Vercel technical writing style.
+metadata:
+  internal: true
 ---
 
 # Insight Error Page — Write & Audit

--- a/.agents/skills/next-rspack/SKILL.md
+++ b/.agents/skills/next-rspack/SKILL.md
@@ -7,6 +7,8 @@ description: >
   rspack_* crate versions, Rust toolchain version, building and linking for local
   testing, and NEXT_RSPACK environment variable usage. Does NOT apply to root
   rust-toolchain.toml (that's for Turbopack).
+metadata:
+  internal: true
 ---
 
 # Next.js with Rspack


### PR DESCRIPTION
These two maintainer skills live under `.agents/skills/` alongside the internal dev skills (`flags`, `create-pr`, `react-vendoring`, etc.), all of which carry `metadata.internal: true`. They were missing the flag, so the skill sync pulled them into the external/universal distribution. Adds `metadata.internal: true` to both, matching their siblings.

<!-- NEXT_JS_LLM_PR -->