### PR TITLE
Suppress prefetch={true} warning when route opts out via instant = false

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -255,12 +255,17 @@ export function navigateToKnownRoute(
     // where we don't prefetch, the warning only appears when you actually
     // navigate to the route — existing apps with many `prefetch={true}` links
     // aren't flooded with warnings the moment they enable Cache Components.
+    //
+    // The warning is suppressed if any segment on the target route exports
+    // `instant = false`, which is the explicit API for opting a route out of
+    // this validation.
     const link = getLinkForCurrentNavigation()
     if (
       link !== null &&
       link.fetchStrategy === FetchStrategy.Full &&
       (navigationSeed.routeTree.prefetchHints &
-        PrefetchHint.SubtreeHasPartialPrefetching) ===
+        (PrefetchHint.SubtreeHasPartialPrefetching |
+          PrefetchHint.SubtreeHasInstantFalse)) ===
         0
     ) {
       const error = new Error(

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -104,6 +104,11 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     (typeof instantConfig === 'object' && instantConfig !== null)
   if (isInstant) {
     prefetchHints |= PrefetchHint.SubtreeHasPartialPrefetching
+  } else if (instantConfig === false) {
+    // The segment explicitly opts out of Partial Prefetching. We don't change
+    // the prefetch behavior, but we record it so the dev-time
+    // `<Link prefetch={true}>` warning can be suppressed for this route.
+    prefetchHints |= PrefetchHint.SubtreeHasInstantFalse
   }
 
   if (prefetchConfig === 'partial') {

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -230,6 +230,12 @@ export const enum PrefetchHint {
   // shared app shell and skips its Speculative prefetch. Propagates upward so
   // the root reflects the entire subtree.
   SubtreeHasEagerPrefetch = 0b1000000000000,
+  // This segment or one of its descendants exports `instant = false`,
+  // explicitly opting out of Partial Prefetching. Propagates upward so the root
+  // reflects the entire subtree. Used only to suppress the dev-time
+  // `<Link prefetch={true}>` warning — unlike PrefetchDisabled, it has no effect
+  // on the actual prefetch behavior.
+  SubtreeHasInstantFalse = 0b10000000000000,
 }
 
 /**
@@ -254,6 +260,7 @@ export const SubtreePrefetchHints =
   PrefetchHint.SubtreeHasPartialPrefetching |
   PrefetchHint.SubtreeHasLoadingBoundary |
   PrefetchHint.SubtreeHasRuntimePrefetch |
+  PrefetchHint.SubtreeHasInstantFalse |
   PrefetchHint.SubtreeHasEagerPrefetch
 
 /**
@@ -294,6 +301,11 @@ export function propagateSubtreeBits(
   // there's no separate segment-local flag — propagate it as-is.
   if (childHints & PrefetchHint.SubtreeHasEagerPrefetch) {
     parentHints |= PrefetchHint.SubtreeHasEagerPrefetch
+  }
+  // And for `instant = false`. Like eager prefetch, the bit is set directly on
+  // each opted-out segment, so propagate it as-is.
+  if (childHints & PrefetchHint.SubtreeHasInstantFalse) {
+    parentHints |= PrefetchHint.SubtreeHasInstantFalse
   }
   return parentHints
 }

--- a/test/development/app-dir/prefetch-true-partial-warning/app/instant-false-layout/layout.tsx
+++ b/test/development/app-dir/prefetch-true-partial-warning/app/instant-false-layout/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+
+// `instant = false` lives on the layout, not the page. The
+// SubtreeHasInstantFalse hint should propagate up from the layout to the root,
+// so a `prefetch={true}` link to a page underneath it should NOT warn.
+export const instant = false
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>
+}

--- a/test/development/app-dir/prefetch-true-partial-warning/app/instant-false-layout/page.tsx
+++ b/test/development/app-dir/prefetch-true-partial-warning/app/instant-false-layout/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// No config on the page itself — the `instant = false` opt-out comes from the
+// parent layout and should still suppress the warning.
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Layout-instant-false static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Layout-instant-false dynamic</div>
+}

--- a/test/development/app-dir/prefetch-true-partial-warning/app/instant-false-route/page.tsx
+++ b/test/development/app-dir/prefetch-true-partial-warning/app/instant-false-route/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// Explicitly opts out of partial prefetching via `instant = false`. This is the
+// API for silencing the warning, so navigating here via a `prefetch={true}`
+// link should NOT warn even though there's no partial prefetching opt-in.
+export const instant = false
+
+export default function Page() {
+  return (
+    <main>
+      <div id="static-content">Instant-false static</div>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Instant-false dynamic</div>
+}

--- a/test/development/app-dir/prefetch-true-partial-warning/app/page.tsx
+++ b/test/development/app-dir/prefetch-true-partial-warning/app/page.tsx
@@ -23,6 +23,20 @@ export default function Page() {
               even though the route has no partial prefetching opt-in */}
           <LinkAccordion href="/control-route">/control-route</LinkAccordion>
         </li>
+        <li>
+          {/* prefetch={true} but the page exports `instant = false`, the
+              explicit opt-out => should NOT warn */}
+          <LinkAccordion href="/instant-false-route" prefetch={true}>
+            /instant-false-route
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* prefetch={true} and `instant = false` is on a parent layout (not
+              the page) => should NOT warn (the hint propagates up) */}
+          <LinkAccordion href="/instant-false-layout" prefetch={true}>
+            /instant-false-layout
+          </LinkAccordion>
+        </li>
       </ul>
     </main>
   )

--- a/test/development/app-dir/prefetch-true-partial-warning/prefetch-true-partial-warning.test.ts
+++ b/test/development/app-dir/prefetch-true-partial-warning/prefetch-true-partial-warning.test.ts
@@ -88,4 +88,38 @@ describe('prefetch-true-partial-warning', () => {
       })
     )
   })
+
+  it('does not warn when the target page exports instant = false', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/instant-false-route')
+
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Instant-false dynamic'
+    )
+
+    expect(await browser.log()).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
+
+  it('does not warn when instant = false is set on a parent layout', async () => {
+    const browser = await next.browser('/')
+    await navigateViaAccordion(browser, '/instant-false-layout')
+
+    await browser.waitForElementByCss('#dynamic-content')
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Layout-instant-false dynamic'
+    )
+
+    expect(await browser.log()).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining(WARNING),
+      })
+    )
+  })
 })


### PR DESCRIPTION
In dev with Cache Components, navigating via a `<Link prefetch={true}>` to a route that hasn't opted into Partial Prefetching logs a warning, since the full prefetch pulls in dynamic data and defeats the static/dynamic split.

`instant = false` is the explicit API for opting a route out of this validation, so it should silence the warning. Previously it didn't: an `instant = false` segment set no prefetch hint at all, so the warning still fired.

Add a `SubtreeHasInstantFalse` PrefetchHint, set on any segment that exports `instant = false` and propagated up to the root (mirroring `SubtreeHasPartialPrefetching`). The dev warning now skips routes where this bit is present anywhere on the target subtree.

This is warning-only and kept separate from the existing `PrefetchDisabled` bit, which feeds `StaticPrefetchDisabled` and would change actual prefetch behavior.
