### PR TITLE
[ci] Add support for auth based preview build registries

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -142,6 +142,9 @@ env:
   VERCEL_ADAPTER_TEST_TEAM: vtest314-next-adapter-e2e-tests
   VERCEL_TURBOPACK_TEST_TOKEN: ${{ secrets.VERCEL_TURBOPACK_TEST_TOKEN }}
   VERCEL_TURBOPACK_TEST_TEAM: vtest314-next-turbo-e2e-tests
+  # Read token for the auth-protected preview-builds npm mirror, used by deploy
+  # tests to install Next.js artifacts during the remote build.
+  PREVIEW_BUILDS_READ_TOKEN: ${{ secrets.PREVIEW_BUILDS_READ_TOKEN }}
   NEXT_TEST_PREFER_OFFLINE: 1
   NEXT_CI_RUNNER: ${{ inputs.runs_on_labels }}
   NEXT_TEST_PROXY_ADDRESS: ${{ inputs.overrideProxyAddress || '' }}

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -98,13 +98,18 @@ async function main() {
       ? `${previewBuildsBaseUrl}/commits/${commitSha}/next`
       : undefined
 
+  const previewBuildsReadToken = process.env.PREVIEW_BUILDS_READ_TOKEN
+
   if (nextTestVersion) {
     console.log(`Verifying artifacts for commit ${commitSha}`)
     // Attempt to fetch the deploy artifacts for the commit
     // These might take a moment to become available, so we'll retry a few times
+    const fetchHeaders = previewBuildsReadToken
+      ? { Authorization: `Bearer ${previewBuildsReadToken}` }
+      : undefined
     const fetchWithRetry = async (url, retries = 5, timeout = 5000) => {
       for (let i = 0; i < retries; i++) {
-        const res = await fetch(url)
+        const res = await fetch(url, { headers: fetchHeaders })
         if (res.ok) {
           return res
         } else if (i < retries - 1) {
@@ -162,6 +167,7 @@ async function main() {
           ...process.env,
           NEXT_TEST_MODE: testMode,
           NEXT_TEST_VERSION: nextTestVersion,
+          NEXT_TEST_PREVIEW_BUILDS_BASE_URL: previewBuildsBaseUrl,
           NEXT_EXTERNAL_TESTS_FILTERS,
           NEXT_FLAKE_DETECTION: '1',
           IS_TURBOPACK_TEST: '1',
@@ -182,6 +188,7 @@ async function main() {
           NEXT_EXTERNAL_TESTS_FILTERS,
           NEXT_TEST_MODE: testMode,
           NEXT_TEST_VERSION: nextTestVersion,
+          NEXT_TEST_PREVIEW_BUILDS_BASE_URL: previewBuildsBaseUrl,
           IS_WEBPACK_TEST: '1',
           NEXT_TEST_SKIP_RESULT_CACHE: '1',
         },

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -189,6 +189,8 @@ export class NextDeployInstance extends NextInstance {
     super.setup(parentSpan)
     await super.createTestDir({ parentSpan, skipInstall: true })
 
+    await this.writeMirrorNpmrcIfNecessary()
+
     const existingDeployUrl = process.env.NEXT_TEST_DEPLOY_URL?.trim()
     const customDeployScriptPath =
       process.env.NEXT_TEST_DEPLOY_SCRIPT_PATH?.trim()
@@ -451,6 +453,30 @@ export class NextDeployInstance extends NextInstance {
     this.parseIdsFromCliOuput()
     // Use the stdout from the logs command as the CLI output. The CLI will
     // output other unrelated logs to stderr.
+  }
+
+  // When the preview-builds npm mirror is auth-protected, the deploy build
+  // installs Next.js artifacts from it and needs credentials. We write an
+  // `.npmrc` with a read token (provided as a CI secret) so the remote install
+  // can authenticate. Only written when the token is set, so unprotected and
+  // local deploy runs are unaffected.
+  private async writeMirrorNpmrcIfNecessary(): Promise<void> {
+    const token = process.env.PREVIEW_BUILDS_READ_TOKEN
+    const baseUrlRaw = process.env.NEXT_TEST_PREVIEW_BUILDS_BASE_URL
+
+    if (!token || !baseUrlRaw) {
+      return
+    }
+
+    const baseUrl = new URL(baseUrlRaw)
+    // Derive the npmrc auth key from the mirror base URL: strip the scheme and
+    // ensure a trailing slash so it matches requests to that registry path.
+    const registryKey = `//${baseUrl.host}${baseUrl.pathname.replace(/\/?$/, '/')}`
+
+    await fs.writeFile(
+      path.join(this.testDir, '.npmrc'),
+      `${registryKey}:_authToken=${token}\n`
+    )
   }
 
   private async configureProxyAddress(): Promise<void> {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/93464 which didn't consider auth based preview build registries.

