### PR TITLE
Turbopack: Add test for node package with incompatible module and default exports

### DIFF
--- a/test/e2e/externals-shape-mismatch/app/layout.js
+++ b/test/e2e/externals-shape-mismatch/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/externals-shape-mismatch/app/page.js
+++ b/test/e2e/externals-shape-mismatch/app/page.js
@@ -1,0 +1,11 @@
+import { useMessageFormatter } from 'dual-pkg'
+
+// `dual-pkg` is externalized via `serverExternalPackages`. It is rendered
+// per-request on the server. With the Turbopack externalization bug the flat
+// CommonJS copy is loaded at runtime, where `useMessageFormatter` is undefined,
+// so this throws.
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  return <p id="message">{useMessageFormatter()}</p>
+}

--- a/test/e2e/externals-shape-mismatch/dual-pkg/flat.js
+++ b/test/e2e/externals-shape-mismatch/dual-pkg/flat.js
@@ -1,0 +1,10 @@
+
+// Old, flat shape (mirrors @react-aria/i18n@3.3.x): a single flat CommonJS
+// bundle with no `./private` directory and no `useMessageFormatter` export.
+//
+// Node.js resolves the package entry here (via `main`/the `default` condition)
+// because it does not honor the `module` condition that the bundler used. When
+// the externalized import is loaded at runtime, `useMessageFormatter` is missing.
+exports.somethingElse = function somethingElse() {
+  return 'old-flat-v1'
+}

--- a/test/e2e/externals-shape-mismatch/dual-pkg/modern/index.mjs
+++ b/test/e2e/externals-shape-mismatch/dual-pkg/modern/index.mjs
@@ -1,0 +1,5 @@
+// Modern shape (mirrors @react-aria/i18n@3.12.x): an ESM entry that re-exports
+// the named binding from a `./private/*` submodule. The bundler resolves the
+// package here, via the `module` condition in the `exports` map, and sees the
+// `useMessageFormatter` named export.
+export { useMessageFormatter } from './private/useMessageFormatter.mjs'

--- a/test/e2e/externals-shape-mismatch/dual-pkg/modern/private/useMessageFormatter.mjs
+++ b/test/e2e/externals-shape-mismatch/dual-pkg/modern/private/useMessageFormatter.mjs
@@ -1,0 +1,3 @@
+export function useMessageFormatter() {
+  return 'message-from-modern-v2'
+}

--- a/test/e2e/externals-shape-mismatch/dual-pkg/package.json
+++ b/test/e2e/externals-shape-mismatch/dual-pkg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dual-pkg",
+  "version": "1.0.0",
+  "main": "./flat.js",
+  "exports": {
+    ".": {
+      "module": "./modern/index.mjs",
+      "default": "./flat.js"
+    }
+  }
+}

--- a/test/e2e/externals-shape-mismatch/externals-shape-mismatch.test.ts
+++ b/test/e2e/externals-shape-mismatch/externals-shape-mismatch.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression test for a Turbopack server-externalization bug.
+//
+// `dual-pkg` is externalized via `serverExternalPackages` and has two shapes
+// selected by its `exports` map:
+//   - the modern ESM shape (`./modern/index.mjs`, reached via the `module`
+//     condition) re-exports `useMessageFormatter` from a `./private/*` submodule.
+//   - the old, flat CommonJS shape (`./flat.js`, the `main`/`default` entry) has
+//     no `useMessageFormatter` export.
+//
+// Turbopack resolves the externalized import against the modern shape (it honors
+// the `module` condition), so the build succeeds. At runtime Node.js loads the
+// package via its own conditions (no `module`), landing on the flat shape, where
+// `useMessageFormatter` is missing — rendering throws
+// "useMessageFormatter is not a function".
+//
+// This mirrors the real-world failure where geist pulled in @react-aria/i18n: the
+// bundler externalized against the modern module shape but the flat build was
+// loaded on disk. This is specific to Turbopack's externalization.
+;(!process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
+  'externals-shape-mismatch',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      dependencies: require('./package.json').dependencies,
+    })
+
+    it('externalizes the package shape that Node.js actually loads at runtime', async () => {
+      const $ = await next.render$('/')
+      expect($('#message').text()).toBe('message-from-modern-v2')
+    })
+  }
+)

--- a/test/e2e/externals-shape-mismatch/next.config.js
+++ b/test/e2e/externals-shape-mismatch/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  // Force `dual-pkg` to be externalized (resolved at runtime by Node.js instead
+  // of bundled). This is the code path the externalization bug lives in.
+  serverExternalPackages: ['dual-pkg'],
+}

--- a/test/e2e/externals-shape-mismatch/package.json
+++ b/test/e2e/externals-shape-mismatch/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "dual-pkg": "file:./dual-pkg"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->