### PR TITLE
defer and batch leaf distance updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10064,6 +10064,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "crossbeam-utils",
  "dashmap 6.1.0",
+ "either",
  "futures",
  "hashbrown 0.14.5",
  "indexmap 2.13.0",

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -32,7 +32,7 @@ trace_task_completion = []
 trace_task_modification = []
 trace_task_dirty = ["trace_aggregation_update_queue", "task_dirty_cause"]
 trace_task_output_dependencies = []
-trace_task_details = []
+trace_task_details = ["dep:either"]
 trace_prepare_tasks = []
 
 [dependencies]
@@ -42,6 +42,7 @@ auto-hash-map = { workspace = true }
 bitfield = { workspace = true }
 crossbeam-utils = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"]}
+either = { workspace = true, optional = true }
 hashbrown = { workspace = true, features = ["raw"] }
 indexmap = { workspace = true }
 lzzzz = { workspace = true, optional = true }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2184,11 +2184,17 @@ impl TurboTasksBackend {
             (*stale, *is_once_task, take(leaf_distance_update_queue))
         };
 
-        // Execute the leaf distance updates that were accumulated while the task executed: this
-        // updates the task's own leaf distance and propagates the change to its (already completed)
-        // output dependents. This is done here, before the stale check below, so that
-        // `compute_stale_priority` reads the freshly computed value. The queue re-locks the task
-        // internally, so the current lock must be released first.
+        // Leaf distance only feeds invalidation/re-execution scheduling priority, so it is only
+        // accumulated when dependency tracking is on (see the read path: the reader is only locked
+        // when `should_track_dependencies()`). With tracking off nothing should ever be pushed.
+        debug_assert!(
+            self.should_track_dependencies() || leaf_distance_update_queue.is_empty(),
+            "leaf distance updates were accumulated without dependency tracking enabled"
+        );
+        // We also expect the queue to be empty for immutable tasks.
+
+        // Execute the leaf distance updates that were accumulated while the task executed, this
+        // needs to run before the 'stale' reexecution logic below.
         if !leaf_distance_update_queue.is_empty() {
             drop(task);
             leaf_distance_update_queue.execute(ctx);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1,6 +1,6 @@
 mod cell_data;
 mod counter_map;
-mod operation;
+pub(crate) mod operation;
 mod snapshot_coordinator;
 mod storage;
 pub mod storage_schema;
@@ -60,9 +60,8 @@ use crate::{
         operation::{
             AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext,
             CleanupOldEdgesOperation, ConnectChildOperation, ExecuteContext, ExecuteContextImpl,
-            LeafDistanceUpdateQueue, Operation, OutdatedEdge, TaskGuard, TaskType, TaskTypeRef,
-            connect_children, get_aggregation_number, get_uppers, make_task_dirty_internal,
-            prepare_new_children,
+            Operation, OutdatedEdge, TaskGuard, TaskType, TaskTypeRef, connect_children,
+            get_aggregation_number, get_uppers, make_task_dirty_internal, prepare_new_children,
         },
         snapshot_coordinator::{OperationGuard, SnapshotCoordinator},
         storage::Storage,
@@ -493,8 +492,7 @@ impl TurboTasksBackend {
             task: &impl TaskGuard,
             reader_description: Option<EventDescription>,
             tracking: ReadTracking,
-        ) -> Option<std::result::Result<std::result::Result<RawVc, EventListener>, anyhow::Error>>
-        {
+        ) -> Option<Result<std::result::Result<RawVc, EventListener>>> {
             match task.get_in_progress() {
                 Some(InProgressState::Scheduled { done_event, .. }) => Some(Ok(Err(
                     listen_to_done_event(reader_description, tracking, done_event),
@@ -704,19 +702,35 @@ impl TurboTasksBackend {
                     dependent_task = ?reader
                 )
                 .entered();
-                let mut queue = LeafDistanceUpdateQueue::new();
                 let reader = reader.unwrap();
-                if task.add_output_dependent(reader) {
+                if task.add_output_dependent(reader)
+                    // Immutable producers are excluded: they never re-execute so we don't need to defer our invalidations relative to their leaf distance.
+                    && !task.immutable()
+                {
                     // Ensure that dependent leaf distance is strictly monotonic increasing
                     let leaf_distance = task.get_leaf_distance().copied().unwrap_or_default();
                     let reader_leaf_distance =
                         reader_task.get_leaf_distance().copied().unwrap_or_default();
                     if reader_leaf_distance.distance <= leaf_distance.distance {
-                        queue.push(
-                            reader,
-                            leaf_distance.distance,
-                            leaf_distance.max_distance_in_buffer,
+                        // Accumulate the dependencies leaf distance in the in_progress state, it
+                        // will be finalized during our task completion.
+                        let in_progress = reader_task.get_in_progress_mut();
+                        debug_assert!(
+                            matches!(in_progress, Some(InProgressState::InProgress(_))),
+                            "a tracked read implies the reader is in progress, but it was \
+                             {in_progress:?}"
                         );
+                        if let Some(InProgressState::InProgress(box InProgressStateInner {
+                            leaf_distance_update_queue,
+                            ..
+                        })) = in_progress
+                        {
+                            leaf_distance_update_queue.push(
+                                reader,
+                                leaf_distance.distance,
+                                leaf_distance.max_distance_in_buffer,
+                            );
+                        }
                     }
                 }
 
@@ -731,8 +745,6 @@ impl TurboTasksBackend {
                     let _ = reader_task.add_output_dependencies(task_id);
                 }
                 drop(reader_task);
-
-                queue.execute(&mut ctx);
             } else {
                 drop(task);
             }
@@ -1893,6 +1905,7 @@ impl TurboTasksBackend {
                     done_event,
                     marked_as_completed: false,
                     new_children: Default::default(),
+                    leaf_distance_update_queue: Default::default(),
                 },
             )));
             debug_assert!(old.is_none(), "InProgress already exists");
@@ -2155,14 +2168,38 @@ impl TurboTasksBackend {
                 is_session_dependent,
             });
         }
-        let &mut InProgressState::InProgress(box InProgressStateInner {
-            stale,
-            ref mut new_children,
-            once_task: is_once_task,
-            ..
-        }) = in_progress
+        // Capture the Copy fields and take the accumulated leaf distance update queue before
+        // computing the leaf distance, so the borrow of `in_progress` is released and `task` can be
+        // mutated below.
+        let (stale, is_once_task, leaf_distance_update_queue) = {
+            let InProgressState::InProgress(box InProgressStateInner {
+                stale,
+                once_task: is_once_task,
+                leaf_distance_update_queue,
+                ..
+            }) = in_progress
+            else {
+                panic!("Task execution completed, but task is not in progress: {task:#?}");
+            };
+            (*stale, *is_once_task, take(leaf_distance_update_queue))
+        };
+
+        // Execute the leaf distance updates that were accumulated while the task executed: this
+        // updates the task's own leaf distance and propagates the change to its (already completed)
+        // output dependents. This is done here, before the stale check below, so that
+        // `compute_stale_priority` reads the freshly computed value. The queue re-locks the task
+        // internally, so the current lock must be released first.
+        if !leaf_distance_update_queue.is_empty() {
+            drop(task);
+            leaf_distance_update_queue.execute(ctx);
+            task = ctx.task(task_id, TaskDataCategory::All);
+        }
+
+        // Re-borrow the in-progress children for the rest of completion.
+        let Some(InProgressState::InProgress(box InProgressStateInner { new_children, .. })) =
+            task.get_in_progress_mut()
         else {
-            panic!("Task execution completed, but task is not in progress: {task:#?}");
+            unreachable!("checked above");
         };
 
         // If the task is stale, reschedule it
@@ -2666,6 +2703,7 @@ impl TurboTasksBackend {
             stale,
             marked_as_completed: _,
             new_children,
+            leaf_distance_update_queue: _,
         }) = in_progress
         else {
             panic!("Task execution completed, but task is not in progress: {task:#?}");

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/leaf_distance_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/leaf_distance_update.rs
@@ -26,7 +26,7 @@ const MAX_COUNT_BEFORE_YIELD: usize = 1000;
 const BASE_LEAF_DISTANCE_BUFFER: u32 = 128;
 
 /// An leaf distance update job that is enqueued.
-#[derive(Encode, Decode, Clone)]
+#[derive(Debug, Encode, Decode, Clone)]
 struct LeafDistanceUpdate {
     dependencies_distance: u32,
     dependencies_max_distance_in_buffer: u32,
@@ -48,17 +48,13 @@ impl LeafDistanceUpdate {
 /// A queue of leaf distance update jobs.
 /// It will execute these jobs in order of their minimum dependency leaf distance.
 /// This ensures that we never have to re-process a task.
-#[derive(Default, Encode, Decode, Clone)]
+#[derive(Debug, Default, Encode, Decode, Clone)]
 pub struct LeafDistanceUpdateQueue {
     queue: BinaryHeap<(Reverse<u32>, TaskId)>,
     leaf_distance_updates: FxHashMap<TaskId, LeafDistanceUpdate>,
 }
 
 impl LeafDistanceUpdateQueue {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn is_empty(&self) -> bool {
         self.queue.is_empty()
     }
@@ -90,7 +86,7 @@ impl LeafDistanceUpdateQueue {
     }
 
     /// Executes a single step of the queue. Returns true, when the queue is empty.
-    pub fn process(&mut self, ctx: &mut impl ExecuteContext) -> bool {
+    pub fn process(&mut self, ctx: &mut impl ExecuteContext<'_>) -> bool {
         let mut remaining = MAX_COUNT_BEFORE_YIELD;
         while remaining > 0 {
             if let Some((Reverse(queue_dependencies_distance), task_id)) = self.queue.pop() {
@@ -126,7 +122,7 @@ impl LeafDistanceUpdateQueue {
 
     fn update_leaf_distance(
         &mut self,
-        ctx: &mut impl ExecuteContext,
+        ctx: &mut impl ExecuteContext<'_>,
         task_id: TaskId,
         dependencies_distance: u32,
         dependencies_max_distance_in_buffer: u32,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -16,7 +16,7 @@ use turbo_tasks::{
     event::{Event, EventDescription, EventListener},
 };
 
-use crate::error::TaskError;
+use crate::{backend::operation::LeafDistanceUpdateQueue, error::TaskError};
 
 // this traits are needed for the transient variants of `CachedDataItem`
 // transient variants are never cloned or compared
@@ -253,6 +253,11 @@ pub struct InProgressStateInner {
     /// Children that should be connected to the task and have their active_count decremented
     /// once the task completes.
     pub new_children: FxHashSet<TaskId>,
+    /// Leaf distance updates accumulated while the task executes. Each dependency read pushes the
+    /// dependency's leaf distance here (keyed by this task); the queue is executed once at
+    /// completion to update this task's leaf distance and propagate the change to its dependents.
+    /// Deferring the execution to completion avoids redundant per-read propagation.
+    pub leaf_distance_update_queue: LeafDistanceUpdateQueue,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
### What?

Defer and batch the "leaf distance" updates in `turbo-tasks-backend` so that a task's leaf distance is computed once, when the task completes, instead of eagerly on every dependency read.

### Why?

Leaf distance is a per-task heuristic used only for **invalidation/re-execution scheduling priority** (`compute_stale_priority` and `schedule_task`'s `TaskPriority::invalidation`). On `canary` it was recomputed and propagated on *every* output-dependency read: each read built a one-shot `LeafDistanceUpdateQueue`, pushed the reader, and executed it immediately. A task reading N dependencies therefore did N separate queue executions (with N transitive propagation passes) during its execution.

This batches that work: a task reads many dependencies, but we only need its final leaf distance once it finishes executing.

### How?

- The per-read `push` calls stay exactly where they were, but instead of executing a throwaway local queue, they push into a single `LeafDistanceUpdateQueue` stored in the reader's `InProgressState` (`InProgressStateInner.leaf_distance_update_queue`).
- The queue is executed once, at task completion (`task_execution_completed_prepare`), which updates the task's own leaf distance and propagates the change to its output dependents — same logic as before, just deferred and de-duplicated. It runs before the stale check so `compute_stale_priority` still sees the freshly computed value.
- The leaf-distance computation/propagation code in `leaf_distance_update.rs` is unchanged (the queue type just gains `Debug` so it can live in the in-progress state, and its now-unused `new()` is dropped).

Behavior is otherwise identical to `canary`:

- A task that reads no dependencies never accumulates anything, so its leaf distance stays at its default (no spurious bump).
- Leaf distance is only accumulated when dependency tracking is enabled (it is meaningless when tasks never re-execute); a `debug_assert!` at completion documents and enforces this.
- Under `verify_immutable`, immutable producers are still excluded from leaf-distance accumulation (checked explicitly), so `verify_immutable` builds compute the same leaf distance as release builds.

<!-- NEXT_JS_LLM_PR -->
