### PR TITLE
[turbopack] Don't evict when there is little memory to save

### DIFF
--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -21,7 +21,7 @@ use turbo_tasks::{
     message_queue::{CompilationEvent, Severity},
 };
 use turbo_tasks_backend::{
-    BackendOptions, GitVersionInfo, StartupCacheState, TurboTasksBackend,
+    BackendOptions, EvictionMode, GitVersionInfo, StartupCacheState, TurboTasksBackend,
     db_invalidation::invalidation_reasons, noop_backing_storage, turbo_backing_storage,
 };
 
@@ -35,7 +35,7 @@ pub type NextTurboTasks = Arc<TurboTasks<TurboTasksBackend>>;
 /// It should not be passed to a [`turbo_tasks::function`]. For serializable information about the
 /// project, use the [`next_api::project::Project`] type instead.
 ///
-/// This type is a wrapper around an [`Arc`] and is therefore cheaply clonable. It is [`Send`] and
+/// This type is a wrapper around an [`Arc`] and is therefore cheaply cloneable. It is [`Send`] and
 /// [`Sync`].
 #[derive(Clone)]
 pub struct NextTurbopackContext {
@@ -224,22 +224,29 @@ pub fn git_version_info(describe: &str) -> GitVersionInfo<'_> {
 
 /// Turbopack's memory eviction strategy for the persistent cache, mirroring the
 /// `experimental.turbopackMemoryEviction` config option.
+///
+/// This is a napi-facing mirror of [`EvictionMode`] (the backend crate can't
+/// depend on napi). Keep the variants in sync; the `From` impl below is
+/// exhaustive, so adding a variant to one enum forces updating the other.
 #[napi(string_enum = "lowercase")]
 #[derive(Debug, PartialEq, Eq)]
 pub enum MemoryEvictionMode {
     /// Never evict.
     Off,
+    /// Evict after a snapshot only once enough memory has been allocated since
+    /// the last eviction to justify the cost of restoring evicted tasks.
+    Auto,
     /// After every snapshot, evict all evictable tasks from memory, reloading
     /// them from disk on demand.
     Full,
 }
 
-impl MemoryEvictionMode {
-    /// Whether this mode evicts evictable tasks after each snapshot.
-    fn evicts_after_snapshot(self) -> bool {
-        match self {
-            Self::Off => false,
-            Self::Full => true,
+impl From<MemoryEvictionMode> for EvictionMode {
+    fn from(mode: MemoryEvictionMode) -> Self {
+        match mode {
+            MemoryEvictionMode::Off => EvictionMode::Off,
+            MemoryEvictionMode::Auto => EvictionMode::Auto,
+            MemoryEvictionMode::Full => EvictionMode::Full,
         }
     }
 }
@@ -254,7 +261,6 @@ pub fn create_turbo_tasks(
     skip_compaction: bool,
     turbopack_memory_eviction: MemoryEvictionMode,
 ) -> Result<NextTurboTasks> {
-    let evict_after_snapshot = turbopack_memory_eviction.evicts_after_snapshot();
     Ok(if persistent_caching {
         let describe = cache_describe(next_version);
         let version_info = git_version_info(&describe);
@@ -276,7 +282,7 @@ pub fn create_turbo_tasks(
                 }),
                 dependency_tracking,
                 num_workers: Some(tokio::runtime::Handle::current().metrics().num_workers()),
-                evict_after_snapshot,
+                eviction_mode: EvictionMode::from(turbopack_memory_eviction),
                 ..Default::default()
             },
             backing_storage,

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackMemoryEviction.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackMemoryEviction.mdx
@@ -6,12 +6,13 @@ description: Learn how to control Turbopack's memory eviction strategy for the p
 
 ## Usage
 
-`turbopackMemoryEviction` controls how whether Turbopack reclaims memory while the persistent (FileSystem) cache is enabled. After Turbopack writes a snapshot of its cache to disk, it can 'evict' the in-memory copies of that data and reload them from disk on demand.
+`turbopackMemoryEviction` controls whether Turbopack reclaims memory while the persistent (FileSystem) cache is enabled. After Turbopack writes a snapshot of its cache to disk, it can 'evict' the in-memory copies of that data and reload them from disk on demand.
 
-Currently there are two options
+Currently there are three options
 
 - `false`: never evict. Cached data stays in memory for the lifetime of the process.
-- `'full'` (default): after every snapshot, evict all possible data from memory. They are reloaded from disk on demand.
+- `'auto'` (default): evict after a snapshot only once enough memory has been allocated since the last eviction to make it worthwhile. Leverages thresholds and memory pressure feedback from the operating system.
+- `'full'`: evict all possible data from memory every time we save to disk.
 
 > **Good to know:** This option only has an effect in `next dev` sessions when the [FileSystem Cache](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled, since eviction relies on data already being persisted to disk. It is experimental and under active development.
 
@@ -20,8 +21,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   experimental: {
-    // Evict in-memory cache data after each snapshot to reduce memory usage
-    turbopackMemoryEviction: 'full',
+    turbopackMemoryEviction: 'auto',
   },
 }
 
@@ -32,8 +32,7 @@ export default nextConfig
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    // Evict in-memory cache data after each snapshot to reduce memory usage
-    turbopackMemoryEviction: 'full',
+    turbopackMemoryEviction: 'auto',
   },
 }
 

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -550,6 +550,11 @@ export const enum MemoryEvictionMode {
    * them from disk on demand.
    */
   Full = 'full',
+  /**
+   * Evict after a snapshot only once enough memory has been allocated since
+   * the last eviction to justify the cost of restoring evicted tasks.
+   */
+  Auto = 'auto',
 }
 export declare function rootTaskDispose(rootTask: {
   __napiType: 'RootTask'

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -541,20 +541,24 @@ export interface TurbopackInternalErrorOpts {
 /**
  * Turbopack's memory eviction strategy for the persistent cache, mirroring the
  * `experimental.turbopackMemoryEviction` config option.
+ *
+ * This is a napi-facing mirror of [`EvictionMode`] (the backend crate can't
+ * depend on napi). Keep the variants in sync; the `From` impl below is
+ * exhaustive, so adding a variant to one enum forces updating the other.
  */
 export const enum MemoryEvictionMode {
   /** Never evict. */
   Off = 'off',
   /**
-   * After every snapshot, evict all evictable tasks from memory, reloading
-   * them from disk on demand.
-   */
-  Full = 'full',
-  /**
    * Evict after a snapshot only once enough memory has been allocated since
    * the last eviction to justify the cost of restoring evicted tasks.
    */
   Auto = 'auto',
+  /**
+   * After every snapshot, evict all evictable tasks from memory, reloading
+   * them from disk on demand.
+   */
+  Full = 'full',
 }
 export declare function rootTaskDispose(rootTask: {
   __napiType: 'RootTask'

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -371,7 +371,7 @@ export const experimentalSchema = {
   webpackBuildWorker: z.boolean().optional(),
   webpackMemoryOptimizations: z.boolean().optional(),
   turbopackMemoryEviction: z
-    .union([z.literal(false), z.literal('full')])
+    .union([z.literal(false), z.literal('full'), z.literal('auto')])
     .optional(),
   turbopackPluginRuntimeStrategy: z
     .enum(['workerThreads', 'childProcesses'])

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -730,10 +730,11 @@ export interface ExperimentalConfig {
    *
    * - `false`: disable eviction.
    * - `'full'`: after every snapshot, drop as much memory as possible.
+   * - `'auto'`: evict after a snapshot when we expect to save a lot of memory or the system is under pressure
    *
-   * Defaults to `'full'`
+   * Defaults to `'auto'`
    */
-  turbopackMemoryEviction?: false | 'full'
+  turbopackMemoryEviction?: false | 'full' | 'auto'
 
   /**
    * Selects the backend used by Turbopack for Node.js evaluation, e.g. webpack

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -438,7 +438,8 @@ function assignDefaultsAndValidate(
       turbopackMemoryEvictionMode = result.experimental.turbopackMemoryEviction
       break
     case undefined:
-      // Not set by the user: enable eviction in 'auto' mode by default
+    default:
+      // Not set by the user, or an invalid value, use the default.
       turbopackMemoryEvictionMode = 'auto'
   }
   ;(result as NextConfigComplete).experimental.turbopackMemoryEvictionMode =

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -425,18 +425,21 @@ function assignDefaultsAndValidate(
   }
 
   // Normalize the user-facing `turbopackMemoryEviction` (`false | 'full' |
-  // undefined`) into the `turbopackMemoryEvictionMode` enum expected by napi
-  // (`'off' | 'full'`).
-  let turbopackMemoryEvictionMode: 'off' | 'full'
-  if (result.experimental.turbopackMemoryEviction === false) {
-    turbopackMemoryEvictionMode = 'off'
-  } else if (result.experimental.turbopackMemoryEviction === 'full') {
-    turbopackMemoryEvictionMode = 'full'
-  } else {
-    // Not set by the user: fall back to the env var if present, otherwise 'off'.
-    const rawEnv = process.env.TURBO_ENGINE_EVICT_AFTER_SNAPSHOT
-    turbopackMemoryEvictionMode =
-      rawEnv == null || rawEnv === '1' || rawEnv === 'true' ? 'full' : 'off'
+  // 'auto' | undefined`) into the `turbopackMemoryEvictionMode` enum expected by
+  // napi (`'off' | 'full' | 'auto'`).
+  let turbopackMemoryEvictionMode: 'off' | 'full' | 'auto'
+
+  switch (result.experimental.turbopackMemoryEviction) {
+    case false:
+      turbopackMemoryEvictionMode = 'off'
+      break
+    case 'full':
+    case 'auto':
+      turbopackMemoryEvictionMode = result.experimental.turbopackMemoryEviction
+      break
+    case undefined:
+      // Not set by the user: enable eviction in 'auto' mode by default
+      turbopackMemoryEvictionMode = 'auto'
   }
   ;(result as NextConfigComplete).experimental.turbopackMemoryEvictionMode =
     turbopackMemoryEvictionMode as MemoryEvictionMode

--- a/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
@@ -135,8 +135,6 @@ fn scale_threshold(base: usize, pressure: Option<u8>) -> usize {
 mod tests {
     use super::{EvictionControl, EvictionMode, scale_threshold};
 
-    const BASE: usize = 128 * 1024 * 1024;
-
     #[test]
     fn off_mode_never_evicts() {
         let mut control = EvictionControl::new(EvictionMode::Off);
@@ -180,22 +178,19 @@ mod tests {
     }
 
     #[test]
-    fn scale_threshold() {
-        assert_eq!(scale_threshold(BASE, Some(0)), BASE);
-        assert_eq!(scale_threshold(BASE, Some(50)), BASE / 2);
-        assert_eq!(scale_threshold(BASE, Some(100)), 0);
+    fn scale_threshold_behavior() {
+        assert_eq!(scale_threshold(100, Some(0)), 100);
+        assert_eq!(scale_threshold(100, Some(50)), 50);
+        assert_eq!(scale_threshold(100, Some(100)), 0);
         // Pressure is documented as 0..=100; values above clamp to 100.
-        assert_eq!(
-            scale_threshold(BASE, Some(200)),
-            scale_threshold(BASE, Some(100))
-        );
+        assert_eq!(scale_threshold(100, Some(200)), 0);
     }
 
     #[test]
     fn scale_threshold_is_monotonic_non_increasing() {
-        let mut prev = scale_threshold(BASE, Some(0));
+        let mut prev = scale_threshold(100, Some(0));
         for p in 1..=100u8 {
-            let cur = scale_threshold(BASE, Some(p));
+            let cur = scale_threshold(100, Some(p));
             assert!(
                 cur <= prev,
                 "threshold should not increase with pressure: p={p}, cur={cur}, prev={prev}"

--- a/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
@@ -1,0 +1,206 @@
+//! Eviction policy for the background snapshot loop.
+//!
+//! When the persistent cache is enabled, the backend periodically snapshots its
+//! in-memory state to disk. After a snapshot it may evict the evictable tasks
+//! from memory and reload them from disk on demand. [`EvictionControl`] decides
+//! whether each snapshot cycle should run such a sweep, based on the configured
+//! [`EvictionMode`].
+
+use std::sync::LazyLock;
+
+use turbo_tasks_malloc::TurboMalloc;
+
+/// Strategy for evicting evictable tasks from in-memory storage after a
+/// snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictionMode {
+    /// Never evict.
+    Off,
+    /// Evict after a snapshot only once enough memory has been allocated since
+    /// the last eviction to justify the cost of restoring evicted tasks on
+    /// demand. Uses allocator statistics to estimate reclaimable memory.
+    /// See [`EvictionControl::auto_threshold_exceeded`].
+    Auto,
+    /// After every snapshot, evict all evictable tasks from memory, reloading
+    /// them from disk on demand.
+    Full,
+}
+
+/// Owns the eviction policy for the development time background snapshot loop: the configured
+/// [`EvictionMode`] plus the threshold bookkeeping for [`EvictionMode::Auto`].
+pub(crate) struct EvictionControl {
+    mode: EvictionMode,
+    /// Global net live bytes ([`TurboMalloc::memory_usage`]) sampled immediately
+    /// after the most recent eviction, or `None` before the first eviction.
+    /// Only meaningful in [`EvictionMode::Auto`].
+    memory_at_last_eviction: Option<usize>,
+}
+
+impl EvictionControl {
+    pub(crate) fn new(mode: EvictionMode) -> Self {
+        Self {
+            mode,
+            memory_at_last_eviction: None,
+        }
+    }
+
+    /// Whether any prior cycle has evicted. Derived from the recorded baseline,
+    /// which [`EvictionControl::record_eviction`] sets after each sweep.
+    fn has_evicted_before(&self) -> bool {
+        self.memory_at_last_eviction.is_some()
+    }
+
+    /// Whether to run an eviction sweep this snapshot cycle.
+    ///
+    /// `snapshot_had_new_data` is whether the just-completed snapshot persisted
+    /// new data. We only evict when there's new data to persist (the common case)
+    /// or on the very first eviction after startup (data was already on disk from
+    /// a prior run, so `snapshot_had_new_data` may be false but in-memory state
+    /// can still be evicted).
+    ///
+    /// Within that, `Off` never evicts, `Full` always evicts, and `Auto` requires
+    /// enough net memory allocated since the last eviction to justify the
+    /// restore-then-re-evict churn (always evicting the first time, since there's
+    /// no prior baseline).
+    pub(crate) fn should_evict(&self, snapshot_had_new_data: bool) -> bool {
+        // Only evict when there's new data to persist, or on the very first
+        // eviction after startup (restored on-disk state can be reclaimed even
+        // when this snapshot had no new data).
+        if !snapshot_had_new_data && self.has_evicted_before() {
+            return false;
+        }
+        match self.mode {
+            EvictionMode::Off => false,
+            EvictionMode::Full => {
+                if !snapshot_had_new_data && self.has_evicted_before() {
+                    return false;
+                }
+                true
+            }
+            EvictionMode::Auto => self.auto_threshold_exceeded(),
+        }
+    }
+
+    /// For [`EvictionMode::Auto`]: whether enough net memory has been allocated
+    /// since the last eviction to justify another sweep. Always evicts the first
+    /// time (no prior baseline). The threshold scales down under OS memory
+    /// pressure so we evict more eagerly when memory is tight.
+    fn auto_threshold_exceeded(&self) -> bool {
+        /// Minimum net bytes ([`TurboMalloc::memory_usage`] delta) that must be
+        /// allocated since the last eviction before another is worthwhile.
+        /// Allocated bytes are the proxy for how much a sweep would reclaim.
+        /// Default 128 MiB; overridable via `TURBO_ENGINE_EVICT_MIN_BYTES`.
+        static MIN_EVICT_BYTES: LazyLock<usize> = LazyLock::new(|| {
+            std::env::var("TURBO_ENGINE_EVICT_MIN_BYTES")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(128 * 1024 * 1024)
+        });
+        let Some(last) = self.memory_at_last_eviction else {
+            // First eviction: no baseline to compare against, so always evict.
+            return true;
+        };
+        let current = TurboMalloc::memory_usage();
+        // saturating: if memory shrank since the last eviction there is nothing
+        // new to reclaim, so the delta is 0 and we skip.
+        let allocated_since = current.saturating_sub(last);
+        let threshold = scale_threshold(*MIN_EVICT_BYTES, TurboMalloc::memory_pressure());
+        allocated_since >= threshold
+    }
+
+    /// Call after completing an eviction cycle.
+    pub(crate) fn record_eviction(&mut self) {
+        self.memory_at_last_eviction = Some(TurboMalloc::memory_usage());
+    }
+}
+
+/// Scale a base eviction threshold down linearly with OS memory pressure.
+///
+/// `threshold = base * (1 - pressure / 100)`. At pressure 0 the base is
+/// unchanged; at pressure 100 the threshold is 0, so every cycle evicts (the
+/// `Auto` mode degrades to `Full` when memory is maxed out, reclaiming as much
+/// as possible). When pressure is unavailable (`None`) the base is returned
+/// unchanged.
+fn scale_threshold(base: usize, pressure: Option<u8>) -> usize {
+    match pressure {
+        // Integer math, multiply before divide to avoid truncation. `p` is
+        // clamped to 0..=100, so `100 - p` never underflows and the result is in
+        // `0..=base`. `base * 100` stays well within usize on 64-bit targets.
+        Some(p) => base * (100 - p.min(100) as usize) / 100,
+        None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EvictionControl, EvictionMode, scale_threshold};
+
+    const BASE: usize = 128 * 1024 * 1024;
+
+    #[test]
+    fn off_mode_never_evicts() {
+        let mut control = EvictionControl::new(EvictionMode::Off);
+        for &new_data in &[true, false] {
+            assert!(!control.should_evict(new_data));
+            // Even after a (forced) eviction, Off never evicts.
+            control.record_eviction();
+            assert!(!control.should_evict(new_data));
+        }
+    }
+
+    #[test]
+    fn full_mode_evicts_on_new_data() {
+        let mut control = EvictionControl::new(EvictionMode::Full);
+        // New data → always evict, before and after a prior eviction.
+        assert!(control.should_evict(true));
+        control.record_eviction();
+        assert!(control.should_evict(true));
+    }
+
+    #[test]
+    fn full_mode_evicts_first_time_without_new_data() {
+        let mut control = EvictionControl::new(EvictionMode::Full);
+        // No new data, but never evicted before → first eviction still runs.
+        assert!(control.should_evict(false));
+        // No new data and already evicted → skip.
+        control.record_eviction();
+        assert!(!control.should_evict(false));
+    }
+
+    #[test]
+    fn auto_mode_evicts_first_time() {
+        // Fresh control has no baseline, so the first eligible cycle always
+        // evicts regardless of the memory threshold.
+        let mut control = EvictionControl::new(EvictionMode::Auto);
+        assert!(control.should_evict(true));
+        assert!(control.should_evict(false));
+        // But still respects the new-data/first-time trigger once it has evicted.
+        control.record_eviction();
+        assert!(!control.should_evict(false));
+    }
+
+    #[test]
+    fn scale_threshold() {
+        assert_eq!(scale_threshold(BASE, Some(0)), BASE);
+        assert_eq!(scale_threshold(BASE, Some(50)), BASE / 2);
+        assert_eq!(scale_threshold(BASE, Some(100)), 0);
+        // Pressure is documented as 0..=100; values above clamp to 100.
+        assert_eq!(
+            scale_threshold(BASE, Some(200)),
+            scale_threshold(BASE, Some(100))
+        );
+    }
+
+    #[test]
+    fn scale_threshold_is_monotonic_non_increasing() {
+        let mut prev = scale_threshold(BASE, Some(0));
+        for p in 1..=100u8 {
+            let cur = scale_threshold(BASE, Some(p));
+            assert!(
+                cur <= prev,
+                "threshold should not increase with pressure: p={p}, cur={cur}, prev={prev}"
+            );
+            prev = cur;
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
@@ -58,10 +58,7 @@ impl EvictionControl {
     /// Whether to run an eviction sweep this snapshot cycle.
     ///
     /// `snapshot_had_new_data` is whether the just-completed snapshot persisted
-    /// new data. We only evict when there's new data to persist (the common case)
-    /// or on the very first eviction after startup (data was already on disk from
-    /// a prior run, so `snapshot_had_new_data` may be false but in-memory state
-    /// can still be evicted).
+    /// new data.  Used only by the `full` variant
     ///
     /// Within that, `Off` never evicts, `Full` always evicts, and `Auto` requires
     /// enough net memory allocated since the last eviction to justify the
@@ -75,7 +72,8 @@ impl EvictionControl {
         match self.mode {
             EvictionMode::Off => false,
             EvictionMode::Full => {
-                // In full mode we only skip evicting
+                // In full mode we only skip evicting if we didn't save anything and have already
+                // evicted
                 snapshot_had_new_data || !self.has_evicted_before()
             }
             EvictionMode::Auto => self.auto_threshold_exceeded(),
@@ -94,7 +92,29 @@ impl EvictionControl {
         static MIN_EVICT_BYTES: LazyLock<usize> = LazyLock::new(|| {
             std::env::var("TURBO_ENGINE_EVICT_MIN_BYTES")
                 .ok()
-                .and_then(|v| v.parse::<usize>().ok())
+                .and_then(|s| {
+                    let s = s.trim();
+                    let lower = s.to_ascii_lowercase();
+                    let (num, mult) = if let Some(n) = lower.strip_suffix('g') {
+                        (n, 1024 * 1024 * 1024)
+                    } else if let Some(n) = lower.strip_suffix('m') {
+                        (n, 1024 * 1024)
+                    } else if let Some(n) = lower.strip_suffix('k') {
+                        (n, 1024)
+                    } else {
+                        (lower.as_str(), 1)
+                    };
+                    match num.trim().parse::<usize>() {
+                        Ok(n) => Some(n * mult),
+                        Err(e) => {
+                            eprintln!(
+                                "error: could not parse `TURBO_ENGINE_EVICT_MIN_BYTES` value: \
+                                 {e:?}"
+                            );
+                            None
+                        }
+                    }
+                })
                 .unwrap_or(128 * 1024 * 1024)
         });
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/eviction.rs
@@ -30,24 +30,29 @@ pub enum EvictionMode {
 /// [`EvictionMode`] plus the threshold bookkeeping for [`EvictionMode::Auto`].
 pub(crate) struct EvictionControl {
     mode: EvictionMode,
-    /// Global net live bytes ([`TurboMalloc::memory_usage`]) sampled immediately
-    /// after the most recent eviction, or `None` before the first eviction.
+    /// The lowest global net live bytes ([`TurboMalloc::memory_usage`]) observed
+    /// since the most recent eviction, or `None` before the first eviction.
     /// Only meaningful in [`EvictionMode::Auto`].
-    memory_at_last_eviction: Option<usize>,
+    ///
+    /// Tracking the running minimum (rather than trusting the single post-eviction sample) matters
+    /// because memory can keep falling *after* a sweep returns typically because some other
+    /// threads are holding onto some Arc managed values that will `drop` once their temporary
+    /// holds are gone.
+    memory_floor: Option<usize>,
 }
 
 impl EvictionControl {
     pub(crate) fn new(mode: EvictionMode) -> Self {
         Self {
             mode,
-            memory_at_last_eviction: None,
+            memory_floor: None,
         }
     }
 
     /// Whether any prior cycle has evicted. Derived from the recorded baseline,
     /// which [`EvictionControl::record_eviction`] sets after each sweep.
     fn has_evicted_before(&self) -> bool {
-        self.memory_at_last_eviction.is_some()
+        self.memory_floor.is_some()
     }
 
     /// Whether to run an eviction sweep this snapshot cycle.
@@ -62,20 +67,16 @@ impl EvictionControl {
     /// enough net memory allocated since the last eviction to justify the
     /// restore-then-re-evict churn (always evicting the first time, since there's
     /// no prior baseline).
-    pub(crate) fn should_evict(&self, snapshot_had_new_data: bool) -> bool {
+    pub(crate) fn should_evict(&mut self, snapshot_had_new_data: bool) -> bool {
         // Only evict when there's new data to persist, or on the very first
         // eviction after startup (restored on-disk state can be reclaimed even
         // when this snapshot had no new data).
-        if !snapshot_had_new_data && self.has_evicted_before() {
-            return false;
-        }
+
         match self.mode {
             EvictionMode::Off => false,
             EvictionMode::Full => {
-                if !snapshot_had_new_data && self.has_evicted_before() {
-                    return false;
-                }
-                true
+                // In full mode we only skip evicting
+                snapshot_had_new_data || !self.has_evicted_before()
             }
             EvictionMode::Auto => self.auto_threshold_exceeded(),
         }
@@ -85,7 +86,7 @@ impl EvictionControl {
     /// since the last eviction to justify another sweep. Always evicts the first
     /// time (no prior baseline). The threshold scales down under OS memory
     /// pressure so we evict more eagerly when memory is tight.
-    fn auto_threshold_exceeded(&self) -> bool {
+    fn auto_threshold_exceeded(&mut self) -> bool {
         /// Minimum net bytes ([`TurboMalloc::memory_usage`] delta) that must be
         /// allocated since the last eviction before another is worthwhile.
         /// Allocated bytes are the proxy for how much a sweep would reclaim.
@@ -96,21 +97,36 @@ impl EvictionControl {
                 .and_then(|v| v.parse::<usize>().ok())
                 .unwrap_or(128 * 1024 * 1024)
         });
-        let Some(last) = self.memory_at_last_eviction else {
-            // First eviction: no baseline to compare against, so always evict.
-            return true;
-        };
+
         let current = TurboMalloc::memory_usage();
-        // saturating: if memory shrank since the last eviction there is nothing
-        // new to reclaim, so the delta is 0 and we skip.
-        let allocated_since = current.saturating_sub(last);
         let threshold = scale_threshold(*MIN_EVICT_BYTES, TurboMalloc::memory_pressure());
-        allocated_since >= threshold
+        let (lowered_floor, evict) = evaluate_threshold(self.memory_floor, current, threshold);
+        // Only a memory drop lowers the floor here; seeding it is left to
+        // `record_eviction` so a decision alone never counts as "has evicted".
+        if let Some(floor) = lowered_floor {
+            self.memory_floor = Some(floor);
+        }
+        evict
     }
 
-    /// Call after completing an eviction cycle.
+    /// Call after completing an eviction cycle. Seeds the memory floor with the
+    /// post-eviction usage; later cycles lower it further as memory settles.
     pub(crate) fn record_eviction(&mut self) {
-        self.memory_at_last_eviction = Some(TurboMalloc::memory_usage());
+        self.memory_floor = Some(TurboMalloc::memory_usage());
+    }
+}
+
+/// The pure decision behind [`EvictionControl::auto_threshold_exceeded`], split
+/// out so it can be unit-tested without touching the allocator.
+fn evaluate_threshold(
+    floor: Option<usize>,
+    current: usize,
+    threshold: usize,
+) -> (Option<usize>, bool) {
+    match floor {
+        None => (None, true),
+        Some(floor) if current < floor => (Some(current), false),
+        Some(floor) => (None, current - floor >= threshold),
     }
 }
 
@@ -123,17 +139,50 @@ impl EvictionControl {
 /// unchanged.
 fn scale_threshold(base: usize, pressure: Option<u8>) -> usize {
     match pressure {
-        // Integer math, multiply before divide to avoid truncation. `p` is
-        // clamped to 0..=100, so `100 - p` never underflows and the result is in
-        // `0..=base`. `base * 100` stays well within usize on 64-bit targets.
-        Some(p) => base * (100 - p.min(100) as usize) / 100,
+        Some(p) => (base as f64 * (1.0 - p.min(100) as f64 / 100.0)).round() as usize,
         None => base,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{EvictionControl, EvictionMode, scale_threshold};
+    use super::{EvictionControl, EvictionMode, evaluate_threshold, scale_threshold};
+
+    const MIB: usize = 1024 * 1024;
+
+    #[test]
+    fn evaluate_threshold_first_eviction_always_runs() {
+        // No floor yet → evict; floor not seeded here (record_eviction does that).
+        assert_eq!(evaluate_threshold(None, 500 * MIB, 128 * MIB), (None, true));
+    }
+
+    #[test]
+    fn evaluate_threshold_growth_below_threshold_skips() {
+        // Grew 64 MiB since the floor, threshold is 128 MiB → skip, floor unchanged.
+        assert_eq!(
+            evaluate_threshold(Some(900 * MIB), 964 * MIB, 128 * MIB),
+            (None, false)
+        );
+    }
+
+    #[test]
+    fn evaluate_threshold_growth_at_threshold_evicts() {
+        // Grew exactly the threshold → evict, floor unchanged (record_eviction resets it).
+        assert_eq!(
+            evaluate_threshold(Some(900 * MIB), 1028 * MIB, 128 * MIB),
+            (None, true)
+        );
+    }
+
+    #[test]
+    fn evaluate_threshold_drop_below_floor_lowers_floor_and_skips() {
+        // Regression: after a sweep we recorded ~926 MiB, but memory kept falling
+        // to ~677 MiB. The floor must follow memory down and we must not evict.
+        assert_eq!(
+            evaluate_threshold(Some(926 * MIB), 677 * MIB, 56 * MIB),
+            (Some(677 * MIB), false)
+        );
+    }
 
     #[test]
     fn off_mode_never_evicts() {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -50,6 +50,7 @@ use turbo_tasks::{
 };
 #[cfg(feature = "task_dirty_cause")]
 use turbo_tasks::{FunctionId, TaskDirtyCause};
+use turbo_tasks_malloc::TurboMalloc;
 
 pub use self::{
     operation::AnyOperation,
@@ -114,6 +115,139 @@ pub enum StorageMode {
     ReadWriteOnShutdown,
 }
 
+/// Strategy for evicting evictable tasks from in-memory storage after a
+/// snapshot. This is an EXPERIMENTAL FEATURE under development.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictionMode {
+    /// Never evict.
+    Off,
+    /// Evict after a snapshot only once enough memory has been allocated since
+    /// the last eviction to justify the cost of restoring evicted tasks on
+    /// demand. Uses allocator statistics to estimate reclaimable memory.
+    /// See [`EvictionControl::auto_threshold_exceeded`].
+    Auto,
+    /// After every snapshot, evict all evictable tasks from memory, reloading
+    /// them from disk on demand.
+    Full,
+}
+
+/// Owns the eviction policy for the background snapshot loop: the configured
+/// [`EvictionMode`] plus the threshold bookkeeping for [`EvictionMode::Auto`].
+///
+/// The loop consults [`EvictionControl::should_evict`] once per snapshot cycle
+/// and calls [`EvictionControl::record_eviction`] after a sweep. All
+/// mode-specific decisions live here so the loop doesn't have to branch on the
+/// mode itself.
+///
+/// For [`EvictionMode::Auto`]: eviction reclaims memory but forces evicted tasks
+/// to be restored from disk on next access. A sweep is only worth that churn if
+/// it reclaims a meaningful amount of memory. We can't measure reclaimable memory
+/// directly, so we use the net bytes allocated since the last eviction (via
+/// [`TurboMalloc::memory_usage`]) as a proxy and require it to exceed a threshold.
+struct EvictionControl {
+    mode: EvictionMode,
+    /// Global net live bytes ([`TurboMalloc::memory_usage`]) sampled immediately
+    /// after the most recent eviction, or `None` before the first eviction.
+    /// Only meaningful in [`EvictionMode::Auto`].
+    memory_at_last_eviction: Option<usize>,
+}
+
+impl EvictionControl {
+    fn new(mode: EvictionMode) -> Self {
+        Self {
+            mode,
+            memory_at_last_eviction: None,
+        }
+    }
+
+    /// Whether any prior cycle has evicted. Derived from the recorded baseline,
+    /// which [`EvictionControl::record_eviction`] sets after each sweep.
+    fn has_evicted_before(&self) -> bool {
+        self.memory_at_last_eviction.is_some()
+    }
+
+    /// Whether to run an eviction sweep this snapshot cycle.
+    ///
+    /// `snapshot_had_new_data` is whether the just-completed snapshot persisted
+    /// new data. We only evict when there's new data to persist (the common case)
+    /// or on the very first eviction after startup (data was already on disk from
+    /// a prior run, so `snapshot_had_new_data` may be false but in-memory state
+    /// can still be evicted).
+    ///
+    /// Within that, `Off` never evicts, `Full` always evicts, and `Auto` requires
+    /// enough net memory allocated since the last eviction to justify the
+    /// restore-then-re-evict churn (always evicting the first time, since there's
+    /// no prior baseline).
+    fn should_evict(&self, snapshot_had_new_data: bool) -> bool {
+        // Only evict when there's new data to persist, or on the very first
+        // eviction after startup (restored on-disk state can be reclaimed even
+        // when this snapshot had no new data).
+        if !snapshot_had_new_data && self.has_evicted_before() {
+            return false;
+        }
+        match self.mode {
+            EvictionMode::Off => false,
+            EvictionMode::Full => true,
+            EvictionMode::Auto => self.auto_threshold_exceeded(),
+        }
+    }
+
+    /// For [`EvictionMode::Auto`]: whether enough net memory has been allocated
+    /// since the last eviction to justify another sweep. Always evicts the first
+    /// time (no prior baseline). The threshold scales down under OS memory
+    /// pressure so we evict more eagerly when memory is tight.
+    fn auto_threshold_exceeded(&self) -> bool {
+        /// Minimum net bytes ([`TurboMalloc::memory_usage`] delta) that must be
+        /// allocated since the last eviction before another is worthwhile.
+        /// Allocated bytes are the proxy for how much a sweep would reclaim.
+        /// Default 128 MiB; overridable via `TURBO_ENGINE_EVICT_MIN_BYTES`.
+        static MIN_EVICT_BYTES: LazyLock<usize> = LazyLock::new(|| {
+            std::env::var("TURBO_ENGINE_EVICT_MIN_BYTES")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(128 * 1024 * 1024)
+        });
+        /// At full pressure the threshold shrinks to `(1 - 0.75) = 25%` of base.
+        const MAX_PRESSURE_REDUCTION: f64 = 0.75;
+
+        let Some(last) = self.memory_at_last_eviction else {
+            // First eviction: no baseline to compare against, so always evict.
+            return true;
+        };
+        let current = TurboMalloc::memory_usage();
+        // saturating: if memory shrank since the last eviction there is nothing
+        // new to reclaim, so the delta is 0 and we skip.
+        let allocated_since = current.saturating_sub(last);
+        let threshold = scale_threshold(
+            *MIN_EVICT_BYTES,
+            TurboMalloc::memory_pressure(),
+            MAX_PRESSURE_REDUCTION,
+        );
+        allocated_since >= threshold
+    }
+
+    /// Record the post-eviction memory floor as the new baseline.
+    fn record_eviction(&mut self) {
+        self.memory_at_last_eviction = Some(TurboMalloc::memory_usage());
+    }
+}
+
+/// Scale a base eviction threshold down according to OS memory pressure.
+///
+/// `factor = 1.0 - (pressure / 100) * max_reduction`. At pressure 0 the base is
+/// unchanged; at pressure 100 it is reduced by at most `max_reduction`. The
+/// result never reaches zero, so we always require *some* allocation before
+/// evicting. When pressure is unavailable (`None`) the base is returned unchanged.
+fn scale_threshold(base: usize, pressure: Option<u8>, max_reduction: f64) -> usize {
+    match pressure {
+        Some(p) => {
+            let p = (p.min(100) as f64) / 100.0;
+            (base as f64 * (1.0 - p * max_reduction)) as usize
+        }
+        None => base,
+    }
+}
+
 pub struct BackendOptions {
     /// Enables dependency tracking.
     ///
@@ -138,10 +272,10 @@ pub struct BackendOptions {
     /// Avoid big preallocations for faster startup. Should only be used for testing purposes.
     pub small_preallocation: bool,
 
-    /// When enabled, evict all evictable tasks from in-memory storage after every snapshot.
+    /// Strategy for evicting evictable tasks from in-memory storage after a snapshot.
     /// This reclaims memory by clearing persisted data that can be re-loaded from disk on demand.
     /// This is an EXPERIMENTAL FEATURE under development
-    pub evict_after_snapshot: bool,
+    pub eviction_mode: EvictionMode,
 }
 
 impl Default for BackendOptions {
@@ -152,7 +286,7 @@ impl Default for BackendOptions {
             storage_mode: Some(StorageMode::ReadWrite),
             num_workers: None,
             small_preallocation: false,
-            evict_after_snapshot: false,
+            eviction_mode: EvictionMode::Off,
         }
     }
 }
@@ -295,10 +429,6 @@ impl TurboTasksBackend {
             self.options.storage_mode,
             Some(StorageMode::ReadWrite) | Some(StorageMode::ReadWriteOnShutdown)
         )
-    }
-
-    fn should_evict(&self) -> bool {
-        self.options.evict_after_snapshot && self.should_persist()
     }
 
     /// Perform a snapshot and then evict all evictable tasks from memory.
@@ -2841,8 +2971,10 @@ impl TurboTasksBackend {
                     // Whether to immediately set an idle timeout if possible.
                     // Set to false if we don't persist anything in a cycle.
                     let mut fresh_idle = true;
-                    let mut evicted = false;
                     let mut is_first = true;
+                    // Owns the eviction policy (mode + threshold state); decides each
+                    // cycle whether an eviction sweep is worthwhile.
+                    let mut eviction_control = EvictionControl::new(self.options.eviction_mode);
                     // Accumulated compilation (non-idle) time since the last persisted
                     // snapshot. Runs while not idle, stops while idle. Used to skip periodic
                     // snapshots that wouldn't save enough work to justify their fixed
@@ -2970,30 +3102,27 @@ impl TurboTasksBackend {
                                 // Like compaction, this runs after snapshot_and_persist
                                 // as a separate concern.
                                 //
-                                // TODO: improve eviction policy — current approach is a full sweep
-                                // after every snapshot. Better strategies to consider:
-                                //   - Memory pressure signals: only evict when RSS exceeds a
-                                //     threshold rather than unconditionally.
+                                // TODO: improve the eviction policy further. Better
+                                // strategies to consider:
                                 //   - Recency data: track last-access time per task and evict
                                 //     least-recently-used entries first rather than all at once.
                                 //   - Eviction intensity: partial sweeps (evict a fraction of
                                 //     eligible tasks per cycle) to reduce latency spikes.
-                                // Evict when there is new data to persist (the common
-                                // case) or on the very first snapshot after startup
-                                // (data was already on disk from a prior run, so
-                                // new_data may be false but in-memory state can still
-                                // be evicted).
-                                let mut ran_eviction = false;
-                                if self.should_evict() && (new_data || !evicted) {
-                                    if check_idle_ended!() {
-                                        // need to start all the way over so we catch the next
-                                        // signal
-                                        continue 'outer;
-                                    }
-                                    evicted = true;
-                                    ran_eviction = true;
+                                // `eviction_control` owns the mode + threshold decision. On a
+                                // skipped cycle its baseline and `ran_eviction` stay untouched
+                                // so growth accumulates toward the next cycle.
+                                let ran_eviction = if eviction_control.should_evict(new_data) {
+                                    // NOTE: we do not check for idle here, eviction is fast and
+                                    // when enabled we should expect it to reclaim substantial
+                                    // memory so racing with execution is as likely to save time as
+                                    // cost it.
                                     self.storage.evict_after_snapshot(background_span.id());
-                                }
+                                    // Sample the post-eviction floor as the new baseline.
+                                    eviction_control.record_eviction();
+                                    true
+                                } else {
+                                    false
+                                };
 
                                 // Compact while idle (up to limit), regardless of
                                 // whether the snapshot had new data.
@@ -3033,15 +3162,14 @@ impl TurboTasksBackend {
                                         }
                                     }
                                 }
-                                if check_idle_ended!() {
-                                    continue 'outer;
-                                }
                                 // After running snapshotting/eviction/compaction we have churned a
                                 // _lot_ of memory if we are still
                                 // idle tell `mimalloc` that now would be a good time to release
                                 // memory back to the OS
-                                if new_data || ran_compaction || ran_eviction {
-                                    turbo_tasks_malloc::TurboMalloc::collect(true);
+                                if !check_idle_ended!()
+                                    && (new_data || ran_compaction || ran_eviction)
+                                {
+                                    TurboMalloc::collect(true);
                                 }
                             }
                         }
@@ -3871,4 +3999,102 @@ fn encode_task_data(
             })?;
     }
     Ok(SmallVec::from_slice(scratch_buffer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EvictionControl, EvictionMode, scale_threshold};
+
+    const BASE: usize = 128 * 1024 * 1024;
+    const MAX_REDUCTION: f64 = 0.75;
+
+    #[test]
+    fn off_mode_never_evicts() {
+        let mut control = EvictionControl::new(EvictionMode::Off);
+        for &new_data in &[true, false] {
+            assert!(!control.should_evict(new_data));
+            // Even after a (forced) eviction, Off never evicts.
+            control.record_eviction();
+            assert!(!control.should_evict(new_data));
+        }
+    }
+
+    #[test]
+    fn full_mode_evicts_on_new_data() {
+        let mut control = EvictionControl::new(EvictionMode::Full);
+        // New data → always evict, before and after a prior eviction.
+        assert!(control.should_evict(true));
+        control.record_eviction();
+        assert!(control.should_evict(true));
+    }
+
+    #[test]
+    fn full_mode_evicts_first_time_without_new_data() {
+        let mut control = EvictionControl::new(EvictionMode::Full);
+        // No new data, but never evicted before → first eviction still runs.
+        assert!(control.should_evict(false));
+        // No new data and already evicted → skip.
+        control.record_eviction();
+        assert!(!control.should_evict(false));
+    }
+
+    #[test]
+    fn auto_mode_evicts_first_time() {
+        // Fresh control has no baseline, so the first eligible cycle always
+        // evicts regardless of the memory threshold.
+        let mut control = EvictionControl::new(EvictionMode::Auto);
+        assert!(control.should_evict(true));
+        assert!(control.should_evict(false));
+        // But still respects the new-data/first-time trigger once it has evicted.
+        control.record_eviction();
+        assert!(!control.should_evict(false));
+    }
+
+    #[test]
+    fn scale_threshold_unavailable_pressure_uses_base() {
+        assert_eq!(scale_threshold(BASE, None, MAX_REDUCTION), BASE);
+    }
+
+    #[test]
+    fn scale_threshold_zero_pressure_uses_base() {
+        assert_eq!(scale_threshold(BASE, Some(0), MAX_REDUCTION), BASE);
+    }
+
+    #[test]
+    fn scale_threshold_full_pressure_applies_max_reduction() {
+        // At pressure 100 the threshold is (1 - 0.75) = 25% of base.
+        assert_eq!(scale_threshold(BASE, Some(100), MAX_REDUCTION), BASE / 4);
+    }
+
+    #[test]
+    fn scale_threshold_clamps_pressure_over_100() {
+        // Pressure is documented as 0..=100; values above clamp to 100.
+        assert_eq!(
+            scale_threshold(BASE, Some(200), MAX_REDUCTION),
+            scale_threshold(BASE, Some(100), MAX_REDUCTION)
+        );
+    }
+
+    #[test]
+    fn scale_threshold_is_monotonic_non_increasing() {
+        let mut prev = scale_threshold(BASE, Some(0), MAX_REDUCTION);
+        for p in 1..=100u8 {
+            let cur = scale_threshold(BASE, Some(p), MAX_REDUCTION);
+            assert!(
+                cur <= prev,
+                "threshold should not increase with pressure: p={p}, cur={cur}, prev={prev}"
+            );
+            prev = cur;
+        }
+    }
+
+    #[test]
+    fn scale_threshold_never_zero_for_nonzero_base() {
+        for p in 0..=100u8 {
+            assert!(
+                scale_threshold(BASE, Some(p), MAX_REDUCTION) > 0,
+                "threshold reached zero at pressure {p}"
+            );
+        }
+    }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1,5 +1,6 @@
 mod cell_data;
 mod counter_map;
+mod eviction;
 mod operation;
 mod snapshot_coordinator;
 mod storage;
@@ -52,7 +53,9 @@ use turbo_tasks::{
 use turbo_tasks::{FunctionId, TaskDirtyCause};
 use turbo_tasks_malloc::TurboMalloc;
 
+use self::eviction::EvictionControl;
 pub use self::{
+    eviction::EvictionMode,
     operation::AnyOperation,
     storage::{EvictionCounts, SpecificTaskDataCategory, TaskDataCategory},
 };
@@ -113,139 +116,6 @@ pub enum StorageMode {
     /// Queries the storage for cache entries that don't exist locally.
     /// On shutdown, pushes all changes to the backing storage.
     ReadWriteOnShutdown,
-}
-
-/// Strategy for evicting evictable tasks from in-memory storage after a
-/// snapshot. This is an EXPERIMENTAL FEATURE under development.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EvictionMode {
-    /// Never evict.
-    Off,
-    /// Evict after a snapshot only once enough memory has been allocated since
-    /// the last eviction to justify the cost of restoring evicted tasks on
-    /// demand. Uses allocator statistics to estimate reclaimable memory.
-    /// See [`EvictionControl::auto_threshold_exceeded`].
-    Auto,
-    /// After every snapshot, evict all evictable tasks from memory, reloading
-    /// them from disk on demand.
-    Full,
-}
-
-/// Owns the eviction policy for the background snapshot loop: the configured
-/// [`EvictionMode`] plus the threshold bookkeeping for [`EvictionMode::Auto`].
-///
-/// The loop consults [`EvictionControl::should_evict`] once per snapshot cycle
-/// and calls [`EvictionControl::record_eviction`] after a sweep. All
-/// mode-specific decisions live here so the loop doesn't have to branch on the
-/// mode itself.
-///
-/// For [`EvictionMode::Auto`]: eviction reclaims memory but forces evicted tasks
-/// to be restored from disk on next access. A sweep is only worth that churn if
-/// it reclaims a meaningful amount of memory. We can't measure reclaimable memory
-/// directly, so we use the net bytes allocated since the last eviction (via
-/// [`TurboMalloc::memory_usage`]) as a proxy and require it to exceed a threshold.
-struct EvictionControl {
-    mode: EvictionMode,
-    /// Global net live bytes ([`TurboMalloc::memory_usage`]) sampled immediately
-    /// after the most recent eviction, or `None` before the first eviction.
-    /// Only meaningful in [`EvictionMode::Auto`].
-    memory_at_last_eviction: Option<usize>,
-}
-
-impl EvictionControl {
-    fn new(mode: EvictionMode) -> Self {
-        Self {
-            mode,
-            memory_at_last_eviction: None,
-        }
-    }
-
-    /// Whether any prior cycle has evicted. Derived from the recorded baseline,
-    /// which [`EvictionControl::record_eviction`] sets after each sweep.
-    fn has_evicted_before(&self) -> bool {
-        self.memory_at_last_eviction.is_some()
-    }
-
-    /// Whether to run an eviction sweep this snapshot cycle.
-    ///
-    /// `snapshot_had_new_data` is whether the just-completed snapshot persisted
-    /// new data. We only evict when there's new data to persist (the common case)
-    /// or on the very first eviction after startup (data was already on disk from
-    /// a prior run, so `snapshot_had_new_data` may be false but in-memory state
-    /// can still be evicted).
-    ///
-    /// Within that, `Off` never evicts, `Full` always evicts, and `Auto` requires
-    /// enough net memory allocated since the last eviction to justify the
-    /// restore-then-re-evict churn (always evicting the first time, since there's
-    /// no prior baseline).
-    fn should_evict(&self, snapshot_had_new_data: bool) -> bool {
-        // Only evict when there's new data to persist, or on the very first
-        // eviction after startup (restored on-disk state can be reclaimed even
-        // when this snapshot had no new data).
-        if !snapshot_had_new_data && self.has_evicted_before() {
-            return false;
-        }
-        match self.mode {
-            EvictionMode::Off => false,
-            EvictionMode::Full => true,
-            EvictionMode::Auto => self.auto_threshold_exceeded(),
-        }
-    }
-
-    /// For [`EvictionMode::Auto`]: whether enough net memory has been allocated
-    /// since the last eviction to justify another sweep. Always evicts the first
-    /// time (no prior baseline). The threshold scales down under OS memory
-    /// pressure so we evict more eagerly when memory is tight.
-    fn auto_threshold_exceeded(&self) -> bool {
-        /// Minimum net bytes ([`TurboMalloc::memory_usage`] delta) that must be
-        /// allocated since the last eviction before another is worthwhile.
-        /// Allocated bytes are the proxy for how much a sweep would reclaim.
-        /// Default 128 MiB; overridable via `TURBO_ENGINE_EVICT_MIN_BYTES`.
-        static MIN_EVICT_BYTES: LazyLock<usize> = LazyLock::new(|| {
-            std::env::var("TURBO_ENGINE_EVICT_MIN_BYTES")
-                .ok()
-                .and_then(|v| v.parse::<usize>().ok())
-                .unwrap_or(128 * 1024 * 1024)
-        });
-        /// At full pressure the threshold shrinks to `(1 - 0.75) = 25%` of base.
-        const MAX_PRESSURE_REDUCTION: f64 = 0.75;
-
-        let Some(last) = self.memory_at_last_eviction else {
-            // First eviction: no baseline to compare against, so always evict.
-            return true;
-        };
-        let current = TurboMalloc::memory_usage();
-        // saturating: if memory shrank since the last eviction there is nothing
-        // new to reclaim, so the delta is 0 and we skip.
-        let allocated_since = current.saturating_sub(last);
-        let threshold = scale_threshold(
-            *MIN_EVICT_BYTES,
-            TurboMalloc::memory_pressure(),
-            MAX_PRESSURE_REDUCTION,
-        );
-        allocated_since >= threshold
-    }
-
-    /// Record the post-eviction memory floor as the new baseline.
-    fn record_eviction(&mut self) {
-        self.memory_at_last_eviction = Some(TurboMalloc::memory_usage());
-    }
-}
-
-/// Scale a base eviction threshold down according to OS memory pressure.
-///
-/// `factor = 1.0 - (pressure / 100) * max_reduction`. At pressure 0 the base is
-/// unchanged; at pressure 100 it is reduced by at most `max_reduction`. The
-/// result never reaches zero, so we always require *some* allocation before
-/// evicting. When pressure is unavailable (`None`) the base is returned unchanged.
-fn scale_threshold(base: usize, pressure: Option<u8>, max_reduction: f64) -> usize {
-    match pressure {
-        Some(p) => {
-            let p = (p.min(100) as f64) / 100.0;
-            (base as f64 * (1.0 - p * max_reduction)) as usize
-        }
-        None => base,
-    }
 }
 
 pub struct BackendOptions {
@@ -3999,102 +3869,4 @@ fn encode_task_data(
             })?;
     }
     Ok(SmallVec::from_slice(scratch_buffer))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{EvictionControl, EvictionMode, scale_threshold};
-
-    const BASE: usize = 128 * 1024 * 1024;
-    const MAX_REDUCTION: f64 = 0.75;
-
-    #[test]
-    fn off_mode_never_evicts() {
-        let mut control = EvictionControl::new(EvictionMode::Off);
-        for &new_data in &[true, false] {
-            assert!(!control.should_evict(new_data));
-            // Even after a (forced) eviction, Off never evicts.
-            control.record_eviction();
-            assert!(!control.should_evict(new_data));
-        }
-    }
-
-    #[test]
-    fn full_mode_evicts_on_new_data() {
-        let mut control = EvictionControl::new(EvictionMode::Full);
-        // New data → always evict, before and after a prior eviction.
-        assert!(control.should_evict(true));
-        control.record_eviction();
-        assert!(control.should_evict(true));
-    }
-
-    #[test]
-    fn full_mode_evicts_first_time_without_new_data() {
-        let mut control = EvictionControl::new(EvictionMode::Full);
-        // No new data, but never evicted before → first eviction still runs.
-        assert!(control.should_evict(false));
-        // No new data and already evicted → skip.
-        control.record_eviction();
-        assert!(!control.should_evict(false));
-    }
-
-    #[test]
-    fn auto_mode_evicts_first_time() {
-        // Fresh control has no baseline, so the first eligible cycle always
-        // evicts regardless of the memory threshold.
-        let mut control = EvictionControl::new(EvictionMode::Auto);
-        assert!(control.should_evict(true));
-        assert!(control.should_evict(false));
-        // But still respects the new-data/first-time trigger once it has evicted.
-        control.record_eviction();
-        assert!(!control.should_evict(false));
-    }
-
-    #[test]
-    fn scale_threshold_unavailable_pressure_uses_base() {
-        assert_eq!(scale_threshold(BASE, None, MAX_REDUCTION), BASE);
-    }
-
-    #[test]
-    fn scale_threshold_zero_pressure_uses_base() {
-        assert_eq!(scale_threshold(BASE, Some(0), MAX_REDUCTION), BASE);
-    }
-
-    #[test]
-    fn scale_threshold_full_pressure_applies_max_reduction() {
-        // At pressure 100 the threshold is (1 - 0.75) = 25% of base.
-        assert_eq!(scale_threshold(BASE, Some(100), MAX_REDUCTION), BASE / 4);
-    }
-
-    #[test]
-    fn scale_threshold_clamps_pressure_over_100() {
-        // Pressure is documented as 0..=100; values above clamp to 100.
-        assert_eq!(
-            scale_threshold(BASE, Some(200), MAX_REDUCTION),
-            scale_threshold(BASE, Some(100), MAX_REDUCTION)
-        );
-    }
-
-    #[test]
-    fn scale_threshold_is_monotonic_non_increasing() {
-        let mut prev = scale_threshold(BASE, Some(0), MAX_REDUCTION);
-        for p in 1..=100u8 {
-            let cur = scale_threshold(BASE, Some(p), MAX_REDUCTION);
-            assert!(
-                cur <= prev,
-                "threshold should not increase with pressure: p={p}, cur={cur}, prev={prev}"
-            );
-            prev = cur;
-        }
-    }
-
-    #[test]
-    fn scale_threshold_never_zero_for_nonzero_base() {
-        for p in 0..=100u8 {
-            assert!(
-                scale_threshold(BASE, Some(p), MAX_REDUCTION) > 0,
-                "threshold reached zero at pressure {p}"
-            );
-        }
-    }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -16,7 +16,7 @@ use turbo_persistence::{CompactConfig, TurboPersistence};
 
 use crate::database::turbo::{self, TurboKeyValueDatabase};
 pub use crate::{
-    backend::{BackendOptions, StorageMode, TurboTasksBackend},
+    backend::{BackendOptions, EvictionMode, StorageMode, TurboTasksBackend},
     database::{
         db_invalidation,
         db_invalidation::StartupCacheState,

--- a/turbopack/crates/turbo-tasks-backend/tests/eviction.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/eviction.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use turbo_tasks::{
     ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
 };
-use turbo_tasks_backend::{BackendOptions, GitVersionInfo, TurboTasksBackend};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
 
 /// Creates a fresh per-call persistence directory rooted under
 /// `CARGO_TARGET_TMPDIR/.cache/`, with the test `name` as a prefix so failed
@@ -43,7 +43,7 @@ fn create_tt_with_workers(
             // Avoid racing with the background snapshot loop; the test drives
             // snapshot_and_evict_for_testing manually.
             storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
-            evict_after_snapshot: true,
+            eviction_mode: EvictionMode::Full,
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -85,7 +85,12 @@ impl AllocationCounters {
 pub struct TurboMalloc;
 
 impl TurboMalloc {
-    // Returns the current amount of memory
+    /// Returns the current amount of live memory (bytes allocated minus freed)
+    /// tracked across all threads.
+    ///
+    /// For efficiency reasons every thread only synchronizes with this counter after ~100K bytes of
+    /// allocations or deallocations.  So this could be off by as much as 100K*number of thread in
+    /// either direction.
     pub fn memory_usage() -> usize {
         get()
     }


### PR DESCRIPTION
### What?

Adds a new `'auto'` mode to the experimental `turbopackMemoryEviction` config option and makes it the default. In `'auto'` mode, Turbopack only evicts in-memory cache after a snapshot once enough memory has been allocated since the last eviction to make the work worthwhile.

The option now accepts three values:

- `false`: never evict.
- `'auto'` (new default): evict after a snapshot only once a memory threshold has been crossed.
- `'full'`: evict all evictable data after every snapshot (the previous behavior).

### Why?

When the persistent (FileSystem) cache is enabled, Turbopack snapshots its in-memory state to disk and can then evict those in-memory copies to reclaim memory, reloading them from disk on demand.

Previously, with eviction enabled (`'full'`), we evicted after *every* snapshot. This is too aggressive: tasks get restored from disk and then immediately evicted again, cycle after cycle, wasting work for little memory benefit.

`'auto'` mirrors the existing persistence-threshold model (we already skip a snapshot when too little compilation time has accumulated to justify its cost). Here the proxy is memory instead of time: it isn't worth paying the restore-then-re-evict churn to reclaim a small amount of memory.

This was motivated by an example in v0.app where the client would poll the server every 5 seconds leading to a pathological behavior
* client poll ->
* next.js ensurePage ->
* turbopack writeEndpointToDisk
*  recompute and restore settings for that endpoint (3-10ms of io work)
* realize there is nothing to do
* respond to client
* 2 seconds later..... persist and evict everything saving 0.5M of ram (100ms of work! writes out 2 SSTs and then compacts them!)
* 3 seconds after that restart the loop

This is silly, #95137 will prevent the persistence loop from occurring , this PR will also just skip the 'restore and recompute' work using a similar strategy.

### How?

We can't measure exactly how much memory a sweep would reclaim, so we use `TurboMalloc::memory_usage()` (process-global net live bytes) as a proxy. In `'auto'` mode an eviction sweep runs only once the net bytes allocated since the last eviction exceed a threshold (default 128 MiB, overridable via `TURBO_ENGINE_EVICT_MIN_BYTES`). The first eviction after startup always runs. The threshold scales down under OS memory pressure (`TurboMalloc::memory_pressure()`) so we evict more eagerly when memory is tight.

**Backend (`turbo-tasks-backend`):**
- `BackendOptions.evict_after_snapshot: bool` → `eviction_mode: EvictionMode` (`Off` / `Full` / `Auto`).
- New `EvictionControl` type owns the policy: the mode plus the threshold bookkeeping. The background snapshot loop calls `should_evict(snapshot_had_new_data)` once per cycle and `record_eviction()` after a sweep, so the loop no longer branches on the mode. `'full'` and `false` behave exactly as before.


<!-- NEXT_JS_LLM_PR -->
