### PR TITLE
[turbopack] Support undoable modifications for many field types on TaskStorage

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1251,7 +1251,9 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         // tracked
         self.check_access(SpecificTaskDataCategory::Data);
         if matches!(persistence, ValueTypePersistence::Persistable(..)) {
-            self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
+            // Unconditional track when persistable: an insert always changes the data snapshot
+            // (a fresh cell, or a replaced value). No no-op to undo.
+            let _ = self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
         }
         self.typed_mut().cell_data_mut().insert(cell, value)
     }
@@ -1263,15 +1265,20 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         persistence: &ValueTypePersistence,
     ) -> Option<SharedReference> {
         self.check_access(SpecificTaskDataCategory::Data);
-        // Track only when a persistable entry is actually removed (the entry must
-        // exist and be Persistable; Skip/HashOnly cells contribute nothing to the
-        // data snapshot).
-        if matches!(persistence, ValueTypePersistence::Persistable(..))
-            && self.cell_data_contains(cell)
-        {
-            self.track_modification(SpecificTaskDataCategory::Data, "cell_data");
+        // Track only when a persistable entry is actually removed (Skip/HashOnly cells contribute
+        // nothing to the data snapshot). Track BEFORE mutating (snapshot mode clones pre-mutation
+        // state), then undo if the entry turned out not to be present — avoiding a redundant
+        // `cell_data_contains` probe.
+        let outcome = if matches!(persistence, ValueTypePersistence::Persistable(..)) {
+            self.track_modification(SpecificTaskDataCategory::Data, "cell_data")
+        } else {
+            crate::backend::storage::TrackOutcome::NoChange
+        };
+        let old = self.typed_mut().cell_data_mut().remove(cell);
+        if old.is_none() {
+            self.undo_track_modification(outcome);
         }
-        self.typed_mut().cell_data_mut().remove(cell)
+        old
     }
 
     /// Add new cell data. Panics if the cell already had a value. See
@@ -1405,9 +1412,12 @@ impl TaskGuard for TaskGuardImpl<'_> {
         // TODO this causes race conditions, since we never know when a value is changed. We can't
         // "snapshot" the value correctly.
         if !self.task_id.is_transient() {
-            self.task
+            // Unconditional track (no mutation to detect a no-op against): always mark dirty.
+            let _ = self
+                .task
                 .track_modification(SpecificTaskDataCategory::Data, "invalidate_serialization");
-            self.task
+            let _ = self
+                .task
                 .track_modification(SpecificTaskDataCategory::Meta, "invalidate_serialization");
         }
     }
@@ -1466,10 +1476,19 @@ impl TaskStorageAccessors for TaskGuardImpl<'_> {
         &mut self,
         category: crate::backend::storage::SpecificTaskDataCategory,
         name: &str,
-    ) {
-        if !self.task_id.is_transient() {
-            self.task.track_modification(category, name);
+    ) -> crate::backend::storage::TrackOutcome {
+        if self.task_id.is_transient() {
+            // Transient tasks are never persisted, so there is nothing to track or undo.
+            crate::backend::storage::TrackOutcome::NoChange
+        } else {
+            self.task.track_modification(category, name)
         }
+    }
+
+    #[inline(always)]
+    fn undo_track_modification(&mut self, outcome: crate::backend::storage::TrackOutcome) {
+        // Transient tasks return `NoChange` above, so undo is harmlessly a no-op for them.
+        self.task.undo_track_modification(outcome);
     }
 
     fn check_access(&self, category: crate::backend::storage::SpecificTaskDataCategory) {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     backend::{
         EventDescription, TaskDataCategory, TurboTasksBackend,
         snapshot_coordinator::OperationGuard,
-        storage::{SpecificTaskDataCategory, StorageWriteGuard},
+        storage::{SpecificTaskDataCategory, StorageWriteGuard, TrackOutcome},
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
     data::{ActivenessState, CollectibleRef, Dirtyness, InProgressState, TransientTask},
@@ -1272,7 +1272,7 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         let outcome = if matches!(persistence, ValueTypePersistence::Persistable(..)) {
             self.track_modification(SpecificTaskDataCategory::Data, "cell_data")
         } else {
-            crate::backend::storage::TrackOutcome::NoChange
+            TrackOutcome::NoChange
         };
         let old = self.typed_mut().cell_data_mut().remove(cell);
         if old.is_none() {
@@ -1476,17 +1476,17 @@ impl TaskStorageAccessors for TaskGuardImpl<'_> {
         &mut self,
         category: crate::backend::storage::SpecificTaskDataCategory,
         name: &str,
-    ) -> crate::backend::storage::TrackOutcome {
+    ) -> TrackOutcome {
         if self.task_id.is_transient() {
             // Transient tasks are never persisted, so there is nothing to track or undo.
-            crate::backend::storage::TrackOutcome::NoChange
+            TrackOutcome::NoChange
         } else {
             self.task.track_modification(category, name)
         }
     }
 
     #[inline(always)]
-    fn undo_track_modification(&mut self, outcome: crate::backend::storage::TrackOutcome) {
+    fn undo_track_modification(&mut self, outcome: TrackOutcome) {
         // Transient tasks return `NoChange` above, so undo is harmlessly a no-op for them.
         self.task.undo_track_modification(outcome);
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -125,6 +125,39 @@ impl SpecificTaskDataCategory {
     }
 }
 
+/// Records exactly what a `track_modification` call changed, so that
+/// [`StorageWriteGuard::undo_track_modification`] can reverse it precisely when the mutation it
+/// guarded turns out to be a no-op.
+///
+/// The "track before mutate" ordering requirement (snapshot mode clones pre-mutation state) means
+/// mutators can't use a data structure's native "did anything change" return value to decide
+/// whether to track. Instead they track first, mutate using that native signal, and undo if the
+/// mutation changed nothing. Undo is only ever applied while the same map shard write lock is
+/// still held, so no other thread can have observed the tracked state in between.
+///
+/// This is a plain owned value (no borrow of the guard) on purpose; see
+/// [`StorageWriteGuard::undo_track_modification`] for why a lifetime can't encode the
+/// "same guard, lock held" invariant.
+#[must_use = "a no-op mutation must undo its TrackOutcome; dropping it leaks an over-track"]
+pub enum TrackOutcome {
+    /// Nothing was tracked: either the category was already modified, or (in snapshot mode) it was
+    /// already modified-during-snapshot. Undo is a no-op.
+    NoChange,
+    /// Non-snapshot path: `modified(category)` was set. `bumped` is true if this call also
+    /// incremented the per-shard modified counter (i.e. the task had no prior modifications).
+    Tracked {
+        category: SpecificTaskDataCategory,
+        bumped: bool,
+    },
+    /// Snapshot path: `modified_during_snapshot(category)` was set. `inserted_snapshot` is true if
+    /// this call also inserted the task's entry into the `snapshots` map (the pre-mutation copy or
+    /// a `None` marker).
+    TrackedDuringSnapshot {
+        category: SpecificTaskDataCategory,
+        inserted_snapshot: bool,
+    },
+}
+
 pub struct Storage {
     snapshot_mode: AtomicBool,
     /// Per-shard counts of tasks with modified flags set. Incremented when a task
@@ -254,7 +287,9 @@ impl Storage {
         if let Some(task_type) = task_type {
             task.set_persistent_task_type(task_type);
             if !task_id.is_transient() {
-                task.track_modification(SpecificTaskDataCategory::Data, "persistent_task_type");
+                // Unconditional track: a new task's type is always a real persistable change.
+                let _ =
+                    task.track_modification(SpecificTaskDataCategory::Data, "persistent_task_type");
             }
         }
     }
@@ -660,13 +695,17 @@ pub struct StorageWriteGuard<'a> {
 }
 
 impl StorageWriteGuard<'_> {
-    /// Tracks mutation of this task
+    /// Tracks mutation of this task.
+    ///
+    /// Returns a [`TrackOutcome`] describing exactly what changed. If the mutation this call
+    /// guards turns out to be a no-op, pass the outcome to [`Self::undo_track_modification`] to
+    /// reverse it. Otherwise the outcome may be dropped (it carries no resources).
     #[inline(always)]
     pub fn track_modification(
         &mut self,
         category: SpecificTaskDataCategory,
         #[allow(unused_variables)] name: &str,
-    ) {
+    ) -> TrackOutcome {
         debug_assert!(
             !self.inner.key().is_transient(),
             "transient task_ids should never be enqueued to be persisted"
@@ -675,14 +714,14 @@ impl StorageWriteGuard<'_> {
             category,
             #[cfg(feature = "trace_task_modification")]
             name,
-        );
+        )
     }
 
     fn track_modification_internal(
         &mut self,
         category: SpecificTaskDataCategory,
         #[cfg(feature = "trace_task_modification")] name: &str,
-    ) {
+    ) -> TrackOutcome {
         // Transient tasks are never persisted, so tracking modifications is meaningless.
         // All callers (TaskGuard, invalidate_serialization) already
         // guard against this, but we enforce it here as defense-in-depth.
@@ -694,52 +733,112 @@ impl StorageWriteGuard<'_> {
         let flags = &self.inner.flags;
         if flags.is_modified_during_snapshot(category) {
             // We can early return since `end_snapshot` is responsible for reconciling.
-            return;
+            return TrackOutcome::NoChange;
         }
         #[cfg(feature = "trace_task_modification")]
         let _span = (!modified).then(|| tracing::trace_span!("mark_modified", name).entered());
         match (self.storage.snapshot_mode(), flags.is_modified(category)) {
             (false, false) => {
                 // Not in snapshot mode and item is unmodified
-                if !flags.any_modified() {
+                let bumped = !flags.any_modified();
+                if bumped {
                     let shard_idx = self.storage.shard_index(self.inner.key());
                     self.storage.shard_modified_counts[shard_idx].fetch_add(1, Ordering::Relaxed);
                 }
                 self.inner.flags.set_modified(category, true);
+                TrackOutcome::Tracked { category, bumped }
             }
             (false, true) => {
                 // Not in snapshot mode and item is already modified
                 // Do nothing
+                TrackOutcome::NoChange
             }
             (true, false) => {
-                // In snapshot mode and item is unmodified (so it's not part of the snapshot)
-                // Mark it so it gets re-added as Modified after this snapshot completes.
-                // Insert a None entry into snapshots so end_snapshot discovers this task
-                // and promotes its _during_snapshot flags.
-                if !flags.any_modified_during_snapshot() {
-                    self.storage.snapshots.insert(*self.inner.key(), None);
-                }
-                self.inner
-                    .flags
-                    .set_modified_during_snapshot(category, true);
+                self.track_during_snapshot(category, /* part_of_snapshot */ false)
             }
-            (true, true) => {
-                // In snapshot mode and item is modified (so it's part of the snapshot)
-                // We need to store the original version that is part of the snapshot
-                if !flags.any_modified_during_snapshot() {
-                    // Snapshot all non-transient fields, carrying the modified bits into
-                    // the copy so the iterator knows which categories to persist.
-                    let mut snapshot = self.inner.clone_snapshot();
-                    snapshot.flags.set_data_modified(flags.data_modified());
-                    snapshot.flags.set_meta_modified(flags.meta_modified());
-                    snapshot.flags.set_new_task(flags.new_task());
-                    self.storage
-                        .snapshots
-                        .insert(*self.inner.key(), Some(Box::new(snapshot)));
+            (true, true) => self.track_during_snapshot(category, /* part_of_snapshot */ true),
+        }
+    }
+
+    /// Slow path of [`Self::track_modification_internal`] for the two snapshot-mode arms.
+    ///
+    /// `part_of_snapshot` distinguishes `(true, true)` (the category is already modified, so the
+    /// pre-mutation state is part of the in-flight snapshot and must be cloned) from
+    /// `(true, false)` (not part of the snapshot, so only a `None` marker is needed).
+    #[cold]
+    fn track_during_snapshot(
+        &mut self,
+        category: SpecificTaskDataCategory,
+        part_of_snapshot: bool,
+    ) -> TrackOutcome {
+        let flags = &self.inner.flags;
+        // Insert the snapshots entry only the first time the task is touched during this snapshot.
+        let inserted_snapshot = !flags.any_modified_during_snapshot();
+        if inserted_snapshot {
+            let entry = if part_of_snapshot {
+                // The category is part of the snapshot: store the original version so the iterator
+                // serializes the pre-mutation state. Carry the modified bits into the copy so the
+                // iterator knows which categories to persist.
+                let mut snapshot = self.inner.clone_snapshot();
+                snapshot.flags.set_data_modified(flags.data_modified());
+                snapshot.flags.set_meta_modified(flags.meta_modified());
+                snapshot.flags.set_new_task(flags.new_task());
+                Some(Box::new(snapshot))
+            } else {
+                // Not part of the snapshot: a None marker so end_snapshot discovers this task and
+                // promotes its _during_snapshot flags.
+                None
+            };
+            self.storage.snapshots.insert(*self.inner.key(), entry);
+        }
+        self.inner
+            .flags
+            .set_modified_during_snapshot(category, true);
+        TrackOutcome::TrackedDuringSnapshot {
+            category,
+            inserted_snapshot,
+        }
+    }
+
+    /// Reverse a [`TrackOutcome`] produced by [`Self::track_modification`] when the mutation it
+    /// guarded changed nothing persistable.
+    ///
+    /// # Correctness
+    ///
+    /// The `outcome` MUST be applied to the **same `StorageWriteGuard`** that produced it, with the
+    /// map shard write lock held continuously in between — i.e. `track_modification`, the mutation,
+    /// and `undo_track_modification` all run within one guard's lifetime. The guard holds its shard
+    /// write lock for its whole lifetime, so this guarantees no other thread observed the tracked
+    /// state, and that `bumped` / `inserted_snapshot` still describe reality (the counter and
+    /// `snapshots` entry are only mutated under that lock). Because those flags record whether
+    /// *this* call created the state, undo never clears a flag, counter, or snapshot entry that a
+    /// prior modification owns.
+    ///
+    /// This invariant is intentionally **not** encoded as a borrow on `TrackOutcome`: a lifetime
+    /// tying the outcome to `&mut self` would forbid the mutation between track and undo (it also
+    /// needs `&mut self`), which is the entire reason the API is split this way. The constraint is
+    /// instead upheld structurally — every caller is a single mutator body holding one guard.
+    #[cold]
+    pub fn undo_track_modification(&mut self, outcome: TrackOutcome) {
+        match outcome {
+            TrackOutcome::NoChange => {}
+            TrackOutcome::Tracked { category, bumped } => {
+                self.inner.flags.set_modified(category, false);
+                if bumped {
+                    let shard_idx = self.storage.shard_index(self.inner.key());
+                    self.storage.shard_modified_counts[shard_idx].fetch_sub(1, Ordering::Relaxed);
                 }
+            }
+            TrackOutcome::TrackedDuringSnapshot {
+                category,
+                inserted_snapshot,
+            } => {
                 self.inner
                     .flags
-                    .set_modified_during_snapshot(category, true);
+                    .set_modified_during_snapshot(category, false);
+                if inserted_snapshot {
+                    self.storage.snapshots.remove(self.inner.key());
+                }
             }
         }
     }
@@ -952,7 +1051,7 @@ mod tests {
     use turbo_bincode::TurboBincodeBuffer;
     use turbo_tasks::TaskId;
 
-    use super::{SpecificTaskDataCategory, Storage};
+    use super::{SpecificTaskDataCategory, Storage, TrackOutcome};
     use crate::backing_storage::SnapshotItem;
 
     fn non_transient_task(id: u32) -> TaskId {
@@ -1002,7 +1101,7 @@ mod tests {
         // Step 1: modify the task outside snapshot mode (data_modified = true).
         {
             let mut guard = storage.access_mut(task_id);
-            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            let _ = guard.track_modification(SpecificTaskDataCategory::Data, "test");
         }
 
         // Step 2: enter snapshot mode.
@@ -1020,7 +1119,7 @@ mod tests {
         // modified bits) and sets `data_modified_during_snapshot=true`.
         {
             let mut guard = storage.access_mut(task_id);
-            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            let _ = guard.track_modification(SpecificTaskDataCategory::Data, "test");
             // We should have set a snapshot bit
             assert!(guard.flags.data_modified_during_snapshot())
         }
@@ -1074,7 +1173,7 @@ mod tests {
         // Step 1: modify meta only, outside snapshot mode.
         {
             let mut guard = storage.access_mut(task_id);
-            guard.track_modification(SpecificTaskDataCategory::Meta, "test");
+            let _ = guard.track_modification(SpecificTaskDataCategory::Meta, "test");
             assert!(guard.flags.meta_modified());
             assert!(!guard.flags.data_modified());
         }
@@ -1090,7 +1189,7 @@ mod tests {
         // data was not previously modified, so snapshots gets a None entry.
         {
             let mut guard = storage.access_mut(task_id);
-            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            let _ = guard.track_modification(SpecificTaskDataCategory::Data, "test");
             assert!(guard.flags.data_modified_during_snapshot());
             assert!(!guard.flags.meta_modified_during_snapshot());
         }
@@ -1133,7 +1232,7 @@ mod tests {
         // Modify the task outside snapshot mode so it lands in the modified list.
         {
             let mut guard = storage.access_mut(task_id);
-            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            let _ = guard.track_modification(SpecificTaskDataCategory::Data, "test");
         }
         assert!(storage.map.get(&task_id).is_some());
 
@@ -1170,7 +1269,7 @@ mod tests {
         let task_ids: Vec<_> = (1..=256).map(non_transient_task).collect();
         for &task_id in &task_ids {
             let mut guard = storage.access_mut(task_id);
-            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            let _ = guard.track_modification(SpecificTaskDataCategory::Data, "test");
         }
         let grown_capacity: usize = storage
             .map
@@ -1218,7 +1317,7 @@ mod tests {
         // never dirtied) that just occupies memory and must not be serialized.
         {
             let mut guard = storage.access_mut(modified_id);
-            guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            let _ = guard.track_modification(SpecificTaskDataCategory::Data, "test");
         }
         // `access_mut` inserts an entry; leaving it without track_modification keeps it unmodified.
         let _ = storage.access_mut(unmodified_id);
@@ -1248,5 +1347,152 @@ mod tests {
             .collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].task_id, modified_id);
+    }
+
+    // ==========================================================================
+    // undo_track_modification
+    // ==========================================================================
+
+    /// Non-snapshot path: tracking an unmodified task sets the modified flag and bumps the shard
+    /// counter; undo reverses both, leaving the task exactly as it was (no modifications visible to
+    /// the next snapshot cycle).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn undo_non_snapshot_reverses_flag_and_counter() {
+        let storage = Storage::new(2, true);
+        let task_id = non_transient_task(1);
+
+        {
+            let mut guard = storage.access_mut(task_id);
+            let outcome = guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            assert!(guard.flags.data_modified());
+            guard.undo_track_modification(outcome);
+            assert!(!guard.flags.data_modified());
+            assert!(!guard.flags.any_modified());
+        }
+
+        // Counter is back to zero: the next snapshot sees no modifications.
+        let (_guard, has_modifications) = storage.start_snapshot();
+        assert!(
+            !has_modifications,
+            "undo must decrement the shard counter so no modifications remain"
+        );
+    }
+
+    /// A second track on an already-modified category returns `NoChange`; undoing it is a no-op and
+    /// must NOT clear the real modification recorded by the first track.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn undo_nochange_preserves_prior_modification() {
+        let storage = Storage::new(2, true);
+        let task_id = non_transient_task(1);
+
+        let mut guard = storage.access_mut(task_id);
+        // First track is the real modification.
+        let _first = guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        // Second track on the same category changes nothing.
+        let second = guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        assert!(matches!(second, TrackOutcome::NoChange));
+        // Undoing the no-op must leave the prior modification intact.
+        guard.undo_track_modification(second);
+        assert!(
+            guard.flags.data_modified(),
+            "undoing a NoChange outcome must not clear a real prior modification"
+        );
+    }
+
+    /// Undo only reverses the category it tracked: tracking Data then Meta, undoing only the Meta
+    /// outcome must leave Data modified and the shard counter still non-zero.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn undo_only_reverses_its_own_category() {
+        let storage = Storage::new(2, true);
+        let task_id = non_transient_task(1);
+
+        {
+            let mut guard = storage.access_mut(task_id);
+            let _data = guard.track_modification(SpecificTaskDataCategory::Data, "test");
+            let meta = guard.track_modification(SpecificTaskDataCategory::Meta, "test");
+            assert!(guard.flags.meta_modified());
+            guard.undo_track_modification(meta);
+            assert!(!guard.flags.meta_modified());
+            assert!(guard.flags.data_modified());
+        }
+
+        // Data is still modified, so the counter is still non-zero.
+        let (_guard, has_modifications) = storage.start_snapshot();
+        assert!(has_modifications);
+    }
+
+    /// During-snapshot `(true, false)` arm: a task unmodified-before-snapshot, tracked during
+    /// snapshot, inserts a `None` marker into `snapshots` and sets the `_during_snapshot` bit.
+    /// Undo must remove the marker and clear the bit.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn undo_during_snapshot_true_false_removes_marker() {
+        let storage = Storage::new(2, true);
+        let task_id = non_transient_task(1);
+        // Insert the task (unmodified) so it exists in the map.
+        let _ = storage.access_mut(task_id);
+
+        let (_snapshot_guard, _) = storage.start_snapshot();
+
+        let mut guard = storage.access_mut(task_id);
+        let outcome = guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        assert!(matches!(
+            outcome,
+            TrackOutcome::TrackedDuringSnapshot {
+                inserted_snapshot: true,
+                ..
+            }
+        ));
+        assert!(guard.flags.data_modified_during_snapshot());
+        assert!(storage.snapshots.get(&task_id).is_some());
+
+        guard.undo_track_modification(outcome);
+        assert!(!guard.flags.data_modified_during_snapshot());
+        assert!(
+            storage.snapshots.get(&task_id).is_none(),
+            "undo must remove the snapshots marker it inserted"
+        );
+    }
+
+    /// During-snapshot `(true, true)` arm: a task modified-before-snapshot, tracked again during
+    /// snapshot, stores a pre-mutation copy in `snapshots`. Undo must remove that copy and clear
+    /// the `_during_snapshot` bit, while leaving the pre-existing `modified` flag intact (it
+    /// belongs to the snapshot, not to this call).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn undo_during_snapshot_true_true_removes_copy_preserves_modified() {
+        let storage = Storage::new(2, true);
+        let task_id = non_transient_task(1);
+
+        // Modify before snapshot so the category is part of the snapshot.
+        {
+            let mut guard = storage.access_mut(task_id);
+            let _ = guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        }
+
+        let (_snapshot_guard, _) = storage.start_snapshot();
+
+        let mut guard = storage.access_mut(task_id);
+        let outcome = guard.track_modification(SpecificTaskDataCategory::Data, "test");
+        assert!(matches!(
+            outcome,
+            TrackOutcome::TrackedDuringSnapshot {
+                inserted_snapshot: true,
+                ..
+            }
+        ));
+        assert!(matches!(
+            storage.snapshots.get(&task_id).as_deref(),
+            Some(Some(_))
+        ));
+
+        guard.undo_track_modification(outcome);
+        assert!(!guard.flags.data_modified_during_snapshot());
+        assert!(
+            guard.flags.data_modified(),
+            "the pre-snapshot modification belongs to the snapshot and must survive undo"
+        );
+        assert!(
+            storage.snapshots.get(&task_id).is_none(),
+            "undo must remove the pre-mutation copy it inserted"
+        );
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -127,17 +127,9 @@ impl SpecificTaskDataCategory {
 
 /// Records exactly what a `track_modification` call changed, so that
 /// [`StorageWriteGuard::undo_track_modification`] can reverse it precisely when the mutation it
-/// guarded turns out to be a no-op.
-///
-/// The "track before mutate" ordering requirement (snapshot mode clones pre-mutation state) means
-/// mutators can't use a data structure's native "did anything change" return value to decide
-/// whether to track. Instead they track first, mutate using that native signal, and undo if the
-/// mutation changed nothing. Undo is only ever applied while the same map shard write lock is
-/// still held, so no other thread can have observed the tracked state in between.
-///
-/// This is a plain owned value (no borrow of the guard) on purpose; see
-/// [`StorageWriteGuard::undo_track_modification`] for why a lifetime can't encode the
-/// "same guard, lock held" invariant.
+/// guarded turns out to be a no-op.  This allows us to track modifications 'optimistically' and
+/// undo it if the modification turned out to be a no op.  Useful when dealing with datastructures
+/// like `AutoSet` that can efficiently say whether or not they were modified.
 #[must_use = "a no-op mutation must undo its TrackOutcome; dropping it leaks an over-track"]
 pub enum TrackOutcome {
     /// Nothing was tracked: either the category was already modified, or (in snapshot mode) it was
@@ -696,10 +688,6 @@ pub struct StorageWriteGuard<'a> {
 
 impl StorageWriteGuard<'_> {
     /// Tracks mutation of this task.
-    ///
-    /// Returns a [`TrackOutcome`] describing exactly what changed. If the mutation this call
-    /// guards turns out to be a no-op, pass the outcome to [`Self::undo_track_modification`] to
-    /// reverse it. Otherwise the outcome may be dropped (it carries no resources).
     #[inline(always)]
     pub fn track_modification(
         &mut self,
@@ -754,49 +742,45 @@ impl StorageWriteGuard<'_> {
                 TrackOutcome::NoChange
             }
             (true, false) => {
-                self.track_during_snapshot(category, /* part_of_snapshot */ false)
+                // In snapshot mode and item is unmodified (so it's not part of the snapshot)
+                // Mark it so it gets re-added as Modified after this snapshot completes.
+                // Insert a None entry into snapshots so end_snapshot discovers this task
+                // and promotes its _during_snapshot flags.
+                let inserted_snapshot = !flags.any_modified_during_snapshot();
+                if inserted_snapshot {
+                    self.storage.snapshots.insert(*self.inner.key(), None);
+                }
+                self.inner
+                    .flags
+                    .set_modified_during_snapshot(category, true);
+                TrackOutcome::TrackedDuringSnapshot {
+                    category,
+                    inserted_snapshot,
+                }
             }
-            (true, true) => self.track_during_snapshot(category, /* part_of_snapshot */ true),
-        }
-    }
-
-    /// Slow path of [`Self::track_modification_internal`] for the two snapshot-mode arms.
-    ///
-    /// `part_of_snapshot` distinguishes `(true, true)` (the category is already modified, so the
-    /// pre-mutation state is part of the in-flight snapshot and must be cloned) from
-    /// `(true, false)` (not part of the snapshot, so only a `None` marker is needed).
-    #[cold]
-    fn track_during_snapshot(
-        &mut self,
-        category: SpecificTaskDataCategory,
-        part_of_snapshot: bool,
-    ) -> TrackOutcome {
-        let flags = &self.inner.flags;
-        // Insert the snapshots entry only the first time the task is touched during this snapshot.
-        let inserted_snapshot = !flags.any_modified_during_snapshot();
-        if inserted_snapshot {
-            let entry = if part_of_snapshot {
-                // The category is part of the snapshot: store the original version so the iterator
-                // serializes the pre-mutation state. Carry the modified bits into the copy so the
-                // iterator knows which categories to persist.
-                let mut snapshot = self.inner.clone_snapshot();
-                snapshot.flags.set_data_modified(flags.data_modified());
-                snapshot.flags.set_meta_modified(flags.meta_modified());
-                snapshot.flags.set_new_task(flags.new_task());
-                Some(Box::new(snapshot))
-            } else {
-                // Not part of the snapshot: a None marker so end_snapshot discovers this task and
-                // promotes its _during_snapshot flags.
-                None
-            };
-            self.storage.snapshots.insert(*self.inner.key(), entry);
-        }
-        self.inner
-            .flags
-            .set_modified_during_snapshot(category, true);
-        TrackOutcome::TrackedDuringSnapshot {
-            category,
-            inserted_snapshot,
+            (true, true) => {
+                // In snapshot mode and item is modified (so it's part of the snapshot)
+                // We need to store the original version that is part of the snapshot
+                let inserted_snapshot = !flags.any_modified_during_snapshot();
+                if inserted_snapshot {
+                    // Snapshot all non-transient fields, carrying the modified bits into
+                    // the copy so the iterator knows which categories to persist.
+                    let mut snapshot = self.inner.clone_snapshot();
+                    snapshot.flags.set_data_modified(flags.data_modified());
+                    snapshot.flags.set_meta_modified(flags.meta_modified());
+                    snapshot.flags.set_new_task(flags.new_task());
+                    self.storage
+                        .snapshots
+                        .insert(*self.inner.key(), Some(Box::new(snapshot)));
+                }
+                self.inner
+                    .flags
+                    .set_modified_during_snapshot(category, true);
+                TrackOutcome::TrackedDuringSnapshot {
+                    category,
+                    inserted_snapshot,
+                }
+            }
         }
     }
 
@@ -813,12 +797,6 @@ impl StorageWriteGuard<'_> {
     /// `snapshots` entry are only mutated under that lock). Because those flags record whether
     /// *this* call created the state, undo never clears a flag, counter, or snapshot entry that a
     /// prior modification owns.
-    ///
-    /// This invariant is intentionally **not** encoded as a borrow on `TrackOutcome`: a lifetime
-    /// tying the outcome to `&mut self` would forbid the mutation between track and undo (it also
-    /// needs `&mut self`), which is the entire reason the API is split this way. The constraint is
-    /// instead upheld structurally — every caller is a single mutator body holding one guard.
-    #[cold]
     pub fn undo_track_modification(&mut self, outcome: TrackOutcome) {
         match outcome {
             TrackOutcome::NoChange => {}
@@ -1349,13 +1327,6 @@ mod tests {
         assert_eq!(items[0].task_id, modified_id);
     }
 
-    // ==========================================================================
-    // undo_track_modification
-    // ==========================================================================
-
-    /// Non-snapshot path: tracking an unmodified task sets the modified flag and bumps the shard
-    /// counter; undo reverses both, leaving the task exactly as it was (no modifications visible to
-    /// the next snapshot cycle).
     #[tokio::test(flavor = "multi_thread")]
     async fn undo_non_snapshot_reverses_flag_and_counter() {
         let storage = Storage::new(2, true);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -548,24 +548,20 @@ impl TaskStorage {
     pub fn evictability(&self) -> (KeyEvictability, ValueEvictability) {
         let flags = &self.flags;
 
-        let key_evictability = if flags.new_task() {
-            KeyEvictability::Unevictable
-        } else {
-            match &self.persistent_task_type {
-                None => KeyEvictability::Unevictable,
-                // strong_count == 1: only this TaskStorage holds this Arc, so no task_cache entry
-                // references it. It must have been already evicted on a prior cycle.
-                Some(arc) if arc.count() == 1 => KeyEvictability::AlreadyEvicted,
-                Some(_) => KeyEvictability::Evictable,
-            }
-        };
         // === Absolute blockers ===
         if flags.new_task() {
             return (
-                key_evictability,
+                KeyEvictability::Unevictable,
                 ValueEvictability::Unevictable(UnevictableReason::Modified),
             );
         }
+        let key_evictability = match &self.persistent_task_type {
+            None => KeyEvictability::Unevictable,
+            // strong_count == 1: only this TaskStorage holds this Arc, so no task_cache entry
+            // references it. It must have been already evicted on a prior cycle.
+            Some(arc) if arc.count() == 1 => KeyEvictability::AlreadyEvicted,
+            Some(_) => KeyEvictability::Evictable,
+        };
         // All these flags imply that the task is currently being used in some way
         // either literally executing, or about to
         if self.get_in_progress().is_some()

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -123,15 +123,19 @@ impl FieldInfo {
         }
     }
 
-    /// Generate the full `self.track_modification(...)` call for this field.
+    /// Generate the full `self.track_modification(...)` call *statement* for this field.
+    ///
+    /// Used by mutators that track unconditionally (a replace/batch/counter update that reaches the
+    /// track call is always a real change), so the returned `TrackOutcome` is discarded with
+    /// `let _ =`. Mutators that track-then-undo use [`track_modification_outcome_expr`] instead.
     fn track_modification_call(&self) -> TokenStream {
         let field_name_str = self.field_name.to_string();
         match self.category {
             Category::Data => {
-                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Data, #field_name_str); }
+                quote! { let _the_modification_is_unconditional = self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Data, #field_name_str); }
             }
             Category::Meta => {
-                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Meta, #field_name_str); }
+                quote! { let _the_modification_is_unconditional = self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Meta, #field_name_str); }
             }
             Category::Transient => {
                 quote! {
@@ -158,6 +162,46 @@ impl FieldInfo {
                 #track
             }
         }
+    }
+
+    /// An *expression* (no trailing `;`) that calls `self.track_modification(...)` and evaluates to
+    /// a `TrackOutcome`. Used by mutators that track-before-mutate and then undo if the mutation
+    /// was a no-op (see [`track_modification_undo_expr`]). For transient *fields* there is nothing
+    /// to track, so it evaluates to `TrackOutcome::NoChange`.
+    fn track_modification_outcome_expr(&self) -> TokenStream {
+        let field_name_str = self.field_name.to_string();
+        match self.category {
+            Category::Data => {
+                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Data, #field_name_str) }
+            }
+            Category::Meta => {
+                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Meta, #field_name_str) }
+            }
+            Category::Transient => quote! { crate::backend::storage::TrackOutcome::NoChange },
+        }
+    }
+
+    /// Like [`track_modification_outcome_expr`], but for `filter_transient` fields it only tracks
+    /// when `key_expr` is not transient (transient entries change no persistable bytes), evaluating
+    /// to `TrackOutcome::NoChange` otherwise. Identical to [`track_modification_outcome_expr`] for
+    /// non-`filter_transient` fields.
+    fn track_modification_outcome_expr_guarded(&self, key_expr: TokenStream) -> TokenStream {
+        if !self.filter_transient || self.is_transient() {
+            return self.track_modification_outcome_expr();
+        }
+        let track = self.track_modification_outcome_expr();
+        quote! {
+            if !(#key_expr).is_transient() {
+                #track
+            } else {
+                crate::backend::storage::TrackOutcome::NoChange
+            }
+        }
+    }
+
+    /// The `self.undo_track_modification(<outcome_ident>)` call statement.
+    fn track_modification_undo_expr(&self, outcome_ident: TokenStream) -> TokenStream {
+        quote! { self.undo_track_modification(#outcome_ident); }
     }
 
     /// Whether this field is stored inline (not lazy).
@@ -1618,10 +1662,15 @@ fn generate_task_storage_accessors_trait(grouped_fields: &GroupedFields) -> Toke
 
             #[doc = "Track that a modification occurred for the given category."]
             #[doc = ""]
-            #[doc = "Should be called after confirming that data actually changed."]
-            #[doc = "This is separate from `typed_mut()` to allow optimizations where"]
-            #[doc = "we only track modifications when something actually changes."]
-            fn track_modification(&mut self, category: crate::backend::storage::SpecificTaskDataCategory, name: &str);
+            #[doc = "Returns a `TrackOutcome` recording what changed. Mutators that track *before*"]
+            #[doc = "mutating (to preserve the snapshot-mode ordering invariant) and only afterwards"]
+            #[doc = "learn the mutation was a no-op pass the outcome to `undo_track_modification`."]
+            #[doc = "When the mutation is known to be a real change, the outcome can be dropped."]
+            fn track_modification(&mut self, category: crate::backend::storage::SpecificTaskDataCategory, name: &str) -> crate::backend::storage::TrackOutcome;
+
+            #[doc = "Reverse a `TrackOutcome` from `track_modification` when the guarded mutation"]
+            #[doc = "turned out to change nothing persistable."]
+            fn undo_track_modification(&mut self, outcome: crate::backend::storage::TrackOutcome);
 
             #[doc = "Verify that the task was accessed with the correct category before reading/writing."]
             #[doc = ""]
@@ -2037,12 +2086,9 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
     };
 
     let check_access = field.check_access_call();
+    // Used by `set`/`extend` which track unconditionally (a replace/batch that reaches the track
+    // call is always a real change). `add`/`remove` instead track-then-undo (see below).
     let track_modification = field.track_modification_call();
-    // For `filter_transient` fields, tracking on add/remove is guarded so it
-    // only fires for non-transient `item`s (transient entries are dropped at
-    // encode, so they change zero persistable bytes). For non-filter_transient
-    // fields this is identical to `track_modification`.
-    let track_modification_item = field.track_modification_call_guarded(quote! { item });
     let mut_expr = field.collection_mut_expr();
     let ref_expr = field.collection_ref_expr();
 
@@ -2114,58 +2160,43 @@ fn generate_autoset_ops(field: &FieldInfo) -> TokenStream {
             #mut_expr.extend(items);
         };
     } else {
-        // Remove: only track modification if the item exists.
-        // For lazy fields, find the index once and reuse it to avoid double-scanning.
+        // `track_modification` returns a `TrackOutcome`; for `filter_transient` fields it is
+        // `NoChange` when `item` is transient (those change no persistable bytes). We track BEFORE
+        // mutating (snapshot mode clones pre-mutation state) and `undo` if the native return value
+        // of the mutation reveals it changed nothing — avoiding the redundant `contains` probe.
+        let track_item_outcome = field.track_modification_outcome_expr_guarded(quote! { item });
+        let undo = field.track_modification_undo_expr(quote! { _track_outcome });
+
+        // Remove: track, remove (native bool), undo if the item wasn't present.
+        // For lazy fields we still must locate the set without allocating it, but we use the
+        // index found to remove directly and rely on `remove`'s return for the undo decision.
         remove_body = if is_option {
             let extractor = field.lazy_extractor_closure();
             quote! {
-                let Some((idx, val)) = self.typed().find_lazy_ref(#extractor) else {
+                let Some((idx, _)) = self.typed().find_lazy_ref(#extractor) else {
                     return false;
                 };
-                if !val.contains(item) {
-                    return false;
-                }
-                #track_modification_item
-                self.typed_mut().lazy_at_mut(idx, #extractor).remove(item)
+                let _track_outcome = #track_item_outcome;
+                let removed = self.typed_mut().lazy_at_mut(idx, #extractor).remove(item);
+                if !removed { #undo }
+                removed
             }
         } else {
             quote! {
-                if !#ref_expr.contains(item) {
-                    return false;
-                }
-                #track_modification_item
-                #mut_expr.remove(item)
+                let _track_outcome = #track_item_outcome;
+                let removed = #mut_expr.remove(item);
+                if !removed { #undo }
+                removed
             }
         };
 
-        // Add: only track modification if the item is actually new.
-        // For lazy fields, use find_lazy_ref + lazy_at_mut to avoid double-scanning.
-        add_body = if is_option {
-            let extractor = field.lazy_extractor_closure();
-            let ctor = field.lazy_constructor(quote! { set });
-            quote! {
-                if let Some((idx, existing)) = self.typed().find_lazy_ref(#extractor) {
-                    if existing.contains(&item) {
-                        return false;
-                    }
-                    #track_modification_item
-                    self.typed_mut().lazy_at_mut(idx, #extractor).insert(item)
-                } else {
-                    #track_modification_item
-                    let mut set = <#field_type as Default>::default();
-                    set.insert(item);
-                    self.typed_mut().lazy.push(#ctor);
-                    true
-                }
-            }
-        } else {
-            quote! {
-                if #ref_expr.contains(&item) {
-                    return false;
-                }
-                #track_modification_item
-                #mut_expr.insert(item)
-            }
+        // Add: track, insert (native bool), undo if the item already existed.
+        // For lazy fields `#mut_expr` (field_mut) get-or-creates the set in a single scan.
+        add_body = quote! {
+            let _track_outcome = #track_item_outcome;
+            let inserted = #mut_expr.insert(item);
+            if !inserted { #undo }
+            inserted
         };
 
         if is_option {
@@ -2409,28 +2440,35 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
         quote! { #ref_expr.get(key) }
     };
 
-    // Generate remove body - for lazy fields, we need to check if the map exists first
-    // without allocating it. For inline fields, we can use the mut_expr directly.
-    // Only track modification if the key exists (check before mutating).
-    // For transient fields, skip guards since track_modification is a no-op.
+    // Generate remove body. `remove` returns `Option<V>` natively, so (like AutoSet remove) we
+    // track BEFORE mutating (snapshot mode clones pre-mutation state), use that return to learn
+    // whether anything was actually removed, and undo the track if the key was absent — avoiding
+    // the redundant `get` probe the check-first form needed. For transient fields tracking is a
+    // no-op so no undo is needed.
+    let remove_outcome = field.track_modification_outcome_expr_guarded(quote! { key });
+    let remove_undo = field.track_modification_undo_expr(quote! { _track_outcome });
     let remove_body = if field.is_transient() {
         quote! {
             #track_modification
             #mut_expr.remove(key)
         }
     } else if is_option {
+        // Lazy: still locate the map without allocating it (a bare `field_mut()` would create an
+        // empty map on a remove), but drop the separate membership probe.
         let extractor = field.lazy_extractor_closure();
         quote! {
-            let (idx, val) = self.typed().find_lazy_ref(#extractor)?;
-            val.get(key)?;
-            #track_modification_key
-            self.typed_mut().lazy_at_mut(idx, #extractor).remove(key)
+            let (idx, _) = self.typed().find_lazy_ref(#extractor)?;
+            let _track_outcome = #remove_outcome;
+            let removed = self.typed_mut().lazy_at_mut(idx, #extractor).remove(key);
+            if removed.is_none() { #remove_undo }
+            removed
         }
     } else {
         quote! {
-            self.#get_name(key)?;
-            #track_modification_key
-            #mut_expr.remove(key)
+            let _track_outcome = #remove_outcome;
+            let removed = #mut_expr.remove(key);
+            if removed.is_none() { #remove_undo }
+            removed
         }
     };
 
@@ -2517,6 +2555,9 @@ fn generate_countermap_ops(field: &FieldInfo) -> TokenStream {
                 return;
             }
             let keys: Vec<_> = keys.collect();
+            if keys.is_empty() {
+                return;
+            }
             if keys.iter().any(|key| !key.is_transient()) {
                 #track_modification
             }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -2796,25 +2796,33 @@ fn generate_automap_ops(field: &FieldInfo) -> TokenStream {
     // Generate remove body - for lazy fields, avoid allocation if map doesn't exist.
     // Only track modification if the key exists (check before mutating).
     // For transient fields, skip guards since track_modification is a no-op.
+    // `remove` returns `Option<V>` natively, so (like AutoSet / CounterMap remove) we track BEFORE
+    // mutating (snapshot mode clones pre-mutation state), use that return to learn whether anything
+    // was removed, and undo the track if the key was absent — dropping the redundant membership
+    // probe. `insert` stays an unconditional track: callers only ever insert distinct values, so an
+    // equality check would pay `PartialEq` on every insert to catch a no-op that never happens.
+    let remove_outcome = field.track_modification_outcome_expr();
+    let remove_undo = field.track_modification_undo_expr(quote! { _track_outcome });
     let remove_body = if field.is_transient() {
         quote! {
             #mut_expr.remove(key)
         }
     } else if is_option {
+        // Lazy: still locate the map without allocating it, but drop the separate membership probe.
         let extractor = field.lazy_extractor_closure();
         quote! {
-            let (idx, val) = self.typed().find_lazy_ref(#extractor)?;
-            val.get(key)?;
-            #track_modification
-            self.typed_mut().lazy_at_mut(idx, #extractor).remove(key)
+            let (idx, _) = self.typed().find_lazy_ref(#extractor)?;
+            let _track_outcome = #remove_outcome;
+            let removed = self.typed_mut().lazy_at_mut(idx, #extractor).remove(key);
+            if removed.is_none() { #remove_undo }
+            removed
         }
     } else {
         quote! {
-            if !self.#has_entry_name(key) {
-                return None;
-            }
-            #track_modification
-            #mut_expr.remove(key)
+            let _track_outcome = #remove_outcome;
+            let removed = #mut_expr.remove(key);
+            if removed.is_none() { #remove_undo }
+            removed
         }
     };
 


### PR DESCRIPTION
## What
Allow some modifications that turn out to be no-ops to be undone on TaskStorage.  This saves us some redundant check-then-mutate cycles.

This doesn't apply to every field type
* `Option<T>` - still read-check-modify
* `CounterMap<T>` - updates are unconditional tracks and removals use the undo approach
* `AutoSet`/`AutoMap` - mostly uses the new 'undo' approach 
   * `take` as a bulk operation does not, taking an empty set is rare and cheap to check for
   * `AutoMap::insert` doesn't use the undo approach or even check, we always track a modification since all callers are only inserting unique values anyway

A few other incidental cleanups were landed as well.

## Why

Avoid redundant hash lookups.

## How

Have `track_modification` return a new TrackOutcome that records what modifications were made and then in the undo case we can pass it to a new `undo_track_modification` function which can reverse it.   This is a little brittle since both operations need to occur within a single lock transition

I considered using a 'lambda' oriented approach but decided against it since it would be awkward for some of the mutators and as all the callers are generated by a macro (well _almost_ all callers) it isn't too risky.


