### PR TITLE
Turbopack: make hash_xxh3_hash128 return u128

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -937,7 +937,7 @@ impl FileSystem for DiskFileSystem {
         // require recomputing the content on cache restore — avoiding unnecessary downstream
         // recomputation.
         let content = content.persist().to_resolved().await?;
-        let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content.await?));
+        let content_hash = hash_xxh3_hash128(&*content.await?);
 
         #[turbo_tasks::value(eq = "manual", cell = "new")]
         struct WriteEffect {
@@ -1162,7 +1162,7 @@ impl FileSystem for DiskFileSystem {
         }
         let full_path = this.to_sys_path(&fs_path);
 
-        let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*target.await?));
+        let content_hash = hash_xxh3_hash128(&*target.await?);
 
         #[turbo_tasks::value(eq = "manual", cell = "new")]
         struct WriteLinkEffect {

--- a/turbopack/crates/turbo-tasks-hash/src/xxh3_hash128.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/xxh3_hash128.rs
@@ -5,10 +5,10 @@ use xxhash_rust::xxh3::Xxh3Default;
 use crate::{DeterministicHash, DeterministicHasher};
 
 /// Hash some content with the Xxh3Hash128 non-cryptographic hash function.
-pub fn hash_xxh3_hash128<T: DeterministicHash>(input: T) -> [u8; 16] {
+pub fn hash_xxh3_hash128<T: DeterministicHash>(input: T) -> u128 {
     let mut hasher = Xxh3Hash128Hasher::new();
     input.deterministic_hash(&mut hasher);
-    hasher.finish_bytes()
+    hasher.finish()
 }
 
 /// Xxh3Hash128 hasher.

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -2061,7 +2061,8 @@ impl CurrentCellRef {
             {
                 return None;
             }
-            let content_hash = hash_xxh3_hash128(&new_value);
+            let content_hash = hash_xxh3_hash128(&new_value).to_le_bytes();
+
             Some((new_value, None, Some(content_hash)))
         });
     }
@@ -2085,7 +2086,8 @@ impl CurrentCellRef {
                     return None;
                 }
             }
-            let content_hash = hash_xxh3_hash128(extract_sr_value::<T>(&new_shared_reference));
+            let content_hash =
+                hash_xxh3_hash128(extract_sr_value::<T>(&new_shared_reference)).to_le_bytes();
             Some((new_shared_reference, None, Some(content_hash)))
         });
     }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -117,7 +117,7 @@ impl MergedModuleMap {
 
     /// Returns the hash of the module with the given id, or `None` if the
     /// module is not present in any of the versions.
-    fn get(&self, id: &ModuleId) -> Option<u64> {
+    fn get(&self, id: &ModuleId) -> Option<u128> {
         for version in &self.versions {
             if let Some(hash) = version.entries_hashes.get(id) {
                 return Some(*hash);

--- a/turbopack/crates/turbopack-browser/src/ecmascript/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/update.rs
@@ -11,8 +11,8 @@ pub(super) enum EcmascriptChunkUpdate {
 }
 
 pub(super) struct EcmascriptChunkPartialUpdate {
-    pub added: FxIndexMap<ModuleId, (u64, ResolvedVc<Code>)>,
-    pub deleted: FxIndexMap<ModuleId, u64>,
+    pub added: FxIndexMap<ModuleId, (u128, ResolvedVc<Code>)>,
+    pub deleted: FxIndexMap<ModuleId, u128>,
     pub modified: FxIndexMap<ModuleId, ResolvedVc<Code>>,
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -9,7 +9,7 @@ use turbopack_ecmascript::chunk::{EcmascriptChunkContent, EcmascriptChunkContent
 #[turbo_tasks::value(serialization = "skip")]
 pub(super) struct EcmascriptBrowserChunkVersion {
     pub(super) chunk_path: String,
-    pub(super) entries_hashes: FxIndexMap<ModuleId, u64>,
+    pub(super) entries_hashes: FxIndexMap<ModuleId, u128>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -14,7 +14,7 @@ use turbo_tasks_fs::{
     File, FileContent,
     rope::{Rope, RopeBuilder},
 };
-use turbo_tasks_hash::hash_xxh3_hash64;
+use turbo_tasks_hash::hash_xxh3_hash128;
 
 use crate::{
     debug_id::generate_debug_id,
@@ -292,9 +292,9 @@ pub struct OptionDebugId(Option<RcStr>);
 impl Code {
     /// Returns the hash of the source code of this Code.
     #[turbo_tasks::function]
-    pub fn source_code_hash(&self) -> Vc<u64> {
+    pub fn source_code_hash(&self) -> Vc<u128> {
         let code = self;
-        let hash = hash_xxh3_hash64(code.source_code());
+        let hash = hash_xxh3_hash128(code.source_code());
         Vc::cell(hash)
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content_entry.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content_entry.rs
@@ -21,7 +21,7 @@ use crate::chunk::{
 #[derive(Debug)]
 pub struct EcmascriptChunkContentEntry {
     pub code: ResolvedVc<Code>,
-    pub hash: ResolvedVc<u64>,
+    pub hash: ResolvedVc<u128>,
 }
 
 impl EcmascriptChunkContentEntry {

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/update.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/update.rs
@@ -166,7 +166,7 @@ enum NodeChunkUpdate {
     Partial {
         added: FxIndexMap<ModuleId, Vc<Code>>,
         modified: FxIndexMap<ModuleId, Vc<Code>>,
-        deleted: FxIndexMap<ModuleId, u64>,
+        deleted: FxIndexMap<ModuleId, u128>,
     },
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -13,7 +13,7 @@ use turbopack_ecmascript::chunk::{EcmascriptChunkContent, EcmascriptChunkContent
 pub(super) struct EcmascriptBuildNodeChunkVersion {
     pub(super) chunk_path: RcStr,
     pub(super) minify_type: MinifyType,
-    pub(super) entries_hashes: FxIndexMap<ModuleId, u64>,
+    pub(super) entries_hashes: FxIndexMap<ModuleId, u128>,
 }
 
 #[turbo_tasks::value_impl]


### PR DESCRIPTION
We already switched to 128 bit hashes for many operations, these were still using 64 bit hashes.

- make `hash_xxh3_hash128` return `u128`, just like `hash_xxh3_hash64` returns a `u64`
- Make `Code::source_code_hash` return a u128