### PR TITLE
Fix PPR not working with Cache Components and legacy builders

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1570,6 +1570,11 @@ function assignDefaultsAndValidate(
     result.experimental.mcpServer = true
   }
 
+  if (result.cacheComponents) {
+    // TODO: Kept for backwards compatibility with legacy builders.
+    result.experimental.cacheComponents = true
+  }
+
   // "use cache" was originally implicitly enabled with the cacheComponents flag, so
   // we transfer the value for cacheComponents to the explicit useCache flag to ensure
   // backwards compatibility.


### PR DESCRIPTION
Required until changes like https://github.com/vercel/vercel/pull/16706 land and we dropped support for using versions prior.

See https://github.com/vercel/next.js/pull/94955/changes#r3465285336

## Test plan

- [x] e2e release deploy tests using a version from this branch are green: https://github.com/vercel/next.js/actions/runs/28083525033