### PR TITLE
[turbopack] Don't persist if there is little work to do

### DIFF
--- a/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
+++ b/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
@@ -8,6 +8,9 @@ import { retry, waitFor } from 'next-test-utils'
     'ENABLE_CACHING=1',
     'TURBO_ENGINE_IGNORE_DIRTY=1',
     'TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000',
+    // Persist even tiny snapshots so the test doesn't depend on the
+    // minimum-compilation-time threshold.
+    'TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0',
     'ENABLE_EVICTION=1',
   ].join(' ')
 

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -42,6 +42,9 @@ for (const cacheEnabled of [false, true]) {
       `TURBO_ENGINE_IGNORE_DIRTY=1`,
       // decrease the idle timeout to make the test more reliable
       `TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000`,
+      // persist even tiny snapshots so the test doesn't depend on the
+      // minimum-compilation-time threshold
+      `TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0`,
     ].join(' ')
 
     const { skipped, next, isTurbopack } = nextTestSetup({

--- a/test/e2e/filesystem-cache/next.config.js
+++ b/test/e2e/filesystem-cache/next.config.js
@@ -21,7 +21,7 @@ const nextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: enableCaching,
     turbopackFileSystemCacheForDev: enableCaching,
-    turbopackMemoryEviction: enableEviction ? false : 'off',
+    turbopackMemoryEviction: enableEviction ? 'full' : false,
   },
   env: {
     NEXT_PUBLIC_CONFIG_ENV: 'hello world',

--- a/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
+++ b/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
@@ -32,6 +32,9 @@ const STATS_RELATIVE_PATH = '.next/warm-restart-task-stats.json'
       'ENABLE_CACHING=1',
       'TURBO_ENGINE_IGNORE_DIRTY=1',
       'TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000',
+      // Persist even tiny snapshots so the test doesn't depend on the
+      // minimum-compilation-time threshold.
+      'TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0',
       `NEXT_TURBOPACK_TASK_STATISTICS=${STATS_RELATIVE_PATH}`,
       // The task-statistics file is written by an `on_exit` handler in the
       // napi binding. In dev that handler only runs if the child process

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -78,6 +78,7 @@ use crate::{
     utils::{
         dash_map_raw_entry::{RawEntry, get_shard, raw_entry_in_shard, raw_get_in_shard},
         shard_amount::compute_shard_amount,
+        stopwatch::Stopwatch,
     },
 };
 
@@ -85,16 +86,6 @@ use crate::{
 /// If the number of dependent tasks exceeds this threshold,
 /// the operation will be parallelized.
 const DEPENDENT_TASKS_DIRTY_PARALLELIZATION_THRESHOLD: usize = 10000;
-
-/// Configurable idle timeout for snapshot persistence.
-/// Defaults to 2 seconds if not set or if the value is invalid.
-static IDLE_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
-    std::env::var("TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(Duration::from_secs(2))
-});
 
 /// Priority used to re-schedule a task that became stale during execution.
 ///
@@ -2827,6 +2818,31 @@ impl TurboTasksBackend {
                 TurboTasksBackendJob::Snapshot => {
                     debug_assert!(self.should_persist());
 
+                    /// Configurable idle timeout for snapshot persistence.
+                    /// Defaults to 2 seconds if not set or if the value is invalid.
+                    static IDLE_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
+                        std::env::var("TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS")
+                            .ok()
+                            .and_then(|v| v.parse::<u64>().ok())
+                            .map(Duration::from_millis)
+                            .unwrap_or(Duration::from_secs(2))
+                    });
+
+                    /// Minimum accumulated compilation (non-idle) time since the last persisted
+                    /// snapshot before a periodic snapshot is worth its fixed
+                    /// overhead/ Persistence exists to save work on the next run, and
+                    /// accumulated compilation time is a good proxy for how
+                    /// much work a snapshot would save. Snapshots triggered by
+                    /// shutdown or tests bypass this.
+                    /// Defaults to 1s
+                    static MIN_SNAPSHOT_ACTIVE_TIME: LazyLock<Duration> = LazyLock::new(|| {
+                        std::env::var("TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS")
+                            .ok()
+                            .and_then(|v| v.parse::<u64>().ok())
+                            .map(Duration::from_millis)
+                            .unwrap_or(Duration::from_secs(1))
+                    });
+
                     let mut last_snapshot = self.start_time;
                     let mut idle_start_listener = self.idle_start_event.listen();
                     let mut idle_end_listener = self.idle_end_event.listen();
@@ -2835,6 +2851,11 @@ impl TurboTasksBackend {
                     let mut fresh_idle = true;
                     let mut evicted = false;
                     let mut is_first = true;
+                    // Accumulated compilation (non-idle) time since the last persisted
+                    // snapshot. Runs while not idle, stops while idle. Used to skip periodic
+                    // snapshots that wouldn't save enough work to justify their fixed
+                    // overhead. Reset after each completed snapshot attempt.
+                    let mut active_time = Stopwatch::new();
                     'outer: loop {
                         const FIRST_SNAPSHOT_WAIT: Duration = Duration::from_secs(300);
                         const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(120);
@@ -2844,6 +2865,12 @@ impl TurboTasksBackend {
                         } else {
                             (SNAPSHOT_INTERVAL, SnapshotReason::RegularSnapshotInterval)
                         };
+
+                        // Begin (or continue) timing if we're not idle. Transitions below
+                        // keep this in sync via the idle events.
+                        if !turbo_tasks.is_idle() {
+                            active_time.start(std::time::Instant::now());
+                        }
 
                         let until = last_snapshot + time;
                         if until > Instant::now() {
@@ -2862,10 +2889,14 @@ impl TurboTasksBackend {
                                         return;
                                     },
                                     _ = &mut idle_start_listener => {
+                                        // Became idle: stop accumulating active time.
+                                        active_time.stop(std::time::Instant::now());
                                         idle_time = Instant::now() + idle_timeout;
                                         idle_start_listener = self.idle_start_event.listen()
                                     },
                                     _ = &mut idle_end_listener => {
+                                        // Became active: resume accumulating active time.
+                                        active_time.start(std::time::Instant::now());
                                         idle_time = far_future();
                                         idle_end_listener = self.idle_end_event.listen()
                                     },
@@ -2880,6 +2911,27 @@ impl TurboTasksBackend {
                                     },
                                 }
                             }
+                        }
+
+                        // Persistence exists to save work; accumulated compilation time is
+                        // the proxy for how much work a snapshot would save. Skip periodic
+                        // snapshots below the threshold. Shutdown (Stop) and tests must always
+                        // flush, but they don't run through this loop (Stop is handled in
+                        // stop(), Test in snapshot_and_evict_for_testing), so every reason
+                        // reaching here is subject to the threshold.
+                        if active_time.elapsed(std::time::Instant::now())
+                            < *MIN_SNAPSHOT_ACTIVE_TIME
+                        {
+                            // Not enough compilation time accumulated — skip the (potentially
+                            // expensive) snapshot. Advance scheduling state as if we had run,
+                            // but keep active_time running so it carries toward the next cycle.
+                            // Clear fresh_idle (as a no-data snapshot would) so we don't re-arm
+                            // the short idle timeout every cycle and spin while idle; a new
+                            // active period (idle_end) re-triggers timing and progress.
+                            fresh_idle = false;
+                            is_first = false;
+                            last_snapshot = Instant::now();
+                            continue 'outer;
                         }
 
                         // Create a root span shared by both the snapshot/persist
@@ -2900,6 +2952,14 @@ impl TurboTasksBackend {
                                 fresh_idle = new_data;
                                 is_first = false;
                                 last_snapshot = snapshot_start;
+                                // A completed snapshot attempt means the accumulated
+                                // compilation time has been accounted for: either it produced
+                                // work we just persisted (new_data), or it produced nothing to
+                                // persist — in which case that time amounted to no savable
+                                // state. Either way, reset so stale time doesn't carry into the
+                                // next cycle. If still timing an active period, reset() keeps it
+                                // running from now so time before this snapshot isn't counted.
+                                active_time.reset(std::time::Instant::now());
 
                                 // Polls the idle-end event without blocking. Returns
                                 // `true` and refreshes the listener if idle has ended,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2869,7 +2869,7 @@ impl TurboTasksBackend {
                         // Begin (or continue) timing if we're not idle. Transitions below
                         // keep this in sync via the idle events.
                         if !turbo_tasks.is_idle() {
-                            active_time.start(std::time::Instant::now());
+                            active_time.start();
                         }
 
                         let until = last_snapshot + time;
@@ -2890,13 +2890,13 @@ impl TurboTasksBackend {
                                     },
                                     _ = &mut idle_start_listener => {
                                         // Became idle: stop accumulating active time.
-                                        active_time.stop(std::time::Instant::now());
+                                        active_time.stop();
                                         idle_time = Instant::now() + idle_timeout;
                                         idle_start_listener = self.idle_start_event.listen()
                                     },
                                     _ = &mut idle_end_listener => {
                                         // Became active: resume accumulating active time.
-                                        active_time.start(std::time::Instant::now());
+                                        active_time.start();
                                         idle_time = far_future();
                                         idle_end_listener = self.idle_end_event.listen()
                                     },
@@ -2919,9 +2919,7 @@ impl TurboTasksBackend {
                         // flush, but they don't run through this loop (Stop is handled in
                         // stop(), Test in snapshot_and_evict_for_testing), so every reason
                         // reaching here is subject to the threshold.
-                        if active_time.elapsed(std::time::Instant::now())
-                            < *MIN_SNAPSHOT_ACTIVE_TIME
-                        {
+                        if active_time.elapsed() < *MIN_SNAPSHOT_ACTIVE_TIME {
                             // Not enough compilation time accumulated — skip the (potentially
                             // expensive) snapshot. Advance scheduling state as if we had run,
                             // but keep active_time running so it carries toward the next cycle.
@@ -2959,7 +2957,7 @@ impl TurboTasksBackend {
                                 // state. Either way, reset so stale time doesn't carry into the
                                 // next cycle. If still timing an active period, reset() keeps it
                                 // running from now so time before this snapshot isn't counted.
-                                active_time.reset(std::time::Instant::now());
+                                active_time.reset();
 
                                 // Polls the idle-end event without blocking. Returns
                                 // `true` and refreshes the listener if idle has ended,

--- a/turbopack/crates/turbo-tasks-backend/src/utils/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod dash_map_raw_entry;
 pub mod markdown_table;
 pub mod ptr_eq_arc;
 pub mod shard_amount;
+pub mod stopwatch;
 pub mod swap_retain;
 
 pub use swap_retain::swap_retain;

--- a/turbopack/crates/turbo-tasks-backend/src/utils/stopwatch.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/stopwatch.rs
@@ -1,0 +1,140 @@
+use std::time::{Duration, Instant};
+
+/// A simple accumulating stopwatch for measuring total elapsed time across multiple
+/// start/stop intervals.
+///
+/// Time accrues only while the stopwatch is running. [`Stopwatch::start`] begins an
+/// interval, [`Stopwatch::stop`] ends it and folds the interval into the accumulated
+/// total, and [`Stopwatch::elapsed`] reports the accumulated total plus any currently
+/// running interval. Both `start` and `stop` are idempotent, so callers don't need to
+/// track the running state themselves.
+///
+/// The current time is supplied by the caller (rather than read internally) so the type
+/// stays a pure value: callers pass `Instant::now()`, and tests can supply a controlled
+/// clock.
+#[derive(Debug, Default)]
+pub struct Stopwatch {
+    /// Total time accumulated from completed intervals.
+    accumulated: Duration,
+    /// Start of the current running interval, or `None` while stopped.
+    started_at: Option<Instant>,
+}
+
+impl Stopwatch {
+    /// Creates a new, stopped stopwatch with zero elapsed time.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Starts timing a new interval at `now`. No-op if already running.
+    pub fn start(&mut self, now: Instant) {
+        if self.started_at.is_none() {
+            self.started_at = Some(now);
+        }
+    }
+
+    /// Stops the current interval at `now`, folding its duration into the accumulated
+    /// total. No-op if already stopped.
+    pub fn stop(&mut self, now: Instant) {
+        if let Some(started_at) = self.started_at.take() {
+            self.accumulated += now.saturating_duration_since(started_at);
+        }
+    }
+
+    /// Resets the accumulated total to zero. If the stopwatch is currently running, it
+    /// keeps running but the current interval restarts from `now` (so time before the
+    /// reset is discarded rather than carried forward).
+    pub fn reset(&mut self, now: Instant) {
+        self.accumulated = Duration::ZERO;
+        if self.started_at.is_some() {
+            self.started_at = Some(now);
+        }
+    }
+
+    /// The total elapsed time as of `now`: completed intervals plus any currently running
+    /// interval.
+    pub fn elapsed(&self, now: Instant) -> Duration {
+        self.accumulated
+            + self.started_at.map_or(Duration::ZERO, |started_at| {
+                now.saturating_duration_since(started_at)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::Stopwatch;
+
+    /// Returns a base instant and a helper to derive instants offset by milliseconds.
+    fn clock() -> (Instant, impl Fn(u64) -> Instant) {
+        let base = Instant::now();
+        (base, move |ms: u64| base + Duration::from_millis(ms))
+    }
+
+    #[test]
+    fn accumulates_across_intervals() {
+        let (base, at) = clock();
+        let mut sw = Stopwatch::new();
+        assert_eq!(sw.elapsed(base), Duration::ZERO);
+
+        sw.start(at(0));
+        sw.stop(at(100));
+        assert_eq!(sw.elapsed(at(150)), Duration::from_millis(100));
+
+        // Stopped: time does not accrue.
+        assert_eq!(sw.elapsed(at(200)), Duration::from_millis(100));
+
+        // A second interval adds on top.
+        sw.start(at(200));
+        sw.stop(at(230));
+        assert_eq!(sw.elapsed(at(500)), Duration::from_millis(130));
+    }
+
+    #[test]
+    fn elapsed_includes_running_interval() {
+        let (_, at) = clock();
+        let mut sw = Stopwatch::new();
+        sw.start(at(0));
+        // Without stopping, elapsed reflects the in-flight interval.
+        assert_eq!(sw.elapsed(at(40)), Duration::from_millis(40));
+        assert_eq!(sw.elapsed(at(50)), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn start_and_stop_are_idempotent() {
+        let (base, at) = clock();
+        let mut sw = Stopwatch::new();
+        // Redundant stop is a no-op.
+        sw.stop(base);
+        assert_eq!(sw.elapsed(base), Duration::ZERO);
+
+        sw.start(at(0));
+        // Redundant start does not restart the interval.
+        sw.start(at(20));
+        sw.stop(at(40));
+        assert_eq!(sw.elapsed(at(40)), Duration::from_millis(40));
+    }
+
+    #[test]
+    fn reset_while_stopped_zeroes_total() {
+        let (_, at) = clock();
+        let mut sw = Stopwatch::new();
+        sw.start(at(0));
+        sw.stop(at(70));
+        sw.reset(at(70));
+        assert_eq!(sw.elapsed(at(200)), Duration::ZERO);
+    }
+
+    #[test]
+    fn reset_while_running_keeps_running_from_now() {
+        let (_, at) = clock();
+        let mut sw = Stopwatch::new();
+        sw.start(at(0));
+        // Reset mid-interval: prior time discarded, but still running from at(70).
+        sw.reset(at(70));
+        assert_eq!(sw.elapsed(at(70)), Duration::ZERO);
+        assert_eq!(sw.elapsed(at(95)), Duration::from_millis(25));
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/utils/stopwatch.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/stopwatch.rs
@@ -8,10 +8,6 @@ use std::time::{Duration, Instant};
 /// total, and [`Stopwatch::elapsed`] reports the accumulated total plus any currently
 /// running interval. Both `start` and `stop` are idempotent, so callers don't need to
 /// track the running state themselves.
-///
-/// The current time is supplied by the caller (rather than read internally) so the type
-/// stays a pure value: callers pass `Instant::now()`, and tests can supply a controlled
-/// clock.
 #[derive(Debug, Default)]
 pub struct Stopwatch {
     /// Total time accumulated from completed intervals.
@@ -26,34 +22,52 @@ impl Stopwatch {
         Self::default()
     }
 
-    /// Starts timing a new interval at `now`. No-op if already running.
-    pub fn start(&mut self, now: Instant) {
+    /// Starts timing a new interval. No-op if already running.
+    pub fn start(&mut self) {
+        self.start_at(Instant::now());
+    }
+
+    /// Stops the current interval, folding its duration into the accumulated total.
+    /// No-op if already stopped.
+    pub fn stop(&mut self) {
+        self.stop_at(Instant::now());
+    }
+
+    /// Resets the accumulated total to zero. If the stopwatch is currently running, it
+    /// keeps running but the current interval restarts from now (so time before the reset
+    /// is discarded rather than carried forward).
+    pub fn reset(&mut self) {
+        self.reset_at(Instant::now());
+    }
+
+    /// The total elapsed time: completed intervals plus any currently running interval.
+    pub fn elapsed(&self) -> Duration {
+        self.elapsed_at(Instant::now())
+    }
+
+    // The `*_at` methods take `now` explicitly so the accounting logic can be unit-tested
+    // with a controlled clock. The public API reads the real clock and delegates here.
+
+    fn start_at(&mut self, now: Instant) {
         if self.started_at.is_none() {
             self.started_at = Some(now);
         }
     }
 
-    /// Stops the current interval at `now`, folding its duration into the accumulated
-    /// total. No-op if already stopped.
-    pub fn stop(&mut self, now: Instant) {
+    fn stop_at(&mut self, now: Instant) {
         if let Some(started_at) = self.started_at.take() {
             self.accumulated += now.saturating_duration_since(started_at);
         }
     }
 
-    /// Resets the accumulated total to zero. If the stopwatch is currently running, it
-    /// keeps running but the current interval restarts from `now` (so time before the
-    /// reset is discarded rather than carried forward).
-    pub fn reset(&mut self, now: Instant) {
+    fn reset_at(&mut self, now: Instant) {
         self.accumulated = Duration::ZERO;
         if self.started_at.is_some() {
             self.started_at = Some(now);
         }
     }
 
-    /// The total elapsed time as of `now`: completed intervals plus any currently running
-    /// interval.
-    pub fn elapsed(&self, now: Instant) -> Duration {
+    fn elapsed_at(&self, now: Instant) -> Duration {
         self.accumulated
             + self.started_at.map_or(Duration::ZERO, |started_at| {
                 now.saturating_duration_since(started_at)
@@ -77,29 +91,29 @@ mod tests {
     fn accumulates_across_intervals() {
         let (base, at) = clock();
         let mut sw = Stopwatch::new();
-        assert_eq!(sw.elapsed(base), Duration::ZERO);
+        assert_eq!(sw.elapsed_at(base), Duration::ZERO);
 
-        sw.start(at(0));
-        sw.stop(at(100));
-        assert_eq!(sw.elapsed(at(150)), Duration::from_millis(100));
+        sw.start_at(at(0));
+        sw.stop_at(at(100));
+        assert_eq!(sw.elapsed_at(at(150)), Duration::from_millis(100));
 
         // Stopped: time does not accrue.
-        assert_eq!(sw.elapsed(at(200)), Duration::from_millis(100));
+        assert_eq!(sw.elapsed_at(at(200)), Duration::from_millis(100));
 
         // A second interval adds on top.
-        sw.start(at(200));
-        sw.stop(at(230));
-        assert_eq!(sw.elapsed(at(500)), Duration::from_millis(130));
+        sw.start_at(at(200));
+        sw.stop_at(at(230));
+        assert_eq!(sw.elapsed_at(at(500)), Duration::from_millis(130));
     }
 
     #[test]
     fn elapsed_includes_running_interval() {
         let (_, at) = clock();
         let mut sw = Stopwatch::new();
-        sw.start(at(0));
+        sw.start_at(at(0));
         // Without stopping, elapsed reflects the in-flight interval.
-        assert_eq!(sw.elapsed(at(40)), Duration::from_millis(40));
-        assert_eq!(sw.elapsed(at(50)), Duration::from_millis(50));
+        assert_eq!(sw.elapsed_at(at(40)), Duration::from_millis(40));
+        assert_eq!(sw.elapsed_at(at(50)), Duration::from_millis(50));
     }
 
     #[test]
@@ -107,34 +121,34 @@ mod tests {
         let (base, at) = clock();
         let mut sw = Stopwatch::new();
         // Redundant stop is a no-op.
-        sw.stop(base);
-        assert_eq!(sw.elapsed(base), Duration::ZERO);
+        sw.stop_at(base);
+        assert_eq!(sw.elapsed_at(base), Duration::ZERO);
 
-        sw.start(at(0));
+        sw.start_at(at(0));
         // Redundant start does not restart the interval.
-        sw.start(at(20));
-        sw.stop(at(40));
-        assert_eq!(sw.elapsed(at(40)), Duration::from_millis(40));
+        sw.start_at(at(20));
+        sw.stop_at(at(40));
+        assert_eq!(sw.elapsed_at(at(40)), Duration::from_millis(40));
     }
 
     #[test]
     fn reset_while_stopped_zeroes_total() {
         let (_, at) = clock();
         let mut sw = Stopwatch::new();
-        sw.start(at(0));
-        sw.stop(at(70));
-        sw.reset(at(70));
-        assert_eq!(sw.elapsed(at(200)), Duration::ZERO);
+        sw.start_at(at(0));
+        sw.stop_at(at(70));
+        sw.reset_at(at(70));
+        assert_eq!(sw.elapsed_at(at(200)), Duration::ZERO);
     }
 
     #[test]
     fn reset_while_running_keeps_running_from_now() {
         let (_, at) = clock();
         let mut sw = Stopwatch::new();
-        sw.start(at(0));
+        sw.start_at(at(0));
         // Reset mid-interval: prior time discarded, but still running from at(70).
-        sw.reset(at(70));
-        assert_eq!(sw.elapsed(at(70)), Duration::ZERO);
-        assert_eq!(sw.elapsed(at(95)), Duration::from_millis(25));
+        sw.reset_at(at(70));
+        assert_eq!(sw.elapsed_at(at(70)), Duration::ZERO);
+        assert_eq!(sw.elapsed_at(at(95)), Duration::from_millis(25));
     }
 }


### PR DESCRIPTION
Currently we skip a persist cycle when there are no dirty tasks. This PR extends that to skip persist cycles when little compilation work has happened since the last snapshot, avoiding small writes and expensive compaction for little benefit.

Compilation time is a better proxy for "how much work a snapshot would save" than a raw dirty-task count. The background snapshot loop accumulates active (non-idle) wall-clock time and skips a cycle when less than a threshold has elapsed since the last persisted snapshot. Default is 1s, overridable via `TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS` (set to `0` in tests). Shutdown and test snapshots bypass the gate.

The active-time bookkeeping is encapsulated in a small `Stopwatch` helper.

<!-- NEXT_JS_LLM_PR -->