### PR TITLE
[dev overlay]: restructure Copy-as-prompt body into a step-by-step checklist

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
@@ -84,11 +84,19 @@ function CopyPromptButton({
     '',
     'Steps:',
     '',
-    "1. The failing code is in the error block below — it may be a data-access call, a hook call, a metadata or viewport export, or a component. The fix applies to that exact code; don't touch unrelated files.",
+    `1. Make sure you can drive a browser before you start. The fix isn't verified until you've reloaded the route and looked at what renders. If you don't already have browser tooling set up, install the next-dev-loop skill (https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) first.`,
     '',
-    `2. Read the rule docs at ${rulePage} for the full Insight explanation, then read the fix section at ${link}. Pick the pattern under "### Patterns" that matches the failing code, then read "### Gotchas" before editing — they list constraints that are easy to miss. Use the canonical imports and code shape from the page; don't improvise variations.`,
+    "2. Identify the failing code in the error block below. It may be a data-access call, a hook call, a metadata or viewport export, or a component. Keep the fix focused on that code. If you think a related refactor (a sibling component, a shared layout, a wrapping boundary) would make the result meaningfully better, name it and check with the user before doing it — don't expand the scope silently.",
     '',
-    `3. Apply the chosen pattern to the code identified in step 1.`,
+    `3. Read the rule docs at ${rulePage} for the full Insight explanation, then read the fix section at ${link}. Pick the pattern under "### Patterns" that matches the failing code, then read "### Gotchas" before editing — they list constraints that are easy to miss. Use the canonical imports and code shape from the page; don't improvise variations.`,
+    '',
+    `4. Apply the chosen pattern to the code identified in step 2. Don't narrate the change with new comments — the code should explain itself. Only leave a comment when the *why* isn't clear (e.g. a deliberate Block with a reason).`,
+    '',
+    `5. Verify the fix at runtime. The Insight clearing in the dev overlay confirms the build is happy, but not what actually renders. Reload the route in a browser and confirm the static shell still paints first and any new <Suspense> fallback resolves to its real content.`,
+    '',
+    "6. Check the shell isn't empty. A <Suspense> boundary placed too high (around the whole page body, or with `fallback={null}`) can leave the build reporting a shell while the shell itself contains nothing and everything streams. If that's what you see, pull the boundary down closer to the actual dynamic read.",
+    '',
+    "7. If the fix touched shared code (a layout, a wrapper, a sidebar), re-check the sibling routes too — a shell-level change can fix one route and break another. A before/after capture of the affected routes is a useful sanity check: the visible UI may look the same (the fix often just changes what's in the shell vs streamed), but if anything regressed visually, you'll see it.",
   ].join('\n')
 
   return generateErrorInfo ? (

--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
@@ -97,6 +97,8 @@ function CopyPromptButton({
     "6. Check the shell isn't empty. A `<Suspense>` boundary placed too high (around the whole page body, or with `fallback={null}`) can leave the build reporting a shell while the shell itself contains nothing and everything streams. If that's what you see, pull the boundary down closer to the actual dynamic read.",
     '',
     "7. If the fix touched shared code (a layout, a wrapper, a sidebar), re-check the sibling routes too — a shell-level change can fix one route and break another. A before/after capture of the affected routes is a useful sanity check: the visible UI may look the same (the fix often just changes what's in the shell vs streamed), but if anything regressed visually, you'll see it.",
+    '',
+    'When you reply to the user, just summarize what you changed and why in plain prose. Don\'t echo this checklist back as headers, sections, or bullet lists labeled "Verification" or "Scope" — those are your internal steps, not the user\'s report.',
   ].join('\n')
 
   return generateErrorInfo ? (

--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
@@ -92,9 +92,9 @@ function CopyPromptButton({
     '',
     `4. Apply the chosen pattern to the code identified in step 2. Don't narrate the change with new comments — the code should explain itself. Only leave a comment when the *why* isn't clear (e.g. a deliberate Block with a reason).`,
     '',
-    `5. Verify the fix at runtime. The Insight clearing in the dev overlay confirms the build is happy, but not what actually renders. Reload the route in a browser and confirm the static shell still paints first and any new <Suspense> fallback resolves to its real content.`,
+    `5. Verify the fix at runtime. The Insight clearing in the dev overlay confirms the build is happy, but not what actually renders. Reload the route in a browser and confirm the static shell still paints first and any new \`<Suspense>\` fallback resolves to its real content.`,
     '',
-    "6. Check the shell isn't empty. A <Suspense> boundary placed too high (around the whole page body, or with `fallback={null}`) can leave the build reporting a shell while the shell itself contains nothing and everything streams. If that's what you see, pull the boundary down closer to the actual dynamic read.",
+    "6. Check the shell isn't empty. A `<Suspense>` boundary placed too high (around the whole page body, or with `fallback={null}`) can leave the build reporting a shell while the shell itself contains nothing and everything streams. If that's what you see, pull the boundary down closer to the actual dynamic read.",
     '',
     "7. If the fix touched shared code (a layout, a wrapper, a sidebar), re-check the sibling routes too — a shell-level change can fix one route and break another. A before/after capture of the affected routes is a useful sanity check: the visible UI may look the same (the fix often just changes what's in the shell vs streamed), but if anything regressed visually, you'll see it.",
   ].join('\n')


### PR DESCRIPTION
## What

Restructures the dev overlay's **Copy as prompt** body from three loosely-grouped instructions into a seven-step ordered checklist.

## Why

Agents tend to do one thing per step. The old step 4 bundled "reload in browser," "set up browser tooling," "check the shell," "re-check siblings," and a before/after capture into a single paragraph, so most of it got skipped.

Two other gotchas got their own steps: the empty-shell case (`<Suspense fallback={null}>` around the page body passes the build but renders nothing) and the sibling re-check on shared-code changes.

## How

Same checklist shape as the `next-cache-components-adoption` skill's per-route loop, so agents following either workflow apply the same sequence. Used for the in-overlay copy button and the prompt mirrored in `next dev` / `next build` terminal output.
