### PR TITLE
Add missing switch case

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3158,6 +3158,7 @@ export async function cache(
               case 'prerender-legacy':
               case 'unstable-cache':
               case 'generate-static-params':
+              case 'prerender-ppr':
                 break
               default:
                 workUnitStore satisfies never


### PR DESCRIPTION
The `switch` statement was added in #95100 when the `'prerender-ppr'` didn't exist anymore. Afterwards #95113 landed and re-introduced the `'prerender-ppr'` case, but it was not added to the `switch` statement, which caused a type error.