### PR TITLE
fix(types): support custom props in AppType generic

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -28,10 +28,10 @@ export type DocumentType = NextComponentType<
   DocumentProps
 >
 
-export type AppType<P = {}> = NextComponentType<
+export type AppType<P = {}, CP = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<any, P> & CP
 >
 
 export type AppTreeType = ComponentType<

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -30,7 +30,7 @@ export type DocumentType = NextComponentType<
 
 export type AppType<P = {}, CP = {}> = NextComponentType<
   AppContextType,
-  P,
+  P & CP,
   AppPropsType<any, P> & CP
 >
 

--- a/test/e2e/typescript/pages/_app.tsx
+++ b/test/e2e/typescript/pages/_app.tsx
@@ -1,6 +1,16 @@
 import type { AppType } from 'next/app'
 
-const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
+const MyApp: AppType<{}, { foo: string }> = ({
+  Component,
+  pageProps,
+  foo,
+}) => {
+  const appProp: string = foo
+  void appProp
+
+  // @ts-expect-error foo is a custom App prop, not a page prop
+  pageProps.foo
+
   return <Component {...pageProps} />
 }
 


### PR DESCRIPTION
Closes #42846. This PR adds a second generic parameter to AppType to allow users to specify custom props for their custom App component while keeping backward compatibility.