### PR TITLE
Bump Rust toolchain

### DIFF
--- a/.devcontainer/rust/devcontainer-feature.json
+++ b/.devcontainer/rust/devcontainer-feature.json
@@ -5,7 +5,7 @@
   "dependsOn": {
     "ghcr.io/devcontainers/features/rust:1": {
       // this should match the `rust-toolchain.toml`
-      "version": "nightly-2026-05-15",
+      "version": "nightly-2026-06-24",
       "profile": "minimal",
       "components": "rustfmt,clippy,rust-analyzer"
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
 # if you move the file, also update any turbo.json inputs that references it.
 [toolchain]
-channel = "nightly-2026-05-15"
+channel = "nightly-2026-06-24"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1478,7 +1478,7 @@ fn get_import_symbol_from_export(specifier: &ExportSpecifier) -> ImportedSymbol 
 
 #[cfg(test)]
 mod tests {
-    use swc_core::{atoms::Atom, common::DUMMY_SP, ecma::ast::*};
+    use swc_core::{atoms::Atom, common::DUMMY_SP};
 
     use super::*;
 


### PR DESCRIPTION
Bump rust nightly version

Critically this fixes a bug in Rust Analyzer where it didn't understand 'pattern_types' a new rust feature that is used by `NonZero<T>` types for example)

![image.png](https://app.graphite.com/user-attachments/assets/04c3a119-d08b-457a-bd55-6fe94da24806.png)

So now we can get feedback on the size of types containing vc!

From scanning release notes there is nothing major that i can see.  Clippy did flag one new warning that is being addressed as well.