### PR TITLE
[ci] Make automatic native binding install opt-in

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -136,9 +136,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      # we build a dev binary for use in CI so skip downloading
-      # canary next-swc binaries in the monorepo
-      NEXT_SKIP_NATIVE_POSTINSTALL: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -147,8 +147,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
-    env:
-      NEXT_SKIP_NATIVE_POSTINSTALL: 1
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -123,8 +123,10 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   NEXT_TELEMETRY_DISABLED: 1
-  # allow not skipping install-native postinstall script if we don't have a binary available already
-  NEXT_SKIP_NATIVE_POSTINSTALL: ${{ inputs.skipNativeInstall == 'yes' && '1' || '' }}
+  # `skipNativeInstall: 'no'` must force the download even though CI otherwise
+  # skips it by default (see scripts/install-native.mjs), so emit an explicit
+  # '0' rather than an empty value.
+  NEXT_SKIP_NATIVE_POSTINSTALL: ${{ inputs.skipNativeInstall == 'yes' && '1' || '0' }}
   DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
   NEXT_JUNIT_TEST_REPORT: 'true'
   DD_ENV: 'ci'

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -24,9 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      # we build a dev binary for use in CI so skip downloading
-      # canary next-swc binaries in the monorepo
-      NEXT_SKIP_NATIVE_POSTINSTALL: 1
 
     steps:
       - name: Setup node

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -23,9 +23,6 @@ env:
   TURBO_CACHE: 'local:rw,remote:rw'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   NEXT_TELEMETRY_DISABLED: 1
-  # we build a dev binary for use in CI so skip downloading
-  # canary next-swc binaries in the monorepo
-  NEXT_SKIP_NATIVE_POSTINSTALL: 1
   # Vercel KV Store for test timings
   KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
   KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -22,6 +22,10 @@ jobs:
     timeout-minutes: 120
     env:
       NEXT_TELEMETRY_DISABLED: 1
+      # This job runs `pnpm build` (JS only) and runs the example apps, so it
+      # needs the published next-swc binary. Opt back into the download since CI
+      # skips it by default (see scripts/install-native.mjs).
+      NEXT_SKIP_NATIVE_POSTINSTALL: 0
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -42,9 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      # we build a dev binary for use in CI so skip downloading
-      # canary next-swc binaries in the monorepo
-      NEXT_SKIP_NATIVE_POSTINSTALL: 1
 
     steps:
       - name: Setup node

--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -13,11 +13,6 @@ permissions:
   actions: read
   contents: read
 
-env:
-  # Not needed. Just breaks the job needlessly while a new canary version is
-  # being published.
-  NEXT_SKIP_NATIVE_POSTINSTALL: 1
-
 jobs:
   upload:
     name: Upload preview tarballs to Blob

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -5,9 +5,17 @@ import fs from 'fs'
 import fsp from 'fs/promises'
 import { outdent } from 'outdent'
 ;(async function () {
-  if (process.env.NEXT_SKIP_NATIVE_POSTINSTALL) {
+  // Automatically installing native bindings is opt-in in CI and opt-out in local development.
+  // Most CI jobs use native bindings built from the commit they run on anyway.
+  const rawSkip = process.env.NEXT_SKIP_NATIVE_POSTINSTALL
+  const skipNativePostinstall =
+    rawSkip == null || rawSkip === ''
+      ? process.env.CI === 'true'
+      : rawSkip !== '0' && rawSkip !== 'false'
+
+  if (skipNativePostinstall) {
     console.log(
-      `Skipping next-swc postinstall due to NEXT_SKIP_NATIVE_POSTINSTALL env`
+      `Skipping next-swc postinstall (NEXT_SKIP_NATIVE_POSTINSTALL=${String(JSON.stringify(rawSkip))}, CI=${String(JSON.stringify(process.env.CI))})`
     )
     return
   }


### PR DESCRIPTION
A `pnpm install` installs native bindings for Next.js by default. This makes sense for local development where half of the team doesn't work on native code and just needs the most recent bindings. However, CI almost exclusively wants to test with bindings that are built from the current commit. The rest doesn't need native bindings at all.

The only exception is `test_examples` which is likely not functional. Though we still support it by allowing to opt-into automatically installing native bindings in CI.

## test plan

- [x] fetch test timings still skips: https://github.com/vercel/next.js/actions/runs/28087707205/job/83157705446?pr=95114#step:7:228