### PR TITLE
[cd] add ad-hoc preview release cut from canary

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -96,6 +96,9 @@ jobs:
               elif [[ "$RELEASE_VERSION" == *-rc.* ]];
               then
                 RELEASE_ENVIRONMENT="release-release-candidate"
+              elif [[ "$RELEASE_VERSION" == *-preview.* ]];
+              then
+                RELEASE_ENVIRONMENT="release-preview"
               elif [[ "$RELEASE_VERSION" != *-* ]];
               then
                 RELEASE_ENVIRONMENT="release-stable"

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: stable, canary, beta, or release candidate?
+        description: stable, canary, beta, preview, or release candidate?
         required: true
         type: choice
         options:
@@ -14,6 +14,7 @@ on:
           - stable
           - release-candidate
           - beta
+          - preview
 
       semverType:
         description: semver type?

--- a/scripts/github-utils/signed-commit.js
+++ b/scripts/github-utils/signed-commit.js
@@ -87,15 +87,24 @@ async function getTreeEntry(commitSha, filePath) {
 /**
  * Upload one file from a local commit as a GitHub blob and return the blob
  * SHA for the recreated tree entry.
+ *
+ * `request` defaults to the real `githubRequest`; callers can inject a mock
+ * (e.g. a dry-run logger) to exercise the flow without hitting the API.
  */
-async function createBlobForFile(token, repoApiPath, commitSha, filePath) {
+async function createBlobForFile(
+  token,
+  repoApiPath,
+  commitSha,
+  filePath,
+  request = githubRequest
+) {
   const content = await git(['show', `${commitSha}:${filePath}`], {
     captureOutput: true,
     encoding: null,
     stripFinalNewline: false,
     maxBuffer: 1024 * 1024 * 100,
   })
-  const blob = await githubRequest(token, 'POST', `${repoApiPath}/git/blobs`, {
+  const blob = await request(token, 'POST', `${repoApiPath}/git/blobs`, {
     content: Buffer.from(content).toString('base64'),
     encoding: 'base64',
   })
@@ -114,6 +123,7 @@ async function createTreeFromLocalCommit({
   baseTreeSha,
   localCommitSha,
   allowEmpty = false,
+  request = githubRequest,
 }) {
   const changedFiles = await getChangedFiles(diffBaseSha, localCommitSha)
 
@@ -150,7 +160,8 @@ async function createTreeFromLocalCommit({
         token,
         repoApiPath,
         localCommitSha,
-        filePath
+        filePath,
+        request
       )
 
       return {
@@ -162,15 +173,10 @@ async function createTreeFromLocalCommit({
     })
   )
 
-  const createdTree = await githubRequest(
-    token,
-    'POST',
-    `${repoApiPath}/git/trees`,
-    {
-      base_tree: baseTreeSha,
-      tree,
-    }
-  )
+  const createdTree = await request(token, 'POST', `${repoApiPath}/git/trees`, {
+    base_tree: baseTreeSha,
+    tree,
+  })
 
   return createdTree.sha
 }
@@ -243,6 +249,7 @@ async function replayLocalCommitsAsSigned({
   fromBaseSha,
   toLocalSha,
   allowEmpty = false,
+  request = githubRequest,
 }) {
   const repoApiPath = `/repos/${owner}/${repo}`
 
@@ -279,18 +286,14 @@ async function replayLocalCommitsAsSigned({
       baseTreeSha: parentTreeSha,
       localCommitSha: localSha,
       allowEmpty,
+      request,
     })
 
-    const commit = await githubRequest(
-      token,
-      'POST',
-      `${repoApiPath}/git/commits`,
-      {
-        message,
-        tree: treeSha,
-        parents: [parentSha],
-      }
-    )
+    const commit = await request(token, 'POST', `${repoApiPath}/git/commits`, {
+      message,
+      tree: treeSha,
+      parents: [parentSha],
+    })
 
     if (!commit.verification?.verified) {
       throw new Error(

--- a/scripts/github-utils/signed-commit.js
+++ b/scripts/github-utils/signed-commit.js
@@ -232,7 +232,9 @@ async function createSignedCommit({
  * top of the previous signed commit's tree. The local commit message is
  * preserved.
  *
- * Returns the SHA of the final signed commit.
+ * Returns `{ headSha, signedCommits }` where `headSha` is the final signed
+ * commit and `signedCommits` maps each local commit to its signed counterpart
+ * (`{ localSha, signedSha }`, in replay order).
  */
 async function replayLocalCommitsAsSigned({
   token,
@@ -260,6 +262,7 @@ async function replayLocalCommitsAsSigned({
   let parentTreeSha = await git(['rev-parse', `${fromBaseSha}^{tree}`], {
     captureOutput: true,
   })
+  const signedCommits = []
 
   for (const localSha of localCommits) {
     const localParentSha = await git(['rev-parse', `${localSha}^`], {
@@ -297,9 +300,10 @@ async function replayLocalCommitsAsSigned({
 
     parentSha = commit.sha
     parentTreeSha = treeSha
+    signedCommits.push({ localSha, signedSha: commit.sha })
   }
 
-  return parentSha
+  return { headSha: parentSha, signedCommits }
 }
 
 /**

--- a/scripts/release-github-api.js
+++ b/scripts/release-github-api.js
@@ -83,8 +83,16 @@ async function getSingleParent(commitSha) {
  * `options.baseSha` and `options.tagName` let the caller pin both explicitly
  * (required for preview, since after the revert `lerna.json` no longer matches
  * HEAD).
+ *
+ * `options.githubRequest` injects a custom GitHub client (signature matching
+ * `githubRequest`). A dry run passes a logging mock so the whole sign/tag/push
+ * flow is exercised without touching the API; when a mock is used the final
+ * local-branch sync is skipped (the signed commits don't exist on the remote).
  */
 async function createGitHubReleaseCommit(token, options = {}) {
+  const request = options.githubRequest ?? githubRequest
+  const usingMockClient = options.githubRequest != null
+
   const branch = await git(['rev-parse', '--abbrev-ref', 'HEAD'], {
     captureOutput: true,
   })
@@ -112,6 +120,7 @@ async function createGitHubReleaseCommit(token, options = {}) {
     repo: 'next.js',
     fromBaseSha: baseSha,
     toLocalSha: localHead,
+    request,
   })
 
   const taggedCommit = signedCommits.find(
@@ -127,24 +136,19 @@ async function createGitHubReleaseCommit(token, options = {}) {
   let createdTag = false
 
   try {
-    await githubRequest(token, 'POST', `${REPO_API_PATH}/git/refs`, {
+    await request(token, 'POST', `${REPO_API_PATH}/git/refs`, {
       ref: `refs/tags/${tagName}`,
       sha: signedTagSha,
     })
     createdTag = true
 
-    await githubRequest(
-      token,
-      'PATCH',
-      `${REPO_API_PATH}/git/refs/heads/${branch}`,
-      {
-        sha: headSha,
-        force: false,
-      }
-    )
+    await request(token, 'PATCH', `${REPO_API_PATH}/git/refs/heads/${branch}`, {
+      sha: headSha,
+      force: false,
+    })
   } catch (error) {
     if (createdTag) {
-      await githubRequest(
+      await request(
         token,
         'DELETE',
         `${REPO_API_PATH}/git/refs/tags/${tagName}`
@@ -157,7 +161,15 @@ async function createGitHubReleaseCommit(token, options = {}) {
     throw error
   }
 
-  await alignLocalBranchWithSignedCommit(branch, headSha, { tagName })
+  if (usingMockClient) {
+    // The signed commits only exist in the mock; there is nothing on the remote
+    // to sync the local branch against.
+    console.log(
+      `Dry run: skipping local branch sync; would set ${branch} to ${headSha} and tag ${tagName} at ${signedTagSha}`
+    )
+  } else {
+    await alignLocalBranchWithSignedCommit(branch, headSha, { tagName })
+  }
 
   console.log(
     `Created GitHub-signed release tag ${tagName} at ${signedTagSha}; branch ${branch} now at ${headSha}`

--- a/scripts/release-github-api.js
+++ b/scripts/release-github-api.js
@@ -3,7 +3,7 @@
 const execa = require('execa')
 const fs = require('fs/promises')
 const {
-  createSignedCommit,
+  replayLocalCommitsAsSigned,
   githubRequest,
   alignLocalBranchWithSignedCommit,
 } = require('./github-utils/signed-commit')
@@ -68,10 +68,23 @@ async function getSingleParent(commitSha) {
 }
 
 /**
- * Replace Lerna's local release commit with an equivalent GitHub-signed commit,
- * then move the release tag and current branch to that new commit.
+ * Replace Lerna's local release commit(s) with equivalent GitHub-signed
+ * commits, then move the release tag and current branch in a single branch
+ * push.
+ *
+ * Signs every local commit between the remote base and local HEAD. The release
+ * tag is placed on the signed commit that corresponds to the local Lerna
+ * release commit; the branch is fast-forwarded to the final signed commit.
+ *
+ * For a normal release this is a single commit (tag == branch head). For an
+ * ad-hoc preview release the local history is two commits — the preview
+ * version bump (tagged) followed by a revert restoring the canary version — so
+ * the tag points at the preview commit while the branch ends on the revert.
+ * `options.baseSha` and `options.tagName` let the caller pin both explicitly
+ * (required for preview, since after the revert `lerna.json` no longer matches
+ * HEAD).
  */
-async function createGitHubReleaseCommit(token) {
+async function createGitHubReleaseCommit(token, options = {}) {
   const branch = await git(['rev-parse', '--abbrev-ref', 'HEAD'], {
     captureOutput: true,
   })
@@ -80,34 +93,43 @@ async function createGitHubReleaseCommit(token) {
     throw new Error('Cannot create a GitHub release commit from detached HEAD')
   }
 
-  const localReleaseSha = await git(['rev-parse', 'HEAD'], {
+  const localHead = await git(['rev-parse', 'HEAD'], {
     captureOutput: true,
   })
-  const baseSha = await getSingleParent(localReleaseSha)
-  const tagName = await getLocalReleaseTagName(localReleaseSha)
-  const message = await git(['log', '-1', '--pretty=%B'], {
+  const baseSha = options.baseSha ?? (await getSingleParent(localHead))
+  const tagName = options.tagName ?? (await getLocalReleaseTagName(localHead))
+  const localTaggedSha = await git(['rev-list', '-n', '1', tagName], {
     captureOutput: true,
   })
 
   console.log(
-    `Creating GitHub-signed release commit for ${tagName} from local Lerna commit ${localReleaseSha}`
+    `Creating GitHub-signed release commit(s) for ${tagName} from local commits ${baseSha}..${localHead}`
   )
 
-  const commit = await createSignedCommit({
+  const { headSha, signedCommits } = await replayLocalCommitsAsSigned({
     token,
     owner: 'vercel',
     repo: 'next.js',
-    baseSha,
-    localCommitSha: localReleaseSha,
-    message,
+    fromBaseSha: baseSha,
+    toLocalSha: localHead,
   })
+
+  const taggedCommit = signedCommits.find(
+    (entry) => entry.localSha === localTaggedSha
+  )
+  if (!taggedCommit) {
+    throw new Error(
+      `Could not find a signed commit for the release tag ${tagName} (local ${localTaggedSha})`
+    )
+  }
+  const signedTagSha = taggedCommit.signedSha
 
   let createdTag = false
 
   try {
     await githubRequest(token, 'POST', `${REPO_API_PATH}/git/refs`, {
       ref: `refs/tags/${tagName}`,
-      sha: commit.sha,
+      sha: signedTagSha,
     })
     createdTag = true
 
@@ -116,7 +138,7 @@ async function createGitHubReleaseCommit(token) {
       'PATCH',
       `${REPO_API_PATH}/git/refs/heads/${branch}`,
       {
-        sha: commit.sha,
+        sha: headSha,
         force: false,
       }
     )
@@ -135,16 +157,18 @@ async function createGitHubReleaseCommit(token) {
     throw error
   }
 
-  await alignLocalBranchWithSignedCommit(branch, commit.sha, { tagName })
+  await alignLocalBranchWithSignedCommit(branch, headSha, { tagName })
 
   console.log(
-    `Created GitHub-signed release commit ${commit.sha} and tag ${tagName}`
+    `Created GitHub-signed release tag ${tagName} at ${signedTagSha}; branch ${branch} now at ${headSha}`
   )
 
   return {
     branch,
-    sha: commit.sha,
+    sha: signedTagSha,
     tagName,
+    headSha,
+    baseSha,
   }
 }
 

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -1,6 +1,8 @@
 // @ts-check
 const path = require('path')
 const execa = require('execa')
+const fs = require('fs/promises')
+const semver = require('semver')
 const resolveFrom = require('resolve-from')
 const {
   configureGitHubAuth,
@@ -12,6 +14,61 @@ const { createGitHubReleaseCommit } = require('./release-github-api')
 
 const SEMVER_TYPES = ['patch', 'minor', 'major']
 
+/**
+ * Compute the next `@preview` version when cutting ad-hoc from `canary`.
+ *
+ * Unlike the other prerelease channels, the preview line has no branch of its
+ * own to hold its counter (we cut from canary and immediately revert the
+ * version), so the next number is derived from the highest of the current
+ * canary base and the published `next@preview` version:
+ *
+ *   base = max(canary major.minor.patch, npm @preview major.minor.patch)
+ *   - base still on the published preview line -> continue it (n + 1)
+ *   - canary advanced to a higher base (or no @preview published) -> reset to .0
+ *
+ * e.g. canary 16.3.0-canary.61 + @preview 16.3.0-preview.5 -> 16.3.0-preview.6;
+ * if canary had advanced to 18.0.0-canary.x -> 18.0.0-preview.0.
+ */
+async function computePreviewVersion(canaryVersion) {
+  const parsed = semver.parse(canaryVersion)
+  if (!parsed) {
+    throw new Error(`Invalid version in lerna.json: ${canaryVersion}`)
+  }
+  const canaryBase = `${parsed.major}.${parsed.minor}.${parsed.patch}`
+
+  let previewTag
+  try {
+    const res = await fetch(
+      'https://registry.npmjs.org/-/package/next/dist-tags'
+    )
+    const tags = await res.json()
+    previewTag = tags.preview
+  } catch (error) {
+    console.log('Failed to fetch Next.js dist tags from the NPM registry.')
+    throw error
+  }
+
+  // Default: start a fresh preview line at the current canary base.
+  let version = `${canaryBase}-preview.0`
+
+  if (previewTag) {
+    const parsedPreview = semver.parse(previewTag)
+    if (parsedPreview) {
+      const previewBase = `${parsedPreview.major}.${parsedPreview.minor}.${parsedPreview.patch}`
+      // Continue the published preview line only while the canary base hasn't
+      // moved past it; otherwise keep the fresh `.0` at the higher base.
+      if (semver.gte(previewBase, canaryBase)) {
+        const incremented = semver.inc(previewTag, 'prerelease', 'preview')
+        if (incremented) {
+          version = incremented
+        }
+      }
+    }
+  }
+
+  return version
+}
+
 async function main() {
   const args = process.argv
   const releaseType = args[args.indexOf('--release-type') + 1]
@@ -19,20 +76,24 @@ async function main() {
   const isCanary = releaseType === 'canary'
   const isReleaseCandidate = releaseType === 'release-candidate'
   const isBeta = releaseType === 'beta'
+  const isPreview = releaseType === 'preview'
   const dryRun = args.includes('--dry-run')
 
   if (
     releaseType !== 'stable' &&
     releaseType !== 'canary' &&
     releaseType !== 'release-candidate' &&
-    releaseType !== 'beta'
+    releaseType !== 'beta' &&
+    releaseType !== 'preview'
   ) {
     console.log(
-      `Invalid release type ${releaseType}, must be stable, canary, release-candidate, or beta`
+      `Invalid release type ${releaseType}, must be stable, canary, release-candidate, beta, or preview`
     )
     return
   }
-  if (!isCanary && !SEMVER_TYPES.includes(semverType)) {
+  // canary and preview derive their version automatically, so they don't need
+  // a semver type.
+  if (!isCanary && !isPreview && !SEMVER_TYPES.includes(semverType)) {
     console.log(
       `Invalid semver type ${semverType}, must be one of ${SEMVER_TYPES.join(
         ', '
@@ -71,6 +132,22 @@ async function main() {
   }
 
   console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
+
+  const { version: canaryVersion } = JSON.parse(
+    await fs.readFile(path.join(process.cwd(), 'lerna.json'), 'utf-8')
+  )
+
+  // The current branch tip, captured before Lerna creates the release
+  // commit(s). For a preview release this is the base that both the
+  // preview-bump and the revert-to-canary commits are signed on top of.
+  const { stdout: baseSha } = await execa('git', ['rev-parse', 'HEAD'])
+
+  // Preview cuts ad-hoc from canary use an explicit, computed version rather
+  // than a Lerna prerelease bump (see computePreviewVersion).
+  const previewVersion = isPreview
+    ? await computePreviewVersion(canaryVersion)
+    : null
+
   const preleaseType =
     semverType === 'major'
       ? 'premajor'
@@ -78,11 +155,11 @@ async function main() {
         ? 'preminor'
         : 'prerelease'
 
-  const lernaArgs = [
-    'lerna',
-    'version',
-    isCanary || isReleaseCandidate || isBeta ? preleaseType : semverType,
-  ]
+  const versionArg =
+    previewVersion ??
+    (isCanary || isReleaseCandidate || isBeta ? preleaseType : semverType)
+
+  const lernaArgs = ['lerna', 'version', versionArg]
 
   if (isCanary) {
     lernaArgs.push('--preid', 'canary')
@@ -106,14 +183,37 @@ async function main() {
 
   await child
 
+  if (isPreview) {
+    // Lerna's bump commit (now HEAD, tagged v<previewVersion>) carries the
+    // preview versions. Add a second commit that restores the canary versions
+    // so `canary` keeps advancing its own line; the preview tag still points at
+    // the bump commit. Both land in a single push (see
+    // createGitHubReleaseCommit). The message intentionally does not end in a
+    // version so check-is-release.js doesn't treat the new canary HEAD as a
+    // publish commit.
+    await execa('git', ['revert', '--no-commit', 'HEAD'], { stdio: 'inherit' })
+    await execa(
+      'git',
+      [
+        'commit',
+        '-m',
+        `Restore canary version ${canaryVersion} after v${previewVersion} preview release`,
+      ],
+      { stdio: 'inherit' }
+    )
+  }
+
   if (dryRun) {
     console.log(
       'Dry run: skipping GitHub-signed release commit and GitHub release creation'
     )
   } else {
-    await createGitHubReleaseCommit(githubToken)
+    await createGitHubReleaseCommit(
+      githubToken,
+      isPreview ? { baseSha, tagName: `v${previewVersion}` } : {}
+    )
 
-    if (isCanary || isReleaseCandidate || isBeta) {
+    if (isCanary || isReleaseCandidate || isBeta || isPreview) {
       const releaseChild = execa(
         'pnpm',
         ['release', '--pre', '--skip-questions', '--show-url'],

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -152,7 +152,7 @@ async function main() {
     )
   }
 
-  console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
+  console.log(`Running pnpm release-${releaseType}...`)
 
   const { version: canaryVersion } = JSON.parse(
     await fs.readFile(path.join(process.cwd(), 'lerna.json'), 'utf-8')

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -15,6 +15,27 @@ const { createGitHubReleaseCommit } = require('./release-github-api')
 const SEMVER_TYPES = ['patch', 'minor', 'major']
 
 /**
+ * A GitHub client (matching the `githubRequest` signature) for dry runs: it
+ * just logs the request and returns a minimal canned response instead of
+ * hitting the API, so the sign/tag/push flow can be exercised without creating
+ * remote refs. Bodies are not logged (blob uploads carry base64 file contents).
+ */
+function createMockGitHubRequest() {
+  let counter = 0
+
+  return async function mockGitHubRequest(_token, method, apiPath) {
+    console.log(`[dry-run] GitHub API ${method} ${apiPath}`)
+
+    // One canned shape covers every consumer: `.sha` (blobs/trees/commits) and
+    // `.verification.verified` (commits). Ref writes ignore the return value.
+    return {
+      sha: (++counter).toString(16).padStart(40, '0'),
+      verification: { verified: true },
+    }
+  }
+}
+
+/**
  * Compute the next `@preview` version when cutting ad-hoc from `canary`.
  *
  * Unlike the other prerelease channels, the preview line has no branch of its
@@ -203,15 +224,24 @@ async function main() {
     )
   }
 
+  const releaseCommitOptions = isPreview
+    ? { baseSha, tagName: `v${previewVersion}` }
+    : {}
+
   if (dryRun) {
+    // Exercise the full sign/tag/push flow with a mock GitHub client that logs
+    // instead of calling the API, so the replay and tagging logic is covered
+    // without creating any remote commits, tags, or refs.
     console.log(
-      'Dry run: skipping GitHub-signed release commit and GitHub release creation'
+      'Dry run: creating GitHub-signed release commit(s) with a mock GitHub client (no API calls)'
     )
+    await createGitHubReleaseCommit(githubToken, {
+      ...releaseCommitOptions,
+      githubRequest: createMockGitHubRequest(),
+    })
+    console.log('Dry run: skipping GitHub release creation')
   } else {
-    await createGitHubReleaseCommit(
-      githubToken,
-      isPreview ? { baseSha, tagName: `v${previewVersion}` } : {}
-    )
+    await createGitHubReleaseCommit(githubToken, releaseCommitOptions)
 
     if (isCanary || isReleaseCandidate || isBeta || isPreview) {
       const releaseChild = execa(

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -16,15 +16,27 @@ const SEMVER_TYPES = ['patch', 'minor', 'major']
 
 /**
  * A GitHub client (matching the `githubRequest` signature) for dry runs: it
- * just logs the request and returns a minimal canned response instead of
- * hitting the API, so the sign/tag/push flow can be exercised without creating
- * remote refs. Bodies are not logged (blob uploads carry base64 file contents).
+ * logs the request (method, path, and body) and returns a minimal canned
+ * response instead of hitting the API, so the sign/tag/push flow can be
+ * exercised without creating remote refs. Long string values (e.g. the base64
+ * blob content of file uploads) are truncated so the log stays readable.
  */
 function createMockGitHubRequest() {
   let counter = 0
 
-  return async function mockGitHubRequest(_token, method, apiPath) {
-    console.log(`[dry-run] GitHub API ${method} ${apiPath}`)
+  const formatBody = (body) =>
+    JSON.stringify(body, (_key, value) =>
+      typeof value === 'string' && value.length > 200
+        ? `${value.slice(0, 120)}… (${value.length} chars)`
+        : value
+    )
+
+  return async function mockGitHubRequest(_token, method, apiPath, body) {
+    console.log(
+      `[dry-run] GitHub API ${method} ${apiPath}${
+        body ? ` ${formatBody(body)}` : ''
+      }`
+    )
 
     // One canned shape covers every consumer: `.sha` (blobs/trees/commits) and
     // `.verification.verified` (commits). Ref writes ignore the return value.

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -684,7 +684,7 @@ Or run this command again without the --no-install flag to do both automatically
       await execa('git', ['rev-parse', 'HEAD'])
     ).stdout.trim()
 
-    const finalSignedSha = await replayLocalCommitsAsSigned({
+    const { headSha: finalSignedSha } = await replayLocalCommitsAsSigned({
       token: releaseGithubToken,
       owner: repoOwner,
       repo: repoName,


### PR DESCRIPTION
Add a `preview` release type so `@preview` npm releases can be cut **ad-hoc from `canary`** via the `Trigger Release` workflow, retiring the dedicated long-lived preview branch. The GitHub environment has been updated accordingly.

A preview cut produces **two commits**, pushed in a single update:

1. **Bump-to-preview** — all packages set to the computed preview version, tagged `v…-preview.N`. This tag's build publishes `@preview` (relies on #95085).
2. **Revert-to-canary** — restores the `-canary.N` versions so `canary` keeps advancing its own line and isn't stranded on a preview version.

```
B  canary HEAD before cut (e.g. 16.3.0-canary.61)
│
P  v16.3.0-preview.N   ← tag here; tag build publishes @preview
│
R  canary HEAD after cut (versions restored to 16.3.0-canary.61)
```

### Preview version numbering

`base = max(canary major.minor.patch, npm @preview major.minor.patch)`:
- base still on the published preview line → continue it (`n + 1`)
- canary advanced to a higher base (or no `@preview` published) → reset to `.0`

So if `canary` jumps to `18.0.0-canary.x` since the last `16.3.0-preview.x`, the next cut is `18.0.0-preview.0`, not a continuation.

## Test plan

The dry mode of `start-release.js` was extended to intercept the GH requests and log the relevant data.

```console
$ node ./scripts/start-release.js --release-type preview --dry-run
Dry run: keeping commits locally, skipping git push and GitHub release creation
Running pnpm release-preview...
[...]
> lerna version 16.3.0-preview.4 --force-publish -y --no-push --allow-branch '**'
[...]
Creating GitHub-signed release commit(s) for v16.3.0-preview.4 from local commits 0f5c1e865cc34edb257a16823ed6525d9cd58bfc..0062348c411776271fe7eac64e97b8bad2775b77
[dry-run] GitHub API POST /repos/vercel/next.js/git/blobs [...]
[dry-run] GitHub API POST /repos/vercel/next.js/git/commits {"message":"v16.3.0-preview.4","tree":"0000000000000000000000000000000000000016","parents":["0f5c1e865cc34edb257a16823ed6525d9cd58bfc"]}
[dry-run] GitHub API POST /repos/vercel/next.js/git/commits {"message":"Restore canary version 16.3.0-canary.61 after v16.3.0-preview.4 preview release","tree":"000000000000000000000000000000000000002d","parents":["0000000000000000000000000000000000000017"]}
[dry-run] GitHub API POST /repos/vercel/next.js/git/refs {"ref":"refs/tags/v16.3.0-preview.4","sha":"0000000000000000000000000000000000000017"}
[dry-run] GitHub API PATCH /repos/vercel/next.js/git/refs/heads/sebbie/preview-release-from-canary {"sha":"000000000000000000000000000000000000002e","force":false}
Dry run: skipping local branch sync; would set sebbie/preview-release-from-canary to 000000000000000000000000000000000000002e and tag v16.3.0-preview.4 at 0000000000000000000000000000000000000017
Created GitHub-signed release tag v16.3.0-preview.4 at 0000000000000000000000000000000000000017; branch sebbie/preview-release-from-canary now at 000000000000000000000000000000000000002e
Dry run: skipping GitHub release creation
Release process is finished
```
