### PR TITLE
Document mixed router dynamic prefix behavior

### DIFF
--- a/docs/01-app/02-guides/migrating/app-router-migration.mdx
+++ b/docs/01-app/02-guides/migrating/app-router-migration.mdx
@@ -963,7 +963,13 @@ Learn more about [styling with Tailwind CSS](/docs/app/getting-started/css#tailw
 
 When navigating between routes served by the different Next.js routers, there will be a hard navigation. Automatic link prefetching with `next/link` will not prefetch across routers.
 
-Instead, you can [optimize navigations](https://vercel.com/guides/optimizing-hard-navigations) between App Router and Pages Router to retain the prefetched and fast page transitions. [Learn more](https://vercel.com/guides/optimizing-hard-navigations).
+> **Good to know**:
+>
+> Next.js uses a compact client router filter, implemented as a Bloom filter, to detect when a navigation from the Pages Router should be handled by the App Router. For dynamic App Router routes, the filter records the fixed path prefix before the first dynamic segment. For example, `app/shop/[locale]/about/page.tsx` uses the prefix `/shop`.
+>
+> A route that starts with a dynamic segment, such as `app/[locale]/about/page.tsx`, has no fixed prefix. Next.js cannot automatically identify it as an App Router destination during client-side navigation. If an overlapping dynamic Pages Router route also matches the URL, the Pages Router may handle the navigation instead.
+>
+> For links from the Pages Router to these routes, use a standard `<a>` element to force a hard navigation, or organize the App Router routes under a fixed prefix.
 
 ## Codemods
 

--- a/test/e2e/app-dir/interoperability-with-pages/app/[locale]/about/page.tsx
+++ b/test/e2e/app-dir/interoperability-with-pages/app/[locale]/about/page.tsx
@@ -1,0 +1,14 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+
+  return (
+    <main id="app-about-page">
+      <h1>App Router About</h1>
+      <p>Locale: {locale}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/interoperability-with-pages/app/[locale]/about/page.tsx
+++ b/test/e2e/app-dir/interoperability-with-pages/app/[locale]/about/page.tsx
@@ -1,14 +1,7 @@
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ locale: string }>
-}) {
-  const { locale } = await params
-
+export default function Page() {
   return (
     <main id="app-about-page">
       <h1>App Router About</h1>
-      <p>Locale: {locale}</p>
     </main>
   )
 }

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -36,6 +36,29 @@ describe('navigation between pages and app dir', () => {
     expect(await browser.elementById('app-page').text()).toBe('App Page')
   })
 
+  // The client router filter only records the static prefix before a dynamic
+  // segment. `/[locale]/about` has no static prefix, and recording `/` would
+  // make every route a possible App Router route. The Pages Router therefore
+  // handles this client navigation and matches `/[locale]/[category]`.
+  it('should use a dynamic pages route when the app route has no static prefix', async () => {
+    const browser = await next.browser('/en/some-page')
+
+    expect(await browser.elementByCss('#pages-some-page h1').text()).toBe(
+      'Pages Router Some Page'
+    )
+
+    await browser
+      .elementById('link-to-app-about')
+      .click()
+      .waitForElementByCss('#pages-category-page', { timeout: 30000 })
+
+    expect(new URL(await browser.url()).pathname).toBe('/en/about')
+    expect(await browser.hasElementByCssSelector('#app-about-page')).toBeFalse()
+    expect(
+      await browser.hasElementByCssSelector('#pages-category-page')
+    ).toBeTrue()
+  })
+
   // TODO: re-enable after 404 transition bug is addressed
   if (!(global as any).isNextDeploy) {
     it('It should be able to navigate pages -> app and go back an forward', async () => {

--- a/test/e2e/app-dir/interoperability-with-pages/pages/[locale]/[category]/index.tsx
+++ b/test/e2e/app-dir/interoperability-with-pages/pages/[locale]/[category]/index.tsx
@@ -1,0 +1,28 @@
+import type { GetStaticPropsContext } from 'next'
+
+const categories = ['test-category']
+
+export default function CategoryPage({ category }: { category: string }) {
+  return (
+    <main id="pages-category-page">
+      <h1>Pages Router Category: {category}</h1>
+    </main>
+  )
+}
+
+export function getStaticProps({ params }: GetStaticPropsContext) {
+  return {
+    props: {
+      category: params?.category,
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: categories.map((category) => ({
+      params: { category, locale: 'en' },
+    })),
+    fallback: false,
+  }
+}

--- a/test/e2e/app-dir/interoperability-with-pages/pages/[locale]/[category]/index.tsx
+++ b/test/e2e/app-dir/interoperability-with-pages/pages/[locale]/[category]/index.tsx
@@ -23,6 +23,8 @@ export function getStaticPaths() {
     paths: categories.map((category) => ({
       params: { category, locale: 'en' },
     })),
-    fallback: false,
+    // Allow arbitrary category segments such as `/en/about` to resolve to this
+    // dynamic route instead of returning a 404 in production.
+    fallback: 'blocking',
   }
 }

--- a/test/e2e/app-dir/interoperability-with-pages/pages/[locale]/some-page/index.tsx
+++ b/test/e2e/app-dir/interoperability-with-pages/pages/[locale]/some-page/index.tsx
@@ -1,0 +1,28 @@
+import type { GetStaticPropsContext } from 'next'
+import Link from 'next/link'
+
+export default function SomePage({ locale }: { locale: string }) {
+  return (
+    <main id="pages-some-page">
+      <h1>Pages Router Some Page</h1>
+      <Link id="link-to-app-about" href={`/${locale}/about`}>
+        Go to App Router about page
+      </Link>
+    </main>
+  )
+}
+
+export function getStaticProps({ params }: GetStaticPropsContext) {
+  return {
+    props: {
+      locale: params?.locale,
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { locale: 'en' } }],
+    fallback: false,
+  }
+}


### PR DESCRIPTION
## Summary

- Document that mixed-router detection uses fixed prefixes for dynamic App Router routes, including the limitation for routes that begin with a dynamic segment.
- Add an interoperability fixture and test that captures the expected Pages Router match for /[locale]/about during client-side navigation.
- Provide full-navigation and fixed-prefix migration guidance.

## Verification

- NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-turbo test/e2e/app-dir/interoperability-with-pages/navigation.test.ts -t "should use a dynamic pages route when the app route has no static prefix"
- pnpm lint-staged (passed via the commit hook)
- Not run: pnpm lint (unrelated unused Turbo Tasks and sandbox process-inspection EPERM)

<!-- NEXT_JS_LLM_PR -->