### PR TITLE
Fix Navigation Inspector styles in dark mode

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.css
@@ -76,8 +76,15 @@
   width: 100%;
   height: 42px;
   padding: 0 20px;
-  background: #e0ebff;
+  background: var(--color-blue-100);
   box-sizing: border-box;
+}
+@media (prefers-color-scheme: dark) {
+  :host(:not(.light)) {
+    .instant-nav-waiting-status {
+      background: var(--color-blue-300);
+    }
+  }
 }
 
 .instant-nav-waiting-status-dot {
@@ -87,6 +94,13 @@
   height: 16px;
   border-radius: 50%;
   background: #b8cffb;
+}
+@media (prefers-color-scheme: dark) {
+  :host(:not(.light)) {
+    .instant-nav-waiting-status-dot {
+      background: #25548f;
+    }
+  }
 }
 
 .instant-nav-waiting-status-dot::after {
@@ -98,6 +112,13 @@
   height: 8px;
   border-radius: 50%;
   background: var(--color-blue-700);
+}
+@media (prefers-color-scheme: dark) {
+  :host(:not(.light)) {
+    .instant-nav-waiting-status-dot::after {
+      background: #468be2;
+    }
+  }
 }
 
 .instant-nav-waiting-status-title {
@@ -172,6 +193,15 @@
   font-weight: 400;
   line-height: 1;
 }
+@media (prefers-color-scheme: dark) {
+  :host(:not(.light)) {
+    .instant-nav-debugger-paused {
+      color: #171717;
+      background-color: #e7c755;
+    }
+  }
+}
+
 .instant-nav-debugger-paused-button {
   margin-left: auto;
   font-size: var(--size-12);
@@ -180,10 +210,20 @@
   padding: 7px 12px 7px 14px;
   border-radius: 9999px;
   background-color: white;
-  border: 1px solid #dfd587;
+  border: 1px solid var(--color-gray-alpha-300);
   display: inline-flex;
   gap: 8px;
   align-items: center;
+}
+@media (prefers-color-scheme: dark) {
+  :host(:not(.light)) {
+    .instant-nav-debugger-paused-button {
+      background-color: #000000;
+    }
+    .instant-nav-debugger-paused-button:hover {
+      background-color: #2e2e2e;
+    }
+  }
 }
 
 .instant-nav-debugger-paused-button:hover {


### PR DESCRIPTION
Before:
<img width="505" height="457" alt="image" src="https://github.com/user-attachments/assets/5f30079f-1d6e-44f6-8c3a-476f6463f346" />

<img width="498" height="457" alt="image" src="https://github.com/user-attachments/assets/d14e3cb2-fc14-4d01-bf13-00dd8478f06e" />


After:

<img width="518" height="464" alt="image" src="https://github.com/user-attachments/assets/0d89a389-eb25-4d3a-b6e6-58cb084bc661" />
<img width="505" height="454" alt="image" src="https://github.com/user-attachments/assets/a985e10a-a7c1-4314-9061-f531fab49a05" />
