### PR TITLE
fix(ppr): decompress gzip-encoded resume request body before parsing postponed state

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1127,10 +1127,24 @@ export default abstract class Server<
             // The resume body can arrive compressed (e.g. `gzip` behind a
             // proxy). Decode it honoring `Content-Encoding`; reading the raw
             // bytes as UTF-8 would yield an invalid postponed state.
-            const postponed = decodePostponedRequestBody(
-              body,
-              req.headers['content-encoding']
-            )
+            // Decompression is bounded by the postponed-state size limit so a
+            // small payload cannot expand to unbounded memory.
+            let postponed: string
+            try {
+              postponed = decodePostponedRequestBody(
+                body,
+                req.headers['content-encoding'],
+                maxPostponedStateSizeBytes
+              )
+            } catch {
+              res.statusCode = 413
+              res
+                .body(
+                  getPostponedStateExceededErrorMessage(maxPostponedStateSize)
+                )
+                .send()
+              return
+            }
 
             addRequestMeta(req, 'postponed', postponed)
           }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -154,6 +154,7 @@ import { createOpaqueFallbackRouteParams } from './request/fallback-params'
 import { RouteKind } from './route-kind'
 import type { ErrorModule } from './load-default-error-components'
 import {
+  decodePostponedRequestBody,
   getMaxPostponedStateSize,
   getPostponedStateExceededErrorMessage,
   readBodyWithSizeLimit,
@@ -1123,7 +1124,13 @@ export default abstract class Server<
                 .send()
               return
             }
-            const postponed = body.toString('utf8')
+            // The resume body can arrive compressed (e.g. `gzip` behind a
+            // proxy). Decode it honoring `Content-Encoding`; reading the raw
+            // bytes as UTF-8 would yield an invalid postponed state.
+            const postponed = decodePostponedRequestBody(
+              body,
+              req.headers['content-encoding']
+            )
 
             addRequestMeta(req, 'postponed', postponed)
           }

--- a/packages/next/src/server/lib/postponed-request-body.test.ts
+++ b/packages/next/src/server/lib/postponed-request-body.test.ts
@@ -4,45 +4,69 @@ import { decodePostponedRequestBody } from './postponed-request-body'
 describe('decodePostponedRequestBody', () => {
   // A representative serialized postponed state (always starts with `<len>:`).
   const state = '4:null'
+  // A bound generous enough for any of these small fixtures.
+  const maxOutputLength = 1024 * 1024
 
   it('returns the body as UTF-8 when there is no content-encoding', () => {
-    expect(decodePostponedRequestBody(Buffer.from(state), undefined)).toBe(state)
+    expect(
+      decodePostponedRequestBody(Buffer.from(state), undefined, maxOutputLength)
+    ).toBe(state)
   })
 
   it('returns the body as UTF-8 for the identity encoding', () => {
-    expect(decodePostponedRequestBody(Buffer.from(state), 'identity')).toBe(
-      state
-    )
+    expect(
+      decodePostponedRequestBody(Buffer.from(state), 'identity', maxOutputLength)
+    ).toBe(state)
   })
 
   it('decompresses a gzip-encoded body', () => {
-    expect(decodePostponedRequestBody(gzipSync(Buffer.from(state)), 'gzip')).toBe(
-      state
-    )
+    expect(
+      decodePostponedRequestBody(
+        gzipSync(Buffer.from(state)),
+        'gzip',
+        maxOutputLength
+      )
+    ).toBe(state)
   })
 
   it('decompresses a br-encoded body', () => {
     expect(
-      decodePostponedRequestBody(brotliCompressSync(Buffer.from(state)), 'br')
+      decodePostponedRequestBody(
+        brotliCompressSync(Buffer.from(state)),
+        'br',
+        maxOutputLength
+      )
     ).toBe(state)
   })
 
   it('decompresses a deflate-encoded body', () => {
     expect(
-      decodePostponedRequestBody(deflateSync(Buffer.from(state)), 'deflate')
+      decodePostponedRequestBody(
+        deflateSync(Buffer.from(state)),
+        'deflate',
+        maxOutputLength
+      )
     ).toBe(state)
   })
 
   it('handles a header provided as an array', () => {
     expect(
-      decodePostponedRequestBody(gzipSync(Buffer.from(state)), ['gzip'])
+      decodePostponedRequestBody(
+        gzipSync(Buffer.from(state)),
+        ['gzip'],
+        maxOutputLength
+      )
     ).toBe(state)
   })
 
   it('is case-insensitive about the encoding', () => {
-    expect(decodePostponedRequestBody(gzipSync(Buffer.from(state)), 'GZIP')).toBe(
-      state
-    )
+    expect(
+      decodePostponedRequestBody(
+        gzipSync(Buffer.from(state)),
+        'GZIP',
+        maxOutputLength
+      )
+    ).toBe(state)
   })
 
   // The production-realistic case: a proxy gzips the resume body but does not
@@ -50,13 +74,28 @@ describe('decodePostponedRequestBody', () => {
   // the body is still decompressed rather than read as UTF-8 garbage.
   it('decompresses a gzip body even when content-encoding is absent', () => {
     expect(
-      decodePostponedRequestBody(gzipSync(Buffer.from(state)), undefined)
+      decodePostponedRequestBody(
+        gzipSync(Buffer.from(state)),
+        undefined,
+        maxOutputLength
+      )
     ).toBe(state)
   })
 
   it('leaves a plain UTF-8 body untouched (no false gzip detection)', () => {
     const plain = '12:{"some":"state"}'
-    expect(decodePostponedRequestBody(Buffer.from(plain), undefined)).toBe(plain)
+    expect(
+      decodePostponedRequestBody(Buffer.from(plain), undefined, maxOutputLength)
+    ).toBe(plain)
+  })
+
+  // A small compressed payload that expands past the limit must throw rather
+  // than allocate unbounded memory (decompression-bomb guard).
+  it('throws when the decompressed output exceeds maxOutputLength', () => {
+    const bomb = gzipSync(Buffer.alloc(8 * 1024 * 1024, 0))
+    expect(() =>
+      decodePostponedRequestBody(bomb, 'gzip', 64 * 1024)
+    ).toThrow()
   })
 
   // Regression: previously the gzip bytes were read as UTF-8 without
@@ -65,7 +104,8 @@ describe('decodePostponedRequestBody', () => {
   it('round-trips so the decoded gzip body is a valid postponed-state string', () => {
     const decoded = decodePostponedRequestBody(
       gzipSync(Buffer.from(state)),
-      'gzip'
+      'gzip',
+      maxOutputLength
     )
     expect(decoded).toMatch(/^[0-9]+:/)
   })

--- a/packages/next/src/server/lib/postponed-request-body.test.ts
+++ b/packages/next/src/server/lib/postponed-request-body.test.ts
@@ -1,0 +1,72 @@
+import { brotliCompressSync, deflateSync, gzipSync } from 'node:zlib'
+import { decodePostponedRequestBody } from './postponed-request-body'
+
+describe('decodePostponedRequestBody', () => {
+  // A representative serialized postponed state (always starts with `<len>:`).
+  const state = '4:null'
+
+  it('returns the body as UTF-8 when there is no content-encoding', () => {
+    expect(decodePostponedRequestBody(Buffer.from(state), undefined)).toBe(state)
+  })
+
+  it('returns the body as UTF-8 for the identity encoding', () => {
+    expect(decodePostponedRequestBody(Buffer.from(state), 'identity')).toBe(
+      state
+    )
+  })
+
+  it('decompresses a gzip-encoded body', () => {
+    expect(decodePostponedRequestBody(gzipSync(Buffer.from(state)), 'gzip')).toBe(
+      state
+    )
+  })
+
+  it('decompresses a br-encoded body', () => {
+    expect(
+      decodePostponedRequestBody(brotliCompressSync(Buffer.from(state)), 'br')
+    ).toBe(state)
+  })
+
+  it('decompresses a deflate-encoded body', () => {
+    expect(
+      decodePostponedRequestBody(deflateSync(Buffer.from(state)), 'deflate')
+    ).toBe(state)
+  })
+
+  it('handles a header provided as an array', () => {
+    expect(
+      decodePostponedRequestBody(gzipSync(Buffer.from(state)), ['gzip'])
+    ).toBe(state)
+  })
+
+  it('is case-insensitive about the encoding', () => {
+    expect(decodePostponedRequestBody(gzipSync(Buffer.from(state)), 'GZIP')).toBe(
+      state
+    )
+  })
+
+  // The production-realistic case: a proxy gzips the resume body but does not
+  // forward `Content-Encoding`. The leading gzip magic number is detected so
+  // the body is still decompressed rather than read as UTF-8 garbage.
+  it('decompresses a gzip body even when content-encoding is absent', () => {
+    expect(
+      decodePostponedRequestBody(gzipSync(Buffer.from(state)), undefined)
+    ).toBe(state)
+  })
+
+  it('leaves a plain UTF-8 body untouched (no false gzip detection)', () => {
+    const plain = '12:{"some":"state"}'
+    expect(decodePostponedRequestBody(Buffer.from(plain), undefined)).toBe(plain)
+  })
+
+  // Regression: previously the gzip bytes were read as UTF-8 without
+  // decompression, producing a non-`<len>:` string that parsePostponedState
+  // rejects as "Invariant: invalid postponed state".
+  it('round-trips so the decoded gzip body is a valid postponed-state string', () => {
+    const decoded = decodePostponedRequestBody(
+      gzipSync(Buffer.from(state)),
+      'gzip'
+    )
+    expect(decoded).toMatch(/^[0-9]+:/)
+  })
+})

--- a/packages/next/src/server/lib/postponed-request-body.ts
+++ b/packages/next/src/server/lib/postponed-request-body.ts
@@ -59,3 +59,44 @@ export async function readBodyWithSizeLimit(
 
   return Buffer.concat(chunks)
 }
+
+/**
+ * Decodes the postponed-state request body. PPR resume requests can arrive
+ * compressed (e.g. `gzip` applied by a proxy/CDN that issues the resume
+ * request); reading the raw bytes as UTF-8 without decompressing yields an
+ * invalid postponed state.
+ *
+ * The request's `Content-Encoding` is honored when present. Because some
+ * proxies compress the body without forwarding that header, a leading gzip
+ * magic number is also detected: a valid serialized postponed state always
+ * begins with `<len>:` (an ASCII digit or `:`, `0x30`–`0x3a`), so a leading
+ * `0x1f 0x8b` is unambiguous and safe to decompress.
+ */
+export function decodePostponedRequestBody(
+  body: Buffer,
+  contentEncoding: string | string[] | undefined
+): string {
+  const { gunzipSync, brotliDecompressSync, inflateSync } =
+    require('node:zlib') as typeof import('node:zlib')
+
+  const encoding = (
+    Array.isArray(contentEncoding) ? contentEncoding[0] : contentEncoding
+  )?.toLowerCase()
+
+  switch (encoding) {
+    case 'gzip':
+      return gunzipSync(body).toString('utf8')
+    case 'br':
+      return brotliDecompressSync(body).toString('utf8')
+    case 'deflate':
+      return inflateSync(body).toString('utf8')
+    default:
+      break
+  }
+
+  if (body.length >= 2 && body[0] === 0x1f && body[1] === 0x8b) {
+    return gunzipSync(body).toString('utf8')
+  }
+
+  return body.toString('utf8')
+}

--- a/packages/next/src/server/lib/postponed-request-body.ts
+++ b/packages/next/src/server/lib/postponed-request-body.ts
@@ -71,10 +71,15 @@ export async function readBodyWithSizeLimit(
  * magic number is also detected: a valid serialized postponed state always
  * begins with `<len>:` (an ASCII digit or `:`, `0x30`–`0x3a`), so a leading
  * `0x1f 0x8b` is unambiguous and safe to decompress.
+ *
+ * Decompression is bounded by `maxOutputLength` (the same postponed-state size
+ * limit applied to the raw body) so a small compressed payload cannot expand to
+ * an unbounded amount of memory; zlib throws `ERR_BUFFER_TOO_LARGE` if exceeded.
  */
 export function decodePostponedRequestBody(
   body: Buffer,
-  contentEncoding: string | string[] | undefined
+  contentEncoding: string | string[] | undefined,
+  maxOutputLength: number
 ): string {
   const { gunzipSync, brotliDecompressSync, inflateSync } =
     require('node:zlib') as typeof import('node:zlib')
@@ -85,17 +90,17 @@ export function decodePostponedRequestBody(
 
   switch (encoding) {
     case 'gzip':
-      return gunzipSync(body).toString('utf8')
+      return gunzipSync(body, { maxOutputLength }).toString('utf8')
     case 'br':
-      return brotliDecompressSync(body).toString('utf8')
+      return brotliDecompressSync(body, { maxOutputLength }).toString('utf8')
     case 'deflate':
-      return inflateSync(body).toString('utf8')
+      return inflateSync(body, { maxOutputLength }).toString('utf8')
     default:
       break
   }
 
   if (body.length >= 2 && body[0] === 0x1f && body[1] === 0x8b) {
-    return gunzipSync(body).toString('utf8')
+    return gunzipSync(body, { maxOutputLength }).toString('utf8')
   }
 
   return body.toString('utf8')


### PR DESCRIPTION
> **Draft / candidate.** This is a proposed fix accompanying a detailed bug report and a standalone reproduction. The diagnosis is solid; the exact fix locus may warrant maintainer triage (see "Open question" below). Opening as draft to start that conversation.

### What & why

On a **PPR (Cache Components) resume**, the postponed state is read from the **POST request body** in `base-server.ts` via `body.toString('utf8')`. When the chained resume request is issued by infrastructure that **compresses the body** (e.g. a proxy/CDN in front of `next start` / minimal mode), the gzip bytes decoded as UTF-8 are not a valid postponed-state string, so [`parsePostponedState`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/postponed-state.ts) fails its `^<digits>:` format check, logs

```
Failed to parse postponed state: Error: Invariant: invalid postponed state <gzip garbage>
```

and **degrades to `type:1`**. In production this surfaces as a **logged server error with an HTTP 200 fallback on every resumed `◐ PARTIALLY_STATIC` route** (cart, checkout, category/content pages, …) — the page can't resume its prerendered shell. The garbage consistently starts with the gzip magic header `1f 8b 08`.

This is **not** client/deployment skew and **not** attacker input — a clean gzip header is the legitimate resume body.

### Reproduction

Standalone repo with a deterministic, server-free proof that calls the installed `parsePostponedState` exactly as `base-server` does and emits the byte-identical production log line:

**https://github.com/arjenblokzijl/next-ppr-gzip-resume-repro**

```bash
npm install && npm run repro:unit
# -> gzip header "1f 8b 08 .." then:
#    "Failed to parse postponed state: Invariant: invalid postponed state <gzip>"  -> degrades to type:1
```

The path is byte-for-byte identical in `16.2.x` and `16.3`, so it reproduces on both — this is pre-existing, not a regression.

### The fix

`decodePostponedRequestBody(body, contentEncoding)` decodes the resume body before parsing:

1. Honor `Content-Encoding` when present (`gzip` / `br` / `deflate`).
2. Otherwise, detect a leading **gzip magic number** (`0x1f 0x8b`) and decompress.
3. Otherwise, plain `toString('utf8')` (unchanged behavior).

Step 2 is unambiguous and false-positive-proof: a valid serialized postponed state always begins with `<len>:` — an ASCII digit or `:` (`0x30`–`0x3a`) — which never collides with the gzip magic byte `0x1f`.

This mirrors how the `renderResumeDataCache` portion is already gunzipped downstream.

### Open question (why magic-byte detection, not header-only)

The PPR resume "chain" contract emitted by the build only sets:

```js
// generate-routes-manifest.ts / build-complete.ts
ppr: { chain: { headers: { [NEXT_RESUME_HEADER]: '1' } } }
```

It carries **no `Content-Encoding`**, and nothing in this tree gzips the resume body — the compression is applied by whatever infrastructure issues the chained request. So a fix relying *solely* on a forwarded `Content-Encoding` header may be a no-op in the environments where this actually fires. Hence the magic-byte fallback. If maintainers consider the right locus to be "ensure the resume request never arrives compressed" (or to forward `Content-Encoding`), I'm happy to adjust — this PR fixes it defensively at the read site, which is also where the data is already trusted.

### Tests

`packages/next/src/server/lib/postponed-request-body.test.ts` covers: no/identity encoding, gzip/br/deflate via header, array & case-insensitive headers, the **production-realistic gzip body with no `Content-Encoding`**, and a plain-UTF-8 body that must *not* be mis-detected.

> Note: I verified the helper logic in isolation but did not spin up the full Next.js jest suite locally; CI here will be the first full run.

### Workaround (for affected users, until this lands)

Make the affected routes fully dynamic (`ƒ`) so there is no postponed state to resume — e.g. `await connection()` at the page root (16.3+). Only viable for session-specific routes (cart/checkout), not cacheable catalog/content pages.

---

Signed off (DCO). Happy to sign the Vercel CLA when the bot posts the link.
