### PR TITLE
Don't track modifications to transient data stored in tasks

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1344,7 +1344,7 @@ pub async fn project_write_all_entrypoints_to_disk(
     let phase_build_paths = if has_deferred_entrypoints {
         Some(
             tt.run(async move {
-                #[turbo_tasks::value]
+                #[turbo_tasks::value(serialization = "skip")]
                 struct DeferredEntrypointInfo(ReadRef<Entrypoints>, ReadRef<Vec<RcStr>>);
 
                 #[turbo_tasks::function(operation, root)]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -842,7 +842,7 @@ impl TurboTasksBackend {
         };
 
         let content = if final_read_hint {
-            task.remove_cell_data(&cell)
+            task.remove_cell_data(&cell, &get_value_type(cell.type_id()).persistence)
         } else {
             task.get_cell_data(&cell).cloned()
         };
@@ -2778,7 +2778,9 @@ impl TurboTasksBackend {
                 .collect();
             removed_cell_data.reserve_exact(to_remove.len());
             for cell in to_remove {
-                if let Some(data) = task.remove_cell_data(&cell) {
+                if let Some(data) =
+                    task.remove_cell_data(&cell, &get_value_type(cell.type_id()).persistence)
+                {
                     removed_cell_data.push(data);
                 }
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -19,7 +19,7 @@ use tracing::info_span;
 use tracing::trace_span;
 use turbo_tasks::{
     CellId, DynTaskInputs, FxIndexMap, RawVc, SharedReference, TaskExecutionReason, TaskId,
-    TaskPriority, TurboTasks, TurboTasksCallApi, backend::CachedTaskTypeArc,
+    TaskPriority, TurboTasks, TurboTasksCallApi, ValueTypePersistence, backend::CachedTaskTypeArc,
     macro_helpers::NativeFunction,
 };
 
@@ -1240,9 +1240,57 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
             .unwrap_or_default();
         dirty_count > clean_count
     }
-    /// Add new cell data. Panics if the cell already had a value.
-    fn add_cell_data(&mut self, cell: CellId, value: SharedReference) {
-        let old = self.insert_cell_data(cell, value);
+    /// Insert cell data, returning the old value if present.
+    ///
+    /// Tracks a Data-category modification (dirtying the task for the next
+    /// persistence snapshot) only when the cell's value type actually persists
+    /// something. A `ValueTypePersistence::Skip` cell is dropped by
+    /// `CellData::encode`, so writing one changes zero persistable bytes and
+    /// must not dirty the task; `Persistable`/`HashOnly` cells do persist
+    /// (`HashOnly` via the separate `cell_data_hash` field) and are tracked.
+    ///
+    /// This is hand-written rather than macro-generated (`cell_data` carries
+    /// `custom_mutators`) so the tracking decision can read the persistence the
+    /// caller already resolved, avoiding a per-write registry lookup. It writes
+    /// through `cell_data_mut()`, which is documented to NOT track on its own.
+    fn insert_cell_data(
+        &mut self,
+        cell: CellId,
+        value: SharedReference,
+        persistence: &ValueTypePersistence,
+    ) -> Option<SharedReference> {
+        self.check_access(SpecificTaskDataCategory::Data);
+        if !matches!(persistence, ValueTypePersistence::Skip) {
+            self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
+        }
+        self.typed_mut().cell_data_mut().insert(cell, value)
+    }
+
+    /// Remove cell data, returning the old value if present. See
+    /// [`insert_cell_data`](Self::insert_cell_data) for the tracking rationale.
+    fn remove_cell_data(
+        &mut self,
+        cell: &CellId,
+        persistence: &ValueTypePersistence,
+    ) -> Option<SharedReference> {
+        self.check_access(SpecificTaskDataCategory::Data);
+        // Only track when something persistable is actually removed: the entry
+        // must exist AND not be a Skip cell (Skip cells were never persisted).
+        if !matches!(persistence, ValueTypePersistence::Skip) && self.cell_data_contains(cell) {
+            self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
+        }
+        self.typed_mut().cell_data_mut().remove(cell)
+    }
+
+    /// Add new cell data. Panics if the cell already had a value. See
+    /// [`insert_cell_data`](Self::insert_cell_data) for the tracking rationale.
+    fn add_cell_data(
+        &mut self,
+        cell: CellId,
+        value: SharedReference,
+        persistence: &ValueTypePersistence,
+    ) {
+        let old = self.insert_cell_data(cell, value, persistence);
         assert!(old.is_none(), "Cell data already exists for {cell:?}");
     }
 
@@ -1507,3 +1555,441 @@ pub use self::{
     prepare_new_children::prepare_new_children,
     update_collectible::UpdateCollectibleOperation,
 };
+
+#[cfg(test)]
+mod filter_transient_tracking_tests {
+    //! `filter_transient` fields drop transient entries at encode time, so a
+    //! mutation that only touches a transient key/value changes zero persistable
+    //! bytes and must NOT dirty the (persistent) task for the snapshot. These
+    //! tests exercise the macro-generated guarded `track_modification` on a real
+    //! [`TaskGuardImpl`] over a [`Storage`], asserting the modified flag is only
+    //! set for non-transient mutations. Tracking is monotonic: a persistent
+    //! mutation still sets the flag even after a transient one was skipped.
+    use turbo_tasks::{CellId, TRANSIENT_TASK_BIT, TaskId, ValueTypeId};
+
+    use super::*;
+    use crate::{
+        backend::{TaskDataCategory, storage::Storage},
+        data::{CellRef, OutputValue},
+    };
+
+    fn persistent_task(id: u32) -> TaskId {
+        assert!(id & TRANSIENT_TASK_BIT == 0);
+        TaskId::new(id).unwrap()
+    }
+
+    fn transient_task(id: u32) -> TaskId {
+        TaskId::new(id | TRANSIENT_TASK_BIT).unwrap()
+    }
+
+    fn cell_ref(task: TaskId) -> CellRef {
+        CellRef {
+            task,
+            cell: CellId::new(unsafe { ValueTypeId::new_unchecked(1) }, 0),
+        }
+    }
+
+    /// Build a `TaskGuardImpl` for a persistent task, fully restored and with
+    /// `All` category so `check_access` passes for both data and meta fields.
+    /// The guard must be dropped before `storage` (enforced by the borrow).
+    fn guard_for(storage: &Storage, task_id: TaskId) -> TaskGuardImpl<'_> {
+        let mut write = storage.access_mut(task_id);
+        write.flags.set_restored(TaskDataCategory::All);
+        TaskGuardImpl {
+            task: write,
+            task_id,
+            #[cfg(debug_assertions)]
+            category: TaskDataCategory::All,
+            task_lock_counter: TaskLockCounter::new(),
+        }
+    }
+
+    #[test]
+    fn autoset_add_remove_only_tracks_persistent_keys() {
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+
+        // `children` is an AutoSet<TaskId> meta field with filter_transient.
+        {
+            let mut g = guard_for(&storage, task_id);
+            assert!(g.add_children(transient_task(2)));
+            assert!(
+                !g.meta_modified(),
+                "adding a transient child must not dirty meta"
+            );
+            // The entry is still stored in memory.
+            assert!(g.children_contains(&transient_task(2)));
+
+            assert!(g.add_children(persistent_task(3)));
+            assert!(
+                g.meta_modified(),
+                "adding a persistent child must dirty meta"
+            );
+        }
+
+        // Fresh task: removing a transient entry must not dirty; removing a
+        // persistent entry must.
+        let task_id = persistent_task(10);
+        {
+            let mut g = guard_for(&storage, task_id);
+            // Seed via the tracked accessors, then clear the flag so the removal
+            // assertions below start from a clean state. (`children_mut` is not
+            // accessible cross-module, so we can't seed untracked here.)
+            assert!(g.add_children(transient_task(11)));
+            assert!(g.add_children(persistent_task(12)));
+            g.task.flags.set_meta_modified(false);
+            assert!(!g.meta_modified());
+
+            assert!(g.remove_children(&transient_task(11)));
+            assert!(
+                !g.meta_modified(),
+                "removing a transient child must not dirty meta"
+            );
+
+            assert!(g.remove_children(&persistent_task(12)));
+            assert!(
+                g.meta_modified(),
+                "removing a persistent child must dirty meta"
+            );
+        }
+    }
+
+    #[test]
+    fn autoset_extend_tracks_iff_any_persistent() {
+        let storage = Storage::new(2, true);
+
+        // Extend with only transient children: no meta modification.
+        let task_id = persistent_task(1);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.extend_children([transient_task(2), transient_task(3)]);
+            assert!(g.children_contains(&transient_task(2)));
+            assert!(
+                !g.meta_modified(),
+                "extending with only transient children must not dirty meta"
+            );
+        }
+
+        // Extend with a mix: meta modification.
+        let task_id = persistent_task(10);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.extend_children([transient_task(11), persistent_task(12)]);
+            assert!(
+                g.meta_modified(),
+                "extending with at least one persistent child must dirty meta"
+            );
+        }
+    }
+
+    #[test]
+    fn countermap_update_count_only_tracks_persistent_keys() {
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+
+        // `upper` is a CounterMap<TaskId> meta field with filter_transient.
+        {
+            let mut g = guard_for(&storage, task_id);
+            let _ = g.update_upper_count(transient_task(2), 1);
+            assert!(
+                !g.meta_modified(),
+                "bumping a transient upper must not dirty meta"
+            );
+            assert_eq!(g.get_upper(&transient_task(2)), Some(&1));
+
+            let _ = g.update_upper_count(persistent_task(3), 1);
+            assert!(
+                g.meta_modified(),
+                "bumping a persistent upper must dirty meta"
+            );
+        }
+    }
+
+    #[test]
+    fn countermap_update_counts_batch_tracks_iff_any_persistent() {
+        let storage = Storage::new(2, true);
+
+        // followers: CounterMap<TaskId>, filter_transient, has update_counts.
+        let task_id = persistent_task(1);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.update_followers_counts([transient_task(2), transient_task(3)].into_iter(), 1);
+            assert!(
+                !g.meta_modified(),
+                "batch of only transient followers must not dirty meta"
+            );
+        }
+
+        let task_id = persistent_task(10);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.update_followers_counts([transient_task(11), persistent_task(12)].into_iter(), 1);
+            assert!(
+                g.meta_modified(),
+                "batch with a persistent follower must dirty meta"
+            );
+        }
+    }
+
+    #[test]
+    fn direct_option_set_take_tracks_by_value_transience() {
+        let storage = Storage::new(2, true);
+
+        // `output` is a direct Option<OutputValue> meta field with filter_transient.
+        // Setting a transient output: no meta modification.
+        let task_id = persistent_task(1);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.set_output(OutputValue::Output(transient_task(2)));
+            assert!(
+                !g.meta_modified(),
+                "setting a transient output must not dirty meta"
+            );
+            assert!(g.get_output().is_some());
+            // Taking a transient output: still no meta modification.
+            assert!(g.take_output().is_some());
+            assert!(
+                !g.meta_modified(),
+                "taking a transient output must not dirty meta"
+            );
+        }
+
+        // Setting a persistent output: meta modification.
+        let task_id = persistent_task(10);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.set_output(OutputValue::Output(persistent_task(11)));
+            assert!(
+                g.meta_modified(),
+                "setting a persistent output must dirty meta"
+            );
+        }
+
+        // Taking a persistent output dirties meta (seed untracked first).
+        let task_id = persistent_task(20);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.typed_mut()
+                .set_output(OutputValue::Cell(cell_ref(persistent_task(21))));
+            assert!(!g.meta_modified());
+            assert!(g.take_output().is_some());
+            assert!(
+                g.meta_modified(),
+                "taking a persistent output must dirty meta"
+            );
+        }
+    }
+
+    #[test]
+    fn data_category_cell_dependents_tracks_by_key_transience() {
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+
+        // `cell_dependents` is an inline AutoSet<CellRef> DATA field with
+        // filter_transient. The CellRef.task here is the (possibly transient)
+        // dependent reader.
+        {
+            let mut g = guard_for(&storage, task_id);
+            assert!(g.add_cell_dependents(cell_ref(transient_task(2))));
+            assert!(
+                !g.data_modified(),
+                "a transient cell dependent must not dirty data"
+            );
+
+            assert!(g.add_cell_dependents(cell_ref(persistent_task(3))));
+            assert!(
+                g.data_modified(),
+                "a persistent cell dependent must dirty data"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod cell_data_tracking_tests {
+    //! `cell_data` writes track a Data modification only when the cell's value
+    //! type persists something. A `ValueTypePersistence::Skip` cell is dropped by
+    //! `CellData::encode`, so writing one changes zero persistable bytes and must
+    //! not dirty the (persistent) task; `Persistable`/`HashOnly` cells do persist
+    //! and are tracked. In-memory retention is governed by `CellData::drop_partial`
+    //! (by `Evictability`), independent of the modified flag — so a Skip cell that
+    //! must stay in memory survives eviction even though the task was never marked
+    //! modified.
+    use turbo_tasks::{
+        self as turbo_tasks, CellId, TRANSIENT_TASK_BIT, TaskId, ValueTypePersistence, VcValueType,
+        registry,
+    };
+
+    use super::*;
+    use crate::backend::{
+        TaskDataCategory, storage::Storage, storage_schema::TaskStorageAccessors,
+    };
+
+    #[turbo_tasks::value]
+    struct PersistableV(#[allow(dead_code)] u32);
+
+    #[turbo_tasks::value(serialization = "skip")]
+    struct SkipCheapV(
+        #[turbo_tasks(trace_ignore)]
+        #[allow(dead_code)]
+        u32,
+    );
+
+    #[turbo_tasks::value(serialization = "skip", evict = "never", cell = "new", eq = "manual")]
+    struct SkipNeverV;
+
+    fn persistent_task(id: u32) -> TaskId {
+        assert!(id & TRANSIENT_TASK_BIT == 0);
+        TaskId::new(id).unwrap()
+    }
+
+    fn cell_of<V: VcValueType>(index: u32) -> CellId {
+        CellId::new(V::get_value_type_id(), index)
+    }
+
+    fn persistence_of(cell: &CellId) -> &'static ValueTypePersistence {
+        &registry::get_value_type(cell.type_id()).persistence
+    }
+
+    fn dummy_ref() -> SharedReference {
+        SharedReference::new(triomphe::Arc::new(0u32))
+    }
+
+    fn guard_for(storage: &Storage, task_id: TaskId) -> TaskGuardImpl<'_> {
+        let mut write = storage.access_mut(task_id);
+        write.flags.set_restored(TaskDataCategory::All);
+        TaskGuardImpl {
+            task: write,
+            task_id,
+            #[cfg(debug_assertions)]
+            category: TaskDataCategory::All,
+            task_lock_counter: TaskLockCounter::new(),
+        }
+    }
+
+    #[test]
+    fn insert_skip_cell_does_not_dirty_data() {
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+        let cell = cell_of::<SkipCheapV>(0);
+
+        let mut g = guard_for(&storage, task_id);
+        assert!(
+            g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell))
+                .is_none()
+        );
+        assert!(
+            !g.data_modified(),
+            "writing a Skip cell must not dirty data for the snapshot"
+        );
+        // ...but the value is present in memory.
+        assert!(g.cell_data_contains(&cell));
+    }
+
+    #[test]
+    fn insert_persistable_cell_dirties_data() {
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+        let cell = cell_of::<PersistableV>(0);
+
+        let mut g = guard_for(&storage, task_id);
+        assert!(
+            g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell))
+                .is_none()
+        );
+        assert!(
+            g.data_modified(),
+            "writing a Persistable cell must dirty data"
+        );
+    }
+
+    #[test]
+    fn remove_skip_cell_does_not_dirty_data() {
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+        let cell = cell_of::<SkipCheapV>(0);
+
+        let mut g = guard_for(&storage, task_id);
+        // Seed via the (untracked-for-Skip) insert.
+        g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell));
+        assert!(!g.data_modified());
+
+        assert!(g.remove_cell_data(&cell, persistence_of(&cell)).is_some());
+        assert!(
+            !g.data_modified(),
+            "removing a Skip cell must not dirty data"
+        );
+    }
+
+    #[test]
+    fn remove_persistable_cell_dirties_data() {
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+        let cell = cell_of::<PersistableV>(0);
+
+        let mut g = guard_for(&storage, task_id);
+        // Seed without tracking by going through the tracking-free TaskStorage
+        // accessor, then clear the flag so the removal assertion is meaningful.
+        g.typed_mut().cell_data_mut().insert(cell, dummy_ref());
+        assert!(!g.data_modified());
+
+        assert!(g.remove_cell_data(&cell, persistence_of(&cell)).is_some());
+        assert!(
+            g.data_modified(),
+            "removing a Persistable cell must dirty data"
+        );
+    }
+
+    #[test]
+    fn mixed_writes_track_only_persistable_but_keep_skip_in_memory() {
+        // A task that writes both a Skip cell and a Persistable cell: the
+        // Persistable write dirties the task (tracking is monotonic), and the
+        // Skip value is still readable in memory regardless of the flag.
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+        let skip = cell_of::<SkipCheapV>(0);
+        let persistable = cell_of::<PersistableV>(0);
+
+        let mut g = guard_for(&storage, task_id);
+        g.insert_cell_data(skip, dummy_ref(), persistence_of(&skip));
+        assert!(!g.data_modified(), "skip-only so far: not dirty");
+        g.insert_cell_data(persistable, dummy_ref(), persistence_of(&persistable));
+        assert!(g.data_modified(), "a persistable write dirties the task");
+
+        assert!(g.cell_data_contains(&skip));
+        assert!(g.cell_data_contains(&persistable));
+    }
+
+    // `evict_after_snapshot` uses `parallel::for_each`/`map_collect`, which call
+    // `block_in_place` internally and require a multi-threaded Tokio runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn skip_never_cell_survives_eviction_without_modified_flag() {
+        // A Skip + evict="never" cell must be retained in memory by
+        // `drop_partial` (which keys on Evictability, not the modified flag), so
+        // a task that only wrote such a cell is both evictable-clean AND keeps the
+        // value. This is the core safety property of not tracking Skip writes.
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+        let cell = cell_of::<SkipNeverV>(0);
+
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell));
+            assert!(
+                !g.data_modified(),
+                "a Skip cell write must leave the task clean for the snapshot"
+            );
+        }
+
+        // Run the post-snapshot eviction sweep: the task is clean (not modified),
+        // so data is eligible to drop, but the Skip+never value is retained as
+        // residue. The entry stays in the map with the value still present.
+        storage.evict_after_snapshot(None);
+
+        let g = guard_for(&storage, task_id);
+        assert!(
+            g.cell_data_contains(&cell),
+            "Skip + evict=never cell must survive eviction even though the task was never modified"
+        );
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1559,17 +1559,12 @@ pub use self::{
 
 #[cfg(test)]
 mod filter_transient_tracking_tests {
-    //! `filter_transient` fields drop transient entries at encode time, so a
-    //! mutation that only touches a transient key/value changes zero persistable
-    //! bytes and must NOT dirty the (persistent) task for the snapshot. These
-    //! tests exercise the macro-generated guarded `track_modification` on a real
-    //! [`TaskGuardImpl`] over a [`Storage`], asserting the modified flag is only
-    //! set for non-transient mutations. Tracking is monotonic: a persistent
-    //! mutation still sets the flag even after a transient one was skipped.
+    //! Test that changes to transient data inside of `filter_transient` fields does not call
+    //! `track_modification`.
     //!
-    //! These live here (rather than next to the schema in `storage_schema.rs`)
-    //! because the tracking accessors are only implemented by [`TaskGuardImpl`],
-    //! whose fields are private to this module.
+    //! These live here (rather than next to the schema in
+    //! `storage_schema.rs`) because the tracking accessors are only implemented by
+    //! [`TaskGuardImpl`], whose fields are private to this module.
     use turbo_tasks::{CellId, TRANSIENT_TASK_BIT, TaskId, ValueTypeId};
 
     use super::*;
@@ -1822,17 +1817,7 @@ mod filter_transient_tracking_tests {
 #[cfg(test)]
 mod cell_data_tracking_tests {
     //! `cell_data` writes track a Data modification only when the cell's value
-    //! type persists something. A `ValueTypePersistence::Skip` cell is dropped by
-    //! `CellData::encode`, so writing one changes zero persistable bytes and must
-    //! not dirty the (persistent) task; `Persistable`/`HashOnly` cells do persist
-    //! and are tracked. In-memory retention is governed by `CellData::drop_partial`
-    //! (by `Evictability`), independent of the modified flag — so a Skip cell that
-    //! must stay in memory survives eviction even though the task was never marked
-    //! modified.
-    //!
-    //! Like [`super::filter_transient_tracking_tests`], these live here because
-    //! the `cell_data` mutators are hand-written on [`TaskGuardImpl`] (private to
-    //! this module), not in `storage_schema.rs`.
+    //! type persists something.
     use turbo_tasks::{
         self as turbo_tasks, CellId, TRANSIENT_TASK_BIT, TaskId, ValueTypePersistence, VcValueType,
         registry,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1242,17 +1242,15 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
     }
     /// Insert cell data, returning the old value if present.
     ///
-    /// Tracks a Data-category modification (dirtying the task for the next
-    /// persistence snapshot) only when the cell's value type actually persists
-    /// something. A `ValueTypePersistence::Skip` cell is dropped by
-    /// `CellData::encode`, so writing one changes zero persistable bytes and
-    /// must not dirty the task; `Persistable`/`HashOnly` cells do persist
-    /// (`HashOnly` via the separate `cell_data_hash` field) and are tracked.
+    /// Only `Persistable` cells are written to the data snapshot
+    /// (`CellData::encode` drops `Skip` and `HashOnly`), so we dirty the task
+    /// only for those. A `HashOnly` cell's persisted state lives in the separate
+    /// `cell_data_hash` field, which tracks its own modifications.
     ///
-    /// This is hand-written rather than macro-generated (`cell_data` carries
-    /// `custom_mutators`) so the tracking decision can read the persistence the
-    /// caller already resolved, avoiding a per-write registry lookup. It writes
-    /// through `cell_data_mut()`, which is documented to NOT track on its own.
+    /// Hand-written rather than macro-generated (`cell_data` has
+    /// `custom_mutators`) so the decision reads the caller-supplied persistence
+    /// instead of a per-write registry lookup. Writes through `cell_data_mut()`,
+    /// which does not track on its own.
     fn insert_cell_data(
         &mut self,
         cell: CellId,
@@ -1260,7 +1258,7 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         persistence: &ValueTypePersistence,
     ) -> Option<SharedReference> {
         self.check_access(SpecificTaskDataCategory::Data);
-        if !matches!(persistence, ValueTypePersistence::Skip) {
+        if matches!(persistence, ValueTypePersistence::Persistable(..)) {
             self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
         }
         self.typed_mut().cell_data_mut().insert(cell, value)
@@ -1274,9 +1272,12 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         persistence: &ValueTypePersistence,
     ) -> Option<SharedReference> {
         self.check_access(SpecificTaskDataCategory::Data);
-        // Only track when something persistable is actually removed: the entry
-        // must exist AND not be a Skip cell (Skip cells were never persisted).
-        if !matches!(persistence, ValueTypePersistence::Skip) && self.cell_data_contains(cell) {
+        // Track only when a persistable entry is actually removed (the entry must
+        // exist and be Persistable; Skip/HashOnly cells contribute nothing to the
+        // data snapshot).
+        if matches!(persistence, ValueTypePersistence::Persistable(..))
+            && self.cell_data_contains(cell)
+        {
             self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
         }
         self.typed_mut().cell_data_mut().remove(cell)
@@ -1778,6 +1779,39 @@ mod filter_transient_tracking_tests {
                 "taking a persistent output must dirty meta"
             );
         }
+
+        // REPLACE persistent -> transient must dirty meta: the old persistent
+        // value was in the snapshot and is being removed, so the persisted form
+        // changes even though the new value is transient. (Seed the persistent
+        // value untracked, clear the flag, then replace.)
+        let task_id = persistent_task(30);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.typed_mut()
+                .set_output(OutputValue::Output(persistent_task(31)));
+            g.task.flags.set_meta_modified(false);
+            assert!(!g.meta_modified());
+
+            g.set_output(OutputValue::Output(transient_task(32)));
+            assert!(
+                g.meta_modified(),
+                "replacing a persistent output with a transient one must dirty meta"
+            );
+        }
+
+        // REPLACE transient -> transient must NOT dirty meta (neither value
+        // persists).
+        let task_id = persistent_task(40);
+        {
+            let mut g = guard_for(&storage, task_id);
+            g.set_output(OutputValue::Output(transient_task(41)));
+            assert!(!g.meta_modified());
+            g.set_output(OutputValue::Output(transient_task(42)));
+            assert!(
+                !g.meta_modified(),
+                "replacing one transient output with another must not dirty meta"
+            );
+        }
     }
 
     #[test]
@@ -1837,6 +1871,9 @@ mod cell_data_tracking_tests {
 
     #[turbo_tasks::value(serialization = "skip", evict = "never", cell = "new", eq = "manual")]
     struct SkipNeverV;
+
+    #[turbo_tasks::value(serialization = "hash")]
+    struct HashOnlyV(#[allow(dead_code)] u32);
 
     fn persistent_task(id: u32) -> TaskId {
         assert!(id & TRANSIENT_TASK_BIT == 0);
@@ -1901,6 +1938,28 @@ mod cell_data_tracking_tests {
             g.data_modified(),
             "writing a Persistable cell must dirty data"
         );
+    }
+
+    #[test]
+    fn insert_hash_only_cell_does_not_dirty_cell_data() {
+        // A HashOnly cell's value is NOT in the data snapshot (only its hash, in
+        // the separate cell_data_hash field, which tracks itself). So the
+        // cell_data write must not dirty the task.
+        let storage = Storage::new(2, true);
+        let task_id = persistent_task(1);
+        let cell = cell_of::<HashOnlyV>(0);
+
+        let mut g = guard_for(&storage, task_id);
+        assert!(
+            g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell))
+                .is_none()
+        );
+        assert!(
+            !g.data_modified(),
+            "writing a HashOnly cell's value must not dirty data (the hash field tracks \
+             separately)"
+        );
+        assert!(g.cell_data_contains(&cell));
     }
 
     #[test]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1566,6 +1566,10 @@ mod filter_transient_tracking_tests {
     //! [`TaskGuardImpl`] over a [`Storage`], asserting the modified flag is only
     //! set for non-transient mutations. Tracking is monotonic: a persistent
     //! mutation still sets the flag even after a transient one was skipped.
+    //!
+    //! These live here (rather than next to the schema in `storage_schema.rs`)
+    //! because the tracking accessors are only implemented by [`TaskGuardImpl`],
+    //! whose fields are private to this module.
     use turbo_tasks::{CellId, TRANSIENT_TASK_BIT, TaskId, ValueTypeId};
 
     use super::*;
@@ -1825,6 +1829,10 @@ mod cell_data_tracking_tests {
     //! (by `Evictability`), independent of the modified flag — so a Skip cell that
     //! must stay in memory survives eviction even though the task was never marked
     //! modified.
+    //!
+    //! Like [`super::filter_transient_tracking_tests`], these live here because
+    //! the `cell_data` mutators are hand-written on [`TaskGuardImpl`] (private to
+    //! this module), not in `storage_schema.rs`.
     use turbo_tasks::{
         self as turbo_tasks, CellId, TRANSIENT_TASK_BIT, TaskId, ValueTypePersistence, VcValueType,
         registry,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1813,30 +1813,6 @@ mod filter_transient_tracking_tests {
             );
         }
     }
-
-    #[test]
-    fn data_category_cell_dependents_tracks_by_key_transience() {
-        let storage = Storage::new(2, true);
-        let task_id = persistent_task(1);
-
-        // `cell_dependents` is an inline AutoSet<CellRef> DATA field with
-        // filter_transient. The CellRef.task here is the (possibly transient)
-        // dependent reader.
-        {
-            let mut g = guard_for(&storage, task_id);
-            assert!(g.add_cell_dependents(cell_ref(transient_task(2))));
-            assert!(
-                !g.data_modified(),
-                "a transient cell dependent must not dirty data"
-            );
-
-            assert!(g.add_cell_dependents(cell_ref(persistent_task(3))));
-            assert!(
-                g.data_modified(),
-                "a persistent cell dependent must dirty data"
-            );
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1905,118 +1881,64 @@ mod cell_data_tracking_tests {
     }
 
     #[test]
-    fn insert_skip_cell_does_not_dirty_data() {
+    fn insert_tracks_only_for_persistable() {
+        // Only `Persistable` cells reach the data snapshot, so only they dirty
+        // the task. `Skip` and `HashOnly` values are dropped by `CellData::encode`
+        // (HashOnly persists via the separate `cell_data_hash` field) — but both
+        // are still stored in memory. Tracking is monotonic: a later persistable
+        // write flips the flag even after skipped writes left it clean.
         let storage = Storage::new(2, true);
-        let task_id = persistent_task(1);
-        let cell = cell_of::<SkipCheapV>(0);
+        let mut g = guard_for(&storage, persistent_task(1));
 
-        let mut g = guard_for(&storage, task_id);
-        assert!(
-            g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell))
-                .is_none()
-        );
-        assert!(
-            !g.data_modified(),
-            "writing a Skip cell must not dirty data for the snapshot"
-        );
-        // ...but the value is present in memory.
-        assert!(g.cell_data_contains(&cell));
-    }
+        let skip = cell_of::<SkipCheapV>(0);
+        g.insert_cell_data(skip, dummy_ref(), persistence_of(&skip));
+        assert!(!g.data_modified(), "Skip write must not dirty data");
+        assert!(g.cell_data_contains(&skip), "Skip value still in memory");
 
-    #[test]
-    fn insert_persistable_cell_dirties_data() {
-        let storage = Storage::new(2, true);
-        let task_id = persistent_task(1);
-        let cell = cell_of::<PersistableV>(0);
+        let hash_only = cell_of::<HashOnlyV>(0);
+        g.insert_cell_data(hash_only, dummy_ref(), persistence_of(&hash_only));
+        assert!(!g.data_modified(), "HashOnly write must not dirty data");
+        assert!(g.cell_data_contains(&hash_only));
 
-        let mut g = guard_for(&storage, task_id);
-        assert!(
-            g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell))
-                .is_none()
-        );
+        let persistable = cell_of::<PersistableV>(0);
+        g.insert_cell_data(persistable, dummy_ref(), persistence_of(&persistable));
         assert!(
             g.data_modified(),
-            "writing a Persistable cell must dirty data"
+            "Persistable write dirties data (monotonic: flips even after skipped writes)"
         );
     }
 
     #[test]
-    fn insert_hash_only_cell_does_not_dirty_cell_data() {
-        // A HashOnly cell's value is NOT in the data snapshot (only its hash, in
-        // the separate cell_data_hash field, which tracks itself). So the
-        // cell_data write must not dirty the task.
+    fn remove_tracks_only_for_persistable() {
         let storage = Storage::new(2, true);
-        let task_id = persistent_task(1);
-        let cell = cell_of::<HashOnlyV>(0);
+        let skip = cell_of::<SkipCheapV>(0);
+        let persistable = cell_of::<PersistableV>(0);
 
-        let mut g = guard_for(&storage, task_id);
-        assert!(
-            g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell))
-                .is_none()
-        );
-        assert!(
-            !g.data_modified(),
-            "writing a HashOnly cell's value must not dirty data (the hash field tracks \
-             separately)"
-        );
-        assert!(g.cell_data_contains(&cell));
-    }
-
-    #[test]
-    fn remove_skip_cell_does_not_dirty_data() {
-        let storage = Storage::new(2, true);
-        let task_id = persistent_task(1);
-        let cell = cell_of::<SkipCheapV>(0);
-
-        let mut g = guard_for(&storage, task_id);
-        // Seed via the (untracked-for-Skip) insert.
-        g.insert_cell_data(cell, dummy_ref(), persistence_of(&cell));
+        // Removing a Skip cell: no tracking.
+        let mut g = guard_for(&storage, persistent_task(1));
+        g.insert_cell_data(skip, dummy_ref(), persistence_of(&skip));
         assert!(!g.data_modified());
-
-        assert!(g.remove_cell_data(&cell, persistence_of(&cell)).is_some());
+        assert!(g.remove_cell_data(&skip, persistence_of(&skip)).is_some());
         assert!(
             !g.data_modified(),
             "removing a Skip cell must not dirty data"
         );
-    }
 
-    #[test]
-    fn remove_persistable_cell_dirties_data() {
-        let storage = Storage::new(2, true);
-        let task_id = persistent_task(1);
-        let cell = cell_of::<PersistableV>(0);
-
-        let mut g = guard_for(&storage, task_id);
-        // Seed without tracking by going through the tracking-free TaskStorage
-        // accessor, then clear the flag so the removal assertion is meaningful.
-        g.typed_mut().cell_data_mut().insert(cell, dummy_ref());
+        // Removing a Persistable cell: tracks. Seed via the tracking-free
+        // TaskStorage accessor so the removal is the only tracked mutation.
+        let mut g = guard_for(&storage, persistent_task(2));
+        g.typed_mut()
+            .cell_data_mut()
+            .insert(persistable, dummy_ref());
         assert!(!g.data_modified());
-
-        assert!(g.remove_cell_data(&cell, persistence_of(&cell)).is_some());
+        assert!(
+            g.remove_cell_data(&persistable, persistence_of(&persistable))
+                .is_some()
+        );
         assert!(
             g.data_modified(),
             "removing a Persistable cell must dirty data"
         );
-    }
-
-    #[test]
-    fn mixed_writes_track_only_persistable_but_keep_skip_in_memory() {
-        // A task that writes both a Skip cell and a Persistable cell: the
-        // Persistable write dirties the task (tracking is monotonic), and the
-        // Skip value is still readable in memory regardless of the flag.
-        let storage = Storage::new(2, true);
-        let task_id = persistent_task(1);
-        let skip = cell_of::<SkipCheapV>(0);
-        let persistable = cell_of::<PersistableV>(0);
-
-        let mut g = guard_for(&storage, task_id);
-        g.insert_cell_data(skip, dummy_ref(), persistence_of(&skip));
-        assert!(!g.data_modified(), "skip-only so far: not dirty");
-        g.insert_cell_data(persistable, dummy_ref(), persistence_of(&persistable));
-        assert!(g.data_modified(), "a persistable write dirties the task");
-
-        assert!(g.cell_data_contains(&skip));
-        assert!(g.cell_data_contains(&persistable));
     }
 
     // `evict_after_snapshot` uses `parallel::for_each`/`map_collect`, which call

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1241,22 +1241,14 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         dirty_count > clean_count
     }
     /// Insert cell data, returning the old value if present.
-    ///
-    /// Only `Persistable` cells are written to the data snapshot
-    /// (`CellData::encode` drops `Skip` and `HashOnly`), so we dirty the task
-    /// only for those. A `HashOnly` cell's persisted state lives in the separate
-    /// `cell_data_hash` field, which tracks its own modifications.
-    ///
-    /// Hand-written rather than macro-generated (`cell_data` has
-    /// `custom_mutators`) so the decision reads the caller-supplied persistence
-    /// instead of a per-write registry lookup. Writes through `cell_data_mut()`,
-    /// which does not track on its own.
     fn insert_cell_data(
         &mut self,
         cell: CellId,
         value: SharedReference,
         persistence: &ValueTypePersistence,
     ) -> Option<SharedReference> {
+        // We implement this here instead of in the generated code to optimize how mutations are
+        // tracked
         self.check_access(SpecificTaskDataCategory::Data);
         if matches!(persistence, ValueTypePersistence::Persistable(..)) {
             self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
@@ -1264,8 +1256,7 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         self.typed_mut().cell_data_mut().insert(cell, value)
     }
 
-    /// Remove cell data, returning the old value if present. See
-    /// [`insert_cell_data`](Self::insert_cell_data) for the tracking rationale.
+    /// Remove cell data, returning the old value if present.
     fn remove_cell_data(
         &mut self,
         cell: &CellId,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -188,7 +188,7 @@ impl UpdateCellOperation {
                 // tasks and after that set the new cell content. When the cell content is unset,
                 // readers will wait for it to be set via InProgressCell.
 
-                let old_content = task.remove_cell_data(&cell);
+                let old_content = task.remove_cell_data(&cell, &value_type.persistence);
 
                 // Update cell_data_hash before dropping the task lock
                 if matches!(value_type.persistence, ValueTypePersistence::HashOnly) {
@@ -225,9 +225,9 @@ impl UpdateCellOperation {
         // So we can just update the cell content.
 
         let old_content = if let Some(new_content) = content {
-            task.insert_cell_data(cell, new_content)
+            task.insert_cell_data(cell, new_content, &value_type.persistence)
         } else {
-            task.remove_cell_data(&cell)
+            task.remove_cell_data(&cell, &value_type.persistence)
         };
 
         // Update cell_data_hash for hash-only cells.
@@ -355,7 +355,11 @@ impl Operation for UpdateCellOperation {
                     let mut task = ctx.task(task, TaskDataCategory::Data);
 
                     if let Some(content) = content {
-                        task.add_cell_data(cell, content.into_untyped());
+                        // This arm only carries the CellId, so resolve the cell's
+                        // persistence here (one lookup per final change, not on the
+                        // inner hot path) to decide whether the write tracks.
+                        let persistence = &registry::get_value_type(cell.type_id()).persistence;
+                        task.add_cell_data(cell, content.into_untyped(), persistence);
                     }
 
                     let in_progress_cell = task.remove_in_progress_cells(&cell);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -327,6 +327,7 @@ struct TaskStorageSchema {
         category = "data",
         shrink_on_completion,
         custom_drop_partial,
+        custom_mutators,
         as_type = "AutoMap<CellId, SharedReference, 1>"
     )]
     cell_data: CellData,

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -90,14 +90,10 @@ struct FieldInfo {
     ///
     /// When absent, the macro parses the outer field type directly.
     as_type: Option<Type>,
-    /// If true, the macro does NOT generate the mutating accessors
-    /// (`insert_*`/`remove_*`) for this field on the `TaskGuard`/
-    /// `TaskStorageAccessors` trait; the read accessors and the inline
-    /// `<field>_mut()` on `TaskStorage` are still generated. The mutators are
-    /// instead hand-written so they can own a custom `track_modification`
-    /// decision. Currently used by `cell_data`, whose write tracking depends on
-    /// the cell's `ValueTypePersistence` (a `Skip` cell persists nothing, so it
-    /// must not dirty the task). Only supported for `auto_map` fields.
+    /// If true, the macro skips generating the mutating accessors
+    /// (`insert_*`/`remove_*`); read accessors and `<field>_mut()` are still
+    /// generated. Lets the mutators be hand-written with a custom
+    /// `track_modification` decision (used by `cell_data`). `auto_map` only.
     custom_mutators: bool,
 }
 
@@ -145,25 +141,13 @@ impl FieldInfo {
         }
     }
 
-    /// Like [`track_modification_call`], but for `filter_transient` fields the
-    /// emitted tracking is guarded so it only fires when the entry being
-    /// mutated is *not* transient.
-    ///
-    /// A `filter_transient` field drops transient entries at encode time (see
-    /// [`generate_filter_predicate`]), so adding/removing a transient entry
-    /// changes zero persistable bytes and must not dirty the task for the
-    /// persistence snapshot. This is safe because modification tracking is
-    /// monotonic: we only ever *omit* setting the modified flag here; a later
-    /// persistent-keyed mutation still sets it via the same path.
-    ///
-    /// `key_expr` must evaluate to the entry whose transience decides tracking
-    /// (the inserted/removed key, or the value for a direct `Option` field). It
-    /// is matched against `.is_transient()` using the same inherent-or-trait
-    /// method-call convention as [`generate_filter_predicate`] (the `IsTransient`
-    /// trait from `storage_schema` is in scope wherever this macro expands).
-    ///
-    /// For non-`filter_transient` fields this is identical to
-    /// [`track_modification_call`].
+    /// [`track_modification_call`], but for `filter_transient` fields it only
+    /// fires when `key_expr` is not transient — transient entries are dropped at
+    /// encode (see [`generate_filter_predicate`]), so mutating one changes no
+    /// persistable bytes. Safe because tracking is monotonic (we only omit, never
+    /// clear). `key_expr` is the entry whose transience decides tracking and is
+    /// matched with `.is_transient()`. Identical to [`track_modification_call`]
+    /// for non-`filter_transient` fields.
     fn track_modification_call_guarded(&self, key_expr: TokenStream) -> TokenStream {
         if !self.filter_transient || self.is_transient() {
             return self.track_modification_call();
@@ -1828,13 +1812,6 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
     let field_type = &field.field_type;
     let check_access = field.check_access_call();
     let track_modification = field.track_modification_call();
-    // For a `filter_transient` direct `Option` field (`output`), `set` tracks only
-    // when the new value is non-transient (a transient output is dropped at
-    // encode, so it changes zero persistable bytes). `take` is handled inline
-    // below, gated on the *old* value's transience. For non-filter_transient
-    // fields these equal `track_modification`.
-    let track_modification_value = field.track_modification_call_guarded(quote! { value });
-    let track_modification_old = field.track_modification_call_guarded(quote! { old });
 
     // Use FieldInfo helpers for TaskStorage delegation
     let get_expr = field.direct_get_expr();
@@ -1904,6 +1881,26 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
         }
     };
 
+    // `track_modification` must run BEFORE the field is mutated: under snapshot
+    // mode it clones the pre-mutation state into the snapshot, so a value being
+    // overwritten/removed would otherwise be lost from the in-flight snapshot.
+    //
+    // For `filter_transient` fields, transient entries are dropped at encode, so
+    // a write only changes persistable bytes when a non-transient value is
+    // involved. For `set` (a replace) that means EITHER the new value OR the
+    // value being overwritten is non-transient; for `take` it means the removed
+    // value is non-transient. `gen_track` builds the gated call from a boolean
+    // expression that must be evaluated before mutating; non-filter_transient
+    // fields track unconditionally.
+    let gen_track = |persistent_cond: TokenStream| -> TokenStream {
+        if field.filter_transient && !field.is_transient() {
+            let track = field.track_modification_call();
+            quote! { if #persistent_cond { #track } }
+        } else {
+            field.track_modification_call()
+        }
+    };
+
     let set_body = if field.is_transient() {
         quote! {
             #set_expr(value)
@@ -1915,26 +1912,46 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
         let extractor = field.lazy_extractor_closure();
         let unwraper = field.lazy_unwrap_closure();
         let constructor = field.lazy_constructor(quote! { value });
+        // Replace branch. For filter_transient fields we must capture the
+        // old/new transience into a bool BEFORE the `&mut self` track call so the
+        // immutable borrow of `old_ref` has ended; non-filter_transient fields
+        // just track unconditionally.
+        let replace_track = if field.filter_transient {
+            let track = field.track_modification_call();
+            quote! {
+                let should_track = !value.is_transient() || !old_ref.is_transient();
+                if should_track { #track }
+            }
+        } else {
+            field.track_modification_call()
+        };
+        // Fresh insert: only the new value matters.
+        let track_insert = gen_track(quote! { !value.is_transient() });
         quote! {
             if let Some((idx, old_ref)) = self.typed().find_lazy_ref(#extractor) {
                 if old_ref == &value {
                     return None;
                 }
-                #track_modification_value
+                #replace_track
                 let old = std::mem::replace(&mut self.typed_mut().lazy[idx], #constructor);
                 Some((#unwraper)(old))
             } else {
-                #track_modification_value
+                #track_insert
                 self.typed_mut().lazy.push(#constructor);
                 None
             }
         }
     } else {
+        // Inline replace: track if the new OR the existing value is non-transient.
+        // `#get_expr` is `Option<&T>`; read it before `#set_expr` mutates.
+        let track_replace = gen_track(
+            quote! { !value.is_transient() || #get_expr.is_some_and(|old| !old.is_transient()) },
+        );
         quote! {
             if #get_expr.is_some_and(|old| old == &value) {
                 return None;
             }
-            #track_modification_value
+            #track_replace
             #set_expr(value)
         }
     };
@@ -1949,24 +1966,32 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
         // scans again via take_lazy).
         let extractor = field.lazy_extractor_closure();
         let unwraper = field.lazy_unwrap_closure();
+        // Track before taking. For filter_transient fields, capture the removed
+        // value's transience into a bool before the `&mut self` track call so the
+        // `old_ref` borrow has ended.
+        let take_track = if field.filter_transient {
+            let track = field.track_modification_call();
+            quote! {
+                let should_track = !old_ref.is_transient();
+                if should_track { #track }
+            }
+        } else {
+            field.track_modification_call()
+        };
         quote! {
-            let (idx, _) = self.typed().find_lazy_ref(#extractor)?;
-            let old = self.typed_mut().lazy_take_at(idx, #unwraper);
-            // Track on the removed value's transience: removing a transient entry
-            // changes nothing persistable (it was filtered at encode).
-            #track_modification_old
-            Some(old)
+            let (idx, old_ref) = self.typed().find_lazy_ref(#extractor)?;
+            #take_track
+            Some(self.typed_mut().lazy_take_at(idx, #unwraper))
         }
     } else {
+        // Track before taking, gated on the existing value's transience.
+        let track_take = gen_track(quote! { #get_expr.is_some_and(|old| !old.is_transient()) });
         quote! {
-            let old = #take_expr;
-            if let Some(old) = old.as_ref() {
-                // Track on the removed value's transience: removing a transient
-                // entry changes nothing persistable (filtered at encode). For
-                // non-filter_transient fields this tracks unconditionally.
-                #track_modification_old
+            if #get_expr.is_none() {
+                return None;
             }
-            old
+            #track_take
+            #take_expr
         }
     };
 
@@ -2182,33 +2207,35 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
         // Extend: use peekable iterator to avoid Vec allocation.
         // For lazy fields, look up the set once via find_lazy_ref to avoid repeated scans.
         //
-        // `filter_transient` fields take a different shape: the batch tracks once
-        // for a mix of entries, so we must track iff at least one *newly inserted*
-        // entry is non-transient (transient entries are dropped at encode and
-        // change zero persistable bytes). We insert one by one and set the modified
-        // flag lazily on the first non-transient new entry. This is slightly less
-        // allocation-optimal than the non-filter path, but `filter_transient`
-        // extend has a single caller (`extend_children`).
+        // `filter_transient` fields track once for the batch, and must do so
+        // BEFORE mutating (under snapshot mode `track_modification` clones the
+        // pre-mutation state). Tracking is needed iff the batch will actually add
+        // a non-transient entry (a transient entry is dropped at encode; an entry
+        // already present changes nothing). So materialize the items, decide
+        // against the current set via a read borrow, track if needed, then insert.
+        // `filter_transient` extend has a single caller (`extend_children`).
         extend_body = if field.filter_transient {
-            // `track_modification` is the unconditional call here; we gate it
-            // ourselves on `inserted_persistent` below. `#mut_expr`
-            // (`<field>_mut()`) get-or-creates the inner set for lazy fields and
-            // returns it directly for inline ones, so a single form covers both.
+            // Membership probe differs by storage shape: lazy `#ref_expr` is
+            // `Option<&set>`, inline is `&set`.
+            let contains_probe = if is_option {
+                quote! { #ref_expr.is_some_and(|set| set.contains(item)) }
+            } else {
+                quote! { #ref_expr.contains(item) }
+            };
             quote! {
-                let mut iter = items.into_iter().peekable();
-                if iter.peek().is_none() {
+                let items: Vec<_> = items.into_iter().collect();
+                if items.is_empty() {
                     return;
                 }
-                let mut inserted_persistent = false;
-                let set = #mut_expr;
-                for item in iter {
-                    let is_transient = item.is_transient();
-                    if set.insert(item) && !is_transient {
-                        inserted_persistent = true;
-                    }
-                }
-                if inserted_persistent {
+                let should_track = items
+                    .iter()
+                    .any(|item| !item.is_transient() && !(#contains_probe));
+                if should_track {
                     #track_modification
+                }
+                let set = #mut_expr;
+                for item in items {
+                    set.insert(item);
                 }
             }
         } else if is_option {
@@ -2483,24 +2510,22 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
             }
         }
     } else if field.filter_transient {
-        // Batch update: track iff at least one applied key is non-transient
-        // (transient entries are dropped at encode). `update_count` returns
-        // whether the count crossed zero, which is irrelevant here; we gate
-        // tracking on the key's transience, decided before the loop body runs.
+        // Batch update: track once, iff at least one key is non-transient
+        // (transient entries are dropped at encode). We must decide and track
+        // BEFORE mutating: under snapshot mode `track_modification` clones the
+        // pre-mutation state. So materialize the keys, check transience, track,
+        // then apply.
         quote! {
             if delta == 0 {
                 return;
             }
-            let mut applied_persistent = false;
+            let keys: Vec<_> = keys.collect();
+            if keys.iter().any(|key| !key.is_transient()) {
+                #track_modification
+            }
             let map = #mut_expr;
             for key in keys {
-                if !key.is_transient() {
-                    applied_persistent = true;
-                }
                 map.update_count(key, delta);
-            }
-            if applied_persistent {
-                #track_modification
             }
         }
     } else {

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1985,11 +1985,8 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
         }
     } else {
         // Track before taking, gated on the existing value's transience.
-        let track_take = gen_track(quote! { #get_expr.is_some_and(|old| !old.is_transient()) });
+        let track_take = gen_track(quote! { !#get_expr?.is_transient() });
         quote! {
-            if #get_expr.is_none() {
-                return None;
-            }
             #track_take
             #take_expr
         }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -90,6 +90,15 @@ struct FieldInfo {
     ///
     /// When absent, the macro parses the outer field type directly.
     as_type: Option<Type>,
+    /// If true, the macro does NOT generate the mutating accessors
+    /// (`insert_*`/`remove_*`) for this field on the `TaskGuard`/
+    /// `TaskStorageAccessors` trait; the read accessors and the inline
+    /// `<field>_mut()` on `TaskStorage` are still generated. The mutators are
+    /// instead hand-written so they can own a custom `track_modification`
+    /// decision. Currently used by `cell_data`, whose write tracking depends on
+    /// the cell's `ValueTypePersistence` (a `Skip` cell persists nothing, so it
+    /// must not dirty the task). Only supported for `auto_map` fields.
+    custom_mutators: bool,
 }
 
 impl FieldInfo {
@@ -132,6 +141,37 @@ impl FieldInfo {
                 quote! {
                     let _we_dont_track_mutations_for_transient_data = ();
                 }
+            }
+        }
+    }
+
+    /// Like [`track_modification_call`], but for `filter_transient` fields the
+    /// emitted tracking is guarded so it only fires when the entry being
+    /// mutated is *not* transient.
+    ///
+    /// A `filter_transient` field drops transient entries at encode time (see
+    /// [`generate_filter_predicate`]), so adding/removing a transient entry
+    /// changes zero persistable bytes and must not dirty the task for the
+    /// persistence snapshot. This is safe because modification tracking is
+    /// monotonic: we only ever *omit* setting the modified flag here; a later
+    /// persistent-keyed mutation still sets it via the same path.
+    ///
+    /// `key_expr` must evaluate to the entry whose transience decides tracking
+    /// (the inserted/removed key, or the value for a direct `Option` field). It
+    /// is matched against `.is_transient()` using the same inherent-or-trait
+    /// method-call convention as [`generate_filter_predicate`] (the `IsTransient`
+    /// trait from `storage_schema` is in scope wherever this macro expands).
+    ///
+    /// For non-`filter_transient` fields this is identical to
+    /// [`track_modification_call`].
+    fn track_modification_call_guarded(&self, key_expr: TokenStream) -> TokenStream {
+        if !self.filter_transient || self.is_transient() {
+            return self.track_modification_call();
+        }
+        let track = self.track_modification_call();
+        quote! {
+            if !(#key_expr).is_transient() {
+                #track
             }
         }
     }
@@ -385,6 +425,7 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
     let mut shrink_on_completion = false;
     let mut drop_on_completion_if_immutable = false;
     let mut custom_drop_partial = false;
+    let mut custom_mutators = false;
     let mut as_type: Option<Type> = None;
 
     // Find and parse the field attribute
@@ -508,13 +549,16 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
                         drop_on_completion_if_immutable = true;
                     } else if ident == "custom_drop_partial" {
                         custom_drop_partial = true;
+                    } else if ident == "custom_mutators" {
+                        custom_mutators = true;
                     } else {
                         meta.span()
                             .unwrap()
                             .error(format!(
                                 "unknown modifier `{ident}`, expected `inline`, \
                                  `filter_transient`, `default`, `shrink_on_completion`, \
-                                 `drop_on_completion_if_immutable`, or `custom_drop_partial`"
+                                 `drop_on_completion_if_immutable`, `custom_drop_partial`, or \
+                                 `custom_mutators`"
                             ))
                             .emit();
                     }
@@ -644,6 +688,17 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
         }
     }
 
+    if custom_mutators && !matches!(storage_type, StorageType::AutoMap) {
+        field_name
+            .span()
+            .unwrap()
+            .error(format!(
+                "`custom_mutators` on field `{field_name}` is only supported for `auto_map` \
+                 storage (the only consumer is `cell_data`)"
+            ))
+            .emit();
+    }
+
     FieldInfo {
         is_pub,
         field_name,
@@ -658,6 +713,7 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
         drop_on_completion_if_immutable,
         custom_drop_partial,
         as_type,
+        custom_mutators,
     }
 }
 
@@ -1482,6 +1538,12 @@ fn generate_collection_field_accessors(
     let take_name = field.take_ident();
     let vis = if field.is_pub {
         quote! {pub}
+    } else if field.custom_mutators {
+        // `custom_mutators` fields have their mutating accessors hand-written on
+        // `TaskGuard` in another module; those reach the tracking-free
+        // `<field>_mut()` here, so it must be at least crate-visible even when
+        // the schema field itself is private.
+        quote! {pub(crate)}
     } else {
         quote! {}
     };
@@ -1766,6 +1828,13 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
     let field_type = &field.field_type;
     let check_access = field.check_access_call();
     let track_modification = field.track_modification_call();
+    // For a `filter_transient` direct `Option` field (`output`), `set` tracks only
+    // when the new value is non-transient (a transient output is dropped at
+    // encode, so it changes zero persistable bytes). `take` is handled inline
+    // below, gated on the *old* value's transience. For non-filter_transient
+    // fields these equal `track_modification`.
+    let track_modification_value = field.track_modification_call_guarded(quote! { value });
+    let track_modification_old = field.track_modification_call_guarded(quote! { old });
 
     // Use FieldInfo helpers for TaskStorage delegation
     let get_expr = field.direct_get_expr();
@@ -1851,11 +1920,11 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
                 if old_ref == &value {
                     return None;
                 }
-                #track_modification
+                #track_modification_value
                 let old = std::mem::replace(&mut self.typed_mut().lazy[idx], #constructor);
                 Some((#unwraper)(old))
             } else {
-                #track_modification
+                #track_modification_value
                 self.typed_mut().lazy.push(#constructor);
                 None
             }
@@ -1865,7 +1934,7 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
             if #get_expr.is_some_and(|old| old == &value) {
                 return None;
             }
-            #track_modification
+            #track_modification_value
             #set_expr(value)
         }
     };
@@ -1882,17 +1951,22 @@ fn generate_direct_accessors(field: &FieldInfo) -> TokenStream {
         let unwraper = field.lazy_unwrap_closure();
         quote! {
             let (idx, _) = self.typed().find_lazy_ref(#extractor)?;
-            #track_modification
-            Some(self.typed_mut().lazy_take_at(idx, #unwraper))
+            let old = self.typed_mut().lazy_take_at(idx, #unwraper);
+            // Track on the removed value's transience: removing a transient entry
+            // changes nothing persistable (it was filtered at encode).
+            #track_modification_old
+            Some(old)
         }
     } else {
         quote! {
-            if #get_expr.is_some() {
-                #track_modification
-                #take_expr
-            } else {
-                None
+            let old = #take_expr;
+            if let Some(old) = old.as_ref() {
+                // Track on the removed value's transience: removing a transient
+                // entry changes nothing persistable (filtered at encode). For
+                // non-filter_transient fields this tracks unconditionally.
+                #track_modification_old
             }
+            old
         }
     };
 
@@ -1942,6 +2016,11 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
 
     let check_access = field.check_access_call();
     let track_modification = field.track_modification_call();
+    // For `filter_transient` fields, tracking on add/remove is guarded so it
+    // only fires for non-transient `item`s (transient entries are dropped at
+    // encode, so they change zero persistable bytes). For non-filter_transient
+    // fields this is identical to `track_modification`.
+    let track_modification_item = field.track_modification_call_guarded(quote! { item });
     let mut_expr = field.collection_mut_expr();
     let ref_expr = field.collection_ref_expr();
 
@@ -2024,7 +2103,7 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
                 if !val.contains(item) {
                     return false;
                 }
-                #track_modification
+                #track_modification_item
                 self.typed_mut().lazy_at_mut(idx, #extractor).remove(item)
             }
         } else {
@@ -2032,7 +2111,7 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
                 if !#ref_expr.contains(item) {
                     return false;
                 }
-                #track_modification
+                #track_modification_item
                 #mut_expr.remove(item)
             }
         };
@@ -2047,10 +2126,10 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
                     if existing.contains(&item) {
                         return false;
                     }
-                    #track_modification
+                    #track_modification_item
                     self.typed_mut().lazy_at_mut(idx, #extractor).insert(item)
                 } else {
-                    #track_modification
+                    #track_modification_item
                     let mut set = <#field_type as Default>::default();
                     set.insert(item);
                     self.typed_mut().lazy.push(#ctor);
@@ -2062,7 +2141,7 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
                 if #ref_expr.contains(&item) {
                     return false;
                 }
-                #track_modification
+                #track_modification_item
                 #mut_expr.insert(item)
             }
         };
@@ -2102,7 +2181,37 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
 
         // Extend: use peekable iterator to avoid Vec allocation.
         // For lazy fields, look up the set once via find_lazy_ref to avoid repeated scans.
-        extend_body = if is_option {
+        //
+        // `filter_transient` fields take a different shape: the batch tracks once
+        // for a mix of entries, so we must track iff at least one *newly inserted*
+        // entry is non-transient (transient entries are dropped at encode and
+        // change zero persistable bytes). We insert one by one and set the modified
+        // flag lazily on the first non-transient new entry. This is slightly less
+        // allocation-optimal than the non-filter path, but `filter_transient`
+        // extend has a single caller (`extend_children`).
+        extend_body = if field.filter_transient {
+            // `track_modification` is the unconditional call here; we gate it
+            // ourselves on `inserted_persistent` below. `#mut_expr`
+            // (`<field>_mut()`) get-or-creates the inner set for lazy fields and
+            // returns it directly for inline ones, so a single form covers both.
+            quote! {
+                let mut iter = items.into_iter().peekable();
+                if iter.peek().is_none() {
+                    return;
+                }
+                let mut inserted_persistent = false;
+                let set = #mut_expr;
+                for item in iter {
+                    let is_transient = item.is_transient();
+                    if set.insert(item) && !is_transient {
+                        inserted_persistent = true;
+                    }
+                }
+                if inserted_persistent {
+                    #track_modification
+                }
+            }
+        } else if is_option {
             let extractor = field.lazy_extractor_closure();
             let ctor = field.lazy_constructor(quote! { set });
             quote! {
@@ -2249,6 +2358,10 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
 
     let check_access = field.check_access_call();
     let track_modification = field.track_modification_call();
+    // For `filter_transient` counter maps, single-key mutators guard tracking on
+    // `key` so it only fires for non-transient keys (transient entries are dropped
+    // at encode). For non-filter_transient fields this equals `track_modification`.
+    let track_modification_key = field.track_modification_call_guarded(quote! { key });
     let mut_expr = field.collection_mut_expr();
     let ref_expr = field.collection_ref_expr();
     let is_option = field.is_option_ref();
@@ -2286,13 +2399,13 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
         quote! {
             let (idx, val) = self.typed().find_lazy_ref(#extractor)?;
             val.get(key)?;
-            #track_modification
+            #track_modification_key
             self.typed_mut().lazy_at_mut(idx, #extractor).remove(key)
         }
     } else {
         quote! {
             self.#get_name(key)?;
-            #track_modification
+            #track_modification_key
             #mut_expr.remove(key)
         }
     };
@@ -2330,7 +2443,7 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
                 if delta == 0 {
                     return false;
                 }
-                #track_modification
+                #track_modification_key
                 #mut_expr.update_positive_crossing(key, delta)
             }
         };
@@ -2357,7 +2470,7 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
             if delta == 0 {
                 return false;
             }
-            #track_modification
+            #track_modification_key
             #mut_expr.update_count(key, delta)
         }
     };
@@ -2367,6 +2480,27 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
             let map = #mut_expr;
             for key in keys {
                 map.update_count(key, delta);
+            }
+        }
+    } else if field.filter_transient {
+        // Batch update: track iff at least one applied key is non-transient
+        // (transient entries are dropped at encode). `update_count` returns
+        // whether the count crossed zero, which is irrelevant here; we gate
+        // tracking on the key's transience, decided before the loop body runs.
+        quote! {
+            if delta == 0 {
+                return;
+            }
+            let mut applied_persistent = false;
+            let map = #mut_expr;
+            for key in keys {
+                if !key.is_transient() {
+                    applied_persistent = true;
+                }
+                map.update_count(key, delta);
+            }
+            if applied_persistent {
+                #track_modification
             }
         }
     } else {
@@ -2391,7 +2525,7 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
             if delta == 0 {
                 return self.#get_name(&key).copied().unwrap_or_default();
             }
-            #track_modification
+            #track_modification_key
             #mut_expr.update_and_get(key, delta)
         }
     };
@@ -2412,7 +2546,7 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
             };
             let new_value = f(old_value);
             if old_value != new_value {
-                #track_modification
+                #track_modification_key
                 match new_value {
                     Some(value) => {
                         if let Some(position) = position {
@@ -2436,7 +2570,7 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
             let old = self.#get_name(&key).copied();
             let new = f(old);
             if old != new {
-                #track_modification
+                #track_modification_key
                 match new {
                     Some(value) => { #mut_expr.insert(key, value); }
                     None => { #mut_expr.remove(&key); }
@@ -2486,7 +2620,7 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
         #[doc = "Add a new entry, panicking if the entry already exists."]
         fn #add_entry_name(&mut self, key: #key_type, value: #value_type) {
             #check_access
-            #track_modification
+            #track_modification_key
             #mut_expr.add_entry(key, value)
         }
 
@@ -2648,6 +2782,38 @@ fn generate_automap_ops(field: &FieldInfo) -> TokenStream {
         }
     };
 
+    // The mutating accessors. When `custom_mutators` is set, these are omitted
+    // from the trait and hand-written elsewhere (so they can own a custom
+    // `track_modification` decision — see `cell_data`).
+    let mutators = if field.custom_mutators {
+        quote! {}
+    } else {
+        quote! {
+            #[doc = "Insert an entry, returning the old value if present."]
+            fn #insert_entry_name(&mut self, key: #key_type, value: #value_type) -> Option<#value_type> {
+                #check_access
+                #track_modification
+                #mut_expr.insert(key, value)
+            }
+
+
+            #[doc = "Remove an entry, returning the value if present."]
+            #[doc = "Only tracks modification if an entry was actually removed."]
+            fn #remove_entry_name(&mut self, key: &#key_type) -> Option<#value_type> {
+                #check_access
+                #remove_body
+            }
+
+
+            #[doc = "Remove the full map and return it"]
+            #[doc = "Only tracks modification if the map is non-empty."]
+            fn #take_name(&mut self) -> Option<#field_type> {
+                #check_access
+                #take_body
+            }
+        }
+    };
+
     quote! {
         #[doc = "Get an entry from the map by key"]
         fn #get_entry_name(&self, key: &#key_type) -> Option<&#value_type> {
@@ -2661,28 +2827,7 @@ fn generate_automap_ops(field: &FieldInfo) -> TokenStream {
             #has_entry_body
         }
 
-        #[doc = "Insert an entry, returning the old value if present."]
-        fn #insert_entry_name(&mut self, key: #key_type, value: #value_type) -> Option<#value_type> {
-            #check_access
-            #track_modification
-            #mut_expr.insert(key, value)
-        }
-
-
-        #[doc = "Remove an entry, returning the value if present."]
-        #[doc = "Only tracks modification if an entry was actually removed."]
-        fn #remove_entry_name(&mut self, key: &#key_type) -> Option<#value_type> {
-            #check_access
-            #remove_body
-        }
-
-
-        #[doc = "Remove the full map and return it"]
-        #[doc = "Only tracks modification if the map is non-empty."]
-        fn #take_name(&mut self) -> Option<#field_type> {
-            #check_access
-            #take_body
-        }
+        #mutators
 
         #[doc = "Iterate over all key-value pairs in the map"]
         fn #iter_entries_name(&self) -> impl Iterator<Item = (&#key_type, &#value_type)> + '_ {


### PR DESCRIPTION
Many fields in TaskStorage store a mix of transient and persistent data.  When we serialize we leverage the `filter_transient` tag (and the `IsTransient` trait) to avoid persisting it, however, when mutations occur we are still marking the tasks as `modified` even when we are only modifying transient data.

This leads to unnecessary persistence cycles.

The solution is simply to not call `track_modification` when the modification is about transient data items.

For most fields this is handled in the macro accessors, but for `cell_data` this is managed via some new 'handwritten' mutators implemented on `TaskGuard`.  This is desirable to decrease the number of times we do registry lookups since most callers who modify the cell_data already have the ValueType in hand