### PR TITLE
feat(eslint): add pageExtensions support to no-html-link-for-pages

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -10,6 +10,37 @@ import {
   getUrlFromAppDirectory,
 } from '../utils/url'
 
+/**
+ * Reads pageExtensions from next.config.js
+ */
+function getPageExtensions(rootDirs: string[]): string[] {
+  const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
+  
+  for (const dir of rootDirs) {
+    const configPaths = [
+      path.join(dir, 'next.config.js'),
+      path.join(dir, 'next.config.mjs'),
+      path.join(dir, 'next.config.cjs'),
+    ]
+    
+    for (const configPath of configPaths) {
+      if (fs.existsSync(configPath)) {
+        try {
+          delete require.cache[require.resolve(configPath)]
+          const config = require(configPath)
+          if (config.pageExtensions && Array.isArray(config.pageExtensions)) {
+            return config.pageExtensions
+          }
+        } catch {
+          // ignore errors reading config
+        }
+      }
+    }
+  }
+  
+  return defaultExtensions
+}
+
 const pagesDirWarning = execOnce((pagesDirs) => {
   console.warn(
     `Pages directory cannot be found at ${pagesDirs.join(' or ')}. ` +
@@ -107,8 +138,9 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageExtensions = getPageExtensions(rootDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, pageExtensions)
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, pageExtensions)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -13,8 +13,8 @@ function parseUrlForPages(urlprefix: string, directory: string, extensions: stri
     withFileTypes: true,
   })
   const res = []
-  const extPattern = new RegExp('\.(' + extensions.join('|') + ')$')
-  const indexPattern = new RegExp('^index\.(' + extensions.join('|') + ')$')
+  const extPattern = new RegExp('\\.(' + extensions.join('|') + ')$')
+  const indexPattern = new RegExp('^index\\.(' + extensions.join('|') + ')$')
   fsReadDirSyncCache[directory].forEach((dirent) => {
     if (extPattern.test(dirent.name)) {
       if (indexPattern.test(dirent.name)) {
@@ -41,9 +41,9 @@ function parseUrlForAppDir(urlprefix: string, directory: string, extensions: str
     withFileTypes: true,
   })
   const res = []
-  const extPattern = new RegExp('\.(' + extensions.join('|') + ')$')
-  const pagePattern = new RegExp('^page\.(' + extensions.join('|') + ')$')
-  const layoutPattern = new RegExp('^layout\.(' + extensions.join('|') + ')$')
+  const extPattern = new RegExp('\\.(' + extensions.join('|') + ')$')
+  const pagePattern = new RegExp('^page\\.(' + extensions.join('|') + ')$')
+  const layoutPattern = new RegExp('^layout\\.(' + extensions.join('|') + ')$')
   fsReadDirSyncCache[directory].forEach((dirent) => {
     if (extPattern.test(dirent.name)) {
       if (pagePattern.test(dirent.name)) {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -8,7 +8,7 @@ const fsReadDirSyncCache = {}
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(urlprefix: string, directory: string, extensions: string[] = ['js', 'jsx', 'ts', 'tsx']) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
@@ -26,7 +26,7 @@ function parseUrlForPages(urlprefix: string, directory: string) {
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensions))
       }
     }
   })
@@ -36,7 +36,7 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(urlprefix: string, directory: string, extensions: string[] = ['js', 'jsx', 'ts', 'tsx']) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
@@ -53,7 +53,7 @@ function parseUrlForAppDir(urlprefix: string, directory: string) {
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensions))
       }
     }
   })
@@ -136,7 +136,8 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensions: string[] = ['js', 'jsx', 'ts', 'tsx']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
@@ -156,7 +157,8 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensions: string[] = ['js', 'jsx', 'ts', 'tsx']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -13,16 +13,16 @@ function parseUrlForPages(urlprefix: string, directory: string, extensions: stri
     withFileTypes: true,
   })
   const res = []
+  const extPattern = new RegExp('\.(' + extensions.join('|') + ')$')
+  const indexPattern = new RegExp('^index\.(' + extensions.join('|') + ')$')
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (extPattern.test(dirent.name)) {
+      if (indexPattern.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(indexPattern, '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extPattern, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
@@ -41,14 +41,15 @@ function parseUrlForAppDir(urlprefix: string, directory: string, extensions: str
     withFileTypes: true,
   })
   const res = []
+  const extPattern = new RegExp('\.(' + extensions.join('|') + ')$')
+  const pagePattern = new RegExp('^page\.(' + extensions.join('|') + ')$')
+  const layoutPattern = new RegExp('^layout\.(' + extensions.join('|') + ')$')
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extPattern.test(dirent.name)) {
+      if (pagePattern.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pagePattern, '')}`)
+      } else if (!layoutPattern.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extPattern, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
@@ -143,7 +144,7 @@ export function getUrlFromPagesDirectories(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, extensions))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -164,7 +165,7 @@ export function getUrlFromAppDirectory(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, extensions))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.


### PR DESCRIPTION
## Description
Adds support for custom `pageExtensions` in the `@next/next/no-html-link-for-pages` ESLint rule. The rule now reads `pageExtensions` from `next.config.js` and uses those extensions when scanning for page files.

Fixes #53473

### Motivation
Currently, the rule only recognizes `.js`, `.jsx`, `.ts`, and `.tsx` files. When users configure custom `pageExtensions` in their `next.config.js`, the rule doesn't detect those pages and fails to report violations.

### Changes
- Modified `parseUrlForPages` and `parseUrlForAppDir` to accept an `extensions` parameter
- Added `getPageExtensions()` helper that reads `pageExtensions` from `next.config.js`
- Updated `getUrlFromPagesDirectories` and `getUrlFromAppDirectory` to pass extensions through
- Default extensions remain `['js', 'jsx', 'ts', 'tsx']` for backwards compatibility
