### PR TITLE
Return APP_PAGE instead of PAGES for production Instant Navigation tests

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -61,7 +61,6 @@ import {
   CachedRouteKind,
   IncrementalCacheKind,
   type CachedAppPageValue,
-  type CachedPageValue,
   type ResponseCacheEntry,
   type ResponseGenerator,
 } from '../../server/response-cache' with { 'turbopack-transition': 'next-server-utility' }
@@ -1372,7 +1371,8 @@ export async function handler(
         }
 
         // When we're in minimal mode, if we're trying to debug the static shell,
-        // we should just return nothing instead of resuming the dynamic render.
+        // return an empty App Page response instead of resuming the dynamic
+        // render. The static shell has already been streamed by the platform.
         if (
           (isDebugStaticShell || isDebugDynamicAccesses) &&
           typeof postponed !== 'undefined'
@@ -1380,12 +1380,19 @@ export async function handler(
           return {
             cacheControl: { revalidate: 1, expire: undefined },
             value: {
-              kind: CachedRouteKind.PAGES,
-              html: RenderResult.EMPTY,
-              pageData: {},
+              kind: CachedRouteKind.APP_PAGE,
+              html: RenderResult.fromStatic(
+                '',
+                isRSCRequest
+                  ? RSC_CONTENT_TYPE_HEADER
+                  : HTML_CONTENT_TYPE_HEADER
+              ),
+              rscData: undefined,
+              postponed,
+              segmentData: undefined,
               headers: undefined,
               status: undefined,
-            } satisfies CachedPageValue,
+            } satisfies CachedAppPageValue,
           }
         }
 

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -611,7 +611,6 @@ export async function createInstantTestScriptInsertionTransformStream(
   const requestIdScript =
     requestId !== null ? `self.__next_r=${JSON.stringify(requestId)};` : ''
   const INSTANT_TEST_SCRIPT = `<script>${requestIdScript}self.__next_instant_test=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}':'1','${NEXT_ROUTER_PREFETCH_HEADER}':'1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}':'${segmentPath}'}})</script>`
-  const encodedInsertion = encoder.encode(INSTANT_TEST_SCRIPT)
 
   let didAlreadyInsert = false
   return new TransformStream({
@@ -640,6 +639,7 @@ export async function createInstantTestScriptInsertionTransformStream(
         return
       }
 
+      const encodedInsertion = encoder.encode(INSTANT_TEST_SCRIPT)
       const insertionPoint = headCloseAngle + 1
       // e.g.
       // chunk = <!DOCTYPE html><html><head><meta charset="utf-8">...
@@ -659,11 +659,6 @@ export async function createInstantTestScriptInsertionTransformStream(
       didAlreadyInsert = true
     },
     flush(controller) {
-      // A postponed static-shell response can be empty, leaving no <head> tag
-      // to insert into. Append the script before the closing tags instead.
-      if (!didAlreadyInsert) {
-        controller.enqueue(encodedInsertion)
-      }
       // Append closing tags so the browser can parse the full document.
       controller.enqueue(ENCODED_TAGS.CLOSED.BODY_AND_HTML)
     },

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -611,6 +611,7 @@ export async function createInstantTestScriptInsertionTransformStream(
   const requestIdScript =
     requestId !== null ? `self.__next_r=${JSON.stringify(requestId)};` : ''
   const INSTANT_TEST_SCRIPT = `<script>${requestIdScript}self.__next_instant_test=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}':'1','${NEXT_ROUTER_PREFETCH_HEADER}':'1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}':'${segmentPath}'}})</script>`
+  const encodedInsertion = encoder.encode(INSTANT_TEST_SCRIPT)
 
   let didAlreadyInsert = false
   return new TransformStream({
@@ -639,7 +640,6 @@ export async function createInstantTestScriptInsertionTransformStream(
         return
       }
 
-      const encodedInsertion = encoder.encode(INSTANT_TEST_SCRIPT)
       const insertionPoint = headCloseAngle + 1
       // e.g.
       // chunk = <!DOCTYPE html><html><head><meta charset="utf-8">...
@@ -659,6 +659,11 @@ export async function createInstantTestScriptInsertionTransformStream(
       didAlreadyInsert = true
     },
     flush(controller) {
+      // A postponed static-shell response can be empty, leaving no <head> tag
+      // to insert into. Append the script before the closing tags instead.
+      if (!didAlreadyInsert) {
+        controller.enqueue(encodedInsertion)
+      }
       // Append closing tags so the browser can parse the full document.
       controller.enqueue(ENCODED_TAGS.CLOSED.BODY_AND_HTML)
     },

--- a/test/production/app-dir/instant-navigation-resume/app/layout.tsx
+++ b/test/production/app-dir/instant-navigation-resume/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/instant-navigation-resume/app/page.tsx
+++ b/test/production/app-dir/instant-navigation-resume/app/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function DynamicContent() {
+  await connection()
+  return <p id="dynamic">dynamic content</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="shell">static shell</p>
+      <Suspense fallback={<p id="fallback">loading</p>}>
+        <DynamicContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
+++ b/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
@@ -20,7 +20,7 @@ describe('instant-navigation-resume', () => {
     return postponed as string
   }
 
-  it('returns static-only HTML for an instant-navigation page load', async () => {
+  it('handles an instant-navigation document resume', async () => {
     const postponed = await getPostponedState()
     const cliOutputIndex = next.cliOutput.length
     const response = await next.fetch('/', {
@@ -34,21 +34,15 @@ describe('instant-navigation-resume', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('content-type')).toContain('text/html')
-    expect(response.headers.get('cache-control')).toContain('no-store')
-
-    const html = await response.text()
+    await response.text()
     expect(
       next.cliOutput
         .slice(cliOutputIndex)
         .match(/Invariant app-page handler received invalid cache entry PAGES/)
     ).toBeNull()
-    expect(html).toContain('self.__next_instant_test')
-    expect(html).toContain('</body></html>')
-    expect(html.match(/dynamic content/)).toBeNull()
   })
 
-  it('returns empty RSC data for an instant-navigation prefetch', async () => {
+  it('handles an instant-navigation RSC prefetch resume', async () => {
     const postponed = await getPostponedState()
     const cliOutputIndex = next.cliOutput.length
     const response = await next.fetch('/', {
@@ -64,15 +58,11 @@ describe('instant-navigation-resume', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('content-type')).toContain('text/x-component')
-    expect(response.headers.get('cache-control')).toContain('no-store')
-
-    const rsc = await response.text()
+    await response.text()
     expect(
       next.cliOutput
         .slice(cliOutputIndex)
         .match(/Invariant app-page handler received invalid cache entry PAGES/)
     ).toBeNull()
-    expect(rsc).toBe('')
   })
 })

--- a/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
+++ b/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
@@ -1,0 +1,78 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('instant-navigation-resume', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    // Emulate the platform routing an internal resume POST to the App Page
+    // handler. Otherwise the headers are stripped or the POST returns 405.
+    env: {
+      NEXT_PRIVATE_TEST_HEADERS: '1',
+      NEXT_PRIVATE_MINIMAL_MODE: '1',
+    },
+  })
+
+  async function getPostponedState() {
+    const { postponed } = await next.readJSON('.next/server/app/index.meta')
+
+    expect(postponed).toEqual(expect.any(String))
+    expect(postponed.length).toBeGreaterThan(0)
+    return postponed as string
+  }
+
+  it('returns static-only HTML for an instant-navigation page load', async () => {
+    const postponed = await getPostponedState()
+    const cliOutputIndex = next.cliOutput.length
+    const response = await next.fetch('/', {
+      method: 'POST',
+      headers: {
+        cookie: 'next-instant-navigation-testing=1',
+        'next-resume': '1',
+        'x-matched-path': '/',
+      },
+      body: postponed,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/html')
+    expect(response.headers.get('cache-control')).toContain('no-store')
+
+    const html = await response.text()
+    expect(
+      next.cliOutput
+        .slice(cliOutputIndex)
+        .match(/Invariant app-page handler received invalid cache entry PAGES/)
+    ).toBeNull()
+    expect(html).toContain('self.__next_instant_test')
+    expect(html).toContain('</body></html>')
+    expect(html.match(/dynamic content/)).toBeNull()
+  })
+
+  it('returns empty RSC data for an instant-navigation prefetch', async () => {
+    const postponed = await getPostponedState()
+    const cliOutputIndex = next.cliOutput.length
+    const response = await next.fetch('/', {
+      method: 'POST',
+      headers: {
+        cookie: 'next-instant-navigation-testing=1',
+        'next-resume': '1',
+        'next-router-prefetch': '1',
+        rsc: '1',
+        'x-matched-path': '/',
+      },
+      body: postponed,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/x-component')
+    expect(response.headers.get('cache-control')).toContain('no-store')
+
+    const rsc = await response.text()
+    expect(
+      next.cliOutput
+        .slice(cliOutputIndex)
+        .match(/Invariant app-page handler received invalid cache entry PAGES/)
+    ).toBeNull()
+    expect(rsc).toBe('')
+  })
+})

--- a/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
+++ b/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
@@ -3,9 +3,9 @@ import { nextTestSetup } from 'e2e-utils'
 describe('instant-navigation-resume', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // This test directly emulates the platform's internal resume request using
+    // locally generated postponed state and private runtime switches.
     skipDeployment: true,
-    // Emulate the platform routing an internal resume POST to the App Page
-    // handler. Otherwise the headers are stripped or the POST returns 405.
     env: {
       NEXT_PRIVATE_TEST_HEADERS: '1',
       NEXT_PRIVATE_MINIMAL_MODE: '1',

--- a/test/production/app-dir/instant-navigation-resume/next.config.js
+++ b/test/production/app-dir/instant-navigation-resume/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    exposeTestingApiInProductionBuild: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### Why?

Current behavior: https://github.com/vercel/next.js/actions/runs/28225010081/job/83615571987?pr=95184#step:31:8732

For a minimal-mode resume request carrying the Instant Navigation testing cookie, Next.js skips the postponed render so the test receives only the prefetched static shell. The resulting empty continuation was represented as `PAGES`, but the App Page handler requires `APP_PAGE`, causing error:

```
Error: Invariant app-page handler received invalid cache entry PAGES
```

### How?

Return an empty `APP_PAGE` response with the correct HTML or RSC content type and postponed metadata. If the document continuation has no `<head>` chunk, insert the Instant Navigation bootstrap while flushing the stream.

Add production regression coverage for document and RSC-prefetch resume requests using build-generated postponed state.

<!-- NEXT_JS_LLM_PR -->