### PR TITLE
router instrumentation: consolidate unmerged transition lifecycle stack

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive a third `event` argument:
+Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_onRouterTransitionCommit` hook:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -68,39 +68,72 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-The event includes the transition metadata and source context known when the navigation is dispatched:
+Then export the optional commit hook:
 
 ```ts filename="instrumentation-client.ts" switcher
-import type { RouterTransitionStartEvent, RouterTransitionType } from 'next'
+import type {
+  RouterTransitionCommitEvent,
+  RouterTransitionStartEvent,
+  RouterTransitionType,
+} from 'next'
+
+const starts = new Map<string, number>()
 
 export function onRouterTransitionStart(
   url: string,
   navigationType: RouterTransitionType,
   { id, timestamp, fromRoutes, prefetchIntent }: RouterTransitionStartEvent
 ) {
-  console.log(id, timestamp, url, navigationType, fromRoutes, prefetchIntent)
+  console.log('Navigating from:', fromRoutes, prefetchIntent)
+  starts.set(id, timestamp)
+}
+
+export function unstable_onRouterTransitionCommit(
+  url: string,
+  navigationType: RouterTransitionType,
+  event: RouterTransitionCommitEvent
+) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation commit:', event.timestamp - start)
+    starts.delete(event.id)
+  }
 }
 ```
 
 ```js filename="instrumentation-client.js" switcher
+const starts = new Map()
+
 export function onRouterTransitionStart(url, navigationType, event) {
-  console.log(
-    event.id,
-    event.timestamp,
-    url,
-    navigationType,
-    event.fromRoutes,
-    event.prefetchIntent
-  )
+  console.log('Navigating from:', event.fromRoutes, event.prefetchIntent)
+  starts.set(event.id, event.timestamp)
+}
+
+export function unstable_onRouterTransitionCommit(url, navigationType, event) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation commit:', event.timestamp - start)
+    starts.delete(event.id)
+  }
 }
 ```
 
-`onRouterTransitionStart` receives:
+Each hook receives the same three parameters:
 
 - `url: string` - The URL being navigated to
 - `navigationType: 'push' | 'replace' | 'traverse'` - The type of navigation
 - `event.id` - An opaque ID shared by events for this transition
 - `event.timestamp` - A framework-captured Unix timestamp in milliseconds
+
+The available hooks are:
+
+| Hook                                | Timing                                   |
+| ----------------------------------- | ---------------------------------------- |
+| `onRouterTransitionStart`           | The navigation is dispatched.            |
+| `unstable_onRouterTransitionCommit` | The first destination UI and URL commit. |
+
+The start event (`onRouterTransitionStart`) also includes:
+
 - `event.fromRoutes` - Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order
 - `event.prefetchIntent` - For link navigations, whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`). For navigations with no associated link (programmatic `router.push()`/`router.replace()`, or browser back/forward) this is `null`, since no link prefetch intent applies
 
@@ -126,7 +159,7 @@ This timing makes it ideal for setting up error tracking, analytics, and perform
 
 ## See also
 
-`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition start hook. Application code should continue to use this file convention directly.
+`next.config.js` plugins (for example, wrappers like `withSentry`) can register their own client instrumentation module via the [`instrumentationClientInject`](/docs/app/api-reference/config/next-config-js/instrumentationClientInject) option. Injected modules run before this file, in array order, and may export the same router transition hooks. Application code should continue to use this file convention directly.
 
 ## Examples
 
@@ -260,7 +293,7 @@ if (!window.ResizeObserver) {
 
 ## Version history
 
-| Version   | Changes                                               |
-| --------- | ----------------------------------------------------- |
-| `v16.3.0` | Experimental router transition start event introduced |
-| `v15.3`   | `instrumentation-client` introduced                   |
+| Version   | Changes                                                   |
+| --------- | --------------------------------------------------------- |
+| `v16.3.0` | Experimental router transition lifecycle hooks introduced |
+| `v15.3`   | `instrumentation-client` introduced                       |

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit and abort hooks:
+Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit, route mismatch, and abort hooks:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -74,6 +74,7 @@ Then export the optional commit hook:
 import type {
   RouterTransitionAbortEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionRouteMismatchEvent,
   RouterTransitionStartEvent,
   RouterTransitionType,
 } from 'next'
@@ -108,6 +109,14 @@ export function unstable_onRouterTransitionAbort(
 ) {
   starts.delete(id)
 }
+
+export function unstable_onRouterTransitionRouteMismatch(
+  url: string,
+  navigationType: RouterTransitionType,
+  event: RouterTransitionRouteMismatchEvent
+) {
+  console.log('Route mismatch:', event.id, url)
+}
 ```
 
 ```js filename="instrumentation-client.js" switcher
@@ -129,6 +138,14 @@ export function unstable_onRouterTransitionCommit(url, navigationType, event) {
 export function unstable_onRouterTransitionAbort(url, navigationType, event) {
   starts.delete(event.id)
 }
+
+export function unstable_onRouterTransitionRouteMismatch(
+  url,
+  navigationType,
+  event
+) {
+  console.log('Route mismatch:', event.id, url)
+}
 ```
 
 Each hook receives the same three parameters:
@@ -140,11 +157,14 @@ Each hook receives the same three parameters:
 
 The available hooks are:
 
-| Hook                                | Timing                                   |
-| ----------------------------------- | ---------------------------------------- |
-| `onRouterTransitionStart`           | The navigation is dispatched.            |
-| `unstable_onRouterTransitionCommit` | The first destination UI and URL commit. |
-| `unstable_onRouterTransitionAbort`  | The transition stops before completion.  |
+| Hook                                       | Timing                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------ |
+| `onRouterTransitionStart`                  | The navigation is dispatched.                                            |
+| `unstable_onRouterTransitionCommit`        | The first destination UI and URL commit.                                 |
+| `unstable_onRouterTransitionRouteMismatch` | The live route tree differs from the prefetched or predicted route tree. |
+| `unstable_onRouterTransitionAbort`         | The transition stops before completion.                                  |
+
+`unstable_onRouterTransitionRouteMismatch` is diagnostic and non-terminal. It indicates that Next.js detected a different route tree and retried the navigation.
 
 The start event (`onRouterTransitionStart`) also includes:
 

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_onRouterTransitionCommit` hook:
+Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit and abort hooks:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -72,6 +72,7 @@ Then export the optional commit hook:
 
 ```ts filename="instrumentation-client.ts" switcher
 import type {
+  RouterTransitionAbortEvent,
   RouterTransitionCommitEvent,
   RouterTransitionStartEvent,
   RouterTransitionType,
@@ -99,6 +100,14 @@ export function unstable_onRouterTransitionCommit(
     starts.delete(event.id)
   }
 }
+
+export function unstable_onRouterTransitionAbort(
+  url: string,
+  navigationType: RouterTransitionType,
+  { id }: RouterTransitionAbortEvent
+) {
+  starts.delete(id)
+}
 ```
 
 ```js filename="instrumentation-client.js" switcher
@@ -116,6 +125,10 @@ export function unstable_onRouterTransitionCommit(url, navigationType, event) {
     starts.delete(event.id)
   }
 }
+
+export function unstable_onRouterTransitionAbort(url, navigationType, event) {
+  starts.delete(event.id)
+}
 ```
 
 Each hook receives the same three parameters:
@@ -131,6 +144,7 @@ The available hooks are:
 | ----------------------------------- | ---------------------------------------- |
 | `onRouterTransitionStart`           | The navigation is dispatched.            |
 | `unstable_onRouterTransitionCommit` | The first destination UI and URL commit. |
+| `unstable_onRouterTransitionAbort`  | The transition stops before completion.  |
 
 The start event (`onRouterTransitionStart`) also includes:
 
@@ -144,7 +158,7 @@ The commit event also includes:
 
 Route entries use filesystem-style patterns, so `/blog/hello` may report `/blog/[slug]`.
 
-Hook errors are isolated and do not affect navigation or other hooks.
+`unstable_onRouterTransitionAbort` receives a `reason` of `superseded`, `hard-navigation`, or `error`. Hook errors are isolated and do not affect navigation or other hooks.
 
 ## Performance considerations
 

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -137,7 +137,12 @@ The start event (`onRouterTransitionStart`) also includes:
 - `event.fromRoutes` - Route patterns visible before navigation. The primary `children` route is first, followed by parallel slots in deterministic order
 - `event.prefetchIntent` - For link navigations, whether the clicked link requested full prefetching (`full`), used automatic prefetching (`auto`), or did not request prefetching (`none`). For navigations with no associated link (programmatic `router.push()`/`router.replace()`, or browser back/forward) this is `null`, since no link prefetch intent applies
 
-Route entries use filesystem-style patterns, so a navigation away from `/blog/hello` may report `/blog/[slug]`.
+The commit event also includes:
+
+- `routes`: Active route patterns in the destination UI. The primary `children` route is first, followed by parallel slots in deterministic order.
+- `prefetch`: Whether the navigation used a fully cached route (`hit-route`), a cached shell with dynamic data remaining (`hit-shell`), no matching prefetch (`miss`), or did not use prefetching (`none`).
+
+Route entries use filesystem-style patterns, so `/blog/hello` may report `/blog/[slug]`.
 
 Hook errors are isolated and do not affect navigation or other hooks.
 

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -54,7 +54,7 @@ export function onRouterTransitionStart(
 }
 ```
 
-Additional router transition information is experimental. Enable it to receive the third `event` argument and the `unstable_` commit, route mismatch, and abort hooks:
+The complete router transition lifecycle is experimental. Enable it to receive the third `event` argument and the `unstable_` commit, settled, mismatch, and abort hooks:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -68,13 +68,14 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-Then export the optional commit hook:
+Then export any of the optional `unstable_` lifecycle hooks:
 
 ```ts filename="instrumentation-client.ts" switcher
 import type {
   RouterTransitionAbortEvent,
   RouterTransitionCommitEvent,
   RouterTransitionRouteMismatchEvent,
+  RouterTransitionSettledEvent,
   RouterTransitionStartEvent,
   RouterTransitionType,
 } from 'next'
@@ -98,7 +99,18 @@ export function unstable_onRouterTransitionCommit(
   const start = starts.get(event.id)
   if (start !== undefined) {
     console.log('Time to navigation commit:', event.timestamp - start)
-    starts.delete(event.id)
+  }
+}
+
+export function unstable_onRouterTransitionSettled(
+  url: string,
+  navigationType: RouterTransitionType,
+  { id, timestamp }: RouterTransitionSettledEvent
+) {
+  const start = starts.get(id)
+  if (start !== undefined) {
+    console.log('Time to navigation settled:', timestamp - start)
+    starts.delete(id)
   }
 }
 
@@ -131,6 +143,13 @@ export function unstable_onRouterTransitionCommit(url, navigationType, event) {
   const start = starts.get(event.id)
   if (start !== undefined) {
     console.log('Time to navigation commit:', event.timestamp - start)
+  }
+}
+
+export function unstable_onRouterTransitionSettled(url, navigationType, event) {
+  const start = starts.get(event.id)
+  if (start !== undefined) {
+    console.log('Time to navigation settled:', event.timestamp - start)
     starts.delete(event.id)
   }
 }
@@ -157,14 +176,15 @@ Each hook receives the same three parameters:
 
 The available hooks are:
 
-| Hook                                       | Timing                                                                   |
-| ------------------------------------------ | ------------------------------------------------------------------------ |
-| `onRouterTransitionStart`                  | The navigation is dispatched.                                            |
-| `unstable_onRouterTransitionCommit`        | The first destination UI and URL commit.                                 |
-| `unstable_onRouterTransitionRouteMismatch` | The live route tree differs from the prefetched or predicted route tree. |
-| `unstable_onRouterTransitionAbort`         | The transition stops before completion.                                  |
+| Hook                                       | Timing                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `onRouterTransitionStart`                  | The navigation is dispatched.                                             |
+| `unstable_onRouterTransitionCommit`        | The first destination UI and URL commit.                                  |
+| `unstable_onRouterTransitionSettled`       | All router-owned response streams and retries finish.                     |
+| `unstable_onRouterTransitionRouteMismatch` | The live route tree differs from the prefetched or predicted route tree.  |
+| `unstable_onRouterTransitionAbort`         | The transition is superseded, falls back to a hard navigation, or errors. |
 
-`unstable_onRouterTransitionRouteMismatch` is diagnostic and non-terminal. It indicates that Next.js detected a different route tree and retried the navigation.
+`unstable_onRouterTransitionRouteMismatch` is diagnostic and non-terminal. It indicates that Next.js detected a different route tree and retried the navigation. The same transition will later settle or abort.
 
 The start event (`onRouterTransitionStart`) also includes:
 
@@ -178,7 +198,7 @@ The commit event also includes:
 
 Route entries use filesystem-style patterns, so `/blog/hello` may report `/blog/[slug]`.
 
-`unstable_onRouterTransitionAbort` receives a `reason` of `superseded`, `hard-navigation`, or `error`. Hook errors are isolated and do not affect navigation or other hooks.
+`unstable_onRouterTransitionAbort` receives a `reason` of `superseded`, `hard-navigation`, or `error`. Every started transition ends with either `unstable_onRouterTransitionSettled` or `unstable_onRouterTransitionAbort`. Hook errors are isolated and do not affect navigation or other hooks.
 
 ## Performance considerations
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/instrumentationClientInject.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/instrumentationClientInject.mdx
@@ -5,7 +5,7 @@ description: Inject additional client-side instrumentation modules before the us
 
 `instrumentationClientInject` is a list of modules that are imported on the client for their side effects before the user's [`instrumentation-client.{js,ts}`](/docs/app/api-reference/file-conventions/instrumentation-client) file runs, ahead of React hydration.
 
-This option is primarily intended for **`next.config.js` plugins** (for example, wrappers like `withSentry` or `withAnalytics` that extend a project's config). It lets such a plugin inject its own client instrumentation module — including a navigation hook — without requiring every project to author or modify an `instrumentation-client` file. Application code should generally continue to use the [`instrumentation-client.{js,ts}`](/docs/app/api-reference/file-conventions/instrumentation-client) file convention directly.
+This option is primarily intended for **`next.config.js` plugins** (for example, wrappers like `withSentry` or `withAnalytics` that extend a project's config). It lets such a plugin inject its own client instrumentation module, including navigation hooks, without requiring every project to author or modify an `instrumentation-client` file. Application code should generally continue to use the [`instrumentation-client.{js,ts}`](/docs/app/api-reference/file-conventions/instrumentation-client) file convention directly.
 
 A plugin typically appends its own module to whatever the project already has configured:
 
@@ -48,7 +48,9 @@ Modules run on the client in this order:
 
 ## Router navigation hook
 
-Each injected module may optionally export an `onRouterTransitionStart` function with the same signature as the one documented for the [`instrumentation-client` file convention](/docs/app/api-reference/file-conventions/instrumentation-client#router-navigation-tracking). Next.js composes a single hook that fans out to every exported `onRouterTransitionStart` on each navigation, calling them in array order, with the user file's hook running last.
+Each injected module may optionally export any of the router transition hooks documented for the [`instrumentation-client` file convention](/docs/app/api-reference/file-conventions/instrumentation-client#router-navigation-tracking). Next.js composes each hook across injected modules in array order, with the user file's hook running last.
+
+The `onRouterTransitionStart(url, navigationType)` hook is available by default. The third event argument and remaining `unstable_` lifecycle hooks require `experimental.instrumentationClientRouterTransitionEvents`.
 
 ```js filename="lib/sentry-client.js"
 // Side-effectful setup runs at load time.
@@ -57,9 +59,13 @@ setupSentry()
 export function onRouterTransitionStart(url, navigationType) {
   recordNavigationBreadcrumb(url, navigationType)
 }
+
+export function unstable_onRouterTransitionCommit(url, navigationType, event) {
+  recordNavigationCommit(url, navigationType, event)
+}
 ```
 
-Modules that do not export `onRouterTransitionStart` are skipped during navigation.
+Modules that do not export a particular hook are skipped when that hook fires. Errors thrown by one module do not prevent later modules from running.
 
 ## Version history
 

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -6,6 +6,7 @@ import {
   ACTION_SERVER_ACTION,
   ACTION_NAVIGATE,
   ACTION_RESTORE,
+  ACTION_SERVER_PATCH,
   type NavigateAction,
   ACTION_HMR_REFRESH,
   PrefetchKind,
@@ -38,7 +39,10 @@ import { setLinkForCurrentNavigation, type LinkInstance } from './links'
 import type { RouterTransitionPrefetchIntent } from '../router-transition-types'
 import type { GlobalErrorComponent } from './builtin/global-error'
 import { isJavaScriptURLString } from '../lib/javascript-url'
-import { startRouterTransition } from './router-transition'
+import {
+  abortRouterTransition,
+  startRouterTransition,
+} from './router-transition'
 
 export type DispatchStatePromise = React.Dispatch<ReducerState>
 
@@ -63,6 +67,14 @@ export type ActionQueueNode = {
   resolve: (value: ReducerState) => void
   reject: (err: Error) => void
   discarded?: boolean
+}
+
+function getActionTransitionId(action: ReducerActions): string | null {
+  return action.type === ACTION_NAVIGATE ||
+    action.type === ACTION_RESTORE ||
+    action.type === ACTION_SERVER_PATCH
+    ? action.transitionId
+    : null
 }
 
 function runRemainingActions(
@@ -133,6 +145,7 @@ async function runAction({
   if (isThenable(actionResult)) {
     actionResult.then(handleResult, (err) => {
       runRemainingActions(actionQueue, setState)
+      abortRouterTransition(getActionTransitionId(action.payload), 'error')
       action.reject(err)
     })
   } else {

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -281,7 +281,7 @@ export function dispatchNavigateAction(
   }
 
   setLinkForCurrentNavigation(linkInstanceRef)
-  startRouterTransition(
+  const transitionId = startRouterTransition(
     href,
     navigateType,
     getAppRouterActionQueue().state.tree,
@@ -295,6 +295,7 @@ export function dispatchNavigateAction(
     locationSearch: location.search,
     scrollBehavior,
     navigateType,
+    transitionId,
   })
 }
 
@@ -302,7 +303,7 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
-  startRouterTransition(
+  const transitionId = startRouterTransition(
     href,
     'traverse',
     getAppRouterActionQueue().state.tree,
@@ -312,6 +313,7 @@ export function dispatchTraverseAction(
     type: ACTION_RESTORE,
     url: new URL(href),
     historyState,
+    transitionId,
   })
 }
 
@@ -365,7 +367,8 @@ function gesturePush(href: string, options?: NavigateOptions): void {
       state.nextUrl,
       freshnessPolicy,
       scrollBehavior,
-      'push'
+      'push',
+      null
     )
     dispatchGestureState(forkedGestureState)
   }

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -271,6 +271,22 @@ function getAppRouterActionQueue(): AppRouterActionQueue {
   return globalActionQueue
 }
 
+// A hash-only navigation changes nothing but the URL fragment (same pathname
+// and query). The browser just scrolls — no new route is loaded and no data is
+// fetched — so it is not a real router transition. Mirrors the `onlyHashChange`
+// check the navigate reducer uses (segment-cache/navigation.ts).
+function isHashOnlyNavigation(
+  currentCanonicalUrl: string,
+  target: URL
+): boolean {
+  const current = new URL(currentCanonicalUrl, target)
+  return (
+    current.pathname === target.pathname &&
+    current.search === target.search &&
+    current.hash !== target.hash
+  )
+}
+
 export function dispatchNavigateAction(
   href: string,
   navigateType: NavigateAction['navigateType'],
@@ -294,11 +310,13 @@ export function dispatchNavigateAction(
   }
 
   setLinkForCurrentNavigation(linkInstanceRef)
+  const { state } = getAppRouterActionQueue()
   const transitionId = startRouterTransition(
     href,
     navigateType,
-    getAppRouterActionQueue().state.tree,
-    prefetchIntent
+    state.tree,
+    prefetchIntent,
+    isHashOnlyNavigation(state.canonicalUrl, url)
   )
 
   dispatchAppRouterAction({
@@ -316,15 +334,18 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
+  const url = new URL(href)
+  const { state } = getAppRouterActionQueue()
   const transitionId = startRouterTransition(
     href,
     'traverse',
-    getAppRouterActionQueue().state.tree,
-    null
+    state.tree,
+    null,
+    isHashOnlyNavigation(state.canonicalUrl, url)
   )
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
-    url: new URL(href),
+    url,
     historyState,
     transitionId,
   })

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -99,7 +99,7 @@ function HistoryUpdater({
       window.history.replaceState(historyState, '', canonicalUrl)
     }
 
-    commitRouterTransition(transitionId, canonicalUrl)
+    commitRouterTransition(transitionId, canonicalUrl, tree)
     setLastCommittedTree(tree)
   }, [appRouterState])
 

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -51,6 +51,7 @@ import DefaultGlobalError from './builtin/global-error'
 import { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-app'
 import { getAssetTokenQuery } from '../../shared/lib/deployment-id'
+import { commitRouterTransition } from './router-transition'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -68,7 +69,8 @@ function HistoryUpdater({
       window.next.__pendingUrl = undefined
     }
 
-    const { tree, pushRef, canonicalUrl, renderedSearch } = appRouterState
+    const { tree, pushRef, canonicalUrl, renderedSearch, transitionId } =
+      appRouterState
 
     const appHistoryState: AppHistoryState = {
       tree,
@@ -97,6 +99,7 @@ function HistoryUpdater({
       window.history.replaceState(historyState, '', canonicalUrl)
     }
 
+    commitRouterTransition(transitionId, canonicalUrl)
     setLastCommittedTree(tree)
   }, [appRouterState])
 
@@ -229,6 +232,7 @@ function Router({
         type: ACTION_RESTORE,
         url: new URL(window.location.href),
         historyState: window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
+        transitionId: null,
       })
     }
 
@@ -319,6 +323,7 @@ function Router({
           type: ACTION_RESTORE,
           url: new URL(url ?? href, href),
           historyState: appHistoryState,
+          transitionId: null,
         })
       })
     }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -269,6 +269,7 @@ export function createInitialRouterState({
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??
       null,
     previousNextUrl: null,
+    transitionId: null,
     debugInfo: null,
   }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -66,6 +66,7 @@ export interface FetchServerResponseOptions {
   readonly flightRouterState: FlightRouterState
   readonly nextUrl: string | null
   readonly isHmrRefresh?: boolean
+  readonly onResponseEnd?: () => void
 }
 
 export type StaticStageData<
@@ -150,6 +151,14 @@ export async function fetchServerResponse(
   options: FetchServerResponseOptions
 ): Promise<FetchServerResponseResult> {
   const { flightRouterState, nextUrl } = options
+  const onResponseEnd = options.onResponseEnd
+  let responseEndNotified = false
+  const notifyResponseEnd = () => {
+    if (!responseEndNotified) {
+      responseEndNotified = true
+      onResponseEnd?.()
+    }
+  }
 
   const headers: RequestHeaders = {
     // Enable flight response
@@ -198,8 +207,13 @@ export async function fetchServerResponse(
       url,
       headers,
       'auto',
-      shouldImmediatelyDecode
+      shouldImmediatelyDecode,
+      undefined,
+      onResponseEnd !== undefined
     )
+    if (onResponseEnd !== undefined) {
+      res.responseEnd.then(notifyResponseEnd, notifyResponseEnd)
+    }
 
     // If the fetch succeeds while we're in the offline state, notify the
     // offline module so it can short-circuit the polling loop.
@@ -335,6 +349,7 @@ export async function fetchServerResponse(
       }
     }
 
+    notifyResponseEnd()
     if (!isPageUnloading) {
       console.error(
         `Failed to fetch RSC payload for ${originalUrl}. Falling back to browser navigation.`,
@@ -363,6 +378,7 @@ export type RSCResponse<T> = {
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
   cacheData: Promise<FetchResponseCacheData | null>
+  responseEnd: Promise<void>
 }
 
 type FetchResponseCacheData = {
@@ -387,20 +403,97 @@ type FetchResponseCacheData = {
  * When cache components is disabled, returns the original response with
  * cacheData: null.
  */
-export async function processFetch(response: Response): Promise<{
+function trackReadableStream(stream: ReadableStream<Uint8Array<ArrayBuffer>>): {
+  stream: ReadableStream<Uint8Array<ArrayBuffer>>
+  responseEnd: Promise<void>
+} {
+  const reader = stream.getReader()
+  let resolveResponseEnd!: () => void
+  const responseEnd = new Promise<void>((resolve) => {
+    resolveResponseEnd = resolve
+  })
+  let finished = false
+  const finish = () => {
+    if (!finished) {
+      finished = true
+      resolveResponseEnd()
+    }
+  }
+
+  return {
+    stream: new ReadableStream<Uint8Array<ArrayBuffer>>({
+      async pull(controller) {
+        try {
+          const result = await reader.read()
+          if (result.done) {
+            finish()
+            controller.close()
+          } else {
+            controller.enqueue(result.value)
+          }
+        } catch (error) {
+          finish()
+          controller.error(error)
+        }
+      },
+      cancel(reason) {
+        finish()
+        return reader.cancel(reason)
+      },
+    }),
+    responseEnd,
+  }
+}
+
+function cloneResponseWithBody(
+  response: Response,
+  body: ReadableStream<Uint8Array>
+): Response {
+  const clonedResponse = new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
+  Object.defineProperty(clonedResponse, 'url', { value: response.url })
+  Object.defineProperty(clonedResponse, 'redirected', {
+    value: response.redirected,
+  })
+  return clonedResponse
+}
+
+export async function processFetch(
+  response: Response,
+  trackResponseEnd: boolean = false
+): Promise<{
   response: Response
   cacheData: FetchResponseCacheData | null
+  responseEnd: Promise<void>
 }> {
-  if (process.env.__NEXT_CACHE_COMPONENTS) {
-    if (!response.body) {
+  if (!response.body) {
+    if (process.env.__NEXT_CACHE_COMPONENTS) {
       throw new InvariantError(
         'Expected RSC navigation response to have a body'
       )
     }
+    return {
+      response,
+      cacheData: null,
+      responseEnd: Promise.resolve(),
+    }
+  }
 
-    const { stream, isPartial } = await stripIsPartialByte(response.body)
+  let responseStream = response.body
+  let responseEnd = Promise.resolve()
+  if (trackResponseEnd) {
+    const tracked = trackReadableStream(responseStream)
+    responseStream = tracked.stream
+    responseEnd = tracked.responseEnd
+  }
 
-    let responseStream: ReadableStream<Uint8Array>
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    const { stream, isPartial } = await stripIsPartialByte(responseStream)
+
+    let flightResponseStream: ReadableStream<Uint8Array>
     let cacheData: FetchResponseCacheData
 
     if (process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS) {
@@ -408,35 +501,37 @@ export async function processFetch(response: Response): Promise<{
       // extractor, and the shell-stage extractor. Tee twice.
       const [stream1, rest] = stream.tee()
       const [staticBodyClone, shellBodyClone] = rest.tee()
-      responseStream = stream1
+      flightResponseStream = stream1
       cacheData = {
         isResponsePartial: isPartial,
         staticBodyClone,
         shellBodyClone,
       }
     } else {
-      responseStream = stream
+      flightResponseStream = stream
       cacheData = { isResponsePartial: isPartial }
     }
 
-    const strippedResponse = new Response(responseStream, {
-      headers: response.headers,
-      status: response.status,
-      statusText: response.statusText,
-    })
-
-    // The Response constructor doesn't preserve `url` or `redirected` from
-    // the original. We need both: `url` for React DevTools and `redirected`
-    // for the redirect replay logic below.
-    Object.defineProperty(strippedResponse, 'url', { value: response.url })
-    Object.defineProperty(strippedResponse, 'redirected', {
-      value: response.redirected,
-    })
-
-    return { response: strippedResponse, cacheData }
+    return {
+      response: cloneResponseWithBody(response, flightResponseStream),
+      cacheData,
+      responseEnd,
+    }
   }
 
-  return { response, cacheData: null }
+  if (!trackResponseEnd) {
+    return {
+      response,
+      cacheData: null,
+      responseEnd,
+    }
+  }
+
+  return {
+    response: cloneResponseWithBody(response, responseStream),
+    cacheData: null,
+    responseEnd,
+  }
 }
 
 /**
@@ -554,7 +649,8 @@ export async function createFetch<T>(
   headers: RequestHeaders,
   fetchPriority: 'auto' | 'high' | 'low' | null,
   shouldImmediatelyDecode: boolean,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  trackResponseEnd: boolean = false
 ): Promise<RSCResponse<T>> {
   // TODO: In output: "export" mode, the headers do nothing. Omit them (and the
   // cache busting search param) from the request so they're
@@ -594,7 +690,10 @@ export async function createFetch<T>(
   // track them separately.
   let fetchUrl = new URL(url)
   await setCacheBustingSearchParam(fetchUrl, headers)
-  let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  let processed = fetch(fetchUrl, fetchOptions).then((response) =>
+    processFetch(response, trackResponseEnd)
+  )
+  const responseEnds = [processed.then(({ responseEnd }) => responseEnd)]
   let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
@@ -664,7 +763,10 @@ export async function createFetch<T>(
       // TODO: We should abort the previous request.
       fetchUrl = new URL(responseUrl)
       await setCacheBustingSearchParam(fetchUrl, headers)
-      processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+      processed = fetch(fetchUrl, fetchOptions).then((response) =>
+        processFetch(response, trackResponseEnd)
+      )
+      responseEnds.push(processed.then(({ responseEnd }) => responseEnd))
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
         ? createFromNextFetch<T>(fetchPromise, headers)
@@ -703,6 +805,7 @@ export async function createFetch<T>(
     flightResponsePromise: flightResponsePromise,
 
     cacheData: processed.then(({ cacheData }) => cacheData),
+    responseEnd: Promise.all(responseEnds).then(() => {}),
   }
 
   return rscResponse

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -46,6 +46,7 @@ import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import { urlSearchParamsToParsedUrlQuery } from '../../route-params'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
+import { routeMismatchRouterTransition } from '../router-transition'
 import {
   getRenderedSearchFromVaryPath,
   type PageVaryPath,
@@ -113,8 +114,8 @@ const enum NavigationTaskExitStatus {
    */
   SoftRetry = 1,
   /**
-   * Some data failed to load in an unrecoverable way, e.g. in an inactive
-   * parallel route. Fall back to a hard (MPA-style) retry.
+   * Some data failed to load in an unrecoverable way. Fall back to a hard
+   * (MPA-style) retry.
    */
   HardRetry = 2,
   /**
@@ -125,6 +126,11 @@ const enum NavigationTaskExitStatus {
    * the retry reuses it instead of re-fetching.
    */
   RedirectRetry = 3,
+  /**
+   * A route tree mismatch occurred inside an inactive parallel route. Fall
+   * back to a hard retry.
+   */
+  HardMismatch = 4,
 }
 
 export type NavigationRequestAccumulation = {
@@ -1411,7 +1417,8 @@ export function spawnDynamicRequests(
   // server-patch retry logic so it can inherit the intent if the original
   // transition hasn't committed yet.
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
   if (dynamicRequestTree === null) {
@@ -1504,7 +1511,8 @@ export function spawnDynamicRequests(
     primaryRequestPromise,
     refreshRequestPromises,
     routeCacheEntry,
-    navigateType
+    navigateType,
+    transitionId
   )
   // `finishNavigationTask` is responsible for error handling, so we can attach
   // noop callbacks to this promise.
@@ -1519,7 +1527,8 @@ async function finishNavigationTask(
     ReturnType<typeof fetchMissingDynamicData>
   > | null,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null
 ): Promise<void> {
   // Wait for all the requests to finish, or for the first one to fail.
   let exitStatus = await waitForRequestsToFinish(
@@ -1544,41 +1553,45 @@ async function finishNavigationTask(
       return
     }
     case NavigationTaskExitStatus.SoftRetry: {
-      // Some data failed to finish loading. Trigger a soft retry that re-fetches
-      // the tree's dynamic data.
+      // Some data failed to finish loading, or the served tree didn't match
+      // the prefetched route — a route mismatch. Trigger a soft retry that
+      // re-fetches the tree's dynamic data.
       // TODO: As an extra precaution against soft retry loops, consider
       // tracking whether a navigation was itself triggered by a retry. If two
       // happen in a row, fall back to a hard retry.
-      const isHardRetry = false
       const primaryRequestResult = await primaryRequestPromise
+      routeMismatchRouterTransition(transitionId, primaryRequestResult.url.href)
       dispatchRetryDueToTreeMismatch(
-        isHardRetry,
+        false,
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
         task.route,
         routeCacheEntry,
         navigateType,
-        FreshnessPolicy.RefreshAll
+        FreshnessPolicy.RefreshAll,
+        transitionId
       )
       return
     }
     case NavigationTaskExitStatus.RedirectRetry: {
       // The route matched, but the request was redirected, so we committed the
       // wrong canonical URL. Re-resolve the route to invalidate the now-stale
-      // route cache and correct the URL — but reuse the data we already received
-      // (HistoryTraversal) instead of re-fetching it. See issue #95195.
-      const isHardRetry = false
+      // route cache and correct the URL — but reuse the data we already
+      // received (HistoryTraversal) instead of re-fetching it. See issue
+      // #95195. This is a redirect, not a tree mismatch, so it is not reported
+      // as one.
       const primaryRequestResult = await primaryRequestPromise
       dispatchRetryDueToTreeMismatch(
-        isHardRetry,
+        false,
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
         task.route,
         routeCacheEntry,
         navigateType,
-        FreshnessPolicy.HistoryTraversal
+        FreshnessPolicy.HistoryTraversal,
+        transitionId
       )
       return
     }
@@ -1591,17 +1604,36 @@ async function finishNavigationTask(
       // browser behavior for offline navigations. In the future, Next.js may
       // introduce its own custom handling of offline navigations, but that
       // doesn't exist yet.
-      const isHardRetry = true
       const primaryRequestResult = await primaryRequestPromise
       dispatchRetryDueToTreeMismatch(
-        isHardRetry,
+        true,
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
         task.route,
         routeCacheEntry,
         navigateType,
-        FreshnessPolicy.RefreshAll
+        FreshnessPolicy.RefreshAll,
+        transitionId
+      )
+      return
+    }
+    case NavigationTaskExitStatus.HardMismatch: {
+      // A route tree mismatch occurred inside an inactive parallel route — a
+      // route mismatch we can't recover with a soft retry. Report it, then fall
+      // back to a hard retry.
+      const primaryRequestResult = await primaryRequestPromise
+      routeMismatchRouterTransition(transitionId, primaryRequestResult.url.href)
+      dispatchRetryDueToTreeMismatch(
+        true,
+        primaryRequestResult.url,
+        nextUrl,
+        primaryRequestResult.seed,
+        task.route,
+        routeCacheEntry,
+        navigateType,
+        FreshnessPolicy.RefreshAll,
+        transitionId
       )
       return
     }
@@ -1678,7 +1710,8 @@ function dispatchRetryDueToTreeMismatch(
   // correcting after a redirect).
   retryFreshnessPolicy:
     | FreshnessPolicy.RefreshAll
-    | FreshnessPolicy.HistoryTraversal
+    | FreshnessPolicy.HistoryTraversal,
+  transitionId: string | null
 ) {
   // If the navigation used a route prediction, mark it as having a dynamic
   // rewrite since it resulted in a mismatch.
@@ -1747,7 +1780,7 @@ function dispatchRetryDueToTreeMismatch(
     mpa: isHardRetry,
     navigateType: retryNavigateType,
     freshnessPolicy: retryFreshnessPolicy,
-    transitionId: null,
+    transitionId,
   }
   dispatchAppRouterAction(retryAction)
 }
@@ -2122,7 +2155,7 @@ function abortRemainingPendingTasks(
       // TODO: An alternative could be to trigger a soft refresh but to _not_
       // re-use the inactive parallel routes this time. Similar to what would
       // happen if were to do a hard refrehs, but without the HTML page.
-      exitStatus = NavigationTaskExitStatus.HardRetry
+      exitStatus = NavigationTaskExitStatus.HardMismatch
     }
   } else {
     // This segment finished. (An error here is treated as Done because they are

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -46,7 +46,10 @@ import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import { urlSearchParamsToParsedUrlQuery } from '../../route-params'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
-import { routeMismatchRouterTransition } from '../router-transition'
+import {
+  beginRouterTransitionRequest,
+  routeMismatchRouterTransition,
+} from '../router-transition'
 import {
   getRenderedSearchFromVaryPath,
   type PageVaryPath,
@@ -135,6 +138,7 @@ const enum NavigationTaskExitStatus {
 
 export type NavigationRequestAccumulation = {
   separateRefreshUrls: Set<string> | null
+  prefetchedResponseEnds: Set<Promise<void>> | null
   /**
    * Set when a navigation creates new leaf segments that should be
    * scrolled to. Stays null when no new segments are created (e.g.
@@ -147,6 +151,17 @@ export type NavigationLock = NavigationLockState | null
 
 const noop = () => {}
 
+function accumulatePrefetchedResponseEnd(
+  accumulation: NavigationRequestAccumulation,
+  responseEnd: Promise<void>
+): void {
+  let responseEnds = accumulation.prefetchedResponseEnds
+  if (responseEnds === null) {
+    responseEnds = accumulation.prefetchedResponseEnds = new Set()
+  }
+  responseEnds.add(responseEnd)
+}
+
 export function createInitialCacheNodeForHydration(
   navigatedAt: number,
   initialTree: RouteTree,
@@ -158,6 +173,7 @@ export function createInitialCacheNodeForHydration(
   // HTML document.
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
+    prefetchedResponseEnds: null,
     scrollRef: null,
   }
   const restrictToShell = false
@@ -398,6 +414,7 @@ function updateCacheNodeOnNavigation(
       oldCacheNode !== undefined
         ? oldCacheNode.bfcacheId
         : generateBFCacheId(freshness),
+      accumulation,
       restrictToShell
     )
     newCacheNode = result.cacheNode
@@ -687,6 +704,7 @@ function createCacheNodeOnNavigation(
     // This segment was not part of the previous route, so mint a fresh
     // bfcacheId.
     generateBFCacheId(freshness),
+    accumulation,
     restrictToShell
   )
   const newCacheNode = result.cacheNode
@@ -952,6 +970,7 @@ function createCacheNodeForSegment(
   freshness: FreshnessPolicy,
   dynamicStaleAt: number,
   bfcacheId: number,
+  accumulation: NavigationRequestAccumulation,
   // Instant Navigation Testing API only — restricts segment reads to shell
   // entries. Always false outside the testing API. See navigation-testing-lock.
   restrictToShell: boolean
@@ -1106,6 +1125,9 @@ function createCacheNodeForSegment(
     restrictToShell
   )
   if (segmentEntry !== null) {
+    if (!segmentEntry.isPartial) {
+      accumulatePrefetchedResponseEnd(accumulation, segmentEntry.responseEnd)
+    }
     switch (segmentEntry.status) {
       case EntryStatus.Fulfilled: {
         // Happy path: a cache hit
@@ -1213,6 +1235,12 @@ function createCacheNodeForSegment(
         restrictToShell
       )
       if (metadataEntry !== null) {
+        if (!metadataEntry.isPartial) {
+          accumulatePrefetchedResponseEnd(
+            accumulation,
+            metadataEntry.responseEnd
+          )
+        }
         switch (metadataEntry.status) {
           case EntryStatus.Fulfilled: {
             cachedHead = metadataEntry.rsc
@@ -1387,6 +1415,22 @@ function compareSegments(
 // mismatches, we will fall back to an MPA navigation, to prevent a retry loop.
 let previousNavigationDidMismatch = false
 
+export function trackPrefetchedResponseEnds(
+  accumulation: NavigationRequestAccumulation,
+  transitionId: string | null
+): void {
+  const responseEnds = accumulation.prefetchedResponseEnds
+  if (responseEnds === null) {
+    return
+  }
+  for (const responseEnd of responseEnds) {
+    const finishRequest = beginRouterTransitionRequest(transitionId)
+    if (finishRequest !== undefined) {
+      responseEnd.then(finishRequest, finishRequest)
+    }
+  }
+}
+
 // Writes a dynamic server response into the tree created by
 // updateCacheNodeOnNavigation. All pending promises that were spawned by the
 // navigation will be resolved, either with dynamic data from the server, or
@@ -1443,7 +1487,8 @@ export function spawnDynamicRequests(
     nextUrl,
     freshnessPolicy,
     routeCacheEntry,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 
   const separateRefreshUrls = accumulation.separateRefreshUrls
@@ -1496,7 +1541,8 @@ export function spawnDynamicRequests(
             nextUrl,
             freshnessPolicy,
             routeCacheEntry,
-            navigationLock
+            navigationLock,
+            transitionId
           )
         )
       }
@@ -1792,17 +1838,20 @@ async function fetchMissingDynamicData(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
   url: URL
   seed: NavigationSeed | null
 }> {
   try {
+    const finishRequest = beginRouterTransitionRequest(transitionId)
     const result = await fetchServerResponse(url, {
       flightRouterState: dynamicRequestTree,
       nextUrl,
       isHmrRefresh: freshnessPolicy === FreshnessPolicy.HMRRefresh,
+      onResponseEnd: finishRequest,
     })
     if (typeof result === 'string') {
       // fetchServerResponse will return an href to indicate that the SPA

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1747,6 +1747,7 @@ function dispatchRetryDueToTreeMismatch(
     mpa: isHardRetry,
     navigateType: retryNavigateType,
     freshnessPolicy: retryFreshnessPolicy,
+    transitionId: null,
   }
   dispatchAppRouterAction(retryAction)
 }

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -24,16 +24,17 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, isExternalUrl, navigateType, scrollBehavior } = action
+  const { url, isExternalUrl, navigateType, scrollBehavior, transitionId } =
+    action
 
   if (isExternalUrl) {
-    return completeHardNavigation(state, url, navigateType)
+    return completeHardNavigation(state, url, navigateType, transitionId)
   }
 
   // Handles case where `<meta http-equiv="refresh">` tag is present,
   // which will trigger an MPA navigation.
   if (document.getElementById('__next-page-redirect')) {
-    return completeHardNavigation(state, url, navigateType)
+    return completeHardNavigation(state, url, navigateType, transitionId)
   }
 
   // Temporary glue code between the router reducer and the new navigation
@@ -51,6 +52,7 @@ export function navigateReducer(
     state.nextUrl,
     FreshnessPolicy.Default,
     scrollBehavior,
-    navigateType
+    navigateType,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -99,6 +99,7 @@ export function refreshDynamicData(
     // cache entry to mark as having a dynamic rewrite on mismatch. If a
     // mismatch occurs, the retry handler will traverse the known route tree
     // to find and mark the entry.
+    null,
     null
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -95,7 +95,8 @@ export function restoreReducer(
     null,
     // History traversal always uses 'replace'.
     'replace',
-    navigationLock
+    navigationLock,
+    transitionId
   )
   return completeTraverseNavigation(
     state,

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -9,6 +9,7 @@ import {
   getCurrentNavigationLock,
   spawnDynamicRequests,
   startPPRNavigation,
+  trackPrefetchedResponseEnds,
   type NavigationRequestAccumulation,
 } from '../ppr-navigations'
 import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
@@ -52,6 +53,7 @@ export function restoreReducer(
   // during restores and refreshes.
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
+    prefetchedResponseEnds: null,
     scrollRef: null,
   }
   const restoreSeed = convertServerPatchToFullTree(
@@ -82,6 +84,7 @@ export function restoreReducer(
   if (task === null) {
     return completeHardNavigation(state, restoredUrl, 'replace', transitionId)
   }
+  trackPrefetchedResponseEnds(accumulation, transitionId)
   spawnDynamicRequests(
     task,
     restoredUrl,

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -32,6 +32,7 @@ export function restoreReducer(
   let treeToRestore: FlightRouterState | undefined
   let renderedSearch: string | undefined
   const historyState = action.historyState
+  const transitionId = action.transitionId
   if (historyState) {
     treeToRestore = historyState.tree
     renderedSearch = historyState.renderedSearch
@@ -79,7 +80,7 @@ export function restoreReducer(
   )
 
   if (task === null) {
-    return completeHardNavigation(state, restoredUrl, 'replace')
+    return completeHardNavigation(state, restoredUrl, 'replace', transitionId)
   }
   spawnDynamicRequests(
     task,
@@ -102,6 +103,7 @@ export function restoreReducer(
     renderedSearch,
     task.node,
     task.route,
-    restoredNextUrl
+    restoredNextUrl,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -385,7 +385,14 @@ export function serverActionReducer(
             navigateType
           )
           reject(redirectError)
-          return completeHardNavigation(state, redirectLocation, navigateType)
+          // A server action redirect is not a router transition, so there is
+          // no transition id to correlate.
+          return completeHardNavigation(
+            state,
+            redirectLocation,
+            navigateType,
+            null
+          )
         } else {
           // Internal redirect. Triggers an SPA navigation.
           const redirectWithBasepath = createHrefFromUrl(
@@ -425,7 +432,12 @@ export function serverActionReducer(
         // an external redirect.
         // TODO: We should refactor the action response type to be more explicit
         // about the various response types.
-        return completeHardNavigation(state, redirectLocation, navigateType)
+        return completeHardNavigation(
+          state,
+          redirectLocation,
+          navigateType,
+          null
+        )
       }
 
       if (typeof flightData === 'string') {
@@ -434,7 +446,8 @@ export function serverActionReducer(
         return completeHardNavigation(
           state,
           new URL(flightData, location.origin),
-          navigateType
+          navigateType,
+          null
         )
       }
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -518,6 +518,7 @@ export function serverActionReducer(
           // have the route tree from the server response. If a mismatch occurs
           // during dynamic data fetch, the retry handler will traverse the
           // known route tree to mark the entry as having a dynamic rewrite.
+          null,
           null
         )
       }
@@ -534,7 +535,8 @@ export function serverActionReducer(
         nextUrl,
         freshnessPolicy,
         scrollBehavior,
-        navigateType
+        navigateType,
+        null
       )
     },
     (e: any) => {

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -25,10 +25,11 @@ export function serverPatchReducer(
   const retryUrl = new URL(action.url, location.origin)
   const retrySeed = action.seed
   const navigateType = action.navigateType
+  const transitionId = action.transitionId
   if (retryMpa || retrySeed === null) {
     // If the server did not send back data during the mismatch, fall back to
     // an MPA navigation.
-    return completeHardNavigation(state, retryUrl, navigateType)
+    return completeHardNavigation(state, retryUrl, navigateType, transitionId)
   }
   const currentUrl = new URL(state.canonicalUrl, location.origin)
   const currentRenderedSearch = state.renderedSearch
@@ -69,6 +70,7 @@ export function serverPatchReducer(
     // Server patch (retry) navigations don't use route prediction. This is
     // typically a retry after a previous mismatch, so the route was already
     // marked as having a dynamic rewrite when the mismatch was detected.
-    null
+    null,
+    transitionId
   )
 }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -93,6 +93,7 @@ export interface NavigateAction {
   locationSearch: Location['search']
   navigateType: 'push' | 'replace'
   scrollBehavior: ScrollBehavior
+  transitionId: string | null
 }
 
 /**
@@ -108,6 +109,7 @@ export interface RestoreAction {
   type: typeof ACTION_RESTORE
   url: URL
   historyState: AppHistoryState | undefined
+  transitionId: string | null
 }
 
 export type AppHistoryState = {
@@ -133,6 +135,7 @@ export interface ServerPatchAction {
    * redirect).
    */
   freshnessPolicy: FreshnessPolicy.RefreshAll | FreshnessPolicy.HistoryTraversal
+  transitionId: string | null
 }
 
 /**
@@ -253,6 +256,11 @@ export type AppRouterState = {
    * The previous next-url that was used previous to a dynamic navigation.
    */
   previousNextUrl: string | null
+
+  /**
+   * Identifies the router transition represented by this state, if any.
+   */
+  transitionId: string | null
 
   debugInfo: Array<unknown> | null
 }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -21,6 +21,7 @@ type RouterTransitionRecord = {
   resolvedUrl: string
   type: RouterTransitionType
   prefetch: RouterTransitionPrefetch
+  pendingRequests: number
   committed: boolean
   routeMismatchEmitted: boolean
 }
@@ -42,6 +43,7 @@ export function initializeRouterTransitionModules(
     instrumentationModules.some(
       (hooks) =>
         typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+        typeof hooks.unstable_onRouterTransitionSettled === 'function' ||
         typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
         typeof hooks.unstable_onRouterTransitionAbort === 'function'
     )
@@ -75,6 +77,7 @@ function hasLifecycleInstrumentation(): boolean {
     (hooks) =>
       typeof hooks.onRouterTransitionStart === 'function' ||
       typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+      typeof hooks.unstable_onRouterTransitionSettled === 'function' ||
       typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
       typeof hooks.unstable_onRouterTransitionAbort === 'function'
   )
@@ -97,11 +100,7 @@ export function startRouterTransition(
     }
 
     if (activeTransition !== null) {
-      if (activeTransition.committed) {
-        activeTransition = null
-      } else {
-        abortRouterTransition(activeTransition.id, 'superseded')
-      }
+      abortRouterTransition(activeTransition.id, 'superseded')
     }
 
     const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
@@ -110,6 +109,7 @@ export function startRouterTransition(
       resolvedUrl: url,
       type,
       prefetch: 'none',
+      pendingRequests: 0,
       committed: false,
       routeMismatchEmitted: false,
     }
@@ -144,6 +144,31 @@ export function setRouterTransitionPrefetch(
   }
 }
 
+export function beginRouterTransitionRequest(
+  id: string | null
+): (() => void) | undefined {
+  const record = getActiveTransition(id)
+  if (record === null) {
+    return undefined
+  }
+
+  record.pendingRequests++
+  const transitionId = record.id
+  let finished = false
+  return () => {
+    if (finished) {
+      return
+    }
+    finished = true
+    const current = getActiveTransition(transitionId)
+    if (current === null) {
+      return
+    }
+    current.pendingRequests--
+    scheduleSettle(current)
+  }
+}
+
 export function commitRouterTransition(
   id: string | null,
   url: string,
@@ -164,6 +189,7 @@ export function commitRouterTransition(
       prefetch: record.prefetch,
     })
   )
+  scheduleSettle(record)
 }
 
 export function routeMismatchRouterTransition(
@@ -204,6 +230,35 @@ export function abortRouterTransition(
       reason,
     })
   )
+}
+
+function scheduleSettle(record: RouterTransitionRecord): void {
+  if (!record.committed || record.pendingRequests !== 0) {
+    return
+  }
+
+  setTimeout(() => {
+    const current = getActiveTransition(record.id)
+    if (
+      current === null ||
+      !current.committed ||
+      current.pendingRequests !== 0
+    ) {
+      return
+    }
+
+    activeTransition = null
+    callHooks((hooks) =>
+      hooks.unstable_onRouterTransitionSettled?.(
+        current.resolvedUrl,
+        current.type,
+        {
+          id: current.id,
+          timestamp: timestamp(),
+        }
+      )
+    )
+  }, 0)
 }
 
 function classifySegment(segment: Segment): {

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -11,6 +11,7 @@ import { segmentToSourcePagePathname } from './router-reducer/compute-changed-pa
 import type {
   ClientInstrumentationHooks,
   ClientInstrumentationModules,
+  RouterTransitionPrefetch,
   RouterTransitionPrefetchIntent,
   RouterTransitionType,
 } from '../router-transition-types'
@@ -18,6 +19,7 @@ import type {
 type RouterTransitionRecord = {
   id: string
   type: RouterTransitionType
+  prefetch: RouterTransitionPrefetch
   committed: boolean
 }
 
@@ -91,6 +93,7 @@ export function startRouterTransition(
     const record: RouterTransitionRecord = {
       id,
       type,
+      prefetch: 'none',
       committed: false,
     }
     activeTransition = record
@@ -110,7 +113,25 @@ export function startRouterTransition(
   }
 }
 
-export function commitRouterTransition(id: string | null, url: string): void {
+export function setRouterTransitionPrefetch(
+  id: string | null,
+  prefetch: RouterTransitionPrefetch
+): void {
+  const record = getActiveTransition(id)
+  if (record !== null) {
+    // A route prediction can provide a tree after the prefetch cache misses.
+    // Preserve the miss instead of later reclassifying it as a shell hit.
+    if (record.prefetch !== 'miss') {
+      record.prefetch = prefetch
+    }
+  }
+}
+
+export function commitRouterTransition(
+  id: string | null,
+  url: string,
+  tree: FlightRouterState
+): void {
   const record = getActiveTransition(id)
   if (record === null || record.committed) {
     return
@@ -121,6 +142,8 @@ export function commitRouterTransition(id: string | null, url: string): void {
     hooks.unstable_onRouterTransitionCommit?.(url, record.type, {
       id: record.id,
       timestamp: timestamp(),
+      routes: getActiveRoutePaths(tree),
+      prefetch: record.prefetch,
     })
   )
 }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -91,11 +91,20 @@ export function startRouterTransition(
   url: string,
   type: RouterTransitionType,
   fromTree: FlightRouterState,
-  prefetchIntent: RouterTransitionPrefetchIntent | null
+  prefetchIntent: RouterTransitionPrefetchIntent | null,
+  onlyHashChange: boolean
 ): string | null {
   // Positive flag check so the instrumentation-only path is removed by DCE when disabled.
   if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
     if (!hasLifecycleInstrumentation()) {
+      return null
+    }
+
+    // A hash-only navigation (e.g. an in-page anchor link) does not change the
+    // route or fetch any data — the browser just scrolls. Skip the lifecycle so
+    // these near-instant, empty transitions don't inflate the metrics. The
+    // legacy two-argument start hook (the `else` branch below) is unaffected.
+    if (onlyHashChange) {
       return null
     }
 

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -15,8 +15,15 @@ import type {
   RouterTransitionType,
 } from '../router-transition-types'
 
+type RouterTransitionRecord = {
+  id: string
+  type: RouterTransitionType
+  committed: boolean
+}
+
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
 let nextTransitionId = 0
+let activeTransition: RouterTransitionRecord | null = null
 
 export function initializeRouterTransitionModules(
   modules: ClientInstrumentationModules
@@ -24,6 +31,23 @@ export function initializeRouterTransitionModules(
   instrumentationModules = modules.filter(
     (module): module is ClientInstrumentationHooks => module != null
   )
+
+  if (
+    !process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS &&
+    process.env.NODE_ENV !== 'production' &&
+    instrumentationModules.some(
+      (hooks) => typeof hooks.unstable_onRouterTransitionCommit === 'function'
+    )
+  ) {
+    console.warn(
+      'Router transition lifecycle hooks in instrumentation-client require ' +
+        '`experimental.instrumentationClientRouterTransitionEvents` to be enabled.'
+    )
+  }
+}
+
+function timestamp(): number {
+  return performance.timeOrigin + performance.now()
 }
 
 function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
@@ -39,8 +63,16 @@ function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
   }
 }
 
-function timestamp(): number {
-  return performance.timeOrigin + performance.now()
+function hasLifecycleInstrumentation(): boolean {
+  return instrumentationModules.some(
+    (hooks) =>
+      typeof hooks.onRouterTransitionStart === 'function' ||
+      typeof hooks.unstable_onRouterTransitionCommit === 'function'
+  )
+}
+
+function getActiveTransition(id: string | null): RouterTransitionRecord | null {
+  return id !== null && activeTransition?.id === id ? activeTransition : null
 }
 
 export function startRouterTransition(
@@ -48,18 +80,20 @@ export function startRouterTransition(
   type: RouterTransitionType,
   fromTree: FlightRouterState,
   prefetchIntent: RouterTransitionPrefetchIntent | null
-): void {
+): string | null {
   // Positive flag check so the instrumentation-only path is removed by DCE when disabled.
   if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
-    if (
-      !instrumentationModules.some(
-        (hooks) => typeof hooks.onRouterTransitionStart === 'function'
-      )
-    ) {
-      return
+    if (!hasLifecycleInstrumentation()) {
+      return null
     }
 
     const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
+    const record: RouterTransitionRecord = {
+      id,
+      type,
+      committed: false,
+    }
+    activeTransition = record
 
     callHooks((hooks) =>
       hooks.onRouterTransitionStart?.(url, type, {
@@ -69,9 +103,26 @@ export function startRouterTransition(
         prefetchIntent,
       })
     )
+    return id
   } else {
     callHooks((hooks) => hooks.onRouterTransitionStart?.(url, type, null))
+    return null
   }
+}
+
+export function commitRouterTransition(id: string | null, url: string): void {
+  const record = getActiveTransition(id)
+  if (record === null || record.committed) {
+    return
+  }
+
+  record.committed = true
+  callHooks((hooks) =>
+    hooks.unstable_onRouterTransitionCommit?.(url, record.type, {
+      id: record.id,
+      timestamp: timestamp(),
+    })
+  )
 }
 
 function classifySegment(segment: Segment): {

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -143,6 +143,9 @@ export function setRouterTransitionPrefetch(
   id: string | null,
   prefetch: RouterTransitionPrefetch
 ): void {
+  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    return
+  }
   const record = getActiveTransition(id)
   if (record !== null) {
     // A route prediction can provide a tree after the prefetch cache misses.
@@ -156,6 +159,9 @@ export function setRouterTransitionPrefetch(
 export function beginRouterTransitionRequest(
   id: string | null
 ): (() => void) | undefined {
+  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    return undefined
+  }
   const record = getActiveTransition(id)
   if (record === null) {
     return undefined
@@ -183,6 +189,9 @@ export function commitRouterTransition(
   url: string,
   tree: FlightRouterState
 ): void {
+  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    return
+  }
   const record = getActiveTransition(id)
   if (record === null || record.committed) {
     return
@@ -205,6 +214,9 @@ export function routeMismatchRouterTransition(
   id: string | null,
   url: string
 ): void {
+  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    return
+  }
   const record = getActiveTransition(id)
   if (record === null || record.routeMismatchEmitted) {
     return
@@ -225,6 +237,9 @@ export function abortRouterTransition(
   reason: 'superseded' | 'hard-navigation' | 'error',
   url?: string
 ): void {
+  if (!process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    return
+  }
   const record = getActiveTransition(id)
   if (record === null) {
     return

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -18,6 +18,7 @@ import type {
 
 type RouterTransitionRecord = {
   id: string
+  resolvedUrl: string
   type: RouterTransitionType
   prefetch: RouterTransitionPrefetch
   committed: boolean
@@ -38,7 +39,9 @@ export function initializeRouterTransitionModules(
     !process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS &&
     process.env.NODE_ENV !== 'production' &&
     instrumentationModules.some(
-      (hooks) => typeof hooks.unstable_onRouterTransitionCommit === 'function'
+      (hooks) =>
+        typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+        typeof hooks.unstable_onRouterTransitionAbort === 'function'
     )
   ) {
     console.warn(
@@ -69,7 +72,8 @@ function hasLifecycleInstrumentation(): boolean {
   return instrumentationModules.some(
     (hooks) =>
       typeof hooks.onRouterTransitionStart === 'function' ||
-      typeof hooks.unstable_onRouterTransitionCommit === 'function'
+      typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+      typeof hooks.unstable_onRouterTransitionAbort === 'function'
   )
 }
 
@@ -89,9 +93,14 @@ export function startRouterTransition(
       return null
     }
 
+    if (activeTransition !== null) {
+      abortRouterTransition(activeTransition.id, 'superseded')
+    }
+
     const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
     const record: RouterTransitionRecord = {
       id,
+      resolvedUrl: url,
       type,
       prefetch: 'none',
       committed: false,
@@ -138,12 +147,35 @@ export function commitRouterTransition(
   }
 
   record.committed = true
+  record.resolvedUrl = url
   callHooks((hooks) =>
     hooks.unstable_onRouterTransitionCommit?.(url, record.type, {
       id: record.id,
       timestamp: timestamp(),
       routes: getActiveRoutePaths(tree),
       prefetch: record.prefetch,
+    })
+  )
+  activeTransition = null
+}
+
+export function abortRouterTransition(
+  id: string | null,
+  reason: 'superseded' | 'hard-navigation' | 'error',
+  url?: string
+): void {
+  const record = getActiveTransition(id)
+  if (record === null) {
+    return
+  }
+
+  record.resolvedUrl = url ?? record.resolvedUrl
+  activeTransition = null
+  callHooks((hooks) =>
+    hooks.unstable_onRouterTransitionAbort?.(record.resolvedUrl, record.type, {
+      id: record.id,
+      timestamp: timestamp(),
+      reason,
     })
   )
 }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -22,6 +22,7 @@ type RouterTransitionRecord = {
   type: RouterTransitionType
   prefetch: RouterTransitionPrefetch
   committed: boolean
+  routeMismatchEmitted: boolean
 }
 
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
@@ -41,6 +42,7 @@ export function initializeRouterTransitionModules(
     instrumentationModules.some(
       (hooks) =>
         typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+        typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
         typeof hooks.unstable_onRouterTransitionAbort === 'function'
     )
   ) {
@@ -73,6 +75,7 @@ function hasLifecycleInstrumentation(): boolean {
     (hooks) =>
       typeof hooks.onRouterTransitionStart === 'function' ||
       typeof hooks.unstable_onRouterTransitionCommit === 'function' ||
+      typeof hooks.unstable_onRouterTransitionRouteMismatch === 'function' ||
       typeof hooks.unstable_onRouterTransitionAbort === 'function'
   )
 }
@@ -94,7 +97,11 @@ export function startRouterTransition(
     }
 
     if (activeTransition !== null) {
-      abortRouterTransition(activeTransition.id, 'superseded')
+      if (activeTransition.committed) {
+        activeTransition = null
+      } else {
+        abortRouterTransition(activeTransition.id, 'superseded')
+      }
     }
 
     const id = `${Date.now().toString(36)}-${(++nextTransitionId).toString(36)}`
@@ -104,6 +111,7 @@ export function startRouterTransition(
       type,
       prefetch: 'none',
       committed: false,
+      routeMismatchEmitted: false,
     }
     activeTransition = record
 
@@ -156,7 +164,25 @@ export function commitRouterTransition(
       prefetch: record.prefetch,
     })
   )
-  activeTransition = null
+}
+
+export function routeMismatchRouterTransition(
+  id: string | null,
+  url: string
+): void {
+  const record = getActiveTransition(id)
+  if (record === null || record.routeMismatchEmitted) {
+    return
+  }
+
+  record.routeMismatchEmitted = true
+  record.resolvedUrl = url
+  callHooks((hooks) =>
+    hooks.unstable_onRouterTransitionRouteMismatch?.(url, record.type, {
+      id: record.id,
+      timestamp: timestamp(),
+    })
+  )
 }
 
 export function abortRouterTransition(

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -236,6 +236,7 @@ export type RouteCacheEntry =
 
 type SegmentCacheEntryShared = {
   fetchStrategy: FetchStrategy
+  responseEnd: Promise<void>
 
   /**
    * True if this entry was fulfilled from a fallback shell response (the page
@@ -323,6 +324,7 @@ export const MetadataOnlyRequestTree: FlightRouterState = [
 
 let routeCacheMap: CacheMap<RouteCacheEntry> = createCacheMap()
 let segmentCacheMap: CacheMap<SegmentCacheEntry> = createCacheMap()
+const resolvedResponseEnd = Promise.resolve()
 
 // All invalidation listeners for the whole cache are tracked in single set.
 // Since we don't yet support tag or path-based invalidation, there's no point
@@ -1053,6 +1055,7 @@ export function createDetachedSegmentCacheEntry(
     isPartial: true,
     isUpgradeableISRFallback: false,
     promise: null,
+    responseEnd: resolvedResponseEnd,
 
     // Map-related fields
     ref: null,
@@ -2482,6 +2485,12 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
   const key = task.key
   const url = new URL(route.canonicalUrl, location.origin)
   const nextUrl = key.nextUrl
+  const responseEnd = createPromiseWithResolvers<void>()
+  if (fetchStrategy === FetchStrategy.Full) {
+    for (const entry of spawnedEntries.values()) {
+      entry.responseEnd = responseEnd.promise
+    }
+  }
 
   if (
     spawnedEntries.size === 1 &&
@@ -2533,6 +2542,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      responseEnd.resolve()
       return null
     }
 
@@ -2546,14 +2556,13 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // the proper way to handle this is to evict the stale route tree entry
       // then fill the cache with the new response.
       rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      responseEnd.resolve()
       return null
     }
 
     // Track when the network connection closes. Only meaningful for Full
     // (dynamic) prefetches which use incremental streaming. For buffered
     // paths, this is resolved immediately — see TODO in fetchRouteOnCacheMiss.
-    const closed = createPromiseWithResolvers<void>()
-
     let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null = null
     let prefetchStream: ReadableStream<Uint8Array>
     let bufferedResponseSize: number | null = null
@@ -2564,7 +2573,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // processed as it arrives.
       prefetchStream = createIncrementalPrefetchResponseStream(
         response.body,
-        closed.resolve,
+        responseEnd.resolve,
         function onResponseSizeUpdate(totalBytesReceivedSoFar) {
           // When processing a dynamic response, we don't know how large each
           // individual segment is, so approximate by assigning each segment
@@ -2584,7 +2593,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       const { stream, size } = await createNonTaskyPrefetchResponseStream(
         response.body
       )
-      closed.resolve()
+      responseEnd.resolve()
       prefetchStream = stream
       bufferedResponseSize = size
     }
@@ -2721,6 +2730,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     )
     if (typeof flightDatas === 'string') {
       rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      responseEnd.resolve()
       return null
     }
     const navigationSeed = convertServerPatchToFullTree(
@@ -2746,6 +2756,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       navigationSeed,
       spawnedEntries
     )
+    if (fetchStrategy === FetchStrategy.Full && fulfilledEntries !== null) {
+      for (const entry of fulfilledEntries) {
+        entry.responseEnd = responseEnd.promise
+      }
+    }
 
     // For buffered responses, update LRU sizes now that we know which
     // entries were fulfilled.
@@ -2762,7 +2777,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
 
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
-    return { value: null, closed: closed.promise }
+    return { value: null, closed: responseEnd.promise }
   } catch (error) {
     if (process.env.__NEXT_USE_OFFLINE) {
       const { checkOfflineError } =
@@ -2773,10 +2788,12 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
         // immediate expiration so it gets retried once the scheduler is
         // re-pinged after connectivity is restored.
         rejectSegmentEntriesIfStillPending(spawnedEntries, -1)
+        responseEnd.resolve()
         return null
       }
     }
     rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+    responseEnd.resolve()
     return null
   }
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -370,7 +370,8 @@ export function navigateToKnownRoute(
         accumulation,
         routeCacheEntry,
         navigateType,
-        navigationLock
+        navigationLock,
+        transitionId
       )
     }
     return completeSoftNavigation(

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -657,7 +657,7 @@ export function completeHardNavigation(
   state: AppRouterState,
   url: URL,
   navigateType: 'push' | 'replace',
-  transitionId: string | null = null
+  transitionId: string | null
 ): AppRouterState {
   if (isJavaScriptURLString(url.href)) {
     console.error(

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -66,7 +66,8 @@ export function navigate(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null
 ): AppRouterState | Promise<AppRouterState> {
   let navigationLock: NavigationLock = null
 
@@ -92,7 +93,8 @@ export function navigate(
         freshnessPolicy,
         scrollBehavior,
         navigateType,
-        navigationLock
+        navigationLock,
+        transitionId
       )
     }
   }
@@ -108,7 +110,8 @@ export function navigate(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 }
 
@@ -123,7 +126,8 @@ function navigateImpl(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): AppRouterState | Promise<AppRouterState> {
   const now = Date.now()
   const href = url.href
@@ -145,7 +149,8 @@ function navigateImpl(
       scrollBehavior,
       navigateType,
       route,
-      navigationLock
+      navigationLock,
+      transitionId
     )
   }
 
@@ -182,7 +187,8 @@ function navigateImpl(
           scrollBehavior,
           navigateType,
           optimisticRoute,
-          navigationLock
+          navigationLock,
+          transitionId
         )
       }
     }
@@ -205,7 +211,8 @@ function navigateImpl(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   ).catch(() => {
     // If the navigation fails, return the current state
     return state
@@ -239,7 +246,8 @@ export function navigateToKnownRoute(
   // In these cases, if a mismatch occurs, we still mark the route as having a
   // dynamic rewrite by traversing the known route tree (see
   // dispatchRetryDueToTreeMismatch).
-  routeCacheEntry: FulfilledRouteCacheEntry | null
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  transitionId: string | null
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
@@ -366,11 +374,12 @@ export function navigateToKnownRoute(
       navigateType,
       scrollBehavior,
       accumulation.scrollRef,
-      debugInfo
+      debugInfo,
+      transitionId
     )
   }
   // Could not perform a SPA navigation. Revert to a full-page (MPA) navigation.
-  return completeHardNavigation(state, url, navigateType)
+  return completeHardNavigation(state, url, navigateType, transitionId)
 }
 
 function navigateUsingPrefetchedRouteTree(
@@ -386,7 +395,8 @@ function navigateUsingPrefetchedRouteTree(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
   route: FulfilledRouteCacheEntry,
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): AppRouterState {
   const routeTree = route.tree
   const canonicalUrl = route.canonicalUrl + url.hash
@@ -415,7 +425,8 @@ function navigateUsingPrefetchedRouteTree(
     navigateType,
     navigationLock,
     null,
-    route
+    route,
+    transitionId
   )
 }
 
@@ -443,7 +454,8 @@ async function navigateToUnknownRoute(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<AppRouterState> {
   // Runs when a navigation happens but there's no cached prefetch we can use.
   // Don't bother to wait for a prefetch response; go straight to a full
@@ -483,7 +495,12 @@ async function navigateToUnknownRoute(
   if (typeof result === 'string') {
     // This is an MPA navigation.
     const redirectUrl = new URL(result, location.origin)
-    return completeHardNavigation(state, redirectUrl, navigateType)
+    return completeHardNavigation(
+      state,
+      redirectUrl,
+      navigateType,
+      transitionId
+    )
   }
 
   const {
@@ -631,14 +648,16 @@ async function navigateToUnknownRoute(
     // came directly from the server. If a mismatch occurs during dynamic data
     // fetch, the retry handler will traverse the known route tree to mark the
     // entry as having a dynamic rewrite.
-    null
+    null,
+    transitionId
   )
 }
 
 export function completeHardNavigation(
   state: AppRouterState,
   url: URL,
-  navigateType: 'push' | 'replace'
+  navigateType: 'push' | 'replace',
+  transitionId: string | null = null
 ): AppRouterState {
   if (isJavaScriptURLString(url.href)) {
     console.error(
@@ -665,6 +684,7 @@ export function completeHardNavigation(
     tree: state.tree,
     nextUrl: state.nextUrl,
     previousNextUrl: state.previousNextUrl,
+    transitionId,
     debugInfo: null,
   }
   return newState
@@ -681,7 +701,8 @@ export function completeSoftNavigation(
   navigateType: 'push' | 'replace',
   scrollBehavior: ScrollBehavior,
   scrollRef: ScrollRef | null,
-  collectedDebugInfo: Array<unknown> | null
+  collectedDebugInfo: Array<unknown> | null,
+  transitionId: string | null
 ) {
   // The "Next-Url" is a special representation of the URL that Next.js
   // uses to implement interception routes.
@@ -803,6 +824,7 @@ export function completeSoftNavigation(
     tree,
     nextUrl: nextUrlForNewRoute,
     previousNextUrl,
+    transitionId,
     debugInfo: collectedDebugInfo,
   }
   return newState
@@ -814,7 +836,8 @@ export function completeTraverseNavigation(
   renderedSearch: string,
   cache: CacheNode,
   tree: FlightRouterState,
-  nextUrl: string | null
+  nextUrl: string | null,
+  transitionId: string | null
 ) {
   return {
     // Set canonical url
@@ -835,6 +858,7 @@ export function completeTraverseNavigation(
     // Next-Url that was used to fetch the data. Anywhere we fetch using the
     // canonical URL, there should be a corresponding Next-Url.
     previousNextUrl: null,
+    transitionId,
     debugInfo: null,
   }
 }
@@ -1064,7 +1088,8 @@ async function ensurePrefetchThenNavigate(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  transitionId: string | null
 ): Promise<AppRouterState> {
   const link = getLinkForCurrentNavigation()
   const fetchStrategy = link !== null ? link.fetchStrategy : FetchStrategy.PPR
@@ -1104,7 +1129,8 @@ async function ensurePrefetchThenNavigate(
     freshnessPolicy,
     scrollBehavior,
     navigateType,
-    navigationLock
+    navigationLock,
+    transitionId
   )
 
   // Only transition to captured-SPA once the navigation is known to be an SPA.

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -47,7 +47,10 @@ import { computeChangedPath } from '../router-reducer/compute-changed-path'
 import { isJavaScriptURLString } from '../../lib/javascript-url'
 import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
 import { createLinkPrefetchPartialError } from '../../../shared/lib/instant-messages'
-import { setRouterTransitionPrefetch } from '../router-transition'
+import {
+  abortRouterTransition,
+  setRouterTransitionPrefetch,
+} from '../router-transition'
 
 /**
  * Navigate to a new URL, using the Segment Cache to construct a response.
@@ -216,6 +219,7 @@ function navigateImpl(
     navigationLock,
     transitionId
   ).catch(() => {
+    abortRouterTransition(transitionId, 'error')
     // If the navigation fails, return the current state
     return state
   })
@@ -670,8 +674,10 @@ export function completeHardNavigation(
     console.error(
       'Next.js has blocked a javascript: URL as a security precaution.'
     )
+    abortRouterTransition(transitionId, 'error', url.href)
     return state
   }
+  abortRouterTransition(transitionId, 'hard-navigation', url.href)
   const newState: AppRouterState = {
     canonicalUrl:
       url.origin === location.origin ? createHrefFromUrl(url) : url.href,

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -16,6 +16,7 @@ import { fetchServerResponse } from '../router-reducer/fetch-server-response'
 import {
   startPPRNavigation,
   spawnDynamicRequests,
+  trackPrefetchedResponseEnds,
   FreshnessPolicy,
   getCurrentNavigationLock,
   type NavigationLock,
@@ -49,6 +50,7 @@ import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
 import { createLinkPrefetchPartialError } from '../../../shared/lib/instant-messages'
 import {
   abortRouterTransition,
+  beginRouterTransitionRequest,
   setRouterTransitionPrefetch,
 } from '../router-transition'
 
@@ -319,6 +321,7 @@ export function navigateToKnownRoute(
 
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
+    prefetchedResponseEnds: null,
     scrollRef: null,
   }
   // We special case navigations to the exact same URL as the current location.
@@ -357,6 +360,7 @@ export function navigateToKnownRoute(
     restrictToShell
   )
   if (task !== null) {
+    trackPrefetchedResponseEnds(accumulation, transitionId)
     setRouterTransitionPrefetch(
       transitionId,
       task.dynamicRequestTree === null ? 'hit-route' : 'hit-shell'
@@ -499,9 +503,11 @@ async function navigateToUnknownRoute(
   }
 
   setRouterTransitionPrefetch(transitionId, 'miss')
+  const finishRequest = beginRouterTransitionRequest(transitionId)
   const promiseForDynamicServerResponse = fetchServerResponse(url, {
     flightRouterState: dynamicRequestTree,
     nextUrl,
+    onResponseEnd: finishRequest,
   })
   const result = await promiseForDynamicServerResponse
   if (typeof result === 'string') {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -47,6 +47,7 @@ import { computeChangedPath } from '../router-reducer/compute-changed-path'
 import { isJavaScriptURLString } from '../../lib/javascript-url'
 import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
 import { createLinkPrefetchPartialError } from '../../../shared/lib/instant-messages'
+import { setRouterTransitionPrefetch } from '../router-transition'
 
 /**
  * Navigate to a new URL, using the Segment Cache to construct a response.
@@ -174,6 +175,7 @@ function navigateImpl(
       )
       if (optimisticRoute !== null) {
         // We have an optimistic route tree. Proceed with the normal flow.
+        setRouterTransitionPrefetch(transitionId, 'miss')
         return navigateUsingPrefetchedRouteTree(
           now,
           state,
@@ -351,6 +353,10 @@ export function navigateToKnownRoute(
     restrictToShell
   )
   if (task !== null) {
+    setRouterTransitionPrefetch(
+      transitionId,
+      task.dynamicRequestTree === null ? 'hit-route' : 'hit-shell'
+    )
     if (freshnessPolicy !== FreshnessPolicy.Gesture) {
       spawnDynamicRequests(
         task,
@@ -487,6 +493,7 @@ async function navigateToUnknownRoute(
       break
   }
 
+  setRouterTransitionPrefetch(transitionId, 'miss')
   const promiseForDynamicServerResponse = fetchServerResponse(url, {
     flightRouterState: dynamicRequestTree,
     nextUrl,

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -1,5 +1,11 @@
 export type RouterTransitionType = 'push' | 'replace' | 'traverse'
 
+export type RouterTransitionPrefetch =
+  | 'hit-route'
+  | 'hit-shell'
+  | 'miss'
+  | 'none'
+
 export type RouterTransitionPrefetchIntent = 'full' | 'auto' | 'none'
 
 export type RouterTransitionEvent = {
@@ -13,7 +19,10 @@ export type RouterTransitionStartEvent = RouterTransitionEvent & {
   prefetchIntent: RouterTransitionPrefetchIntent | null
 }
 
-export type RouterTransitionCommitEvent = RouterTransitionEvent
+export type RouterTransitionCommitEvent = RouterTransitionEvent & {
+  routes: string[]
+  prefetch: RouterTransitionPrefetch
+}
 
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -24,6 +24,8 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   prefetch: RouterTransitionPrefetch
 }
 
+export type RouterTransitionRouteMismatchEvent = RouterTransitionEvent
+
 export type RouterTransitionAbortEvent = RouterTransitionEvent & {
   reason: 'superseded' | 'hard-navigation' | 'error'
 }
@@ -38,6 +40,11 @@ export type ClientInstrumentationHooks = {
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionCommitEvent
+  ) => void
+  unstable_onRouterTransitionRouteMismatch?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionRouteMismatchEvent
   ) => void
   unstable_onRouterTransitionAbort?: (
     url: string,

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -13,11 +13,18 @@ export type RouterTransitionStartEvent = RouterTransitionEvent & {
   prefetchIntent: RouterTransitionPrefetchIntent | null
 }
 
+export type RouterTransitionCommitEvent = RouterTransitionEvent
+
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionStartEvent | null
+  ) => void
+  unstable_onRouterTransitionCommit?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionCommitEvent
   ) => void
 }
 

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -24,6 +24,8 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   prefetch: RouterTransitionPrefetch
 }
 
+export type RouterTransitionSettledEvent = RouterTransitionEvent
+
 export type RouterTransitionRouteMismatchEvent = RouterTransitionEvent
 
 export type RouterTransitionAbortEvent = RouterTransitionEvent & {
@@ -40,6 +42,11 @@ export type ClientInstrumentationHooks = {
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionCommitEvent
+  ) => void
+  unstable_onRouterTransitionSettled?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionSettledEvent
   ) => void
   unstable_onRouterTransitionRouteMismatch?: (
     url: string,

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -24,6 +24,10 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   prefetch: RouterTransitionPrefetch
 }
 
+export type RouterTransitionAbortEvent = RouterTransitionEvent & {
+  reason: 'superseded' | 'hard-navigation' | 'error'
+}
+
 export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (
     url: string,
@@ -34,6 +38,11 @@ export type ClientInstrumentationHooks = {
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionCommitEvent
+  ) => void
+  unstable_onRouterTransitionAbort?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionAbortEvent
   ) => void
 }
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,6 +50,7 @@ export type {
   RouterTransitionEvent,
   RouterTransitionStartEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionSettledEvent,
   RouterTransitionRouteMismatchEvent,
   RouterTransitionAbortEvent,
 } from './client/router-transition-types'

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,6 +50,7 @@ export type {
   RouterTransitionEvent,
   RouterTransitionStartEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionRouteMismatchEvent,
   RouterTransitionAbortEvent,
 } from './client/router-transition-types'
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -45,6 +45,7 @@ export type { Instant } from './build/segment-config/app/app-segment-config'
 export type { Instrumentation } from './server/instrumentation/types'
 export type {
   RouterTransitionType,
+  RouterTransitionPrefetch,
   RouterTransitionPrefetchIntent,
   RouterTransitionEvent,
   RouterTransitionStartEvent,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,6 +50,7 @@ export type {
   RouterTransitionEvent,
   RouterTransitionStartEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionAbortEvent,
 } from './client/router-transition-types'
 
 /**

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -48,6 +48,7 @@ export type {
   RouterTransitionPrefetchIntent,
   RouterTransitionEvent,
   RouterTransitionStartEvent,
+  RouterTransitionCommitEvent,
 } from './client/router-transition-types'
 
 /**

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/instrumentation-client.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/instrumentation-client.ts
@@ -1,0 +1,41 @@
+type TransitionEvent = {
+  id: string
+  timestamp: number
+  fromRoutes?: string[]
+  routes?: string[]
+  prefetch?: string
+  prefetchIntent?: string
+}
+
+function record(phase: string, url: string, event: TransitionEvent) {
+  const events = ((window as any).__ROUTER_TRANSITION_EVENTS ??= [])
+  events.push({
+    phase,
+    url: new URL(url, window.location.href).pathname,
+    event,
+  })
+}
+
+export function onRouterTransitionStart(
+  url: string,
+  _navigationType: string,
+  event: TransitionEvent
+) {
+  record('start', url, event)
+}
+
+export function unstable_onRouterTransitionCommit(
+  url: string,
+  _navigationType: string,
+  event: TransitionEvent
+) {
+  record('commit', url, event)
+}
+
+export function unstable_onRouterTransitionSettled(
+  url: string,
+  _navigationType: string,
+  event: TransitionEvent
+) {
+  record('settled', url, event)
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
     cachedNavigations: true,
     appShells: true,
     varyParams: true,
+    instrumentationClientRouterTransitionEvents: true,
   },
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
+import { retry } from 'next-test-utils'
 
 // This suite asserts directly on App Shell prefetch responses, so every
 // `createRouterAct` call passes `{ includeAppShellRequests: true }`. By default
@@ -64,6 +65,68 @@ describe('App Shell prefetching', () => {
     expect(await browser.elementById('dynamic-content').text()).toEqual(
       'Post body for 124'
     )
+  })
+
+  it('reports an App Shell navigation as a shell prefetch hit', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/posts/1"]')
+          .click()
+      },
+      { includes: 'App shell for posts' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/posts/124"]').click()
+      expect(await browser.elementById('shell').text()).toEqual(
+        'App shell for posts'
+      )
+
+      const events = await browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
+      expect(events.map((event) => event.phase)).toEqual(['start', 'commit'])
+      expect(events[0]).toMatchObject({
+        phase: 'start',
+        url: '/posts/124',
+        event: {
+          fromRoutes: ['/'],
+          prefetchIntent: 'none',
+        },
+      })
+      expect(events[1]).toMatchObject({
+        phase: 'commit',
+        url: '/posts/124',
+        event: {
+          routes: ['/posts/[id]'],
+          prefetch: 'hit-shell',
+        },
+      })
+      expect(events[1].event.id).toBe(events[0].event.id)
+      expect(events[1].event.timestamp).toBeGreaterThanOrEqual(
+        events[0].event.timestamp
+      )
+    })
+
+    await retry(async () => {
+      const events = await browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
+      expect(events.map((event) => event.phase)).toEqual([
+        'start',
+        'commit',
+        'settled',
+      ])
+      expect(events[2].event.id).toBe(events[0].event.id)
+      expect(events[2].event.timestamp).toBeGreaterThanOrEqual(
+        events[1].event.timestamp
+      )
+    })
   })
 
   it('skips the per-link Speculative prefetch for a non-eager (allow-runtime) route', async () => {

--- a/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
@@ -19,6 +19,11 @@ export default function RootLayout({ children }) {
           <li>
             <Link href="/blog/hello">Blog post</Link>
           </li>
+          <li>
+            <Link href="/slow" prefetch={true}>
+              Slow page
+            </Link>
+          </li>
         </ul>
         {children}
       </body>

--- a/test/e2e/instrumentation-client-hook/app-router/app/push-button.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/push-button.tsx
@@ -5,8 +5,13 @@ import { useRouter } from 'next/navigation'
 export function PushButton() {
   const router = useRouter()
   return (
-    <button id="push-some-page" onClick={() => router.push('/some-page')}>
-      Push some page
-    </button>
+    <>
+      <button id="push-some-page" onClick={() => router.push('/some-page')}>
+        Push some page
+      </button>
+      <button id="push-hash" onClick={() => router.push('/#section')}>
+        Push hash
+      </button>
+    </>
   )
 }

--- a/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
@@ -1,7 +1,19 @@
 import { connection } from 'next/server'
+import { Suspense } from 'react'
 
-export default async function Page() {
+async function SlowContent() {
   await connection()
   await new Promise((resolve) => setTimeout(resolve, 500))
-  return <h1 id="slow-page">Slow page</h1>
+  return <p id="slow-content">Slow content</p>
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="slow-shell">Slow page</h1>
+      <Suspense fallback={<p id="slow-fallback">Loading</p>}>
+        <SlowContent />
+      </Suspense>
+    </>
+  )
 }

--- a/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/slow/page.tsx
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return <h1 id="slow-page">Slow page</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -37,3 +37,11 @@ export function unstable_onRouterTransitionCommit(
 ) {
   record('commit', href, navigateType, event)
 }
+
+export function unstable_onRouterTransitionAbort(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('abort', href, navigateType, event)
+}

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -29,3 +29,11 @@ export function onRouterTransitionStart(
   console.log(`[Router Transition Start] [${navigateType}] ${pathname}`)
   record('start', href, navigateType, event)
 }
+
+export function unstable_onRouterTransitionCommit(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('commit', href, navigateType, event)
+}

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -38,6 +38,14 @@ export function unstable_onRouterTransitionCommit(
   record('commit', href, navigateType, event)
 }
 
+export function unstable_onRouterTransitionSettled(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('settled', href, navigateType, event)
+}
+
 export function unstable_onRouterTransitionRouteMismatch(
   href: string,
   navigateType: string,

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -38,6 +38,14 @@ export function unstable_onRouterTransitionCommit(
   record('commit', href, navigateType, event)
 }
 
+export function unstable_onRouterTransitionRouteMismatch(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('route-mismatch', href, navigateType, event)
+}
+
 export function unstable_onRouterTransitionAbort(
   href: string,
   navigateType: string,

--- a/test/e2e/instrumentation-client-hook/inject/inject-a.js
+++ b/test/e2e/instrumentation-client-hook/inject/inject-a.js
@@ -9,3 +9,8 @@ export function onRouterTransitionStart(href, navigateType) {
     throw new Error('inject a transition hook failed')
   }
 }
+
+export function unstable_onRouterTransitionCommit(href, navigateType) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} a`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/inject-b.js
+++ b/test/e2e/instrumentation-client-hook/inject/inject-b.js
@@ -6,3 +6,8 @@ export function onRouterTransitionStart(href, navigateType) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname} b`)
 }
+
+export function unstable_onRouterTransitionCommit(href, navigateType) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} b`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/inject/instrumentation-client.ts
@@ -6,3 +6,11 @@ export function onRouterTransitionStart(href: string, navigateType: string) {
   const pathname = new URL(href, window.location.href).pathname
   console.log(`[Router Transition Start] [${navigateType}] ${pathname} user`)
 }
+
+export function unstable_onRouterTransitionCommit(
+  href: string,
+  navigateType: string
+) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition Commit] [${navigateType}] ${pathname} user`)
+}

--- a/test/e2e/instrumentation-client-hook/inject/next.config.mjs
+++ b/test/e2e/instrumentation-client-hook/inject/next.config.mjs
@@ -6,4 +6,7 @@ export default {
     './inject-a.js',
     './inject-b.js',
   ],
+  experimental: {
+    instrumentationClientRouterTransitionEvents: true,
+  },
 }

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -149,10 +149,10 @@ describe('Instrumentation Client Hook', () => {
       await retry(async () => {
         expect(
           (await getTransitionEvents(browser)).map((event) => event.phase)
-        ).toEqual(['start', 'commit'])
+        ).toEqual(['start', 'commit', 'settled'])
       })
 
-      const [start, commit] = await getTransitionEvents(browser)
+      const [start, commit, settled] = await getTransitionEvents(browser)
       expect(start.url).toBe('/some-page')
       expect(start.navigateType).toBe('push')
       expect(typeof start.event.id).toBe('string')
@@ -168,8 +168,12 @@ describe('Instrumentation Client Hook', () => {
         )
       }
       expect(commit.event.id).toBe(start.event.id)
+      expect(settled.event.id).toBe(start.event.id)
       expect(commit.event.timestamp).toBeGreaterThanOrEqual(
         start.event.timestamp
+      )
+      expect(settled.event.timestamp).toBeGreaterThanOrEqual(
+        commit.event.timestamp
       )
     })
 
@@ -248,22 +252,57 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementByCss('a[href="/blog/hello"]').click()
       await browser.elementById('blog-post')
       await retry(async () => {
-        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+        expect(
+          (await getTransitionEvents(browser)).some(
+            (event) => event.phase === 'commit'
+          )
+        ).toBe(true)
       })
-      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
-        '/blog/[slug]',
-      ])
+      expect(
+        (await getTransitionEvents(browser))
+          .filter((event) => event.phase === 'commit')
+          .at(-1).event.routes
+      ).toEqual(['/blog/[slug]'])
 
       await browser.elementByCss('a[href="/dashboard"]').click()
       await browser.elementById('dashboard')
       await browser.elementById('analytics')
       await retry(async () => {
-        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+        expect(
+          (await getTransitionEvents(browser))
+            .filter((event) => event.phase === 'commit')
+            .at(-1).event.routes
+        ).toEqual(['/dashboard', '/dashboard/@analytics'])
       })
-      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
-        '/dashboard',
-        '/dashboard/@analytics',
-      ])
+    })
+
+    it('commits the shell before the response settles', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/slow"]').click()
+      await browser.elementById('slow-shell')
+
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).some(
+            (event) => event.phase === 'commit'
+          )
+        ).toBe(true)
+      })
+      if (!process.env.IS_WEBPACK_TEST) {
+        expect(
+          (await getTransitionEvents(browser)).some(
+            (event) => event.phase === 'settled'
+          )
+        ).toBe(false)
+      }
+
+      await browser.elementById('slow-content')
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).map((event) => event.phase)
+        ).toEqual(['start', 'commit', 'settled'])
+      })
     })
 
     it('aborts a transition when it is superseded', async () => {
@@ -277,15 +316,20 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementByCss('a[href="/some-page"]').click()
       await browser.elementById('some-page')
       await retry(async () => {
-        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe(
+          'settled'
+        )
       })
 
       const events = await getTransitionEvents(browser)
       const firstId = events[0].event.id
-      const abort = events.find(
-        (event) => event.event.id === firstId && event.phase === 'abort'
+      const firstTerminalEvent = events.find(
+        (event) =>
+          event.event.id === firstId &&
+          (event.phase === 'abort' || event.phase === 'settled')
       )
-      expect(abort.event.reason).toBe('superseded')
+      expect(firstTerminalEvent.phase).toBe('abort')
+      expect(firstTerminalEvent.event.reason).toBe('superseded')
     })
   })
 

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -140,7 +140,7 @@ describe('Instrumentation Client Hook', () => {
       return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
     }
 
-    it('reports correlated start and commit events', async () => {
+    it('reports correlated lifecycle events and route information', async () => {
       const browser = await next.browser('/')
 
       await browser.elementByCss('a[href="/some-page"]').click()
@@ -159,6 +159,14 @@ describe('Instrumentation Client Hook', () => {
       expect(start.event.timestamp).toBeGreaterThan(0)
       expect(start.event.fromRoutes).toEqual(['/'])
       expect(start.event.prefetchIntent).toBe('full')
+      expect(commit.event.routes).toEqual(['/some-page'])
+      if (isNextDev) {
+        expect(commit.event.prefetch).toBe('miss')
+      } else {
+        expect(['hit-route', 'hit-shell', 'miss']).toContain(
+          commit.event.prefetch
+        )
+      }
       expect(commit.event.id).toBe(start.event.id)
       expect(commit.event.timestamp).toBeGreaterThanOrEqual(
         start.event.timestamp
@@ -232,6 +240,30 @@ describe('Instrumentation Client Hook', () => {
           .filter((e) => e.phase === 'start')
           .at(-1).event.fromRoutes
       ).toEqual(['/gallery', '/gallery/@modal/(.)photos/[id]'])
+    })
+
+    it('uses route patterns and puts the primary destination route first', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/blog/hello"]').click()
+      await browser.elementById('blog-post')
+      await retry(async () => {
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+      })
+      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
+        '/blog/[slug]',
+      ])
+
+      await browser.elementByCss('a[href="/dashboard"]').click()
+      await browser.elementById('dashboard')
+      await browser.elementById('analytics')
+      await retry(async () => {
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+      })
+      expect((await getTransitionEvents(browser)).at(-1).event.routes).toEqual([
+        '/dashboard',
+        '/dashboard/@analytics',
+      ])
     })
   })
 

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -1,6 +1,8 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import path from 'path'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
 
 describe('Instrumentation Client Hook', () => {
   describe.each([
@@ -352,6 +354,65 @@ describe('Instrumentation Client Hook', () => {
           (await getTransitionEvents(browser)).map((e) => e.phase)
         ).toEqual(['start', 'commit', 'settled'])
       })
+    })
+  })
+
+  describe('router transition route mismatch', () => {
+    const { next, isNextDev: isDevMode } = nextTestSetup({
+      files: path.join(__dirname, 'mismatch'),
+    })
+
+    // Prod-only: dev never prefetches, so the navigation takes the unknown-route
+    // path and never produces a tree mismatch.
+    if (isDevMode) {
+      it('is disabled in development', () => {})
+      return
+    }
+
+    async function getTransitionEvents(browser) {
+      return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
+    }
+
+    it('emits a route-mismatch event when a navigation rewrites to a different route', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      // Reveal the link so it prefetches page A.
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/dynamic-page/a?mismatch-rewrite=./b"]'
+      )
+      await act(async () => await toggle.click(), {
+        includes: 'Loading a...',
+      })
+
+      // Clicking navigates to the prefetched route A, but the proxy rewrites the
+      // navigation request to route B. The client detects the mismatch and
+      // recovers by rendering route B.
+      await act(async () => {
+        const link = await browser.elementByCss(
+          'a[href="/dynamic-page/a?mismatch-rewrite=./b"]'
+        )
+        await link.click()
+      }, [{ includes: 'Dynamic page b' }])
+      await browser.elementById('dynamic-page-content-b')
+
+      const events = await getTransitionEvents(browser)
+      const start = events.find((e) => e.phase === 'start')
+      const mismatch = events.find((e) => e.phase === 'route-mismatch')
+      expect(start).toBeDefined()
+      expect(mismatch).toBeDefined()
+      // The mismatch is correlated to the originating transition...
+      expect(mismatch.event.id).toBe(start.event.id)
+      // ...and is a milestone, not a terminal event, so its timestamp falls
+      // after the start.
+      expect(mismatch.event.timestamp).toBeGreaterThanOrEqual(
+        start.event.timestamp
+      )
     })
   })
 

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -265,6 +265,28 @@ describe('Instrumentation Client Hook', () => {
         '/dashboard/@analytics',
       ])
     })
+
+    it('aborts a transition when it is superseded', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/slow"]').click()
+      await retry(async () => {
+        expect((await getTransitionEvents(browser))[0].phase).toBe('start')
+      })
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await retry(async () => {
+        expect((await getTransitionEvents(browser)).at(-1).phase).toBe('commit')
+      })
+
+      const events = await getTransitionEvents(browser)
+      const firstId = events[0].event.id
+      const abort = events.find(
+        (event) => event.event.id === firstId && event.phase === 'abort'
+      )
+      expect(abort.event.reason).toBe('superseded')
+    })
   })
 
   describe.each([

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -331,6 +331,28 @@ describe('Instrumentation Client Hook', () => {
       expect(firstTerminalEvent.phase).toBe('abort')
       expect(firstTerminalEvent.event.reason).toBe('superseded')
     })
+
+    it('does not emit transition events for a hash-only navigation', async () => {
+      const browser = await next.browser('/')
+
+      // A hash-only navigation (in-page anchor) only scrolls — it is not a
+      // route transition and must not produce any lifecycle events.
+      await browser.elementById('push-hash').click()
+      await retry(async () => {
+        expect(await browser.eval('location.hash')).toBe('#section')
+      })
+      expect(await getTransitionEvents(browser)).toEqual([])
+
+      // A subsequent real navigation still instruments, proving the hooks are
+      // installed and the empty result above is the hash-skip, not a dead hook.
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).map((e) => e.phase)
+        ).toEqual(['start', 'commit', 'settled'])
+      })
+    })
   })
 
   describe.each([

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -57,6 +57,16 @@ describe('Instrumentation Client Hook', () => {
     return result
   }
 
+  function filterNavigationCommitLogs(logs: Array<{ message: string }>) {
+    const result = []
+    for (const log of logs) {
+      if (log.message.startsWith('[Router Transition Commit]')) {
+        result.push(log.message)
+      }
+    }
+    return result
+  }
+
   describe('onRouterTransitionStart', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'app-router'),
@@ -116,7 +126,7 @@ describe('Instrumentation Client Hook', () => {
     })
   })
 
-  describe('router transition start context', () => {
+  describe('router transition lifecycle', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'app-router'),
       nextConfig: {
@@ -130,20 +140,29 @@ describe('Instrumentation Client Hook', () => {
       return browser.eval(`window.__ROUTER_TRANSITION_EVENTS`)
     }
 
-    it('reports transition metadata, source routes, and prefetch intent', async () => {
+    it('reports correlated start and commit events', async () => {
       const browser = await next.browser('/')
 
       await browser.elementByCss('a[href="/some-page"]').click()
       await browser.elementById('some-page')
 
-      const [start] = await getTransitionEvents(browser)
-      expect(start.phase).toBe('start')
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).map((event) => event.phase)
+        ).toEqual(['start', 'commit'])
+      })
+
+      const [start, commit] = await getTransitionEvents(browser)
       expect(start.url).toBe('/some-page')
       expect(start.navigateType).toBe('push')
       expect(typeof start.event.id).toBe('string')
       expect(start.event.timestamp).toBeGreaterThan(0)
       expect(start.event.fromRoutes).toEqual(['/'])
       expect(start.event.prefetchIntent).toBe('full')
+      expect(commit.event.id).toBe(start.event.id)
+      expect(commit.event.timestamp).toBeGreaterThanOrEqual(
+        start.event.timestamp
+      )
     })
 
     it('reports a null prefetch intent for programmatic navigation', async () => {
@@ -168,7 +187,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/blog/[slug]'])
 
       await browser.elementByCss('a[href="/dashboard"]').click()
@@ -178,7 +199,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/dashboard', '/dashboard/@analytics'])
     })
 
@@ -189,7 +212,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/about'])
     })
 
@@ -203,7 +228,9 @@ describe('Instrumentation Client Hook', () => {
       await browser.elementById('home')
 
       expect(
-        (await getTransitionEvents(browser)).at(-1).event.fromRoutes
+        (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'start')
+          .at(-1).event.fromRoutes
       ).toEqual(['/gallery', '/gallery/@modal/(.)photos/[id]'])
     })
   })
@@ -267,6 +294,15 @@ describe('Instrumentation Client Hook', () => {
         '[Router Transition Start] [push] / a',
         '[Router Transition Start] [push] / b',
         '[Router Transition Start] [push] / user',
+      ])
+
+      expect(filterNavigationCommitLogs(await browser.log())).toEqual([
+        '[Router Transition Commit] [push] /some-page a',
+        '[Router Transition Commit] [push] /some-page b',
+        '[Router Transition Commit] [push] /some-page user',
+        '[Router Transition Commit] [push] / a',
+        '[Router Transition Commit] [push] / b',
+        '[Router Transition Commit] [push] / user',
       ])
     })
 

--- a/test/e2e/instrumentation-client-hook/mismatch/app/dynamic-page/[param]/page.tsx
+++ b/test/e2e/instrumentation-client-hook/mismatch/app/dynamic-page/[param]/page.tsx
@@ -1,0 +1,32 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateStaticParams() {
+  return [{ param: 'a' }, { param: 'b' }]
+}
+
+async function DynamicContent({ children }: { children: React.ReactNode }) {
+  await connection()
+  return children
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ param: string }>
+}) {
+  const { param } = await params
+  return (
+    <Suspense
+      fallback={
+        <div id={`dynamic-page-loading-${param}`}>{`Loading ${param}...`}</div>
+      }
+    >
+      <DynamicContent>
+        <div
+          id={`dynamic-page-content-${param}`}
+        >{`Dynamic page ${param}`}</div>
+      </DynamicContent>
+    </Suspense>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/mismatch/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/mismatch/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/mismatch/app/page.tsx
+++ b/test/e2e/instrumentation-client-hook/mismatch/app/page.tsx
@@ -1,0 +1,12 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <div>
+      <h1 id="home">Home</h1>
+      <LinkAccordion href="/dynamic-page/a?mismatch-rewrite=./b">
+        <code>{`/dynamic-page/a ──[ rewrites to ]──→ /dynamic-page/b`}</code>
+      </LinkAccordion>
+    </div>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/mismatch/components/link-accordion.tsx
+++ b/test/e2e/instrumentation-client-hook/mismatch/components/link-accordion.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children?: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  const resolvedChildren = children ?? href
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {resolvedChildren}
+        </Link>
+      ) : (
+        <>{resolvedChildren} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/mismatch/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/mismatch/instrumentation-client.ts
@@ -1,0 +1,55 @@
+;(window as any).__ROUTER_TRANSITION_EVENTS = []
+
+function record(
+  phase: string,
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  ;(window as any).__ROUTER_TRANSITION_EVENTS.push({
+    phase,
+    url: new URL(href, window.location.href).pathname,
+    navigateType,
+    event,
+  })
+}
+
+export function onRouterTransitionStart(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('start', href, navigateType, event)
+}
+
+export function unstable_onRouterTransitionCommit(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('commit', href, navigateType, event)
+}
+
+export function unstable_onRouterTransitionSettled(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('settled', href, navigateType, event)
+}
+
+export function unstable_onRouterTransitionRouteMismatch(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('route-mismatch', href, navigateType, event)
+}
+
+export function unstable_onRouterTransitionAbort(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  record('abort', href, navigateType, event)
+}

--- a/test/e2e/instrumentation-client-hook/mismatch/next.config.js
+++ b/test/e2e/instrumentation-client-hook/mismatch/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    instrumentationClientRouterTransitionEvents: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/instrumentation-client-hook/mismatch/proxy.ts
+++ b/test/e2e/instrumentation-client-hook/mismatch/proxy.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// Simulates a proxy/firewall that modifies the request based on a condition
+// that changes after the prefetch but before the actual navigation. The proxy
+// only acts during a navigation — not during a prefetch — so the prefetched
+// tree is for the requested route but the navigation resolves to a different
+// one, which is what produces a router-transition route mismatch.
+export const config = {
+  matcher: [
+    {
+      source: '/:path*',
+      // Exclude prefetch requests.
+      missing: [{ type: 'header', key: 'Next-Router-Prefetch' }],
+    },
+  ],
+}
+
+export default function proxy(req: NextRequest) {
+  const mismatchRewrite = req.nextUrl.searchParams.get('mismatch-rewrite')
+  if (mismatchRewrite) {
+    return NextResponse.rewrite(new URL(mismatchRewrite, req.url))
+  }
+}


### PR DESCRIPTION
## Summary

Consolidates the unmerged tail of the router-transition instrumentation stack onto `canary`, adding the `unstable_` lifecycle hooks to `instrumentation-client`: commit / settled / route-mismatch / abort (start, with `fromRoutes` + `prefetchIntent`, already merged via #94755/#94766). Gated by `experimental.instrumentationClientRouterTransitionEvents`; hooks share a per-transition `id`, errors stay isolated.

Folds #94756 + #94765 + #94757 + #94758 + #94737. Per-commit authorship preserved.

### Hardening done in review

- **Hash-only navigations are no longer instrumented.** They used to emit a full start→commit→settled cycle (inflating metrics with empty transitions); now skipped at the dispatch layer (legacy 2-arg hook untouched). + e2e.
- **Route-mismatch e2e added** (was untested): prefetch route A, click a link the proxy rewrites to B, assert a `route-mismatch` event correlated to the start.
- **Tree-shaken when the flag is off.** All lifecycle functions now early-return on the flag (matching `startRouterTransition`), so terser drops their bodies + `getActiveRoutePaths`/`scheduleSettle` from the default (flag-off) client bundle.

### Reconciliation note (verified)

Canary refactored the retry taxonomy under this stack (`RedirectRetry` + per-case `freshnessPolicy`, #95195). Kept **both** `RedirectRetry` (=3) and `HardMismatch` (=4), preserved canary's per-case retry behavior, and threaded `transitionId` through all four retry cases. **Decision (verified against the producers):** `SoftRetry` and `HardMismatch` are reported as route mismatches; `RedirectRetry` is **not** (it fires only on an actual HTTP redirect — `res.redirected` — which is mutually exclusive with a tree mismatch), nor is `HardRetry` (network failure).

### Coverage notes

- `route-mismatch` is e2e-tested via the `SoftRetry` (rewrite) path. The `HardMismatch` path emits the **same** instrumentation call but can't be e2e-tested deterministically (it only fires inside a refresh of an inactive default-slot parallel route and ends in an MPA reload that tears down the event array) — covered by symmetry.
- `abort` reason `error` has no deterministic e2e (client fetch failures resolve to `hard-navigation`, not a rejection); `superseded` is tested.

## Verification

- `thank you, next` + `thank you, build` green; full suite passes incl. the instrumentation e2e in dev, prod, and deploy.
- start / commit / settled / route-mismatch / abort(superseded) / hash-only-skip all asserted in `test/e2e/instrumentation-client-hook`.

<!-- NEXT_JS_LLM_PR -->
