### PR TITLE
Gate the dev Cold cache badge behind an experimental flag

### DIFF
--- a/packages/next/.storybook/main.ts
+++ b/packages/next/.storybook/main.ts
@@ -37,6 +37,13 @@ const config: StorybookConfig = {
       },
     },
   }),
+  // The cold-cache badge is gated behind an experimental flag that is off by
+  // default in real apps, but its stories are where we iterate on the badge's
+  // UI, so force the flag on in Storybook.
+  env: (config) => ({
+    ...config,
+    __NEXT_EXPERIMENTAL_COLD_CACHE_BADGE: 'true',
+  }),
   webpackFinal: async (webpackConfig) => {
     // Find and override CSS rule to use the devtool style injection
     const cssRule = webpackConfig.module?.rules?.find((rule) => {

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -179,6 +179,9 @@ export function getDefineEnv({
       config.experimental.cachedNavigations
     ),
     'process.env.__NEXT_INSTANT_NAV_TOGGLE': isCacheComponentsEnabled,
+    'process.env.__NEXT_EXPERIMENTAL_COLD_CACHE_BADGE': Boolean(
+      config.experimental.coldCacheBadge
+    ),
     'process.env.__NEXT_USE_CACHE': isUseCacheEnabled,
     'process.env.__NEXT_USE_NODE_STREAMS': isEdgeServer ? false : true,
 

--- a/packages/next/src/next-devtools/dev-overlay/hooks/use-indicator-display.ts
+++ b/packages/next/src/next-devtools/dev-overlay/hooks/use-indicator-display.ts
@@ -18,6 +18,12 @@ import {
  */
 const INDICATOR_TRANSITION_MS = 200
 
+// The cold-cache badge is gated behind an experimental flag while its UI/UX is
+// iterated on. This is a build-time constant (DefinePlugin replaces it), and a
+// Next config change restarts the dev server, so reading it once at module
+// scope is safe.
+const coldCacheBadgeEnabled = !!process.env.__NEXT_EXPERIMENTAL_COLD_CACHE_BADGE
+
 type CacheBadge = 'cold' | 'bypass'
 
 /**
@@ -55,7 +61,13 @@ function computeIntent(
   if (status !== Status.None) {
     return { kind: 'pill', status }
   }
-  if (cacheIndicator === 'cold' || cacheIndicator === 'bypass') {
+  // The transient cold-cache rendering pill above is shown regardless of the
+  // flag; only the persistent cold badge is gated. The pre-existing "Cache
+  // disabled" (bypass) badge is unaffected.
+  if (
+    cacheIndicator === 'bypass' ||
+    (cacheIndicator === 'cold' && coldCacheBadgeEnabled)
+  ) {
     return { kind: 'badge', cache: cacheIndicator }
   }
   return { kind: 'idle' }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -195,6 +195,7 @@ export const experimentalSchema = {
   after: z.boolean().optional(),
   appNavFailHandling: z.boolean().optional(),
   appNewScrollHandler: z.boolean().optional(),
+  coldCacheBadge: z.boolean().optional(),
   preloadEntriesOnStart: z.boolean().optional(),
   allowedRevalidateHeaderKeys: z.array(z.string()).optional(),
   staleTimes: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -459,6 +459,13 @@ export interface ExperimentalConfig {
   outputHashSalt?: string
 
   appNewScrollHandler?: boolean
+  /**
+   * Shows a persistent "Cold cache" badge in the dev overlay after a load that
+   * filled an empty cache while streaming. Off by default while the badge's
+   * UI/UX is iterated on; the transient "Rendering (cold cache)" pill is shown
+   * regardless of this flag.
+   */
+  coldCacheBadge?: boolean
   useSkewCookie?: boolean
   /** @deprecated use top-level `cacheHandlers` instead */
   cacheHandlers?: NextConfig['cacheHandlers']
@@ -2031,6 +2038,7 @@ export const defaultConfig = Object.freeze({
   adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
   experimental: {
     appNewScrollHandler: false,
+    coldCacheBadge: false,
     useSkewCookie: false,
     cssChunking: true,
     multiZoneDraftMode: false,

--- a/test/development/app-dir/cache-indicator-partial-prefetching/next.config.js
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/next.config.js
@@ -4,6 +4,9 @@
 const nextConfig = {
   cacheComponents: true,
   partialPrefetching: true,
+  experimental: {
+    coldCacheBadge: true,
+  },
 }
 
 module.exports = nextConfig

--- a/test/development/app-dir/cache-indicator/next.config.js
+++ b/test/development/app-dir/cache-indicator/next.config.js
@@ -1,6 +1,10 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    coldCacheBadge: true,
+  },
+}
 
 module.exports = nextConfig

--- a/test/development/app-dir/use-cache-custom-handler-dev/next.config.js
+++ b/test/development/app-dir/use-cache-custom-handler-dev/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    coldCacheBadge: true,
+  },
   // Route the default `"use cache"` kind through a custom handler that
   // simulates a remote cache (its `get` has macro-task latency). In dev this is
   // fronted by a built-in in-memory handler so warm reads still resolve in a

--- a/test/development/app-dir/use-cache-size-zero/next.config.js
+++ b/test/development/app-dir/use-cache-size-zero/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    coldCacheBadge: true,
+  },
   // Disable the in-memory cache to emulate a deploy environment without one. In
   // development this should still cache (stale-while-revalidate) so reloads
   // stay fast; in production it caches nothing.


### PR DESCRIPTION
The cold cache dev indicator added in #94611 surfaces a load that filled an empty cache while streaming. After the load settles it leaves a persistent "Cold cache" badge in the corner. That badge is visually too loud and disruptive in its current form, so we want to keep iterating on its UI and UX before showing it to everyone. Until then it should be off by default.

This change puts that persistent badge behind a new, default-off `experimental.coldCacheBadge` flag, plumbed to the dev overlay as `process.env.__NEXT_EXPERIMENTAL_COLD_CACHE_BADGE` via the define plugin. The transient "Rendering (cold cache)" pill shown during a navigation is intentionally kept regardless of the flag: it is transient and clears itself once the blocking navigation transition has committed, so it stays valuable without being disruptive. Only the permanent badge was the problem. The pre-existing "Cache disabled" (bypass) badge and the DevTools menu's cold-cache entry are also unaffected.

The gate lives in `computeIntent`, so when the flag is off a cold load resolves to no badge and the indicator follows its existing empty-badge render path. Storybook forces the flag on through its `env` hook so the badge stories remain the surface for iterating on the design, and every test suite that asserts on the badge opts into the flag so none of them regress while it is disabled by default.