### PR TITLE
bundle-analyzer: flag async-only modules per route

### DIFF
--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -2,12 +2,12 @@
 
 import type React from 'react'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import useSWR from 'swr'
 import { CompareLayout } from '@/components/compare-layout'
 import { ErrorState } from '@/components/error-state'
 import { Sidebar } from '@/components/sidebar'
-import { TopBar, Environment } from '@/components/top-bar'
+import { TopBar, Environment, CompareView } from '@/components/top-bar'
 import { TreemapVisualizer } from '@/components/treemap-visualizer'
 
 import { Badge } from '@/components/ui/badge'
@@ -53,6 +53,22 @@ export default function Home() {
   // compare mode and starts fetching from `history/<id>/...`.
   const [baselineSnapshot, setBaselineSnapshot] =
     useState<SnapshotMetadata | null>(null)
+  // Default view depends on mode: compare mode opens to the diff table
+  // (the change list is the headline), single-build mode opens to the
+  // treemap (size-by-area is the headline). Whenever the user toggles
+  // between modes we reset to that mode's default; explicit user choices
+  // within a mode are preserved until the mode changes again.
+  const [compareView, setCompareView] = useState<CompareView>(
+    CompareView.Treemap
+  )
+  const wasCompareModeRef = useRef(baselineSnapshot != null)
+  useEffect(() => {
+    const isNowCompare = baselineSnapshot != null
+    if (wasCompareModeRef.current !== isNowCompare) {
+      wasCompareModeRef.current = isNowCompare
+      setCompareView(isNowCompare ? CompareView.Table : CompareView.Treemap)
+    }
+  }, [baselineSnapshot])
 
   const {
     data: modulesData,
@@ -346,6 +362,9 @@ export default function Home() {
     >
       <TopBar
         hasSourceData={analyzeData != null}
+        showViewToggle={isCompareMode}
+        compareView={compareView}
+        onCompareViewChange={setCompareView}
         selectedRoute={selectedRoute}
         setSelectedRoute={setSelectedRoute}
         environmentFilter={environmentFilter}
@@ -367,6 +386,8 @@ export default function Home() {
         ) : isCompareMode ? (
           <CompareLayout
             baselineSnapshot={baselineSnapshot!}
+            compareView={compareView}
+            searchQuery={searchQuery}
             selectedRoute={selectedRoute}
             currentRouteCount={currentRoutes?.length ?? null}
             routeDiff={routeDiff}

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -4,39 +4,36 @@ import type React from 'react'
 
 import { useEffect, useMemo, useState } from 'react'
 import useSWR from 'swr'
+import { CompareLayout } from '@/components/compare-layout'
 import { ErrorState } from '@/components/error-state'
-import { FileSearch } from '@/components/file-search'
-import { RouteTypeahead } from '@/components/route-typeahead'
 import { Sidebar } from '@/components/sidebar'
+import { TopBar, Environment } from '@/components/top-bar'
 import { TreemapVisualizer } from '@/components/treemap-visualizer'
 
 import { Badge } from '@/components/ui/badge'
 import { TreemapSkeleton } from '@/components/ui/skeleton'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { MultiSelect } from '@/components/ui/multi-select'
 import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
+import { diffRoutesWithSizes, diffSources } from '@/lib/diff'
+import { useRouteTotals } from '@/lib/use-route-totals'
 import { computeActiveEntries, computeModuleDepthMap } from '@/lib/module-graph'
-import { fetchStrict } from '@/lib/utils'
+import { type SnapshotMetadata } from '@/lib/snapshot'
+import { fetchStrict, jsonFetcher } from '@/lib/utils'
 import { formatBytes } from '@/lib/utils'
 import { SizeMode } from '@/lib/treemap-layout'
-import {
-  Monitor,
-  Server,
-  FileCode,
-  FileJson,
-  Palette,
-  Package,
-} from 'lucide-react'
 
-enum Environment {
-  Client = 'client',
-  Server = 'server',
+/**
+ * Resolve the URL of an `analyze.data` file for a given route. When `baseDir`
+ * is non-empty, the file is fetched from a historical snapshot directory
+ * instead of the live `data/` directory. Returns `null` when no route is
+ * selected.
+ */
+function getAnalyzeDataPath(
+  route: string | null,
+  baseDir: 'data' | string
+): string | null {
+  if (!route) return null
+  if (route === '/') return `${baseDir}/analyze.data`
+  return `${baseDir}/${route.replace(/^\//, '')}/analyze.data`
 }
 
 export default function Home() {
@@ -52,20 +49,67 @@ export default function Home() {
     null
   )
 
+  // Comparison state. When `baselineSnapshot` is set the UI flips into
+  // compare mode and starts fetching from `history/<id>/...`.
+  const [baselineSnapshot, setBaselineSnapshot] =
+    useState<SnapshotMetadata | null>(null)
+
   const {
     data: modulesData,
     isLoading: isModulesLoading,
     error: modulesError,
   } = useSWR<ModulesData>('data/modules.data', fetchModulesData)
 
-  let analyzeDataPath
-  if (selectedRoute && selectedRoute === '/') {
-    analyzeDataPath = 'data/analyze.data'
-  } else if (selectedRoute) {
-    analyzeDataPath = `data/${selectedRoute.replace(/^\//, '')}/analyze.data`
-  } else {
-    analyzeDataPath = null
-  }
+  // Baseline modules.data, only fetched in compare mode. Used to power the
+  // import-chain panel for the baseline ("A") side of the compare sidebar.
+  // Snapshots are produced by copying the entire data dir (see
+  // `packages/next/src/build/analyze/snapshot.ts`), so this file is
+  // expected to exist for any historical snapshot.
+  const baselineModulesPath = baselineSnapshot
+    ? `history/${baselineSnapshot.id}/modules.data`
+    : null
+  const { data: baselineModulesData } = useSWR<ModulesData>(
+    baselineModulesPath,
+    fetchModulesData,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false,
+    }
+  )
+
+  // Always-loaded list of routes in the current build. Used as the route
+  // diff's "B" side and as the existing route picker's source of truth.
+  const { data: currentRoutes } = useSWR<string[]>(
+    'data/routes.json',
+    jsonFetcher,
+    { revalidateOnFocus: false, revalidateOnReconnect: false }
+  )
+
+  // Routes for the historical baseline, used only in compare mode.
+  const baselineRoutesPath = baselineSnapshot
+    ? `history/${baselineSnapshot.id}/routes.json`
+    : null
+  const { data: baselineRoutes } = useSWR<string[]>(
+    baselineRoutesPath,
+    jsonFetcher,
+    { revalidateOnFocus: false, revalidateOnReconnect: false }
+  )
+
+  // Whether the selected route exists in the *current* build. We only
+  // fetch `data/<route>/analyze.data` when this is true — the analyzer's
+  // output directory can contain stale per-route subdirectories from
+  // previous builds that no longer correspond to real routes (the build
+  // doesn't clean removed routes out of `data/`). Trusting those would
+  // make a `removed` route render as identical-to-itself, hiding the
+  // actual diff. `routes.json` is the source of truth for the live build.
+  const currentAnalyzeRouteExists =
+    currentRoutes != null &&
+    selectedRoute != null &&
+    currentRoutes.includes(selectedRoute)
+  const analyzeDataPath = !currentAnalyzeRouteExists
+    ? null
+    : getAnalyzeDataPath(selectedRoute, 'data')
 
   const {
     data: analyzeData,
@@ -81,6 +125,28 @@ export default function Home() {
     },
   })
 
+  // Per-route analyze.data for the baseline build. Only fetched when both a
+  // baseline and a route are selected and the route exists in the baseline.
+  const baselineAnalyzeRouteExists =
+    baselineRoutes != null &&
+    selectedRoute != null &&
+    baselineRoutes.includes(selectedRoute)
+  const baselineAnalyzePath =
+    baselineSnapshot && baselineAnalyzeRouteExists
+      ? getAnalyzeDataPath(selectedRoute, `history/${baselineSnapshot.id}`)
+      : null
+  const {
+    data: baselineAnalyzeData,
+    isLoading: isBaselineAnalyzeLoading,
+    error: baselineAnalyzeError,
+  } = useSWR<AnalyzeData>(baselineAnalyzePath, fetchAnalyzeData, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    // Don't blow up if the baseline file is missing — the UI handles it
+    // gracefully by labeling the route as "added".
+    shouldRetryOnError: false,
+  })
+
   const [sidebarWidth, setSidebarWidth] = useState(20) // percentage
   const [isResizing, setIsResizing] = useState(false)
   const [isMouseInTreemap, setIsMouseInTreemap] = useState(false)
@@ -92,6 +158,18 @@ export default function Home() {
     traced?: boolean
   } | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  // Selected source in compare mode, identified by its full source path
+  // (the diff row's `key`). Source indices differ between the two builds,
+  // so we can't reuse `selectedSourceIndex`.
+  const [compareSelectedKey, setCompareSelectedKey] = useState<string | null>(
+    null
+  )
+
+  // Reset compare selection when the route or baseline changes — the
+  // previous selection is unlikely to exist in the new diff.
+  useEffect(() => {
+    setCompareSelectedKey(null)
+  }, [selectedRoute, baselineSnapshot])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -122,6 +200,18 @@ export default function Home() {
     return computeModuleDepthMap(modulesData, activeEntries)
   }, [modulesData, analyzeData])
 
+  // Same as `moduleDepthMap`, but for the baseline ("A") build. Only
+  // computed in compare mode when both the baseline modules.data and
+  // baseline analyze.data have loaded.
+  const baselineModuleDepthMap = useMemo(() => {
+    if (!baselineModulesData || !baselineAnalyzeData) return new Map()
+    const activeEntries = computeActiveEntries(
+      baselineModulesData,
+      baselineAnalyzeData
+    )
+    return computeModuleDepthMap(baselineModulesData, activeEntries)
+  }, [baselineModulesData, baselineAnalyzeData])
+
   const filterSource = useMemo(() => {
     if (!analyzeData) return () => true
 
@@ -144,9 +234,91 @@ export default function Home() {
     }
   }, [analyzeData, environmentFilter, typeFilter])
 
-  const handleMouseDown = () => {
-    setIsResizing(true)
-  }
+  // Build a per-side filter usable by the source diff. Each side gets its own
+  // closure over its own `analyzeData`, since the source flags are
+  // route/build-specific.
+  const compareFilterSource = useMemo(() => {
+    return (side: 'A' | 'B', sourceIndex: number): boolean => {
+      const data = side === 'A' ? baselineAnalyzeData : analyzeData
+      if (!data) return false
+      const flags = data.getSourceFlags(sourceIndex)
+      const hasEnvironment =
+        (environmentFilter === Environment.Client && flags.client) ||
+        (environmentFilter === Environment.Server && flags.server)
+      const hasType =
+        (typeFilter.includes('js') && flags.js) ||
+        (typeFilter.includes('css') && flags.css) ||
+        (typeFilter.includes('json') && flags.json) ||
+        (typeFilter.includes('asset') && flags.asset)
+      return hasEnvironment && hasType
+    }
+  }, [analyzeData, baselineAnalyzeData, environmentFilter, typeFilter])
+
+  // Source-level diff for the currently selected route. Recomputed when
+  // either side's data or the active filters change.
+  //
+  // Three cases:
+  // 1. Route exists in both builds → diff(baseline, current).
+  // 2. Route exists only in the baseline (removed) → there is no current
+  //    `analyze.data`, but we still want to show the baseline's sources
+  //    flagged as `removed`. We synthesize this by passing the baseline
+  //    as both A and the empty-stand-in for B, then dropping the B side.
+  //    `diffSources` accepts a non-null B, so we feed an empty walk by
+  //    using the baseline data with a filter that always returns false
+  //    for the B side.
+  // 3. Route exists only in the current build (added) → analyzeData
+  //    present, baselineAnalyzeData absent. Already handled below by
+  //    passing `null` for A.
+  const sourceDiff = useMemo(() => {
+    if (!baselineSnapshot) return null
+    if (analyzeData) {
+      return diffSources(baselineAnalyzeData ?? null, analyzeData, {
+        filterSource: compareFilterSource,
+      })
+    }
+    // Removed-route case: only the baseline has data. Diff baseline vs.
+    // baseline but suppress the B side via the filter so every source
+    // appears as `removed`.
+    if (baselineAnalyzeData) {
+      return diffSources(baselineAnalyzeData, baselineAnalyzeData, {
+        filterSource: (side, index) =>
+          side === 'A' && compareFilterSource('A', index),
+      })
+    }
+    return null
+  }, [analyzeData, baselineAnalyzeData, baselineSnapshot, compareFilterSource])
+
+  // Per-route totals for both sides, used to size the route-level diff so
+  // that routes whose modules changed can be reported as `changed` rather
+  // than `identical`. Only fetched in compare mode.
+  const { totals: currentRouteTotals } = useRouteTotals(
+    baselineSnapshot ? (currentRoutes ?? null) : null,
+    baselineSnapshot ? 'data' : null
+  )
+  const { totals: baselineRouteTotals } = useRouteTotals(
+    baselineSnapshot ? (baselineRoutes ?? null) : null,
+    baselineSnapshot ? `history/${baselineSnapshot.id}` : null
+  )
+
+  // Route-level diff. Falls back to a name-only diff (`sizesA == null`)
+  // while totals are still loading; once both sides' totals arrive, real
+  // sizes drive `changed`/`identical` classification.
+  const routeDiff = useMemo(() => {
+    if (!baselineSnapshot || !currentRoutes) return null
+    if (!currentRouteTotals) return null
+    return diffRoutesWithSizes(
+      baselineRoutes ?? null,
+      currentRoutes,
+      baselineRouteTotals,
+      currentRouteTotals
+    )
+  }, [
+    baselineSnapshot,
+    baselineRoutes,
+    currentRoutes,
+    baselineRouteTotals,
+    currentRouteTotals,
+  ])
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!isResizing) return
@@ -158,9 +330,13 @@ export default function Home() {
     setIsResizing(false)
   }
 
+  // The compare panel can render even when the *baseline's* per-route data
+  // failed to load (e.g., the route is new). Don't surface that as a top-level
+  // error in compare mode.
   const error = analyzeError || modulesError
   const isAnyLoading = isAnalyzeLoading || isModulesLoading
   const rootSourceIndex = getRootSourceIndex(analyzeData)
+  const isCompareMode = baselineSnapshot != null
 
   return (
     <main
@@ -169,7 +345,7 @@ export default function Home() {
       onMouseUp={handleMouseUp}
     >
       <TopBar
-        analyzeData={analyzeData}
+        hasSourceData={analyzeData != null}
         selectedRoute={selectedRoute}
         setSelectedRoute={setSelectedRoute}
         environmentFilter={environmentFilter}
@@ -180,11 +356,39 @@ export default function Home() {
         setTypeFilter={setTypeFilter}
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
+        baselineSnapshot={baselineSnapshot}
+        onBaselineChange={setBaselineSnapshot}
+        routeDiff={routeDiff}
       />
 
       <div className="flex-1 flex min-h-0">
         {error && !analyzeData ? (
           <ErrorState error={error} />
+        ) : isCompareMode ? (
+          <CompareLayout
+            baselineSnapshot={baselineSnapshot!}
+            selectedRoute={selectedRoute}
+            currentRouteCount={currentRoutes?.length ?? null}
+            routeDiff={routeDiff}
+            sourceDiff={sourceDiff}
+            analyzeData={analyzeData ?? null}
+            baselineAnalyzeData={baselineAnalyzeData ?? null}
+            isAnalyzeLoading={isAnalyzeLoading}
+            isBaselineAnalyzeLoading={isBaselineAnalyzeLoading}
+            baselineAnalyzeError={
+              baselineAnalyzeError && baselineAnalyzeRouteExists
+                ? baselineAnalyzeError
+                : null
+            }
+            useCompressed
+            compareSelectedKey={compareSelectedKey}
+            setCompareSelectedKey={setCompareSelectedKey}
+            modulesData={modulesData ?? null}
+            baselineModulesData={baselineModulesData ?? null}
+            moduleDepthMap={moduleDepthMap}
+            baselineModuleDepthMap={baselineModuleDepthMap}
+            environmentFilter={environmentFilter}
+          />
         ) : isAnyLoading ? (
           <>
             <div className="flex-1 min-w-0 p-4 bg-background">
@@ -230,7 +434,7 @@ export default function Home() {
             <button
               type="button"
               className="flex-none w-1 bg-border hover:bg-primary cursor-col-resize transition-colors"
-              onMouseDown={handleMouseDown}
+              onMouseDown={() => setIsResizing(true)}
               aria-label="Resize sidebar"
             />
 
@@ -247,7 +451,7 @@ export default function Home() {
         ) : null}
       </div>
 
-      {analyzeData && (
+      {analyzeData && !isCompareMode ? (
         <div className="flex-none border-t border-border bg-background px-4 py-2 h-10">
           <div className="text-sm text-muted-foreground">
             {hoveredNodeInfo ? (
@@ -277,118 +481,9 @@ export default function Home() {
             )}
           </div>
         </div>
-      )}
+      ) : null}
     </main>
   )
-}
-
-const typeFilterOptions = [
-  {
-    value: 'js',
-    label: 'JavaScript',
-    icon: <FileCode className="h-3.5 w-3.5" />,
-  },
-  { value: 'css', label: 'CSS', icon: <Palette className="h-3.5 w-3.5" /> },
-  {
-    value: 'json',
-    label: 'JSON',
-    icon: <FileJson className="h-3.5 w-3.5" />,
-  },
-  {
-    value: 'asset',
-    label: 'Asset',
-    icon: <Package className="h-3.5 w-3.5" />,
-  },
-]
-
-function TopBar({
-  analyzeData,
-  selectedRoute,
-  setSelectedRoute,
-  environmentFilter,
-  setEnvironmentFilter,
-  setSelectedSourceIndex,
-  setFocusedSourceIndex,
-  typeFilter,
-  setTypeFilter,
-  searchQuery,
-  setSearchQuery,
-}: {
-  analyzeData: AnalyzeData | undefined
-  selectedRoute: string | null
-  setSelectedRoute: (route: string | null) => void
-  environmentFilter: Environment
-  setEnvironmentFilter: (env: Environment) => void
-  setSelectedSourceIndex: (index: number | null) => void
-  setFocusedSourceIndex: (index: number | null) => void
-  typeFilter: string[]
-  setTypeFilter: (types: string[]) => void
-  searchQuery: string
-  setSearchQuery: (query: string) => void
-}) {
-  return (
-    <div className="flex-none px-4 py-2 border-b border-border flex items-center gap-3">
-      <div className="flex-1 flex">
-        <RouteTypeahead
-          selectedRoute={selectedRoute}
-          onRouteSelected={(route) => {
-            setSelectedRoute(route)
-            setSelectedSourceIndex(null)
-            setFocusedSourceIndex(null)
-          }}
-        />
-      </div>
-
-      <div className="flex items-center gap-2">
-        {analyzeData && (
-          <>
-            <Select
-              value={environmentFilter}
-              onValueChange={(value: Environment) =>
-                setEnvironmentFilter(value)
-              }
-            >
-              <SelectTrigger className="w-28">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={Environment.Client}>
-                  <div className="flex items-center gap-1.5">
-                    <Monitor className="h-3.5 w-3.5" />
-                    <span className="text-xs">Client</span>
-                  </div>
-                </SelectItem>
-                <SelectItem value={Environment.Server}>
-                  <div className="flex items-center gap-1.5">
-                    <Server className="h-3.5 w-3.5" />
-                    <span className="text-xs">Server</span>
-                  </div>
-                </SelectItem>
-              </SelectContent>
-            </Select>
-
-            <MultiSelect
-              options={typeFilterOptions}
-              value={typeFilter}
-              onValueChange={setTypeFilter}
-              selectionName={{ singular: 'file type', plural: 'file types' }}
-              triggerIcon={<FileCode className="h-3.5 w-3.5" />}
-              triggerClassName="w-36"
-              aria-label="Filter by file type"
-            />
-
-            <ControlDivider />
-
-            <FileSearch value={searchQuery} onChange={setSearchQuery} />
-          </>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function ControlDivider() {
-  return <span className="h-6 w-px bg-muted-foreground/30" />
 }
 
 function getRootSourceIndex(analyzeData: AnalyzeData | undefined): number {

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -5,6 +5,7 @@ import type React from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import useSWR from 'swr'
 import { CompareLayout } from '@/components/compare-layout'
+import { DiffTable } from '@/components/diff-table'
 import { ErrorState } from '@/components/error-state'
 import { Sidebar } from '@/components/sidebar'
 import { TopBar, Environment, CompareView } from '@/components/top-bar'
@@ -304,6 +305,18 @@ export default function Home() {
     return null
   }, [analyzeData, baselineAnalyzeData, baselineSnapshot, compareFilterSource])
 
+  // In single-build (non-compare) mode the table view still wants a list
+  // of every source for the current route. We synthesize this by diffing
+  // the build against itself, which produces an all-`identical` summary
+  // that we feed into `<DiffTable mode="single">`. This keeps a single
+  // sources-listing implementation regardless of mode.
+  const singleSourceListing = useMemo(() => {
+    if (!analyzeData || baselineSnapshot) return null
+    return diffSources(analyzeData, analyzeData, {
+      filterSource: (_, index) => filterSource(index),
+    })
+  }, [analyzeData, baselineSnapshot, filterSource])
+
   // Per-route totals for both sides, used to size the route-level diff so
   // that routes whose modules changed can be reported as `changed` rather
   // than `identical`. Only fetched in compare mode.
@@ -362,7 +375,7 @@ export default function Home() {
     >
       <TopBar
         hasSourceData={analyzeData != null}
-        showViewToggle={isCompareMode}
+        showViewToggle={analyzeData != null}
         compareView={compareView}
         onCompareViewChange={setCompareView}
         selectedRoute={selectedRoute}
@@ -436,20 +449,40 @@ export default function Home() {
         ) : analyzeData ? (
           <>
             <div className="flex-1 min-w-0">
-              <TreemapVisualizer
-                analyzeData={analyzeData}
-                sourceIndex={rootSourceIndex}
-                selectedSourceIndex={selectedSourceIndex ?? rootSourceIndex}
-                onSelectSourceIndex={setSelectedSourceIndex}
-                focusedSourceIndex={focusedSourceIndex ?? rootSourceIndex}
-                onFocusSourceIndex={setFocusedSourceIndex}
-                isMouseInTreemap={isMouseInTreemap}
-                onMouseInTreemapChange={setIsMouseInTreemap}
-                onHoveredNodeChange={setHoveredNodeInfo}
-                searchQuery={searchQuery}
-                filterSource={filterSource}
-                sizeMode={SizeMode.Compressed}
-              />
+              {compareView === CompareView.Table && singleSourceListing ? (
+                <DiffTable
+                  summary={singleSourceListing}
+                  useCompressed
+                  nameHeading="Source"
+                  mode="single"
+                  searchQuery={searchQuery}
+                  onRowSelect={(row) => {
+                    // Each table row is a leaf source in the current build,
+                    // so `sourceIndexB` is always defined here. Selecting it
+                    // surfaces the import trace in the sidebar — same UX as
+                    // clicking a tile in the treemap.
+                    if (row.sourceIndexB != null) {
+                      setSelectedSourceIndex(row.sourceIndexB)
+                      setFocusedSourceIndex(row.sourceIndexB)
+                    }
+                  }}
+                />
+              ) : (
+                <TreemapVisualizer
+                  analyzeData={analyzeData}
+                  sourceIndex={rootSourceIndex}
+                  selectedSourceIndex={selectedSourceIndex ?? rootSourceIndex}
+                  onSelectSourceIndex={setSelectedSourceIndex}
+                  focusedSourceIndex={focusedSourceIndex ?? rootSourceIndex}
+                  onFocusSourceIndex={setFocusedSourceIndex}
+                  isMouseInTreemap={isMouseInTreemap}
+                  onMouseInTreemapChange={setIsMouseInTreemap}
+                  onHoveredNodeChange={setHoveredNodeInfo}
+                  searchQuery={searchQuery}
+                  filterSource={filterSource}
+                  sizeMode={SizeMode.Compressed}
+                />
+              )}
             </div>
 
             <button
@@ -472,7 +505,7 @@ export default function Home() {
         ) : null}
       </div>
 
-      {analyzeData && !isCompareMode ? (
+      {analyzeData && !isCompareMode && compareView === CompareView.Treemap ? (
         <div className="flex-none border-t border-border bg-background px-4 py-2 h-10">
           <div className="text-sm text-muted-foreground">
             {hoveredNodeInfo ? (

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -173,6 +173,7 @@ export default function Home() {
     server?: boolean
     client?: boolean
     traced?: boolean
+    asyncOnly?: boolean
   } | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   // Selected source in compare mode, identified by its full source path
@@ -480,6 +481,9 @@ export default function Home() {
                   onHoveredNodeChange={setHoveredNodeInfo}
                   searchQuery={searchQuery}
                   filterSource={filterSource}
+                  isAsyncOnlySource={analyzeData.isAsyncOnlySource.bind(
+                    analyzeData
+                  )}
                   sizeMode={SizeMode.Compressed}
                 />
               )}
@@ -506,8 +510,8 @@ export default function Home() {
       </div>
 
       {analyzeData && !isCompareMode && compareView === CompareView.Treemap ? (
-        <div className="flex-none border-t border-border bg-background px-4 py-2 h-10">
-          <div className="text-sm text-muted-foreground">
+        <div className="flex-none border-t border-border bg-background px-4 py-2 h-10 flex items-center justify-between">
+          <div className="text-sm text-muted-foreground min-w-0 truncate">
             {hoveredNodeInfo ? (
               <>
                 <span className="font-medium text-foreground">
@@ -527,12 +531,23 @@ export default function Home() {
                     {hoveredNodeInfo.traced && (
                       <Badge variant="traced">traced</Badge>
                     )}
+                    {hoveredNodeInfo.asyncOnly && (
+                      <Badge variant="async">async-only</Badge>
+                    )}
                   </span>
                 )}
               </>
             ) : (
               'Hover over a file to see details'
             )}
+          </div>
+          <div className="flex-none ml-4 inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span
+              className="inline-block w-3 h-3 rounded-sm border-2"
+              style={{ borderColor: '#f59e0b' }}
+              aria-hidden
+            />
+            <span>async-only (dynamic import on this route)</span>
           </div>
         </div>
       ) : null}

--- a/apps/bundle-analyzer/components/baseline-picker.tsx
+++ b/apps/bundle-analyzer/components/baseline-picker.tsx
@@ -1,0 +1,248 @@
+'use client'
+
+import useSWR from 'swr'
+import {
+  Check,
+  ChevronsUpDown,
+  GitCompareArrows,
+  Loader,
+  X,
+} from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { cn, jsonFetcher } from '@/lib/utils'
+import { NetworkError } from '@/lib/errors'
+import {
+  formatRelativeTime,
+  formatSnapshotLabel,
+  type HistoryIndex,
+  type SnapshotMetadata,
+} from '@/lib/snapshot'
+
+interface BaselinePickerProps {
+  /** Selected snapshot id, or null when no comparison is active. */
+  selectedSnapshotId: string | null
+  onSelectionChange: (snapshot: SnapshotMetadata | null) => void
+}
+
+/**
+ * Top-bar control that lets the user pick a historical analyze snapshot to
+ * compare the latest build against. When no snapshot is selected, the
+ * analyzer behaves as before (single-build view).
+ *
+ * Snapshots are loaded from `history/history.json` — written by
+ * `writeAnalyzeSnapshot` after each `next build --experimental-analyze`.
+ */
+export function BaselinePicker({
+  selectedSnapshotId,
+  onSelectionChange,
+}: BaselinePickerProps) {
+  const [open, setOpen] = useState(false)
+
+  const {
+    data: history,
+    isLoading,
+    error,
+  } = useSWR<HistoryIndex>('history/history.json', jsonFetcher, {
+    // History rarely changes during a session — avoid spamming refetches.
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    // Treat 404 as "no history yet" rather than an error so users on fresh
+    // installs see a graceful disabled state instead of a red banner.
+    shouldRetryOnError: false,
+  })
+
+  // Metadata for the *current* build, so we can exclude its corresponding
+  // entry from the history picker (you can't compare a build with itself).
+  const { data: currentMetadata } = useSWR<SnapshotMetadata>(
+    'data/metadata.json',
+    jsonFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false,
+    }
+  )
+
+  const allSnapshots = history?.snapshots ?? []
+  // Filter out the current build's snapshot — comparing to self is a no-op.
+  const snapshots = currentMetadata
+    ? allSnapshots.filter((s) => s.id !== currentMetadata.id)
+    : allSnapshots
+  const selected =
+    selectedSnapshotId != null
+      ? snapshots.find((s) => s.id === selectedSnapshotId)
+      : null
+
+  // Surface only fatal/network problems; missing history files are not errors.
+  const hasError = error instanceof NetworkError
+
+  const isEmpty = !isLoading && snapshots.length === 0
+  // When the only snapshot on disk is the current build itself, surface a
+  // distinct label/tooltip telling the user to run another build.
+  const isOnlyCurrentBuild =
+    !isLoading && allSnapshots.length > 0 && snapshots.length === 0
+
+  let triggerText: React.ReactNode
+  if (isLoading) {
+    triggerText = 'Loading history…'
+  } else if (selected) {
+    triggerText = (
+      <span className="flex items-center gap-1.5 truncate">
+        <span className="text-muted-foreground text-xs">vs</span>
+        <span className="font-mono truncate">
+          {formatSnapshotLabel(selected)}
+        </span>
+      </span>
+    )
+  } else {
+    triggerText = 'Compare with…'
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={isLoading || hasError}
+            className="min-w-44 max-w-72 justify-between text-sm"
+            title={hasError ? 'Unable to load build history' : undefined}
+          >
+            <div className="flex items-center min-w-0">
+              {isLoading ? (
+                <Loader className="mr-2 h-3.5 w-3.5 inline animate-spin" />
+              ) : (
+                <GitCompareArrows className="mr-2 h-3.5 w-3.5 inline" />
+              )}
+              <span className="truncate">{triggerText}</span>
+            </div>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-96 p-0">
+          <Command>
+            {snapshots.length > 0 ? (
+              <CommandInput placeholder="Search snapshots…" className="h-9" />
+            ) : null}
+            <CommandList>
+              {isOnlyCurrentBuild ? (
+                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  <div className="font-medium text-foreground">
+                    No prior builds yet
+                  </div>
+                  <div className="mt-1">
+                    Run{' '}
+                    <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                      next experimental-analyze
+                    </code>{' '}
+                    again to capture a baseline you can compare against.
+                  </div>
+                </div>
+              ) : isEmpty ? (
+                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  <div className="font-medium text-foreground">
+                    No build history
+                  </div>
+                  <div className="mt-1">
+                    Run{' '}
+                    <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                      next build --experimental-analyze
+                    </code>{' '}
+                    to start collecting snapshots.
+                  </div>
+                </div>
+              ) : (
+                <CommandEmpty>No snapshots found.</CommandEmpty>
+              )}
+              <CommandGroup>
+                {snapshots.map((snapshot) => (
+                  <CommandItem
+                    key={snapshot.id}
+                    value={`${snapshot.id} ${snapshot.gitBranch ?? ''} ${snapshot.gitShortSha ?? ''}`}
+                    onSelect={() => {
+                      onSelectionChange(snapshot)
+                      setOpen(false)
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        'mr-2 h-4 w-4',
+                        selectedSnapshotId === snapshot.id
+                          ? 'opacity-100'
+                          : 'opacity-0'
+                      )}
+                    />
+                    <SnapshotRow snapshot={snapshot} />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {selected != null && (
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Stop comparing"
+          onClick={() => onSelectionChange(null)}
+          className="h-8 w-8"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+/** A single row in the snapshot picker list. */
+function SnapshotRow({ snapshot }: { snapshot: SnapshotMetadata }) {
+  return (
+    <div className="flex flex-col min-w-0 flex-1">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="font-mono text-sm truncate">
+          {formatSnapshotLabel(snapshot)}
+        </span>
+        {snapshot.gitDirty ? (
+          <span
+            title="Working tree was dirty when this snapshot was taken"
+            className="text-xs text-amber-600 dark:text-amber-400"
+          >
+            dirty
+          </span>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span>{formatRelativeTime(snapshot.createdAt)}</span>
+        <span aria-hidden>·</span>
+        <span>
+          {snapshot.routeCount} route
+          {snapshot.routeCount === 1 ? '' : 's'}
+        </span>
+        {snapshot.nextVersion ? (
+          <>
+            <span aria-hidden>·</span>
+            <span>v{snapshot.nextVersion}</span>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/baseline-picker.tsx
+++ b/apps/bundle-analyzer/components/baseline-picker.tsx
@@ -230,7 +230,7 @@ function SnapshotRow({ snapshot }: { snapshot: SnapshotMetadata }) {
         ) : null}
       </div>
       {snapshot.gitMessage ? (
-        <div className="text-xs text-foreground/70 truncate italic">
+        <div className="text-xs text-foreground/70 truncate">
           {snapshot.gitMessage}
         </div>
       ) : null}

--- a/apps/bundle-analyzer/components/baseline-picker.tsx
+++ b/apps/bundle-analyzer/components/baseline-picker.tsx
@@ -174,7 +174,7 @@ export function BaselinePicker({
                 {snapshots.map((snapshot) => (
                   <CommandItem
                     key={snapshot.id}
-                    value={`${snapshot.id} ${snapshot.gitBranch ?? ''} ${snapshot.gitShortSha ?? ''} ${snapshot.gitMessage ?? ''} ${snapshot.snapshotLabel ?? ''}`}
+                    value={`${snapshot.id} ${snapshot.gitBranch ?? ''} ${snapshot.gitShortSha ?? ''} ${snapshot.gitMessage ?? ''} ${snapshot.baselineName ?? ''}`}
                     onSelect={() => {
                       onSelectionChange(snapshot)
                       setOpen(false)

--- a/apps/bundle-analyzer/components/baseline-picker.tsx
+++ b/apps/bundle-analyzer/components/baseline-picker.tsx
@@ -174,7 +174,7 @@ export function BaselinePicker({
                 {snapshots.map((snapshot) => (
                   <CommandItem
                     key={snapshot.id}
-                    value={`${snapshot.id} ${snapshot.gitBranch ?? ''} ${snapshot.gitShortSha ?? ''}`}
+                    value={`${snapshot.id} ${snapshot.gitBranch ?? ''} ${snapshot.gitShortSha ?? ''} ${snapshot.gitMessage ?? ''} ${snapshot.snapshotLabel ?? ''}`}
                     onSelect={() => {
                       onSelectionChange(snapshot)
                       setOpen(false)
@@ -229,6 +229,11 @@ function SnapshotRow({ snapshot }: { snapshot: SnapshotMetadata }) {
           </span>
         ) : null}
       </div>
+      {snapshot.gitMessage ? (
+        <div className="text-xs text-foreground/70 truncate italic">
+          {snapshot.gitMessage}
+        </div>
+      ) : null}
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <span>{formatRelativeTime(snapshot.createdAt)}</span>
         <span aria-hidden>·</span>

--- a/apps/bundle-analyzer/components/compare-layout.tsx
+++ b/apps/bundle-analyzer/components/compare-layout.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useEffect } from 'react'
 import { CompareSidebar } from '@/components/sidebar'
+import { DiffTable } from '@/components/diff-table'
 import { DiffTreemap } from '@/components/diff-treemap'
 import { TreemapSkeleton } from '@/components/ui/skeleton'
 import { StatCard, CountCard } from '@/components/stat-cards'
-import { Environment } from '@/components/top-bar'
+import { CompareView, Environment } from '@/components/top-bar'
 import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
 import {
   diffRoutesWithSizes,
@@ -18,6 +19,7 @@ import { cn, formatBytes } from '@/lib/utils'
 
 export interface CompareLayoutProps {
   baselineSnapshot: SnapshotMetadata
+  compareView: CompareView
   selectedRoute: string | null
   currentRouteCount: number | null
   routeDiff: ReturnType<typeof diffRoutesWithSizes> | null
@@ -28,6 +30,7 @@ export interface CompareLayoutProps {
   isBaselineAnalyzeLoading: boolean
   baselineAnalyzeError: unknown | null
   useCompressed: boolean
+  searchQuery: string
   compareSelectedKey: string | null
   setCompareSelectedKey: (key: string | null) => void
   modulesData: ModulesData | null
@@ -38,16 +41,17 @@ export interface CompareLayoutProps {
 }
 
 /**
- * Renders the comparison view (treemap) with a context strip at the top
- * showing the two builds being compared. The "before" build (A) is rendered
- * on the left and the "after" build (B) — the latest one — on the right,
- * matching the user's mental model.
+ * Renders the comparison view (treemap + table) with a context strip at the
+ * top showing the two builds being compared. The "before" build (A) is
+ * rendered on the left and the "after" build (B) — the latest one — on the
+ * right, matching the user's mental model.
  *
  * Route selection lives in the top-bar route picker (`RouteTypeahead`),
  * which also renders per-route deltas in compare mode.
  */
 export function CompareLayout({
   baselineSnapshot,
+  compareView,
   selectedRoute,
   currentRouteCount,
   routeDiff,
@@ -58,6 +62,7 @@ export function CompareLayout({
   isBaselineAnalyzeLoading,
   baselineAnalyzeError,
   useCompressed,
+  searchQuery,
   compareSelectedKey,
   setCompareSelectedKey,
   modulesData,
@@ -115,12 +120,13 @@ export function CompareLayout({
       </div>
 
       {/*
-        Per-route source diff + sidebar. The sidebar slides in when a
+        Per-route source diff + sidebar. The sidebar slides in when a row or
         treemap tile is selected and shows the import chain for that source.
       */}
       <div className="flex flex-1 min-h-0">
         <div className="flex flex-1 min-w-0 flex-col">
           <ComparePerRoutePanel
+            compareView={compareView}
             selectedRoute={selectedRoute}
             sourceDiff={sourceDiff}
             analyzeData={analyzeData}
@@ -128,6 +134,8 @@ export function CompareLayout({
             isAnalyzeLoading={isAnalyzeLoading}
             isBaselineAnalyzeLoading={isBaselineAnalyzeLoading}
             useCompressed={useCompressed}
+            searchQuery={searchQuery}
+            baselineSnapshot={baselineSnapshot}
             compareSelectedKey={compareSelectedKey}
             onCompareSelectedKeyChange={setCompareSelectedKey}
           />
@@ -381,11 +389,12 @@ function RouteStatsBody({
 }
 
 /**
- * Per-route comparison panel. Shows the diff treemap. Handles missing-route
- * states (the route is new in the latest build, or was removed) with
- * friendly messaging.
+ * Per-route comparison panel. Shows either the diff treemap or the diff table,
+ * controlled by `compareView`. Handles missing-route states (the route is new
+ * in the latest build, or was removed) with friendly messaging.
  */
 function ComparePerRoutePanel({
+  compareView,
   selectedRoute,
   sourceDiff,
   analyzeData,
@@ -393,9 +402,12 @@ function ComparePerRoutePanel({
   isAnalyzeLoading,
   isBaselineAnalyzeLoading,
   useCompressed,
+  searchQuery,
+  baselineSnapshot,
   compareSelectedKey,
   onCompareSelectedKeyChange,
 }: {
+  compareView: CompareView
   selectedRoute: string | null
   sourceDiff: DiffSummary<SourceDiffRow> | null
   analyzeData: AnalyzeData | null
@@ -403,6 +415,8 @@ function ComparePerRoutePanel({
   isAnalyzeLoading: boolean
   isBaselineAnalyzeLoading: boolean
   useCompressed: boolean
+  searchQuery: string
+  baselineSnapshot: SnapshotMetadata
   compareSelectedKey: string | null
   onCompareSelectedKeyChange: (key: string | null) => void
 }) {
@@ -430,14 +444,27 @@ function ComparePerRoutePanel({
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <DiffTreemap
-        summary={sourceDiff}
-        useCompressed={useCompressed}
-        analyzeData={analyzeData}
-        baselineAnalyzeData={baselineAnalyzeData}
-        selectedKey={compareSelectedKey}
-        onSelectKey={onCompareSelectedKeyChange}
-      />
+      {compareView === CompareView.Treemap ? (
+        <DiffTreemap
+          summary={sourceDiff}
+          useCompressed={useCompressed}
+          analyzeData={analyzeData}
+          baselineAnalyzeData={baselineAnalyzeData}
+          selectedKey={compareSelectedKey}
+          onSelectKey={onCompareSelectedKeyChange}
+        />
+      ) : (
+        <DiffTable
+          summary={sourceDiff}
+          useCompressed={useCompressed}
+          nameHeading="Source"
+          aHeading={formatSnapshotLabel(baselineSnapshot)}
+          bHeading="Latest"
+          searchQuery={searchQuery}
+          selectedKey={compareSelectedKey}
+          onRowSelect={(row) => onCompareSelectedKeyChange(row.key)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/bundle-analyzer/components/compare-layout.tsx
+++ b/apps/bundle-analyzer/components/compare-layout.tsx
@@ -1,0 +1,443 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { CompareSidebar } from '@/components/sidebar'
+import { DiffTreemap } from '@/components/diff-treemap'
+import { TreemapSkeleton } from '@/components/ui/skeleton'
+import { StatCard, CountCard } from '@/components/stat-cards'
+import { Environment } from '@/components/top-bar'
+import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
+import {
+  diffRoutesWithSizes,
+  formatDelta,
+  type DiffSummary,
+  type SourceDiffRow,
+} from '@/lib/diff'
+import { formatSnapshotLabel, type SnapshotMetadata } from '@/lib/snapshot'
+import { cn, formatBytes } from '@/lib/utils'
+
+export interface CompareLayoutProps {
+  baselineSnapshot: SnapshotMetadata
+  selectedRoute: string | null
+  currentRouteCount: number | null
+  routeDiff: ReturnType<typeof diffRoutesWithSizes> | null
+  sourceDiff: DiffSummary<SourceDiffRow> | null
+  analyzeData: AnalyzeData | null
+  baselineAnalyzeData: AnalyzeData | null
+  isAnalyzeLoading: boolean
+  isBaselineAnalyzeLoading: boolean
+  baselineAnalyzeError: unknown | null
+  useCompressed: boolean
+  compareSelectedKey: string | null
+  setCompareSelectedKey: (key: string | null) => void
+  modulesData: ModulesData | null
+  baselineModulesData: ModulesData | null
+  moduleDepthMap: Map<number, number>
+  baselineModuleDepthMap: Map<number, number>
+  environmentFilter: Environment
+}
+
+/**
+ * Renders the comparison view (treemap) with a context strip at the top
+ * showing the two builds being compared. The "before" build (A) is rendered
+ * on the left and the "after" build (B) — the latest one — on the right,
+ * matching the user's mental model.
+ *
+ * Route selection lives in the top-bar route picker (`RouteTypeahead`),
+ * which also renders per-route deltas in compare mode.
+ */
+export function CompareLayout({
+  baselineSnapshot,
+  selectedRoute,
+  currentRouteCount,
+  routeDiff,
+  sourceDiff,
+  analyzeData,
+  baselineAnalyzeData,
+  isAnalyzeLoading,
+  isBaselineAnalyzeLoading,
+  baselineAnalyzeError,
+  useCompressed,
+  compareSelectedKey,
+  setCompareSelectedKey,
+  modulesData,
+  baselineModulesData,
+  moduleDepthMap,
+  baselineModuleDepthMap,
+  environmentFilter,
+}: CompareLayoutProps) {
+  const [sidebarWidth, setSidebarWidth] = useState(20)
+  const [isResizing, setIsResizing] = useState(false)
+
+  useEffect(() => {
+    if (!isResizing) return
+    const handleMouseMove = (e: MouseEvent) => {
+      const newWidth =
+        ((window.innerWidth - e.clientX) / window.innerWidth) * 100
+      setSidebarWidth(Math.max(10, Math.min(50, newWidth)))
+    }
+    const handleMouseUp = () => setIsResizing(false)
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isResizing])
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-col">
+      {/*
+        Stats header. On wide viewports the Route stats sit next to the App
+        stats so the user can compare route-level and app-level deltas
+        without scrolling. Route is on the left because it's the primary
+        scope the user's focused on; App is reference context.
+        On narrow viewports the two strips stack vertically (route above
+        app) and fall back to the original layout.
+      */}
+      <div className="flex flex-none flex-col border-b border-border xl:flex-row xl:items-stretch">
+        <RouteStatsCard
+          selectedRoute={selectedRoute}
+          sourceDiff={sourceDiff}
+          isAnalyzeLoading={isAnalyzeLoading}
+          isBaselineAnalyzeLoading={isBaselineAnalyzeLoading}
+          baselineAnalyzeError={baselineAnalyzeError}
+          useCompressed={useCompressed}
+          className="xl:min-w-0 xl:flex-1 xl:basis-0 xl:border-r xl:border-border"
+        />
+        <CompareContextStrip
+          baselineSnapshot={baselineSnapshot}
+          currentRouteCount={currentRouteCount}
+          routeDiff={routeDiff}
+          useCompressed={useCompressed}
+          className="xl:min-w-0 xl:flex-1 xl:basis-0"
+        />
+      </div>
+
+      {/*
+        Per-route source diff + sidebar. The sidebar slides in when a
+        treemap tile is selected and shows the import chain for that source.
+      */}
+      <div className="flex flex-1 min-h-0">
+        <div className="flex flex-1 min-w-0 flex-col">
+          <ComparePerRoutePanel
+            selectedRoute={selectedRoute}
+            sourceDiff={sourceDiff}
+            analyzeData={analyzeData}
+            baselineAnalyzeData={baselineAnalyzeData}
+            isAnalyzeLoading={isAnalyzeLoading}
+            isBaselineAnalyzeLoading={isBaselineAnalyzeLoading}
+            useCompressed={useCompressed}
+            compareSelectedKey={compareSelectedKey}
+            onCompareSelectedKeyChange={setCompareSelectedKey}
+          />
+        </div>
+        <button
+          type="button"
+          className="flex-none w-1 bg-border hover:bg-primary cursor-col-resize transition-colors"
+          onMouseDown={() => setIsResizing(true)}
+          aria-label="Resize sidebar"
+        />
+        <CompareSidebar
+          selectedKey={compareSelectedKey}
+          sourceDiff={sourceDiff}
+          analyzeData={analyzeData}
+          baselineAnalyzeData={baselineAnalyzeData}
+          modulesData={modulesData}
+          baselineModulesData={baselineModulesData}
+          moduleDepthMap={moduleDepthMap}
+          baselineModuleDepthMap={baselineModuleDepthMap}
+          environmentFilter={environmentFilter}
+          sidebarWidth={sidebarWidth}
+          aLabel={formatSnapshotLabel(baselineSnapshot)}
+          bLabel="Latest"
+        />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Strip across the top of the compare view that labels the two builds and
+ * shows headline stats (total routes, added, removed, changed, identical,
+ * total size). Modeled after the vite bundle-stats compare summary cards:
+ * each card uses an `A → B` arrow with a delta chip, so size/count changes
+ * are scannable at a glance.
+ *
+ * A/B label pills below identify which snapshot is which.
+ */
+function CompareContextStrip({
+  baselineSnapshot,
+  currentRouteCount,
+  routeDiff,
+  useCompressed,
+  className,
+}: {
+  baselineSnapshot: SnapshotMetadata
+  currentRouteCount: number | null
+  routeDiff: ReturnType<typeof diffRoutesWithSizes> | null
+  useCompressed: boolean
+  className?: string
+}) {
+  const baselineRoutes = baselineSnapshot.routeCount
+  const latestRoutes =
+    currentRouteCount ??
+    routeDiff?.rows.filter((r) => r.status !== 'removed').length ??
+    null
+
+  const totalA = routeDiff
+    ? useCompressed
+      ? routeDiff.totalCompressedA
+      : routeDiff.totalA
+    : null
+  const totalB = routeDiff
+    ? useCompressed
+      ? routeDiff.totalCompressedB
+      : routeDiff.totalB
+    : null
+  const sizeDelta = totalA != null && totalB != null ? totalB - totalA : null
+
+  const counts = routeDiff?.counts
+
+  return (
+    <div
+      className={cn(
+        'flex flex-none flex-col gap-2 bg-muted/30 px-4 py-3',
+        className
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          App
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-border" />
+      </div>
+      <div className="flex flex-wrap items-stretch gap-2">
+        <StatCard
+          label="Total routes"
+          a={baselineRoutes}
+          b={latestRoutes}
+          deltaTone="neutral"
+        />
+        <StatCard
+          label="Total size"
+          a={totalA}
+          b={totalB}
+          formatValue={formatBytes}
+          deltaValue={sizeDelta}
+          formatDeltaValue={(d) => formatDelta(d)}
+          deltaTone="size"
+        />
+        {counts ? (
+          <>
+            <CountCard label="Routes added" value={counts.added} tone="added" />
+            <CountCard
+              label="Routes removed"
+              value={counts.removed}
+              tone="removed"
+            />
+            <CountCard
+              label="Routes changed"
+              value={counts.changed}
+              tone="changed"
+            />
+            <CountCard
+              label="Routes identical"
+              value={counts.identical}
+              tone="identical"
+            />
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Route-scope stats card shown alongside the app-wide stats in the compare
+ * view header. Handles the various "no data" states (no route picked yet,
+ * loading, missing data) inline so the header always occupies a consistent
+ * slot in the layout.
+ */
+function RouteStatsCard({
+  selectedRoute,
+  sourceDiff,
+  isAnalyzeLoading,
+  isBaselineAnalyzeLoading,
+  baselineAnalyzeError,
+  useCompressed,
+  className,
+}: {
+  selectedRoute: string | null
+  sourceDiff: DiffSummary<SourceDiffRow> | null
+  isAnalyzeLoading: boolean
+  isBaselineAnalyzeLoading: boolean
+  baselineAnalyzeError: unknown | null
+  useCompressed: boolean
+  className?: string
+}) {
+  const isLoading = isAnalyzeLoading || isBaselineAnalyzeLoading
+
+  const body = !selectedRoute ? (
+    <div className="pt-1 text-xs text-muted-foreground">
+      Select a route above to see per-source changes.
+    </div>
+  ) : isLoading ? (
+    <div className="pt-1 text-xs text-muted-foreground">Loading…</div>
+  ) : !sourceDiff ? (
+    <div className="pt-1 text-xs text-muted-foreground">
+      No data for this route.
+    </div>
+  ) : (
+    <RouteStatsBody
+      selectedRoute={selectedRoute}
+      sourceDiff={sourceDiff}
+      baselineAnalyzeError={baselineAnalyzeError}
+      useCompressed={useCompressed}
+    />
+  )
+
+  return (
+    <div className={cn('flex flex-none flex-col gap-2 px-4 py-3', className)}>
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Route
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-border" />
+      </div>
+      {body}
+    </div>
+  )
+}
+
+/**
+ * Inner body for {@link RouteStatsCard} when source diff data is available.
+ * Extracted so the stats card can render a placeholder cleanly when no data
+ * is ready yet without nesting the data-dependent hooks/derivations above.
+ */
+function RouteStatsBody({
+  selectedRoute: _selectedRoute,
+  sourceDiff,
+  baselineAnalyzeError: _baselineAnalyzeError,
+  useCompressed,
+}: {
+  selectedRoute: string
+  sourceDiff: DiffSummary<SourceDiffRow>
+  baselineAnalyzeError: unknown | null
+  useCompressed: boolean
+}) {
+  const routeSizeA = useCompressed
+    ? sourceDiff.totalCompressedA
+    : sourceDiff.totalA
+  const routeSizeB = useCompressed
+    ? sourceDiff.totalCompressedB
+    : sourceDiff.totalB
+  const routeSizeDelta = routeSizeB - routeSizeA
+  const sourceCounts = sourceDiff.counts
+
+  return (
+    <>
+      {/*
+        Per-route stat strip. Mirrors the layout of the app-wide strip
+        but at route scope, so the user reads two parallel summaries:
+        one for the whole build, one drilled into the selected route.
+        The source-level counters use a different label prefix
+        ("Sources added" vs. the app-wide "Routes added") to make the
+        unit unambiguous.
+      */}
+      <div className="flex flex-wrap items-stretch gap-2 pt-1">
+        <StatCard
+          label="Total size"
+          a={routeSizeA}
+          b={routeSizeB}
+          formatValue={formatBytes}
+          deltaValue={routeSizeDelta}
+          formatDeltaValue={(d) => formatDelta(d)}
+          deltaTone="size"
+        />
+        <CountCard
+          label="Sources added"
+          value={sourceCounts.added}
+          tone="added"
+        />
+        <CountCard
+          label="Sources removed"
+          value={sourceCounts.removed}
+          tone="removed"
+        />
+        <CountCard
+          label="Sources changed"
+          value={sourceCounts.changed}
+          tone="changed"
+        />
+        <CountCard
+          label="Sources identical"
+          value={sourceCounts.identical}
+          tone="identical"
+        />
+      </div>
+    </>
+  )
+}
+
+/**
+ * Per-route comparison panel. Shows the diff treemap. Handles missing-route
+ * states (the route is new in the latest build, or was removed) with
+ * friendly messaging.
+ */
+function ComparePerRoutePanel({
+  selectedRoute,
+  sourceDiff,
+  analyzeData,
+  baselineAnalyzeData,
+  isAnalyzeLoading,
+  isBaselineAnalyzeLoading,
+  useCompressed,
+  compareSelectedKey,
+  onCompareSelectedKeyChange,
+}: {
+  selectedRoute: string | null
+  sourceDiff: DiffSummary<SourceDiffRow> | null
+  analyzeData: AnalyzeData | null
+  baselineAnalyzeData: AnalyzeData | null
+  isAnalyzeLoading: boolean
+  isBaselineAnalyzeLoading: boolean
+  useCompressed: boolean
+  compareSelectedKey: string | null
+  onCompareSelectedKeyChange: (key: string | null) => void
+}) {
+  if (!selectedRoute) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground">
+        Select a route above to see per-source changes.
+      </div>
+    )
+  }
+  if (isAnalyzeLoading || isBaselineAnalyzeLoading) {
+    return (
+      <div className="p-4">
+        <TreemapSkeleton />
+      </div>
+    )
+  }
+  if (!sourceDiff) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground">
+        No data for this route.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 min-h-0 flex-col">
+      <DiffTreemap
+        summary={sourceDiff}
+        useCompressed={useCompressed}
+        analyzeData={analyzeData}
+        baselineAnalyzeData={baselineAnalyzeData}
+        selectedKey={compareSelectedKey}
+        onSelectKey={onCompareSelectedKeyChange}
+      />
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/diff-table.tsx
+++ b/apps/bundle-analyzer/components/diff-table.tsx
@@ -1,0 +1,963 @@
+'use client'
+
+import { useMemo, useState, type ReactNode } from 'react'
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronDown,
+  ChevronRight,
+  Minus,
+  MinusCircle,
+  Package,
+  PlusCircle,
+} from 'lucide-react'
+
+import {
+  delta,
+  formatDelta,
+  sortByImpact,
+  type DiffRow,
+  type DiffSummary,
+  type DiffStatus,
+} from '@/lib/diff'
+import { formatBytes } from '@/lib/utils'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+
+/** Which column the table is currently sorted by. */
+type SortColumn = 'name' | 'a' | 'b' | 'delta'
+/** Sort direction. */
+type SortDirection = 'asc' | 'desc'
+
+interface DiffTableProps<Row extends DiffRow> {
+  summary: DiffSummary<Row>
+  useCompressed: boolean
+  /** Optional callback fired when a row is clicked. */
+  onRowSelect?: (row: Row) => void
+  /**
+   * Optional `key` of the currently-selected row. Highlights that row in
+   * the table so it stays visually linked to the compare sidebar.
+   */
+  selectedKey?: string | null
+  /** Optional column heading override for the "name" column. */
+  nameHeading?: string
+  /**
+   * Optional column heading override for the historical (before) column. The
+   * tooltip on hover always identifies the column as the historical build.
+   * Defaults to `'A'`.
+   */
+  aHeading?: string
+  /**
+   * Optional column heading override for the latest (after) column.
+   * Defaults to `'B'`.
+   */
+  bHeading?: string
+  /** Caption shown above the table. */
+  caption?: string
+  /**
+   * Display mode.
+   *
+   * - `'compare'` (default): full A | B | Δ columns, status filter,
+   *   per-row status icons. Used when comparing two builds.
+   * - `'single'`: a single `Size` column (mapped to B). Hides the
+   *   status filter and status iconography because every row is
+   *   `identical` against itself.
+   */
+  mode?: 'compare' | 'single'
+  /**
+   * Optional case-insensitive substring filter applied to each row's
+   * full path (`key`) and display name (`name`). When non-empty, only
+   * matching rows are rendered. Mirrors the treemap's search filter so
+   * the toolbar input affects both views consistently.
+   */
+  searchQuery?: string
+}
+
+/**
+ * Compact table comparing two builds, modeled on the vite-compare module-diff
+ * view. Columns:
+ *
+ *   | Name | A (before) | B (after) | Δ |
+ *
+ * Rows are sorted by absolute delta (largest impact first).
+ */
+export function DiffTable<Row extends DiffRow>({
+  summary,
+  useCompressed,
+  onRowSelect,
+  selectedKey,
+  nameHeading = 'Name',
+  aHeading = 'A',
+  bHeading = 'B',
+  caption,
+  mode = 'compare',
+  searchQuery,
+}: DiffTableProps<Row>) {
+  const isSingle = mode === 'single'
+  const [statusFilter, setStatusFilter] = useState<DiffStatus | 'all'>('all')
+  // Default sort:
+  //   - compare mode: rank by largest absolute delta (most-impactful change first).
+  //   - single mode: rank by size descending (largest contributors first).
+  const [sortColumn, setSortColumn] = useState<SortColumn>(
+    isSingle ? 'b' : 'delta'
+  )
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  // Source rows that live in the same npm package are grouped under a single
+  // collapsible header row. Tracks which package headers are expanded.
+  const [expandedPackages, setExpandedPackages] = useState<ReadonlySet<string>>(
+    () => new Set()
+  )
+
+  const togglePackage = (packageName: string) => {
+    setExpandedPackages((prev) => {
+      const next = new Set(prev)
+      if (next.has(packageName)) next.delete(packageName)
+      else next.add(packageName)
+      return next
+    })
+  }
+
+  const sorted = useMemo(() => {
+    // The default `delta`/`desc` mode preserves the existing impact-ranked
+    // sort, which keeps `identical` rows pinned at the bottom regardless of
+    // direction. Other columns sort lexicographically (name) or numerically
+    // (A, B) using the user's chosen direction.
+    if (sortColumn === 'delta' && sortDirection === 'desc') {
+      return sortByImpact(summary.rows, useCompressed)
+    }
+    return sortRows(summary.rows, sortColumn, sortDirection, useCompressed)
+  }, [summary.rows, sortColumn, sortDirection, useCompressed])
+
+  const onHeaderClick = (column: SortColumn) => {
+    if (column === sortColumn) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortColumn(column)
+      // Sensible default direction for each column type: text columns start
+      // ascending (A→Z), numeric columns start descending (largest first).
+      setSortDirection(column === 'name' ? 'asc' : 'desc')
+    }
+  }
+
+  const filtered = useMemo(() => {
+    const q = searchQuery?.trim().toLowerCase() ?? ''
+    return sorted.filter((row) => {
+      if (statusFilter !== 'all' && row.status !== statusFilter) return false
+      if (q !== '') {
+        const key = row.key.toLowerCase()
+        const name = row.name.toLowerCase()
+        if (!key.includes(q) && !name.includes(q)) return false
+      }
+      return true
+    })
+  }, [sorted, statusFilter, searchQuery])
+
+  // Group filtered rows by package, preserving the user's chosen sort order.
+  // Groups themselves are sorted by their aggregate using the same column +
+  // direction so ranking is consistent whether you look at the package roll-up
+  // or its contents. Rows without a `packageName` (project-relative paths)
+  // render flat as before.
+  const renderItems = useMemo(
+    () => buildRenderItems(filtered, sortColumn, sortDirection, useCompressed),
+    [filtered, sortColumn, sortDirection, useCompressed]
+  )
+
+  const totalDelta = useCompressed
+    ? summary.totalCompressedB - summary.totalCompressedA
+    : summary.totalB - summary.totalA
+
+  return (
+    <div className="flex h-full flex-col">
+      {caption ? (
+        <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
+          <span className="text-sm font-medium text-foreground">{caption}</span>
+        </div>
+      ) : null}
+
+      <div className="overflow-auto">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 z-10 bg-background">
+            <tr className="border-b border-border text-left text-xs uppercase text-muted-foreground">
+              <SortableHeader
+                label={nameHeading}
+                column="name"
+                activeColumn={sortColumn}
+                direction={sortDirection}
+                onClick={onHeaderClick}
+                align="left"
+                trailing={
+                  !isSingle ? (
+                    <DiffStatusFilter
+                      value={statusFilter}
+                      onChange={setStatusFilter}
+                      counts={summary.counts}
+                    />
+                  ) : null
+                }
+              />
+              {!isSingle ? (
+                <SortableHeader
+                  label={aHeading}
+                  column="a"
+                  activeColumn={sortColumn}
+                  direction={sortDirection}
+                  onClick={onHeaderClick}
+                  title="Historical build (before)"
+                  align="right"
+                />
+              ) : null}
+              <SortableHeader
+                label={isSingle ? 'Size' : bHeading}
+                column="b"
+                activeColumn={sortColumn}
+                direction={sortDirection}
+                onClick={onHeaderClick}
+                title={isSingle ? undefined : 'Latest build (after)'}
+                align="right"
+              />
+              {!isSingle ? (
+                <SortableHeader
+                  label="Δ"
+                  column="delta"
+                  activeColumn={sortColumn}
+                  direction={sortDirection}
+                  onClick={onHeaderClick}
+                  align="right"
+                />
+              ) : null}
+            </tr>
+          </thead>
+          <tbody>
+            {renderItems.flatMap((item) => {
+              if (item.kind === 'group') {
+                const isExpanded = expandedPackages.has(item.packageName)
+                const header = (
+                  <DiffPackageHeaderRow
+                    key={`pkg:${item.packageName}`}
+                    packageName={item.packageName}
+                    rows={item.rows}
+                    useCompressed={useCompressed}
+                    isExpanded={isExpanded}
+                    onToggle={() => togglePackage(item.packageName)}
+                    mode={mode}
+                  />
+                )
+                if (!isExpanded) return [header]
+                return [
+                  header,
+                  ...item.rows.map((row) => (
+                    <DiffTableRow
+                      key={`pkg:${item.packageName}:${row.key}`}
+                      row={row}
+                      useCompressed={useCompressed}
+                      indent
+                      onClick={onRowSelect ? () => onRowSelect(row) : undefined}
+                      isSelected={selectedKey === row.key}
+                      mode={mode}
+                    />
+                  )),
+                ]
+              }
+              return [
+                <DiffTableRow
+                  key={item.row.key}
+                  row={item.row}
+                  useCompressed={useCompressed}
+                  onClick={
+                    onRowSelect ? () => onRowSelect(item.row) : undefined
+                  }
+                  isSelected={selectedKey === item.row.key}
+                  mode={mode}
+                />,
+              ]
+            })}
+            {renderItems.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={isSingle ? 2 : 4}
+                  className="px-4 py-8 text-center text-sm text-muted-foreground"
+                >
+                  No matching rows.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+          <tfoot className="sticky bottom-0 bg-background">
+            {/*
+              Footer cells match the body's `text-xs` + `whitespace-nowrap`
+              so size totals (e.g. `259.74 KB`) can't wrap — at `text-sm`
+              the unit broke onto a second line in compare mode where the
+              numbers are larger.
+            */}
+            <tr className="border-t border-border text-xs font-medium">
+              <td className="px-4 py-2">Total</td>
+              {!isSingle ? (
+                <td className="whitespace-nowrap px-4 py-2 text-right font-mono">
+                  {formatBytes(
+                    useCompressed ? summary.totalCompressedA : summary.totalA
+                  )}
+                </td>
+              ) : null}
+              <td className="whitespace-nowrap px-4 py-2 text-right font-mono">
+                {formatBytes(
+                  useCompressed ? summary.totalCompressedB : summary.totalB
+                )}
+              </td>
+              {!isSingle ? (
+                <td
+                  className={cn(
+                    'whitespace-nowrap px-4 py-2 text-right font-mono',
+                    totalDelta > 0 && 'text-red-600 dark:text-red-400',
+                    totalDelta < 0 && 'text-green-600 dark:text-green-400'
+                  )}
+                >
+                  {formatDelta(totalDelta)}
+                </td>
+              ) : null}
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+/** Reads `packageName` off a row without leaking the source-row type. */
+function rowPackageName(row: DiffRow): string | undefined {
+  return (row as unknown as { packageName?: string }).packageName
+}
+
+/**
+ * One entry in the rendered table body. Either a package group header, or a
+ * leaf row. Children of an expanded group appear as separate `row` items
+ * immediately after their group header (`indent: true`).
+ */
+type RenderItem<Row extends DiffRow> =
+  | { kind: 'group'; packageName: string; rows: Row[] }
+  | { kind: 'row'; row: Row; indent: boolean }
+
+/**
+ * Aggregate stats for a package group, summed across all of its filtered
+ * leaves. Mirrors {@link DiffSummary} totals but at the package level.
+ */
+interface PackageAggregate {
+  sizeA: number
+  sizeB: number
+  compressedA: number
+  compressedB: number
+  /** Counts of children by status, used to render a compact summary. */
+  counts: Record<DiffStatus, number>
+  /** Total number of children, regardless of status. */
+  total: number
+}
+
+function aggregatePackage<Row extends DiffRow>(rows: Row[]): PackageAggregate {
+  const agg: PackageAggregate = {
+    sizeA: 0,
+    sizeB: 0,
+    compressedA: 0,
+    compressedB: 0,
+    counts: { added: 0, removed: 0, changed: 0, identical: 0 },
+    total: 0,
+  }
+  for (const row of rows) {
+    agg.sizeA += row.sizeA
+    agg.sizeB += row.sizeB
+    agg.compressedA += row.compressedA
+    agg.compressedB += row.compressedB
+    agg.counts[row.status] += 1
+    agg.total += 1
+  }
+  return agg
+}
+
+/**
+ * Builds the flat list of items to render in `<tbody>`. Source rows that
+ * share a `packageName` are grouped under a single header item; project
+ * rows are passed through as `row` items.
+ *
+ * Ordering: groups and ungrouped rows are interleaved in the order their
+ * top contributor appeared in `filtered`. This means the existing column
+ * sort drives the overall ranking — a package's position is determined by
+ * its highest-impact member, which keeps the most interesting groups near
+ * the top regardless of which column is active.
+ */
+function buildRenderItems<Row extends DiffRow>(
+  filtered: Row[],
+  sortColumn: SortColumn,
+  sortDirection: SortDirection,
+  useCompressed: boolean
+): RenderItem<Row>[] {
+  const items: RenderItem<Row>[] = []
+  const groupIndex = new Map<string, { rows: Row[]; itemIndex: number }>()
+
+  for (const row of filtered) {
+    const pkg = rowPackageName(row)
+    if (!pkg) {
+      items.push({ kind: 'row', row, indent: false })
+      continue
+    }
+    const existing = groupIndex.get(pkg)
+    if (existing) {
+      existing.rows.push(row)
+    } else {
+      const itemIndex = items.length
+      const rows: Row[] = [row]
+      items.push({ kind: 'group', packageName: pkg, rows })
+      groupIndex.set(pkg, { rows, itemIndex })
+    }
+  }
+
+  // Ensure children within each group are sorted using the same column &
+  // direction as the parent table. The first member of each group already
+  // appeared in the right top-level position thanks to the pre-sorted input.
+  if (groupIndex.size > 0) {
+    for (const { rows } of groupIndex.values()) {
+      const sortedChildren = sortRows(
+        rows,
+        sortColumn,
+        sortDirection,
+        useCompressed
+      )
+      rows.length = 0
+      rows.push(...sortedChildren)
+    }
+  }
+
+  return items
+}
+
+/**
+ * Header row for a package group. Renders an expand/collapse chevron, the
+ * package name (with package icon), a count of contained rows, and the
+ * aggregated A/B/Δ totals — the same shape as a leaf row so columns line up.
+ */
+function DiffPackageHeaderRow<Row extends DiffRow>({
+  packageName,
+  rows,
+  useCompressed,
+  isExpanded,
+  onToggle,
+  mode = 'compare',
+}: {
+  packageName: string
+  rows: Row[]
+  useCompressed: boolean
+  isExpanded: boolean
+  onToggle: () => void
+  mode?: 'compare' | 'single'
+}) {
+  const isSingle = mode === 'single'
+  const agg = aggregatePackage(rows)
+  const a = useCompressed ? agg.compressedA : agg.sizeA
+  const b = useCompressed ? agg.compressedB : agg.sizeB
+  const d = b - a
+  const aggregateStatus: DiffStatus =
+    a === 0 && b > 0
+      ? 'added'
+      : a > 0 && b === 0
+        ? 'removed'
+        : a === b
+          ? 'identical'
+          : 'changed'
+
+  return (
+    <tr
+      className={cn(
+        'border-b border-border bg-muted/30 transition-colors hover:bg-muted/50',
+        'cursor-pointer'
+      )}
+      onClick={onToggle}
+      aria-expanded={isExpanded}
+    >
+      <td className="w-full max-w-0 px-4 py-2 font-mono text-xs">
+        <span className="flex min-w-0 items-center gap-2">
+          {isExpanded ? (
+            <ChevronDown
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          ) : (
+            <ChevronRight
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          )}
+          {!isSingle ? <StatusIcon status={aggregateStatus} /> : null}
+          <span className="inline-flex min-w-0 shrink items-center gap-1 rounded border border-border bg-background/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            <Package className="h-3 w-3" aria-hidden />
+            <span className="truncate font-mono normal-case text-foreground">
+              {packageName}
+            </span>
+          </span>
+          <span className="ml-auto inline-flex shrink-0 items-center gap-2 whitespace-nowrap">
+            <span className="text-muted-foreground">
+              {agg.total} {agg.total === 1 ? 'module' : 'modules'}
+            </span>
+            {!isSingle ? <PackageCountBreakdown counts={agg.counts} /> : null}
+          </span>
+        </span>
+      </td>
+      {!isSingle ? (
+        <td className="whitespace-nowrap px-4 py-2 text-right font-mono text-xs text-muted-foreground">
+          {aggregateStatus === 'added' ? '—' : formatBytes(a)}
+        </td>
+      ) : null}
+      <td className="whitespace-nowrap px-4 py-2 text-right font-mono text-xs text-muted-foreground">
+        {aggregateStatus === 'removed' ? '—' : formatBytes(b)}
+      </td>
+      {!isSingle ? (
+        <td
+          className={cn(
+            'whitespace-nowrap px-4 py-2 text-right font-mono text-xs',
+            d > 0 && 'text-red-600 dark:text-red-400',
+            d < 0 && 'text-green-600 dark:text-green-400',
+            d === 0 && 'text-muted-foreground'
+          )}
+        >
+          {formatDelta(d)}
+        </td>
+      ) : null}
+    </tr>
+  )
+}
+
+/**
+ * Tiny inline summary of how many of each status are inside a package
+ * group. Kept extremely compact (single line, only shown statuses) so it
+ * sits comfortably next to the package chip.
+ */
+function PackageCountBreakdown({
+  counts,
+}: {
+  counts: Record<DiffStatus, number>
+}) {
+  const entries: Array<{ label: string; value: number; className: string }> = [
+    {
+      label: 'added',
+      value: counts.added,
+      className: 'text-red-600 dark:text-red-400',
+    },
+    {
+      label: 'removed',
+      value: counts.removed,
+      className: 'text-green-600 dark:text-green-400',
+    },
+    {
+      label: 'changed',
+      value: counts.changed,
+      className: 'text-amber-500',
+    },
+  ]
+  const visible = entries.filter((e) => e.value > 0)
+  if (visible.length === 0) return null
+  return (
+    <span className="inline-flex shrink-0 items-center gap-2 text-xs">
+      {visible.map((e, i) => (
+        <span key={e.label} className="inline-flex items-center gap-2">
+          {i > 0 ? (
+            <span className="text-muted-foreground/40" aria-hidden>
+              ·
+            </span>
+          ) : null}
+          <span className={e.className}>
+            {e.value} {e.label}
+          </span>
+        </span>
+      ))}
+    </span>
+  )
+}
+
+/**
+ * Sorts rows by the chosen column and direction. The `name` column compares
+ * using a locale-aware lexicographic ordering; numeric columns compare by
+ * value. `identical` rows are always pinned to the bottom — they aren't part
+ * of the "what changed" story and would otherwise dominate the top of an
+ * ascending sort.
+ */
+function sortRows<Row extends DiffRow>(
+  rows: Row[],
+  column: SortColumn,
+  direction: SortDirection,
+  useCompressed: boolean
+): Row[] {
+  const sign = direction === 'asc' ? 1 : -1
+  const compareKey = (row: Row): number | string => {
+    if (column === 'name') return row.name
+    if (column === 'a') return useCompressed ? row.compressedA : row.sizeA
+    if (column === 'b') return useCompressed ? row.compressedB : row.sizeB
+    return delta(row, useCompressed)
+  }
+  return [...rows].sort((a, b) => {
+    if (a.status === 'identical' && b.status !== 'identical') return 1
+    if (b.status === 'identical' && a.status !== 'identical') return -1
+    const av = compareKey(a)
+    const bv = compareKey(b)
+    if (typeof av === 'string' && typeof bv === 'string') {
+      const cmp = av.localeCompare(bv)
+      if (cmp !== 0) return cmp * sign
+    } else if (typeof av === 'number' && typeof bv === 'number') {
+      if (av !== bv) return (av - bv) * sign
+    }
+    // Stable tiebreaker on key for deterministic ordering.
+    return a.key < b.key ? -1 : 1
+  })
+}
+
+/**
+ * A clickable column header that surfaces the current sort state via an
+ * adjacent arrow icon. Clicking the active column flips the direction;
+ * clicking an inactive column switches to it with a column-appropriate
+ * default direction (ascending for text, descending for numbers).
+ */
+function SortableHeader({
+  label,
+  column,
+  activeColumn,
+  direction,
+  onClick,
+  title,
+  align,
+  trailing,
+}: {
+  label: ReactNode
+  column: SortColumn
+  activeColumn: SortColumn
+  direction: SortDirection
+  onClick: (column: SortColumn) => void
+  title?: string
+  align: 'left' | 'right'
+  /**
+   * Optional content rendered alongside the sort button inside the same
+   * `<th>`. Used by the name column to host the diff status filter so the
+   * filter pills sit directly next to the column they govern instead of
+   * floating in a separate toolbar above the table.
+   */
+  trailing?: ReactNode
+}) {
+  const isActive = column === activeColumn
+  const Icon = !isActive
+    ? ArrowUpDown
+    : direction === 'asc'
+      ? ArrowUp
+      : ArrowDown
+  return (
+    <th
+      className={cn(
+        'px-4 py-2 font-medium',
+        align === 'right' ? 'text-right' : 'text-left'
+      )}
+      title={title}
+      aria-sort={
+        isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
+      }
+    >
+      <div
+        className={cn(
+          'flex items-center gap-3',
+          align === 'right' ? 'justify-end' : 'justify-start'
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => onClick(column)}
+          className={cn(
+            'inline-flex items-center gap-1 uppercase transition-colors hover:text-foreground',
+            align === 'right' && 'flex-row-reverse',
+            isActive && 'text-foreground'
+          )}
+        >
+          <span>{label}</span>
+          <Icon
+            className={cn(
+              'h-3 w-3 shrink-0',
+              isActive ? 'opacity-100' : 'opacity-40'
+            )}
+            aria-hidden
+          />
+        </button>
+        {trailing}
+      </div>
+    </th>
+  )
+}
+
+/** Renders a single row in the diff table. */
+function DiffTableRow<Row extends DiffRow>({
+  row,
+  useCompressed,
+  onClick,
+  indent = false,
+  isSelected = false,
+  mode = 'compare',
+}: {
+  row: Row
+  useCompressed: boolean
+  onClick?: () => void
+  /** When true, the row is rendered as a child of a package group. */
+  indent?: boolean
+  /** When true, the row is highlighted as the active selection. */
+  isSelected?: boolean
+  mode?: 'compare' | 'single'
+}) {
+  const isSingle = mode === 'single'
+  const d = delta(row, useCompressed)
+  const isInteractive = onClick != null
+  return (
+    <tr
+      className={cn(
+        // `group` lets `DiffRowName` reveal env badges only on hover.
+        'group border-b border-border last:border-0 transition-colors',
+        isInteractive && 'cursor-pointer hover:bg-muted/50',
+        indent && 'bg-muted/10',
+        isSelected && 'bg-primary/10 hover:bg-primary/15'
+      )}
+      onClick={onClick}
+    >
+      <td
+        className={cn(
+          'w-full max-w-0 py-2 font-mono text-xs',
+          indent ? 'pl-12 pr-4' : 'px-4'
+        )}
+      >
+        <DiffRowName
+          row={row}
+          hidePackageBadge={indent}
+          hideStatusIcon={isSingle}
+        />
+      </td>
+      {!isSingle ? (
+        <td className="whitespace-nowrap px-4 py-2 text-right font-mono text-xs text-muted-foreground">
+          {row.status === 'added'
+            ? '—'
+            : formatBytes(useCompressed ? row.compressedA : row.sizeA)}
+        </td>
+      ) : null}
+      <td className="whitespace-nowrap px-4 py-2 text-right font-mono text-xs text-muted-foreground">
+        {row.status === 'removed'
+          ? '—'
+          : formatBytes(useCompressed ? row.compressedB : row.sizeB)}
+      </td>
+      {!isSingle ? (
+        <td
+          className={cn(
+            'whitespace-nowrap px-4 py-2 text-right font-mono text-xs',
+            d > 0 && 'text-red-600 dark:text-red-400',
+            d < 0 && 'text-green-600 dark:text-green-400',
+            d === 0 && 'text-muted-foreground'
+          )}
+        >
+          {formatDelta(d)}
+        </td>
+      ) : null}
+    </tr>
+  )
+}
+
+/**
+ * Renders the row name cell. For source rows that live inside an npm package,
+ * the package name is rendered as a styled "chip" root (with a package icon)
+ * and the rest of the path follows in muted tone — e.g.
+ *
+ *   📦 react/jsx-runtime.js
+ *
+ * The original full path is preserved on `title` for hover inspection.
+ *
+ * Project-relative paths render unchanged.
+ */
+function DiffRowName<Row extends DiffRow>({
+  row,
+  hidePackageBadge = false,
+  hideStatusIcon = false,
+}: {
+  row: Row
+  /** When true, only render the within-package path (no package chip). Used
+   * for rows displayed beneath an expanded package group header where the
+   * package name is already visible. */
+  hidePackageBadge?: boolean
+  /** When true, omit the per-status icon (used in single-build mode where
+   * every row is `identical` against itself, making the icon noise). */
+  hideStatusIcon?: boolean
+}) {
+  // Narrow without dragging SourceDiffRow's typings into the generic table.
+  const pathKind = (row as unknown as { pathKind?: 'package' | 'project' })
+    .pathKind
+  const packageName = (row as unknown as { packageName?: string }).packageName
+  const client = (row as unknown as { client?: boolean }).client === true
+  const server = (row as unknown as { server?: boolean }).server === true
+
+  if (pathKind === 'package' && packageName) {
+    const rest = row.name.startsWith(`${packageName}/`)
+      ? row.name.slice(packageName.length + 1)
+      : ''
+    if (hidePackageBadge) {
+      return (
+        <span className="flex min-w-0 items-center gap-2" title={row.key}>
+          {!hideStatusIcon ? <StatusIcon status={row.status} /> : null}
+          <span className="truncate text-muted-foreground">
+            {rest || packageName}
+          </span>
+          <EnvBadges client={client} server={server} />
+        </span>
+      )
+    }
+    return (
+      <span className="flex min-w-0 items-center gap-2" title={row.key}>
+        <ChevronSpacer />
+        {!hideStatusIcon ? <StatusIcon status={row.status} /> : null}
+        <span className="inline-flex min-w-0 items-center gap-1.5 truncate">
+          <span className="inline-flex shrink-0 items-center gap-1 rounded border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            <Package className="h-3 w-3" aria-hidden />
+            <span className="font-mono normal-case text-foreground">
+              {packageName}
+            </span>
+          </span>
+          {rest ? (
+            <span className="truncate text-muted-foreground">{rest}</span>
+          ) : null}
+        </span>
+        <EnvBadges client={client} server={server} />
+      </span>
+    )
+  }
+
+  return (
+    <span className="flex items-center gap-2">
+      <ChevronSpacer />
+      {!hideStatusIcon ? <StatusIcon status={row.status} /> : null}
+      <span className="truncate" title={row.key}>
+        {row.name}
+      </span>
+      <EnvBadges client={client} server={server} />
+    </span>
+  )
+}
+
+/**
+ * Invisible placeholder matching a {@link ChevronRight} icon's footprint.
+ * Used on non-expandable rows so their status icon aligns horizontally
+ * with expandable package-group rows that render a real chevron.
+ */
+function ChevronSpacer() {
+  return <span className="h-3.5 w-3.5 shrink-0" aria-hidden />
+}
+
+/**
+ * Inline `client` / `server` badges shown only on row hover. Mirrors the
+ * treemap hover footer's affordance — environment is signal users want when
+ * scanning a single row, but rendering it on every row makes the table
+ * noisy. The `group-hover:` reveal relies on the parent `<tr>` declaring
+ * `group`. Renders nothing when both flags are false (e.g. aggregate rows
+ * where flags weren't computed, or sources absent from both client and
+ * server graphs).
+ */
+function EnvBadges({ client, server }: { client: boolean; server: boolean }) {
+  if (!client && !server) return null
+  return (
+    <span
+      className={cn(
+        // `invisible` (vs `hidden`) keeps the badges in the flow so the
+        // row's height doesn't shift when they appear on hover. They
+        // still occupy layout space at rest, but the row's right edge
+        // is empty anyway in the name column (the size/delta cells are
+        // separate `<td>`s), so this is purely a height-stability fix.
+        'ml-auto invisible inline-flex shrink-0 items-center gap-1 pl-2',
+        'group-hover:visible'
+      )}
+      aria-hidden
+    >
+      {client ? (
+        <Badge variant="client" className="text-[10px]">
+          client
+        </Badge>
+      ) : null}
+      {server ? (
+        <Badge variant="server" className="text-[10px]">
+          server
+        </Badge>
+      ) : null}
+    </span>
+  )
+}
+
+/** Icon shown next to a row name to immediately convey status. */
+function StatusIcon({ status }: { status: DiffStatus }) {
+  if (status === 'added') {
+    return (
+      <PlusCircle
+        className="h-3.5 w-3.5 shrink-0 text-red-600 dark:text-red-400"
+        aria-label="Added"
+      />
+    )
+  }
+  if (status === 'removed') {
+    return (
+      <MinusCircle
+        className="h-3.5 w-3.5 shrink-0 text-green-600 dark:text-green-400"
+        aria-label="Removed"
+      />
+    )
+  }
+  if (status === 'changed') {
+    return (
+      <ArrowUp
+        className="h-3.5 w-3.5 shrink-0 text-amber-500"
+        aria-label="Changed"
+      />
+    )
+  }
+  return (
+    <Minus
+      className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+      aria-label="Identical"
+    />
+  )
+}
+
+/** Pill-style filter bar for diff statuses with row counts. */
+function DiffStatusFilter({
+  value,
+  onChange,
+  counts,
+}: {
+  value: DiffStatus | 'all'
+  onChange: (value: DiffStatus | 'all') => void
+  counts: Record<DiffStatus, number>
+}) {
+  const total =
+    counts.added + counts.removed + counts.changed + counts.identical
+  const options: Array<{
+    value: DiffStatus | 'all'
+    label: string
+    count: number
+  }> = [
+    { value: 'all', label: 'All', count: total },
+    { value: 'added', label: 'Added', count: counts.added },
+    { value: 'removed', label: 'Removed', count: counts.removed },
+    { value: 'changed', label: 'Changed', count: counts.changed },
+  ]
+  return (
+    <div className="flex items-center gap-1">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            'rounded px-2 py-0.5 text-xs',
+            value === opt.value
+              ? 'bg-secondary text-secondary-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {opt.label}
+          <Badge variant="secondary" className="ml-1.5 px-1 py-0 text-[10px]">
+            {opt.count}
+          </Badge>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/diff-treemap.tsx
+++ b/apps/bundle-analyzer/components/diff-treemap.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import type { AnalyzeData } from '@/lib/analyze-data'
+import type { DiffSummary, SourceDiffRow } from '@/lib/diff'
+import { delta, formatDelta } from '@/lib/diff'
+import { SizeMode, type LayoutNode } from '@/lib/treemap-layout'
+import { TreemapVisualizer } from '@/components/treemap-visualizer'
+
+/**
+ * Threshold (bytes) below which a row's delta is considered "noise" and the
+ * row is rendered as neutral grey rather than red/green. This keeps the
+ * visualization legible when the build pipeline produces tiny non-deterministic
+ * size deltas (e.g., source-map paths, comments).
+ */
+const NEUTRAL_DELTA_THRESHOLD = 4
+
+/** Color palette for diff tiles. Red = more bytes (bad), green = fewer bytes (good). */
+const COLOR_ADDED = '#dc2626' // red-600 — new bytes in bundle
+const COLOR_REMOVED = '#16a34a' // green-600 — bytes removed from bundle
+const COLOR_NEUTRAL = '#9ca3af' // gray-400
+
+interface DiffTreemapProps {
+  summary: DiffSummary<SourceDiffRow>
+  useCompressed: boolean
+  /**
+   * Analyze data for the current ("B") build. Used as the source-of-truth
+   * tree when present.
+   */
+  analyzeData: AnalyzeData | null
+  /**
+   * Analyze data for the baseline ("A") build. Only used when the route was
+   * removed (no B-side data) so we can still render the removed sources.
+   */
+  baselineAnalyzeData: AnalyzeData | null
+  /**
+   * Currently selected diff row (its `key`). Used so the compare sidebar
+   * and treemap stay in sync when the user clicks elsewhere.
+   */
+  selectedKey?: string | null
+  /**
+   * Fires when the user clicks a tile. Receives the diff row's `key`,
+   * or `null` if the click cleared selection.
+   */
+  onSelectKey?: (key: string | null) => void
+}
+
+/**
+ * A treemap that visualizes a build-to-build diff using the same tile/layout
+ * engine as the single-build view. Each leaf tile represents one source
+ * file, and the color encodes the per-file delta:
+ *
+ * - bright red: added in the latest build (more bytes = bad)
+ * - bright green: removed in the historical build (fewer bytes = good)
+ * - red tint: same file, grew since the historical build
+ * - green tint: same file, shrank since the historical build
+ * - neutral: same size in both builds
+ *
+ * Removed files don't exist in the current build's source tree so they
+ * don't appear in the treemap; users can still see them in the table view.
+ */
+export function DiffTreemap({
+  summary,
+  useCompressed,
+  analyzeData,
+  baselineAnalyzeData,
+  selectedKey,
+  onSelectKey,
+}: DiffTreemapProps) {
+  // Pick the side that drives the source tree. Prefer the current build (B);
+  // fall back to baseline (A) for the "removed route" case where there's no
+  // B-side data.
+  const data = analyzeData ?? baselineAnalyzeData
+
+  // Map from this side's source index to its diff row. Used by the color
+  // override to look up the per-tile status.
+  const rowBySourceIndex = useMemo(() => {
+    const map = new Map<number, SourceDiffRow>()
+    const side: 'A' | 'B' = analyzeData ? 'B' : 'A'
+    for (const row of summary.rows) {
+      const idx = side === 'B' ? row.sourceIndexB : row.sourceIndexA
+      if (idx != null) map.set(idx, row)
+    }
+    return map
+  }, [summary, analyzeData])
+
+  // The AnalyzeData tree can contain the same source path at multiple indices
+  // (e.g. one file included in several chunks). In the diff treemap we only
+  // want each unique path to appear once, using the canonical source index
+  // stored on the diff row. Passing this as `filterSource` removes all
+  // duplicate instances from the layout so there are no confusing gray tiles
+  // and clicking always resolves to a diff row.
+  const canonicalSourceIndices = useMemo(
+    () => new Set(rowBySourceIndex.keys()),
+    [rowBySourceIndex]
+  )
+
+  // Reverse lookup so we can map a selected diff key (full source path) back
+  // to a source index in the active side's tree.
+  const sourceIndexByKey = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const [idx, row] of rowBySourceIndex.entries()) {
+      map.set(row.key, idx)
+    }
+    return map
+  }, [rowBySourceIndex])
+
+  const getFileColorOverride = useMemo(() => {
+    return (node: LayoutNode): string | undefined => {
+      if (node.sourceIndex === undefined) return undefined
+      const row = rowBySourceIndex.get(node.sourceIndex)
+      if (!row) return COLOR_NEUTRAL
+      return colorForRow(row, useCompressed)
+    }
+  }, [rowBySourceIndex, useCompressed])
+
+  // Show size deltas on tiles instead of absolute sizes. Identical files fall
+  // back to the default (absolute size) since ±0 on every unchanged tile
+  // would be noise.
+  const getFileSizeLabel = useMemo(() => {
+    return (node: LayoutNode): string | undefined => {
+      if (node.sourceIndex === undefined) return undefined
+      const row = rowBySourceIndex.get(node.sourceIndex)
+      if (!row || row.status === 'identical') return undefined
+      return formatDelta(delta(row, useCompressed))
+    }
+  }, [rowBySourceIndex, useCompressed])
+
+  // Focus state stays local: it controls drill-in/zoom, which is purely a
+  // visual concern of the treemap and shouldn't affect the sidebar.
+  const initialRoot = useMemo(() => {
+    if (!data) return 0
+    const roots = data.sourceRoots()
+    return roots.length > 0 ? roots[0] : 0
+  }, [data])
+  const [focusedSourceIndex, setFocusedSourceIndex] =
+    useState<number>(initialRoot)
+
+  // Translate the externally-driven selection key into the side's source
+  // index. Falls back to the root so the treemap renders something sensible
+  // when the selection lives on the other side (e.g., a removed file).
+  const selectedSourceIndex =
+    (selectedKey != null ? sourceIndexByKey.get(selectedKey) : undefined) ??
+    initialRoot
+
+  const handleSelectSourceIndex = (idx: number) => {
+    if (!onSelectKey) return
+    const row = rowBySourceIndex.get(idx)
+    onSelectKey(row?.key ?? null)
+  }
+
+  if (!data) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No data for this route.
+      </div>
+    )
+  }
+
+  return (
+    <TreemapVisualizer
+      analyzeData={data}
+      sourceIndex={initialRoot}
+      selectedSourceIndex={selectedSourceIndex}
+      onSelectSourceIndex={handleSelectSourceIndex}
+      focusedSourceIndex={focusedSourceIndex}
+      onFocusSourceIndex={setFocusedSourceIndex}
+      filterSource={(idx) => canonicalSourceIndices.has(idx)}
+      getFileSizeLabel={getFileSizeLabel}
+      sizeMode={useCompressed ? SizeMode.Compressed : SizeMode.Uncompressed}
+      getFileColorOverride={getFileColorOverride}
+      overlay={<DiffLegend hasRemoved={summary.counts.removed > 0} />}
+    />
+  )
+}
+
+/**
+ * Picks a fill color for a diff row. Mirrors the previous DiffTreemap's
+ * scheme: bright green/red for added/removed, lighter tints scaled by the
+ * relative magnitude of the change for grew/shrank, and neutral grey for
+ * sub-threshold changes.
+ */
+function colorForRow(row: SourceDiffRow, useCompressed: boolean): string {
+  if (row.status === 'added') return COLOR_ADDED
+  if (row.status === 'removed') return COLOR_REMOVED
+  const deltaValue = useCompressed
+    ? row.compressedB - row.compressedA
+    : row.sizeB - row.sizeA
+  if (Math.abs(deltaValue) <= NEUTRAL_DELTA_THRESHOLD) {
+    return COLOR_NEUTRAL
+  }
+  // For changed rows, scale opacity by relative magnitude so a 1% change is
+  // less alarming than a 50% change.
+  const baseline = useCompressed ? row.compressedA : row.sizeA
+  const ratio =
+    baseline === 0 ? 1 : Math.min(1, Math.abs(deltaValue) / baseline)
+  const alpha = 0.35 + ratio * 0.5
+  return deltaValue > 0
+    ? `rgba(220, 38, 38, ${alpha.toFixed(2)})`
+    : `rgba(22, 163, 74, ${alpha.toFixed(2)})`
+}
+
+/** Static legend overlay so users can decode the color scheme at a glance. */
+function DiffLegend({ hasRemoved }: { hasRemoved: boolean }) {
+  const items: Array<{ label: string; color: string }> = [
+    { label: 'Added', color: COLOR_ADDED },
+    { label: 'Grew', color: 'rgba(220, 38, 38, 0.6)' },
+    { label: 'Unchanged', color: COLOR_NEUTRAL },
+    { label: 'Shrank', color: 'rgba(22, 163, 74, 0.6)' },
+  ]
+  return (
+    <div className="absolute bottom-2 left-2 flex items-center gap-3 rounded border border-border bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
+      {items.map((item) => (
+        <span key={item.label} className="flex items-center gap-1.5">
+          <span
+            aria-hidden
+            className="inline-block h-3 w-3 rounded-sm"
+            style={{ backgroundColor: item.color }}
+          />
+          {item.label}
+        </span>
+      ))}
+      {hasRemoved ? (
+        <span className="border-l border-border pl-3 italic">
+          Removed sources are listed in the table view.
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/import-chain.tsx
+++ b/apps/bundle-analyzer/components/import-chain.tsx
@@ -125,6 +125,178 @@ function getTitle(level: ChainLevel) {
   return parts.join('\n')
 }
 
+/**
+ * Pure builder for the import chain. Given a starting source and the
+ * relevant data structures, returns the chain of dependent modules to
+ * render. Extracted from the {@link ImportChain} component so that the
+ * compare view can build chains for both builds and detect when they're
+ * identical (and avoid showing redundant tabs).
+ */
+export function buildImportChain(
+  startFileId: number,
+  analyzeData: AnalyzeData,
+  modulesData: ModulesData,
+  depthMap: Map<ModuleIndex, number>,
+  environmentFilter: 'client' | 'server',
+  selectedIndices: number[],
+  currentRouteOnly: boolean
+): ChainLevel[] {
+  const result: ChainLevel[] = []
+  const visitedModules = new Set<number>()
+
+  const startPath = analyzeData.getFullSourcePath(startFileId)
+  if (!startPath) return result
+
+  const getModuleIndicesFromSourceIndex = (sourceIndex: number) => {
+    const path = analyzeData.getFullSourcePath(sourceIndex)
+    return modulesData.getModuleIndiciesFromPath(path)
+  }
+
+  const getSourceIndexFromModuleIndex = (moduleIndex: number) => {
+    const module = modulesData.module(moduleIndex)
+    if (!module) return undefined
+
+    const modulePath = module.path
+    for (let i = 0; i < analyzeData.sourceCount(); i++) {
+      if (analyzeData.getFullSourcePath(i) === modulePath) {
+        return i
+      }
+    }
+    return undefined
+  }
+
+  // Get all module indices for the starting source
+  const startModuleIndices = getModuleIndicesFromSourceIndex(
+    startFileId
+  ).filter((moduleIndex) => {
+    if (currentRouteOnly && !depthMap.has(moduleIndex)) {
+      return false
+    }
+    let module = modulesData.module(moduleIndex)
+    let layer = splitIdent(module?.ident || '').layer
+    if (layer) {
+      if (environmentFilter === 'client' && /ssr|rsc|route|api/.test(layer)) {
+        return false
+      }
+      if (environmentFilter === 'server' && /client/.test(layer)) {
+        return false
+      }
+    }
+    return true
+  })
+  if (startModuleIndices.length === 0) return result
+
+  // Get the selected index for the start modules (default to 0)
+  const selectedStartIdx = selectedIndices[0] ?? 0
+  const actualStartIdx = Math.min(
+    selectedStartIdx,
+    startModuleIndices.length - 1
+  )
+  const startModuleIndex = startModuleIndices[actualStartIdx]
+  const startIdent = modulesData.module(startModuleIndex)?.ident ?? ''
+
+  result.push({
+    moduleIndex: startModuleIndex,
+    sourceIndex: startFileId,
+    path: startPath,
+    ...splitIdent(startIdent),
+    depth: depthMap.get(startModuleIndex) ?? Infinity,
+    selectedIndex: actualStartIdx,
+    totalCount: startModuleIndices.length,
+  })
+
+  visitedModules.add(startModuleIndex)
+
+  // Build chain by following selected dependents
+  let levelIndex = 1
+  let currentModuleIndex = startModuleIndex
+
+  while (true) {
+    // Get dependents at the module level (sync and async)
+    const dependentModuleIndices = [
+      ...modulesData
+        .moduleDependents(currentModuleIndex)
+        .map((index: number) => ({
+          index,
+          async: false,
+          depth: depthMap.get(index) ?? Infinity,
+        })),
+      ...modulesData
+        .asyncModuleDependents(currentModuleIndex)
+        .map((index: number) => ({
+          index,
+          async: true,
+          depth: depthMap.get(index) ?? Infinity,
+        })),
+    ]
+
+    // Filter out dependents that would create a cycle
+    const validDependents = dependentModuleIndices.filter(
+      ({ index, depth }) =>
+        !visitedModules.has(index) && (isFinite(depth) || !currentRouteOnly)
+    )
+
+    if (validDependents.length === 0) {
+      break
+    }
+
+    // Build info for each dependent
+    const dependentsInfo: DependentInfo[] = validDependents.map(
+      ({ index: moduleIndex, async: isAsync, depth }) => {
+        const sourceIndex = getSourceIndexFromModuleIndex(moduleIndex)
+        let ident = modulesData.module(moduleIndex)?.ident || ''
+        return {
+          moduleIndex,
+          sourceIndex,
+          ident,
+          isAsync,
+          depth,
+        }
+      }
+    )
+
+    // Sort: sync first, async second, then by source presence, then by depth
+    dependentsInfo.sort((a, b) => {
+      if (a.depth !== b.depth) {
+        return a.depth - b.depth
+      }
+      if (a.ident.length !== b.ident.length) {
+        return a.ident.length - b.ident.length
+      }
+      return a.ident.localeCompare(b.ident)
+    })
+
+    // Get the selected index for this level (default to 0)
+    const selectedIdx = selectedIndices[levelIndex] ?? 0
+    const actualIdx = Math.min(selectedIdx, dependentsInfo.length - 1)
+
+    const selectedDepInfo = dependentsInfo[actualIdx]
+    const selectedDepModule = modulesData.module(selectedDepInfo.moduleIndex)
+
+    if (!selectedDepModule || selectedDepModule.ident == null) break
+
+    result.push({
+      moduleIndex: selectedDepInfo.moduleIndex,
+      sourceIndex: selectedDepInfo.sourceIndex,
+      path: selectedDepModule.path,
+      depth: depthMap.get(selectedDepInfo.moduleIndex) ?? Infinity,
+      ...splitIdent(selectedDepModule.ident),
+      selectedIndex: actualIdx,
+      totalCount: dependentsInfo.length,
+      info: selectedDepInfo,
+    })
+
+    visitedModules.add(selectedDepInfo.moduleIndex)
+    currentModuleIndex = selectedDepInfo.moduleIndex
+    levelIndex++
+
+    // Safety check to prevent infinite loops
+    if (levelIndex > 100) break
+  }
+
+  return result
+}
+
 export function ImportChain({
   startFileId,
   analyzeData,
@@ -138,181 +310,17 @@ export function ImportChain({
   // Track which dependent is selected at each level
   const [selectedIndices, setSelectedIndices] = useState<number[]>([])
 
-  // Helper function to get module indices from source path
-  const getModuleIndicesFromSourceIndex = (sourceIndex: number) => {
-    const path = analyzeData.getFullSourcePath(sourceIndex)
-    return modulesData.getModuleIndiciesFromPath(path)
-  }
-
-  // Helper function to get source index from module path
-  const getSourceIndexFromModuleIndex = (moduleIndex: number) => {
-    const module = modulesData.module(moduleIndex)
-    if (!module) return undefined
-
-    // Search through all sources to find one with matching path
-    const modulePath = module.path
-    for (let i = 0; i < analyzeData.sourceCount(); i++) {
-      if (analyzeData.getFullSourcePath(i) === modulePath) {
-        return i
-      }
-    }
-    return undefined
-  }
-
   // Build the import chain based on current selections
   const chain = useMemo(() => {
-    const result: ChainLevel[] = []
-    const visitedModules = new Set<number>()
-
-    const startPath = analyzeData.getFullSourcePath(startFileId)
-    if (!startPath) return result
-
-    // Get all module indices for the starting source
-    const startModuleIndices = getModuleIndicesFromSourceIndex(
-      startFileId
-    ).filter((moduleIndex) => {
-      if (currentRouteOnly && !depthMap.has(moduleIndex)) {
-        return false
-      }
-      let module = modulesData.module(moduleIndex)
-      let layer = splitIdent(module?.ident || '').layer
-      if (layer) {
-        if (environmentFilter === 'client' && /ssr|rsc|route|api/.test(layer)) {
-          return false
-        }
-        if (environmentFilter === 'server' && /client/.test(layer)) {
-          return false
-        }
-      }
-      return true
-    })
-    if (startModuleIndices.length === 0) return result
-
-    // Get the selected index for the start modules (default to 0)
-    const selectedStartIdx = selectedIndices[0] ?? 0
-    const actualStartIdx = Math.min(
-      selectedStartIdx,
-      startModuleIndices.length - 1
+    return buildImportChain(
+      startFileId,
+      analyzeData,
+      modulesData,
+      depthMap,
+      environmentFilter,
+      selectedIndices,
+      currentRouteOnly
     )
-    const startModuleIndex = startModuleIndices[actualStartIdx]
-    const startIdent = modulesData.module(startModuleIndex)?.ident ?? ''
-
-    result.push({
-      moduleIndex: startModuleIndex,
-      sourceIndex: startFileId,
-      path: startPath,
-      ...splitIdent(startIdent),
-      depth: depthMap.get(startModuleIndex) ?? Infinity,
-      selectedIndex: actualStartIdx,
-      totalCount: startModuleIndices.length,
-    })
-
-    visitedModules.add(startModuleIndex)
-
-    // Build chain by following selected dependents
-    let levelIndex = 1
-    let currentModuleIndex = startModuleIndex
-
-    while (true) {
-      // Get dependents at the module level (sync and async)
-      const dependentModuleIndices = [
-        ...modulesData
-          .moduleDependents(currentModuleIndex)
-          .map((index: number) => ({
-            index,
-            async: false,
-            traced: false,
-            depth: depthMap.get(index) ?? Infinity,
-          })),
-        ...modulesData
-          .asyncModuleDependents(currentModuleIndex)
-          .map((index: number) => ({
-            index,
-            async: true,
-            traced: false,
-            depth: depthMap.get(index) ?? Infinity,
-          })),
-        ...modulesData
-          .tracedModuleDependents(currentModuleIndex)
-          .map((index: number) => ({
-            index,
-            async: false,
-            traced: true,
-            depth: depthMap.get(index) ?? Infinity,
-          })),
-      ]
-
-      // Filter out dependents that would create a cycle
-      const validDependents = dependentModuleIndices.filter(
-        ({ index, depth }) =>
-          !visitedModules.has(index) && (isFinite(depth) || !currentRouteOnly)
-      )
-
-      if (validDependents.length === 0) {
-        // No more dependents or all would create cycles
-        break
-      }
-
-      // Build info for each dependent
-      const dependentsInfo: DependentInfo[] = validDependents.map(
-        ({ index: moduleIndex, async: isAsync, traced: isTraced, depth }) => {
-          const sourceIndex = getSourceIndexFromModuleIndex(moduleIndex)
-          let ident = modulesData.module(moduleIndex)?.ident || ''
-          return {
-            moduleIndex,
-            sourceIndex,
-            ident,
-            isAsync,
-            isTraced,
-            depth,
-          }
-        }
-      )
-
-      // Sort: sync first, async second, then by source presence, then by depth
-      dependentsInfo.sort((a, b) => {
-        // Sort by depth (smallest first)
-        if (a.depth !== b.depth) {
-          return a.depth - b.depth
-        }
-        // Sort by ident length (shortest first)
-        if (a.ident.length !== b.ident.length) {
-          return a.ident.length - b.ident.length
-        }
-        // Sort by ident
-        return a.ident.localeCompare(b.ident)
-      })
-
-      // Get the selected index for this level (default to 0)
-      const selectedIdx = selectedIndices[levelIndex] ?? 0
-      const actualIdx = Math.min(selectedIdx, dependentsInfo.length - 1)
-
-      const selectedDepInfo = dependentsInfo[actualIdx]
-      const selectedDepModule = modulesData.module(selectedDepInfo.moduleIndex)
-
-      if (!selectedDepModule || selectedDepModule.ident == null) break
-
-      result.push({
-        moduleIndex: selectedDepInfo.moduleIndex,
-        sourceIndex: selectedDepInfo.sourceIndex,
-        path: selectedDepModule.path,
-        depth: depthMap.get(selectedDepInfo.moduleIndex) ?? Infinity,
-        ...splitIdent(selectedDepModule.ident),
-        selectedIndex: actualIdx,
-        totalCount: dependentsInfo.length,
-        info: selectedDepInfo,
-      })
-
-      visitedModules.add(selectedDepInfo.moduleIndex)
-      currentModuleIndex = selectedDepInfo.moduleIndex
-      levelIndex++
-
-      // Safety check to prevent infinite loops
-      if (levelIndex > 100) break
-    }
-
-    return result
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     startFileId,
     analyzeData,

--- a/apps/bundle-analyzer/components/import-chain.tsx
+++ b/apps/bundle-analyzer/components/import-chain.tsx
@@ -212,13 +212,14 @@ export function buildImportChain(
   let currentModuleIndex = startModuleIndex
 
   while (true) {
-    // Get dependents at the module level (sync and async)
+    // Get dependents at the module level (sync, async, and traced)
     const dependentModuleIndices = [
       ...modulesData
         .moduleDependents(currentModuleIndex)
         .map((index: number) => ({
           index,
           async: false,
+          traced: false,
           depth: depthMap.get(index) ?? Infinity,
         })),
       ...modulesData
@@ -226,14 +227,24 @@ export function buildImportChain(
         .map((index: number) => ({
           index,
           async: true,
+          traced: false,
+          depth: depthMap.get(index) ?? Infinity,
+        })),
+      ...modulesData
+        .tracedModuleDependents(currentModuleIndex)
+        .map((index: number) => ({
+          index,
+          async: false,
+          traced: true,
           depth: depthMap.get(index) ?? Infinity,
         })),
     ]
 
     // Filter out dependents that would create a cycle
     const validDependents = dependentModuleIndices.filter(
-      ({ index, depth }) =>
-        !visitedModules.has(index) && (isFinite(depth) || !currentRouteOnly)
+      (dep) =>
+        !visitedModules.has(dep.index) &&
+        (isFinite(dep.depth) || !currentRouteOnly)
     )
 
     if (validDependents.length === 0) {
@@ -242,7 +253,7 @@ export function buildImportChain(
 
     // Build info for each dependent
     const dependentsInfo: DependentInfo[] = validDependents.map(
-      ({ index: moduleIndex, async: isAsync, depth }) => {
+      ({ index: moduleIndex, async: isAsync, traced: isTraced, depth }) => {
         const sourceIndex = getSourceIndexFromModuleIndex(moduleIndex)
         let ident = modulesData.module(moduleIndex)?.ident || ''
         return {
@@ -250,6 +261,7 @@ export function buildImportChain(
           sourceIndex,
           ident,
           isAsync,
+          isTraced,
           depth,
         }
       }

--- a/apps/bundle-analyzer/components/route-typeahead.tsx
+++ b/apps/bundle-analyzer/components/route-typeahead.tsx
@@ -2,7 +2,7 @@
 
 import useSWR from 'swr'
 import { Check, ChevronsUpDown, Loader, Route } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Command,
@@ -20,15 +20,33 @@ import {
 import { cn, jsonFetcher } from '@/lib/utils'
 import { NetworkError } from '@/lib/errors'
 import { Kbd } from '@/components/ui/kbd'
+import {
+  delta,
+  formatDelta,
+  sortByImpact,
+  type DiffRow,
+  type DiffSummary,
+} from '@/lib/diff'
 
 interface RouteTypeaheadProps {
   selectedRoute: string | null
   onRouteSelected: (routeName: string) => void
+  /**
+   * When provided, the picker renders per-route size deltas next to each
+   * route, sorts by largest impact, and uses the diff's route list as its
+   * source of truth (so added/removed routes appear with appropriate
+   * styling).
+   */
+  routeDiff?: DiffSummary | null
+  /** Whether to use compressed sizes when computing the delta column. */
+  useCompressed?: boolean
 }
 
 export function RouteTypeahead({
   selectedRoute,
   onRouteSelected,
+  routeDiff,
+  useCompressed = true,
 }: RouteTypeaheadProps) {
   const [open, setOpen] = useState(false)
   const [shortcutLabel, setShortcutLabel] = useState<string | null>(null)
@@ -71,6 +89,27 @@ export function RouteTypeahead({
     },
   })
 
+  // When a route diff is provided, sort routes by largest absolute impact so
+  // the most-changed route bubbles to the top — matching the rest of the
+  // compare UI. Without a diff, fall back to the natural routes.json order.
+  const orderedItems = useMemo<RouteItem[]>(() => {
+    if (routeDiff) {
+      const sorted = sortByImpact(routeDiff.rows, useCompressed)
+      return sorted.map((row) => ({
+        name: row.key,
+        row,
+      }))
+    }
+    return (routes ?? []).map((name) => ({ name, row: null }))
+  }, [routes, routeDiff, useCompressed])
+
+  // Find the currently selected route's diff row, used to render a delta
+  // badge in the trigger button.
+  const selectedRow = useMemo(() => {
+    if (!routeDiff || !selectedRoute) return null
+    return routeDiff.rows.find((r) => r.key === selectedRoute) ?? null
+  }, [routeDiff, selectedRoute])
+
   if (error) {
     return (
       <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-destructive/10 border border-destructive/20 text-destructive text-sm max-w-full">
@@ -84,7 +123,7 @@ export function RouteTypeahead({
     )
   }
 
-  let ctaText
+  let ctaText: React.ReactNode
   if (isLoading) {
     ctaText = 'Loading routes...'
   } else if (selectedRoute != null) {
@@ -104,14 +143,17 @@ export function RouteTypeahead({
             disabled={isLoading}
             className="flex-grow-1 w-full justify-between font-mono text-sm"
           >
-            <div className="flex items-center">
+            <div className="flex items-center min-w-0">
               {isLoading ? (
                 <Loader className="mr-2 inline animate-spin" />
               ) : (
-                <Route className="inline mr-2" />
+                <Route className="inline mr-2 shrink-0" />
               )}
 
-              {ctaText}
+              <span className="truncate">{ctaText}</span>
+              {selectedRow ? (
+                <DeltaBadge row={selectedRow} useCompressed={useCompressed} />
+              ) : null}
             </div>
             <div className="flex items-center gap-2">
               {shortcutLabel && <Kbd>{shortcutLabel}</Kbd>}
@@ -125,32 +167,85 @@ export function RouteTypeahead({
             <CommandList>
               <CommandEmpty>No route found.</CommandEmpty>
               <CommandGroup>
-                {(routes || []).map((route) => {
-                  return (
-                    <CommandItem
-                      key={route}
-                      value={route}
-                      onSelect={() => {
-                        onRouteSelected(route)
-                        setOpen(false)
-                      }}
-                      className="font-mono"
-                    >
-                      <Check
-                        className={cn(
-                          'mr-2 h-4 w-4',
-                          selectedRoute === route ? 'opacity-100' : 'opacity-0'
-                        )}
+                {orderedItems.map(({ name, row }) => (
+                  <CommandItem
+                    key={name}
+                    value={name}
+                    onSelect={() => {
+                      onRouteSelected(name)
+                      setOpen(false)
+                    }}
+                    className="font-mono"
+                  >
+                    <Check
+                      className={cn(
+                        'mr-2 h-4 w-4 shrink-0',
+                        selectedRoute === name ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                    <span className="truncate">{name}</span>
+                    {row ? (
+                      <DeltaBadge
+                        row={row}
+                        useCompressed={useCompressed}
+                        className="ml-auto"
                       />
-                      {route}
-                    </CommandItem>
-                  )
-                })}
+                    ) : null}
+                  </CommandItem>
+                ))}
               </CommandGroup>
             </CommandList>
           </Command>
         </PopoverContent>
       </Popover>
     </div>
+  )
+}
+
+interface RouteItem {
+  name: string
+  row: DiffRow | null
+}
+
+/**
+ * Compact, color-coded badge showing a route's size delta. Hidden when the
+ * row has no meaningful change.
+ */
+function DeltaBadge({
+  row,
+  useCompressed,
+  className,
+}: {
+  row: DiffRow
+  useCompressed: boolean
+  className?: string
+}) {
+  if (row.status === 'identical') return null
+  const d = delta(row, useCompressed)
+  // For added/removed routes the delta carries the only signal, so always
+  // render. For changed routes, suppress sub-byte noise.
+  if (row.status === 'changed' && d === 0) return null
+
+  const tone =
+    row.status === 'added' || d > 0
+      ? 'text-red-600 dark:text-red-400'
+      : row.status === 'removed' || d < 0
+        ? 'text-green-600 dark:text-green-400'
+        : 'text-muted-foreground'
+
+  return (
+    <span
+      className={cn(
+        'ml-2 shrink-0 text-xs tabular-nums font-sans',
+        tone,
+        className
+      )}
+    >
+      {row.status === 'added'
+        ? '+ new'
+        : row.status === 'removed'
+          ? '− removed'
+          : formatDelta(d)}
+    </span>
   )
 }

--- a/apps/bundle-analyzer/components/sidebar.tsx
+++ b/apps/bundle-analyzer/components/sidebar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type React from 'react'
+import { useState, useMemo } from 'react'
 import { CircleHelp } from 'lucide-react'
 import {
   Tooltip,
@@ -12,8 +13,10 @@ import { ImportChain } from '@/components/import-chain'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
 import { SpecialModule } from '@/lib/types'
-import { getSpecialModuleType } from '@/lib/utils'
+import { cn, getSpecialModuleType } from '@/lib/utils'
 import { Badge } from './ui/badge'
+import type { DiffSummary, SourceDiffRow } from '@/lib/diff'
+import { formatDelta } from '@/lib/diff'
 
 interface SidebarProps {
   sidebarWidth: number
@@ -213,6 +216,181 @@ function SelectionDetails({
             ) : null}
           </>
         )}
+    </div>
+  )
+}
+
+export function CompareSidebar({
+  selectedKey,
+  sourceDiff,
+  analyzeData,
+  baselineAnalyzeData,
+  modulesData,
+  baselineModulesData,
+  moduleDepthMap,
+  baselineModuleDepthMap,
+  environmentFilter,
+  sidebarWidth,
+  aLabel,
+  bLabel,
+}: {
+  selectedKey: string | null
+  sourceDiff: DiffSummary<SourceDiffRow> | null
+  analyzeData: AnalyzeData | null
+  baselineAnalyzeData: AnalyzeData | null
+  modulesData: ModulesData | null
+  baselineModulesData: ModulesData | null
+  moduleDepthMap: Map<number, number>
+  baselineModuleDepthMap: Map<number, number>
+  environmentFilter: 'client' | 'server'
+  sidebarWidth: number
+  aLabel: string
+  bLabel: string
+}) {
+  const selectedRow = useMemo(() => {
+    if (!selectedKey || !sourceDiff) return null
+    return sourceDiff.rows.find((r) => r.key === selectedKey) ?? null
+  }, [selectedKey, sourceDiff])
+
+  return (
+    <div
+      className="flex-none bg-muted border-l border-border overflow-y-auto"
+      style={{ width: `${sidebarWidth}%` }}
+    >
+      {selectedRow ? (
+        <CompareSidebarContent
+          key={selectedRow.key}
+          row={selectedRow}
+          analyzeData={analyzeData}
+          baselineAnalyzeData={baselineAnalyzeData}
+          modulesData={modulesData}
+          baselineModulesData={baselineModulesData}
+          moduleDepthMap={moduleDepthMap}
+          baselineModuleDepthMap={baselineModuleDepthMap}
+          environmentFilter={environmentFilter}
+          aLabel={aLabel}
+          bLabel={bLabel}
+        />
+      ) : (
+        <div className="p-3 text-xs text-muted-foreground">
+          Click a row or treemap tile to see import details.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CompareSidebarContent({
+  row,
+  analyzeData,
+  baselineAnalyzeData,
+  modulesData,
+  baselineModulesData,
+  moduleDepthMap,
+  baselineModuleDepthMap,
+  environmentFilter,
+  aLabel,
+  bLabel,
+}: {
+  row: SourceDiffRow
+  analyzeData: AnalyzeData | null
+  baselineAnalyzeData: AnalyzeData | null
+  modulesData: ModulesData | null
+  baselineModulesData: ModulesData | null
+  moduleDepthMap: Map<number, number>
+  baselineModuleDepthMap: Map<number, number>
+  environmentFilter: 'client' | 'server'
+  aLabel: string
+  bLabel: string
+}) {
+  const hasBoth = row.sourceIndexA != null && row.sourceIndexB != null
+  const [activeTab, setActiveTab] = useState<'A' | 'B'>(
+    row.status === 'removed' ? 'A' : 'B'
+  )
+
+  const activeSourceIndex =
+    activeTab === 'A' ? row.sourceIndexA : row.sourceIndexB
+  const activeAnalyzeData =
+    activeTab === 'A' ? baselineAnalyzeData : analyzeData
+  const activeModulesData =
+    activeTab === 'A' ? baselineModulesData : modulesData
+  const activeDepthMap =
+    activeTab === 'A' ? baselineModuleDepthMap : moduleDepthMap
+
+  const compressedDelta = row.compressedB - row.compressedA
+
+  return (
+    <div className="flex-1 p-3 space-y-4 overflow-y-auto">
+      <div className="space-y-1">
+        <h2 className="text-s font-semibold text-foreground break-all">
+          {row.name}
+        </h2>
+        <div className="text-xs space-y-0.5">
+          <div className="flex items-baseline gap-1 flex-wrap">
+            <span className="text-muted-foreground font-mono">
+              {formatBytes(row.compressedA)}
+            </span>
+            <span className="text-muted-foreground">→</span>
+            <span className="font-mono">{formatBytes(row.compressedB)}</span>
+            <span className="text-muted-foreground">compressed</span>
+            {row.status !== 'identical' && (
+              <span
+                className={cn(
+                  'font-mono',
+                  compressedDelta > 0 && 'text-red-600 dark:text-red-400',
+                  compressedDelta < 0 && 'text-green-600 dark:text-green-400',
+                  compressedDelta === 0 && 'text-muted-foreground'
+                )}
+              >
+                {formatDelta(compressedDelta)}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {hasBoth && (
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => setActiveTab('A')}
+            className={cn(
+              'px-2 py-0.5 text-xs rounded transition-colors',
+              activeTab === 'A'
+                ? 'bg-secondary text-secondary-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {aLabel}
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('B')}
+            className={cn(
+              'px-2 py-0.5 text-xs rounded transition-colors',
+              activeTab === 'B'
+                ? 'bg-secondary text-secondary-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {bLabel}
+          </button>
+        </div>
+      )}
+
+      {activeSourceIndex != null && activeAnalyzeData && activeModulesData ? (
+        <ImportChain
+          startFileId={activeSourceIndex}
+          analyzeData={activeAnalyzeData}
+          modulesData={activeModulesData}
+          depthMap={activeDepthMap}
+          environmentFilter={environmentFilter}
+        />
+      ) : (
+        <p className="text-xs text-muted-foreground italic">
+          Import chain not available.
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/bundle-analyzer/components/sidebar.tsx
+++ b/apps/bundle-analyzer/components/sidebar.tsx
@@ -128,6 +128,11 @@ function SelectionDetails({
     filterSource
   )
 
+  const { compressedSize: asyncOnlyCompressedSize } =
+    analyzeData.getRecursiveAsyncOnlySizes(selectedSourceIndex, filterSource)
+  const asyncOnlyPct =
+    compressedSize > 0 ? (asyncOnlyCompressedSize / compressedSize) * 100 : 0
+
   const chunks =
     selectedSourceIndex != null
       ? analyzeData.sourceChunks(selectedSourceIndex)
@@ -161,6 +166,18 @@ function SelectionDetails({
                 compression like gzip.
               </InlineHelpTooltip>
             </div>
+            {asyncOnlyCompressedSize > 0 ? (
+              <div>
+                <span>{formatBytes(asyncOnlyCompressedSize)}</span>{' '}
+                <span className="text-muted-foreground">
+                  async-only ({asyncOnlyPct.toFixed(1)}%)
+                </span>
+                <InlineHelpTooltip>
+                  Modules in this subtree reachable only via dynamic import on
+                  this route. They won't load until the import resolves.
+                </InlineHelpTooltip>
+              </div>
+            ) : null}
             {hasChildModules && childModuleCount != null ? (
               <div>
                 <span>{childModuleCount} </span>

--- a/apps/bundle-analyzer/components/stat-cards.tsx
+++ b/apps/bundle-analyzer/components/stat-cards.tsx
@@ -1,0 +1,129 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Inline colored delta rendered next to the `A → B` value. For size deltas,
+ * positive deltas (regressions) are red and negative (improvements) are
+ * emerald — matching how regressions are usually framed. Neutral deltas
+ * (counts) render muted.
+ */
+export function DeltaChip({
+  delta,
+  tone,
+  render,
+}: {
+  delta: number
+  tone: 'neutral' | 'size'
+  render: (delta: number) => string
+}) {
+  const toneClass =
+    tone === 'size'
+      ? delta > 0
+        ? 'text-red-400'
+        : delta < 0
+          ? 'text-emerald-400'
+          : 'text-muted-foreground'
+      : 'text-muted-foreground'
+  return (
+    <span
+      className={cn(
+        'shrink-0 whitespace-nowrap font-mono text-xs tabular-nums',
+        toneClass
+      )}
+    >
+      {render(delta)}
+    </span>
+  )
+}
+
+/**
+ * Compact `A → B` card. Used for both counts (Total routes) and sizes
+ * (Total size). The delta chip is auto-derived from the values unless an
+ * explicit `deltaValue` is provided (e.g. a precomputed compressed delta).
+ */
+export function StatCard({
+  label,
+  a,
+  b,
+  formatValue = (v: number) => String(v),
+  deltaValue,
+  formatDeltaValue,
+  deltaTone,
+}: {
+  label: string
+  a: number | null
+  b: number | null
+  formatValue?: (value: number) => string
+  deltaValue?: number | null
+  formatDeltaValue?: (delta: number) => string
+  deltaTone: 'neutral' | 'size'
+}) {
+  const computedDelta =
+    deltaValue !== undefined
+      ? deltaValue
+      : a != null && b != null
+        ? b - a
+        : null
+  const renderDelta =
+    formatDeltaValue ??
+    ((d: number) => (d === 0 ? '±0' : d > 0 ? `+${d}` : `${d}`))
+  return (
+    <div className="flex min-w-[112px] flex-1 flex-col gap-1 rounded-md border border-border bg-background/60 px-3 py-2">
+      <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-1">
+        <span className="font-mono text-xs tabular-nums text-foreground">
+          {a != null ? formatValue(a) : '—'}
+        </span>
+        <span aria-hidden className="text-xs text-muted-foreground">
+          →
+        </span>
+        <span className="font-mono text-xs font-semibold tabular-nums text-foreground">
+          {b != null ? formatValue(b) : '—'}
+        </span>
+        {computedDelta != null ? (
+          <DeltaChip
+            delta={computedDelta}
+            tone={deltaTone}
+            render={renderDelta}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/** Single-number card for category counts (Added / Removed / etc). */
+export function CountCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: number
+  tone: 'added' | 'removed' | 'changed' | 'identical'
+}) {
+  const toneClass =
+    tone === 'added'
+      ? 'text-red-500'
+      : tone === 'removed'
+        ? 'text-green-500'
+        : tone === 'changed'
+          ? 'text-amber-500'
+          : 'text-muted-foreground'
+  return (
+    <div className="flex min-w-[80px] flex-col gap-1 rounded-md border border-border bg-background/60 px-3 py-2">
+      <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div
+        className={cn(
+          'font-mono text-base font-semibold tabular-nums',
+          toneClass
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/top-bar.tsx
+++ b/apps/bundle-analyzer/components/top-bar.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { MultiSelect } from '@/components/ui/multi-select'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { diffRoutesWithSizes } from '@/lib/diff'
 import { type SnapshotMetadata } from '@/lib/snapshot'
 import {
@@ -20,11 +21,18 @@ import {
   FileJson,
   Palette,
   Package,
+  Table as TableIcon,
+  LayoutGrid,
 } from 'lucide-react'
 
 export enum Environment {
   Client = 'client',
   Server = 'server',
+}
+
+export enum CompareView {
+  Treemap = 'treemap',
+  Table = 'table',
 }
 
 const typeFilterOptions = [
@@ -63,10 +71,14 @@ export function TopBar({
   setSearchQuery,
   baselineSnapshot,
   onBaselineChange,
+  compareView,
+  onCompareViewChange,
   routeDiff,
   hasSourceData,
+  showViewToggle,
 }: {
   hasSourceData: boolean
+  showViewToggle: boolean
   selectedRoute: string | null
   setSelectedRoute: (route: string | null) => void
   environmentFilter: Environment
@@ -79,6 +91,8 @@ export function TopBar({
   setSearchQuery: (query: string) => void
   baselineSnapshot: SnapshotMetadata | null
   onBaselineChange: (snapshot: SnapshotMetadata | null) => void
+  compareView: CompareView
+  onCompareViewChange: (view: CompareView) => void
   routeDiff: ReturnType<typeof diffRoutesWithSizes> | null
 }) {
   const isCompareMode = baselineSnapshot != null
@@ -102,6 +116,37 @@ export function TopBar({
           selectedSnapshotId={baselineSnapshot?.id ?? null}
           onSelectionChange={onBaselineChange}
         />
+
+        {showViewToggle && (
+          <ToggleGroup
+            type="single"
+            size="sm"
+            value={compareView}
+            onValueChange={(value) => {
+              if (value) onCompareViewChange(value as CompareView)
+            }}
+            aria-label="View"
+          >
+            <ToggleGroupItem
+              value={CompareView.Table}
+              aria-label="Table view"
+              title="Table view"
+              className="gap-1.5"
+            >
+              <TableIcon className="h-3.5 w-3.5" />
+              <span className="text-xs">Table</span>
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value={CompareView.Treemap}
+              aria-label="Treemap view"
+              title="Treemap view"
+              className="gap-1.5"
+            >
+              <LayoutGrid className="h-3.5 w-3.5" />
+              <span className="text-xs">Treemap</span>
+            </ToggleGroupItem>
+          </ToggleGroup>
+        )}
 
         {hasSourceData && (
           <>

--- a/apps/bundle-analyzer/components/top-bar.tsx
+++ b/apps/bundle-analyzer/components/top-bar.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { BaselinePicker } from '@/components/baseline-picker'
+import { FileSearch } from '@/components/file-search'
+import { RouteTypeahead } from '@/components/route-typeahead'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { MultiSelect } from '@/components/ui/multi-select'
+import { diffRoutesWithSizes } from '@/lib/diff'
+import { type SnapshotMetadata } from '@/lib/snapshot'
+import {
+  Monitor,
+  Server,
+  FileCode,
+  FileJson,
+  Palette,
+  Package,
+} from 'lucide-react'
+
+export enum Environment {
+  Client = 'client',
+  Server = 'server',
+}
+
+const typeFilterOptions = [
+  {
+    value: 'js',
+    label: 'JavaScript',
+    icon: <FileCode className="h-3.5 w-3.5" />,
+  },
+  { value: 'css', label: 'CSS', icon: <Palette className="h-3.5 w-3.5" /> },
+  {
+    value: 'json',
+    label: 'JSON',
+    icon: <FileJson className="h-3.5 w-3.5" />,
+  },
+  {
+    value: 'asset',
+    label: 'Asset',
+    icon: <Package className="h-3.5 w-3.5" />,
+  },
+]
+
+export function ControlDivider() {
+  return <span className="h-6 w-px bg-muted-foreground/30" />
+}
+
+export function TopBar({
+  selectedRoute,
+  setSelectedRoute,
+  environmentFilter,
+  setEnvironmentFilter,
+  setSelectedSourceIndex,
+  setFocusedSourceIndex,
+  typeFilter,
+  setTypeFilter,
+  searchQuery,
+  setSearchQuery,
+  baselineSnapshot,
+  onBaselineChange,
+  routeDiff,
+  hasSourceData,
+}: {
+  hasSourceData: boolean
+  selectedRoute: string | null
+  setSelectedRoute: (route: string | null) => void
+  environmentFilter: Environment
+  setEnvironmentFilter: (env: Environment) => void
+  setSelectedSourceIndex: (index: number | null) => void
+  setFocusedSourceIndex: (index: number | null) => void
+  typeFilter: string[]
+  setTypeFilter: (types: string[]) => void
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+  baselineSnapshot: SnapshotMetadata | null
+  onBaselineChange: (snapshot: SnapshotMetadata | null) => void
+  routeDiff: ReturnType<typeof diffRoutesWithSizes> | null
+}) {
+  const isCompareMode = baselineSnapshot != null
+  return (
+    <div className="flex-none px-4 py-2 border-b border-border flex items-center gap-3">
+      <div className="flex-1 flex">
+        <RouteTypeahead
+          selectedRoute={selectedRoute}
+          onRouteSelected={(route) => {
+            setSelectedRoute(route)
+            setSelectedSourceIndex(null)
+            setFocusedSourceIndex(null)
+          }}
+          routeDiff={isCompareMode ? routeDiff : null}
+          useCompressed
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <BaselinePicker
+          selectedSnapshotId={baselineSnapshot?.id ?? null}
+          onSelectionChange={onBaselineChange}
+        />
+
+        {hasSourceData && (
+          <>
+            <ControlDivider />
+
+            <Select
+              value={environmentFilter}
+              onValueChange={(value: Environment) =>
+                setEnvironmentFilter(value)
+              }
+            >
+              <SelectTrigger className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={Environment.Client}>
+                  <div className="flex items-center gap-1.5">
+                    <Monitor className="h-3.5 w-3.5" />
+                    <span className="text-xs">Client</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value={Environment.Server}>
+                  <div className="flex items-center gap-1.5">
+                    <Server className="h-3.5 w-3.5" />
+                    <span className="text-xs">Server</span>
+                  </div>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+
+            <MultiSelect
+              options={typeFilterOptions}
+              value={typeFilter}
+              onValueChange={setTypeFilter}
+              selectionName={{ singular: 'file type', plural: 'file types' }}
+              triggerIcon={<FileCode className="h-3.5 w-3.5" />}
+              triggerClassName="w-36"
+              aria-label="Filter by file type"
+            />
+
+            {!isCompareMode && (
+              <>
+                <ControlDivider />
+                <FileSearch value={searchQuery} onChange={setSearchQuery} />
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/treemap-visualizer.tsx
+++ b/apps/bundle-analyzer/components/treemap-visualizer.tsx
@@ -31,6 +31,23 @@ interface TreemapVisualizerProps {
   isModulePolyfillChunk?: (sourceIndex: number) => boolean
   isNoModulePolyfillChunk?: (sourceIndex: number) => boolean
   sizeMode?: SizeMode
+  /**
+   * Optional override for file tile colors. Returning `undefined` falls back
+   * to the default file-type-based color. Used by the compare view to color
+   * tiles by diff status (added/removed/grew/shrank) instead of by file type.
+   */
+  getFileColorOverride?: (node: LayoutNode) => string | undefined
+  /**
+   * Optional override for the size label shown on a tile. Returning `undefined`
+   * falls back to `formatBytes(node.size)`. Used by the compare view to show
+   * size deltas (e.g. "+1.2 KB") instead of absolute sizes.
+   */
+  getFileSizeLabel?: (node: LayoutNode) => string | undefined
+  /**
+   * Optional overlay rendered on top of the treemap canvas. Used by the
+   * compare view to render a red/green legend.
+   */
+  overlay?: React.ReactNode
 }
 
 function getFileColor(node: {
@@ -275,6 +292,8 @@ function drawTreemap(
   searchQuery: string,
   originalData: LayoutNode,
   immediateHoveredSourceIndex: number | undefined,
+  getFileColorOverride: ((node: LayoutNode) => string | undefined) | undefined,
+  getFileSizeLabel: ((node: LayoutNode) => string | undefined) | undefined,
   currentPath: string[] = [],
   parentFadedOut = false,
   insideActiveSubtree = false
@@ -332,6 +351,8 @@ function drawTreemap(
             searchQuery,
             originalData,
             immediateHoveredSourceIndex,
+            getFileColorOverride,
+            getFileSizeLabel,
             path,
             parentFadedOut,
             insideActiveSubtree
@@ -395,7 +416,7 @@ function drawTreemap(
     sourceIndex !== undefined && sourceIndex === immediateHoveredSourceIndex
 
   if (type === 'file') {
-    let color = getFileColor(node)
+    let color = getFileColorOverride?.(node) ?? getFileColor(node)
 
     // Apply brightness boost to immediately hovered node
     if (isImmediateHovered) {
@@ -418,7 +439,7 @@ function drawTreemap(
 
       const maxWidth = rect.width - 8
 
-      const sizeText = formatBytes(node.size)
+      const sizeText = getFileSizeLabel?.(node) ?? formatBytes(node.size)
       const fontSize = 12
       const sizeFontSize = 10
       const lineHeight = fontSize + 2
@@ -617,6 +638,8 @@ function drawTreemap(
           searchQuery,
           originalData,
           immediateHoveredSourceIndex,
+          getFileColorOverride,
+          getFileSizeLabel,
           path,
           childFadeOut,
           childInsideActiveSubtree
@@ -709,6 +732,9 @@ export function TreemapVisualizer({
   searchQuery = '',
   filterSource,
   sizeMode = SizeMode.Compressed,
+  getFileColorOverride,
+  getFileSizeLabel,
+  overlay,
 }: TreemapVisualizerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -872,7 +898,9 @@ export function TreemapVisualizer({
       focusedAncestorChain,
       searchQuery,
       layout,
-      hoveredNode?.sourceIndex
+      hoveredNode?.sourceIndex,
+      getFileColorOverride,
+      getFileSizeLabel
     )
   }, [
     layout,
@@ -884,6 +912,8 @@ export function TreemapVisualizer({
     focusedAncestorChain,
     searchQuery,
     hoveredNode,
+    getFileColorOverride,
+    getFileSizeLabel,
   ])
 
   const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -1009,7 +1039,7 @@ export function TreemapVisualizer({
   return (
     <div
       ref={containerRef}
-      className="w-full h-full bg-background border border-border rounded-lg overflow-hidden"
+      className="relative w-full h-full bg-background border border-border rounded-lg overflow-hidden"
     >
       <canvas
         ref={canvasRef}
@@ -1021,6 +1051,7 @@ export function TreemapVisualizer({
         onDoubleClick={handleDoubleClick}
         className="block w-full h-full"
       />
+      {overlay}
     </div>
   )
 }

--- a/apps/bundle-analyzer/components/treemap-visualizer.tsx
+++ b/apps/bundle-analyzer/components/treemap-visualizer.tsx
@@ -30,6 +30,7 @@ interface TreemapVisualizerProps {
   filterSource?: (sourceIndex: number) => boolean
   isModulePolyfillChunk?: (sourceIndex: number) => boolean
   isNoModulePolyfillChunk?: (sourceIndex: number) => boolean
+  isAsyncOnlySource?: (sourceIndex: number) => boolean
   sizeMode?: SizeMode
   /**
    * Optional override for file tile colors. Returning `undefined` falls back
@@ -49,6 +50,8 @@ interface TreemapVisualizerProps {
    */
   overlay?: React.ReactNode
 }
+
+const ASYNC_BORDER_COLOR = '#f59e0b'
 
 function getFileColor(node: {
   js?: boolean
@@ -431,6 +434,14 @@ function drawTreemap(
     ctx.lineWidth = 1
     ctx.strokeRect(rect.x, rect.y, rect.width, rect.height)
 
+    // Async-only modules: draw an amber border on top of the standard border
+    // to flag modules only reachable via dynamic import on this route.
+    if (node.asyncOnly && rect.width >= 4 && rect.height >= 4) {
+      ctx.strokeStyle = ASYNC_BORDER_COLOR
+      ctx.lineWidth = 2
+      ctx.strokeRect(rect.x + 1, rect.y + 1, rect.width - 2, rect.height - 2)
+    }
+
     if (rect.width > 60 && rect.height > 30) {
       const textColor = readableColor(color)
       ctx.fillStyle = textColor
@@ -731,6 +742,7 @@ export function TreemapVisualizer({
   onHoveredNodeChangeDelayed,
   searchQuery = '',
   filterSource,
+  isAsyncOnlySource,
   sizeMode = SizeMode.Compressed,
   getFileColorOverride,
   getFileSizeLabel,
@@ -850,7 +862,8 @@ export function TreemapVisualizer({
         height: dimensions.cssHeight,
       },
       filterSource,
-      sizeMode
+      sizeMode,
+      isAsyncOnlySource
     )
 
     // If we're not at the root, wrap with ancestor title bars
@@ -874,6 +887,7 @@ export function TreemapVisualizer({
     dimensions.cssHeight,
     filterSource,
     sizeMode,
+    isAsyncOnlySource,
   ])
 
   useLayoutEffect(() => {

--- a/apps/bundle-analyzer/components/ui/badge.tsx
+++ b/apps/bundle-analyzer/components/ui/badge.tsx
@@ -21,6 +21,8 @@ const badgeVariants = cva(
           'border-transparent bg-purple-50 dark:bg-purple-950 text-purple-700 dark:text-purple-300 ring-1 ring-inset ring-purple-700/10 dark:ring-purple-300/20',
         traced:
           'border-transparent bg-grey-50 dark:bg-grey-950 text-grey-700 dark:text-grey-300 ring-1 ring-inset ring-grey-700/10 dark:ring-grey-300/20',
+        async:
+          'border-transparent bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-700/10 dark:ring-amber-300/20',
         polyfill:
           'border-transparent bg-polyfill/10 dark:bg-polyfill/30 text-polyfill dark:text-polyfill-foreground ring-1 ring-inset ring-polyfill/20',
       },

--- a/apps/bundle-analyzer/lib/analyze-data.ts
+++ b/apps/bundle-analyzer/lib/analyze-data.ts
@@ -42,6 +42,7 @@ interface AnalyzeDataHeader {
   source_chunk_parts: EdgesDataReference
   source_children: EdgesDataReference
   source_roots: number[]
+  async_only_sources: number[]
 }
 
 interface ModulesDataHeader {
@@ -209,6 +210,7 @@ export class AnalyzeData {
   private analyzeHeader: AnalyzeDataHeader
   private analyzeBinaryData: DataView
   private pathToSourceIndex: Map<string, SourceIndex>
+  private asyncOnlySourceSet: Set<SourceIndex>
 
   constructor(analyzeArrayBuffer: ArrayBuffer) {
     // Parse analyze.data
@@ -233,6 +235,10 @@ export class AnalyzeData {
       const fullPath = this.getFullSourcePath(i)
       this.pathToSourceIndex.set(fullPath, i)
     }
+
+    this.asyncOnlySourceSet = new Set(
+      this.analyzeHeader.async_only_sources ?? []
+    )
   }
 
   // Accessor methods for header data
@@ -267,6 +273,10 @@ export class AnalyzeData {
 
   sourceRoots(): SourceIndex[] {
     return this.analyzeHeader.source_roots
+  }
+
+  isAsyncOnlySource(index: SourceIndex): boolean {
+    return this.asyncOnlySourceSet.has(index)
   }
 
   // Methods to read edges data from the binary section
@@ -426,6 +436,40 @@ export class AnalyzeData {
         size: childUncompressedSize,
         compressedSize: childCompressedSize,
       } = this.getRecursiveSizes(childIndex, filterSource)
+      size += childUncompressedSize
+      compressedSize += childCompressedSize
+    }
+
+    return {
+      size,
+      compressedSize,
+    }
+  }
+
+  /**
+   * Like {@link getRecursiveSizes} but only sums sources flagged async-only
+   * for this route. Used to surface "X of the subtree is reachable solely
+   * via dynamic import" in the sidebar.
+   */
+  getRecursiveAsyncOnlySizes(
+    index: SourceIndex,
+    filterSource: (sourceIndex: SourceIndex) => boolean
+  ): { size: number; compressedSize: number } {
+    let size = 0
+    let compressedSize = 0
+
+    if (this.isAsyncOnlySource(index) && filterSource(index)) {
+      const { size: ownUncompressedSize, compressedSize: ownCompressedSize } =
+        this.getOwnSizes(index)
+      size += ownUncompressedSize
+      compressedSize += ownCompressedSize
+    }
+
+    for (const childIndex of this.sourceChildren(index)) {
+      const {
+        size: childUncompressedSize,
+        compressedSize: childCompressedSize,
+      } = this.getRecursiveAsyncOnlySizes(childIndex, filterSource)
       size += childUncompressedSize
       compressedSize += childCompressedSize
     }

--- a/apps/bundle-analyzer/lib/diff.ts
+++ b/apps/bundle-analyzer/lib/diff.ts
@@ -1,0 +1,454 @@
+import { AnalyzeData, type SourceIndex } from './analyze-data'
+import { formatBytes } from './utils'
+
+/**
+ * Formats a byte delta with an explicit sign (or `±0` for no change). Used
+ * by the diff table and route picker to render compact change indicators.
+ */
+export function formatDelta(deltaBytes: number): string {
+  if (deltaBytes === 0) return '±0'
+  const sign = deltaBytes > 0 ? '+' : '−'
+  return `${sign}${formatBytes(Math.abs(deltaBytes))}`
+}
+
+/**
+ * Represents how a row (route, source, etc.) changed between two builds.
+ *
+ * - `added`: present in `B` (the latest build) only
+ * - `removed`: present in `A` (the historical build) only
+ * - `changed`: present in both, but the size delta is non-zero
+ * - `identical`: present in both with no size change
+ */
+export type DiffStatus = 'added' | 'removed' | 'changed' | 'identical'
+
+/**
+ * Per-row diff entry: one logical thing (a route, a source path) compared
+ * across two builds.
+ *
+ * Sizes are all measured in bytes. We carry both compressed and raw sizes
+ * because the existing UI exposes both modes — comparison should respect the
+ * user's choice.
+ */
+export interface DiffRow {
+  /** Stable join key (route path or full source path). */
+  key: string
+  /** Display label. For routes, same as `key`. For sources, the basename or relative-to-project segment. */
+  name: string
+  status: DiffStatus
+  /** Size in build A (the historical baseline). 0 when added. */
+  sizeA: number
+  /** Size in build B (the latest build). 0 when removed. */
+  sizeB: number
+  /** Compressed size in build A. */
+  compressedA: number
+  /** Compressed size in build B. */
+  compressedB: number
+}
+
+/**
+ * Aggregate totals + categorized rows for a build comparison.
+ */
+export interface DiffSummary<Row extends DiffRow = DiffRow> {
+  rows: Row[]
+  /** Counts by status, useful for headline badges. */
+  counts: Record<DiffStatus, number>
+  /** Sum of `sizeA` over all rows. */
+  totalA: number
+  /** Sum of `sizeB` over all rows. */
+  totalB: number
+  /** Sum of `compressedA` over all rows. */
+  totalCompressedA: number
+  /** Sum of `compressedB` over all rows. */
+  totalCompressedB: number
+}
+
+/** Returns `B - A` for a row. */
+export function delta(row: DiffRow, useCompressed: boolean): number {
+  return useCompressed
+    ? row.compressedB - row.compressedA
+    : row.sizeB - row.sizeA
+}
+
+/** Returns the status for a row given the two sizes. */
+function statusFor(
+  sizeA: number,
+  sizeB: number,
+  presentInA: boolean,
+  presentInB: boolean
+): DiffStatus {
+  if (presentInA && !presentInB) return 'removed'
+  if (!presentInA && presentInB) return 'added'
+  if (sizeA === sizeB) return 'identical'
+  return 'changed'
+}
+
+/** Builds an empty {@link DiffSummary}. */
+function emptySummary<Row extends DiffRow>(): DiffSummary<Row> {
+  return {
+    rows: [],
+    counts: { added: 0, removed: 0, changed: 0, identical: 0 },
+    totalA: 0,
+    totalB: 0,
+    totalCompressedA: 0,
+    totalCompressedB: 0,
+  }
+}
+
+/** Adds a row to a summary, updating counts and totals. */
+function pushRow<Row extends DiffRow>(
+  summary: DiffSummary<Row>,
+  row: Row
+): void {
+  summary.rows.push(row)
+  summary.counts[row.status] += 1
+  summary.totalA += row.sizeA
+  summary.totalB += row.sizeB
+  summary.totalCompressedA += row.compressedA
+  summary.totalCompressedB += row.compressedB
+}
+
+/**
+ * Diffs two route lists. Routes are compared by their page path. Without
+ * per-route data loaded (which would be N round-trips), the size columns are
+ * left at zero; the table view fills them in lazily as the user expands rows.
+ */
+export function diffRouteLists(
+  routesA: string[] | null,
+  routesB: string[]
+): DiffSummary {
+  const summary = emptySummary()
+  const setA = new Set(routesA ?? [])
+  const setB = new Set(routesB)
+  const all = new Set<string>([...setA, ...setB])
+  const sorted = Array.from(all).sort()
+
+  for (const route of sorted) {
+    const inA = setA.has(route)
+    const inB = setB.has(route)
+    pushRow(summary, {
+      key: route,
+      name: route,
+      status: statusFor(0, 0, inA, inB),
+      sizeA: 0,
+      sizeB: 0,
+      compressedA: 0,
+      compressedB: 0,
+    })
+  }
+
+  return summary
+}
+
+/**
+ * Per-route size aggregates contributed by a single side (A or B). When a
+ * route is missing from the corresponding map entirely, it's treated as
+ * "not present in that build".
+ */
+export interface RouteSizeTotals {
+  size: number
+  compressedSize: number
+}
+
+/**
+ * Sums the `getOwnSizes` of every leaf source in an {@link AnalyzeData},
+ * giving a single route's total contribution. This matches what the existing
+ * route sidebar shows for each route in non-compare mode.
+ */
+export function totalsFromAnalyzeData(
+  data: AnalyzeData,
+  filter?: (sourceIndex: SourceIndex) => boolean
+): RouteSizeTotals {
+  let size = 0
+  let compressedSize = 0
+  const count = data.sourceCount()
+  for (let i = 0; i < count; i++) {
+    if (data.sourceChildren(i).length > 0) continue
+    if (filter && !filter(i)) continue
+    const own = data.getOwnSizes(i)
+    size += own.size
+    compressedSize += own.compressedSize
+  }
+  return { size, compressedSize }
+}
+
+/**
+ * Size-aware variant of {@link diffRouteLists}. When `sizesA`/`sizesB` are
+ * provided, routes get real `changed`/`identical` classification based on
+ * their summed source sizes — not just name-presence.
+ *
+ * A route is `added` if it is missing from `sizesA`, `removed` if missing
+ * from `sizesB`. `sizesA == null` means the baseline is still loading and we
+ * fall back to the name-only diff (`diffRouteLists`).
+ */
+export function diffRoutesWithSizes(
+  routesA: string[] | null,
+  routesB: string[],
+  sizesA: ReadonlyMap<string, RouteSizeTotals> | null,
+  sizesB: ReadonlyMap<string, RouteSizeTotals>
+): DiffSummary {
+  if (!sizesA) return diffRouteLists(routesA, routesB)
+
+  const summary = emptySummary()
+  const setA = new Set(routesA ?? [])
+  const setB = new Set(routesB)
+  const all = new Set<string>([...setA, ...setB])
+  const sorted = Array.from(all).sort()
+
+  for (const route of sorted) {
+    const a = sizesA.get(route)
+    const b = sizesB.get(route)
+    const inA = setA.has(route)
+    const inB = setB.has(route)
+    const sizeA = a?.size ?? 0
+    const sizeB = b?.size ?? 0
+    pushRow(summary, {
+      key: route,
+      name: route,
+      status: statusFor(sizeA, sizeB, inA, inB),
+      sizeA,
+      sizeB,
+      compressedA: a?.compressedSize ?? 0,
+      compressedB: b?.compressedSize ?? 0,
+    })
+  }
+
+  return summary
+}
+
+/**
+ * A {@link DiffRow} for a source (file or module), including the indices we
+ * need to look it back up in either side's {@link AnalyzeData}.
+ */
+export interface SourceDiffRow extends DiffRow {
+  sourceIndexA: SourceIndex | null
+  sourceIndexB: SourceIndex | null
+  /**
+   * Whether the source lives in an npm package (`package`) or is part of the
+   * user's project (`project`). Used by the diff table to pick an icon.
+   */
+  pathKind: 'package' | 'project'
+  /** Resolved npm package name when `pathKind === 'package'`. */
+  packageName?: string
+  /**
+   * Environment flags reflecting where the leaf is bundled. Mirrors what
+   * the treemap hover footer already shows. Computed via
+   * `AnalyzeData.getSourceFlags` at diff time so the table can render
+   * `client` / `server` badges without re-deriving them per row.
+   *
+   * Both flags can be `true` simultaneously (a source can be pulled into
+   * both client and server bundles).
+   */
+  client: boolean
+  server: boolean
+}
+
+interface SourceDiffOptions {
+  /** When provided, sources for which `filterSource(side, index) === false` are excluded. */
+  filterSource?: (side: 'A' | 'B', index: SourceIndex) => boolean
+}
+
+/**
+ * Per-side leaf entry as collected from an {@link AnalyzeData}. The
+ * `index` points back into that side's data so callers (e.g. the sidebar
+ * import-chain panel) can resolve the original source.
+ */
+interface LeafEntry {
+  index: SourceIndex
+  size: number
+  compressedSize: number
+  /** Bundled into the client environment. */
+  client: boolean
+  /** Bundled into the server environment. */
+  server: boolean
+}
+
+/**
+ * Walks every leaf source in `data` (skipping directory aggregations and
+ * empty contributions) and returns them keyed by full path.
+ */
+function collectLeaves(
+  side: 'A' | 'B',
+  data: AnalyzeData,
+  options: SourceDiffOptions
+): Map<string, LeafEntry> {
+  const out = new Map<string, LeafEntry>()
+  const count = data.sourceCount()
+  for (let i = 0; i < count; i++) {
+    // Only include leaf sources (real files, not directory aggregations).
+    if (data.sourceChildren(i).length > 0) continue
+    if (options.filterSource && !options.filterSource(side, i)) continue
+    const fullPath = data.getFullSourcePath(i)
+    if (!fullPath) continue
+    const own = data.getOwnSizes(i)
+    // Skip empty contributions — they aren't really "in" the bundle.
+    if (own.size === 0 && own.compressedSize === 0) continue
+    const flags = data.getSourceFlags(i)
+    out.set(fullPath, {
+      index: i,
+      size: own.size,
+      compressedSize: own.compressedSize,
+      client: flags.client,
+      server: flags.server,
+    })
+  }
+  return out
+}
+
+/**
+ * Diffs every source between two analyze datasets, joining by full source
+ * path (stable across builds modulo file moves).
+ *
+ * Directories (sources with children) are excluded — only leaf "files" appear
+ * in the resulting rows. Their own size is the sum of their {@link
+ * AnalyzeData.sourceChunkParts} contributions.
+ */
+export function diffSources(
+  analyzeA: AnalyzeData | null,
+  analyzeB: AnalyzeData,
+  options: SourceDiffOptions = {}
+): DiffSummary<SourceDiffRow> {
+  const summary = emptySummary<SourceDiffRow>()
+
+  const leavesA = analyzeA
+    ? collectLeaves('A', analyzeA, options)
+    : new Map<string, LeafEntry>()
+  const leavesB = collectLeaves('B', analyzeB, options)
+
+  const allKeys = new Set<string>([...leavesA.keys(), ...leavesB.keys()])
+  for (const key of allKeys) {
+    const a = leavesA.get(key)
+    const b = leavesB.get(key)
+    const pretty = prettifySourcePath(key)
+    pushRow(summary, {
+      key,
+      name: pretty.display,
+      status: statusFor(
+        a?.size ?? 0,
+        b?.size ?? 0,
+        a !== undefined,
+        b !== undefined
+      ),
+      sizeA: a?.size ?? 0,
+      sizeB: b?.size ?? 0,
+      compressedA: a?.compressedSize ?? 0,
+      compressedB: b?.compressedSize ?? 0,
+      sourceIndexA: a?.index ?? null,
+      sourceIndexB: b?.index ?? null,
+      pathKind: pretty.kind,
+      packageName: pretty.packageName,
+      // OR-merge env flags across both sides so the badge reflects the
+      // row's overall environment(s). A source that's client-only in A
+      // and removed in B is still "client" for the purpose of the row.
+      client: (a?.client ?? false) || (b?.client ?? false),
+      server: (a?.server ?? false) || (b?.server ?? false),
+    })
+  }
+
+  return summary
+}
+
+/**
+ * Returns a short, human-friendly version of a source path for table /
+ * treemap labels. Source paths look like:
+ *
+ *   `[project]/app/page.tsx`
+ *   `[client-fs]/node_modules/react/index.js`
+ *   `[turbopack]/...`
+ *
+ * For UI purposes the `[bracket]/` prefix is noise — keep the rest.
+ */
+export function shortenSourcePath(fullPath: string): string {
+  const pretty = prettifySourcePath(fullPath)
+  return pretty.display
+}
+
+/**
+ * Result of {@link prettifySourcePath}. Tells the UI both how to render the
+ * path (`display`) and whether it points into an npm package (so callers can
+ * add a package icon, etc.).
+ */
+export interface PrettySourcePath {
+  /** Discriminator the UI uses to decide on iconography. */
+  kind: 'package' | 'project'
+  /** Human-friendly path. For packages: `<pkg>/<rest>`. */
+  display: string
+  /** Resolved npm package name, when `kind === 'package'`. */
+  packageName?: string
+}
+
+/**
+ * Picks a clean, scannable display path for a source. Handles three cases:
+ *
+ * 1. **pnpm-encoded paths** like
+ *    `node_modules/.pnpm/react@19.2.4/node_modules/react/index.js` —
+ *    we collapse all the `.pnpm/...` virtual store noise and report
+ *    `react/index.js` as the display path.
+ * 2. **Plain `node_modules/<pkg>/...` paths** — same treatment, just without
+ *    the virtual store layer.
+ * 3. **Project-relative paths** (e.g. `app/page.tsx`) — pass through unchanged
+ *    after stripping the `[project]/` prefix that {@link shortenSourcePath}
+ *    used to handle.
+ *
+ * The full path is always preserved on the original row's `key` so the UI can
+ * surface it via `title=` for power-users.
+ */
+export function prettifySourcePath(fullPath: string): PrettySourcePath {
+  // Strip Turbopack's `[bracket]/` source-root prefix.
+  const stripped = fullPath.replace(/^\[[^\]]+\]\//, '') || fullPath
+
+  // Walk every `node_modules/<segment>/` occurrence and pick the *last* one —
+  // that's where the real package name lives. pnpm produces paths shaped like
+  // `node_modules/.pnpm/<encoded>/node_modules/<pkg>/...`, where the inner
+  // `node_modules/<pkg>` is the real entry point.
+  const nm = 'node_modules/'
+  let lastNmIndex = -1
+  for (
+    let idx = stripped.indexOf(nm);
+    idx !== -1;
+    idx = stripped.indexOf(nm, idx + nm.length)
+  ) {
+    lastNmIndex = idx
+  }
+  if (lastNmIndex !== -1) {
+    const after = stripped.slice(lastNmIndex + nm.length)
+    // The package name is one or two path segments depending on whether it's
+    // scoped: `@scope/name/...` vs `name/...`. Anything after that is the
+    // path within the package.
+    const segments = after.split('/')
+    if (segments.length > 0 && segments[0]) {
+      const isScoped = segments[0].startsWith('@')
+      const pkgSegments = isScoped ? segments.slice(0, 2) : segments.slice(0, 1)
+      const restSegments = segments.slice(pkgSegments.length)
+      const packageName = pkgSegments.join('/')
+      // Skip pnpm's `.pnpm` virtual-store entry — we only treat real packages
+      // (not the `.pnpm` directory itself) as packages.
+      if (packageName && packageName !== '.pnpm') {
+        const display =
+          restSegments.length > 0
+            ? `${packageName}/${restSegments.join('/')}`
+            : packageName
+        return { kind: 'package', display, packageName }
+      }
+    }
+  }
+
+  return { kind: 'project', display: stripped }
+}
+
+/**
+ * Sorts diff rows by absolute delta (largest impact first), with a stable
+ * tiebreaker on key. Identical rows always sort last.
+ */
+export function sortByImpact<Row extends DiffRow>(
+  rows: Row[],
+  useCompressed: boolean
+): Row[] {
+  return [...rows].sort((a, b) => {
+    if (a.status === 'identical' && b.status !== 'identical') return 1
+    if (b.status === 'identical' && a.status !== 'identical') return -1
+    const da = Math.abs(delta(a, useCompressed))
+    const db = Math.abs(delta(b, useCompressed))
+    if (da !== db) return db - da
+    return a.key < b.key ? -1 : 1
+  })
+}

--- a/apps/bundle-analyzer/lib/snapshot.ts
+++ b/apps/bundle-analyzer/lib/snapshot.ts
@@ -1,0 +1,59 @@
+/**
+ * Mirrors {@link SnapshotMetadata} written by the build (see
+ * `packages/next/src/build/analyze/snapshot.ts`). Field semantics must stay in
+ * sync.
+ */
+export interface SnapshotMetadata {
+  id: string
+  createdAt: string
+  nextVersion?: string
+  gitBranch?: string
+  gitSha?: string
+  gitShortSha?: string
+  gitDirty?: boolean
+  appDirOnly?: boolean
+  noMangling?: boolean
+  routeCount: number
+}
+
+/** Mirrors {@link HistoryIndex}. */
+export interface HistoryIndex {
+  snapshots: SnapshotMetadata[]
+}
+
+/**
+ * Returns a short, human-friendly label for a snapshot. Used by the picker
+ * and the diff header bar. Format prefers branch + short sha, falling back to
+ * timestamp when neither is available.
+ */
+export function formatSnapshotLabel(metadata: SnapshotMetadata): string {
+  const sha = metadata.gitShortSha ? metadata.gitShortSha : null
+  const branch = metadata.gitBranch ?? null
+  if (branch && sha) return `${branch}@${sha}${metadata.gitDirty ? '*' : ''}`
+  if (sha) return `${sha}${metadata.gitDirty ? '*' : ''}`
+  if (branch) return branch
+  return formatRelativeTime(metadata.createdAt)
+}
+
+/**
+ * Returns a relative time string for an ISO timestamp ("3m ago", "2h ago",
+ * "yesterday", "Jan 4"). Designed for compact list rows.
+ */
+export function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return iso
+  const diffMs = Date.now() - then
+  const seconds = Math.round(diffMs / 1000)
+  if (seconds < 45) return 'just now'
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days === 1) return 'yesterday'
+  if (days < 14) return `${days}d ago`
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })
+}

--- a/apps/bundle-analyzer/lib/snapshot.ts
+++ b/apps/bundle-analyzer/lib/snapshot.ts
@@ -11,8 +11,12 @@ export interface SnapshotMetadata {
   gitSha?: string
   gitShortSha?: string
   gitDirty?: boolean
+  /** First line of the HEAD commit message when available. */
+  gitMessage?: string
   appDirOnly?: boolean
   noMangling?: boolean
+  /** Optional label overriding branch/sha in display. See `--snapshot-label`. */
+  snapshotLabel?: string
   routeCount: number
 }
 
@@ -27,6 +31,7 @@ export interface HistoryIndex {
  * timestamp when neither is available.
  */
 export function formatSnapshotLabel(metadata: SnapshotMetadata): string {
+  if (metadata.snapshotLabel) return metadata.snapshotLabel
   const sha = metadata.gitShortSha ? metadata.gitShortSha : null
   const branch = metadata.gitBranch ?? null
   if (branch && sha) return `${branch}@${sha}${metadata.gitDirty ? '*' : ''}`
@@ -44,7 +49,7 @@ export function formatRelativeTime(iso: string): string {
   if (Number.isNaN(then)) return iso
   const diffMs = Date.now() - then
   const seconds = Math.round(diffMs / 1000)
-  if (seconds < 45) return 'just now'
+  if (seconds < 60) return 'just now'
   const minutes = Math.round(seconds / 60)
   if (minutes < 60) return `${minutes}m ago`
   const hours = Math.round(minutes / 60)

--- a/apps/bundle-analyzer/lib/snapshot.ts
+++ b/apps/bundle-analyzer/lib/snapshot.ts
@@ -15,8 +15,8 @@ export interface SnapshotMetadata {
   gitMessage?: string
   appDirOnly?: boolean
   noMangling?: boolean
-  /** Optional label overriding branch/sha in display. See `--snapshot-label`. */
-  snapshotLabel?: string
+  /** User-supplied baseline name, overriding branch/sha in display. See `--baseline-name`. */
+  baselineName?: string
   routeCount: number
 }
 
@@ -31,7 +31,7 @@ export interface HistoryIndex {
  * timestamp when neither is available.
  */
 export function formatSnapshotLabel(metadata: SnapshotMetadata): string {
-  if (metadata.snapshotLabel) return metadata.snapshotLabel
+  if (metadata.baselineName) return metadata.baselineName
   const sha = metadata.gitShortSha ? metadata.gitShortSha : null
   const branch = metadata.gitBranch ?? null
   if (branch && sha) return `${branch}@${sha}${metadata.gitDirty ? '*' : ''}`

--- a/apps/bundle-analyzer/lib/treemap-layout.ts
+++ b/apps/bundle-analyzer/lib/treemap-layout.ts
@@ -16,6 +16,7 @@ export interface LayoutNodeInfo {
   server?: boolean
   client?: boolean
   traced?: boolean
+  asyncOnly?: boolean
 }
 
 export interface LayoutNode extends LayoutNodeInfo {
@@ -112,7 +113,8 @@ function computeTreemapLayoutFromAnalyzeInternal(
   foldedPath: string,
   rect: LayoutRect,
   metadata: SourceMetadata[],
-  sizeMode: SizeMode
+  sizeMode: SizeMode,
+  isAsyncOnlySource?: (sourceIndex: SourceIndex) => boolean
 ): LayoutNode {
   const source = analyzeData.source(sourceIndex)
   if (!source) {
@@ -138,7 +140,8 @@ function computeTreemapLayoutFromAnalyzeInternal(
         foldedPath + source.path,
         rect,
         metadata,
-        sizeMode
+        sizeMode,
+        isAsyncOnlySource
       )
     }
   }
@@ -157,6 +160,7 @@ function computeTreemapLayoutFromAnalyzeInternal(
       rect,
       sourceIndex,
       specialModuleType: getSpecialModuleType(analyzeData, sourceIndex),
+      asyncOnly: isAsyncOnlySource?.(sourceIndex) ?? false,
       ...analyzeData.getSourceFlags(sourceIndex),
     }
   }
@@ -251,7 +255,8 @@ function computeTreemapLayoutFromAnalyzeInternal(
       '',
       childRects[i],
       metadata,
-      sizeMode
+      sizeMode,
+      isAsyncOnlySource
     )
   )
 
@@ -273,7 +278,8 @@ export function computeTreemapLayoutFromAnalyze(
   sourceIndex: SourceIndex,
   rect: LayoutRect,
   filterSource?: (sourceIndex: SourceIndex) => boolean,
-  sizeMode: SizeMode = SizeMode.Compressed
+  sizeMode: SizeMode = SizeMode.Compressed,
+  isAsyncOnlySource?: (sourceIndex: SourceIndex) => boolean
 ): LayoutNode {
   // Precompute metadata once for entire tree
   const metadata = precomputeSourceMetadata(analyzeData, filterSource)
@@ -285,6 +291,7 @@ export function computeTreemapLayoutFromAnalyze(
     '',
     rect,
     metadata,
-    sizeMode
+    sizeMode,
+    isAsyncOnlySource
   )
 }

--- a/apps/bundle-analyzer/lib/use-route-totals.ts
+++ b/apps/bundle-analyzer/lib/use-route-totals.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { AnalyzeData } from './analyze-data'
+import { totalsFromAnalyzeData, type RouteSizeTotals } from './diff'
+import { fetchStrict } from './utils'
+
+/**
+ * Resolve the URL of an `analyze.data` file for a given route, parameterised
+ * by base directory (`'data'` for the live build, `'history/<id>'` for a
+ * historical snapshot).
+ */
+function analyzeDataUrl(route: string, baseDir: string): string {
+  if (route === '/') return `${baseDir}/analyze.data`
+  return `${baseDir}/${route.replace(/^\//, '')}/analyze.data`
+}
+
+/**
+ * Result of loading route totals for one side. `totals` is keyed by route.
+ * Routes whose `analyze.data` failed to load (e.g. deleted between builds)
+ * are simply absent from the map; callers should treat absence as
+ * "not present in this build".
+ */
+export interface RouteTotalsState {
+  totals: ReadonlyMap<string, RouteSizeTotals> | null
+  isLoading: boolean
+}
+
+/**
+ * Loads `analyze.data` for every route in `routes` from `baseDir` and
+ * reduces each to its size totals. Used to power the route-level diff so
+ * that routes can be classified `changed`/`identical` by real bundle size,
+ * not just name presence.
+ *
+ * The fetch fan-out is parallel; for projects with many routes this can be
+ * heavy, but typical analyze runs have a small number of routes. Results
+ * are stored in module-scoped state keyed by `baseDir` to avoid refetching
+ * across re-renders.
+ */
+export function useRouteTotals(
+  routes: string[] | null | undefined,
+  baseDir: string | null
+): RouteTotalsState {
+  const [state, setState] = useState<RouteTotalsState>({
+    totals: null,
+    isLoading: false,
+  })
+
+  useEffect(() => {
+    if (!routes || !baseDir) {
+      setState({ totals: null, isLoading: false })
+      return
+    }
+
+    let cancelled = false
+    setState((prev) => ({ totals: prev.totals, isLoading: true }))
+
+    Promise.all(
+      routes.map(async (route) => {
+        try {
+          const resp = await fetchStrict(analyzeDataUrl(route, baseDir))
+          const data = new AnalyzeData(await resp.arrayBuffer())
+          return [route, totalsFromAnalyzeData(data)] as const
+        } catch {
+          return null
+        }
+      })
+    ).then((results) => {
+      if (cancelled) return
+      const totals = new Map<string, RouteSizeTotals>()
+      for (const result of results) {
+        if (result) totals.set(result[0], result[1])
+      }
+      setState({ totals, isLoading: false })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [routes, baseDir])
+
+  return state
+}

--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, io::Write};
+use std::{borrow::Cow, collections::VecDeque, io::Write};
 
 use anyhow::Result;
 use byteorder::{BE, WriteBytesExt};
@@ -24,6 +24,8 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
     reference::all_assets_from_entries,
 };
+
+use crate::route::ModuleGraphs;
 
 pub struct EdgesData {
     pub offsets: Vec<u32>,
@@ -105,6 +107,11 @@ struct AnalyzeDataHeader {
     pub source_children: EdgesDataReference,
     /// Root level sources, walking their children will reach all sources
     pub source_roots: Vec<u32>,
+    /// Source indices of modules that are only reachable via async (dynamic
+    /// import) edges from this route's entries. Computed per-route against the
+    /// route's module graph, so a module statically imported on another route
+    /// can still be async-only here.
+    pub async_only_sources: Vec<u32>,
 }
 
 #[derive(Serialize)]
@@ -150,6 +157,7 @@ struct AnalyzeDataBuilder {
     source_index_map: FxHashMap<RcStr, u32>,
     chunk_parts: Vec<AnalyzeChunkPart>,
     output_files: Vec<AnalyzeOutputFileBuilder>,
+    async_only_sources: FxHashSet<u32>,
 }
 
 struct ModulesDataBuilder {
@@ -181,6 +189,7 @@ impl AnalyzeDataBuilder {
             source_index_map: FxHashMap::default(),
             chunk_parts: vec![],
             output_files: vec![],
+            async_only_sources: FxHashSet::default(),
         }
     }
 
@@ -229,6 +238,10 @@ impl AnalyzeDataBuilder {
             .push(chunk_part_index);
     }
 
+    fn set_async_only_sources(&mut self, sources: FxHashSet<u32>) {
+        self.async_only_sources = sources;
+    }
+
     fn build(self) -> Rope {
         let source_roots = self
             .sources
@@ -254,6 +267,9 @@ impl AnalyzeDataBuilder {
 
         let mut binary_section = EdgesDataSectionBuilder::new();
 
+        let mut async_only_sources: Vec<u32> = self.async_only_sources.into_iter().collect();
+        async_only_sources.sort_unstable();
+
         let header = AnalyzeDataHeader {
             sources: self.sources.into_iter().map(|s| s.source).collect(),
             chunk_parts: self.chunk_parts,
@@ -266,6 +282,7 @@ impl AnalyzeDataBuilder {
             source_chunk_parts: binary_section.add_edges(&source_chunk_parts),
             source_children: binary_section.add_edges(&source_children),
             source_roots,
+            async_only_sources,
         };
 
         let header_json = serde_json::to_vec(&header).unwrap();
@@ -401,10 +418,363 @@ pub async fn combine_traced_files(
     Ok(Vc::cell(combined))
 }
 
+/// Classified edges from a module graph traversal.
+///
+/// `static_edges`, `async_edges`, and `traced_edges` are `(from, to)` module
+/// pairs. `traced_modules` is the set of modules reached via NFT tracing.
+/// `modules` is every module visited during the traversal (reachable from the
+/// entries).
+struct ClassifiedEdges {
+    modules: FxIndexSet<ResolvedVc<Box<dyn Module>>>,
+    static_edges: FxIndexSet<(ResolvedVc<Box<dyn Module>>, ResolvedVc<Box<dyn Module>>)>,
+    async_edges: FxIndexSet<(ResolvedVc<Box<dyn Module>>, ResolvedVc<Box<dyn Module>>)>,
+    traced_edges: FxIndexSet<(ResolvedVc<Box<dyn Module>>, ResolvedVc<Box<dyn Module>>)>,
+    traced_modules: FxHashSet<ResolvedVc<Box<dyn Module>>>,
+}
+
+/// Traverse `module_graph` from its entries and classify every edge as static,
+/// async, or traced. This is the same logic used by `analyze_module_graphs`,
+/// factored out so the per-route analyzer can reuse it for async-only source
+/// classification.
+fn classify_module_graph_edges(module_graph: &ModuleGraph) -> Result<ClassifiedEdges> {
+    let mut modules = FxIndexSet::default();
+    let mut static_edges = FxIndexSet::default();
+    let mut async_edges = FxIndexSet::default();
+    let mut traced_edges = FxIndexSet::default();
+    let mut traced_modules = FxHashSet::default();
+
+    module_graph.traverse_edges_dfs(
+        module_graph.all_entry_modules(),
+        &mut (),
+        |parent, node, _| {
+            modules.insert(node);
+            let Some((parent_node, reference)) = parent else {
+                return Ok(GraphTraversalAction::Continue);
+            };
+
+            if matches!(
+                reference.chunking_type,
+                ChunkingType::Traced {
+                    mode: TracedMode::Entry
+                }
+            ) || traced_modules.contains(&parent_node)
+            {
+                traced_modules.insert(node);
+                traced_edges.insert((parent_node, node));
+                return Ok(GraphTraversalAction::Continue);
+            };
+
+            match reference.chunking_type {
+                ChunkingType::Async => {
+                    async_edges.insert((parent_node, node));
+                }
+                _ => {
+                    static_edges.insert((parent_node, node));
+                }
+            }
+            Ok(GraphTraversalAction::Continue)
+        },
+        |_, _, _| Ok(()),
+        true,
+    )?;
+
+    Ok(ClassifiedEdges {
+        modules,
+        static_edges,
+        async_edges,
+        traced_edges,
+        traced_modules,
+    })
+}
+
+/// Compute the set of modules reachable from `entries` by following only the
+/// given static edges. Pure and generic over the module identity type so it
+/// can be unit-tested without a real turbo-tasks module graph.
+fn compute_static_reachable<M>(entries: &[M], static_edges: &[(M, M)]) -> FxHashSet<M>
+where
+    M: Copy + Eq + std::hash::Hash,
+{
+    let mut adjacency: FxHashMap<M, Vec<M>> = FxHashMap::default();
+    for (from, to) in static_edges {
+        adjacency.entry(*from).or_default().push(*to);
+    }
+
+    let mut reachable: FxHashSet<M> = FxHashSet::default();
+    let mut queue: VecDeque<M> = VecDeque::new();
+    for entry in entries {
+        if reachable.insert(*entry) {
+            queue.push_back(*entry);
+        }
+    }
+    while let Some(current) = queue.pop_front() {
+        if let Some(neighbors) = adjacency.get(&current) {
+            for to in neighbors {
+                if reachable.insert(*to) {
+                    queue.push_back(*to);
+                }
+            }
+        }
+    }
+    reachable
+}
+
+/// Given the set of all visited modules, the static-reachable set, the traced
+/// set, and a per-module mapping to source indices, return the source indices
+/// that are *exclusively* async-reachable.
+///
+/// A single source path can correspond to multiple module instances (e.g.
+/// client vs ssr layer variants of the same file). The source is async-only
+/// only if it has at least one mapped module AND *every* mapped module
+/// instance is async-only — if any variant is static-reachable or traced, the
+/// source is not exclusively async.
+fn aggregate_async_only_sources<M, I>(
+    all_modules: I,
+    static_reachable: &FxHashSet<M>,
+    traced_modules: &FxHashSet<M>,
+    module_to_source: impl Fn(&M) -> Option<u32>,
+) -> FxHashSet<u32>
+where
+    M: Copy + Eq + std::hash::Hash,
+    I: IntoIterator<Item = M>,
+{
+    #[derive(Default)]
+    struct SourceStatus {
+        has_module: bool,
+        has_static_or_traced: bool,
+    }
+    let mut source_status: FxHashMap<u32, SourceStatus> = FxHashMap::default();
+
+    for module in all_modules {
+        let Some(source_index) = module_to_source(&module) else {
+            continue;
+        };
+        let status = source_status.entry(source_index).or_default();
+        status.has_module = true;
+        if static_reachable.contains(&module) || traced_modules.contains(&module) {
+            status.has_static_or_traced = true;
+        }
+    }
+
+    source_status
+        .into_iter()
+        .filter_map(|(idx, s)| (s.has_module && !s.has_static_or_traced).then_some(idx))
+        .collect()
+}
+
+/// Compute the set of source indices that are only reachable via async (dynamic
+/// import) edges within a single route's module graph(s).
+///
+/// A module is async-only when no path from a route entry to it crosses only
+/// static edges, and it is not traced-only. We BFS from the entries over static
+/// edges to find `static_reachable`, then aggregate per-source via
+/// [`aggregate_async_only_sources`] (a source is async-only only if every
+/// module variant mapping to it is async-only).
+///
+/// When multiple module graphs are provided (a route may have several), a
+/// module is static-reachable if it is static-reachable in *any* graph, and
+/// async-only only if it is async-only in *every* graph that contains it.
+async fn compute_async_only_sources(
+    module_graphs: Vec<ResolvedVc<ModuleGraph>>,
+    source_index_map: &FxHashMap<RcStr, u32>,
+) -> Result<FxHashSet<u32>> {
+    // Union of static-reachable modules across all graphs.
+    let mut static_reachable: FxHashSet<ResolvedVc<Box<dyn Module>>> = FxHashSet::default();
+    // Union of traced modules across all graphs.
+    let mut traced_modules: FxHashSet<ResolvedVc<Box<dyn Module>>> = FxHashSet::default();
+    // Every module visited in any graph.
+    let mut all_modules: FxIndexSet<ResolvedVc<Box<dyn Module>>> = FxIndexSet::default();
+
+    for module_graph_vc in module_graphs {
+        let module_graph = module_graph_vc.await?;
+        let classified = classify_module_graph_edges(&module_graph)?;
+
+        let entries: Vec<_> = module_graph.all_entry_modules().collect();
+        let static_edges: Vec<_> = classified.static_edges.iter().copied().collect();
+        let graph_reachable = compute_static_reachable(&entries, &static_edges);
+        static_reachable.extend(graph_reachable);
+
+        traced_modules.extend(classified.traced_modules.iter().copied());
+        all_modules.extend(classified.modules.iter().copied());
+    }
+
+    // Resolve each module's source path up front so the aggregator closure stays
+    // synchronous.
+    let mut module_to_source: FxHashMap<ResolvedVc<Box<dyn Module>>, u32> = FxHashMap::default();
+    for module in &all_modules {
+        let path = module.ident().await?.path.to_string_ref().await?;
+        if let Some(&source_index) = source_index_map.get(&*path) {
+            module_to_source.insert(*module, source_index);
+        }
+    }
+
+    Ok(aggregate_async_only_sources(
+        all_modules.iter().copied(),
+        &static_reachable,
+        &traced_modules,
+        |module| module_to_source.get(module).copied(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hs<T: Copy + Eq + std::hash::Hash>(items: &[T]) -> FxHashSet<T> {
+        items.iter().copied().collect()
+    }
+
+    /// Smoke test: BFS reaches transitively-static-imported modules but not
+    /// async-imported ones.
+    #[test]
+    fn static_reachable_basic() {
+        // entry -> a (static) -> b (static); entry -> c (async, NOT a static edge)
+        let entries = [0u32];
+        let static_edges = [(0, 1), (1, 2)];
+        let reachable = compute_static_reachable(&entries, &static_edges);
+        assert_eq!(reachable, hs(&[0, 1, 2]));
+    }
+
+    #[test]
+    fn static_reachable_handles_cycles() {
+        let entries = [0u32];
+        // 0 -> 1 -> 2 -> 0 (cycle)
+        let static_edges = [(0, 1), (1, 2), (2, 0)];
+        let reachable = compute_static_reachable(&entries, &static_edges);
+        assert_eq!(reachable, hs(&[0, 1, 2]));
+    }
+
+    #[test]
+    fn static_reachable_skips_unreachable() {
+        let entries = [0u32];
+        // 0 -> 1; orphan: 2 -> 3
+        let static_edges = [(0, 1), (2, 3)];
+        let reachable = compute_static_reachable(&entries, &static_edges);
+        assert_eq!(reachable, hs(&[0, 1]));
+    }
+
+    /// A module that's only async-reachable yields its source as async-only.
+    #[test]
+    fn async_only_basic() {
+        // module 0 is the entry (static), module 1 is async-only
+        let static_reachable = hs(&[0u32]);
+        let traced = hs::<u32>(&[]);
+        let module_to_source: FxHashMap<u32, u32> = [(0, 100), (1, 101)].into_iter().collect();
+
+        let result = aggregate_async_only_sources([0, 1], &static_reachable, &traced, |m| {
+            module_to_source.get(m).copied()
+        });
+
+        assert_eq!(result, hs(&[101]));
+    }
+
+    /// Regression test for the multi-variant bug: a single source path can map
+    /// to multiple module instances (e.g. client vs ssr layer variants). If
+    /// any variant is static-reachable, the source must NOT be marked
+    /// async-only — even though the other variants are async-only.
+    ///
+    /// In the example: source `head.js` has two module variants (ssr layer +
+    /// client layer). The ssr variant is statically imported via
+    /// `image-component.js`; the client variant is only reachable via async
+    /// chunks. The source must not be marked async-only.
+    #[test]
+    fn async_only_source_with_mixed_variants_is_not_async_only() {
+        // modules 0,1 = ssr variant of head.js, client variant of head.js
+        // module 2 = unrelated async-only module
+        let static_reachable = hs(&[0u32]); // ssr variant is statically reached
+        let traced = hs::<u32>(&[]);
+        let head_source = 100u32;
+        let other_source = 101u32;
+        let module_to_source: FxHashMap<u32, u32> = [
+            (0, head_source), // ssr variant -> head.js source
+            (1, head_source), // client variant -> SAME head.js source
+            (2, other_source),
+        ]
+        .into_iter()
+        .collect();
+
+        let result = aggregate_async_only_sources([0, 1, 2], &static_reachable, &traced, |m| {
+            module_to_source.get(m).copied()
+        });
+
+        // head.js is NOT async-only because one of its variants is
+        // static-reachable. Only the unrelated source is async-only.
+        assert_eq!(result, hs(&[other_source]));
+    }
+
+    /// Symmetric case: if ALL variants of a source are async-only, the source
+    /// IS async-only.
+    #[test]
+    fn async_only_source_when_all_variants_async_only() {
+        // Both module variants 0 and 1 map to the same source and neither is
+        // static-reachable or traced.
+        let static_reachable = hs::<u32>(&[]);
+        let traced = hs::<u32>(&[]);
+        let shared_source = 100u32;
+        let module_to_source: FxHashMap<u32, u32> = [(0, shared_source), (1, shared_source)]
+            .into_iter()
+            .collect();
+
+        let result = aggregate_async_only_sources([0, 1], &static_reachable, &traced, |m| {
+            module_to_source.get(m).copied()
+        });
+
+        assert_eq!(result, hs(&[shared_source]));
+    }
+
+    /// Traced modules are not async-only (traced is a separate category).
+    #[test]
+    fn traced_modules_excluded_from_async_only() {
+        let static_reachable = hs::<u32>(&[]);
+        let traced = hs(&[0u32]);
+        let module_to_source: FxHashMap<u32, u32> = [(0, 100)].into_iter().collect();
+
+        let result = aggregate_async_only_sources([0], &static_reachable, &traced, |m| {
+            module_to_source.get(m).copied()
+        });
+
+        assert!(result.is_empty());
+    }
+
+    /// Mixed traced+async variants: if any variant is traced, the source is
+    /// not async-only.
+    #[test]
+    fn traced_variant_disqualifies_source() {
+        let static_reachable = hs::<u32>(&[]);
+        let traced = hs(&[0u32]); // first variant is traced
+        let shared_source = 100u32;
+        let module_to_source: FxHashMap<u32, u32> = [(0, shared_source), (1, shared_source)]
+            .into_iter()
+            .collect();
+
+        let result = aggregate_async_only_sources([0, 1], &static_reachable, &traced, |m| {
+            module_to_source.get(m).copied()
+        });
+
+        assert!(result.is_empty());
+    }
+
+    /// Modules with no source mapping (e.g. runtime-injected modules) are
+    /// silently skipped and don't produce phantom source entries.
+    #[test]
+    fn modules_without_source_are_skipped() {
+        let static_reachable = hs::<u32>(&[]);
+        let traced = hs::<u32>(&[]);
+        // Module 0 has no source mapping; module 1 does.
+        let module_to_source: FxHashMap<u32, u32> = [(1, 100)].into_iter().collect();
+
+        let result = aggregate_async_only_sources([0, 1], &static_reachable, &traced, |m| {
+            module_to_source.get(m).copied()
+        });
+
+        assert_eq!(result, hs(&[100]));
+    }
+}
+
 #[turbo_tasks::function]
 pub async fn analyze_output_assets(
     output_assets: Vc<OutputAssets>,
     traced_files: Vc<FileSystemPathVec>,
+    module_graphs: Vc<ModuleGraphs>,
 ) -> Result<Vc<FileContent>> {
     let output_assets = all_assets_from_entries(output_assets);
 
@@ -492,6 +862,13 @@ pub async fn analyze_output_assets(
         i += 1;
     }
 
+    let async_only_sources = compute_async_only_sources(
+        module_graphs.await?.iter().copied().collect(),
+        &builder.source_index_map,
+    )
+    .await?;
+    builder.set_async_only_sources(async_only_sources);
+
     let rope = builder.build();
     Ok(FileContent::Content(File::from(rope)).cell())
 }
@@ -500,50 +877,13 @@ pub async fn analyze_output_assets(
 pub async fn analyze_module_graphs(module_graph: Vc<ModuleGraph>) -> Result<Vc<FileContent>> {
     let mut builder = ModulesDataBuilder::new();
 
-    let mut all_modules = FxIndexSet::default();
-    let mut all_edges = FxIndexSet::default();
-    let mut all_async_edges = FxIndexSet::default();
-    let mut all_traced_edges = FxIndexSet::default();
-    let mut traced_modules = FxHashSet::default();
-
     let module_graph = module_graph.await?;
-    module_graph.traverse_edges_dfs(
-        module_graph.all_entry_modules(),
-        &mut (),
-        |parent, node, _| {
-            all_modules.insert(node);
-            let Some((parent_node, reference)) = parent else {
-                return Ok(GraphTraversalAction::Continue);
-            };
+    let classified = classify_module_graph_edges(&module_graph)?;
 
-            // ChunkingType::Traced{TracedMode::Entry}     => target is always traced
-            // ChunkingType::Traced{TracedMode::Transitive}=> target only traced if parent is traced
-            // ChunkingType::*                             => target only traced if parent is traced
-            if matches!(
-                reference.chunking_type,
-                ChunkingType::Traced {
-                    mode: TracedMode::Entry
-                }
-            ) || traced_modules.contains(&parent_node)
-            {
-                traced_modules.insert(node);
-                all_traced_edges.insert((parent_node, node));
-                return Ok(GraphTraversalAction::Continue);
-            };
-
-            match reference.chunking_type {
-                ChunkingType::Async => {
-                    all_async_edges.insert((parent_node, node));
-                }
-                _ => {
-                    all_edges.insert((parent_node, node));
-                }
-            }
-            Ok(GraphTraversalAction::Continue)
-        },
-        |_, _, _| Ok(()),
-        true,
-    )?;
+    let all_modules = classified.modules;
+    let all_edges = classified.static_edges;
+    let all_async_edges = classified.async_edges;
+    let all_traced_edges = classified.traced_edges;
 
     type ModulePair = (ResolvedVc<Box<dyn Module>>, ResolvedVc<Box<dyn Module>>);
     async fn mapper((from, to): ModulePair) -> Result<Option<(RcStr, RcStr)>> {
@@ -637,6 +977,7 @@ pub struct AnalyzeDataOutputAsset {
     pub path: FileSystemPath,
     pub output_assets: ResolvedVc<OutputAssets>,
     pub traced_files: ResolvedVc<FileSystemPathVec>,
+    pub module_graphs: ResolvedVc<ModuleGraphs>,
 }
 
 #[turbo_tasks::value_impl]
@@ -646,11 +987,13 @@ impl AnalyzeDataOutputAsset {
         path: FileSystemPath,
         output_assets: ResolvedVc<OutputAssets>,
         traced_files: ResolvedVc<FileSystemPathVec>,
+        module_graphs: ResolvedVc<ModuleGraphs>,
     ) -> Result<Vc<Self>> {
         Ok(Self {
             path,
             output_assets,
             traced_files,
+            module_graphs,
         }
         .cell())
     }
@@ -660,7 +1003,8 @@ impl AnalyzeDataOutputAsset {
 impl Asset for AnalyzeDataOutputAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        let file_content = analyze_output_assets(*self.output_assets, *self.traced_files);
+        let file_content =
+            analyze_output_assets(*self.output_assets, *self.traced_files, *self.module_graphs);
         AssetContent::file(file_content)
     }
 }

--- a/crates/next-napi-bindings/src/next_api/analyze.rs
+++ b/crates/next-napi-bindings/src/next_api/analyze.rs
@@ -119,6 +119,7 @@ async fn get_analyze_data_operation(
                     .join("analyze.data")?,
                 output_assets,
                 traced_files,
+                endpoint_group.module_graphs(),
             )
             .to_resolved()
             .await?;

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -267,6 +267,11 @@ program
   )
   .option('--no-mangling', 'Disables mangling.')
   .option('--profile', 'Enables production profiling for React.')
+  .option('--experimental-app-only', 'Analyzes only App Router routes.')
+  .option(
+    '--snapshot-label <label>',
+    'Label stored in the snapshot metadata, overriding branch/sha in the comparison UI.'
+  )
   .option(
     '-o, --output',
     'Only write analysis files to disk. Does not start the server.'

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -269,8 +269,8 @@ program
   .option('--profile', 'Enables production profiling for React.')
   .option('--experimental-app-only', 'Analyzes only App Router routes.')
   .option(
-    '--snapshot-label <label>',
-    'Label stored in the snapshot metadata, overriding branch/sha in the comparison UI.'
+    '--baseline-name <name>',
+    'Name this baseline in the snapshot metadata, overriding branch/sha in the comparison UI.'
   )
   .option(
     '-o, --output',

--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -15,6 +15,7 @@ import loadCustomRoutes from '../../lib/load-custom-routes'
 import { generateRoutesManifest } from '../generate-routes-manifest'
 import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
+import { writeAnalyzeSnapshot } from './snapshot'
 import http from 'node:http'
 
 // @ts-expect-error types are in @types/serve-handler
@@ -85,6 +86,16 @@ export default async function analyze({
       path.join(analyzeDir, 'data', 'routes.json'),
       JSON.stringify(routes, null, 2)
     )
+
+    // Capture this build alongside any prior builds so the analyzer UI can
+    // offer it as a comparison baseline in the future.
+    await writeAnalyzeSnapshot({
+      projectDir: dir,
+      analyzeDir,
+      routes,
+      appDirOnly,
+      noMangling,
+    })
 
     let logMessage = `Analyze completed in ${durationString}.`
     if (output) {

--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -33,8 +33,8 @@ export type AnalyzeOptions = {
   appDirOnly?: boolean
   output?: boolean
   port?: number
-  /** Optional label stored in the snapshot metadata, overriding branch/sha in the UI. */
-  snapshotLabel?: string
+  /** User-supplied baseline name stored in the snapshot metadata, overriding branch/sha in the UI. */
+  baselineName?: string
 }
 
 export default async function analyze({
@@ -44,7 +44,7 @@ export default async function analyze({
   appDirOnly = false,
   output = false,
   port = 4000,
-  snapshotLabel,
+  baselineName,
 }: AnalyzeOptions): Promise<void> {
   try {
     const config: NextConfigComplete = await loadConfig(PHASE_ANALYZE, dir, {
@@ -98,7 +98,7 @@ export default async function analyze({
       routes,
       appDirOnly,
       noMangling,
-      snapshotLabel,
+      baselineName,
     })
 
     let logMessage = `Analyze completed in ${durationString}.`

--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -33,6 +33,8 @@ export type AnalyzeOptions = {
   appDirOnly?: boolean
   output?: boolean
   port?: number
+  /** Optional label stored in the snapshot metadata, overriding branch/sha in the UI. */
+  snapshotLabel?: string
 }
 
 export default async function analyze({
@@ -42,6 +44,7 @@ export default async function analyze({
   appDirOnly = false,
   output = false,
   port = 4000,
+  snapshotLabel,
 }: AnalyzeOptions): Promise<void> {
   try {
     const config: NextConfigComplete = await loadConfig(PHASE_ANALYZE, dir, {
@@ -95,6 +98,7 @@ export default async function analyze({
       routes,
       appDirOnly,
       noMangling,
+      snapshotLabel,
     })
 
     let logMessage = `Analyze completed in ${durationString}.`

--- a/packages/next/src/build/analyze/snapshot.ts
+++ b/packages/next/src/build/analyze/snapshot.ts
@@ -1,0 +1,207 @@
+import * as path from 'node:path'
+import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+
+import { getGitBranch, getGitCommit, getGitDirty } from '../../lib/helpers/git'
+
+/**
+ * Maximum number of historical snapshots to keep on disk by default. When the
+ * history exceeds this number, the oldest snapshots are pruned.
+ */
+const MAX_HISTORY = 20
+
+/**
+ * On-disk metadata captured for each analyze snapshot. Mirrored on the web UI
+ * side so the comparison picker can render branch / sha / timestamp labels
+ * without re-fetching.
+ */
+export interface SnapshotMetadata {
+  /** Snapshot identifier (also the directory name under `history/`). */
+  id: string
+  /** ISO timestamp the snapshot was written. */
+  createdAt: string
+  /** Next.js version string. */
+  nextVersion?: string
+  /** Git branch (or VERCEL_GIT_COMMIT_REF) when available. */
+  gitBranch?: string
+  /** Full git commit SHA when available. */
+  gitSha?: string
+  /** Short (7 char) git commit SHA when available. */
+  gitShortSha?: string
+  /** Whether the working tree had uncommitted changes when the build ran. */
+  gitDirty?: boolean
+  /** `true` when built with `--app-dir-only`. */
+  appDirOnly?: boolean
+  /** `true` when built with `--no-mangling`. */
+  noMangling?: boolean
+  /** Number of routes captured in this snapshot. */
+  routeCount: number
+}
+
+/** Index file describing the current "live" build (always present). */
+export interface CurrentSnapshotIndex {
+  metadata: SnapshotMetadata
+}
+
+/** Index file describing all stored historical snapshots, newest first. */
+export interface HistoryIndex {
+  snapshots: SnapshotMetadata[]
+}
+
+const DATA_DIRNAME = 'data'
+const HISTORY_DIRNAME = 'history'
+const METADATA_FILENAME = 'metadata.json'
+const HISTORY_INDEX_FILENAME = 'history.json'
+
+interface BuildSnapshotInputs {
+  /** Project root, used to resolve git metadata. */
+  projectDir: string
+  /** Absolute path of the analyzer output directory (`.next/diagnostics/analyze`). */
+  analyzeDir: string
+  /** List of route page paths captured in this snapshot. */
+  routes: string[]
+  appDirOnly?: boolean
+  noMangling?: boolean
+  /** Maximum number of historical snapshots to keep. Defaults to `MAX_HISTORY`. */
+  maxHistory?: number
+}
+
+/**
+ * Persists a snapshot of the just-emitted analyze data into the rolling
+ * `history/` directory and updates the index so the web UI can list it as a
+ * comparison baseline.
+ *
+ * This is invoked after the data files (`analyze.data`, `modules.data`,
+ * `routes.json`) have already been written into `<analyzeDir>/data/`. We:
+ *
+ * 1. Write a `metadata.json` next to `routes.json` describing the *current*
+ *    build (so the UI can label it).
+ * 2. Copy `<analyzeDir>/data/` into `<analyzeDir>/history/<id>/` so the same
+ *    static-file server can serve historical builds via relative URLs.
+ * 3. Rebuild `<analyzeDir>/history/history.json` (newest first) and prune
+ *    snapshots beyond `maxHistory`.
+ *
+ * Failures to capture git metadata (no git, detached HEAD, etc.) are non-fatal
+ * — fields are simply omitted.
+ */
+export async function writeAnalyzeSnapshot({
+  projectDir,
+  analyzeDir,
+  routes,
+  appDirOnly,
+  noMangling,
+  maxHistory = MAX_HISTORY,
+}: BuildSnapshotInputs): Promise<SnapshotMetadata> {
+  const dataDir = path.join(analyzeDir, DATA_DIRNAME)
+  const historyDir = path.join(analyzeDir, HISTORY_DIRNAME)
+
+  const gitSha = getGitCommit(projectDir)
+  const gitBranch = getGitBranch(projectDir)
+  const gitDirty = getGitDirty(projectDir)
+
+  const createdAt = new Date()
+  const id = makeSnapshotId(createdAt, gitSha)
+
+  const metadata: SnapshotMetadata = {
+    id,
+    createdAt: createdAt.toISOString(),
+    nextVersion: process.env.__NEXT_VERSION,
+    gitBranch,
+    gitSha,
+    gitShortSha: gitSha ? gitSha.slice(0, 7) : undefined,
+    gitDirty,
+    appDirOnly,
+    noMangling,
+    routeCount: routes.length,
+  }
+
+  // 1. Write metadata.json into the live data directory.
+  await writeFile(
+    path.join(dataDir, METADATA_FILENAME),
+    JSON.stringify(metadata, null, 2)
+  )
+
+  // 2. Snapshot the entire data dir into history/<id>/.
+  const snapshotDir = path.join(historyDir, id)
+  await mkdir(historyDir, { recursive: true })
+  // If the same id already exists (same second + same sha) replace it so the
+  // latest run wins.
+  await rm(snapshotDir, { recursive: true, force: true })
+  await cp(dataDir, snapshotDir, { recursive: true })
+
+  // 3. Rebuild the history index.
+  await rewriteHistoryIndex(historyDir, maxHistory)
+
+  return metadata
+}
+
+/**
+ * Build the snapshot id from the timestamp and git sha. The format is
+ * sortable lexicographically (newest last) which keeps directory listings
+ * tidy. Format: `YYYYMMDD-HHMMSS-<shortSha|local>`.
+ */
+function makeSnapshotId(date: Date, gitSha: string | undefined): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const ts =
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `-${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`
+  const sha = gitSha ? gitSha.slice(0, 7) : 'local'
+  return `${ts}-${sha}`
+}
+
+/**
+ * Walks `<historyDir>/<id>/metadata.json` for every subdirectory, sorts by
+ * `createdAt` (newest first), prunes anything beyond `maxHistory`, and writes
+ * the resulting `history.json` index.
+ *
+ * Snapshots whose metadata file is missing or unreadable are dropped from the
+ * index but not deleted from disk (they may still be useful for manual
+ * inspection).
+ */
+async function rewriteHistoryIndex(
+  historyDir: string,
+  maxHistory: number
+): Promise<HistoryIndex> {
+  let entries: string[] = []
+  try {
+    entries = await readdir(historyDir)
+  } catch {
+    return { snapshots: [] }
+  }
+
+  const snapshots: SnapshotMetadata[] = []
+  for (const entry of entries) {
+    if (entry === HISTORY_INDEX_FILENAME) continue
+    const metadataPath = path.join(historyDir, entry, METADATA_FILENAME)
+    try {
+      const text = await readFile(metadataPath, 'utf8')
+      const parsed = JSON.parse(text) as SnapshotMetadata
+      // Trust the on-disk metadata's id if present, otherwise fall back to
+      // the directory name (backwards compat / hand-edited cases).
+      snapshots.push({ ...parsed, id: parsed.id ?? entry })
+    } catch {
+      // Ignore unreadable / non-snapshot entries.
+    }
+  }
+
+  // Newest first.
+  snapshots.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+
+  // Prune: anything past the cap is removed from disk.
+  const kept = snapshots.slice(0, maxHistory)
+  const pruned = snapshots.slice(maxHistory)
+  await Promise.all(
+    pruned.map((snapshot) =>
+      rm(path.join(historyDir, snapshot.id), {
+        recursive: true,
+        force: true,
+      })
+    )
+  )
+
+  const index: HistoryIndex = { snapshots: kept }
+  await writeFile(
+    path.join(historyDir, HISTORY_INDEX_FILENAME),
+    JSON.stringify(index, null, 2)
+  )
+  return index
+}

--- a/packages/next/src/build/analyze/snapshot.ts
+++ b/packages/next/src/build/analyze/snapshot.ts
@@ -1,7 +1,14 @@
 import * as path from 'node:path'
-import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import * as fs from 'node:fs'
+import { cp, mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 
-import { getGitBranch, getGitCommit, getGitDirty } from '../../lib/helpers/git'
+import {
+  getGitBranch,
+  getGitCommit,
+  getGitDirty,
+  getGitMessage,
+} from '../../lib/helpers/git'
+import { recursiveDeleteSyncWithAsyncRetries } from '../../lib/recursive-delete'
 
 /**
  * Maximum number of historical snapshots to keep on disk by default. When the
@@ -29,10 +36,14 @@ export interface SnapshotMetadata {
   gitShortSha?: string
   /** Whether the working tree had uncommitted changes when the build ran. */
   gitDirty?: boolean
+  /** First line of the HEAD commit message when available. */
+  gitMessage?: string
   /** `true` when built with `--app-dir-only`. */
   appDirOnly?: boolean
   /** `true` when built with `--no-mangling`. */
   noMangling?: boolean
+  /** Optional label overriding branch/sha in display. See `--snapshot-label`. */
+  snapshotLabel?: string
   /** Number of routes captured in this snapshot. */
   routeCount: number
 }
@@ -53,7 +64,7 @@ const METADATA_FILENAME = 'metadata.json'
 const HISTORY_INDEX_FILENAME = 'history.json'
 
 interface BuildSnapshotInputs {
-  /** Project root, used to resolve git metadata. */
+  /** Absolute path to the Next.js project root (the directory containing `next.config.*`). */
   projectDir: string
   /** Absolute path of the analyzer output directory (`.next/diagnostics/analyze`). */
   analyzeDir: string
@@ -61,6 +72,8 @@ interface BuildSnapshotInputs {
   routes: string[]
   appDirOnly?: boolean
   noMangling?: boolean
+  /** Optional label to use instead of branch/sha when displaying this snapshot. */
+  snapshotLabel?: string
   /** Maximum number of historical snapshots to keep. Defaults to `MAX_HISTORY`. */
   maxHistory?: number
 }
@@ -89,6 +102,7 @@ export async function writeAnalyzeSnapshot({
   routes,
   appDirOnly,
   noMangling,
+  snapshotLabel,
   maxHistory = MAX_HISTORY,
 }: BuildSnapshotInputs): Promise<SnapshotMetadata> {
   const dataDir = path.join(analyzeDir, DATA_DIRNAME)
@@ -97,6 +111,7 @@ export async function writeAnalyzeSnapshot({
   const gitSha = getGitCommit(projectDir)
   const gitBranch = getGitBranch(projectDir)
   const gitDirty = getGitDirty(projectDir)
+  const gitMessage = getGitMessage(projectDir)
 
   const createdAt = new Date()
   const id = makeSnapshotId(createdAt, gitSha)
@@ -109,8 +124,10 @@ export async function writeAnalyzeSnapshot({
     gitSha,
     gitShortSha: gitSha ? gitSha.slice(0, 7) : undefined,
     gitDirty,
+    gitMessage,
     appDirOnly,
     noMangling,
+    snapshotLabel,
     routeCount: routes.length,
   }
 
@@ -124,8 +141,11 @@ export async function writeAnalyzeSnapshot({
   const snapshotDir = path.join(historyDir, id)
   await mkdir(historyDir, { recursive: true })
   // If the same id already exists (same second + same sha) replace it so the
-  // latest run wins.
-  await rm(snapshotDir, { recursive: true, force: true })
+  // latest run wins. Use Windows-safe deletion with retry logic.
+  if (fs.existsSync(snapshotDir)) {
+    await recursiveDeleteSyncWithAsyncRetries(snapshotDir)
+    fs.rmdirSync(snapshotDir)
+  }
   await cp(dataDir, snapshotDir, { recursive: true })
 
   // 3. Rebuild the history index.
@@ -190,12 +210,15 @@ async function rewriteHistoryIndex(
   const kept = snapshots.slice(0, maxHistory)
   const pruned = snapshots.slice(maxHistory)
   await Promise.all(
-    pruned.map((snapshot) =>
-      rm(path.join(historyDir, snapshot.id), {
-        recursive: true,
-        force: true,
-      })
-    )
+    pruned.map(async (snapshot) => {
+      const snapshotDir = path.join(historyDir, snapshot.id)
+      await recursiveDeleteSyncWithAsyncRetries(snapshotDir)
+      try {
+        fs.rmdirSync(snapshotDir)
+      } catch {
+        // Already gone or non-empty due to a race — not fatal.
+      }
+    })
   )
 
   const index: HistoryIndex = { snapshots: kept }

--- a/packages/next/src/build/analyze/snapshot.ts
+++ b/packages/next/src/build/analyze/snapshot.ts
@@ -42,8 +42,8 @@ export interface SnapshotMetadata {
   appDirOnly?: boolean
   /** `true` when built with `--no-mangling`. */
   noMangling?: boolean
-  /** Optional label overriding branch/sha in display. See `--snapshot-label`. */
-  snapshotLabel?: string
+  /** User-supplied baseline name, overriding branch/sha in display. See `--baseline-name`. */
+  baselineName?: string
   /** Number of routes captured in this snapshot. */
   routeCount: number
 }
@@ -72,8 +72,8 @@ interface BuildSnapshotInputs {
   routes: string[]
   appDirOnly?: boolean
   noMangling?: boolean
-  /** Optional label to use instead of branch/sha when displaying this snapshot. */
-  snapshotLabel?: string
+  /** User-supplied baseline name to use instead of branch/sha when displaying this snapshot. */
+  baselineName?: string
   /** Maximum number of historical snapshots to keep. Defaults to `MAX_HISTORY`. */
   maxHistory?: number
 }
@@ -102,7 +102,7 @@ export async function writeAnalyzeSnapshot({
   routes,
   appDirOnly,
   noMangling,
-  snapshotLabel,
+  baselineName,
   maxHistory = MAX_HISTORY,
 }: BuildSnapshotInputs): Promise<SnapshotMetadata> {
   const dataDir = path.join(analyzeDir, DATA_DIRNAME)
@@ -127,7 +127,7 @@ export async function writeAnalyzeSnapshot({
     gitMessage,
     appDirOnly,
     noMangling,
-    snapshotLabel,
+    baselineName,
     routeCount: routes.length,
   }
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4284,27 +4284,34 @@ export default async function build(
       await shutdownPromise
 
       if (NextBuildContext.analyze) {
-        await cp(
-          path.join(__dirname, '../bundle-analyzer'),
-          path.join(dir, '.next/diagnostics/analyze'),
-          { recursive: true }
-        )
+        const analyzeDir = path.join(dir, '.next/diagnostics/analyze')
+        await cp(path.join(__dirname, '../bundle-analyzer'), analyzeDir, {
+          recursive: true,
+        })
 
-        await mkdir(path.join(dir, '.next/diagnostics/analyze/data'), {
+        await mkdir(path.join(analyzeDir, 'data'), {
           recursive: true,
         })
 
         // Write an index of routes for the route picker
+        const routes = routesManifest.dynamicRoutes
+          .map((r) => r.page)
+          .concat(routesManifest.staticRoutes.map((r) => r.page))
         await writeFile(
-          path.join(dir, '.next/diagnostics/analyze/data/routes.json'),
-          JSON.stringify(
-            routesManifest.dynamicRoutes
-              .map((r) => r.page)
-              .concat(routesManifest.staticRoutes.map((r) => r.page)),
-            null,
-            2
-          )
+          path.join(analyzeDir, 'data/routes.json'),
+          JSON.stringify(routes, null, 2)
         )
+
+        // Capture this build alongside any prior builds so the analyzer UI
+        // can offer it as a comparison baseline in the future.
+        const { writeAnalyzeSnapshot } = await import('./analyze/snapshot')
+        await writeAnalyzeSnapshot({
+          projectDir: dir,
+          analyzeDir,
+          routes,
+          appDirOnly,
+          noMangling: NextBuildContext.noMangling ?? false,
+        })
       }
     })
   } catch (e) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1126,7 +1126,7 @@ export default async function build(
           .traceAsyncFn(() =>
             recursiveDeleteSyncWithAsyncRetries(
               distDir,
-              /^(cache|dev|lock|trace)/
+              /^(cache|dev|diagnostics|lock|trace)/
             )
           )
       }

--- a/packages/next/src/cli/next-analyze.ts
+++ b/packages/next/src/cli/next-analyze.ts
@@ -16,7 +16,7 @@ export type NextAnalyzeOptions = {
   port: number
   output: boolean
   experimentalAppOnly?: boolean
-  snapshotLabel?: string
+  baselineName?: string
 }
 
 const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
@@ -29,14 +29,8 @@ const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
     process.exit(130)
   })
 
-  const {
-    profile,
-    mangling,
-    experimentalAppOnly,
-    output,
-    port,
-    snapshotLabel,
-  } = options
+  const { profile, mangling, experimentalAppOnly, output, port, baselineName } =
+    options
 
   if (!mangling) {
     warn(
@@ -63,7 +57,7 @@ const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
     appDirOnly: experimentalAppOnly,
     output,
     port,
-    snapshotLabel,
+    baselineName,
   })
 }
 

--- a/packages/next/src/cli/next-analyze.ts
+++ b/packages/next/src/cli/next-analyze.ts
@@ -16,6 +16,7 @@ export type NextAnalyzeOptions = {
   port: number
   output: boolean
   experimentalAppOnly?: boolean
+  snapshotLabel?: string
 }
 
 const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
@@ -28,7 +29,14 @@ const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
     process.exit(130)
   })
 
-  const { profile, mangling, experimentalAppOnly, output, port } = options
+  const {
+    profile,
+    mangling,
+    experimentalAppOnly,
+    output,
+    port,
+    snapshotLabel,
+  } = options
 
   if (!mangling) {
     warn(
@@ -55,6 +63,7 @@ const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
     appDirOnly: experimentalAppOnly,
     output,
     port,
+    snapshotLabel,
   })
 }
 

--- a/packages/next/src/lib/helpers/git.ts
+++ b/packages/next/src/lib/helpers/git.ts
@@ -44,3 +44,17 @@ export function getGitCommit(cwd: string): string | undefined {
     return undefined
   }
 }
+
+/**
+ * Returns true if the working tree has uncommitted changes. Returns undefined
+ * when the dirty status cannot be determined (not a git repo, git not
+ * installed, etc.).
+ */
+export function getGitDirty(cwd: string): boolean | undefined {
+  try {
+    const output = gitExec('status --porcelain', cwd)
+    return output.length > 0
+  } catch {
+    return undefined
+  }
+}

--- a/packages/next/src/lib/helpers/git.ts
+++ b/packages/next/src/lib/helpers/git.ts
@@ -58,3 +58,18 @@ export function getGitDirty(cwd: string): boolean | undefined {
     return undefined
   }
 }
+
+/**
+ * Returns the first line of the HEAD commit message, or undefined when it
+ * cannot be determined. Prefers VERCEL_GIT_COMMIT_MESSAGE when set.
+ */
+export function getGitMessage(cwd: string): string | undefined {
+  if (process.env.VERCEL_GIT_COMMIT_MESSAGE) {
+    return process.env.VERCEL_GIT_COMMIT_MESSAGE.split('\n')[0].trim()
+  }
+  try {
+    return gitExec('log -1 --pretty=%s', cwd)
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
Track modules only reachable via dynamic import on a given route ("async-only") and surface them in the analyzer.

### What?

- Compute per-route async-only sources in \`crates/next-api/src/analyze.rs\` against the route's module graph. A module statically imported on another route can still be async-only here.
- Emit \`async_only_sources\` in the \`analyze.data\` header and expose \`isAsyncOnlySource()\` / \`getRecursiveAsyncOnlySizes()\` on \`AnalyzeData\`.
- Render async-only tiles with an amber border in the treemap and an \`async-only\` badge in the hover info bar.
- Add an async-only size row to the right sidebar (with percentage of the selected subtree) alongside \`compressed (estimated)\` and \`uncompressed\`.

### Why?

Dynamic imports load lazily, so isolating their contribution to a route helps users see how much of a route is deferred vs. eager.

<!-- NEXT_JS_LLM_PR -->