### PR TITLE
next-dev-loop: require agent-browser >= 0.31.1

### DIFF
--- a/skills/next-dev-loop/SKILL.md
+++ b/skills/next-dev-loop/SKILL.md
@@ -32,7 +32,7 @@ The two views cross-check each other.
 
 - Next.js **16.3+** with **Turbopack** — `/_next/mcp` plus the
   proactive compile check via `get_compilation_issues`.
-- `agent-browser` **>= 0.31.0** — React introspection, worktree-scoped
+- `agent-browser` **>= 0.31.1** — React introspection, worktree-scoped
   `session id`, idempotent `--restore`, and launch flag reconciliation.
 
 These are hard floors, not soft preferences. If anything is missing,


### PR DESCRIPTION
## Summary

Bump the `agent-browser` floor in the `next-dev-loop` skill from `>= 0.31.0` to `>= 0.31.1`.

One-line change to the `requires` section; the listed capabilities (React introspection, worktree-scoped `session id`, idempotent `--restore`, launch-flag reconciliation) are unchanged.

## Verification

- `prettier --check skills/next-dev-loop/SKILL.md` → clean.

<!-- NEXT_JS_LLM_PR -->