### PR TITLE
turbopack hmr: don't re-ensurePage on subsequent visits

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -304,6 +304,8 @@ function getSourceMapFromTurbopack(
   }
 }
 
+const ensuredPages = new Set()
+
 export async function createHotReloaderTurbopack(
   opts: SetupOpts & { isSrcDir: boolean },
   serverFields: ServerFields,
@@ -1666,6 +1668,10 @@ export async function createHotReloaderTurbopack(
           if (BLOCKED_PAGES.includes(inputPage) && inputPage !== '/_error') {
             return
           }
+          if (ensuredPages.has(inputPage)) {
+            return
+          }
+          ensuredPages.add(inputPage)
 
           await currentEntriesHandling
 


### PR DESCRIPTION
Each call to `ensurePage` resulted in recomputation in Turbopack for a page that was already built and being monitored. Instead, continue to let Turbopack communicate changes back as needed.

Test Plan: In an app with repeated polling of an api endpoint, verified via Turbopack tracing that periodic recomputations (and snapshots, and compactions) no longer occur.
