### PR TITLE
fix(server-actions): handle malformed Origin headers

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -76,6 +76,7 @@ import {
 import { computeCacheBustingSearchParam } from '../../shared/lib/router/utils/cache-busting-search-param'
 
 const INLINE_ACTION_PREFIX = '$$RSC_SERVER_ACTION_'
+const INVALID_ORIGIN_SENTINEL = '\x00INVALID_ORIGIN'
 
 /**
  * Checks if the app has any server actions defined in any runtime.
@@ -535,6 +536,17 @@ type HandleActionResult =
   /** The request turned out not to be a server action. */
   | null
 
+function parseOriginHost(originHeader: string): string {
+  if (originHeader === 'null') {
+    return 'null'
+  }
+  try {
+    return new URL(originHeader).host
+  } catch {
+    return INVALID_ORIGIN_SENTINEL
+  }
+}
+
 export async function handleAction({
   req,
   res,
@@ -624,14 +636,7 @@ export async function handleAction({
 
   const originHeader = req.headers['origin']
   const originHost =
-    typeof originHeader === 'string'
-      ? // 'null' is a valid origin e.g. from privacy-sensitive contexts like sandboxed iframes.
-        // However, these contexts can still send along credentials like cookies,
-        // so we need to check if they're allowed cross-origin requests.
-        originHeader === 'null'
-        ? 'null'
-        : new URL(originHeader).host
-      : undefined
+    typeof originHeader === 'string' ? parseOriginHost(originHeader) : undefined
   const host = parseHostHeader(req.headers)
 
   let warning: string | undefined = undefined

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-malformed-origin.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-malformed-origin.test.ts
@@ -1,0 +1,53 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+
+describe('app-dir action malformed origin', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(__dirname, 'unsafe-origins'),
+    skipDeployment: true,
+    dependencies: {
+      'server-only': 'latest',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  async function postWithMalformedOrigin(origin: string) {
+    const outputIndex = next.cliOutput.length
+
+    const res = await next.fetch('/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=----PoC',
+        origin,
+      },
+      body: '------PoC--\r\n',
+    })
+
+    const output = next.cliOutput.slice(outputIndex)
+
+    expect(output).not.toContain('TypeError: Invalid URL')
+    expect(output).not.toContain('Missing `origin` header')
+    expect(output).toContain('Invalid Server Actions request.')
+
+    return res
+  }
+
+  it('should reject multipart action requests with http:// origin without throwing', async () => {
+    await postWithMalformedOrigin('http://')
+  })
+
+  it('should reject multipart action requests with non-URL origin without throwing', async () => {
+    await postWithMalformedOrigin('not-a-url')
+  })
+
+  it('should keep serving pages after malformed origin requests', async () => {
+    await postWithMalformedOrigin('http://')
+
+    const res = await next.fetch('/')
+
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary

This updates Server Actions origin parsing so malformed but present `Origin` headers do not throw while being evaluated for CSRF origin checks.

Malformed origins are converted to an invalid sentinel value instead of being treated as missing origins. This preserves the existing rejection path for invalid forwarded Server Actions requests while avoiding `TypeError: Invalid URL`.

## Changes

- Safely parse Server Actions `Origin` headers before comparing them against the request host.
- Preserve the existing `Origin: null` behavior.
- Ensure malformed origins are not treated as missing origins.
- Add e2e regression coverage for raw `multipart/form-data` Server Action requests without a `Next-Action` header.

## Validation

- `pnpm build`
- `pnpm test-dev test/e2e/app-dir/actions-allowed-origins/app-action-malformed-origin.test.ts`
- `pnpm test-start test/e2e/app-dir/actions-allowed-origins/app-action-malformed-origin.test.ts`

Fixes #92703.
