### PR TITLE
[cd] Allow forcing a release without new commits

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -97,7 +97,7 @@ jobs:
         run: echo "LATEST_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Check if new commits since last tag
-        if: ${{ github.event.inputs.releaseType != 'stable' && github.event.inputs.force != true }}
+        if: ${{ github.event.inputs.releaseType != 'stable' && inputs.force != true }}
         run: |
           if [ "$LATEST_TAG_COMMIT" = "$LATEST_COMMIT" ]; then
             echo "No new commits. Exiting..."


### PR DESCRIPTION
The event payload contains strings not actual booleans. We should use the `inputs` context everywhere. Not doing that now in case existing code relies on `github.events.input.*` being a string all the time.