### PR TITLE
[ci] skip Datadog git metadata upload on junit upload

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -427,6 +427,7 @@ jobs:
           # Add a `nextjs.test_session.name` tag to help identify the job
           if [ -d ./test/test-junit-report ]; then
             "$DATADOG_CI_PATH" junit upload \
+              --skip-git-metadata-upload \
               --service nextjs \
               --tags test.type:nextjs \
               --tags test_session.name:"${{ inputs.stepName }}" \
@@ -435,6 +436,7 @@ jobs:
           fi
           if [ -d ./test/turbopack-test-junit-report ]; then
             "$DATADOG_CI_PATH" junit upload \
+              --skip-git-metadata-upload \
               --service nextjs \
               --tags test.type:turbopack \
               --tags test_session.name:"${{ inputs.stepName }}" \

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -256,7 +256,7 @@ jobs:
         if: ${{ env.DATADOG_API_KEY != '' }}
         run: |
           if [ -d ./test/test-junit-report ]; then
-            DD_ENV=ci "$DATADOG_CI_PATH" junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
+            DD_ENV=ci "$DATADOG_CI_PATH" junit upload --skip-git-metadata-upload --tags test.type:deploy --service nextjs ./test/test-junit-report
           fi
 
   upload-adapter-test-results:


### PR DESCRIPTION
Pass `--skip-git-metadata-upload` to all `datadog-ci junit upload` invocations. This stops the in-CI git metadata sync, which forces an expensive `git fetch` unshallow on every shallow CI checkout before each test-report upload. On Windows builds we even saw this timing out.

We don't need to upload git metadata manually since our GH actions are directly integrated with DataDog via app.

> Git metadata upload is only required if you can’t integrate your CI provider directly with Datadog. If you are using a [source code provider integration](https://docs.datadoghq.com/code_coverage/setup/?tab=github#integrate-with-source-code-provider), such as Datadog GitHub app or Gitlab integration, you can disable the git metadata upload by passing the --skip-git-metadata-upload=1 flag to the datadog-ci coverage upload command, like this:

--https://docs.datadoghq.com/code_coverage/setup/?tab=github#coverage-upload-outputs-could-not-sync-git-metadata-error

## test plan

- [x] no more unshallow when uploading junit reports to DataDog: [upload from this branch shows no "syncing git metadata"](https://github.com/vercel/next.js/actions/runs/28252881331/job/83708778650?pr=95210#step:38:113) that [you'd used to see on prior uploads](https://github.com/vercel/next.js/actions/runs/28252765955/job/83708485242?pr=95207#step:38:112)