### PR TITLE
skill(next-cache-components-adoption): clarify prereqs

### DIFF
--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -53,10 +53,6 @@ export default nextConfig
 
 > **Good to know:** If you were using `experimental.dynamicIO` or `experimental.useCache`, `cacheComponents` replaces them. See the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16#experimentaldynamicio-and-experimentalusecache).
 
-Before enabling the flag, remove `export const dynamic` from your route segments. Pages that still export it will fail to build. Also remove `export const revalidate` and `export const fetchCache`: under `cacheComponents`, they no longer configure caching. The sections below cover the replacements (`cacheLife` and `'use cache'`).
-
-Your existing `unstable_cache` calls and `fetch` cache options keep working as a separate caching layer after the flag is on. Translate them as the validation insights and errors surface each one.
-
 ## `dynamic = "force-dynamic"`
 
 **Not needed.** All pages are dynamic by default.
@@ -400,7 +396,7 @@ Like the `fetch` Data Cache, `unstable_cache` persists cached values across depl
 On-demand invalidation still works by tagging cached data and expiring it after an event. Tag data with [`cacheTag`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function instead of the `fetch` `next.tags` option, then choose the invalidation API by the behavior you want:
 
 - [`updateTag`](/docs/app/api-reference/functions/updateTag): for mutations whose result the user must see immediately (read-your-own-writes). Called from a Server Action, it expires the tag so the next request waits for fresh data instead of serving stale content.
-- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. A cache profile is **required** as the second argument, for example use `'max'` to serve cached data while it refreshes in the background. Works in Server Actions and Route Handlers.
+- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. Pass a cache profile like `'max'` to serve cached data while it refreshes in the background. Works in Server Actions and Route Handlers.
 - [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath): unchanged from the previous caching model.
 
 `updateTag` isn't exclusive to Cache Components (it also works with the previous caching model), but migrating is a good time to adopt it. After a mutation in a Server Action, reach for it when the user should see their own change right away.
@@ -425,49 +421,7 @@ export async function createPost(formData) {
 }
 ```
 
-> **Good to know:** `updateTag` can only be called from a Server Action; calling it elsewhere throws. In Route Handlers or webhooks, use `revalidateTag` instead with a cache profile.
-
-Pass `'max'` as the second argument to `revalidateTag` to expire the tag with stale-while-revalidate semantics:
-
-```tsx filename="app/api/webhook/route.ts" switcher
-// Before
-import { revalidateTag } from 'next/cache'
-
-export async function POST() {
-  revalidateTag('posts')
-  return Response.json({ ok: true })
-}
-```
-
-```js filename="app/api/webhook/route.js" switcher
-// Before
-import { revalidateTag } from 'next/cache'
-
-export async function POST() {
-  revalidateTag('posts')
-  return Response.json({ ok: true })
-}
-```
-
-```tsx filename="app/api/webhook/route.ts" switcher
-// After - Pass a cache profile
-import { revalidateTag } from 'next/cache'
-
-export async function POST() {
-  revalidateTag('posts', 'max')
-  return Response.json({ ok: true })
-}
-```
-
-```js filename="app/api/webhook/route.js" switcher
-// After - Pass a cache profile
-import { revalidateTag } from 'next/cache'
-
-export async function POST() {
-  revalidateTag('posts', 'max')
-  return Response.json({ ok: true })
-}
-```
+> **Good to know:** `updateTag` can only be called from a Server Action; calling it elsewhere throws. In Route Handlers or webhooks, use `revalidateTag` instead.
 
 ## `unstable_noStore`
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -400,7 +400,7 @@ Like the `fetch` Data Cache, `unstable_cache` persists cached values across depl
 On-demand invalidation still works by tagging cached data and expiring it after an event. Tag data with [`cacheTag`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function instead of the `fetch` `next.tags` option, then choose the invalidation API by the behavior you want:
 
 - [`updateTag`](/docs/app/api-reference/functions/updateTag): for mutations whose result the user must see immediately (read-your-own-writes). Called from a Server Action, it expires the tag so the next request waits for fresh data instead of serving stale content.
-- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. Works in Server Actions and Route Handlers. Pass a cache profile like `'max'` as the second argument to serve cached data while it refreshes in the background. The single-argument form `revalidateTag(tag)` is deprecated in newer versions and may be removed in the future.
+- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. A cache profile is **required** as the second argument, for example use `'max'` to serve cached data while it refreshes in the background. Works in Server Actions and Route Handlers.
 - [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath): unchanged from the previous caching model.
 
 `updateTag` isn't exclusive to Cache Components (it also works with the previous caching model), but migrating is a good time to adopt it. After a mutation in a Server Action, reach for it when the user should see their own change right away.

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -53,7 +53,7 @@ export default nextConfig
 
 > **Good to know:** If you were using `experimental.dynamicIO` or `experimental.useCache`, `cacheComponents` replaces them. See the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16#experimentaldynamicio-and-experimentalusecache).
 
-Before enabling the flag, remove every `export const dynamic` from your route segments. Pages that still export this config are rejected.
+Before enabling the flag, remove every `export const dynamic` from your route segments. Pages that still export this config will fail to build.
 
 Legacy caching APIs (`revalidate`, `fetchCache`, `unstable_cache`, and the `fetch` cache options) keep working as a separate caching layer after the flag is on. The sections below cover how to translate each one as the validation insights and errors surface them.
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -53,9 +53,9 @@ export default nextConfig
 
 > **Good to know:** If you were using `experimental.dynamicIO` or `experimental.useCache`, `cacheComponents` replaces them. See the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16#experimentaldynamicio-and-experimentalusecache).
 
-Before enabling the flag, remove every `export const dynamic` from your route segments. Pages that still export this config will fail to build.
+Before enabling the flag, remove `export const dynamic` from your route segments. Pages that still export it will fail to build. Also remove `export const revalidate` and `export const fetchCache`: under `cacheComponents`, they no longer configure caching. The sections below cover the replacements (`cacheLife` and `'use cache'`).
 
-Legacy caching APIs (`revalidate`, `fetchCache`, `unstable_cache`, and the `fetch` cache options) keep working as a separate caching layer after the flag is on. The sections below cover how to translate each one as the validation insights and errors surface them.
+Your existing `unstable_cache` calls and `fetch` cache options keep working as a separate caching layer after the flag is on. Translate them as the validation insights and errors surface each one.
 
 ## `dynamic = "force-dynamic"`
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -53,6 +53,10 @@ export default nextConfig
 
 > **Good to know:** If you were using `experimental.dynamicIO` or `experimental.useCache`, `cacheComponents` replaces them. See the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16#experimentaldynamicio-and-experimentalusecache).
 
+Before enabling the flag, remove every `export const dynamic` from your route segments. `cacheComponents: true` rejects pages that still export this config.
+
+Other legacy APIs (`revalidate`, `fetchCache`, `unstable_cache`, and the `fetch` cache options) keep working as a separate caching layer after the flag is on. The sections below cover how to translate each one. Migrate them as the validation insights and errors point at each one.
+
 ## `dynamic = "force-dynamic"`
 
 **Not needed.** All pages are dynamic by default.
@@ -396,7 +400,7 @@ Like the `fetch` Data Cache, `unstable_cache` persists cached values across depl
 On-demand invalidation still works by tagging cached data and expiring it after an event. Tag data with [`cacheTag`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function instead of the `fetch` `next.tags` option, then choose the invalidation API by the behavior you want:
 
 - [`updateTag`](/docs/app/api-reference/functions/updateTag): for mutations whose result the user must see immediately (read-your-own-writes). Called from a Server Action, it expires the tag so the next request waits for fresh data instead of serving stale content.
-- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. Pass a cache profile like `'max'` to serve cached data while it refreshes in the background. Works in Server Actions and Route Handlers.
+- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. Pass a cache profile like `'max'` as the second argument to serve cached data while it refreshes in the background. The single-argument form `revalidateTag(tag)` is deprecated under Cache Components and may be removed in a future version. Works in Server Actions and Route Handlers.
 - [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath): unchanged from the previous caching model.
 
 `updateTag` isn't exclusive to Cache Components (it also works with the previous caching model), but migrating is a good time to adopt it. After a mutation in a Server Action, reach for it when the user should see their own change right away.
@@ -422,6 +426,48 @@ export async function createPost(formData) {
 ```
 
 > **Good to know:** `updateTag` can only be called from a Server Action; calling it elsewhere throws. In Route Handlers or webhooks, use `revalidateTag` instead.
+
+For `revalidateTag`, add the cache profile as the second argument:
+
+```tsx filename="app/api/webhook/route.ts" switcher
+// Before
+import { revalidateTag } from 'next/cache'
+
+export async function POST() {
+  revalidateTag('posts')
+  return Response.json({ ok: true })
+}
+```
+
+```js filename="app/api/webhook/route.js" switcher
+// Before
+import { revalidateTag } from 'next/cache'
+
+export async function POST() {
+  revalidateTag('posts')
+  return Response.json({ ok: true })
+}
+```
+
+```tsx filename="app/api/webhook/route.ts" switcher
+// After - Pass a cache profile
+import { revalidateTag } from 'next/cache'
+
+export async function POST() {
+  revalidateTag('posts', 'max')
+  return Response.json({ ok: true })
+}
+```
+
+```js filename="app/api/webhook/route.js" switcher
+// After - Pass a cache profile
+import { revalidateTag } from 'next/cache'
+
+export async function POST() {
+  revalidateTag('posts', 'max')
+  return Response.json({ ok: true })
+}
+```
 
 ## `unstable_noStore`
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -400,7 +400,7 @@ Like the `fetch` Data Cache, `unstable_cache` persists cached values across depl
 On-demand invalidation still works by tagging cached data and expiring it after an event. Tag data with [`cacheTag`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function instead of the `fetch` `next.tags` option, then choose the invalidation API by the behavior you want:
 
 - [`updateTag`](/docs/app/api-reference/functions/updateTag): for mutations whose result the user must see immediately (read-your-own-writes). Called from a Server Action, it expires the tag so the next request waits for fresh data instead of serving stale content.
-- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. Pass a cache profile like `'max'` as the second argument to serve cached data while it refreshes in the background. The single-argument form `revalidateTag(tag)` is deprecated under Cache Components and may be removed in a future version. Works in Server Actions and Route Handlers.
+- [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag): for stale-while-revalidate. Works in Server Actions and Route Handlers. Pass a cache profile like `'max'` as the second argument to serve cached data while it refreshes in the background. The single-argument form `revalidateTag(tag)` is deprecated in newer versions and may be removed in the future.
 - [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath): unchanged from the previous caching model.
 
 `updateTag` isn't exclusive to Cache Components (it also works with the previous caching model), but migrating is a good time to adopt it. After a mutation in a Server Action, reach for it when the user should see their own change right away.

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -53,9 +53,9 @@ export default nextConfig
 
 > **Good to know:** If you were using `experimental.dynamicIO` or `experimental.useCache`, `cacheComponents` replaces them. See the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16#experimentaldynamicio-and-experimentalusecache).
 
-Before enabling the flag, remove every `export const dynamic` from your route segments. `cacheComponents: true` rejects pages that still export this config.
+Before enabling the flag, remove every `export const dynamic` from your route segments. Pages that still export this config are rejected.
 
-Other legacy APIs (`revalidate`, `fetchCache`, `unstable_cache`, and the `fetch` cache options) keep working as a separate caching layer after the flag is on. The sections below cover how to translate each one. Migrate them as the validation insights and errors point at each one.
+Legacy caching APIs (`revalidate`, `fetchCache`, `unstable_cache`, and the `fetch` cache options) keep working as a separate caching layer after the flag is on. The sections below cover how to translate each one as the validation insights and errors surface them.
 
 ## `dynamic = "force-dynamic"`
 
@@ -425,9 +425,9 @@ export async function createPost(formData) {
 }
 ```
 
-> **Good to know:** `updateTag` can only be called from a Server Action; calling it elsewhere throws. In Route Handlers or webhooks, use `revalidateTag` instead.
+> **Good to know:** `updateTag` can only be called from a Server Action; calling it elsewhere throws. In Route Handlers or webhooks, use `revalidateTag` instead with a cache profile.
 
-For `revalidateTag`, add the cache profile as the second argument:
+Pass `'max'` as the second argument to `revalidateTag` to expire the tag with stale-while-revalidate semantics:
 
 ```tsx filename="app/api/webhook/route.ts" switcher
 // Before

--- a/skills/next-cache-components-adoption/SKILL.md
+++ b/skills/next-cache-components-adoption/SKILL.md
@@ -23,7 +23,7 @@ Confirm each item before starting milestone A. The skill won't apply cleanly if 
   - `npx @next/codemod@latest upgrade latest` to apply the version-to-version codemods.
   - Read the relevant [version upgrade guide](https://nextjs.org/docs/app/guides/upgrading) (e.g. [Version 16](https://nextjs.org/docs/app/guides/upgrading/version-16)) for what the codemod doesn't cover.
 
-- **No incompatible config keys.** `cacheComponents: true` rejects any page that still exports `dynamic`, and `experimental.dynamicIO` / `experimental.useCache` have been renamed. Resolve those via the [migration guide](https://nextjs.org/docs/app/guides/migrating-to-cache-components) before starting. `revalidate`, `fetchCache`, and `unstable_cache` keep working as a separate layer and get translated during milestone B — don't introduce new ones.
+- **No incompatible config keys.** `cacheComponents: true` errors on any page that still exports `dynamic`, and `experimental.dynamicIO` / `experimental.useCache` have been renamed. Resolve those via the [migration guide](https://nextjs.org/docs/app/guides/migrating-to-cache-components) before starting. `revalidate`, `fetchCache`, and `unstable_cache` keep working as a separate layer and get translated during milestone B — don't introduce new ones.
 
 ### notes
 

--- a/skills/next-cache-components-adoption/SKILL.md
+++ b/skills/next-cache-components-adoption/SKILL.md
@@ -23,7 +23,7 @@ Confirm each item before starting milestone A. The skill won't apply cleanly if 
   - `npx @next/codemod@latest upgrade latest` to apply the version-to-version codemods.
   - Read the relevant [version upgrade guide](https://nextjs.org/docs/app/guides/upgrading) (e.g. [Version 16](https://nextjs.org/docs/app/guides/upgrading/version-16)) for what the codemod doesn't cover.
 
-- **No incompatible config keys.** `cacheComponents: true` errors on any page that still exports `dynamic`, and `experimental.dynamicIO` / `experimental.useCache` have been renamed. Resolve those via the [migration guide](https://nextjs.org/docs/app/guides/migrating-to-cache-components) before starting. `revalidate`, `fetchCache`, and `unstable_cache` keep working as a separate layer and get translated during milestone B — don't introduce new ones.
+- **No incompatible config keys.** `cacheComponents: true` errors on any page that still exports `dynamic`. Other legacy route segment configs (`revalidate`, `fetchCache`) and the renamed `experimental.dynamicIO` / `experimental.useCache` should also be migrated. Resolve them via the [migration guide's "Enable Cache Components" section](https://nextjs.org/docs/app/guides/migrating-to-cache-components#enable-cache-components) before starting.
 
 ### notes
 

--- a/skills/next-cache-components-adoption/SKILL.md
+++ b/skills/next-cache-components-adoption/SKILL.md
@@ -15,20 +15,21 @@ Enable Cache Components on an app and walk it to a clean build. This skill **seq
 
 ## requires
 
-**App Router only.** Cache Components is an App Router feature; `cacheComponents: true` does nothing for `pages/` routes. If the project has a `pages/` or `src/pages/` tree but no `app/` or `src/app/` tree, stop and tell the user — Pages → App migration is its own project, not part of this skill. A hybrid app (both `pages/` and `app/`) is fine: the flag affects the `app/` routes; `pages/` routes are unaffected and don't need opt-outs.
+Confirm each item before starting milestone A. The skill won't apply cleanly if any are unmet.
 
-Next.js **16.3+**. That release is where the pieces this skill relies on land: top-level `cacheComponents`, `export const instant`, the dev-overlay instant-navigation validation warnings (including `link-prefetch-partial`), and the `cache-components-instant-false` codemod.
+- **App Router project.** Cache Components is an App Router feature; `cacheComponents: true` does nothing for `pages/` routes. If the project has a `pages/` or `src/pages/` tree but no `app/` or `src/app/` tree, stop and tell the user — Pages → App migration is its own project, not part of this skill. A hybrid app (both `pages/` and `app/`) is fine: the flag affects the `app/` routes; `pages/` routes are unaffected and don't need opt-outs.
 
-If `next --version` reports below 16.3, upgrade first:
+- **Next.js 16.3 or later.** That release is where the pieces this skill relies on land: top-level `cacheComponents`, `export const instant`, the dev-overlay instant-navigation validation warnings, and the `cache-components-instant-false` codemod. If `next --version` reports below 16.3, upgrade first:
+  - `npx @next/codemod@latest upgrade latest` to apply the version-to-version codemods.
+  - Read the relevant [version upgrade guide](https://nextjs.org/docs/app/guides/upgrading) (e.g. [Version 16](https://nextjs.org/docs/app/guides/upgrading/version-16)) for what the codemod doesn't cover.
 
-- `npx @next/codemod@latest upgrade latest` to apply the version-to-version codemods.
-- Read the relevant [version upgrade guide](https://nextjs.org/docs/app/guides/upgrading) (e.g. [Version 16](https://nextjs.org/docs/app/guides/upgrading/version-16)) for what the codemod doesn't cover.
+- **No incompatible config keys.** `cacheComponents: true` rejects any page that still exports `dynamic`, and `experimental.dynamicIO` / `experimental.useCache` have been renamed. Resolve those via the [migration guide](https://nextjs.org/docs/app/guides/migrating-to-cache-components) before starting. `revalidate`, `fetchCache`, and `unstable_cache` keep working as a separate layer and get translated during milestone B — don't introduce new ones.
 
-This skill also assumes a clean starting point. If the app still uses `experimental.dynamicIO` / `experimental.useCache`, route segment configs (`dynamic`, `revalidate`, `fetchCache`), or `unstable_cache()`, work those out first via the [migration guide](https://nextjs.org/docs/app/guides/migrating-to-cache-components), then come back here.
+### notes
 
-**If the app already uses `"use cache"`**, there is no green build before `cacheComponents: true` — the pre-flag build errors with `please enable the feature flag cacheComponents`. Enabling the flag is the first step of milestone A, not a thing to do _after_ getting green; the green baseline comes from milestone A (blanket the opt-outs in), not from before it. Note this in your starting summary so it doesn't read as a regression.
+- **No green baseline before the flag.** If the app already uses `"use cache"`, the pre-flag build errors with `please enable the feature flag cacheComponents`. Enabling the flag is the first step of milestone A, not a thing to do _after_ getting green; the green baseline comes from milestone A (blanket the opt-outs in), not from before it. Note this in your starting summary so it doesn't read as a regression.
 
-Offline copies of guide links live under `node_modules/next/dist/docs/`, with the directory layout numbered for ordering (e.g. `node_modules/next/dist/docs/01-app/02-guides/migrating-to-cache-components.md`). The trailing filename matches the slug. If you can't predict the numbered prefix, `find node_modules/next/dist/docs -name '<slug>.md'` resolves it. The `/docs/messages/*` error pages are not bundled. If offline docs are missing entirely, run `npx @next/codemod@latest agents-md` to write a version-matched index into `AGENTS.md` / `CLAUDE.md`.
+- **Offline docs.** Offline copies of guide links live under `node_modules/next/dist/docs/`, with the directory layout numbered for ordering (e.g. `node_modules/next/dist/docs/01-app/02-guides/migrating-to-cache-components.md`). The trailing filename matches the slug. If you can't predict the numbered prefix, `find node_modules/next/dist/docs -name '<slug>.md'` resolves it. The `/docs/messages/*` error pages are not bundled. If offline docs are missing entirely, run `npx @next/codemod@latest agents-md` to write a version-matched index into `AGENTS.md` / `CLAUDE.md`.
 
 ## the shape of the work
 
@@ -83,6 +84,8 @@ Ask the user; don't assume. **In a non-interactive run** (no way to prompt), def
 ```bash
 npx @next/codemod@canary cache-components-instant-false ./app
 ```
+
+If `@next/codemod@latest` reports `Invalid transform choice`, try `@canary` — new transforms land there first.
 
 Inserts `export const instant = false` (with a `// TODO: Cache Components adoption` comment) into every `app/**/{page,layout,default}` file, skipping files that already declare `instant` and any module marked `"use client"` or `"use server"`. Then set `cacheComponents: true`. The TODO comments are the work queue for milestone B.
 


### PR DESCRIPTION
### What

Driven by three friction logs from agents running `next-cache-components-adoption` against starting points the skill silently assumed.

- Restructure `## requires` as a labeled checklist: **App Router project**, **Next.js 16.3 or later**, **No incompatible config keys**. Each item names what's checked, what the failure mode is, and where to resolve it.
- Hoist the **No green baseline before the flag** note out of the prereq pile into a separate `### notes` block (alongside **Offline docs**), so a reader scanning prereqs doesn't conflate it with a hard requirement.
- Tighten the codemod block: explain `@canary`'s necessity in one line so an agent hitting `Invalid transform choice` from `@latest` knows the workaround.

### Why

Three friction logs each hit a different version of the same gap:

- **react.dev migration**: agent ran codemod with `@latest` (16.2.9) → `Invalid transform choice` → applied transform by hand.
- **Marketing-site case**: agent built the spec with `revalidate` exports, codemod left them in, `cacheComponents: true` rejected the build.
- **E-commerce case**: `experimental.dynamicIO`/`useCache` left in `next.config` → fatal config error.

In each case the skill *technically* said what to do but it was buried.

### Related

The migration-guide changes that were originally in this PR moved to [#94997](https://github.com/vercel/next.js/pull/94997).

### Type of Change

- [x] Documentation (adds or changes documentation)

<!-- NEXT_JS_LLM_PR -->
