### PR TITLE
Turbopack: Avoid clone when sorting by module file path

### DIFF
--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -121,8 +121,11 @@ impl EcmascriptBrowserChunkContent {
         let mut chunk_items = content.chunk_item_code_module_ids_and_paths().await?;
         // Sort items by their module path so that similar modules stay
         // together so that the chunks gzips better.
-        chunk_items
-            .sort_by_key(|item| item.first().map(|(id, _, path)| (path.clone(), id.clone())));
+        chunk_items.sort_by(|a, b| {
+            a.first()
+                .map(|(id, _, path)| (path, id))
+                .cmp(&b.first().map(|(id, _, path)| (path, id)))
+        });
         for item in &chunk_items {
             for (id, item_code, _) in &**item {
                 write!(code, "\n{}, ", StringifyJs(id))?;

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -69,8 +69,11 @@ impl EcmascriptBuildNodeChunkContent {
 
         let content = self.content.await?;
         let mut chunk_items = content.chunk_item_code_module_ids_and_paths().await?;
-        chunk_items
-            .sort_by_key(|item| item.first().map(|(id, _, path)| (path.clone(), id.clone())));
+        chunk_items.sort_by(|a, b| {
+            a.first()
+                .map(|(id, _, path)| (path, id))
+                .cmp(&b.first().map(|(id, _, path)| (path, id)))
+        });
         for item in &chunk_items {
             for (id, item_code, _) in &**item {
                 write!(code, "\n{}, ", StringifyJs(id))?;


### PR DESCRIPTION
Minor nit: In the worst-case (module id can be an `RcStr` or a u64), this eliminates two `RcStr` clones+drops per iteration of the sort algorithm.

The code is cleaner with `sort_by_key`, but `sort_by_key` introduces an artificial lifetime issue that `sort_by` avoids.

This is a long-standing and widely documented language issue: https://github.com/rust-lang/rust/issues/34162