### PR TITLE
Propagate maxDuration to edge adapter outputs

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -656,7 +656,8 @@ export async function handleBuildComplete({
           ? normalizeAppPath(route)
           : route === '/index'
             ? '/'
-            : route
+            : route.replace(/\/index$/, '')
+        const functionConfig = functionsConfigManifest.functions[pathname] || {}
         const edgeEntrypointRelativePath = page.entrypoint
         const edgeEntrypointPath = path.join(
           distDir,
@@ -682,6 +683,7 @@ export async function handleBuildComplete({
           // Computing assetsHash for edge functions isn't implemented for now
           wasmAssets: {},
           config: {
+            maxDuration: functionConfig.maxDuration,
             env: page.env,
             preferredRegion: page.regions,
           },

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -90,6 +90,73 @@ describe('adapter-config', () => {
     expect(staticOutputs.length).toBeGreaterThan(0)
     expect(prerenderOutputs.length).toBeGreaterThan(0)
 
+    const expectedRouteConfigs = [
+      {
+        pathname: '/docs/node-app',
+        type: 'APP_PAGE',
+        runtime: 'nodejs',
+        maxDuration: 10,
+      },
+      {
+        pathname: '/docs/edge-app',
+        type: 'APP_PAGE',
+        runtime: 'edge',
+        maxDuration: 20,
+      },
+      {
+        pathname: '/docs/node-route',
+        type: 'APP_ROUTE',
+        runtime: 'nodejs',
+        maxDuration: 30,
+      },
+      {
+        pathname: '/docs/edge-route',
+        type: 'APP_ROUTE',
+        runtime: 'edge',
+        maxDuration: 40,
+      },
+      {
+        pathname: '/docs/node-pages',
+        type: 'PAGES',
+        runtime: 'nodejs',
+        maxDuration: 50,
+      },
+      {
+        pathname: '/docs/edge-pages',
+        type: 'PAGES',
+        runtime: 'edge',
+        maxDuration: 60,
+      },
+      {
+        pathname: '/docs/api/node-pages',
+        type: 'PAGES_API',
+        runtime: 'nodejs',
+        maxDuration: 70,
+      },
+      {
+        pathname: '/docs/api/edge-pages',
+        type: 'PAGES_API',
+        runtime: 'edge',
+        maxDuration: 80,
+      },
+    ] as const
+
+    for (const {
+      pathname,
+      type,
+      runtime,
+      maxDuration,
+    } of expectedRouteConfigs) {
+      expect(combinedRouteOutputs).toContainEqual(
+        expect.objectContaining({
+          pathname,
+          type,
+          runtime,
+          config: expect.objectContaining({ maxDuration }),
+        })
+      )
+    }
+
     for (const output of staticOutputs) {
       expect(output.id).toBeTruthy()
 

--- a/test/production/adapter-config/app/edge-app/page.tsx
+++ b/test/production/adapter-config/app/edge-app/page.tsx
@@ -1,4 +1,5 @@
 export const runtime = 'edge'
+export const maxDuration = 20
 
 export default function Page() {
   return (

--- a/test/production/adapter-config/app/edge-route/route.ts
+++ b/test/production/adapter-config/app/edge-route/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 export const runtime = 'edge'
+export const maxDuration = 40
 
 export function GET(req: NextRequest) {
   console.log(req.url.toString())

--- a/test/production/adapter-config/app/node-app/page.tsx
+++ b/test/production/adapter-config/app/node-app/page.tsx
@@ -1,4 +1,5 @@
 export const dynamic = 'force-dynamic'
+export const maxDuration = 10
 
 export default function Page() {
   return (

--- a/test/production/adapter-config/app/node-route/route.ts
+++ b/test/production/adapter-config/app/node-route/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+export const maxDuration = 30
+
 export function GET(req: NextRequest) {
   console.log(req.url.toString())
   return NextResponse.json({

--- a/test/production/adapter-config/pages/api/edge-pages.ts
+++ b/test/production/adapter-config/pages/api/edge-pages.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export const config = {
   runtime: 'edge',
+  maxDuration: 80,
 }
 
 export default function handler(req: NextRequest) {

--- a/test/production/adapter-config/pages/api/node-pages.ts
+++ b/test/production/adapter-config/pages/api/node-pages.ts
@@ -1,5 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next/dist/types'
 
+export const config = {
+  maxDuration: 70,
+}
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   console.log(req.url)
   res.json({ now: Date.now() })

--- a/test/production/adapter-config/pages/edge-pages/index.tsx
+++ b/test/production/adapter-config/pages/edge-pages/index.tsx
@@ -1,5 +1,6 @@
 export const config = {
   runtime: 'experimental-edge',
+  maxDuration: 60,
 }
 
 export default function Page() {

--- a/test/production/adapter-config/pages/node-pages/index.tsx
+++ b/test/production/adapter-config/pages/node-pages/index.tsx
@@ -1,3 +1,7 @@
+export const config = {
+  maxDuration: 50,
+}
+
 export function getServerSideProps() {
   return {
     props: {


### PR DESCRIPTION
## Summary

Propagate `maxDuration` to Edge adapter outputs so deployment adapters receive the same route execution limit metadata as Node.js outputs.

Normalize Pages Router Edge adapter pathnames that end in `/index` to their public route pathname, for example `/edge-pages/index` to `/edge-pages`. This matters because the functions config manifest stores route metadata under the public pathname, so matching the unnormalized `/index` form would miss `maxDuration`.

Add adapter coverage for App Router pages and routes, Pages Router pages and API routes, and both Node.js and Edge runtimes, including the Pages Router `/index` normalization case.

## Verification

- `pnpm test-start-turbo test/production/adapter-config/adapter-config.test.ts`
- `pnpm test-start-webpack test/production/adapter-config/adapter-config.test.ts`

<!-- NEXT_JS_LLM_PR -->