### PR TITLE
fix(eslint-plugin): replace destructured re-export with direct property access for CJS named export compatibility

### DIFF
--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -124,4 +124,5 @@ Object.assign(plugin.configs, {
 } satisfies ESLintPluginConfigs)
 
 export default plugin
-export const { rules, configs } = plugin
+export const rules = plugin.rules
+export const configs = plugin.configs


### PR DESCRIPTION
Fixes #86504

The `@next/eslint-plugin-next` package uses destructured re-exports:
```
export const { rules, configs } = plugin
```

When TypeScript compiles this to CJS, it generates `Object.defineProperty` with a **getter** for each named export. Node.js's ESM-CJS interop only creates synthetic named exports for **data properties** (assigned with `=`), not for accessor properties (getters). This causes:
```
SyntaxError: Named export 'configs' not found
```

Replaced with direct property access:
```
export const rules = plugin.rules
export const configs = plugin.configs
```

This compiles to `exports.rules = plugin.rules` / `exports.configs = plugin.configs` (data properties), which Node.js correctly recognizes as synthetic named exports.
