### PR TITLE
Keep the resolved cache life for `cacheMaxMemorySize: 0` caches in dev

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1083,14 +1083,15 @@ async function collectResult(
   // DYNAMIC_EXPIRE`) for private caches, which have no real backing handler.
   // The zero revalidate makes every read serve stale-while-revalidate
   // (regenerating a fresh entry in the background), and `DYNAMIC_EXPIRE` (5
-  // minutes, the shortest expire not treated as dynamically shortened) bounds
-  // how long an entry lingers in the dedicated in-memory private handler. The
-  // size-0 case (`cacheMaxMemorySize: 0`) deliberately does NOT force this: it
-  // keeps its resolved cache life so that the cache entry can be considered
-  // prerenderable instead of being misread as a dynamic hole, and a separate
-  // dev revalidation (see the cache-hit path below) keeps its reloads showing a
-  // fresh value. Custom kinds keep their real cache life too, since their
-  // backing handler owns it.
+  // minutes) caps how long an entry lingers in the dedicated in-memory private
+  // handler. It is the shortest `expire` that isn't treated as dynamic; a
+  // smaller `expire` would exclude the entry from prerenders. The size-0 case
+  // (`cacheMaxMemorySize: 0`) deliberately does NOT force this: it keeps its
+  // resolved cache life so that the cache entry can be considered prerenderable
+  // instead of being misread as a dynamic hole, and a separate dev revalidation
+  // (see the cache-hit path below) keeps its reloads showing a fresh value.
+  // Custom kinds keep their real cache life too, since their backing handler
+  // owns it.
   const forceDynamicCacheLifeInDev = isPrivateCacheInDev
 
   // If cacheLife() was used to set an explicit revalidate/expire/stale time we
@@ -3113,10 +3114,10 @@ export async function cache(
           // `revalidate`), so the next read gets a fresh value without blocking
           // this one. In development with the in-memory cache disabled
           // (`cacheMaxMemorySize: 0`), built-in entries keep their resolved
-          // (potentially non-dynamic) cache life, so a warm hit from the dev
-          // in-memory cache is normally fresh and wouldn't revalidate;
-          // revalidate those on every dynamic request render too, so each
-          // reload still shows a fresh value.
+          // (potentially non-dynamic) cache life, so an entry read back from
+          // the dev in-memory cache is normally still fresh and wouldn't
+          // revalidate on its own; revalidate those on every dynamic request
+          // render too, so each reload still shows a fresh value.
           let shouldTriggerBackgroundRevalidation =
             currentTime > entry.timestamp + entry.revalidate * 1000
           if (

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3124,7 +3124,7 @@ export async function cache(
             !shouldTriggerBackgroundRevalidation &&
             process.env.__NEXT_DEV_SERVER &&
             isMemoryCacheDisabled() &&
-            !isCustomCacheHandler(cacheContext.kind)
+            !isCustomCacheHandler(kind)
           ) {
             switch (workUnitStore.type) {
               case 'request':

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1080,21 +1080,18 @@ async function collectResult(
   )
 
   // In development, force a dynamic cache life (`revalidate: 0`, `expire:
-  // DYNAMIC_EXPIRE`) for caches that have no real backing: private caches, and
-  // any built-in (non-custom) kind when the in-memory cache is disabled
-  // (`cacheMaxMemorySize: 0`). The zero revalidate makes every read serve
-  // stale-while-revalidate (re-warming a fresh entry in the background) so warm
-  // reloads stay fast, and `DYNAMIC_EXPIRE` (5 minutes, the shortest expire not
-  // treated as dynamically shortened) bounds how long an entry lingers in the
-  // dev in-memory cache. Custom kinds keep their real cache life, since their
+  // DYNAMIC_EXPIRE`) for private caches, which have no real backing handler.
+  // The zero revalidate makes every read serve stale-while-revalidate
+  // (regenerating a fresh entry in the background), and `DYNAMIC_EXPIRE` (5
+  // minutes, the shortest expire not treated as dynamically shortened) bounds
+  // how long an entry lingers in the dedicated in-memory private handler. The
+  // size-0 case (`cacheMaxMemorySize: 0`) deliberately does NOT force this: it
+  // keeps its resolved cache life so that the cache entry can be considered
+  // prerenderable instead of being misread as a dynamic hole, and a separate
+  // dev revalidation (see the cache-hit path below) keeps its reloads showing a
+  // fresh value. Custom kinds keep their real cache life too, since their
   // backing handler owns it.
-  const forceDynamicCacheLifeInDev =
-    isPrivateCacheInDev ||
-    Boolean(
-      process.env.__NEXT_DEV_SERVER &&
-        isMemoryCacheDisabled() &&
-        !isCustomCacheHandler(cacheContext.kind)
-    )
+  const forceDynamicCacheLifeInDev = isPrivateCacheInDev
 
   // If cacheLife() was used to set an explicit revalidate/expire/stale time we
   // use that. Otherwise, we use the lowest of all inner fetch(),
@@ -3112,10 +3109,40 @@ export async function cache(
             entry: sharedCacheEntry,
           })
 
-          if (currentTime > entry.timestamp + entry.revalidate * 1000) {
-            // If this is stale, and we're not in a prerender (i.e. this is
-            // dynamic render), then we should warm up the cache with a fresh
-            // revalidated entry.
+          // Trigger a background revalidation when the entry is stale (past its
+          // `revalidate`), so the next read gets a fresh value without blocking
+          // this one. In development with the in-memory cache disabled
+          // (`cacheMaxMemorySize: 0`), built-in entries keep their resolved
+          // (potentially non-dynamic) cache life, so a warm hit from the dev
+          // in-memory cache is normally fresh and wouldn't revalidate;
+          // revalidate those on every dynamic request render too, so each
+          // reload still shows a fresh value.
+          let shouldTriggerBackgroundRevalidation =
+            currentTime > entry.timestamp + entry.revalidate * 1000
+          if (
+            !shouldTriggerBackgroundRevalidation &&
+            process.env.__NEXT_DEV_SERVER &&
+            isMemoryCacheDisabled() &&
+            !isCustomCacheHandler(cacheContext.kind)
+          ) {
+            switch (workUnitStore.type) {
+              case 'request':
+                shouldTriggerBackgroundRevalidation = true
+                break
+              case 'cache':
+              case 'private-cache':
+              case 'prerender':
+              case 'prerender-runtime':
+              case 'prerender-legacy':
+              case 'unstable-cache':
+              case 'generate-static-params':
+                break
+              default:
+                workUnitStore satisfies never
+            }
+          }
+
+          if (shouldTriggerBackgroundRevalidation) {
             const revalidateCacheHandlerKey = cacheHandlerKey
             const revalidatePromise = generateCacheEntry(
               workStore,

--- a/test/development/app-dir/use-cache-size-zero/app/[slug]/page.tsx
+++ b/test/development/app-dir/use-cache-size-zero/app/[slug]/page.tsx
@@ -13,7 +13,7 @@ export function generateStaticParams() {
 async function getCachedValue(slug: string) {
   'use cache'
 
-  // A slow generation, so a warm reload that serves the stale entry is
+  // A slow generation, so a warm reload that serves the cached entry is
   // observably faster than a cold load that has to generate, and so a cold read
   // is still pending at a staged-render boundary (which surfaces the cold cache
   // indicator). The slug keys the entry; the value itself is just a timestamp.

--- a/test/development/app-dir/use-cache-size-zero/app/page.tsx
+++ b/test/development/app-dir/use-cache-size-zero/app/page.tsx
@@ -1,0 +1,5 @@
+export default async function Home() {
+  'use cache'
+
+  return <p>Hello, world!</p>
+}

--- a/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
+++ b/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry, waitFor } from 'next-test-utils'
+import { retry, waitFor, waitForNoErrorToast } from 'next-test-utils'
 
 describe('use-cache-size-zero', () => {
   const { next, skipped } = nextTestSetup({
@@ -34,10 +34,11 @@ describe('use-cache-size-zero', () => {
       .text()
 
     // Warm reload: `cacheMaxMemorySize: 0` still caches in development, so the
-    // reload serves the same (stale) cached value instead of regenerating it.
-    // The forced `revalidate: 0` keeps the value a dynamic hole, so it still
-    // streams behind the loading boundary - but it's the cached value, served
-    // fast, not a fresh generation.
+    // reload serves the previously cached value fast instead of regenerating
+    // it. The entry keeps its default (non-dynamic) cache life, so it's served
+    // straight from the cache rather than treated as a dynamic hole. A
+    // background revalidation regenerates a fresh entry for the next reload
+    // (asserted below).
     await browser.refresh({ waitUntil: 'commit' })
     await retry(async () => {
       expect(
@@ -83,5 +84,24 @@ describe('use-cache-size-zero', () => {
     await browser.elementById('value')
     await waitFor(500)
     expect(await browser.hasElementByCss('[data-cold-cache-badge]')).toBe(false)
+  })
+
+  it('does not surface a blocking-route error on a warm reload of a fully cached route', async () => {
+    const browser = await next.browser('/')
+
+    // Cold load: the page-level `'use cache'` misses and fills in the
+    // background while the result streams in immediately.
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe('Hello, world!')
+    })
+
+    // Warm reload (the second request): the dev cache serves the cached value.
+    // The route has no dynamic data, so serving it from cache must not surface
+    // a false-positive blocking-route red box.
+    await browser.refresh()
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe('Hello, world!')
+    })
+    await waitForNoErrorToast(browser)
   })
 })


### PR DESCRIPTION
To make `cacheMaxMemorySize: 0` fast in development, the `'use cache'` wrapper forced every built-in cache entry to a dynamic cache life (`revalidate: 0`, a five-minute `expire`) so that warm reads would serve the stale value and regenerate a fresh one in the background. That forcing leaked into the stored entry, and an entry with `revalidate: 0` is treated as too dynamic to live in a static shell. On a warm reload of a route that is fully cached and has no `<Suspense>` above the `'use cache'`, the dev validation prerender read the entry and threw an error claiming that a `'use cache'` with zero `revalidate` was nested inside another `'use cache'` that has no explicit `cacheLife`, even though nothing was actually nested, and reported the route as a blocking route. The cold load was unaffected because the entry did not exist yet.

With this change the size-0 case no longer forces a dynamic cache life and keeps the entry's resolved life instead: the explicit `cacheLife()` values when the user set them, otherwise the default (a 15-minute `revalidate` and an infinite `expire`). That default sits well above the dynamic thresholds, so a fully cached route can be prerendered again and the false-positive blocking error is gone. An explicitly short `cacheLife()` still makes the route legitimately dynamic without a spurious throw, because the explicit-revalidate and explicit-expire flags are then set. Private caches are unchanged and remain forced-dynamic.

So that reloads keep showing a fresh value now that the stored life is no longer always stale, the background revalidation in the cache-hit path also fires for size-0 built-in entries regardless of the stored `revalidate`, restricted to the dynamic dev request render so the dev validation prerender does not also regenerate.