### PR TITLE
Fix ISR Cache-Control header being overridden by _app getInitialProps

### DIFF
--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -857,12 +857,31 @@ export async function renderToHTMLImpl(
     return <>{styles}</>
   }
 
+  // `_app`'s `getInitialProps` receives the same `res` as the page, so it
+  // can call `res.setHeader('Cache-Control', ...)`. For an SSG/ISR page the
+  // Cache-Control header is fully determined by `getStaticProps`'
+  // `revalidate` value further down, so snapshot whatever was set before
+  // this call and restore it afterwards to undo any header `_app` added.
+  // Otherwise it would incorrectly take precedence over the ISR header in
+  // `sendRenderResult`, which only applies its own header when none is set.
+  const cacheControlBeforeAppGetInitialProps = isSSG
+    ? res.getHeader('Cache-Control')
+    : undefined
+
   props = await loadGetInitialProps(App, {
     AppTree: ctx.AppTree,
     Component,
     router,
     ctx,
   })
+
+  if (isSSG) {
+    if (cacheControlBeforeAppGetInitialProps === undefined) {
+      res.removeHeader('Cache-Control')
+    } else {
+      res.setHeader('Cache-Control', cacheControlBeforeAppGetInitialProps)
+    }
+  }
 
   if ((isSSG || getServerSideProps) && isPreview) {
     props.__N_PREVIEW = true

--- a/test/production/prerender-revalidate-app-gip-cache-control/pages/[slug].js
+++ b/test/production/prerender-revalidate-app-gip-cache-control/pages/[slug].js
@@ -1,0 +1,17 @@
+export default function Page({ slug }) {
+  return <p>slug: {slug}</p>
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}
+
+export async function getStaticProps({ params }) {
+  return {
+    props: { slug: params.slug },
+    revalidate: 10,
+  }
+}

--- a/test/production/prerender-revalidate-app-gip-cache-control/pages/_app.js
+++ b/test/production/prerender-revalidate-app-gip-cache-control/pages/_app.js
@@ -1,0 +1,12 @@
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+MyApp.getInitialProps = async ({ ctx }) => {
+  // Simulate an app that incidentally sets a Cache-Control header in
+  // `_app`'s `getInitialProps`, unrelated to the page's own ISR config.
+  ctx.res?.setHeader('Cache-Control', 'no-store')
+  return {}
+}
+
+export default MyApp

--- a/test/production/prerender-revalidate-app-gip-cache-control/pages/ssr.js
+++ b/test/production/prerender-revalidate-app-gip-cache-control/pages/ssr.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return <p>hello</p>
+}
+
+export async function getServerSideProps() {
+  return { props: {} }
+}

--- a/test/production/prerender-revalidate-app-gip-cache-control/prerender-revalidate-app-gip-cache-control.test.ts
+++ b/test/production/prerender-revalidate-app-gip-cache-control/prerender-revalidate-app-gip-cache-control.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('prerender-revalidate-app-gip-cache-control', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not let a Cache-Control header set in _app getInitialProps override the ISR Cache-Control header on a fallback: blocking first request', async () => {
+    const res = await next.fetch('/first-request-slug')
+    const cacheControl = res.headers.get('Cache-Control')
+    expect(cacheControl).toMatch(/^s-maxage=10(,|$)/)
+    expect(cacheControl).not.toContain('no-store')
+  })
+
+  it('should still apply a Cache-Control header set in _app getInitialProps for a non-SSG page', async () => {
+    const res = await next.fetch('/ssr')
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+})


### PR DESCRIPTION
Fixes #14244

## Problem

`_app`'s `getInitialProps` receives the same `res` as the page being rendered. For an SSG/ISR page (one using `getStaticProps` with `revalidate`), if `_app` sets a `Cache-Control` header during a live render — for example on the first request to a `fallback: 'blocking'` dynamic route, or during background revalidation — that header sticks around on `res`.

Later, the response is sent via a guard that only applies the ISR-derived `Cache-Control` header when none is already present:

```ts
if (cacheControl && !res.getHeader('Cache-Control')) {
  res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
}
```

Since `_app` already set a header, this guard is skipped, and the page permanently serves `_app`'s (usually incidental) header instead of the correct ISR `s-maxage`/`stale-while-revalidate` value.

## Why not just remove the guard?

Two prior community PRs (#89518, #94257) attempted this fix by removing the `!res.getHeader('Cache-Control')` check entirely in `send-payload.ts` / `pages-handler.ts`. That guard exists on purpose (see the comment where it was introduced) to let a `Cache-Control` header set via `next.config.js`'s documented `headers()` config win over the automatic ISR header. Removing it entirely would silently break that documented, intentional use case for any ISR route — a regression neither of those PRs accounts for or tests against.

## This fix

Instead of touching the guard, this fix addresses the actual source of the unwanted header: in `render.tsx`, it snapshots `res.getHeader('Cache-Control')` immediately before the `_app.getInitialProps` call (`loadGetInitialProps(App, ...)`) when `isSSG`, and restores that snapshot immediately after. This undoes only the `Cache-Control` changes `_app` made during its own `getInitialProps`, while leaving:

- the `next.config.js` `headers()` guard fully intact,
- any `Cache-Control` set before `_app` runs (e.g. by `headers()` config) untouched,
- non-SSG pages (`getServerSideProps`, plain pages) completely unaffected.

## Testing

Added `test/production/prerender-revalidate-app-gip-cache-control`, using a `fallback: 'blocking'` dynamic route (the scenario where `_app.getInitialProps` actually runs on a live `res` before the ISR header would otherwise be applied) plus a non-SSG page to confirm `_app`-set headers still apply where there's no ISR header to protect.

- Verified the new test fails without this fix (`Cache-Control: no-store` from `_app` leaks through) and passes with it (`Cache-Control: s-maxage=10...`), confirmed against a from-scratch rebuild of the `next` package (not a stale cache).
- Re-ran the existing `test/production/prerender-revalidate` suite (17 tests) — all still pass, no regressions.