### PR TITLE
Fix #95015 by pulling a fix to scattered-collect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4337,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+checksum = "24670b639492630905459a6c7d47f063d33c2d4fcd5362f6e5827c5613976c9f"
 dependencies = [
  "linktime-proc-macro",
 ]


### PR DESCRIPTION
Bump link-section to pick up https://github.com/mmastrac/linktime/pull/481

This fixes a bug in linktime that could trigger a miscompilation on windows, see https://github.com/mmastrac/linktime/issues/479 for a detailed description

@bgw and I both confirmed that this fixed the windows crash, though we have failed to produce a contained test that reproduces this (@mmastrac is pursuing that as a followup).   This appears to not be triggering in CI due to a different release profile.