### PR TITLE
fix(app-router): prevent URL revert when external pushState is called with prefetched routes

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -305,20 +305,21 @@ function Router({
     const originalReplaceState = window.history.replaceState.bind(
       window.history
     )
-
     // Ensure the canonical URL in the Next.js Router is updated when the URL is changed so that `usePathname` and `useSearchParams` hold the pushed values.
     const applyUrlFromHistoryPushReplace = (
       url: string | URL | null | undefined
     ) => {
       const href = window.location.href
-      const appHistoryState: AppHistoryState | undefined =
-        window.history.state?.__PRIVATE_NEXTJS_INTERNALS_TREE
 
       startTransition(() => {
         dispatchAppRouterAction({
           type: ACTION_RESTORE,
           url: new URL(url ?? href, href),
-          historyState: appHistoryState,
+          // Do not pass the current historyState: it belongs to the previous URL,
+          // not the new one being pushed. Passing it would cause the router to
+          // restore the old tree and revert the URL change made by external
+          // pushState calls (e.g. nuqs).
+          historyState: undefined,
         })
       })
     }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -32,6 +32,7 @@ export function restoreReducer(
   let treeToRestore: FlightRouterState | undefined
   let renderedSearch: string | undefined
   const historyState = action.historyState
+
   if (historyState) {
     treeToRestore = historyState.tree
     renderedSearch = historyState.renderedSearch
@@ -42,6 +43,9 @@ export function restoreReducer(
 
   const currentUrl = new URL(state.canonicalUrl, location.origin)
   const restoredUrl = action.url
+  if (!historyState) {
+    return completeHardNavigation(state, restoredUrl, 'replace')
+  }
   const restoredNextUrl =
     extractPathFromFlightRouterState(treeToRestore) ?? restoredUrl.pathname
   const navigationLock = getCurrentNavigationLock()


### PR DESCRIPTION
## What?
When `history.pushState` is called externally (e.g. by `nuqs`) on a page that contains:
1. A `<Link>` that prefetches a URL with the current state
2. A `useEffect` that writes state to a cookie
3. A middleware that redirects using that cookie

The URL would flash to the new value and immediately revert to the previous one.

## Why?
`applyUrlFromHistoryPushReplace` in `app-router.tsx` was reading `window.history.state.__PRIVATE_NEXTJS_INTERNALS_TREE` (the **current** history state, belonging to the old URL) and passing it to `ACTION_RESTORE`. The `restoreReducer` would then use that stale tree to restore the old URL, undoing the external `pushState`.

## How?
Two changes:

1. In `app-router.tsx`: stop passing `historyState` to `ACTION_RESTORE` when coming from an external `pushState` call — it belongs to the previous URL, not the new one.

2. In `restore-reducer.ts`: when `historyState` is `undefined`, perform a hard navigation to the new URL instead of trying to restore a stale tree.

## Test
Reproduction: https://github.com/asanoop24/nextjs-pushstate-prefetch-revert-repro

Steps:
1. `pnpm install && pnpm build && pnpm start`
2. Click `7d` to seed the cookie
3. Click `90d` — URL now correctly stays on `?period=90d`

Fixes #93923