### PR TITLE
Add early OpenTelemetry tracer prerender coverage

### DIFF
--- a/packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts
@@ -3,7 +3,11 @@
  * This extension must only be loaded in Node environments.
  */
 
-import type { Tracer } from '@opentelemetry/api'
+import type {
+  ProxyTracerProvider,
+  Tracer,
+  TracerProvider,
+} from '@opentelemetry/api'
 import {
   type WorkUnitStore,
   workUnitAsyncStorage,
@@ -19,6 +23,15 @@ export function afterRegistration(): void {
   }
 
   extendTracerProviderForCacheComponents()
+}
+
+function isProxyTracerProvider(
+  provider: TracerProvider
+): provider is ProxyTracerProvider {
+  return (
+    'getDelegateTracer' in provider &&
+    typeof provider.getDelegateTracer === 'function'
+  )
 }
 
 // In theory we only want to enable this extension when cacheComponents is enabled
@@ -49,66 +62,87 @@ function extendTracerProviderForCacheComponents(): void {
   // to exit the workUnitAsyncStorage context when generating spans.
   const originalGetTracer = provider.getTracer.bind(provider)
   provider.getTracer = (...args) => {
-    const tracer = originalGetTracer.apply(provider, args)
-    if (WeakTracers.has(tracer)) {
-      return tracer
+    return instrumentTracerForCacheComponents(
+      originalGetTracer.apply(provider, args)
+    )
+  }
+
+  // Tracers acquired before registration can use getDelegateTracer() from the
+  // proxy provider to get a tracer from the registered provider, bypassing the
+  // getTracer() patch above. This can be problematic when third-party
+  // instrumentation creates spans that call dynamic APIs like Math.random(),
+  // causing a prerendering error. Therefore, patch getDelegateTracer() to apply
+  // the same tracer instrumentation as getTracer().
+  if (isProxyTracerProvider(provider)) {
+    const originalGetDelegateTracer = provider.getDelegateTracer.bind(provider)
+    provider.getDelegateTracer = (...args) => {
+      const tracer = originalGetDelegateTracer(...args)
+      return tracer === undefined
+        ? undefined
+        : instrumentTracerForCacheComponents(tracer)
     }
-    const originalStartSpan = tracer.startSpan
-    tracer.startSpan = (...startSpanArgs) => {
-      return workUnitAsyncStorage.exit(() =>
-        originalStartSpan.apply(tracer, startSpanArgs)
+  }
+}
+
+function instrumentTracerForCacheComponents(tracer: Tracer): Tracer {
+  if (WeakTracers.has(tracer)) {
+    return tracer
+  }
+  const originalStartSpan = tracer.startSpan
+  tracer.startSpan = (...startSpanArgs) => {
+    return workUnitAsyncStorage.exit(() =>
+      originalStartSpan.apply(tracer, startSpanArgs)
+    )
+  }
+
+  const originalStartActiveSpan = tracer.startActiveSpan
+  // @ts-ignore TS doesn't recognize the overloads correctly
+  tracer.startActiveSpan = (...startActiveSpanArgs: any[]) => {
+    const workUnitStore = workUnitAsyncStorage.getStore()
+    if (!workUnitStore) {
+      // @ts-ignore TS doesn't recognize the overloads correctly
+      return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
+    }
+
+    let fnIdx: number = 0
+    if (
+      startActiveSpanArgs.length === 2 &&
+      typeof startActiveSpanArgs[1] === 'function'
+    ) {
+      fnIdx = 1
+    } else if (
+      startActiveSpanArgs.length === 3 &&
+      typeof startActiveSpanArgs[2] === 'function'
+    ) {
+      fnIdx = 2
+    } else if (
+      startActiveSpanArgs.length > 3 &&
+      typeof startActiveSpanArgs[3] === 'function'
+    ) {
+      fnIdx = 3
+    }
+
+    if (fnIdx) {
+      const originalFn = startActiveSpanArgs[fnIdx]
+      if (isUseCacheFunction(originalFn)) {
+        console.error(
+          'A Cache Function (`use cache`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.'
+        )
+      }
+      startActiveSpanArgs[fnIdx] = withWorkUnitContext(
+        workUnitStore,
+        originalFn
       )
     }
 
-    const originalStartActiveSpan = tracer.startActiveSpan
-    // @ts-ignore TS doesn't recognize the overloads correctly
-    tracer.startActiveSpan = (...startActiveSpanArgs: any[]) => {
-      const workUnitStore = workUnitAsyncStorage.getStore()
-      if (!workUnitStore) {
-        // @ts-ignore TS doesn't recognize the overloads correctly
-        return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
-      }
-
-      let fnIdx: number = 0
-      if (
-        startActiveSpanArgs.length === 2 &&
-        typeof startActiveSpanArgs[1] === 'function'
-      ) {
-        fnIdx = 1
-      } else if (
-        startActiveSpanArgs.length === 3 &&
-        typeof startActiveSpanArgs[2] === 'function'
-      ) {
-        fnIdx = 2
-      } else if (
-        startActiveSpanArgs.length > 3 &&
-        typeof startActiveSpanArgs[3] === 'function'
-      ) {
-        fnIdx = 3
-      }
-
-      if (fnIdx) {
-        const originalFn = startActiveSpanArgs[fnIdx]
-        if (isUseCacheFunction(originalFn)) {
-          console.error(
-            'A Cache Function (`use cache`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.'
-          )
-        }
-        startActiveSpanArgs[fnIdx] = withWorkUnitContext(
-          workUnitStore,
-          originalFn
-        )
-      }
-
-      return workUnitAsyncStorage.exit(() => {
-        // @ts-ignore TS doesn't recognize the overloads correctly
-        return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
-      })
-    }
-
-    WeakTracers.add(tracer)
-    return tracer
+    return workUnitAsyncStorage.exit(() => {
+      // @ts-ignore TS doesn't recognize the overloads correctly
+      return originalStartActiveSpan.apply(tracer, startActiveSpanArgs)
+    })
   }
+
+  WeakTracers.add(tracer)
+  return tracer
 }
 
 const WeakTracers = new WeakSet<Tracer>()

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/early-span/page.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/early-span/page.tsx
@@ -1,0 +1,18 @@
+import { TracedComponentEarlyTracerSpan } from '../../traced-work'
+
+export function generateStaticParams() {
+  return [{ slug: 'prerendered' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  if (slug === 'prerendered') {
+    return null
+  }
+
+  return <TracedComponentEarlyTracerSpan />
+}

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/traced-work.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/traced-work.tsx
@@ -1,4 +1,4 @@
-import { type Span, trace, context } from '@opentelemetry/api'
+import { type Span, type Tracer, trace, context } from '@opentelemetry/api'
 import { Suspense } from 'react'
 
 async function asyncWork() {
@@ -172,6 +172,45 @@ export const TracedComponentActiveSpan = withActiveSpan(async function (
     </section>
   )
 })
+
+type TestGlobal = typeof globalThis & {
+  __nextTestEarlyTracer?: Tracer
+}
+
+export async function TracedComponentEarlyTracerSpan() {
+  const tracer = (globalThis as TestGlobal).__nextTestEarlyTracer
+  if (!tracer) {
+    throw new Error(
+      'Expected instrumentation to register the early tracer before rendering'
+    )
+  }
+
+  const span = tracer.startSpan('span-early-manual-span')
+  const ctx = trace.setSpan(context.active(), span)
+
+  return context.with(ctx, async () => {
+    async function Inner() {
+      const result = await asyncWork()
+      return <Result>{result}</Result>
+    }
+    return (
+      <section id="t9">
+        <h2>(Manual Span) Tracer acquired before provider registration</h2>
+        <div>
+          <p>
+            Span Representative{' '}
+            <span className="span" suppressHydrationWarning>
+              {parseInt(span.spanContext().spanId.slice(10), 16)}
+            </span>
+          </p>
+          <Suspense fallback={<Loading />}>
+            <Inner />
+          </Suspense>
+        </div>
+      </section>
+    )
+  })
+}
 
 function Loading() {
   return <span className="fallback">loading...</span>

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
@@ -347,5 +347,27 @@ describe('cache-components OTEL spans', () => {
         expect(t8againValue).not.toEqual(0)
       }
     })
+    it('should allow creating Spans from a tracer acquired before provider registration', async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/novel/early-span')
+      // Guard the reported regression directly: span ID generation must not be treated as dynamic Math.random() access during prerendering.
+      expect(
+        next.cliOutput
+          .slice(outputIndex)
+          .match(/early-span.*unstable value.*Math\.random\(\).*prerendering/)
+      ).toBeNull()
+      const t9 = await browser.elementByCss('#t9 .span')
+      const t9value = parseInt(await t9.textContent())
+      // the span was prerendered at runtime
+      expect(t9value).not.toEqual(0)
+
+      // load again
+      await browser.loadPage(`${next.url}/novel/early-span`)
+      const t9again = await browser.elementByCss('#t9 .span')
+      const t9againValue = parseInt(await t9again.textContent())
+      // this page renders the span during runtime prerendering on each request
+      expect(t9againValue).not.toEqual(t9value)
+      expect(t9againValue).not.toEqual(0)
+    })
   }
 })

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/instrumentation.node.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/instrumentation.node.ts
@@ -1,7 +1,18 @@
+import { trace, type Tracer } from '@opentelemetry/api'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express'
+
+type TestGlobal = typeof globalThis & {
+  __nextTestEarlyTracer?: Tracer
+}
+
+// Acquire this before sdk.start() to reproduce how instrumentation libraries
+// receive a ProxyTracer before the real provider is registered.
+;(globalThis as TestGlobal).__nextTestEarlyTracer ??= trace.getTracer(
+  'next-test-early-tracer'
+)
 
 const sdk = new NodeSDK({
   serviceName: 'nextjs-otel-app',


### PR DESCRIPTION
### Why?

Current behavior: https://github.com/vercel/next.js/actions/runs/28284411969/job/83806126742?pr=95224#step:31:8803

```
Next.js encountered the unstable value `Math.random()` while prerendering
```

A tracer can be acquired before OpenTelemetry provider registration and then used while Cache Components prerenders a route at runtime. Because early proxy tracers resolve their registered tracer through `getDelegateTracer()`, they can bypass the existing `getTracer()` patch that exits `workUnitAsyncStorage` during span creation. Span ID generation should remain allowed and must not surface as dynamic `Math.random()` access.

This draft adds regression coverage and patches that early tracer resolution path.

### How?

- Capture a tracer before `NodeSDK.start()` and retain it on a typed `globalThis` field.
- Render a manual span on a dynamic route whose first unknown parameter is prerendered at runtime.
- Patch `getDelegateTracer()` for proxy tracer providers to apply the same tracer instrumentation used by `getTracer()`.
- Assert that the first request has no `Math.random()` prerender error and that repeated runtime prerenders create non-zero span IDs.

<!-- NEXT_JS_LLM_PR -->