### PR TITLE
Revert "Add missing switch case"

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3159,7 +3159,6 @@ export async function cache(
               case 'prerender-legacy':
               case 'unstable-cache':
               case 'generate-static-params':
-              case 'prerender-ppr':
                 break
               default:
                 workUnitStore satisfies never


### PR DESCRIPTION
Reverts vercel/next.js#95127

This was a stale merge, now the case was duplicated.