### PR TITLE
docs: server actions guide x-refs

### DIFF
--- a/docs/01-app/01-getting-started/09-revalidating.mdx
+++ b/docs/01-app/01-getting-started/09-revalidating.mdx
@@ -118,7 +118,7 @@ See the [`revalidateTag` API reference](/docs/app/api-reference/functions/revali
 
 ## `updateTag`
 
-`updateTag` immediately expires cached data for read-your-own-writes scenarios — the user sees their change right away instead of stale content. Unlike `revalidateTag`, it can only be used in [Server Actions](/docs/app/getting-started/mutating-data).
+`updateTag` immediately expires cached data for read-your-own-writes scenarios — the user sees their change right away instead of stale content. Unlike `revalidateTag`, it can only be used in [Server Actions](/docs/app/guides/server-actions).
 
 ```tsx filename="app/lib/actions.ts" highlight={1,12} switcher
 import { updateTag } from 'next/cache'

--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1456,7 +1456,7 @@ This pattern allows you to show or hide UI elements based on user permissions wh
 
 ### Server Actions
 
-Treat [Server Actions](/docs/app/getting-started/mutating-data) with the same security considerations as public-facing API endpoints, and verify if the user is allowed to perform a mutation.
+Treat [Server Actions](/docs/app/guides/server-actions) with the same security considerations as public-facing API endpoints, and verify if the user is allowed to perform a mutation.
 
 In the example below, we check the user's role before allowing the action to proceed:
 

--- a/docs/01-app/02-guides/backend-for-frontend.mdx
+++ b/docs/01-app/02-guides/backend-for-frontend.mdx
@@ -897,7 +897,7 @@ For these, use community libraries like [`swr`](https://swr.vercel.app/) or [`re
 
 ### Server Actions
 
-Server Actions let you run server-side code from the client. Their primary purpose is to mutate data from your frontend client.
+[Server Actions](/docs/app/guides/server-actions) let you run server-side code from the client. Their primary purpose is to mutate data from your frontend client.
 
 Server Actions are queued. Using them for data fetching introduces sequential execution.
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -25,7 +25,7 @@ Next.js can automatically code split your JavaScript bundles, and generate multi
 
 The [`next/link`](/docs/app/api-reference/components/link) component automatically [prefetches](/docs/app/api-reference/components/link#prefetch) routes, giving you the fast page transitions of a strict SPA, but with the advantage of persisting application routing state to the URL for linking and sharing.
 
-Next.js can start as a static site or even a strict SPA where everything is rendered client-side. If your project grows, Next.js allows you to progressively add more server features (e.g. [React Server Components](/docs/app/getting-started/server-and-client-components), [Server Actions](/docs/app/getting-started/mutating-data), and more) as needed.
+Next.js can start as a static site or even a strict SPA where everything is rendered client-side. If your project grows, Next.js allows you to progressively add more server features (e.g. [React Server Components](/docs/app/getting-started/server-and-client-components), [Server Actions](/docs/app/guides/server-actions), and more) as needed.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/02-components/form.mdx
+++ b/docs/01-app/03-api-reference/02-components/form.mdx
@@ -401,6 +401,6 @@ export default async function PostPage({ params }) {
 }
 ```
 
-See the [Server Actions](/docs/app/getting-started/mutating-data) docs for more examples.
+See [Mutating data](/docs/app/getting-started/mutating-data) for more examples.
 
 </AppOnly>

--- a/docs/01-app/03-api-reference/04-functions/redirect.mdx
+++ b/docs/01-app/03-api-reference/04-functions/redirect.mdx
@@ -4,6 +4,7 @@ description: API Reference for the redirect function.
 related:
   links:
     - app/api-reference/functions/permanentRedirect
+    - app/guides/server-actions
 ---
 
 The `redirect` function allows you to redirect the user to another URL. `redirect` can be used while rendering in [Server and Client Components](/docs/app/getting-started/server-and-client-components), [Route Handlers](/docs/app/api-reference/file-conventions/route), and [Server Functions](/docs/app/getting-started/mutating-data).

--- a/docs/01-app/03-api-reference/04-functions/refresh.mdx
+++ b/docs/01-app/03-api-reference/04-functions/refresh.mdx
@@ -1,9 +1,12 @@
 ---
 title: refresh
 description: API Reference for the refresh function.
+related:
+  links:
+    - app/guides/server-actions
 ---
 
-`refresh` allows you to refresh the client router from within a [Server Action](/docs/app/getting-started/mutating-data).
+`refresh` allows you to refresh the client router from within a [Server Action](/docs/app/guides/server-actions).
 
 ## Usage
 

--- a/docs/01-app/03-api-reference/04-functions/revalidatePath.mdx
+++ b/docs/01-app/03-api-reference/04-functions/revalidatePath.mdx
@@ -1,6 +1,9 @@
 ---
 title: revalidatePath
 description: API Reference for the revalidatePath function.
+related:
+  links:
+    - app/guides/server-actions
 ---
 
 `revalidatePath` allows you to invalidate [cached data](/docs/app/getting-started/caching) on-demand for a specific path.

--- a/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
@@ -1,6 +1,9 @@
 ---
 title: revalidateTag
 description: API Reference for the revalidateTag function.
+related:
+  links:
+    - app/guides/server-actions
 ---
 
 `revalidateTag` allows you to invalidate cached data on-demand for a specific cache tag.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -1,9 +1,12 @@
 ---
 title: serverActions
 description: Configure Server Actions behavior in your Next.js application.
+related:
+  links:
+    - app/guides/server-actions
 ---
 
-Options for configuring Server Actions behavior in your Next.js application.
+Options for configuring Server Actions behavior in your Next.js application. For how Server Actions work, including the security boundary these options tune, see the [Server Actions guide](/docs/app/guides/server-actions).
 
 ## `allowedOrigins`
 


### PR DESCRIPTION
Before this guide existed, often we linked, incorrectly, to mutating-data. Also adding more related links pointing to this guide.