### PR TITLE
server actions: enforce bodySizeLimit in edge runtime for multipart and non-multipart bodies

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -756,7 +756,32 @@ export async function handleAction({
             throw new Error('invariant: Missing request body.')
           }
 
-          // TODO: add body limit
+          const defaultBodySizeLimitEdge = '1 MB'
+          const bodySizeLimitEdge =
+            serverActions?.bodySizeLimit ?? defaultBodySizeLimitEdge
+          const bodySizeLimitBytesEdge =
+            typeof bodySizeLimitEdge === 'number'
+              ? bodySizeLimitEdge
+              : (() => {
+                  // Parse human-readable size strings (e.g. "2mb", "512 KB") without
+                  // relying on the Node-only `bytes` module, which cannot be bundled
+                  // into the edge runtime.
+                  const match = String(bodySizeLimitEdge)
+                    .trim()
+                    .match(/^(\d+(?:\.\d+)?)\s*(k|m|g|t|p)?b?$/i)
+                  if (!match) return 1024 * 1024 // default 1 MB
+                  const num = parseFloat(match[1])
+                  const unit = (match[2] ?? '').toLowerCase()
+                  const multipliers: Record<string, number> = {
+                    '': 1,
+                    k: 1024,
+                    m: 1024 * 1024,
+                    g: 1024 * 1024 * 1024,
+                    t: 1024 * 1024 * 1024 * 1024,
+                    p: 1024 * 1024 * 1024 * 1024 * 1024,
+                  }
+                  return Math.floor(num * (multipliers[unit] ?? 1))
+                })()
 
           // Use react-server-dom-webpack/server
           const {
@@ -770,7 +795,39 @@ export async function handleAction({
 
           if (isMultipartAction) {
             // TODO-APP: Add streaming support
-            const formData = await req.request.formData()
+            //
+            // Read the body through a size-checking loop before handing it to
+            // formData() so that the edge runtime honours bodySizeLimit the
+            // same way the Node runtime does.
+            const edgeBodyChunks: Uint8Array[] = []
+            let edgeBodySize = 0
+            const edgeReader = req.body.getReader()
+            while (true) {
+              const { done, value } = await edgeReader.read()
+              if (done) break
+              edgeBodySize += value.byteLength
+              if (edgeBodySize > bodySizeLimitBytesEdge) {
+                throw new Error(
+                  `Body exceeded ${bodySizeLimitEdge} limit.\n` +
+                    `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
+                )
+              }
+              edgeBodyChunks.push(value)
+            }
+            // Reconstruct a Request with the same headers so that formData()
+            // can correctly identify the multipart boundary.
+            const edgeBodyBuffer = new Uint8Array(edgeBodySize)
+            let offset = 0
+            for (const chunk of edgeBodyChunks) {
+              edgeBodyBuffer.set(chunk, offset)
+              offset += chunk.byteLength
+            }
+            const sizedRequest = new Request(req.request.url, {
+              method: req.request.method,
+              headers: req.request.headers,
+              body: edgeBodyBuffer,
+            })
+            const formData = await sizedRequest.formData()
             if (isFetchAction) {
               // A fetch action with a multipart body.
 
@@ -848,14 +905,21 @@ export async function handleAction({
             // In practice, this happens if `encodeReply` returned a string instead of FormData,
             // which can happen for very simple JSON-like values that don't need multiple flight rows.
 
-            const chunks: Buffer[] = []
+            const chunks: Uint8Array[] = []
+            let nonMultipartSize = 0
             const reader = req.body.getReader()
             while (true) {
               const { done, value } = await reader.read()
               if (done) {
                 break
               }
-
+              nonMultipartSize += value.byteLength
+              if (nonMultipartSize > bodySizeLimitBytesEdge) {
+                throw new Error(
+                  `Body exceeded ${bodySizeLimitEdge} limit.\n` +
+                    `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
+                )
+              }
               chunks.push(value)
             }
 


### PR DESCRIPTION
Fixes #95172

## What

The edge runtime Server Action handler has a `// TODO: add body limit` comment at the top of the edge branch. Neither the multipart path nor the non-multipart (fetch-action) path enforced `experimental.serverActions.bodySizeLimit`, so a multipart upload that exceeds the configured limit was silently accepted on edge routes while the identical request was correctly rejected on Node routes.

The reporter's repro confirms:
- Node runtime: `Body exceeded 2mb limit.` (correct)
- Edge runtime: action executes with a 3 MiB payload (bug)

## How

**Size parsing.** The Node path uses `require('next/dist/compiled/bytes')` lazily so the dependency is excluded from edge bundles. Because edge bundles cannot load that module at runtime, the limit string is parsed inline with a small multiplier table covering the same kb/mb/gb/tb/pb units that `SizeLimit` accepts. Numeric values pass through directly.

**Multipart path.** `req.request.formData()` reads the body internally with no size hook. Instead, the body stream is now consumed chunk-by-chunk through `req.body.getReader()`, accumulating byte count and throwing on overflow before parsing. The validated chunks are concatenated into a `Uint8Array` and wrapped in a new `Request` that carries the original headers (including the multipart `Content-Type` boundary) so `formData()` can parse the already-buffered body correctly.

**Non-multipart fetch-action path.** The existing chunk-reading loop is extended with the same per-chunk accumulator and overflow check. The `chunks` type is widened from `Buffer[]` to `Uint8Array[]` (which `Buffer.concat` already accepts) to avoid relying on a Node global.

The error message and documentation link match the Node path exactly so client-side error handling sees the same text regardless of runtime.

## Testing

The change is in a dead-code-eliminated block (`process.env.NEXT_RUNTIME === 'edge'`), so the Node runtime path is untouched. Manual verification using the reporter's reproduction repo at https://github.com/Str1ckl4nd/next-edge-server-actions-body-limit-repro confirms that the edge `/edge` route now returns a 500 (body exceeded error) for the 3 MiB upload when `bodySizeLimit: '2mb'` is configured.