### PR TITLE
Split typeof-window server requires into .browser variants

### DIFF
--- a/crates/next-core/src/browser_variant_modules.rs
+++ b/crates/next-core/src/browser_variant_modules.rs
@@ -10,6 +10,7 @@
 // output) instead of collapsing short lists onto a single line.
 #[rustfmt::skip]
 pub static BROWSER_VARIANT_MODULES: &[&str] = &[
+    "client/components/client-boundary-params",
     "client/components/navigation-dynamic-rendering",
     "client/components/server-async-storage",
     "client/components/unstable-rethrow",

--- a/crates/next-core/src/browser_variant_modules.rs
+++ b/crates/next-core/src/browser_variant_modules.rs
@@ -10,5 +10,7 @@
 // output) instead of collapsing short lists onto a single line.
 #[rustfmt::skip]
 pub static BROWSER_VARIANT_MODULES: &[&str] = &[
+    "client/components/navigation-dynamic-rendering",
+    "client/components/server-async-storage",
     "client/components/unstable-rethrow",
 ];

--- a/packages/next/src/build/browser-variant-modules.ts
+++ b/packages/next/src/build/browser-variant-modules.ts
@@ -6,6 +6,7 @@
 // `packages/next/src/build/create-compiler-aliases.ts`. Paths are relative to
 // `packages/next/dist` (extension omitted).
 export const browserVariantModules = [
+  'client/components/client-boundary-params',
   'client/components/navigation-dynamic-rendering',
   'client/components/server-async-storage',
   'client/components/unstable-rethrow',

--- a/packages/next/src/build/browser-variant-modules.ts
+++ b/packages/next/src/build/browser-variant-modules.ts
@@ -6,5 +6,7 @@
 // `packages/next/src/build/create-compiler-aliases.ts`. Paths are relative to
 // `packages/next/dist` (extension omitted).
 export const browserVariantModules = [
+  'client/components/navigation-dynamic-rendering',
+  'client/components/server-async-storage',
   'client/components/unstable-rethrow',
 ] as const

--- a/packages/next/src/client/components/client-boundary-params.browser.ts
+++ b/packages/next/src/client/components/client-boundary-params.browser.ts
@@ -1,0 +1,4 @@
+// Browser variant of `./client-boundary-params`. In the browser the params and
+// searchParams are created at render time rather than dynamically tracked.
+export { createRenderParamsFromClient as createClientParams } from '../request/params.browser'
+export { createRenderSearchParamsFromClient as createClientSearchParams } from '../request/search-params.browser'

--- a/packages/next/src/client/components/client-boundary-params.ts
+++ b/packages/next/src/client/components/client-boundary-params.ts
@@ -1,0 +1,9 @@
+// Client-safe creation of the params/searchParams passed to client Page and
+// Segment components. On the server these produce dynamically-tracked values;
+// in the browser bundle this module is aliased to
+// `./client-boundary-params.browser` (see
+// scripts/generate-browser-variant-aliases.mjs), which produces the render-time
+// values. Both variants share the same call signature, so consumers call them
+// without branching on `typeof window`.
+export { createParamsFromClient as createClientParams } from '../../server/request/params'
+export { createSearchParamsFromClient as createClientSearchParams } from '../../server/request/search-params'

--- a/packages/next/src/client/components/client-page.tsx
+++ b/packages/next/src/client/components/client-page.tsx
@@ -6,6 +6,10 @@ import { LayoutRouterContext } from '../../shared/lib/app-router-context.shared-
 import { use } from 'react'
 import { urlSearchParamsToParsedUrlQuery } from '../route-params'
 import { SearchParamsContext } from '../../shared/lib/hooks-client-context.shared-runtime'
+import {
+  createClientParams,
+  createClientSearchParams,
+} from './client-boundary-params'
 
 /**
  * When the Page is a client component we send the params and searchParams to this client wrapper
@@ -46,35 +50,8 @@ export function ClientPageRoot({
     searchParams = urlSearchParamsToParsedUrlQuery(use(SearchParamsContext)!)
   }
 
-  if (typeof window === 'undefined') {
-    let clientSearchParams: Promise<ParsedUrlQuery>
-    let clientParams: Promise<Params>
+  const clientSearchParams = createClientSearchParams(searchParams)
+  const clientParams = createClientParams(params)
 
-    const { createSearchParamsFromClient } =
-      // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-      // ast-grep-ignore: no-typeof-window-require-tsx
-      require('../../server/request/search-params') as typeof import('../../server/request/search-params')
-    clientSearchParams = createSearchParamsFromClient(searchParams)
-
-    const { createParamsFromClient } =
-      // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-      // ast-grep-ignore: no-typeof-window-require-tsx
-      require('../../server/request/params') as typeof import('../../server/request/params')
-    clientParams = createParamsFromClient(params)
-
-    return <Component params={clientParams} searchParams={clientSearchParams} />
-  } else {
-    const { createRenderSearchParamsFromClient } =
-      // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-      // ast-grep-ignore: no-typeof-window-require-tsx
-      require('../request/search-params.browser') as typeof import('../request/search-params.browser')
-    const clientSearchParams = createRenderSearchParamsFromClient(searchParams)
-    const { createRenderParamsFromClient } =
-      // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-      // ast-grep-ignore: no-typeof-window-require-tsx
-      require('../request/params.browser') as typeof import('../request/params.browser')
-    const clientParams = createRenderParamsFromClient(params)
-
-    return <Component params={clientParams} searchParams={clientSearchParams} />
-  }
+  return <Component params={clientParams} searchParams={clientSearchParams} />
 }

--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -3,6 +3,7 @@
 import type { Params } from '../../server/request/params'
 import { LayoutRouterContext } from '../../shared/lib/app-router-context.shared-runtime'
 import { use } from 'react'
+import { createClientParams } from './client-boundary-params'
 
 /**
  * When the Page is a client component we send the params to this client wrapper
@@ -35,20 +36,7 @@ export function ClientSegmentRoot({
       layoutRouterContext !== null ? layoutRouterContext.parentParams : {}
   }
 
-  if (typeof window === 'undefined') {
-    const { createParamsFromClient } =
-      // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-      // ast-grep-ignore: no-typeof-window-require-tsx
-      require('../../server/request/params') as typeof import('../../server/request/params')
-    const clientParams: Promise<Params> = createParamsFromClient(params)
+  const clientParams = createClientParams(params)
 
-    return <Component {...slots} params={clientParams} />
-  } else {
-    const { createRenderParamsFromClient } =
-      // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-      // ast-grep-ignore: no-typeof-window-require-tsx
-      require('../request/params.browser') as typeof import('../request/params.browser')
-    const clientParams = createRenderParamsFromClient(params)
-    return <Component {...slots} params={clientParams} />
-  }
+  return <Component {...slots} params={clientParams} />
 }

--- a/packages/next/src/client/components/handle-isr-error.tsx
+++ b/packages/next/src/client/components/handle-isr-error.tsx
@@ -1,12 +1,4 @@
-const workAsyncStorage =
-  typeof window === 'undefined'
-    ? // prettier-ignore
-      (
-        // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-        // ast-grep-ignore: no-typeof-window-require-tsx
-        require('../../server/app-render/work-async-storage.external') as typeof import('../../server/app-render/work-async-storage.external')
-      ).workAsyncStorage
-    : undefined
+import { workAsyncStorage } from './server-async-storage'
 
 // if we are revalidating we want to re-throw the error so the
 // function crashes so we can maintain our previous cache

--- a/packages/next/src/client/components/navigation-dynamic-rendering.browser.ts
+++ b/packages/next/src/client/components/navigation-dynamic-rendering.browser.ts
@@ -1,0 +1,5 @@
+// Browser variant of `./navigation-dynamic-rendering`. The dynamic-rendering
+// hooks only run on the server; callers use optional calls, so these are
+// `undefined` in the browser.
+export const useDynamicRouteParams = undefined
+export const useDynamicSearchParams = undefined

--- a/packages/next/src/client/components/navigation-dynamic-rendering.ts
+++ b/packages/next/src/client/components/navigation-dynamic-rendering.ts
@@ -1,0 +1,11 @@
+// Client-safe access to the server-only dynamic-rendering hooks used by the
+// navigation hooks. On the server these re-export the real implementations; in
+// the browser bundle this module is aliased to
+// `./navigation-dynamic-rendering.browser` (see
+// scripts/generate-browser-variant-aliases.mjs), which exports `undefined` so
+// the server module is not bundled into the client. Callers use optional calls
+// (`useDynamicRouteParams?.(...)`), so the browser stub is a no-op.
+export {
+  useDynamicRouteParams,
+  useDynamicSearchParams,
+} from '../../server/app-render/dynamic-rendering'

--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react'
 import { PathnameContext } from '../../shared/lib/hooks-client-context.shared-runtime'
+import { workUnitAsyncStorage } from './server-async-storage'
 
 /**
  * This checks to see if the current render has any unknown route parameters that
@@ -9,13 +10,10 @@ import { PathnameContext } from '../../shared/lib/hooks-client-context.shared-ru
  * @returns true if there are any unknown route parameters, false otherwise
  */
 function hasFallbackRouteParams(): boolean {
+  // The AsyncLocalStorage module is kept out of the client bundle via the
+  // `./server-async-storage` browser alias; the guard ensures the stub is never
+  // dereferenced in the browser.
   if (typeof window === 'undefined') {
-    // AsyncLocalStorage should not be included in the client bundle.
-    const { workUnitAsyncStorage } =
-      // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-      // ast-grep-ignore: no-typeof-window-require
-      require('../../server/app-render/work-unit-async-storage.external') as typeof import('../../server/app-render/work-unit-async-storage.external')
-
     const workUnitStore = workUnitAsyncStorage.getStore()
     if (!workUnitStore) return false
 

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -18,25 +18,10 @@ import {
   getSelectedLayoutSegmentPath,
 } from '../../shared/lib/segment'
 
-const useDynamicRouteParams =
-  typeof window === 'undefined'
-    ? // prettier-ignore
-      (
-        // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-        // ast-grep-ignore: no-typeof-window-require
-        require('../../server/app-render/dynamic-rendering') as typeof import('../../server/app-render/dynamic-rendering')
-      ).useDynamicRouteParams
-    : undefined
-
-const useDynamicSearchParams =
-  typeof window === 'undefined'
-    ? // prettier-ignore
-      (
-        // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-        // ast-grep-ignore: no-typeof-window-require
-        require('../../server/app-render/dynamic-rendering') as typeof import('../../server/app-render/dynamic-rendering')
-      ).useDynamicSearchParams
-    : undefined
+import {
+  useDynamicRouteParams,
+  useDynamicSearchParams,
+} from './navigation-dynamic-rendering'
 
 const {
   instrumentParamsForClientValidation,

--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -5,16 +5,7 @@ import {
   isRedirectError,
   REDIRECT_ERROR_CODE,
 } from './redirect-error'
-
-const actionAsyncStorage =
-  typeof window === 'undefined'
-    ? // prettier-ignore
-      (
-        // TODO(browser-variant): migrate to a .ts/.browser.ts split so the browser bundle drops the server branch; see scripts/generate-browser-variant-aliases.mjs
-        // ast-grep-ignore: no-typeof-window-require
-        require('../../server/app-render/action-async-storage.external') as typeof import('../../server/app-render/action-async-storage.external')
-      ).actionAsyncStorage
-    : undefined
+import { actionAsyncStorage } from './server-async-storage'
 
 export function getRedirectError(
   url: string,

--- a/packages/next/src/client/components/server-async-storage.browser.ts
+++ b/packages/next/src/client/components/server-async-storage.browser.ts
@@ -1,0 +1,7 @@
+// Browser variant of `./server-async-storage`. The server-only async-storage
+// singletons don't exist in the browser, so these are `undefined`. Consumers
+// guard usage behind `typeof window === 'undefined'`, so the stubs are never
+// dereferenced.
+export const actionAsyncStorage = undefined
+export const workAsyncStorage = undefined
+export const workUnitAsyncStorage = undefined

--- a/packages/next/src/client/components/server-async-storage.ts
+++ b/packages/next/src/client/components/server-async-storage.ts
@@ -1,0 +1,9 @@
+// Client-safe access to the server-only async-storage singletons. On the
+// server these re-export the real storages; in the browser bundle this module
+// is aliased to `./server-async-storage.browser` (see
+// scripts/generate-browser-variant-aliases.mjs), which exports `undefined`
+// stubs so the AsyncLocalStorage modules are never bundled into the client.
+// Consumers must guard usage so the stubs are not dereferenced in the browser.
+export { actionAsyncStorage } from '../../server/app-render/action-async-storage.external'
+export { workAsyncStorage } from '../../server/app-render/work-async-storage.external'
+export { workUnitAsyncStorage } from '../../server/app-render/work-unit-async-storage.external'

--- a/test/e2e/app-dir/cache-components-errors/cache-components-client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-client-hook-abort-reasons.test.ts
@@ -315,7 +315,7 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#wrap-in-or-move-into-suspense
                    - [block] Set \`export const instant = false\` to allow a blocking route
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#allow-blocking-route
-                     at useDynamicSearchParams (webpack:///<next-src>)
+                     at Object.useDynamicSearchParams (webpack:///<next-src>)
                      at useSearchParams (webpack:///<next-src>)
                      at UseSearchParams (webpack:///app/client-hook-abort-reasons/client.tsx:27:18)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-search-params/[id]/page.tsx:8:7)

--- a/test/e2e/app-dir/cache-components-errors/cache-components-client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-client-hook-abort-reasons.test.ts
@@ -609,7 +609,7 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#wrap-in-or-move-into-suspense
                    - [block] Set \`export const instant = false\` to allow a blocking route
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#allow-blocking-route
-                     at useDynamicRouteParams (webpack:///<next-src>)
+                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at usePathname (webpack:///<next-src>)
                      at UsePathname (webpack:///app/client-hook-abort-reasons/client.tsx:22:14)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-pathname/[id]/page.tsx:7:7)
@@ -903,7 +903,7 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#wrap-in-or-move-into-suspense
                    - [block] Set \`export const instant = false\` to allow a blocking route
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#allow-blocking-route
-                     at useDynamicRouteParams (webpack:///<next-src>)
+                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-params/[id]/page.tsx:8:7)
@@ -1197,7 +1197,7 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#wrap-in-or-move-into-suspense
                    - [block] Set \`export const instant = false\` to allow a blocking route
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#allow-blocking-route
-                     at useDynamicRouteParams (webpack:///<next-src>)
+                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useSelectedLayoutSegments (webpack:///<next-src>)
                      at UseSelectedLayoutSegments (webpack:///app/client-hook-abort-reasons/client.tsx:37:28)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]/page.tsx:7:7)
@@ -1491,7 +1491,7 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#wrap-in-or-move-into-suspense
                    - [block] Set \`export const instant = false\` to allow a blocking route
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#allow-blocking-route
-                     at useDynamicRouteParams (webpack:///<next-src>)
+                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]/page.tsx:8:7)
@@ -2223,7 +2223,7 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#wrap-in-or-move-into-suspense
                    - [block] Set \`export const instant = false\` to allow a blocking route
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#allow-blocking-route
-                     at useDynamicRouteParams (webpack:///<next-src>)
+                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-params/[id]/page.tsx:7:7)
@@ -2735,7 +2735,7 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#wrap-in-or-move-into-suspense
                    - [block] Set \`export const instant = false\` to allow a blocking route
                      https://nextjs.org/docs/messages/blocking-prerender-client-hook#allow-blocking-route
-                     at useDynamicRouteParams (webpack:///<next-src>)
+                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]/page.tsx:8:7)

--- a/test/production/app-dir/browser-chunks/browser-chunks.test.ts
+++ b/test/production/app-dir/browser-chunks/browser-chunks.test.ts
@@ -76,34 +76,17 @@ describe('browser-chunks', () => {
       if (cacheComponents) {
         expect(serverSources).toMatchInlineSnapshot(`
          [
-           "src/server/app-render/action-async-storage-instance.ts",
-           "src/server/app-render/action-async-storage.external.ts",
-           "src/server/app-render/after-task-async-storage-instance.ts",
-           "src/server/app-render/after-task-async-storage.external.ts",
            "src/server/app-render/async-local-storage.ts",
-           "src/server/app-render/blocking-route-messages.ts",
-           "src/server/app-render/dynamic-access-async-storage-instance.ts",
-           "src/server/app-render/dynamic-access-async-storage.external.ts",
-           "src/server/app-render/dynamic-rendering.ts",
            "src/server/app-render/instant-validation/boundary-constants.ts",
            "src/server/app-render/instant-validation/boundary-impl.tsx",
-           "src/server/app-render/instant-validation/boundary-tracking.tsx",
            "src/server/app-render/instant-validation/instant-samples-client.ts",
            "src/server/app-render/instant-validation/instant-samples.ts",
            "src/server/app-render/instant-validation/instant-validation-error.ts",
            "src/server/app-render/staged-rendering.ts",
-           "src/server/app-render/vary-params.ts",
            "src/server/app-render/work-async-storage-instance.ts",
            "src/server/app-render/work-async-storage.external.ts",
            "src/server/app-render/work-unit-async-storage-instance.ts",
            "src/server/app-render/work-unit-async-storage.external.ts",
-           "src/server/create-deduped-by-callsite-server-error-logger.ts",
-           "src/server/dynamic-rendering-utils.ts",
-           "src/server/lib/params-utils.ts",
-           "src/server/request/params.ts",
-           "src/server/request/search-params.ts",
-           "src/server/request/utils.ts",
-           "src/server/runtime-reacts.external.ts",
            "src/server/web/spec-extension/adapters/headers.ts",
            "src/server/web/spec-extension/adapters/reflect.ts",
            "src/server/web/spec-extension/adapters/request-cookies.ts",
@@ -111,40 +94,7 @@ describe('browser-chunks', () => {
          ]
         `)
       } else {
-        expect(serverSources).toMatchInlineSnapshot(`
-         [
-           "src/server/app-render/action-async-storage-instance.ts",
-           "src/server/app-render/action-async-storage.external.ts",
-           "src/server/app-render/after-task-async-storage-instance.ts",
-           "src/server/app-render/after-task-async-storage.external.ts",
-           "src/server/app-render/async-local-storage.ts",
-           "src/server/app-render/blocking-route-messages.ts",
-           "src/server/app-render/dynamic-access-async-storage-instance.ts",
-           "src/server/app-render/dynamic-access-async-storage.external.ts",
-           "src/server/app-render/dynamic-rendering.ts",
-           "src/server/app-render/instant-validation/boundary-constants.ts",
-           "src/server/app-render/instant-validation/boundary-tracking.tsx",
-           "src/server/app-render/instant-validation/instant-samples.ts",
-           "src/server/app-render/instant-validation/instant-validation-error.ts",
-           "src/server/app-render/staged-rendering.ts",
-           "src/server/app-render/vary-params.ts",
-           "src/server/app-render/work-async-storage-instance.ts",
-           "src/server/app-render/work-async-storage.external.ts",
-           "src/server/app-render/work-unit-async-storage-instance.ts",
-           "src/server/app-render/work-unit-async-storage.external.ts",
-           "src/server/create-deduped-by-callsite-server-error-logger.ts",
-           "src/server/dynamic-rendering-utils.ts",
-           "src/server/lib/params-utils.ts",
-           "src/server/request/params.ts",
-           "src/server/request/search-params.ts",
-           "src/server/request/utils.ts",
-           "src/server/runtime-reacts.external.ts",
-           "src/server/web/spec-extension/adapters/headers.ts",
-           "src/server/web/spec-extension/adapters/reflect.ts",
-           "src/server/web/spec-extension/adapters/request-cookies.ts",
-           "src/server/web/spec-extension/cookies.ts",
-         ]
-        `)
+        expect(serverSources).toMatchInlineSnapshot(`[]`)
       }
     } else {
       if (cacheComponents) {

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -299,7 +299,7 @@ describe('build-output-prerender', () => {
              - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
                https://nextjs.org/docs/messages/blocking-prerender-current-time-client#for-telemetry-use-a-timing-api
                at Page (webpack:///app/client/page.tsx:4:28)
-               at ClientPageRoot (webpack:///src/client/components/client-page.tsx:65:12)
+               at ClientPageRoot (webpack:///src/client/components/client-page.tsx:56:10)
              2 |
              3 | export default function Page() {
            > 4 |   return <p>Current time: {new Date().toISOString()}</p>


### PR DESCRIPTION
First batch of fixes that addresses most of the recent bundle size regressions. 

Part of https://linear.app/vercel/issue/NAR-860/