### PR TITLE
test: Remove unnecessary dynamic timestamp from instant-validation root layouts

### DIFF
--- a/test/e2e/app-dir/instant-validation/app/default/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/default/layout.tsx
@@ -1,5 +1,5 @@
-import { connection } from 'next/server'
-import { ReactNode, Suspense } from 'react'
+import { ReactNode } from 'react'
+import { RootLayoutTimestamp } from '../shared'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -16,17 +16,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 function Header() {
   return (
     <header>
-      <a href="/">Home</a>{' '}
-      <Suspense fallback="...">
-        <div id="root-layout-timestamp">
-          <Now />
-        </div>
-      </Suspense>
+      <a href="/">Home</a>
+      <RootLayoutTimestamp />
     </header>
   )
-}
-
-async function Now() {
-  await connection()
-  return Date.now()
 }

--- a/test/e2e/app-dir/instant-validation/app/shared.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shared.tsx
@@ -1,6 +1,17 @@
+import { connection } from 'next/server'
 import { cacheLife } from 'next/cache'
 import Link from 'next/link'
+import { Suspense } from 'react'
 import { setTimeout } from 'timers/promises'
+
+export function HackilyPreventFullyStaticServerPrerender() {
+  return <Suspense>{connection().then(() => null)}</Suspense>
+}
+
+export function RootLayoutTimestamp() {
+  const timestamp = performance.timeOrigin + performance.now()
+  return <div id="root-layout-timestamp">{timestamp}</div>
+}
 
 export function DebugLinks({ href }: { href: string }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/layout.tsx
@@ -1,5 +1,5 @@
-import { connection } from 'next/server'
 import { ReactNode, Suspense } from 'react'
+import { RootLayoutTimestamp } from '../shared'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -21,17 +21,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 function Header() {
   return (
     <header>
-      <a href="/">Home</a>{' '}
-      <Suspense fallback="...">
-        <div id="root-layout-timestamp">
-          <Now />
-        </div>
-      </Suspense>
+      <a href="/">Home</a>
+      <RootLayoutTimestamp />
     </header>
   )
-}
-
-async function Now() {
-  await connection()
-  return Date.now()
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { FetchesClientData } from './client'
 import { DataCacheProvider } from '../../../../client-data-fetching-lib/server'
+import { HackilyPreventFullyStaticServerPrerender } from '../../../shared'
 
 // Make sure that the holes from this layout aren't factored in for validation
 // (otherwise, we'd check a navigation into it from the root layout and fail)
@@ -8,14 +9,18 @@ export const instant = false
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DataCacheProvider>
-      <div>
-        <p>
-          This layout renders a client component that suspends in SSR and blocks
-          the children. This prevents us from validating the page below.
-        </p>
-        <FetchesClientData>{children}</FetchesClientData>
-      </div>
-    </DataCacheProvider>
+    <>
+      <HackilyPreventFullyStaticServerPrerender />
+      <DataCacheProvider>
+        <div>
+          <p>
+            This layout renders a client component that suspends in SSR and
+            blocks the children. This prevents us from validating the page
+            below.
+          </p>
+          <FetchesClientData>{children}</FetchesClientData>
+        </div>
+      </DataCacheProvider>
+    </>
   )
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { ShouldNotSuspendDuringValidation } from './client'
+import { HackilyPreventFullyStaticServerPrerender } from '../../../../../shared'
 
 // Make sure that the holes from this layout aren't factored in for validation
 // (otherwise, we'd check a navigation into it from the root layout and fail)
@@ -8,6 +9,7 @@ export const instant = false
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <>
+      <HackilyPreventFullyStaticServerPrerender />
       <div>
         <p>
           This layout renders a client component that accesses usePathname()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { ShouldNotSuspendDuringValidation } from './client'
+import { HackilyPreventFullyStaticServerPrerender } from '../../../../shared'
 
 // Make sure that the holes from this layout aren't factored in for validation
 // (otherwise, we'd check a navigation into it from the root layout and fail)
@@ -8,6 +9,7 @@ export const instant = false
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <>
+      <HackilyPreventFullyStaticServerPrerender />
       <div>
         <p>
           This layout renders a client component that accesses

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { SyncIOInClient } from './client'
+import { HackilyPreventFullyStaticServerPrerender } from '../../../../shared'
 
 // Make sure that the holes from this layout aren't factored in for validation
 // (otherwise, we'd check a navigation into it from the root layout and fail)
@@ -8,6 +9,7 @@ export const instant = false
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <>
+      <HackilyPreventFullyStaticServerPrerender />
       <div>
         <p>
           This layout renders a client component that uses sync IO. We're

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { FetchesClientData } from './client'
 import { DataCacheProvider } from '../../../../client-data-fetching-lib/server'
+import { HackilyPreventFullyStaticServerPrerender } from '../../../shared'
 
 // Make sure that the holes from this layout aren't factored in for validation
 // (otherwise, we'd check a navigation into it from the root layout and fail)
@@ -8,16 +9,19 @@ export const instant = false
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DataCacheProvider>
-      <div>
-        <p>
-          This layout renders a client component that suspends in SSR, but it
-          doesn't not block the children, so we can still validate them.
-        </p>
-        <FetchesClientData />
-      </div>
-      <hr />
-      {children}
-    </DataCacheProvider>
+    <>
+      <HackilyPreventFullyStaticServerPrerender />
+      <DataCacheProvider>
+        <div>
+          <p>
+            This layout renders a client component that suspends in SSR, but it
+            doesn't not block the children, so we can still validate them.
+          </p>
+          <FetchesClientData />
+        </div>
+        <hr />
+        {children}
+      </DataCacheProvider>
+    </>
   )
 }

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -1696,7 +1696,7 @@ describe('instant validation', () => {
                 |                   ^",
              "stack": [
                "FetchesClientData app/suspense-in-root/static/invalid-client-data-blocks-validation/client.tsx (12:19)",
-               "Layout app/suspense-in-root/static/invalid-client-data-blocks-validation/layout.tsx (17:9)",
+               "Layout app/suspense-in-root/static/invalid-client-data-blocks-validation/layout.tsx (21:11)",
              ],
            }
           `)


### PR DESCRIPTION
Extracted from #94595 . The root layout includes a timestamp that we use to check if the root layout changed during a navigation, but it was unnecessarily using `await connection(); Date.now()` when a `performance.now()`would be enough. Changing it to not introduce a random dynamic hole which could affect validation in some way.  
  
This change revealed that some client component tests were implicitly relying on the dynamic timestamp component as a workaround for NAR-800 . I've added a workaround dynamic component to each of the relevant tests, those can be removed when we fix the bug.