### PR TITLE
[next-dev-loop] Require --session on every agent-browser command

### DIFF
--- a/skills/next-dev-loop/SKILL.md
+++ b/skills/next-dev-loop/SKILL.md
@@ -22,7 +22,11 @@ You verify through two views of the same running app:
   `tools/list` for the current surface.
 - **`agent-browser`** — a CLI that drives a real Chrome. Knows
   framework-agnostic browser things: DOM, console, network, React
-  fiber, vitals. Run `agent-browser --help` for the current surface.
+  fiber, vitals. Before using it, run
+  `agent-browser skills get core --full` once — its version-matched
+  manual covers the snapshot/ref workflow, sessions, tabs, the full
+  command reference, and examples. Prefer it over `--help` or
+  recalling flags from memory.
 
 The two views cross-check each other.
 
@@ -52,7 +56,12 @@ Once per session, confirm both views are live.
 1. **Open `agent-browser` at the target URL, restoring saved
    login state when present.** Build the `open` command from:
    - `--session <name>` where `<name>` is the project
-     directory basename.
+     directory basename. **Pass this same `--session <name>` on
+     every later `agent-browser` command, not only `open`.** Each
+     invocation is a separate process; the flag is how it finds the
+     browser you opened. Omit it and the command falls back to a
+     different, empty default browser — so reads come back blank and
+     a working page looks broken.
    - `--state ~/.agent-browser/sessions/<name>-default.json` if
      that file exists. Omit on first run — a missing path fails
      the open.
@@ -105,11 +114,16 @@ Four failure modes. Check each:
   server/client boundary shifts, suspense fallbacks) — DOM asserts
   alone miss them.
 
-Pick the specific tool from `tools/list` or `agent-browser
---help` rather than from memory.
+Pick the specific tool from `tools/list` or the agent-browser
+manual rather than from memory.
 
 ## gotchas
 
+- **When the two views disagree, suspect the tooling first.** If
+  `agent-browser` says a route is broken but `/_next/mcp` and the
+  server say it rendered cleanly, a stale or misdirected browser
+  session is the likelier cause than a real bug — reconcile the
+  views (see the agent-browser manual) before debugging the app.
 - React introspection output is stale after navigation. Re-run.
 - Non-3000 dev server: read the `next dev` banner; set
   `NEXT_MCP_URL=http://localhost:<port>/_next/mcp`.
@@ -139,9 +153,10 @@ get_compilation_issues       Turbopack only; errors on webpack
 
 ## teardown
 
-Close the `agent-browser` session — `--session` writes state
-to disk so the next loop's `--state` restores login. Leave
-`next dev` up for the next loop.
+Close the session: `agent-browser --session <name> close` — the
+same `--session` every command uses (preflight step 1). `close` also
+writes that session's state to disk so the next loop's `--state`
+restores login. Leave `next dev` up for the next loop.
 
 ---
 

--- a/skills/next-dev-loop/SKILL.md
+++ b/skills/next-dev-loop/SKILL.md
@@ -124,6 +124,14 @@ manual rather than from memory.
   server say it rendered cleanly, a stale or misdirected browser
   session is the likelier cause than a real bug — reconcile the
   views (see the agent-browser manual) before debugging the app.
+- **After any click or navigation, use `wait --load networkidle`
+  unless you know the exact path suffix.** The manual's
+  `wait --url "**/dashboard"` glob only matches URLs whose path
+  _ends_ with `/dashboard`; a generic placeholder like `**/slug`
+  never matches a real URL (e.g. `http://localhost:3000/posts/my-post`
+  → 25 s timeout). Prefer `--load networkidle` — it always works.
+  Use `--url` only with a literal suffix you can read from the link:
+  `wait --url "**/posts/my-post"`.
 - React introspection output is stale after navigation. Re-run.
 - Non-3000 dev server: read the `next dev` banner; set
   `NEXT_MCP_URL=http://localhost:<port>/_next/mcp`.


### PR DESCRIPTION
The skill set `--session <name>` only on `open`/`close` and framed it as a state-persistence flag, so agents inferred it was an open/close-time concern and dropped it on later commands. A command without `--session` runs against a different session — the unnamed default, a separate browser that never navigated — so its reads come back empty and a working page looks blank, easily mistaken for a broken app.

Preflight now makes `--session <name>` an explicit every-command invariant (each invocation is a separate process; the flag selects which browser it talks to), and teardown back-references that rule. The blank-read gotcha is reduced to the skill's own cross-check principle — when the browser view and `/_next/mcp` disagree, suspect the tooling first — with the agent-browser session/tab specifics deferred to its own manual, which the skill now points at via `agent-browser skills get core --full` instead of `--help`.