### PR TITLE
fix(codemod): don't double-add '.' after boolean ESLint --fix flag (#84616)

### DIFF
--- a/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
+++ b/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
@@ -907,6 +907,9 @@ function updatePackageJsonScripts(packageJsonContent: string): {
 
               if (token === '--strict') {
                 eslintArgs.push('--max-warnings', '0')
+              } else if (token === '--fix' || token === '--fix-dry-run') {
+                // Boolean flags: do not consume the next token as a value.
+                eslintArgs.push(token)
               } else if (token === '--dir' && i + 1 < argTokens.length) {
                 paths.push(argTokens[++i])
               } else if (token === '--file' && i + 1 < argTokens.length) {


### PR DESCRIPTION
Closes #84616

## Description

The `next-lint-to-eslint-cli` codemod transformed scripts like `"next lint --fix ."` into `"eslint --fix . ."`. The parser was treating the trailing path token as the value of the `--fix` flag, causing it to insert that path *and* the default `.` placeholder.

ESLint's `--fix` and `--fix-dry-run` are boolean flags (no value), so the next token should fall through to the positional directory parser instead. Adding an explicit branch in the token loop to push them through unchanged removes the double `.` artifact.

## Test plan

- Existing fixtures continue to assert `"next lint --fix && npm test"` → `"eslint --fix . && npm test"` (verified by reading the test and tracing manually).
- The existing tests are unchanged. A fixture case for `"next lint --fix ."` would be a nice follow-up but is out of scope of this single-fix PR.

## AI assistance

Used an AI coding assistant to draft the diff; verified by hand against the existing token-loop branches (`--strict` case for boolean flag handling).