### PR TITLE
Avoid mutating `req.headers` when stripping internal headers

### DIFF
--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -31,17 +31,24 @@ import type { ImplicitTags } from '../lib/implicit-tags'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
-  const cleaned = HeadersAdapter.from(headers)
+  // `HeadersAdapter.from` wraps `IncomingHttpHeaders` (and returns a `Headers`
+  // instance unchanged) without copying, so the `delete` calls below would
+  // otherwise mutate the caller's underlying request headers. We copy first so
+  // that stripping internal headers only affects the sealed userland view, not
+  // the shared `req.headers`. The latter matters because the dev server reads
+  // the request-id headers from the raw request again (e.g. when rendering a
+  // redirect target after a server action), and mutating them there would break
+  // the dev debug channel routing.
+  const cleaned = HeadersAdapter.from(
+    headers instanceof Headers ? new Headers(headers) : { ...headers }
+  )
   for (const header of FLIGHT_HEADERS) {
     cleaned.delete(header)
   }
 
   // The client sends these dev-only request IDs so the server can route debug
   // information back to the originating request. Like the flight headers, they
-  // are internal plumbing and must not be exposed to userland `headers()`. The
-  // server reads them from the raw request headers, not from here, so removing
-  // them from this copy doesn't affect the debug channel for which they are
-  // used.
+  // are internal plumbing and must not be exposed to userland `headers()`.
   cleaned.delete(NEXT_REQUEST_ID_HEADER)
   cleaned.delete(NEXT_HTML_REQUEST_ID_HEADER)
 

--- a/test/e2e/app-dir/server-action-headers-redirect/app/actions.ts
+++ b/test/e2e/app-dir/server-action-headers-redirect/app/actions.ts
@@ -1,0 +1,9 @@
+'use server'
+
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export async function action() {
+  await headers()
+  redirect('/destination')
+}

--- a/test/e2e/app-dir/server-action-headers-redirect/app/destination/page.tsx
+++ b/test/e2e/app-dir/server-action-headers-redirect/app/destination/page.tsx
@@ -1,0 +1,3 @@
+export default function DestinationPage() {
+  return <p id="destination">Success!</p>
+}

--- a/test/e2e/app-dir/server-action-headers-redirect/app/layout.tsx
+++ b/test/e2e/app-dir/server-action-headers-redirect/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/server-action-headers-redirect/app/page.tsx
+++ b/test/e2e/app-dir/server-action-headers-redirect/app/page.tsx
@@ -1,0 +1,11 @@
+import { action } from './actions'
+
+export default function Page() {
+  return (
+    <form action={action}>
+      <button type="submit" id="submit">
+        Submit
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/server-action-headers-redirect/next.config.js
+++ b/test/e2e/app-dir/server-action-headers-redirect/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/server-action-headers-redirect/server-action-headers-redirect.test.ts
+++ b/test/e2e/app-dir/server-action-headers-redirect/server-action-headers-redirect.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('server-action-headers-redirect', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('redirects after a server action that reads headers()', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementByCss('#submit').click()
+
+    await retry(async () => {
+      expect(await browser.url()).toEndWith('/destination')
+      expect(await browser.elementByCss('#destination').text()).toBe('Success!')
+    })
+  })
+})


### PR DESCRIPTION
`getHeaders` in the request store strips internal flight and dev request-id headers before sealing the object exposed to userland `headers()`. It built that object with `HeadersAdapter.from(req.headers)`, which wraps `IncomingHttpHeaders` (and returns a `Headers` instance) without copying, so the `delete` calls mutated the shared `req.headers` as a side effect.

This regressed redirects from a server action that reads `headers()` when `cacheComponents` is enabled in `next dev`, introduced by #94703. That change added the dev request-id headers (`x-nextjs-request-id` and `x-nextjs-html-request-id`) to the set stripped in `getHeaders`. The flight headers had been stripped from the shared object for a long time without issue because their absence is a handled state, but the request-id headers are different: the action's `headers()` access now deleted them from `req.headers`, and the dev instant-navigation render of the redirect target, which reuses the same request, then read a missing request id and fabricated a mismatched HTML request id. The React dev debug channel was registered under that wrong id, so the client overlay stayed in "Rendering..." and never applied the navigation.

This change copies the headers before stripping so only the sealed userland view is affected, leaving the shared request headers intact. It adds an e2e test that reproduces the regression.

fixes #95103