### PR TITLE
Turbopack: Fix log box test on react 18

### DIFF
--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -126,7 +126,7 @@ describe('ReactRefreshLogBox', () => {
            "stack": [
              "module evaluation index.js (3:7)",
              "module evaluation pages/index.js (1:1)",
-             "module evaluation pages/index.js (1:1)",
+             "module evaluation index.js (9:16)",
              "<FIXME-next-dist-dir>",
            ],
          }


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/95065 modified this test, but didn't update the test for React 18, only React 19.

React 18 tests don't run on PRs by default because of CI cost, they need an explicit label.