### PR TITLE
[next-dev-loop] Adopt agent-browser 0.31.0 idempotent session restore

### DIFF
--- a/skills/next-dev-loop/SKILL.md
+++ b/skills/next-dev-loop/SKILL.md
@@ -32,8 +32,8 @@ The two views cross-check each other.
 
 - Next.js **16.3+** with **Turbopack** — `/_next/mcp` plus the
   proactive compile check via `get_compilation_issues`.
-- `agent-browser` **>= 0.30.1** — React introspection plus `wait --url`
-  matching full dev-server URLs.
+- `agent-browser` **>= 0.31.0** — React introspection, worktree-scoped
+  `session id`, idempotent `--restore`, and launch flag reconciliation.
 
 These are hard floors, not soft preferences. If anything is missing,
 tell the user how to upgrade and stop. Don't fall back to grepping
@@ -53,28 +53,33 @@ at the versions above.
 Once per session, confirm both views are live.
 
 1. **Open `agent-browser` at the target URL, restoring saved
-   login state when present.** Build the `open` command from:
-   - `--session <name>` — you'll reuse this exact name on every later
-     `agent-browser` command, so make it unique to this checkout and
-     stable. Build it from a fixed formula so it never varies between
-     calls: `"$(basename "$PWD")-$(pwd -P | shasum | cut -c1-8)"`. The
-     bare basename collides across parallel worktrees or copies.
-   - `--state ~/.agent-browser/sessions/<name>-default.json` if
-     that file exists. Omit on first run — a missing path fails
-     the open.
-   - `--headed --enable react-devtools` — always pass both on `open`.
-     A running daemon won't reapply launch flags, so you will often see
-     `⚠ --headed ignored: daemon already running`; that's expected.
-     Assuming you always run the daemon with these flags, you can ignore
-     this warning. Only if you're sure the flags of the running daemon
-     are wrong, you may run `agent-browser close` first, then re-open.
+   login state when present.** First derive one stable session id for
+   this checkout and use it for every `agent-browser` command:
 
-   The browser is the user's. If state was not restored (first
-   run, expired session) and the page is gated, the user drives
-   the login — pause until they confirm. Session state is sticky:
-   you can't add `--enable react-devtools` after the session is
-   open, and `cookies set` on a not-yet-opened session creates a
-   sessionless cookie that silently fails to apply.
+   ```bash
+   SESSION="$(agent-browser session id --scope worktree --prefix next-dev-loop)"
+   export AGENT_BROWSER_SESSION="$SESSION"
+   export AGENT_BROWSER_RESTORE="$SESSION"
+   ```
+
+   Then open the target URL:
+
+   ```bash
+   agent-browser --session "$SESSION" --restore --headed --enable react-devtools open <url>
+   ```
+
+   `--scope worktree` keeps parallel worktrees and copied checkouts
+   from colliding. Bare `--restore` uses the session id as the
+   persistence key, loads saved cookies/localStorage before navigation
+   when present, and auto-saves state on close. Always pass the desired
+   launch flags on `open`; agent-browser will reuse, relaunch, or restart
+   its scoped background state as needed.
+
+   The browser is the user's. If state was not restored (first run,
+   expired session) and the page is gated, the user drives the login —
+   pause until they confirm. After login, continue using the same session
+   and restore context; `agent-browser close` saves the cookie state so
+   the next `open` restores it.
 
 2. Probe `/_next/mcp` (`tools/list`) — confirm it's reachable and
    lists `get_compilation_issues`:
@@ -116,12 +121,12 @@ manual rather than from memory.
 
 ## gotchas
 
-- **Every `agent-browser` command must know your session, or it
-  silently uses a different, empty default browser (blank reads; a
-  working page looks broken).** Easiest: `export
-AGENT_BROWSER_SESSION=<name>` at the top of each shell you run
-  agent-browser in; then every command there uses it, with no
-  per-command `--session` flag to repeat.
+- **Every `agent-browser` command must know your session and restore
+  key, or it may use an empty default browser or fail to save login
+  state.** Easiest: export both `AGENT_BROWSER_SESSION="$SESSION"` and
+  `AGENT_BROWSER_RESTORE="$SESSION"` at the top of each shell you run
+  agent-browser in. If you do not export them, pass
+  `--session "$SESSION" --restore` on every command.
 - **When the two views disagree, suspect the tooling first.** If
   `agent-browser` says a route is broken but `/_next/mcp` and the
   server say it rendered cleanly, a stale or misdirected browser
@@ -135,10 +140,11 @@ AGENT_BROWSER_SESSION=<name>` at the top of each shell you run
 - A blank read, empty snapshot, `about:blank`, or a "no browser
   session" error — right after `open` or after a click (even if `open`
   reported the page) — is the browser dropping the page (a stale
-  daemon), not a broken route. Reopen your session at the URL and
-  re-snapshot; if still blank, run `agent-browser --session <name>
-close`, then open again. Don't fall back to `curl`; it bypasses the
-  browser you're testing.
+  session), not a broken route. Reopen your session at the URL with
+  `--session "$SESSION" --restore` and re-snapshot; if still blank,
+  run `agent-browser --session "$SESSION" --restore close`, then open
+  again. Don't fall back to `curl`; it bypasses the browser you're
+  testing.
 - React introspection output is stale after navigation. Re-run.
 - `/_next/mcp` replies are SSE — read the JSON off the `data:` line
   with `sed -n 's/^data: //p'` (a plain `sed 's/^data: //'` leaves the
@@ -171,10 +177,10 @@ get_compilation_issues       Turbopack only; errors on webpack
 
 ## teardown
 
-Close the session: `agent-browser --session <name> close` — the same
-`--session` every command used. `close` writes that session's state to
-disk so the next loop's `--state` restores login. Leave `next dev` up
-for the next loop.
+Close the session with the same session and restore context:
+`agent-browser --session "$SESSION" --restore close`. `close` saves
+that session's cookies and storage so the next loop's `--restore` open
+keeps the user logged in. Leave `next dev` up for the next loop.
 
 ---
 


### PR DESCRIPTION
`next-dev-loop` loses login cookies on the close → reopen cycle, so iterating on an authed app (cookie login) drops the session every loop. The skill drove `agent-browser` with a manual `--state <path>` restore plus sticky launch flags on a shared daemon — a model where a failed restore silently wrote logged-out state back to disk on the next `close`, killing the session for good.

`agent-browser` 0.31.0 (vercel-labs/agent-browser#1486) replaces that with a worktree-scoped `session id` and an idempotent `--restore`: one stable id keys persistence, cookies/localStorage load before navigation and auto-save on `close`, and the desired launch flags drive daemon reuse/relaunch instead of being ignored. This rewrites preflight, gotchas, and teardown to use `--restore` throughout, exports `AGENT_BROWSER_SESSION` + `AGENT_BROWSER_RESTORE`, drops the `--state` path, and raises the floor to `>= 0.31.0`.

Skill change authored and tested against #1486 by Chris Tate.

Verified end-to-end against the published `agent-browser` 0.31.0 (npm) with the exact repro: log into a cookie-gated Next.js 16.3 app, `close` the session (user is "done"), reopen, confirm still logged in. `close` writes `save: saved`; the reopen logs `restore: loaded` and lands on `/` showing `Welcome, demo!` with no re-login. A control reopen *without* `--restore` correctly drops the session, so the assertion is real.

```
deterministic (runs the skill commands)        headless Claude Code (agent follows the skill)
login demo/demo   → "Welcome, demo!"           login demo/demo   → / "Welcome, demo!"
close             → save: saved                close             → save: saved
reopen --restore  → "Welcome, demo!"           reopen --restore  → / "Welcome, demo!"
RESULT: PASS                                   RESULT: PASS
```

Full transcripts (local release-commit build and published npm 0.31.0) are in the comments below.
