### PR TITLE
More granular cache keys for use-cache entries

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -426,7 +426,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn rsc_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
+    pub(crate) fn rsc_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
         Ok(ModuleAssetContext::new(
             self.get_rsc_transitions(
                 self.ecmascript_client_reference_transition(),
@@ -459,7 +459,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn route_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
+    pub(crate) async fn route_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
         let transitions = [
             (
                 AppProject::client_transition_name(),

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -5,7 +5,8 @@ use bincode::{Decode, Encode};
 use next_core::{
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
     next_manifests::{
-        ActionLayer, ActionManifestModuleId, ActionManifestWorkerEntry, ServerReferenceManifest,
+        ActionLayer, ActionManifestModuleId, ActionManifestWorkerEntry,
+        ActionManifestWorkerEntryDurability, ServerReferenceManifest,
     },
     util::NextRuntime,
 };
@@ -315,12 +316,11 @@ impl Asset for ServerActionManifestAsset {
                     is_async: async_module_info
                         .is_async(self.chunk_item.module().to_resolved().await?)
                         .await?,
-                    code_hash: data.as_ref().map(|d| d.ident_code_hash.as_str()),
-                    runtime_env_vars: data.as_ref().map(|d| d.runtime_env_vars.as_slice()),
-                    references_client_component: data
-                        .as_ref()
-                        .map(|d| d.references_client_component)
-                        .unwrap_or(false),
+                    durability: data.as_ref().map(|d| ActionManifestWorkerEntryDurability {
+                        code_hash: d.ident_code_hash.as_str(),
+                        runtime_env_vars: d.runtime_env_vars.as_slice(),
+                        references_client_component: d.references_client_component,
+                    }),
                 },
             );
 

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, collections::BTreeMap, io::Write, sync::LazyLock};
 use anyhow::{Context, Result, bail};
 use bincode::{Decode, Encode};
 use next_core::{
+    get_next_package,
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
     next_manifests::{
         ActionLayer, ActionManifestModuleId, ActionManifestWorkerEntry,
@@ -10,7 +11,6 @@ use next_core::{
     },
     util::NextRuntime,
 };
-use rustc_hash::FxHashSet;
 use swc_core::{
     atoms::{Atom, atom},
     common::comments::Comments,
@@ -38,12 +38,11 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, Modules},
     module_graph::{
         GraphTraversalAction, ModuleGraph, ModuleGraphLayer, async_module_info::AsyncModulesInfo,
     },
     output::{OutputAsset, OutputAssetsReference},
-    reference::ModuleReference,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::ModulePart,
     virtual_source::VirtualSource,
@@ -53,7 +52,6 @@ use turbopack_ecmascript::{
     chunk::{EcmascriptChunkItem, EcmascriptChunkItemExt, EcmascriptChunkPlaceable},
     module_fragments::part::module::EcmascriptModulePartAsset,
     parse::ParseResult,
-    references::esm::EsmAssetReference,
 };
 
 use crate::project::Project;
@@ -251,6 +249,42 @@ impl Asset for ServerActionManifestAsset {
             NextRuntime::NodeJs => &mut manifest.node,
         };
 
+        // These modules end up pulling in a lot of env vars and would always cause invalidations.
+        // But they don't actually read the env vars for the imports that are used. Their code is
+        // versioned anyway via the Next.js version in the cache key.
+        //
+        // `module.compiled.js -> app-page-turbo.runtime.prod.js` is imported by the following
+        // modules. But none of them have values whose runtime value depends on the runtime env
+        // vars.
+        // - react
+        // - react-dom
+        // - react-server-dom-*
+        // - next/dist/shared/lib/app-router-context.shared-runtime
+        // - next/dist/shared/lib/head-manager-context.shared-runtime
+        // - next/dist/shared/lib/hooks-client-context.shared-runtime
+        // - next/dist/shared/lib/image-config-context.shared-runtime
+        // - next/dist/shared/lib/router-context.shared-runtime
+        // - next/dist/shared/lib/server-inserted-html.shared-runtime
+        let app_project = self.project.app_project().await?.unwrap();
+        let next_dir = get_next_package(self.project.project_path().owned().await?).await?;
+        let source_to_ignore = FileSource::new(
+            next_dir.join("dist/server/route-modules/app-page/module.compiled.js")?,
+        );
+        let modules_to_ignore = Vc::cell(
+            [
+                app_project.rsc_module_context(),
+                app_project.route_module_context(),
+            ]
+            .iter()
+            .map(|c| {
+                c.process(Vc::upcast(source_to_ignore), ReferenceType::Undefined)
+                    .module()
+                    .to_resolved()
+            })
+            .try_join()
+            .await?,
+        );
+
         struct ActionMetadata<'a> {
             exported_name: &'a str,
             filename: Cow<'a, str>,
@@ -279,6 +313,7 @@ impl Asset for ServerActionManifestAsset {
                             **module,
                             *self.chunking_context,
                             hash_salt,
+                            modules_to_ignore,
                         )
                         .await?,
                     )
@@ -385,6 +420,7 @@ async fn compute_subtree_content_hash(
     entry: ResolvedVc<Box<dyn Module>>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     hash_salt: Vc<RcStr>,
+    modules_to_ignore: Vc<Modules>,
 ) -> Result<Vc<ModulesInformation>> {
     let span = tracing::info_span!(
         "compute use-cache code hash",
@@ -396,45 +432,7 @@ async fn compute_subtree_content_hash(
 
         let mut references_client_component = false;
 
-        // These modules shouldn't be traversed. They end up pulling in a lot of env vars. But they
-        // don't actually read the env vars for the imports that are used. Their code is versioned
-        // anyway via the Next.js version in the cache key.
-        let modules_to_ignore: FxHashSet<_> = entry
-            .references()
-            .await?
-            .into_iter()
-            .filter_map(ResolvedVc::try_downcast_type::<EsmAssetReference>)
-            .map(async |reference| {
-                let reference_value = reference.await?;
-                Ok(
-                    // These pull in app-page-turbo.runtime.prod.js which reads basically all env
-                    // vars that exist and would always cause a deopt.
-                    if reference_value.request == "private-next-rsc-server-reference"
-                        || reference_value.request == "private-next-rsc-cache-wrapper"
-                        || reference_value.request == "react"
-                        || reference_value.request.starts_with("react/")
-                        || reference_value.request == "react-dom"
-                        || reference_value.request.starts_with("react-dom/")
-                    {
-                        reference
-                            .resolve_reference()
-                            .await?
-                            .primary_modules()
-                            .await?
-                    } else {
-                        vec![]
-                    },
-                )
-            })
-            .try_flat_join()
-            .await?
-            .into_iter()
-            .collect();
-        debug_assert!(
-            !modules_to_ignore.is_empty(),
-            "at least private-next-rsc-server-reference should have been detected"
-        );
-
+        let modules_to_ignore = modules_to_ignore.await?;
         let mut modules = FxIndexSet::default();
         module_graph_value.traverse_edges_dfs(
             std::iter::once(entry),

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -584,7 +584,9 @@ async fn module_hash(
             || ident_str.contains("next/dist/compiled/next-server/app-page-turbo.runtime.dev.js")
             || ident_str.contains("next/dist/compiled/next-server/app-page-turbo.runtime.prod.js"))
     {
-        bail!("use cache subtree shouldn't contain app-page-turbo.");
+        // This isn't exactly a fatal error, but it makes cross-deployment caching completely
+        // ineffective.
+        bail!("use cache subtree shouldn't contain {}", ident_str);
     }
 
     let env_var_info =
@@ -606,8 +608,8 @@ async fn module_hash(
             .as_chunk_item(*module_graph, *chunking_context)
             .to_resolved()
             .await?;
-        let chunk_item =
-            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(chunk_item).unwrap();
+        let chunk_item = ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(chunk_item)
+            .context("expected EcmascriptChunkItem")?;
         let async_info = if async_module_info.is_async(m).await? {
             Some(module_graph.referenced_async_modules(*m))
         } else {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -46,7 +46,7 @@ use turbopack_core::{
     virtual_source::VirtualSource,
 };
 use turbopack_ecmascript::{
-    EcmascriptParsable,
+    EcmascriptAnalyzable, EcmascriptParsable, EnvVarInfo,
     chunk::{EcmascriptChunkItem, EcmascriptChunkItemExt, EcmascriptChunkPlaceable},
     module_fragments::part::module::EcmascriptModulePartAsset,
     parse::ParseResult,
@@ -250,7 +250,7 @@ impl Asset for ServerActionManifestAsset {
         struct ActionMetadata<'a> {
             exported_name: &'a str,
             filename: Cow<'a, str>,
-            code_hash: Option<ReadRef<RcStr>>,
+            data: Option<ReadRef<ModulesInformation>>,
         }
 
         let action_metadata: Vec<(&str, ActionMetadata<'_>)> = actions_value
@@ -265,27 +265,29 @@ impl Asset for ServerActionManifestAsset {
                     Cow::Owned(module.ident().await?.path.to_string())
                 };
 
+                let data = if durable_use_cache_entries
+                    && extract_type_from_server_reference_id(hash_id)
+                        == ServerReferenceType::UseCache
+                {
+                    Some(
+                        compute_subtree_content_hash(
+                            *self.module_graph,
+                            **module,
+                            *self.chunking_context,
+                            hash_salt,
+                        )
+                        .await?,
+                    )
+                } else {
+                    None
+                };
+
                 Ok((
                     &**hash_id,
                     ActionMetadata {
                         exported_name: &meta.name,
                         filename,
-                        code_hash: if durable_use_cache_entries
-                            && extract_type_from_server_reference_id(hash_id)
-                                == ServerReferenceType::UseCache
-                        {
-                            Some(
-                                compute_subtree_content_hash(
-                                    *self.module_graph,
-                                    **module,
-                                    *self.chunking_context,
-                                    hash_salt,
-                                )
-                                .await?,
-                            )
-                        } else {
-                            None
-                        },
+                        data,
                     },
                 ))
             })
@@ -298,7 +300,7 @@ impl Asset for ServerActionManifestAsset {
             ActionMetadata {
                 exported_name,
                 filename,
-                code_hash,
+                data,
             },
         ) in &action_metadata
         {
@@ -310,7 +312,10 @@ impl Asset for ServerActionManifestAsset {
                     is_async: async_module_info
                         .is_async(self.chunk_item.module().to_resolved().await?)
                         .await?,
-                    code_hash: code_hash.as_ref().map(|h| h.as_str()),
+                    code_hash: data.as_ref().map(|d| d.ident_code_hash.as_str()),
+                    runtime_env_vars: data
+                        .as_ref()
+                        .map(|d| d.runtime_env_vars.as_slice()),
                 },
             );
 
@@ -357,13 +362,23 @@ pub async fn to_rsc_context(
     Ok(module)
 }
 
+/// Merged information about a module graph subgraph
+#[turbo_tasks::value]
+#[derive(Debug)]
+struct ModulesInformation {
+    /// The combined code hash of all modules in the subgraph
+    pub ident_code_hash: RcStr,
+    /// The merged and deduplicated list of all runtime env vars referenced in the subgraph
+    pub runtime_env_vars: Vec<RcStr>,
+}
+
 #[turbo_tasks::function]
 async fn compute_subtree_content_hash(
     module_graph: ResolvedVc<ModuleGraph>,
     entry: ResolvedVc<Box<dyn Module>>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     hash_salt: Vc<RcStr>,
-) -> Result<Vc<RcStr>> {
+) -> Result<Vc<ModulesInformation>> {
     let span = tracing::info_span!(
         "compute use-cache code hash",
         entry = display(entry.ident_string().await?)
@@ -407,41 +422,133 @@ async fn compute_subtree_content_hash(
                 entry.ident().await?.path,
                 modules
                     .iter()
-                    .map(async |m| Ok(format!(
-                        "  '{}': {}",
-                        m.ident_string().await?,
-                        module_hash(
+                    .map(async |m| {
+                        let data = module_hash(
                             *module_graph,
                             chunking_context,
                             async_module_info,
                             **m,
-                            hash_salt
+                            hash_salt,
                         )
-                        .await?
-                    )))
+                        .await?;
+                        Ok(format!(
+                            "  '{}': {} with env: {}",
+                            m.ident_string().await?,
+                            data.ident_code_hash,
+                            data.env_var_info
+                                .as_ref()
+                                .map(|e| e.runtime.clone())
+                                .unwrap_or_default()
+                                .join(",")
+                        ))
+                    })
                     .try_join()
                     .await?
                     .join("\n")
             );
         }
 
-        let hashes = modules
+        let data = modules
             .into_iter()
-            .map(|m| {
-                module_hash(
-                    *module_graph,
-                    chunking_context,
-                    async_module_info,
-                    *m,
-                    hash_salt,
-                )
+            .map(async |m| {
+                Ok((
+                    m,
+                    module_hash(
+                        *module_graph,
+                        chunking_context,
+                        async_module_info,
+                        *m,
+                        hash_salt,
+                    )
+                    .await?,
+                ))
             })
             .try_join()
             .await?;
 
-        anyhow::Ok(Vc::cell(
-            deterministic_hash("", hashes, HashAlgorithm::Xxh3Hash128Hex).into(),
-        ))
+        let mut hashes = Vec::with_capacity(data.len());
+        let mut runtime_env_vars = FxIndexSet::default();
+
+        // use async_trait::async_trait;
+        // use turbopack_core::issue::{
+        //     Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString,
+        // };
+        // #[turbo_tasks::value]
+        // pub struct ActionIssue {
+        //     pub ident: ResolvedVc<AssetIdent>,
+        //     pub title: ResolvedVc<StyledString>,
+        //     pub source: Option<IssueSource>,
+        // }
+        // #[turbo_tasks::value_impl]
+        // impl ActionIssue {
+        //     #[turbo_tasks::function]
+        //     pub fn new(
+        //         ident: ResolvedVc<AssetIdent>,
+        //         title: RcStr,
+        //         source: Option<IssueSource>,
+        //     ) -> Vc<Self> {
+        //         ActionIssue {
+        //             ident,
+        //             title: StyledString::Text(title).resolved_cell(),
+        //             source,
+        //         }
+        //         .cell()
+        //     }
+        // }
+
+        // #[async_trait]
+        // #[turbo_tasks::value_impl]
+        // impl Issue for ActionIssue {
+        //     fn severity(&self) -> IssueSeverity {
+        //         IssueSeverity::Warning
+        //     }
+        //     fn stage(&self) -> IssueStage {
+        //         IssueStage::ProcessModule
+        //     }
+
+        //     async fn file_path(&self) -> Result<FileSystemPath> {
+        //         Ok(self.ident.await?.path.clone())
+        //     }
+
+        //     async fn title(&self) -> Result<StyledString> {
+        //         Ok((*self.title.await?).clone())
+        //     }
+
+        //     fn source(&self) -> Option<IssueSource> {
+        //         self.source
+        //     }
+        // }
+
+        for (_m, data) in &data {
+            hashes.push(&data.ident_code_hash);
+            if let Some(env) = &data.env_var_info {
+                runtime_env_vars.extend(env.runtime.iter());
+                // if let Some(issue_source) = &env.runtime_all {
+                //     ActionIssue::new(
+                //         m.ident(),
+                //         format!(
+                //             "Dynamic process.env access from {}",
+                //             entry.ident_string().await?
+                //         )
+                //         .into(),
+                //         Some(*issue_source),
+                //     )
+                //     .to_resolved()
+                //     .await?
+                //     .emit();
+                // }
+            }
+        }
+
+        let hash = deterministic_hash("", hashes, HashAlgorithm::Xxh3Hash128Hex).into();
+
+        anyhow::Ok(
+            ModulesInformation {
+                ident_code_hash: hash,
+                runtime_env_vars: runtime_env_vars.into_iter().cloned().collect(),
+            }
+            .cell(),
+        )
     }
     .instrument(span)
     .await
@@ -458,6 +565,13 @@ async fn compute_subtree_content_hash(
     }
 }
 
+#[turbo_tasks::value]
+#[derive(Debug)]
+struct ModuleInformation {
+    pub ident_code_hash: RcStr,
+    pub env_var_info: Option<ReadRef<EnvVarInfo>>,
+}
+
 #[turbo_tasks::function]
 async fn module_hash(
     module_graph: ResolvedVc<ModuleGraph>,
@@ -465,12 +579,20 @@ async fn module_hash(
     async_module_info: ResolvedVc<AsyncModulesInfo>,
     m: ResolvedVc<Box<dyn Module>>,
     hash_salt: Vc<RcStr>,
-) -> Result<Vc<RcStr>> {
+) -> Result<Vc<ModuleInformation>> {
     let ident = m.ident();
     let ident_value = ident.await?;
     let ident_str = ident.to_string().await?;
 
-    if let Some(placeable_module) = ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(m)
+    let env_var_info =
+        if let Some(module) = ResolvedVc::try_downcast::<Box<dyn EcmascriptAnalyzable>>(m) {
+            Some(module.env_var_info().await?)
+        } else {
+            None
+        };
+
+    let ident_code_hash = if let Some(placeable_module) =
+        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(m)
         && !ident_value
             .layer
             .as_ref()
@@ -489,11 +611,11 @@ async fn module_hash(
             None
         };
         let code = chunk_item.code(async_info);
-        Ok(Vc::cell(RcStr::from(deterministic_hash(
+        RcStr::from(deterministic_hash(
             "",
             (ident_str, code.source_code_hash().await?),
             HashAlgorithm::Xxh3Hash128Hex,
-        ))))
+        ))
     } else {
         // A non-JS static file or an external module
         let content_hash = m
@@ -503,12 +625,18 @@ async fn module_hash(
             .content()
             .hash(hash_salt, HashAlgorithm::Xxh3Hash128Hex)
             .await?;
-        Ok(Vc::cell(RcStr::from(deterministic_hash(
+        RcStr::from(deterministic_hash(
             "",
             (ident_str, content_hash),
             HashAlgorithm::Xxh3Hash128Hex,
-        ))))
+        ))
+    };
+
+    Ok(ModuleInformation {
+        ident_code_hash,
+        env_var_info,
     }
+    .cell())
 }
 
 /// Server action info for JSON parsing

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -313,9 +313,11 @@ impl Asset for ServerActionManifestAsset {
                         .is_async(self.chunk_item.module().to_resolved().await?)
                         .await?,
                     code_hash: data.as_ref().map(|d| d.ident_code_hash.as_str()),
-                    runtime_env_vars: data
+                    runtime_env_vars: data.as_ref().map(|d| d.runtime_env_vars.as_slice()),
+                    references_client_component: data
                         .as_ref()
-                        .map(|d| d.runtime_env_vars.as_slice()),
+                        .map(|d| d.references_client_component)
+                        .unwrap_or(false),
                 },
             );
 
@@ -370,6 +372,8 @@ struct ModulesInformation {
     pub ident_code_hash: RcStr,
     /// The merged and deduplicated list of all runtime env vars referenced in the subgraph
     pub runtime_env_vars: Vec<RcStr>,
+    /// Whether the subgraph imports any client components
+    pub references_client_component: bool,
 }
 
 #[turbo_tasks::function]
@@ -387,6 +391,8 @@ async fn compute_subtree_content_hash(
         let module_graph_value = module_graph.await?;
         let async_module_info = module_graph.async_module_info();
 
+        let mut references_client_component = false;
+
         let mut modules = FxIndexSet::default();
         module_graph_value.traverse_edges_dfs(
             std::iter::once(entry),
@@ -394,11 +400,13 @@ async fn compute_subtree_content_hash(
             /* visit_preorder */
             |_, target, _| {
                 if ResolvedVc::try_downcast_type::<CssClientReferenceModule>(target).is_some() {
+                    references_client_component = true;
                     // Don't include the module at all. There is nothing that executes on the server
                     Ok(GraphTraversalAction::Exclude)
                 } else if ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(target)
                     .is_some()
                 {
+                    references_client_component = true;
                     // Include the client reference proxy module, but not the referenced client
                     // modules themselves.
                     modules.insert(target);
@@ -546,6 +554,7 @@ async fn compute_subtree_content_hash(
             ModulesInformation {
                 ident_code_hash: hash,
                 runtime_env_vars: runtime_env_vars.into_iter().cloned().collect(),
+                references_client_component,
             }
             .cell(),
         )

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -9,6 +9,7 @@ use next_core::{
     },
     util::NextRuntime,
 };
+use rustc_hash::FxHashSet;
 use swc_core::{
     atoms::{Atom, atom},
     common::comments::Comments,
@@ -41,6 +42,7 @@ use turbopack_core::{
         GraphTraversalAction, ModuleGraph, ModuleGraphLayer, async_module_info::AsyncModulesInfo,
     },
     output::{OutputAsset, OutputAssetsReference},
+    reference::ModuleReference,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::ModulePart,
     virtual_source::VirtualSource,
@@ -50,6 +52,7 @@ use turbopack_ecmascript::{
     chunk::{EcmascriptChunkItem, EcmascriptChunkItemExt, EcmascriptChunkPlaceable},
     module_fragments::part::module::EcmascriptModulePartAsset,
     parse::ParseResult,
+    references::esm::EsmAssetReference,
 };
 
 use crate::project::Project;
@@ -393,22 +396,65 @@ async fn compute_subtree_content_hash(
 
         let mut references_client_component = false;
 
+        // These modules shouldn't be traversed. They end up pulling in a lot of env vars. But they
+        // don't actually read the env vars for the imports that are used. Their code is versioned
+        // anyway via the Next.js version in the cache key.
+        let modules_to_ignore: FxHashSet<_> = entry
+            .references()
+            .await?
+            .into_iter()
+            .filter_map(ResolvedVc::try_downcast_type::<EsmAssetReference>)
+            .map(async |reference| {
+                let reference_value = reference.await?;
+                Ok(
+                    // These pull in app-page-turbo.runtime.prod.js which reads basically all env
+                    // vars that exist and would always cause a deopt.
+                    if reference_value.request == "private-next-rsc-server-reference"
+                        || reference_value.request == "private-next-rsc-cache-wrapper"
+                        || reference_value.request == "react"
+                        || reference_value.request.starts_with("react/")
+                        || reference_value.request == "react-dom"
+                        || reference_value.request.starts_with("react-dom/")
+                    {
+                        reference
+                            .resolve_reference()
+                            .await?
+                            .primary_modules()
+                            .await?
+                    } else {
+                        vec![]
+                    },
+                )
+            })
+            .try_flat_join()
+            .await?
+            .into_iter()
+            .collect();
+        debug_assert!(
+            !modules_to_ignore.is_empty(),
+            "at least private-next-rsc-server-reference should have been detected"
+        );
+
         let mut modules = FxIndexSet::default();
         module_graph_value.traverse_edges_dfs(
             std::iter::once(entry),
             /* state */ &mut (),
             /* visit_preorder */
             |_, target, _| {
-                if ResolvedVc::try_downcast_type::<CssClientReferenceModule>(target).is_some() {
-                    references_client_component = true;
+                if modules_to_ignore.contains(&target) {
+                    Ok(GraphTraversalAction::Exclude)
+                } else if ResolvedVc::try_downcast_type::<CssClientReferenceModule>(target)
+                    .is_some()
+                {
                     // Don't include the module at all. There is nothing that executes on the server
+                    references_client_component = true;
                     Ok(GraphTraversalAction::Exclude)
                 } else if ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(target)
                     .is_some()
                 {
-                    references_client_component = true;
                     // Include the client reference proxy module, but not the referenced client
                     // modules themselves.
+                    references_client_component = true;
                     modules.insert(target);
                     Ok(GraphTraversalAction::Exclude)
                 } else {
@@ -592,6 +638,18 @@ async fn module_hash(
     let ident = m.ident();
     let ident_value = ident.await?;
     let ident_str = ident.to_string().await?;
+
+    if cfg!(debug_assertions)
+        && (ident_str
+            .contains("next/dist/compiled/next-server/app-page-turbo-experimental.runtime.dev.js")
+            || ident_str.contains(
+                "next/dist/compiled/next-server/app-page-turbo-experimental.runtime.prod.js",
+            )
+            || ident_str.contains("next/dist/compiled/next-server/app-page-turbo.runtime.dev.js")
+            || ident_str.contains("next/dist/compiled/next-server/app-page-turbo.runtime.prod.js"))
+    {
+        bail!("use cache subtree shouldn't contain app-page-turbo.");
+    }
 
     let env_var_info =
         if let Some(module) = ResolvedVc::try_downcast::<Box<dyn EcmascriptAnalyzable>>(m) {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -523,74 +523,10 @@ async fn compute_subtree_content_hash(
         let mut hashes = Vec::with_capacity(data.len());
         let mut runtime_env_vars = FxIndexSet::default();
 
-        // use async_trait::async_trait;
-        // use turbopack_core::issue::{
-        //     Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString,
-        // };
-        // #[turbo_tasks::value]
-        // pub struct ActionIssue {
-        //     pub ident: ResolvedVc<AssetIdent>,
-        //     pub title: ResolvedVc<StyledString>,
-        //     pub source: Option<IssueSource>,
-        // }
-        // #[turbo_tasks::value_impl]
-        // impl ActionIssue {
-        //     #[turbo_tasks::function]
-        //     pub fn new(
-        //         ident: ResolvedVc<AssetIdent>,
-        //         title: RcStr,
-        //         source: Option<IssueSource>,
-        //     ) -> Vc<Self> {
-        //         ActionIssue {
-        //             ident,
-        //             title: StyledString::Text(title).resolved_cell(),
-        //             source,
-        //         }
-        //         .cell()
-        //     }
-        // }
-
-        // #[async_trait]
-        // #[turbo_tasks::value_impl]
-        // impl Issue for ActionIssue {
-        //     fn severity(&self) -> IssueSeverity {
-        //         IssueSeverity::Warning
-        //     }
-        //     fn stage(&self) -> IssueStage {
-        //         IssueStage::ProcessModule
-        //     }
-
-        //     async fn file_path(&self) -> Result<FileSystemPath> {
-        //         Ok(self.ident.await?.path.clone())
-        //     }
-
-        //     async fn title(&self) -> Result<StyledString> {
-        //         Ok((*self.title.await?).clone())
-        //     }
-
-        //     fn source(&self) -> Option<IssueSource> {
-        //         self.source
-        //     }
-        // }
-
         for (_m, data) in &data {
             hashes.push(&data.ident_code_hash);
             if let Some(env) = &data.env_var_info {
                 runtime_env_vars.extend(env.runtime.iter());
-                // if let Some(issue_source) = &env.runtime_all {
-                //     ActionIssue::new(
-                //         m.ident(),
-                //         format!(
-                //             "Dynamic process.env access from {}",
-                //             entry.ident_string().await?
-                //         )
-                //         .into(),
-                //         Some(*issue_source),
-                //     )
-                //     .to_resolved()
-                //     .await?
-                //     .emit();
-                // }
             }
         }
 

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -465,7 +465,11 @@ pub struct ActionManifestWorkerEntry<'a> {
     #[serde(rename = "async")]
     pub is_async: bool,
     #[serde(rename = "codeHash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub code_hash: Option<&'a str>,
+    #[serde(rename = "runtimeEnvVars")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_env_vars: Option<&'a [RcStr]>,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -459,17 +459,17 @@ pub struct ActionManifestEntry<'a> {
 }
 
 #[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ActionManifestWorkerEntry<'a> {
-    #[serde(rename = "moduleId")]
     pub module_id: ActionManifestModuleId<'a>,
     #[serde(rename = "async")]
     pub is_async: bool,
-    #[serde(rename = "codeHash")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code_hash: Option<&'a str>,
-    #[serde(rename = "runtimeEnvVars")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_env_vars: Option<&'a [RcStr]>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub references_client_component: bool,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -465,9 +465,14 @@ pub struct ActionManifestWorkerEntry<'a> {
     #[serde(rename = "async")]
     pub is_async: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub code_hash: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub runtime_env_vars: Option<&'a [RcStr]>,
+    pub durability: Option<ActionManifestWorkerEntryDurability<'a>>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionManifestWorkerEntryDurability<'a> {
+    pub code_hash: &'a str,
+    pub runtime_env_vars: &'a [RcStr],
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub references_client_component: bool,
 }

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -73,7 +73,7 @@ type Actions = {
         moduleId: string | number
         async: boolean
         codeHash?: string
-        runtimeEnvVars?: string[]
+        runtimeEnvVars?: true | string[]
       }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -72,6 +72,7 @@ type Actions = {
       [name: string]: {
         moduleId: string | number
         async: boolean
+        codeHash?: string
       }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -73,6 +73,7 @@ type Actions = {
         moduleId: string | number
         async: boolean
         codeHash?: string
+        runtimeEnvVars?: string[]
       }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -73,7 +73,7 @@ type Actions = {
         moduleId: string | number
         async: boolean
         codeHash?: string
-        runtimeEnvVars?: true | string[]
+        runtimeEnvVars?: string[]
         referencesClientComponent?: boolean
       }
     }

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -74,6 +74,7 @@ type Actions = {
         async: boolean
         codeHash?: string
         runtimeEnvVars?: true | string[]
+        referencesClientComponent?: boolean
       }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -73,6 +73,7 @@ type Actions = {
         moduleId: string | number
         async: boolean
         codeHash?: string
+        runtimeEnvVars?: true | string[]
       }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -72,9 +72,11 @@ type Actions = {
       [name: string]: {
         moduleId: string | number
         async: boolean
-        codeHash?: string
-        runtimeEnvVars?: string[]
-        referencesClientComponent?: boolean
+        durability?: {
+          codeHash: string
+          runtimeEnvVars: string[]
+          referencesClientComponent?: boolean
+        }
       }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -51,28 +51,26 @@ const pluginState = getProxiedPluginState({
   edgeRscModules: {} as { [rscModuleId: string]: ModuleInfo },
 })
 
-export interface ManifestNodeEntry {
-  /**
-   * Webpack module id
-   */
-  id: ModuleId
-  /**
-   * Export name
-   */
-  name: string
-  /**
-   * Chunks for the module. JS and CSS.
-   */
-  chunks: ManifestChunks
-
-  /**
-   * If chunk contains async module
-   */
-  async?: boolean
-}
-
 export interface ManifestNode {
-  [moduleExport: string]: ManifestNodeEntry
+  [moduleExport: string]: {
+    /**
+     * Webpack module id
+     */
+    id: ModuleId
+    /**
+     * Export name
+     */
+    name: string
+    /**
+     * Chunks for the module. JS and CSS.
+     */
+    chunks: ManifestChunks
+
+    /**
+     * If chunk contains async module
+     */
+    async?: boolean
+  }
 }
 
 export interface ClientReferenceManifestForRsc {

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -51,26 +51,28 @@ const pluginState = getProxiedPluginState({
   edgeRscModules: {} as { [rscModuleId: string]: ModuleInfo },
 })
 
-export interface ManifestNode {
-  [moduleExport: string]: {
-    /**
-     * Webpack module id
-     */
-    id: ModuleId
-    /**
-     * Export name
-     */
-    name: string
-    /**
-     * Chunks for the module. JS and CSS.
-     */
-    chunks: ManifestChunks
+export interface ManifestNodeEntry {
+  /**
+   * Webpack module id
+   */
+  id: ModuleId
+  /**
+   * Export name
+   */
+  name: string
+  /**
+   * Chunks for the module. JS and CSS.
+   */
+  chunks: ManifestChunks
 
-    /**
-     * If chunk contains async module
-     */
-    async?: boolean
-  }
+  /**
+   * If chunk contains async module
+   */
+  async?: boolean
+}
+
+export interface ManifestNode {
+  [moduleExport: string]: ManifestNodeEntry
 }
 
 export interface ClientReferenceManifestForRsc {

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -13,6 +13,7 @@ export interface ServerModuleMap {
     readonly name: string
     readonly chunks: Readonly<Array<string>> // currently not used
     readonly async?: boolean
+    readonly codeHash?: string
   }
 }
 
@@ -195,7 +196,7 @@ function createServerModuleMap(): ServerModuleMap {
         const workStore = workAsyncStorage.getStore()
 
         let workerEntry:
-          | { moduleId: string | number; async: boolean }
+          | { moduleId: string | number; async: boolean; codeHash?: string }
           | undefined
 
         if (workStore) {
@@ -215,9 +216,9 @@ function createServerModuleMap(): ServerModuleMap {
           return undefined
         }
 
-        const { moduleId, async } = workerEntry
+        const { moduleId, async, codeHash } = workerEntry
 
-        return { id: moduleId, name: id, chunks: [], async }
+        return { id: moduleId, name: id, chunks: [], async, codeHash }
       },
     }
   )

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -14,6 +14,7 @@ export interface ServerModuleMap {
     readonly chunks: Readonly<Array<string>> // currently not used
     readonly async?: boolean
     readonly codeHash?: string
+    readonly runtimeEnvVars?: string[]
   }
 }
 
@@ -196,7 +197,12 @@ function createServerModuleMap(): ServerModuleMap {
         const workStore = workAsyncStorage.getStore()
 
         let workerEntry:
-          | { moduleId: string | number; async: boolean; codeHash?: string }
+          | {
+              moduleId: string | number
+              async: boolean
+              codeHash?: string
+              runtimeEnvVars?: readonly string[]
+            }
           | undefined
 
         if (workStore) {
@@ -216,9 +222,16 @@ function createServerModuleMap(): ServerModuleMap {
           return undefined
         }
 
-        const { moduleId, async, codeHash } = workerEntry
+        const { moduleId, async, codeHash, runtimeEnvVars } = workerEntry
 
-        return { id: moduleId, name: id, chunks: [], async, codeHash }
+        return {
+          id: moduleId,
+          name: id,
+          chunks: [],
+          async,
+          codeHash,
+          runtimeEnvVars,
+        }
       },
     }
   )

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -14,7 +14,7 @@ export interface ServerModuleMap {
     readonly chunks: Readonly<Array<string>> // currently not used
     readonly async?: boolean
     readonly codeHash?: string
-    readonly runtimeEnvVars?: string[]
+    readonly runtimeEnvVars?: true | string[]
   }
 }
 
@@ -201,7 +201,7 @@ function createServerModuleMap(): ServerModuleMap {
               moduleId: string | number
               async: boolean
               codeHash?: string
-              runtimeEnvVars?: readonly string[]
+              runtimeEnvVars?: true | readonly string[]
             }
           | undefined
 

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -16,6 +16,7 @@ export interface ServerModuleMap {
     readonly chunks: Readonly<Array<string>> // currently not used
     readonly async?: boolean
     readonly codeHash?: string
+    readonly runtimeEnvVars?: true | string[]
   }
 }
 
@@ -263,7 +264,12 @@ function createServerModuleMap(): ServerModuleMap {
       const workStore = workAsyncStorage.getStore()
 
       let workerEntry:
-        | { moduleId: string | number; async: boolean; codeHash?: string }
+        | {
+            moduleId: string | number
+            async: boolean
+            codeHash?: string
+            runtimeEnvVars?: true | readonly string[]
+          }
         | undefined
 
       if (workStore) {
@@ -283,9 +289,16 @@ function createServerModuleMap(): ServerModuleMap {
         throw getActionNotFoundError(id)
       }
 
-      const { moduleId, async, codeHash } = workerEntry
+      const { moduleId, async, codeHash, runtimeEnvVars } = workerEntry
 
-      return { id: moduleId, name: id, chunks: [], async, codeHash }
+      return {
+        id: moduleId,
+        name: id,
+        chunks: [],
+        async,
+        codeHash,
+        runtimeEnvVars,
+      }
     },
   })
 }

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -16,7 +16,7 @@ export interface ServerModuleMap {
     readonly chunks: Readonly<Array<string>> // currently not used
     readonly async?: boolean
     readonly codeHash?: string
-    readonly runtimeEnvVars?: true | string[]
+    readonly runtimeEnvVars?: string[]
     readonly referencesClientComponent?: boolean
   }
 }
@@ -269,7 +269,7 @@ function createServerModuleMap(): ServerModuleMap {
             moduleId: string | number
             async: boolean
             codeHash?: string
-            runtimeEnvVars?: true | readonly string[]
+            runtimeEnvVars?: readonly string[]
             referencesClientComponent?: boolean
           }
         | undefined

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -1,8 +1,5 @@
 import type { ActionManifest } from '../../build/webpack/plugins/flight-client-entry-plugin'
-import type {
-  ClientReferenceManifest,
-  ManifestNodeEntry,
-} from '../../build/webpack/plugins/flight-manifest-plugin'
+import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
@@ -11,7 +8,6 @@ import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-pref
 import { mightBeServerReferenceId } from '../../shared/lib/server-reference-info'
 import { wellKnownProperties } from '../../shared/lib/utils/reflect-utils'
 import { workAsyncStorage } from './work-async-storage.external'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 
 export interface ServerModuleMap {
   readonly [name: string]: {
@@ -105,43 +101,6 @@ function createProxiedClientReferenceManifest(
       {},
       {
         get(_, id: string) {
-          // `clientModules` is the bundler config that React reads via
-          // `resolveClientReferenceMetadata` during RSC serialization, so this
-          // trap fires for every client reference accessed while serializing.
-          // When we're serializing a `"use cache"` entry (the active work unit
-          // store is a cache store), record the *resolved* client reference
-          // manifest entry (`{ id, name, chunks, async }`) that gets serialized
-          // into the payload. These are folded into the cache key so an entry
-          // is only reused when the underlying client modules haven't changed
-          // (e.g. across deployments).
-          //
-          // Note: this can slightly over-track in development, because a
-          // reference accessed only via `serializeDebugClientReference`
-          // (owner/debug info) is indistinguishable here from one accessed via
-          // an actual `serializeClientReference` render. That's an acceptable
-          // heuristic for now, and only affects dev.
-          const recordAccessedClientReference =
-            prop === 'clientModules'
-              ? (value: ManifestNodeEntry | undefined) => {
-                  if (value === undefined) {
-                    return
-                  }
-
-                  const workUnitStore = workUnitAsyncStorage.getStore()
-
-                  if (workUnitStore) {
-                    switch (workUnitStore.type) {
-                      case 'cache':
-                      case 'private-cache':
-                        workUnitStore.accessedClientReferences.set(id, value)
-                        break
-                      default:
-                        break
-                    }
-                  }
-                }
-              : undefined
-
           const workStore = workAsyncStorage.getStore()
 
           if (workStore) {
@@ -150,9 +109,6 @@ function createProxiedClientReferenceManifest(
             )?.clientReferenceManifest
 
             if (currentManifest?.[prop][id]) {
-              recordAccessedClientReference?.(
-                currentManifest[prop][id] as ManifestNodeEntry
-              )
               return currentManifest[prop][id]
             }
 
@@ -187,7 +143,6 @@ function createProxiedClientReferenceManifest(
                     workStore.additionalClientReferenceManifestPages.add(page)
                   }
 
-                  recordAccessedClientReference?.(entry as ManifestNodeEntry)
                   return entry
                 }
               }

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -1,5 +1,8 @@
 import type { ActionManifest } from '../../build/webpack/plugins/flight-client-entry-plugin'
-import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
+import type {
+  ClientReferenceManifest,
+  ManifestNodeEntry,
+} from '../../build/webpack/plugins/flight-manifest-plugin'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
@@ -8,6 +11,7 @@ import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-pref
 import { mightBeServerReferenceId } from '../../shared/lib/server-reference-info'
 import { wellKnownProperties } from '../../shared/lib/utils/reflect-utils'
 import { workAsyncStorage } from './work-async-storage.external'
+import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 
 export interface ServerModuleMap {
   readonly [name: string]: {
@@ -101,6 +105,43 @@ function createProxiedClientReferenceManifest(
       {},
       {
         get(_, id: string) {
+          // `clientModules` is the bundler config that React reads via
+          // `resolveClientReferenceMetadata` during RSC serialization, so this
+          // trap fires for every client reference accessed while serializing.
+          // When we're serializing a `"use cache"` entry (the active work unit
+          // store is a cache store), record the *resolved* client reference
+          // manifest entry (`{ id, name, chunks, async }`) that gets serialized
+          // into the payload. These are folded into the cache key so an entry
+          // is only reused when the underlying client modules haven't changed
+          // (e.g. across deployments).
+          //
+          // Note: this can slightly over-track in development, because a
+          // reference accessed only via `serializeDebugClientReference`
+          // (owner/debug info) is indistinguishable here from one accessed via
+          // an actual `serializeClientReference` render. That's an acceptable
+          // heuristic for now, and only affects dev.
+          const recordAccessedClientReference =
+            prop === 'clientModules'
+              ? (value: ManifestNodeEntry | undefined) => {
+                  if (value === undefined) {
+                    return
+                  }
+
+                  const workUnitStore = workUnitAsyncStorage.getStore()
+
+                  if (workUnitStore) {
+                    switch (workUnitStore.type) {
+                      case 'cache':
+                      case 'private-cache':
+                        workUnitStore.accessedClientReferences.set(id, value)
+                        break
+                      default:
+                        break
+                    }
+                  }
+                }
+              : undefined
+
           const workStore = workAsyncStorage.getStore()
 
           if (workStore) {
@@ -109,6 +150,9 @@ function createProxiedClientReferenceManifest(
             )?.clientReferenceManifest
 
             if (currentManifest?.[prop][id]) {
+              recordAccessedClientReference?.(
+                currentManifest[prop][id] as ManifestNodeEntry
+              )
               return currentManifest[prop][id]
             }
 
@@ -143,6 +187,7 @@ function createProxiedClientReferenceManifest(
                     workStore.additionalClientReferenceManifestPages.add(page)
                   }
 
+                  recordAccessedClientReference?.(entry as ManifestNodeEntry)
                   return entry
                 }
               }

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -17,6 +17,7 @@ export interface ServerModuleMap {
     readonly async?: boolean
     readonly codeHash?: string
     readonly runtimeEnvVars?: true | string[]
+    readonly referencesClientComponent?: boolean
   }
 }
 
@@ -269,6 +270,7 @@ function createServerModuleMap(): ServerModuleMap {
             async: boolean
             codeHash?: string
             runtimeEnvVars?: true | readonly string[]
+            referencesClientComponent?: boolean
           }
         | undefined
 
@@ -289,7 +291,13 @@ function createServerModuleMap(): ServerModuleMap {
         throw getActionNotFoundError(id)
       }
 
-      const { moduleId, async, codeHash, runtimeEnvVars } = workerEntry
+      const {
+        moduleId,
+        async,
+        codeHash,
+        runtimeEnvVars,
+        referencesClientComponent,
+      } = workerEntry
 
       return {
         id: moduleId,
@@ -298,6 +306,7 @@ function createServerModuleMap(): ServerModuleMap {
         async,
         codeHash,
         runtimeEnvVars,
+        referencesClientComponent,
       }
     },
   })

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -265,9 +265,11 @@ function createServerModuleMap(): ServerModuleMap {
         | {
             moduleId: string | number
             async: boolean
-            codeHash?: string
-            runtimeEnvVars?: readonly string[]
-            referencesClientComponent?: boolean
+            durability?: {
+              codeHash: string
+              runtimeEnvVars: readonly string[]
+              referencesClientComponent?: boolean
+            }
           }
         | undefined
 
@@ -288,22 +290,14 @@ function createServerModuleMap(): ServerModuleMap {
         throw getActionNotFoundError(id)
       }
 
-      const {
-        moduleId,
-        async,
-        codeHash,
-        runtimeEnvVars,
-        referencesClientComponent,
-      } = workerEntry
+      const { moduleId, async, durability } = workerEntry
 
       return {
         id: moduleId,
         name: id,
         chunks: [],
         async,
-        codeHash,
-        runtimeEnvVars,
-        referencesClientComponent,
+        durability,
       }
     },
   })

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -15,9 +15,6 @@ export interface ServerModuleMap {
     readonly name: string
     readonly chunks: Readonly<Array<string>> // currently not used
     readonly async?: boolean
-    readonly codeHash?: string
-    readonly runtimeEnvVars?: string[]
-    readonly referencesClientComponent?: boolean
   }
 }
 
@@ -316,7 +313,7 @@ function createServerModuleMap(): ServerModuleMap {
  * The flight entry loader keys actions by bundlePath. bundlePath corresponds
  * with the relative path (including 'app') to the page entrypoint.
  */
-function normalizeWorkerPageName(pageName: string) {
+export function normalizeWorkerPageName(pageName: string) {
   if (pathHasPrefix(pageName, 'app')) {
     return pageName
   }

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -15,6 +15,7 @@ export interface ServerModuleMap {
     readonly name: string
     readonly chunks: Readonly<Array<string>> // currently not used
     readonly async?: boolean
+    readonly codeHash?: string
   }
 }
 
@@ -261,7 +262,9 @@ function createServerModuleMap(): ServerModuleMap {
 
       const workStore = workAsyncStorage.getStore()
 
-      let workerEntry: { moduleId: string | number; async: boolean } | undefined
+      let workerEntry:
+        | { moduleId: string | number; async: boolean; codeHash?: string }
+        | undefined
 
       if (workStore) {
         workerEntry = workers[normalizeWorkerPageName(workStore.page)]
@@ -280,9 +283,9 @@ function createServerModuleMap(): ServerModuleMap {
         throw getActionNotFoundError(id)
       }
 
-      const { moduleId, async } = workerEntry
+      const { moduleId, async, codeHash } = workerEntry
 
-      return { id: moduleId, name: id, chunks: [], async }
+      return { id: moduleId, name: id, chunks: [], async, codeHash }
     },
   })
 }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -7,6 +7,7 @@ import type { CacheSignal } from './cache-signal'
 import type { ResponseVaryParamsAccumulator } from './vary-params'
 import type { DynamicTrackingState } from './dynamic-rendering'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
+import type { ManifestNodeEntry } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 // Share the instance module in the next-shared layer
 import { workUnitAsyncStorageInstance } from './work-unit-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
@@ -358,6 +359,18 @@ export interface CommonUseCacheStore extends CommonCacheStore, RevalidateStore {
   readonly serverComponentsHmrCache: ServerComponentsHmrCache | undefined
   readonly forceRevalidate: boolean
   readonly outerOwnerStack: string | undefined
+
+  /**
+   * The client references accessed while serializing this cache entry, keyed by
+   * the lookup module path (as resolved by React's
+   * `resolveClientReferenceMetadata`). The value is the resolved client
+   * reference manifest entry (`{ id, name, chunks, async }`) that gets
+   * serialized into the RSC payload. These are folded into the cache key so an
+   * entry is only reused when the underlying client modules haven't changed
+   * (e.g. across deployments). Populated by the client reference manifest proxy
+   * (see `manifests-singleton.ts`).
+   */
+  accessedClientReferences: Map<string, ManifestNodeEntry>
 }
 
 export interface PublicUseCacheStore extends CommonUseCacheStore {

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -7,7 +7,6 @@ import type { CacheSignal } from './cache-signal'
 import type { ResponseVaryParamsAccumulator } from './vary-params'
 import type { DynamicTrackingState } from './dynamic-rendering'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
-import type { ManifestNodeEntry } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 // Share the instance module in the next-shared layer
 import { workUnitAsyncStorageInstance } from './work-unit-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
@@ -359,18 +358,6 @@ export interface CommonUseCacheStore extends CommonCacheStore, RevalidateStore {
   readonly serverComponentsHmrCache: ServerComponentsHmrCache | undefined
   readonly forceRevalidate: boolean
   readonly outerOwnerStack: string | undefined
-
-  /**
-   * The client references accessed while serializing this cache entry, keyed by
-   * the lookup module path (as resolved by React's
-   * `resolveClientReferenceMetadata`). The value is the resolved client
-   * reference manifest entry (`{ id, name, chunks, async }`) that gets
-   * serialized into the RSC payload. These are folded into the cache key so an
-   * entry is only reused when the underlying client modules haven't changed
-   * (e.g. across deployments). Populated by the client reference manifest proxy
-   * (see `manifests-singleton.ts`).
-   */
-  accessedClientReferences: Map<string, ManifestNodeEntry>
 }
 
 export interface PublicUseCacheStore extends CommonUseCacheStore {

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -147,7 +147,7 @@ export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
       )
     }
 
-    const args = decoded[2]
+    const args = decoded[1]
     const workStore: WorkStore = buildProbeWorkStore(msg)
 
     // The outer store is `'request'`-typed and built from the forwarded

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -148,7 +148,7 @@ export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
       )
     }
 
-    const args = decoded[2]
+    const args = decoded[1]
     const workStore: WorkStore = buildProbeWorkStore(msg)
 
     // The outer store is `'request'`-typed and built from the forwarded

--- a/packages/next/src/server/resume-data-cache/cache-store.ts
+++ b/packages/next/src/server/resume-data-cache/cache-store.ts
@@ -102,9 +102,6 @@ export function parseUseCacheCacheStore(
         readRootParamNames: readRootParamNames
           ? new Set(readRootParamNames)
           : undefined,
-        // Not serialized into the RDC wire format; only populated by a fresh
-        // `collectResult`.
-        accessedClientReferences: undefined,
         // Serialized RDC entries are non-dynamic by construction (the
         // serializer drops dynamic entries), so this is never produced from the
         // wire — the throw path that consumes it is only reachable for dynamic

--- a/packages/next/src/server/resume-data-cache/cache-store.ts
+++ b/packages/next/src/server/resume-data-cache/cache-store.ts
@@ -102,6 +102,9 @@ export function parseUseCacheCacheStore(
         readRootParamNames: readRootParamNames
           ? new Set(readRootParamNames)
           : undefined,
+        // Not serialized into the RDC wire format; only populated by a fresh
+        // `collectResult`.
+        accessedClientReferences: undefined,
         // Serialized RDC entries are non-dynamic by construction (the
         // serializer drops dynamic entries), so this is never produced from the
         // wire — the throw path that consumes it is only reachable for dynamic

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -140,9 +140,13 @@ interface PublicCacheContext {
 
 type CacheContext = PrivateCacheContext | PublicCacheContext
 
-export type CacheKeyParts =
-  | [buildId: string, id: string, args: unknown[]]
-  | [buildId: string, id: string, args: unknown[], hmrRefreshHash: string]
+const nextVersion = process.env.__NEXT_VERSION as string
+
+export type CacheKeyParts = [
+  id: string,
+  args: unknown[],
+  implementationHash: unknown,
+]
 
 interface UseCachePageInnerProps {
   params: Promise<Params>
@@ -1175,7 +1179,7 @@ async function generateCacheEntryImpl(
   const temporaryReferences = createServerTemporaryReferenceSet()
   const outerWorkUnitStore = cacheContext.outerWorkUnitStore
 
-  const [, , args] =
+  const [, args] =
     typeof encodedArguments === 'string'
       ? await decodeReply<CacheKeyParts>(
           encodedArguments,
@@ -1833,6 +1837,9 @@ export async function cache(
   // In case getClientReferenceManifestSingleton is implemented using AsyncLocalStorage.
   const clientReferenceManifest = getClientReferenceManifest()
 
+  const serverModuleMap = getServerModuleMap()
+  const codeHash = serverModuleMap?.[id]?.codeHash
+
   // Because the Action ID is not yet unique per implementation of that Action we can't
   // safely reuse the results across builds yet. In the meantime we add the buildId to the
   // arguments as a seed to ensure they're not reused. Remove this once Action IDs hash
@@ -1845,6 +1852,15 @@ export async function cache(
   // also only a temporary solution until Action IDs are unique per
   // implementation. Remove this once Action IDs hash the implementation.
   const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
+
+  // When accurate information is available, use codeHash, otherwise fall back to buildId and/or the
+  // HMR hash.
+  const implementationHash =
+    typeof codeHash === 'string'
+      ? [codeHash, nextVersion]
+      : hmrRefreshHash
+        ? [buildId, hmrRefreshHash]
+        : [buildId]
 
   const hangingInputAbortSignal = createHangingInputAbortSignal(workUnitStore)
 
@@ -2008,9 +2024,7 @@ export async function cache(
   // long as the request. In development private caches are persisted across
   // requests, so `cacheHandlerKeyBase` (below) additionally scopes the handler
   // key by the request's cookies and headers.
-  const cacheKeyParts: CacheKeyParts = hmrRefreshHash
-    ? [buildId, id, args, hmrRefreshHash]
-    : [buildId, id, args]
+  const cacheKeyParts: CacheKeyParts = [id, args, implementationHash]
 
   const encodeCacheKeyParts = () =>
     encodeReply(cacheKeyParts, {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3296,7 +3296,8 @@ async function computeCacheKeyImplementationPart(
   const serverModuleMapEntry = getServerModuleMap()?.[id]
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
-    serverModuleMapEntry?.runtimeEnvVars
+    // if runtimeEnvVars===true, then always invalidate
+    Array.isArray(serverModuleMapEntry?.runtimeEnvVars)
   ) {
     let runtimeEnvVarsWithValues: string[] = await Promise.all(
       serverModuleMapEntry?.runtimeEnvVars?.map(async (v) => {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1837,31 +1837,6 @@ export async function cache(
   // In case getClientReferenceManifestSingleton is implemented using AsyncLocalStorage.
   const clientReferenceManifest = getClientReferenceManifest()
 
-  const serverModuleMap = getServerModuleMap()
-  const codeHash = serverModuleMap?.[id]?.codeHash
-
-  // Because the Action ID is not yet unique per implementation of that Action we can't
-  // safely reuse the results across builds yet. In the meantime we add the buildId to the
-  // arguments as a seed to ensure they're not reused. Remove this once Action IDs hash
-  // the implementation.
-  const buildId = workStore.deploymentId || workStore.buildId
-
-  // In dev mode, when the HMR refresh hash is set, we include it in the
-  // cache key. This ensures that cache entries are not reused when server
-  // components have been edited. This is a very coarse approach. But it's
-  // also only a temporary solution until Action IDs are unique per
-  // implementation. Remove this once Action IDs hash the implementation.
-  const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
-
-  // When accurate information is available, use codeHash, otherwise fall back to buildId and/or the
-  // HMR hash.
-  const implementationHash =
-    typeof codeHash === 'string'
-      ? [codeHash, nextVersion]
-      : hmrRefreshHash
-        ? [buildId, hmrRefreshHash]
-        : [buildId]
-
   const hangingInputAbortSignal = createHangingInputAbortSignal(workUnitStore)
 
   if (cacheContext.kind === 'private') {
@@ -2024,7 +1999,11 @@ export async function cache(
   // long as the request. In development private caches are persisted across
   // requests, so `cacheHandlerKeyBase` (below) additionally scopes the handler
   // key by the request's cookies and headers.
-  const cacheKeyParts: CacheKeyParts = [id, args, implementationHash]
+  const cacheKeyParts: CacheKeyParts = [
+    id,
+    args,
+    await computeCacheKeyImplementationPart(workStore, workUnitStore, id),
+  ]
 
   const encodeCacheKeyParts = () =>
     encodeReply(cacheKeyParts, {
@@ -3278,6 +3257,76 @@ export async function cache(
     replayConsoleLogs,
     environmentName: 'Cache',
   })
+}
+
+const encoder = new TextEncoder()
+
+/**
+ * This returns a cache key that has to cover everything that can affect the result of the cached
+ * function (apart from the arguments). So
+ * - codeHash: the code itself that generates the return value
+ * - runtimeEnvVars: the keys and values runtime environment variables that the code reads (and are
+ *   not inlined)
+ * - the version of Next.js (to account for RSC write format changes, or use-cache-wrapper.ts
+ *   changes, etc...)
+ *
+ * In case that granular information isn't available, fall back to
+ * buildId/deploymentId/hmrRefreshHash, which is a correct hash but over-invalidates way too often.
+ */
+async function computeCacheKeyImplementationPart(
+  workStore: WorkStore,
+  workUnitStore: WorkUnitStore,
+  id: string
+): Promise<unknown> {
+  async function hashString(input: string): Promise<string> {
+    if (process.env.NEXT_RUNTIME === 'edge') {
+      function bufferToHex(buffer: ArrayBuffer): string {
+        return Array.prototype.map
+          .call(new Uint8Array(buffer), (b) => b.toString(16).padStart(2, '0'))
+          .join('')
+      }
+      const buffer = encoder.encode(input)
+      return bufferToHex(await crypto.subtle.digest('SHA-256', buffer))
+    } else {
+      const crypto = require('crypto') as typeof import('crypto')
+      return crypto.createHash('sha256').update(input).digest('hex')
+    }
+  }
+
+  const serverModuleMapEntry = getServerModuleMap()?.[id]
+  if (
+    typeof serverModuleMapEntry?.codeHash === 'string' &&
+    serverModuleMapEntry?.runtimeEnvVars
+  ) {
+    let runtimeEnvVarsWithValues: string[] = await Promise.all(
+      serverModuleMapEntry?.runtimeEnvVars?.map(async (v) => {
+        // Hash the env var values, to not leak secrets into the cache key.
+        let hash = process.env[v] ? await hashString(process.env[v]) : undefined
+        return `${v}=${hash}`
+      }) ?? []
+    )
+
+    // When more accurate analysis information is available, use codeHash + runtimeEnvVars
+    return [serverModuleMapEntry?.codeHash, nextVersion].concat(
+      runtimeEnvVarsWithValues
+    )
+  } else {
+    // Because the Action ID is not yet unique per implementation of that Action we can't
+    // safely reuse the results across builds yet. In the meantime we add the buildId to the
+    // arguments as a seed to ensure they're not reused. Remove this once Action IDs hash
+    // the implementation.
+    const buildId = workStore.deploymentId || workStore.buildId
+
+    // In dev mode, when the HMR refresh hash is set, we include it in the
+    // cache key. This ensures that cache entries are not reused when server
+    // components have been edited. This is a very coarse approach. But it's
+    // also only a temporary solution until Action IDs are unique per
+    // implementation. Remove this once Action IDs hash the implementation.
+    const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
+
+    // otherwise fall back to buildId and/or the HMR hash.
+    return hmrRefreshHash ? [buildId, hmrRefreshHash] : [buildId]
+  }
 }
 
 /**

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3646,12 +3646,9 @@ async function computeCacheKeyImplementationPart(
     }
   }
 
-  let serverModuleMapEntry = undefined
-  try {
-    serverModuleMapEntry = getServerModuleMap()?.[id]
-  } catch (err) {
-    // TODO This fails on Webpack. replace this try-catch with if(durableUseCacheEntries) instead?
-  }
+  let serverModuleMapEntry = workStore.durableUseCacheEntries
+    ? getServerModuleMap()?.[id]
+    : undefined
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
     Array.isArray(serverModuleMapEntry?.runtimeEnvVars) &&

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3643,7 +3643,12 @@ async function computeCacheKeyImplementationPart(
     }
   }
 
-  const serverModuleMapEntry = getServerModuleMap()?.[id]
+  let serverModuleMapEntry = undefined
+  try {
+    serverModuleMapEntry = getServerModuleMap()?.[id]
+  } catch (err) {
+    // TODO This fails on Webpack. replace this try-catch with if(durableUseCacheEntries) instead?
+  }
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
     // if runtimeEnvVars===true, then always invalidate

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3620,8 +3620,7 @@ const encoder = new TextEncoder()
  *    - react, react-dom, private-next-rsc-server-reference, private-next-rsc-cache-wrapper
  * - runtimeEnvVars: the keys and values runtime environment variables that the code reads (and are
  *   not inlined)
- * - the version of Next.js (to account for RSC write format changes, or use-cache-wrapper.ts
- *   changes, etc...)
+ * - the version of Next.js (to account for RSC wire format changes, or use-cache-wrapper.ts
  *
  * In case that granular information isn't available, fall back to
  * buildId/deploymentId/hmrRefreshHash, which is a correct hash but over-invalidates way too often.

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3615,6 +3615,9 @@ const encoder = new TextEncoder()
  * This returns a cache key that has to cover everything that can affect the result of the cached
  * function (apart from the arguments). So
  * - codeHash: the code itself that generates the return value
+ *    - Notably, this excludes the following modules.  Those are included via the Next.js version
+ *      anyway:
+ *    - react, react-dom, private-next-rsc-server-reference, private-next-rsc-cache-wrapper
  * - runtimeEnvVars: the keys and values runtime environment variables that the code reads (and are
  *   not inlined)
  * - the version of Next.js (to account for RSC write format changes, or use-cache-wrapper.ts
@@ -3651,7 +3654,6 @@ async function computeCacheKeyImplementationPart(
   }
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
-    // if runtimeEnvVars===true, then always invalidate
     Array.isArray(serverModuleMapEntry?.runtimeEnvVars) &&
     // TODO replace this with more granular tracking: a list of all client components imported
     serverModuleMapEntry?.referencesClientComponent !== true

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3630,24 +3630,23 @@ async function computeCacheKeyImplementationPart(
   workUnitStore: WorkUnitStore,
   id: string
 ): Promise<unknown> {
-  let serverModuleMapEntry = workStore.durableUseCacheEntries
+  let durability = workStore.durableUseCacheEntries
     ? getServerActionsManifest().node[id].workers?.[
         normalizeWorkerPageName(workStore.page)
-      ]
+      ]?.durability
     : undefined
   if (
-    typeof serverModuleMapEntry?.codeHash === 'string' &&
-    serverModuleMapEntry?.runtimeEnvVars &&
-    // TODO replace this with more granular tracking: a list of all client components imported
-    serverModuleMapEntry?.referencesClientComponent !== true
+    durability &&
+    // TODO replace this with more granular tracking: a list of all imported client components
+    durability.referencesClientComponent !== true
   ) {
-    // Hash the env var values, to not leak secrets into the cache key.
-    // use cache is only suppored in Node.js runtime. So we can use the Node.js crypto module here.
+    // use cache is only supported in Node.js runtime. So we can use the Node.js crypto module here.
     const crypto = require('crypto') as typeof import('crypto')
     let runtimeEnvVarStateHash = crypto
+      // Hash the env var values, to not leak secrets into the cache key.
       .createHash('sha256')
       .update(
-        serverModuleMapEntry.runtimeEnvVars
+        durability.runtimeEnvVars
           .map((k) => {
             // Make sure not to stringify `undefined` and `"undefined"` to the same value.
             return process.env[k] != null ? `${k}=${process.env[k]}` : k
@@ -3657,7 +3656,7 @@ async function computeCacheKeyImplementationPart(
       .digest('hex')
 
     // When more accurate analysis information is available, use codeHash + runtimeEnvVars
-    return [serverModuleMapEntry.codeHash, nextVersion, runtimeEnvVarStateHash]
+    return [durability.codeHash, nextVersion, runtimeEnvVarStateHash]
   } else {
     // Because the Action ID is not yet unique per implementation of that Action we can't
     // safely reuse the results across builds yet. In the meantime we add the buildId to the

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -47,10 +47,7 @@ import {
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 
-import type {
-  ClientReferenceManifest,
-  ManifestNodeEntry,
-} from '../../build/webpack/plugins/flight-manifest-plugin'
+import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 import {
   getClientReferenceManifest,
@@ -785,7 +782,6 @@ function createUseCacheStore(
         workStore,
         outerWorkUnitStore
       ),
-      accessedClientReferences: new Map(),
       rootParams: outerWorkUnitStore.rootParams,
       readRootParamNames: process.env.__NEXT_DEV_SERVER ? new Set() : undefined,
       // Every private cache scope is its own work unit. Any cache keyed on
@@ -836,7 +832,6 @@ function createUseCacheStore(
         workStore,
         outerWorkUnitStore
       ),
-      accessedClientReferences: new Map(),
       rootParams: outerWorkUnitStore.rootParams,
       readRootParamNames: new Set<string>(),
       outerOwnerStack: cacheContext.outerOwnerStack,
@@ -3648,32 +3643,11 @@ async function computeCacheKeyImplementationPart(
     }
   }
 
-  let accessedClientReferences: Map<string, ManifestNodeEntry> | null = null
-  switch (workUnitStore.type) {
-    case 'cache':
-    case 'private-cache':
-      accessedClientReferences = workUnitStore.accessedClientReferences
-      break
-    case 'unstable-cache':
-    case 'prerender':
-    case 'prerender-client':
-    case 'prerender-legacy':
-    case 'request':
-    case 'prerender-runtime':
-    case 'validation-client':
-    case 'generate-static-params':
-      break
-    default:
-      return workUnitStore satisfies never
-  }
-
   const serverModuleMapEntry = getServerModuleMap()?.[id]
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
     // if runtimeEnvVars===true, then always invalidate
-    Array.isArray(serverModuleMapEntry?.runtimeEnvVars) &&
-    // TODO make this more granular, only invalidate based on the client references that were actually accessed
-    (!accessedClientReferences || accessedClientReferences.size === 0)
+    Array.isArray(serverModuleMapEntry?.runtimeEnvVars)
   ) {
     let runtimeEnvVarsWithValues: string[] = await Promise.all(
       serverModuleMapEntry?.runtimeEnvVars?.map(async (v) => {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -47,7 +47,10 @@ import {
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 
-import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
+import type {
+  ClientReferenceManifest,
+  ManifestNodeEntry,
+} from '../../build/webpack/plugins/flight-manifest-plugin'
 
 import {
   getClientReferenceManifest,
@@ -782,6 +785,7 @@ function createUseCacheStore(
         workStore,
         outerWorkUnitStore
       ),
+      accessedClientReferences: new Map(),
       rootParams: outerWorkUnitStore.rootParams,
       readRootParamNames: process.env.__NEXT_DEV_SERVER ? new Set() : undefined,
       // Every private cache scope is its own work unit. Any cache keyed on
@@ -832,6 +836,7 @@ function createUseCacheStore(
         workStore,
         outerWorkUnitStore
       ),
+      accessedClientReferences: new Map(),
       rootParams: outerWorkUnitStore.rootParams,
       readRootParamNames: new Set<string>(),
       outerOwnerStack: cacheContext.outerOwnerStack,
@@ -3643,11 +3648,32 @@ async function computeCacheKeyImplementationPart(
     }
   }
 
+  let accessedClientReferences: Map<string, ManifestNodeEntry> | null = null
+  switch (workUnitStore.type) {
+    case 'cache':
+    case 'private-cache':
+      accessedClientReferences = workUnitStore.accessedClientReferences
+      break
+    case 'unstable-cache':
+    case 'prerender':
+    case 'prerender-client':
+    case 'prerender-legacy':
+    case 'request':
+    case 'prerender-runtime':
+    case 'validation-client':
+    case 'generate-static-params':
+      break
+    default:
+      return workUnitStore satisfies never
+  }
+
   const serverModuleMapEntry = getServerModuleMap()?.[id]
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
     // if runtimeEnvVars===true, then always invalidate
-    Array.isArray(serverModuleMapEntry?.runtimeEnvVars)
+    Array.isArray(serverModuleMapEntry?.runtimeEnvVars) &&
+    // TODO make this more granular, only invalidate based on the client references that were actually accessed
+    (!accessedClientReferences || accessedClientReferences.size === 0)
   ) {
     let runtimeEnvVarsWithValues: string[] = await Promise.all(
       serverModuleMapEntry?.runtimeEnvVars?.map(async (v) => {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1986,31 +1986,6 @@ export async function cache(
   // In case getClientReferenceManifestSingleton is implemented using AsyncLocalStorage.
   const clientReferenceManifest = getClientReferenceManifest()
 
-  const serverModuleMap = getServerModuleMap()
-  const codeHash = serverModuleMap?.[id]?.codeHash
-
-  // Because the Action ID is not yet unique per implementation of that Action we can't
-  // safely reuse the results across builds yet. In the meantime we add the buildId to the
-  // arguments as a seed to ensure they're not reused. Remove this once Action IDs hash
-  // the implementation.
-  const buildId = workStore.deploymentId || workStore.buildId
-
-  // In dev mode, when the HMR refresh hash is set, we include it in the
-  // cache key. This ensures that cache entries are not reused when server
-  // components have been edited. This is a very coarse approach. But it's
-  // also only a temporary solution until Action IDs are unique per
-  // implementation. Remove this once Action IDs hash the implementation.
-  const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
-
-  // When accurate information is available, use codeHash, otherwise fall back to buildId and/or the
-  // HMR hash.
-  const implementationHash =
-    typeof codeHash === 'string'
-      ? [codeHash, nextVersion]
-      : hmrRefreshHash
-        ? [buildId, hmrRefreshHash]
-        : [buildId]
-
   const hangingInputAbortSignal = createHangingInputAbortSignal(workUnitStore)
 
   if (cacheContext.kind === 'private') {
@@ -2171,7 +2146,11 @@ export async function cache(
   // long as the request. In development private caches are persisted across
   // requests, so `cacheHandlerKeyBase` (below) additionally scopes the handler
   // key by the request's cookies and headers.
-  const cacheKeyParts: CacheKeyParts = [id, args, implementationHash]
+  const cacheKeyParts: CacheKeyParts = [
+    id,
+    args,
+    await computeCacheKeyImplementationPart(workStore, workUnitStore, id),
+  ]
 
   const encodeCacheKeyParts = () =>
     encodeReply(cacheKeyParts, {
@@ -3628,6 +3607,77 @@ export async function cache(
     replayConsoleLogs,
     environmentName: 'Cache',
   })
+}
+
+const encoder = new TextEncoder()
+
+/**
+ * This returns a cache key that has to cover everything that can affect the result of the cached
+ * function (apart from the arguments). So
+ * - codeHash: the code itself that generates the return value
+ * - runtimeEnvVars: the keys and values runtime environment variables that the code reads (and are
+ *   not inlined)
+ * - the version of Next.js (to account for RSC write format changes, or use-cache-wrapper.ts
+ *   changes, etc...)
+ *
+ * In case that granular information isn't available, fall back to
+ * buildId/deploymentId/hmrRefreshHash, which is a correct hash but over-invalidates way too often.
+ */
+async function computeCacheKeyImplementationPart(
+  workStore: WorkStore,
+  workUnitStore: WorkUnitStore,
+  id: string
+): Promise<unknown> {
+  async function hashString(input: string): Promise<string> {
+    if (process.env.NEXT_RUNTIME === 'edge') {
+      function bufferToHex(buffer: ArrayBuffer): string {
+        return Array.prototype.map
+          .call(new Uint8Array(buffer), (b) => b.toString(16).padStart(2, '0'))
+          .join('')
+      }
+      const buffer = encoder.encode(input)
+      return bufferToHex(await crypto.subtle.digest('SHA-256', buffer))
+    } else {
+      const crypto = require('crypto') as typeof import('crypto')
+      return crypto.createHash('sha256').update(input).digest('hex')
+    }
+  }
+
+  const serverModuleMapEntry = getServerModuleMap()?.[id]
+  if (
+    typeof serverModuleMapEntry?.codeHash === 'string' &&
+    // if runtimeEnvVars===true, then always invalidate
+    Array.isArray(serverModuleMapEntry?.runtimeEnvVars)
+  ) {
+    let runtimeEnvVarsWithValues: string[] = await Promise.all(
+      serverModuleMapEntry?.runtimeEnvVars?.map(async (v) => {
+        // Hash the env var values, to not leak secrets into the cache key.
+        let hash = process.env[v] ? await hashString(process.env[v]) : undefined
+        return `${v}=${hash}`
+      }) ?? []
+    )
+
+    // When more accurate analysis information is available, use codeHash + runtimeEnvVars
+    return [serverModuleMapEntry?.codeHash, nextVersion].concat(
+      runtimeEnvVarsWithValues
+    )
+  } else {
+    // Because the Action ID is not yet unique per implementation of that Action we can't
+    // safely reuse the results across builds yet. In the meantime we add the buildId to the
+    // arguments as a seed to ensure they're not reused. Remove this once Action IDs hash
+    // the implementation.
+    const buildId = workStore.deploymentId || workStore.buildId
+
+    // In dev mode, when the HMR refresh hash is set, we include it in the
+    // cache key. This ensures that cache entries are not reused when server
+    // components have been edited. This is a very coarse approach. But it's
+    // also only a temporary solution until Action IDs are unique per
+    // implementation. Remove this once Action IDs hash the implementation.
+    const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
+
+    // otherwise fall back to buildId and/or the HMR hash.
+    return hmrRefreshHash ? [buildId, hmrRefreshHash] : [buildId]
+  }
 }
 
 /**

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3609,8 +3609,6 @@ export async function cache(
   })
 }
 
-const encoder = new TextEncoder()
-
 /**
  * This returns a cache key that has to cover everything that can affect the result of the cached
  * function (apart from the arguments). So
@@ -3630,21 +3628,6 @@ async function computeCacheKeyImplementationPart(
   workUnitStore: WorkUnitStore,
   id: string
 ): Promise<unknown> {
-  async function hashString(input: string): Promise<string> {
-    if (process.env.NEXT_RUNTIME === 'edge') {
-      function bufferToHex(buffer: ArrayBuffer): string {
-        return Array.prototype.map
-          .call(new Uint8Array(buffer), (b) => b.toString(16).padStart(2, '0'))
-          .join('')
-      }
-      const buffer = encoder.encode(input)
-      return bufferToHex(await crypto.subtle.digest('SHA-256', buffer))
-    } else {
-      const crypto = require('crypto') as typeof import('crypto')
-      return crypto.createHash('sha256').update(input).digest('hex')
-    }
-  }
-
   let serverModuleMapEntry = workStore.durableUseCacheEntries
     ? getServerModuleMap()?.[id]
     : undefined
@@ -3655,14 +3638,19 @@ async function computeCacheKeyImplementationPart(
     serverModuleMapEntry?.referencesClientComponent !== true
   ) {
     // Hash the env var values, to not leak secrets into the cache key.
-    let runtimeEnvVarStateHash = await hashString(
-      serverModuleMapEntry.runtimeEnvVars
-        .map((k) => {
-          // Make sure not to stringify `undefined` and `"undefined"` to the same value.
-          return process.env[k] != null ? `${k}=${process.env[k]}` : k
-        })
-        .join('\0') ?? ''
-    )
+    // use cache is only suppored in Node.js runtime. So we can use the Node.js crypto module here.
+    const crypto = require('crypto') as typeof import('crypto')
+    let runtimeEnvVarStateHash = crypto
+      .createHash('sha256')
+      .update(
+        serverModuleMapEntry.runtimeEnvVars
+          .map((k) => {
+            // Make sure not to stringify `undefined` and `"undefined"` to the same value.
+            return process.env[k] != null ? `${k}=${process.env[k]}` : k
+          })
+          .join('\0') ?? ''
+      )
+      .digest('hex')
 
     // When more accurate analysis information is available, use codeHash + runtimeEnvVars
     return [serverModuleMapEntry.codeHash, nextVersion, runtimeEnvVarStateHash]

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -153,9 +153,13 @@ interface PublicCacheContext {
 
 type CacheContext = PrivateCacheContext | PublicCacheContext
 
-export type CacheKeyParts =
-  | [buildId: string, id: string, args: unknown[]]
-  | [buildId: string, id: string, args: unknown[], hmrRefreshHash: string]
+const nextVersion = process.env.__NEXT_VERSION as string
+
+export type CacheKeyParts = [
+  id: string,
+  args: unknown[],
+  implementationHash: unknown,
+]
 
 interface UseCachePageInnerProps {
   params: Promise<Params>
@@ -1285,7 +1289,7 @@ async function generateCacheEntryImpl(
   const temporaryReferences = createServerTemporaryReferenceSet()
   const outerWorkUnitStore = cacheContext.outerWorkUnitStore
 
-  const [, , args] =
+  const [, args] =
     typeof encodedArguments === 'string'
       ? await decodeReply<CacheKeyParts>(
           encodedArguments,
@@ -1982,6 +1986,9 @@ export async function cache(
   // In case getClientReferenceManifestSingleton is implemented using AsyncLocalStorage.
   const clientReferenceManifest = getClientReferenceManifest()
 
+  const serverModuleMap = getServerModuleMap()
+  const codeHash = serverModuleMap?.[id]?.codeHash
+
   // Because the Action ID is not yet unique per implementation of that Action we can't
   // safely reuse the results across builds yet. In the meantime we add the buildId to the
   // arguments as a seed to ensure they're not reused. Remove this once Action IDs hash
@@ -1994,6 +2001,15 @@ export async function cache(
   // also only a temporary solution until Action IDs are unique per
   // implementation. Remove this once Action IDs hash the implementation.
   const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
+
+  // When accurate information is available, use codeHash, otherwise fall back to buildId and/or the
+  // HMR hash.
+  const implementationHash =
+    typeof codeHash === 'string'
+      ? [codeHash, nextVersion]
+      : hmrRefreshHash
+        ? [buildId, hmrRefreshHash]
+        : [buildId]
 
   const hangingInputAbortSignal = createHangingInputAbortSignal(workUnitStore)
 
@@ -2155,9 +2171,7 @@ export async function cache(
   // long as the request. In development private caches are persisted across
   // requests, so `cacheHandlerKeyBase` (below) additionally scopes the handler
   // key by the request's cookies and headers.
-  const cacheKeyParts: CacheKeyParts = hmrRefreshHash
-    ? [buildId, id, args, hmrRefreshHash]
-    : [buildId, id, args]
+  const cacheKeyParts: CacheKeyParts = [id, args, implementationHash]
 
   const encodeCacheKeyParts = () =>
     encodeReply(cacheKeyParts, {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3647,7 +3647,9 @@ async function computeCacheKeyImplementationPart(
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
     // if runtimeEnvVars===true, then always invalidate
-    Array.isArray(serverModuleMapEntry?.runtimeEnvVars)
+    Array.isArray(serverModuleMapEntry?.runtimeEnvVars) &&
+    // TODO replace this with more granular tracking: a list of all client components imported
+    serverModuleMapEntry?.referencesClientComponent !== true
   ) {
     let runtimeEnvVarsWithValues: string[] = await Promise.all(
       serverModuleMapEntry?.runtimeEnvVars?.map(async (v) => {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3651,7 +3651,7 @@ async function computeCacheKeyImplementationPart(
     : undefined
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&
-    Array.isArray(serverModuleMapEntry?.runtimeEnvVars) &&
+    serverModuleMapEntry?.runtimeEnvVars &&
     // TODO replace this with more granular tracking: a list of all client components imported
     serverModuleMapEntry?.referencesClientComponent !== true
   ) {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -51,7 +51,9 @@ import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight
 
 import {
   getClientReferenceManifest,
+  getServerActionsManifest,
   getServerModuleMap,
+  normalizeWorkerPageName,
 } from '../app-render/manifests-singleton'
 import type { CacheEntry } from '../lib/cache-handlers/types'
 import type { CacheSignal } from '../app-render/cache-signal'
@@ -3629,7 +3631,9 @@ async function computeCacheKeyImplementationPart(
   id: string
 ): Promise<unknown> {
   let serverModuleMapEntry = workStore.durableUseCacheEntries
-    ? getServerModuleMap()?.[id]
+    ? getServerActionsManifest().node[id].workers?.[
+        normalizeWorkerPageName(workStore.page)
+      ]
     : undefined
   if (
     typeof serverModuleMapEntry?.codeHash === 'string' &&

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -3658,18 +3658,18 @@ async function computeCacheKeyImplementationPart(
     // TODO replace this with more granular tracking: a list of all client components imported
     serverModuleMapEntry?.referencesClientComponent !== true
   ) {
-    let runtimeEnvVarsWithValues: string[] = await Promise.all(
-      serverModuleMapEntry?.runtimeEnvVars?.map(async (v) => {
-        // Hash the env var values, to not leak secrets into the cache key.
-        let hash = process.env[v] ? await hashString(process.env[v]) : undefined
-        return `${v}=${hash}`
-      }) ?? []
+    // Hash the env var values, to not leak secrets into the cache key.
+    let runtimeEnvVarStateHash = await hashString(
+      serverModuleMapEntry.runtimeEnvVars
+        .map((k) => {
+          // Make sure not to stringify `undefined` and `"undefined"` to the same value.
+          return process.env[k] != null ? `${k}=${process.env[k]}` : k
+        })
+        .join('\0') ?? ''
     )
 
     // When more accurate analysis information is available, use codeHash + runtimeEnvVars
-    return [serverModuleMapEntry?.codeHash, nextVersion].concat(
-      runtimeEnvVarsWithValues
-    )
+    return [serverModuleMapEntry.codeHash, nextVersion, runtimeEnvVarStateHash]
   } else {
     // Because the Action ID is not yet unique per implementation of that Action we can't
     // safely reuse the results across builds yet. In the meantime we add the buildId to the

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -27,15 +27,10 @@ describe('use-cache-custom-handler', () => {
 
     expect(cliOutput).toContain('ModernCustomCacheHandler::refreshTags')
 
-    // In development the cache key carries a trailing HMR refresh hash element
-    // (absent in production), so the args array may be followed by an optional
-    // quoted hash.
+    // The implementation parts contain either the code hash and version or the
+    // build ID, followed by an optional HMR refresh hash in development.
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\](,"[^"]+")?\] \[ '_N_T_\/layout', '_N_T_\/page', '_N_T_\/', '_N_T_\/index' \]/
-    )
-
-    expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::set \["(development|[A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\](,"[^"]+")?\]/
+      /ModernCustomCacheHandler::get \["([0-9a-f]{2})+",\[\],\["(development|[A-Za-z0-9_-]+)"(,"[^"]+")*\]\] \[ '_N_T_\/layout', '_N_T_\/page', '_N_T_\/', '_N_T_\/index' \]/
     )
 
     // Since no existing cache entry was retrieved, we don't need to call
@@ -129,7 +124,7 @@ describe('use-cache-custom-handler', () => {
   if (isNextStart) {
     it('should save a short-lived cache during prerendering at buildtime', async () => {
       expect(next.cliOutput).toMatch(
-        /ModernCustomCacheHandler::set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"dynamic-cache"}]\]/
+        /ModernCustomCacheHandler::set \["([0-9a-f]{2})+",\[{"id":"dynamic-cache"}\],\["[A-Za-z0-9_-]+"(,"[^"]+")*\]\]/
       )
     })
   }

--- a/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
+++ b/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
@@ -28,17 +28,17 @@ describe('use-cache-default-handler-expire-zero', () => {
       // The default handler skips storing the `expire: 0` entry (it would never
       // be served back in production)...
       expect(next.cliOutput).toMatch(
-        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}]\] skipped dynamic entry/
+        /DefaultCacheHandler: set \["([0-9a-f]{2})+",\[{"id":"expire-zero"}\],\["[A-Za-z0-9_-]+"(,"[^"]+")*\]\] skipped dynamic entry/
       )
 
       // ...and never reports it as stored.
       expect(next.cliOutput).not.toMatch(
-        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}]\] done/
+        /DefaultCacheHandler: set \["([0-9a-f]{2})+",\[{"id":"expire-zero"}\],\["[A-Za-z0-9_-]+"(,"[^"]+")*\]\] done/
       )
 
       // The short-lived (`expire: 60`) cache is still stored.
       expect(next.cliOutput).toMatch(
-        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"short-lived"}]\] done/
+        /DefaultCacheHandler: set \["([0-9a-f]{2})+",\[{"id":"short-lived"}\],\["[A-Za-z0-9_-]+"(,"[^"]+")*\]\] done/
       )
     })
   } else {
@@ -50,16 +50,16 @@ describe('use-cache-default-handler-expire-zero', () => {
 
       // In development the default handler keeps `expire: 0` entries (its
       // minimum retention serves them warm across reloads), so it stores rather
-      // than skips. The dev cache key always carries a trailing HMR refresh
-      // hash element after the args array.
+      // than skips. The implementation parts include the build ID and a
+      // trailing HMR refresh hash.
       await retry(async () => {
         expect(next.cliOutput).toMatch(
-          /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}],"[^"]+"\] done/
+          /DefaultCacheHandler: set \["([0-9a-f]{2})+",\[{"id":"expire-zero"}\],\["[A-Za-z0-9_-]+"(,"[^"]+")+\]\] done/
         )
       })
 
       expect(next.cliOutput).not.toMatch(
-        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}],"[^"]+"\] skipped/
+        /DefaultCacheHandler: set \["([0-9a-f]{2})+",\[{"id":"expire-zero"}\],\["[A-Za-z0-9_-]+"(,"[^"]+")+\]\] skipped/
       )
     })
   }

--- a/test/production/app-dir/use-cache-code-hash/app/env-dynamic/foo.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/env-dynamic/foo.tsx
@@ -1,0 +1,3 @@
+export function foo() {
+  return 'foo-v1'
+}

--- a/test/production/app-dir/use-cache-code-hash/app/env-dynamic/logic.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/env-dynamic/logic.tsx
@@ -1,0 +1,10 @@
+// @ts-ignore
+globalThis.blackbox = (v) => ({ DECOY: v.FOOBAR })
+
+// @ts-ignore
+const envVar = blackbox(process.env).DECOY
+
+export async function logic() {
+  'use cache'
+  return `${envVar}`
+}

--- a/test/production/app-dir/use-cache-code-hash/app/env-dynamic/page.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/env-dynamic/page.tsx
@@ -1,0 +1,6 @@
+import { logic } from './logic'
+
+export default async function Page() {
+  const value = await logic()
+  return <p>{value}</p>
+}

--- a/test/production/app-dir/use-cache-code-hash/app/use-cache-client/page.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/use-cache-client/page.tsx
@@ -1,9 +1,15 @@
 import { ClientComponent } from './client-reference'
+import { preinit } from 'react-dom'
 
 import './client-reference-css.css'
 
 export default async function Page() {
   'use cache'
+
+  if (Date.now() < 0) {
+    // Try importing anything from react-dom
+    preinit('abc')
+  }
   return (
     <p>
       <ClientComponent />

--- a/test/production/app-dir/use-cache-code-hash/app/use-cache/logic.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/use-cache/logic.tsx
@@ -4,5 +4,5 @@ import { external } from 'external-dep'
 
 export async function logic() {
   'use cache'
-  return `${foo()}:${external()}`
+  return `${foo()}:${external()}:${process.env.BUNDLED_NON_INLINED_ENVVAR}`
 }

--- a/test/production/app-dir/use-cache-code-hash/node_modules/external-dep/index.js
+++ b/test/production/app-dir/use-cache-code-hash/node_modules/external-dep/index.js
@@ -1,3 +1,3 @@
 export function external() {
-  return 'external-v1'
+  return 'external-v1' + process.env.EXTERNAL_ENV_VAR
 }

--- a/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
+++ b/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
@@ -60,10 +60,6 @@ async function getCodeHashes(
         ).toMatchInlineSnapshot(`
          [
            "BUNDLED_NON_INLINED_ENVVAR",
-           "NEXT_PRIVATE_DEBUG_CACHE",
-           "NEXT_OTEL_VERBOSE",
-           "NEXT_OTEL_PERFORMANCE_PREFIX",
-           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
            "EXTERNAL_ENV_VAR",
          ]
         `)
@@ -71,16 +67,7 @@ async function getCodeHashes(
         expect(
           data.filter((e) => e.page === 'app/env-dynamic/page')[0]
             .runtimeEnvVars
-          // TODO DECOY here is wrong
-        ).toMatchInlineSnapshot(`
-         [
-           "DECOY",
-           "NEXT_PRIVATE_DEBUG_CACHE",
-           "NEXT_OTEL_VERBOSE",
-           "NEXT_OTEL_PERFORMANCE_PREFIX",
-           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
-         ]
-        `)
+        ).toMatchInlineSnapshot(`[]`)
       })
     })
 

--- a/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
+++ b/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
@@ -55,19 +55,32 @@ async function getCodeHashes(
       it('lists non-inlined runtime env vars', async () => {
         const data = await getCodeHashes(next)
 
-        expect(
-          data.filter((e) => e.page === 'app/use-cache/page')[0].runtimeEnvVars
-        ).toMatchInlineSnapshot(`
+        expect(data.find((e) => e.page === 'app/use-cache/page').runtimeEnvVars)
+          .toMatchInlineSnapshot(`
          [
            "BUNDLED_NON_INLINED_ENVVAR",
+           "NEXT_PRIVATE_DEBUG_CACHE",
+           "__NEXT_DEV_SERVER",
+           "NEXT_PRIVATE_DEBUG_RUNTIME_DATA",
+           "NEXT_OTEL_VERBOSE",
+           "NEXT_OTEL_PERFORMANCE_PREFIX",
+           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
            "EXTERNAL_ENV_VAR",
          ]
         `)
 
         expect(
-          data.filter((e) => e.page === 'app/env-dynamic/page')[0]
-            .runtimeEnvVars
-        ).toMatchInlineSnapshot(`[]`)
+          data.find((e) => e.page === 'app/env-dynamic/page').runtimeEnvVars
+        ).toMatchInlineSnapshot(`
+         [
+           "NEXT_PRIVATE_DEBUG_CACHE",
+           "__NEXT_DEV_SERVER",
+           "NEXT_PRIVATE_DEBUG_RUNTIME_DATA",
+           "NEXT_OTEL_VERBOSE",
+           "NEXT_OTEL_PERFORMANCE_PREFIX",
+           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+         ]
+        `)
       })
     })
 

--- a/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
+++ b/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
@@ -3,7 +3,9 @@ import { nextTestSetup, type NextInstance } from 'e2e-utils'
 async function getCodeHashes(
   next: NextInstance,
   pages?: string[]
-): Promise<{ id: string; page: string; codeHash?: string }[]> {
+): Promise<
+  { id: string; page: string; codeHash?: string; runtimeEnvVars?: string[] }[]
+> {
   const manifest = await next.readJSON(
     '.next/server/server-reference-manifest.json'
   )
@@ -12,6 +14,7 @@ async function getCodeHashes(
     id: string
     page: string
     codeHash?: string
+    runtimeEnvVars?: string[]
   }[] = []
   for (const [actionId, entry] of Object.entries<any>(manifest.node)) {
     for (const [workerKey, worker] of Object.entries<any>(entry.workers)) {
@@ -20,6 +23,7 @@ async function getCodeHashes(
           id: actionId,
           page: workerKey,
           codeHash: worker?.codeHash,
+          runtimeEnvVars: worker?.runtimeEnvVars,
         })
       }
     }
@@ -32,134 +36,174 @@ async function getCodeHashes(
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
   'app-dir - use-cache-code-hash',
   () => {
-    const { next } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
+    describe('basic', () => {
+      const { next } = nextTestSetup({
+        files: __dirname,
+      })
+
+      it('emits codeHash only for use-cache functions', async () => {
+        const values = Object.values(await getCodeHashes(next))
+        expect(values.length).toBe(4)
+
+        const valuesWithoutCodeHash = values.filter(
+          (e) => typeof e.codeHash !== 'string'
+        )
+        expect(valuesWithoutCodeHash.length).toBe(1)
+        expect(valuesWithoutCodeHash[0].page).toBe('app/use-server/page')
+      })
+
+      it('lists non-inlined runtime env vars', async () => {
+        const data = await getCodeHashes(next)
+
+        expect(
+          data.filter((e) => e.page === 'app/use-cache/page')[0].runtimeEnvVars
+        ).toMatchInlineSnapshot(`
+         [
+           "BUNDLED_NON_INLINED_ENVVAR",
+           "NEXT_PRIVATE_DEBUG_CACHE",
+           "NEXT_OTEL_VERBOSE",
+           "NEXT_OTEL_PERFORMANCE_PREFIX",
+           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+           "EXTERNAL_ENV_VAR",
+         ]
+        `)
+
+        expect(
+          data.filter((e) => e.page === 'app/env-dynamic/page')[0]
+            .runtimeEnvVars
+          // TODO DECOY here is wrong
+        ).toMatchInlineSnapshot(`
+         [
+           "DECOY",
+           "NEXT_PRIVATE_DEBUG_CACHE",
+           "NEXT_OTEL_VERBOSE",
+           "NEXT_OTEL_PERFORMANCE_PREFIX",
+           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+         ]
+        `)
+      })
     })
 
-    it('emits codeHash only for use-cache functions', async () => {
-      await next.build()
-      const values = Object.values(await getCodeHashes(next))
-      expect(values.length).toBe(3)
+    describe('invalidation', () => {
+      const { next } = nextTestSetup({
+        files: __dirname,
+        skipStart: true,
+      })
 
-      const valuesWithoutCodeHash = values.filter(
-        (e) => typeof e.codeHash !== 'string'
-      )
-      expect(valuesWithoutCodeHash.length).toBe(1)
-      expect(valuesWithoutCodeHash[0].page).toBe('app/use-server/page')
-    })
+      it('codeHash stays stable across identical rebuilds', async () => {
+        await next.build()
+        const first = await getCodeHashes(next)
 
-    it('codeHash stays stable across identical rebuilds', async () => {
-      await next.build()
-      const first = await getCodeHashes(next)
+        await next.build()
+        const second = await getCodeHashes(next)
 
-      await next.build()
-      const second = await getCodeHashes(next)
+        expect(second).toEqual(first)
+      })
 
-      expect(second).toEqual(first)
-    })
+      it("changes when the action's own code changes", async () => {
+        await next.build()
+        const before = await getCodeHashes(next, ['app/use-cache/page'])
 
-    it("changes when the action's own code changes", async () => {
-      await next.build()
-      const before = await getCodeHashes(next, ['app/use-cache/page'])
-
-      await next.patchFile(
-        'app/use-cache/logic.tsx',
-        `import { foo } from './foo'
+        await next.patchFile(
+          'app/use-cache/logic.tsx',
+          `import { foo } from './foo'
 import { external } from 'external-dep'
 
 export async function logic() {
   'use cache'
-  return \`\${foo()}:\${external()}\` + ":other"
+  return \`\${foo()}:\${external()}:\${process.env.BUNDLED_NON_INLINED_ENVVAR}\` + ":other"
 }
 `,
-        async () => {
-          await next.build()
-          const after = await getCodeHashes(next, ['app/use-cache/page'])
+          async () => {
+            await next.build()
+            const after = await getCodeHashes(next, ['app/use-cache/page'])
 
-          // Same set of actions, but the hash for the changed action differs.
-          expect(Object.keys(after)).toEqual(Object.keys(before))
-          expect(after).not.toEqual(before)
-        }
-      )
-    })
+            // Same set of actions, but the hash for the changed action differs.
+            expect(Object.keys(after)).toEqual(Object.keys(before))
+            expect(after).not.toEqual(before)
+          }
+        )
+      })
 
-    it('codeHash changes when an imported dependency changes', async () => {
-      await next.build()
-      const before = await getCodeHashes(next, ['app/use-cache/page'])
+      it('codeHash changes when an imported dependency changes', async () => {
+        await next.build()
+        const before = await getCodeHashes(next, ['app/use-cache/page'])
 
-      await next.patchFile(
-        'app/use-cache/foo.tsx',
-        `export function foo() {
+        await next.patchFile(
+          'app/use-cache/foo.tsx',
+          `export function foo() {
   return "foo-v2"
 }
 `,
-        async () => {
-          await next.build()
-          const after = await getCodeHashes(next, ['app/use-cache/page'])
+          async () => {
+            await next.build()
+            const after = await getCodeHashes(next, ['app/use-cache/page'])
 
-          expect(Object.keys(after)).toEqual(Object.keys(before))
-          expect(after).not.toEqual(before)
-        }
-      )
-    })
+            expect(Object.keys(after)).toEqual(Object.keys(before))
+            expect(after).not.toEqual(before)
+          }
+        )
+      })
 
-    it('codeHash changes when an external (node_modules) dependency changes', async () => {
-      await next.build()
-      const before = await getCodeHashes(next, ['app/use-cache/page'])
+      it('codeHash changes when an external (node_modules) dependency changes', async () => {
+        await next.build()
+        const before = await getCodeHashes(next, ['app/use-cache/page'])
 
-      await next.patchFile(
-        'node_modules/external-dep/index.js',
-        `export function external() {
-  return 'external-v2'
+        await next.patchFile(
+          'node_modules/external-dep/index.js',
+          `export function external() {
+  return 'external-v2' + process.env.EXTERNAL_ENV_VAR
 }
 `,
-        async () => {
-          await next.build()
-          const after = await getCodeHashes(next, ['app/use-cache/page'])
+          async () => {
+            await next.build()
+            const after = await getCodeHashes(next, ['app/use-cache/page'])
 
-          expect(Object.keys(after)).toEqual(Object.keys(before))
-          expect(after).not.toEqual(before)
-        }
-      )
-    })
+            expect(Object.keys(after)).toEqual(Object.keys(before))
+            expect(after).not.toEqual(before)
+          }
+        )
+      })
 
-    it('codeHash does not change when an unrelated file changes', async () => {
-      await next.build()
-      const before = await getCodeHashes(next, ['app/use-cache/page'])
+      it('codeHash does not change when an unrelated file changes', async () => {
+        await next.build()
+        const before = await getCodeHashes(next, ['app/use-cache/page'])
 
-      await next.patchFile(
-        'app/use-cache/unrelated.ts',
-        `export function unrelated() {
+        await next.patchFile(
+          'app/use-cache/unrelated.ts',
+          `export function unrelated() {
   return 'unrelated-v2'
 }
 `,
-        async () => {
-          await next.build()
-          const after = await getCodeHashes(next, ['app/use-cache/page'])
+          async () => {
+            await next.build()
+            const after = await getCodeHashes(next, ['app/use-cache/page'])
 
-          expect(after).toEqual(before)
-        }
-      )
-    })
+            expect(after).toEqual(before)
+          }
+        )
+      })
 
-    it('codeHash does not change when a client file changes', async () => {
-      await next.build()
-      const before = await getCodeHashes(next, ['app/use-cache-client/page'])
+      it('codeHash does not change when a client file changes', async () => {
+        await next.build()
+        const before = await getCodeHashes(next, ['app/use-cache-client/page'])
 
-      await next.patchFile(
-        'app/use-cache-client/data.ts',
-        `export function data() {
+        await next.patchFile(
+          'app/use-cache-client/data.ts',
+          `export function data() {
   return 'data-v2'
 }
 `,
-        async () => {
-          await next.build()
-          const after = await getCodeHashes(next, ['app/use-cache-client/page'])
+          async () => {
+            await next.build()
+            const after = await getCodeHashes(next, [
+              'app/use-cache-client/page',
+            ])
 
-          expect(after).toEqual(before)
-        }
-      )
+            expect(after).toEqual(before)
+          }
+        )
+      })
     })
   }
 )

--- a/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
+++ b/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
@@ -22,8 +22,8 @@ async function getCodeHashes(
         hashes.push({
           id: actionId,
           page: workerKey,
-          codeHash: worker?.codeHash,
-          runtimeEnvVars: worker?.runtimeEnvVars,
+          codeHash: worker?.durability?.codeHash,
+          runtimeEnvVars: worker?.durability?.runtimeEnvVars,
         })
       }
     }

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-cache/action.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-cache/action.ts
@@ -1,0 +1,4 @@
+export async function action() {
+  'use cache'
+  return 'first'
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-cache/get-data.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-cache/get-data.ts
@@ -1,0 +1,7 @@
+export async function getData(action) {
+  'use cache: remote'
+
+  console.log(action)
+
+  return Math.random()
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-cache/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-cache/page.tsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+import { action } from './action'
+import { getData } from './get-data'
+
+export default async function Page() {
+  await connection()
+
+  return <span id="data">{await getData(action)}</span>
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-client/client.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-client/client.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function client() {
+  return 'first'
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-client/get-data.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-client/get-data.ts
@@ -1,0 +1,7 @@
+export async function getData(client) {
+  'use cache: remote'
+
+  console.log(client)
+
+  return Math.random()
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-client/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-client/page.tsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+import { client } from './client'
+import { getData } from './get-data'
+
+export default async function Page() {
+  await connection()
+
+  return <span id="data">{await getData(client)}</span>
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-server/action.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-server/action.ts
@@ -1,0 +1,4 @@
+export async function action() {
+  'use server'
+  return 'first'
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-server/get-data.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-server/get-data.ts
@@ -1,0 +1,7 @@
+export async function getData(action) {
+  'use cache: remote'
+
+  console.log(action)
+
+  return Math.random()
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/argument-use-server/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/argument-use-server/page.tsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+import { action } from './action'
+import { getData } from './get-data'
+
+export default async function Page() {
+  await connection()
+
+  return <span id="data">{await getData(action)}</span>
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/client/client.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/client/client.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Client({ children }: { children: React.ReactNode }) {
+  return <span id="data">{children}</span>
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/client/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/client/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { cacheLife } from 'next/cache'
+import { connection } from 'next/server'
+import { getDate } from '../logic'
+import Client from './client'
+
+async function DynamicCache({ id }: { id: string }) {
+  'use cache: remote'
+  cacheLife('days')
+  return <Client>{getDate()}</Client>
+}
+
+export default async function Page() {
+  await connection()
+
+  return (
+    <main>
+      <Suspense>
+        <DynamicCache id="dynamic-cache" />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/logic.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/app/logic.ts
@@ -1,0 +1,3 @@
+export function getDate() {
+  return `${new Date().toISOString()}:${process.env.FOOBAR}`
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/nested/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/nested/page.tsx
@@ -1,0 +1,20 @@
+import { connection } from 'next/server'
+import { getDate } from '../logic'
+
+async function getInnerData() {
+  'use cache: remote'
+
+  return getDate()
+}
+
+async function getOuterData() {
+  'use cache: remote'
+
+  return getInnerData()
+}
+
+export default async function Page() {
+  await connection()
+
+  return <span id="data">{await getOuterData()}</span>
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
+import { getDate } from './logic'
 
 async function getData() {
-  'use cache'
+  'use cache: remote'
 
-  return new Date().toISOString()
+  return getDate()
 }
 
 async function AsyncComp() {

--- a/test/production/app-dir/use-cache-cross-deployment/app/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/page.tsx
@@ -11,7 +11,7 @@ async function getData() {
 async function AsyncComp() {
   let data = await getData()
 
-  return <p id="data">{data}</p>
+  return <span id="data">{data}</span>
 }
 
 export default async function Home() {
@@ -19,7 +19,7 @@ export default async function Home() {
 
   return (
     <main>
-      <Suspense fallback={<p>Loading...</p>}>
+      <Suspense fallback={<div>Loading...</div>}>
         <AsyncComp />
       </Suspense>
     </main>

--- a/test/production/app-dir/use-cache-cross-deployment/app/prerender/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/prerender/page.tsx
@@ -1,11 +1,12 @@
 import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
+import { getDate } from '../logic'
 
 // The id prop is just used to assert on the logged cache key in tests.
 async function DynamicCache({ id }: { id: string }) {
-  'use cache'
+  'use cache: remote'
   cacheLife('seconds')
-  return <p id="data">{new Date().toISOString()}</p>
+  return <p id="data">{getDate()}</p>
 }
 
 export default function Page() {

--- a/test/production/app-dir/use-cache-cross-deployment/app/prerender/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/prerender/page.tsx
@@ -2,7 +2,6 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { getDate } from '../logic'
 
-// The id prop is just used to assert on the logged cache key in tests.
 async function DynamicCache({ id }: { id: string }) {
   'use cache: remote'
   cacheLife('days')
@@ -11,12 +10,10 @@ async function DynamicCache({ id }: { id: string }) {
 
 export default function Page() {
   return (
-    <p>
-      This page uses a short-lived "use cache", which is omitted from the
-      prerender, but should still be saved in the cache handler.
+    <main>
       <Suspense>
         <DynamicCache id="dynamic-cache" />
       </Suspense>
-    </p>
+    </main>
   )
 }

--- a/test/production/app-dir/use-cache-cross-deployment/app/prerender/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/prerender/page.tsx
@@ -1,11 +1,12 @@
 import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
+import { getDate } from '../logic'
 
 // The id prop is just used to assert on the logged cache key in tests.
 async function DynamicCache({ id }: { id: string }) {
-  'use cache'
-  cacheLife('seconds')
-  return <p id="data">{new Date().toISOString()}</p>
+  'use cache: remote'
+  cacheLife('days')
+  return <span id="data">{getDate()}</span>
 }
 
 export default function Page() {

--- a/test/production/app-dir/use-cache-cross-deployment/app/route/route.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/app/route/route.ts
@@ -1,0 +1,14 @@
+import { connection } from 'next/server'
+import { getDate } from '../logic'
+
+async function getData() {
+  'use cache: remote'
+
+  return getDate()
+}
+
+export async function GET() {
+  await connection()
+
+  return new Response(await getData())
+}

--- a/test/production/app-dir/use-cache-cross-deployment/handler-remote.js
+++ b/test/production/app-dir/use-cache-cross-deployment/handler-remote.js
@@ -1,0 +1,119 @@
+// @ts-check
+
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * @type {Record<string, string>}
+ */
+let data = {}
+try {
+  data = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'handler-remote-data.json'), 'utf8')
+  )
+} catch (_e) {}
+
+const client = {
+  /**
+   * @param {string} key
+   * @returns unknown
+   */
+  async get(key) {
+    return data[key]
+  },
+  /**
+   *
+   * @param {string} key
+   * @param {string} value
+   * @param {{expire?: number} | undefined} options
+   */
+  async set(key, value, options) {
+    // options.expire is ignored in this impl
+    data[key] = value
+    fs.writeFileSync(
+      path.join(__dirname, 'handler-remote-data.json'),
+      JSON.stringify(data, null, 2)
+    )
+  },
+}
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+module.exports = {
+  async get(cacheKey, softTags) {
+    console.log('CustomCacheHandler::get', cacheKey, JSON.stringify([softTags]))
+    // Retrieve from Redis
+    const stored = await client.get(cacheKey)
+    if (!stored) return undefined
+
+    // Deserialize the entry
+    const data = JSON.parse(stored)
+
+    // Reconstruct the ReadableStream from stored data
+    return {
+      value: new ReadableStream({
+        start(controller) {
+          controller.enqueue(Buffer.from(data.value, 'base64'))
+          controller.close()
+        },
+      }),
+      tags: data.tags,
+      stale: data.stale,
+      timestamp: data.timestamp,
+      expire: data.expire,
+      revalidate: data.revalidate,
+    }
+  },
+
+  async set(cacheKey, pendingEntry) {
+    console.log('CustomCacheHandler::set', cacheKey)
+    const entry = await pendingEntry
+
+    // Read the stream to get the data
+    const reader = entry.value.getReader()
+    const chunks = []
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        chunks.push(value)
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    // Combine chunks and serialize for Redis storage
+    const data = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)))
+
+    await client.set(
+      cacheKey,
+      JSON.stringify({
+        value: data.toString('base64'),
+        tags: entry.tags,
+        stale: entry.stale,
+        timestamp: entry.timestamp,
+        expire: entry.expire,
+        revalidate: entry.revalidate,
+      }),
+      { expire: entry.expire }
+    )
+  },
+
+  async refreshTags() {
+    // No-op for basic Redis implementation
+    // Could sync with external tag service if needed
+  },
+
+  async getExpiration(tags) {
+    // Return 0 to indicate no tags have been revalidated
+    // Could query Redis for tag expiration timestamps if tracking them
+    return 0
+  },
+
+  async updateTags(tags, durations) {
+    // Implement tag-based invalidation if needed
+    // Could iterate over keys with matching tags and delete them
+  },
+}

--- a/test/production/app-dir/use-cache-cross-deployment/next.config.js
+++ b/test/production/app-dir/use-cache-cross-deployment/next.config.js
@@ -5,12 +5,17 @@ const nextConfig = {
   cacheComponents: true,
   cacheHandlers: {
     default: require.resolve('./handler.js'),
+    remote: require.resolve('./handler-remote.js'),
   },
   generateBuildId: process.env.BUILD_ID
     ? async () => {
         return process.env.BUILD_ID
       }
     : undefined,
+  experimental: {
+    durableUseCacheEntries:
+      process.env.DURABLE_USE_CACHE_ENTRIES === '1' ? true : undefined,
+  },
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -1,6 +1,44 @@
-import { nextTestSetup } from 'e2e-utils'
+import { type NextInstance, nextTestSetup } from 'e2e-utils'
 
-const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+async function execute(next: NextInstance, envKey: string, id: string) {
+  await next.stop()
+  if (envKey !== 'default') {
+    next.env[envKey] = id
+  }
+  try {
+    await next.start()
+
+    let keyRoot: string,
+      keyPrerender: string,
+      dataRoot: string,
+      dataPrerender: string
+    {
+      const match = next.cliOutput.match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/prerender\/layout","_N_T_\/prerender\/page","_N_T_\/prerender"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyPrerender = match[0]
+      const browser = await next.browser(`/prerender`)
+      dataPrerender = await browser.elementById('data').text()
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
+      const browser = await next.browser(`/`)
+      dataRoot = await browser.elementById('data').text()
+      const match = logs().match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/page","_N_T_\/","_N_T_\/index"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyRoot = match[0]
+    }
+    return { keyRoot, keyPrerender, dataRoot, dataPrerender }
+  } finally {
+    if (envKey !== 'default') {
+      delete next.env[envKey]
+    }
+  }
+}
 
 describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
   'use-cache-cross-deployment with %s',
@@ -16,47 +54,81 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
     // In the future, this assertion can be relaxed to only prevent sharing if the implementation
     // changed.
     it('should not have the same cache key across deployments', async () => {
-      async function execute(id: string) {
-        await next.stop()
-        if (envKey !== 'default') {
-          next.env[envKey] = id
-        }
-        try {
-          await next.start()
-          let keyRoot: string, keyPrerender: string
-
-          {
-            let match = next.cliOutput.match(
-              /CustomCacheHandler::get \["([A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\{"id":"dynamic-cache"\}\]\] \[\["_N_T_\/layout","_N_T_\/prerender\/layout","_N_T_\/prerender\/page","_N_T_\/prerender"\]\]/
-            )
-            expect(match).toBeDefined()
-            keyPrerender = match[0]
-          }
-
-          {
-            let logs = next.getCliOutputFromHere()
-            const browser = await next.browser(`/`)
-            const initialData = await browser.elementById('data').text()
-            expect(initialData).toMatch(isoDateRegExp)
-            let match = logs().match(
-              /CustomCacheHandler::get \["([A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\]\] \[\["_N_T_\/layout","_N_T_\/page","_N_T_\/","_N_T_\/index"\]\]/
-            )
-            expect(match).toBeDefined()
-            keyRoot = match[0]
-          }
-          return { keyRoot, keyPrerender }
-        } finally {
-          if (envKey !== 'default') {
-            delete next.env[envKey]
-          }
-        }
-      }
-
-      let key1 = await execute('value-1')
-      let key2 = await execute('value-2')
+      const key1 = await execute(next, envKey, 'dpl-id-1')
+      const key2 = await execute(next, envKey, 'dpl-id-2')
       // Second run should not use the same key
       expect(key1.keyRoot).not.toBe(key2.keyRoot)
       expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+      expect(key1.dataRoot).not.toBe(key2.dataRoot)
+      expect(key1.dataPrerender).not.toBe(key2.dataPrerender)
+    })
+  }
+)
+
+// durableUseCacheEntries is only supported in Turbopack
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'use-cache-cross-deployment with durableUseCacheEntries',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      disableAutoSkewProtection: true,
+      skipStart: true,
+      env: { DURABLE_USE_CACHE_ENTRIES: '1' },
+    })
+
+    if (skipped) return
+
+    it('should not recompute when nothing changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+      const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+      // Should be the same key (because the implementation didn't change)
+      expect(key1.keyRoot).toBe(key2.keyRoot)
+      expect(key1.keyPrerender).toBe(key2.keyPrerender)
+      expect(key1.dataRoot).toBe(key2.dataRoot)
+      expect(key1.dataPrerender).toBe(key2.dataPrerender)
+    })
+
+    it('should recompute when transitive implementation changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+
+      let value = String(Math.random())
+      await next.patchFile(
+        'app/logic.ts',
+        `export function getDate() {
+  return ${JSON.stringify(value)}
+}`,
+        async () => {
+          const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+          // Should not be the same key (because the implementation did change)
+          expect(key1.keyRoot).not.toBe(key2.keyRoot)
+          expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+          expect(key1.dataRoot).not.toBe(key2.dataRoot)
+          expect(key2.dataRoot).toBe(value)
+          expect(key1.dataPrerender).not.toBe(key2.dataPrerender)
+          expect(key2.dataPrerender).toBe(value)
+        }
+      )
+    })
+
+    it('should recompute when runtime env var changes', async () => {
+      let foobar1 = String(Math.random())
+      let foobar2 = String(Math.random())
+      try {
+        next.env['FOOBAR'] = foobar1
+        const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+
+        next.env['FOOBAR'] = foobar2
+        const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+        // Should not be the same key (because process.env.FOOBAR is read at runtime and changed)
+        expect(key1.keyRoot).not.toBe(key2.keyRoot)
+        expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+        expect(key1.dataRoot).toEndWith(`:${foobar1}`)
+        expect(key2.dataRoot).toEndWith(`:${foobar2}`)
+        expect(key1.dataPrerender).toEndWith(`:${foobar1}`)
+        expect(key2.dataPrerender).toEndWith(`:${foobar2}`)
+      } finally {
+        delete next.env['FOOBAR']
+      }
     })
   }
 )

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -10,11 +10,15 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 
     let keyRoot: string,
       keyNested: string,
+      keyArgumentUseCache: string,
+      keyArgumentUseServer: string,
       keyPrerender: string,
       keyClient: string,
       keyRoute: string,
       dataRoot: string,
       dataNested: string,
+      dataArgumentUseCache: string,
+      dataArgumentUseServer: string,
       dataPrerender: string,
       dataClient: string,
       dataRoute: string
@@ -69,6 +73,28 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 
     {
       const logs = next.getCliOutputFromHere()
+      const browser = await next.browser(`/argument-use-cache`)
+      dataArgumentUseCache = await browser.elementById('data').text()
+      const match = logs().match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/argument-use-cache\/layout","_N_T_\/argument-use-cache\/page","_N_T_\/argument-use-cache"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyArgumentUseCache = match[0]
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
+      const browser = await next.browser(`/argument-use-server`)
+      dataArgumentUseServer = await browser.elementById('data').text()
+      const match = logs().match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/argument-use-server\/layout","_N_T_\/argument-use-server\/page","_N_T_\/argument-use-server"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyArgumentUseServer = match[0]
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
       const browser = await next.browser(`/`)
       dataRoot = await browser.elementById('data').text()
       const match = logs().match(
@@ -80,11 +106,15 @@ async function execute(next: NextInstance, envKey: string, id: string) {
     return {
       keyRoot,
       keyNested,
+      keyArgumentUseCache,
+      keyArgumentUseServer,
       keyPrerender,
       keyClient,
       keyRoute,
       dataRoot,
       dataNested,
+      dataArgumentUseCache,
+      dataArgumentUseServer,
       dataPrerender,
       dataClient,
       dataRoute,
@@ -190,6 +220,43 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
           expect(key1.keyRoute).not.toBe(key2.keyRoute)
           expect(key1.dataRoute).not.toBe(key2.dataRoute)
           expect(key2.dataRoute).toBe(value)
+        }
+      )
+    })
+
+    // TODO when serializing server reference arguments, we need to include the server reference's
+    // entropy in the argument-part of the cache key.
+    it.skip('should recompute when a use cache reference argument changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+
+      await next.patchFile(
+        'app/argument-use-cache/action.ts',
+        (content) => content.replace("return 'first'", "return 'second'"),
+        async () => {
+          const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+
+          expect(key1.keyArgumentUseCache).not.toBe(key2.keyArgumentUseCache)
+          expect(key1.dataArgumentUseCache).not.toBe(key2.dataArgumentUseCache)
+        }
+      )
+    })
+
+    // TODO when serializing server reference arguments, we need to include the server reference's
+    // entropy in the argument-part of the cache key.
+    // Furthermore, we need to compute the metadata information for use-server functions.
+    it.skip('should recompute when a use server reference argument changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+
+      await next.patchFile(
+        'app/argument-use-server/action.ts',
+        (content) => content.replace("return 'first'", "return 'second'"),
+        async () => {
+          const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+
+          expect(key1.keyArgumentUseServer).not.toBe(key2.keyArgumentUseServer)
+          expect(key1.dataArgumentUseServer).not.toBe(
+            key2.dataArgumentUseServer
+          )
         }
       )
     })

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -10,8 +10,10 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 
     let keyRoot: string,
       keyPrerender: string,
+      keyClient: string,
       dataRoot: string,
-      dataPrerender: string
+      dataPrerender: string,
+      dataClient: string
     {
       const match = next.cliOutput.match(
         /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/prerender\/layout","_N_T_\/prerender\/page","_N_T_\/prerender"\]\]$/m
@@ -24,6 +26,23 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 
     {
       const logs = next.getCliOutputFromHere()
+      const browser = await next.browser(`/client`)
+      dataClient = await browser.elementById('data').text()
+      // Client references are only known during serialization, so they aren't part of the coarse
+      // cache key; instead the coarse key holds a redirect entry and the real entry lives at a
+      // "specific" key = coarse key + a hash suffix derived from the accessed client references'
+      // resolved manifest values.
+      const matches = [
+        ...logs().matchAll(
+          /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/client\/layout","_N_T_\/client\/page","_N_T_\/client"\]\]$/gm
+        ),
+      ]
+      expect(matches).not.toBeEmpty()
+      keyClient = matches.map((m) => m[0]).join('\n')
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
       const browser = await next.browser(`/`)
       dataRoot = await browser.elementById('data').text()
       const match = logs().match(
@@ -32,7 +51,14 @@ async function execute(next: NextInstance, envKey: string, id: string) {
       expect(match).toBeArray()
       keyRoot = match[0]
     }
-    return { keyRoot, keyPrerender, dataRoot, dataPrerender }
+    return {
+      keyRoot,
+      keyPrerender,
+      keyClient,
+      dataRoot,
+      dataPrerender,
+      dataClient,
+    }
   } finally {
     if (envKey !== 'default') {
       delete next.env[envKey]
@@ -58,13 +84,13 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
       const key2 = await execute(next, envKey, 'dpl-id-2')
       // Second run should not use the same key
       expect(key1.keyRoot).not.toBe(key2.keyRoot)
-      expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
       expect(key1.dataRoot).not.toBe(key2.dataRoot)
 
       expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
       expect(key1.dataPrerender).not.toBe(key2.dataPrerender)
 
       expect(key1.keyClient).not.toBe(key2.keyClient)
+      expect(key1.dataClient).not.toBe(key2.dataClient)
     })
   }
 )
@@ -91,18 +117,14 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
       const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
       // Should be the same key (because the implementation didn't change)
       expect(key1.keyRoot).toBe(key2.keyRoot)
-      // TODO Prerender case appears to be broken due to:
-      // Error: Unexpected cache miss after cache warming phase during prerendering. This is
-      // likely caused by non-deterministic arguments that differ between the cache warming
-      // phase and the final prerender phase (e.g. unstable array order). Ensure that arguments
-      // passed to cached functions are deterministic.
-      // expect(key1.keyPrerender).toBe(key2.keyPrerender)
       expect(key1.dataRoot).toBe(key2.dataRoot)
 
       expect(key1.keyPrerender).toBe(key2.keyPrerender)
       expect(key1.dataPrerender).toBe(key2.dataPrerender)
 
-      expect(key1.keyClient).toBe(key2.keyClient)
+      // TODO needs more granular client reference tracking
+      // expect(key1.keyClient).toBe(key2.keyClient)
+      // expect(key1.dataClient).toBe(key2.dataClient)
     })
 
     it('should recompute when transitive implementation changes', async () => {
@@ -118,7 +140,6 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
           const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
           // Should not be the same key (because the implementation did change)
           expect(key1.keyRoot).not.toBe(key2.keyRoot)
-          expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
           expect(key1.dataRoot).not.toBe(key2.dataRoot)
           expect(key2.dataRoot).toBe(value)
 
@@ -127,6 +148,8 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
           expect(key2.dataPrerender).toBe(value)
 
           expect(key1.keyClient).not.toBe(key2.keyClient)
+          expect(key1.dataClient).not.toBe(key2.dataClient)
+          expect(key2.dataClient).toBe(value)
         }
       )
     })
@@ -142,7 +165,6 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
         const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
         // Should not be the same key (because process.env.FOOBAR is read at runtime and changed)
         expect(key1.keyRoot).not.toBe(key2.keyRoot)
-        expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
         expect(key1.dataRoot).toEndWith(`:${foobar1}`)
         expect(key2.dataRoot).toEndWith(`:${foobar2}`)
 
@@ -151,9 +173,36 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
         expect(key2.dataPrerender).toEndWith(`:${foobar2}`)
 
         expect(key1.keyClient).not.toBe(key2.keyClient)
+        expect(key1.dataClient).toEndWith(`:${foobar1}`)
+        expect(key2.dataClient).toEndWith(`:${foobar2}`)
       } finally {
         delete next.env['FOOBAR']
       }
+    })
+
+    it('should recompute when client reference changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+      await next.patchFile(
+        'app/client/client.tsx',
+        (oldContent) =>
+          oldContent.replace(
+            "'use client'",
+            "'use client'\n\nawait Promise.resolve()"
+          ),
+        async () => {
+          const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+          // Should be the same key (because the implementation didn't change)
+          expect(key1.keyRoot).toBe(key2.keyRoot)
+          expect(key1.dataRoot).toBe(key2.dataRoot)
+
+          expect(key1.keyPrerender).toBe(key2.keyPrerender)
+          expect(key1.dataPrerender).toBe(key2.dataPrerender)
+
+          // Is different, the client code and async:false->true
+          expect(key1.keyClient).not.toBe(key2.keyClient)
+          expect(key1.dataClient).not.toBe(key2.dataClient)
+        }
+      )
     })
   }
 )

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -1,6 +1,44 @@
-import { nextTestSetup } from 'e2e-utils'
+import { type NextInstance, nextTestSetup } from 'e2e-utils'
 
-const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+async function execute(next: NextInstance, envKey: string, id: string) {
+  await next.stop()
+  if (envKey !== 'default') {
+    next.env[envKey] = id
+  }
+  try {
+    await next.start()
+
+    let keyRoot: string,
+      keyPrerender: string,
+      dataRoot: string,
+      dataPrerender: string
+    {
+      const match = next.cliOutput.match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/prerender\/layout","_N_T_\/prerender\/page","_N_T_\/prerender"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyPrerender = match[0]
+      const browser = await next.browser(`/prerender`)
+      dataPrerender = await browser.elementById('data').text()
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
+      const browser = await next.browser(`/`)
+      dataRoot = await browser.elementById('data').text()
+      const match = logs().match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/page","_N_T_\/","_N_T_\/index"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyRoot = match[0]
+    }
+    return { keyRoot, keyPrerender, dataRoot, dataPrerender }
+  } finally {
+    if (envKey !== 'default') {
+      delete next.env[envKey]
+    }
+  }
+}
 
 describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
   'use-cache-cross-deployment with %s',
@@ -16,47 +54,106 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
     // In the future, this assertion can be relaxed to only prevent sharing if the implementation
     // changed.
     it('should not have the same cache key across deployments', async () => {
-      async function execute(id: string) {
-        await next.stop()
-        if (envKey !== 'default') {
-          next.env[envKey] = id
-        }
-        try {
-          await next.start()
-          let keyRoot: string, keyPrerender: string
-
-          {
-            let match = next.cliOutput.match(
-              /CustomCacheHandler::get \["([A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\{"id":"dynamic-cache"\}\]\] \[\["_N_T_\/layout","_N_T_\/prerender\/layout","_N_T_\/prerender\/page","_N_T_\/prerender"\]\]/
-            )
-            expect(match).toBeDefined()
-            keyPrerender = match[0]
-          }
-
-          {
-            let logs = next.getCliOutputFromHere()
-            const browser = await next.browser(`/`)
-            const initialData = await browser.elementById('data').text()
-            expect(initialData).toMatch(isoDateRegExp)
-            let match = logs().match(
-              /CustomCacheHandler::get \["([A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\]\] \[\["_N_T_\/layout","_N_T_\/page","_N_T_\/","_N_T_\/index"\]\]/
-            )
-            expect(match).toBeDefined()
-            keyRoot = match[0]
-          }
-          return { keyRoot, keyPrerender }
-        } finally {
-          if (envKey !== 'default') {
-            delete next.env[envKey]
-          }
-        }
-      }
-
-      let key1 = await execute('value-1')
-      let key2 = await execute('value-2')
+      const key1 = await execute(next, envKey, 'dpl-id-1')
+      const key2 = await execute(next, envKey, 'dpl-id-2')
       // Second run should not use the same key
       expect(key1.keyRoot).not.toBe(key2.keyRoot)
       expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+      expect(key1.dataRoot).not.toBe(key2.dataRoot)
+
+      expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+      expect(key1.dataPrerender).not.toBe(key2.dataPrerender)
+
+      expect(key1.keyClient).not.toBe(key2.keyClient)
+    })
+  }
+)
+
+// durableUseCacheEntries is only supported in Turbopack
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'use-cache-cross-deployment with durableUseCacheEntries',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      disableAutoSkewProtection: true,
+      skipStart: true,
+      env: { DURABLE_USE_CACHE_ENTRIES: '1' },
+    })
+
+    if (skipped) return
+
+    beforeEach(async () => {
+      await next.deleteFile('handler-remote-data.json')
+    })
+
+    it('should not recompute when nothing changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+      const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+      // Should be the same key (because the implementation didn't change)
+      expect(key1.keyRoot).toBe(key2.keyRoot)
+      // TODO Prerender case appears to be broken due to:
+      // Error: Unexpected cache miss after cache warming phase during prerendering. This is
+      // likely caused by non-deterministic arguments that differ between the cache warming
+      // phase and the final prerender phase (e.g. unstable array order). Ensure that arguments
+      // passed to cached functions are deterministic.
+      // expect(key1.keyPrerender).toBe(key2.keyPrerender)
+      expect(key1.dataRoot).toBe(key2.dataRoot)
+
+      expect(key1.keyPrerender).toBe(key2.keyPrerender)
+      expect(key1.dataPrerender).toBe(key2.dataPrerender)
+
+      expect(key1.keyClient).toBe(key2.keyClient)
+    })
+
+    it('should recompute when transitive implementation changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+
+      let value = String(Math.random())
+      await next.patchFile(
+        'app/logic.ts',
+        `export function getDate() {
+  return ${JSON.stringify(value)}
+}`,
+        async () => {
+          const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+          // Should not be the same key (because the implementation did change)
+          expect(key1.keyRoot).not.toBe(key2.keyRoot)
+          expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+          expect(key1.dataRoot).not.toBe(key2.dataRoot)
+          expect(key2.dataRoot).toBe(value)
+
+          expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+          expect(key1.dataPrerender).not.toBe(key2.dataPrerender)
+          expect(key2.dataPrerender).toBe(value)
+
+          expect(key1.keyClient).not.toBe(key2.keyClient)
+        }
+      )
+    })
+
+    it('should recompute when runtime env var changes', async () => {
+      let foobar1 = String(Math.random())
+      let foobar2 = String(Math.random())
+      try {
+        next.env['FOOBAR'] = foobar1
+        const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+
+        next.env['FOOBAR'] = foobar2
+        const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+        // Should not be the same key (because process.env.FOOBAR is read at runtime and changed)
+        expect(key1.keyRoot).not.toBe(key2.keyRoot)
+        expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+        expect(key1.dataRoot).toEndWith(`:${foobar1}`)
+        expect(key2.dataRoot).toEndWith(`:${foobar2}`)
+
+        expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
+        expect(key1.dataPrerender).toEndWith(`:${foobar1}`)
+        expect(key2.dataPrerender).toEndWith(`:${foobar2}`)
+
+        expect(key1.keyClient).not.toBe(key2.keyClient)
+      } finally {
+        delete next.env['FOOBAR']
+      }
     })
   }
 )

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -11,9 +11,11 @@ async function execute(next: NextInstance, envKey: string, id: string) {
     let keyRoot: string,
       keyPrerender: string,
       keyClient: string,
+      keyRoute: string,
       dataRoot: string,
       dataPrerender: string,
-      dataClient: string
+      dataClient: string,
+      dataRoute: string
     {
       const match = next.cliOutput.match(
         /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/prerender\/layout","_N_T_\/prerender\/page","_N_T_\/prerender"\]\]$/m
@@ -43,6 +45,17 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 
     {
       const logs = next.getCliOutputFromHere()
+      const response = await next.fetch(`/route`)
+      dataRoute = await response.text()
+      const match = logs().match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/route","_N_T_\/route\/route"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyRoute = match[0]
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
       const browser = await next.browser(`/`)
       dataRoot = await browser.elementById('data').text()
       const match = logs().match(
@@ -55,9 +68,11 @@ async function execute(next: NextInstance, envKey: string, id: string) {
       keyRoot,
       keyPrerender,
       keyClient,
+      keyRoute,
       dataRoot,
       dataPrerender,
       dataClient,
+      dataRoute,
     }
   } finally {
     if (envKey !== 'default') {
@@ -91,6 +106,9 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
 
       expect(key1.keyClient).not.toBe(key2.keyClient)
       expect(key1.dataClient).not.toBe(key2.dataClient)
+
+      expect(key1.keyRoute).not.toBe(key2.keyRoute)
+      expect(key1.dataRoute).not.toBe(key2.dataRoute)
     })
   }
 )
@@ -122,6 +140,9 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
       expect(key1.keyPrerender).toBe(key2.keyPrerender)
       expect(key1.dataPrerender).toBe(key2.dataPrerender)
 
+      expect(key1.keyRoute).toBe(key2.keyRoute)
+      expect(key1.dataRoute).toBe(key2.dataRoute)
+
       // TODO needs more granular client reference tracking
       // expect(key1.keyClient).toBe(key2.keyClient)
       // expect(key1.dataClient).toBe(key2.dataClient)
@@ -150,6 +171,10 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
           expect(key1.keyClient).not.toBe(key2.keyClient)
           expect(key1.dataClient).not.toBe(key2.dataClient)
           expect(key2.dataClient).toBe(value)
+
+          expect(key1.keyRoute).not.toBe(key2.keyRoute)
+          expect(key1.dataRoute).not.toBe(key2.dataRoute)
+          expect(key2.dataRoute).toBe(value)
         }
       )
     })
@@ -182,6 +207,12 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
         expect(key2.dataClient).toEndWith(`:${foobar2}`)
         expect(key1.keyClient).not.toContain(foobar1)
         expect(key2.keyClient).not.toContain(foobar2)
+
+        expect(key1.keyRoute).not.toBe(key2.keyRoute)
+        expect(key1.dataRoute).toEndWith(`:${foobar1}`)
+        expect(key2.dataRoute).toEndWith(`:${foobar2}`)
+        expect(key1.keyRoute).not.toContain(foobar1)
+        expect(key2.keyRoute).not.toContain(foobar2)
       } finally {
         delete next.env['FOOBAR']
       }
@@ -204,6 +235,9 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
 
           expect(key1.keyPrerender).toBe(key2.keyPrerender)
           expect(key1.dataPrerender).toBe(key2.dataPrerender)
+
+          expect(key1.keyRoute).toBe(key2.keyRoute)
+          expect(key1.dataRoute).toBe(key2.dataRoute)
 
           // Is different, the client code and async:false->true
           expect(key1.keyClient).not.toBe(key2.keyClient)

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -11,6 +11,7 @@ async function execute(next: NextInstance, envKey: string, id: string) {
     let keyRoot: string,
       keyNested: string,
       keyArgumentUseCache: string,
+      keyArgumentUseClient: string,
       keyArgumentUseServer: string,
       keyPrerender: string,
       keyClient: string,
@@ -18,6 +19,7 @@ async function execute(next: NextInstance, envKey: string, id: string) {
       dataRoot: string,
       dataNested: string,
       dataArgumentUseCache: string,
+      dataArgumentUseClient: string,
       dataArgumentUseServer: string,
       dataPrerender: string,
       dataClient: string,
@@ -84,6 +86,17 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 
     {
       const logs = next.getCliOutputFromHere()
+      const browser = await next.browser(`/argument-use-client`)
+      dataArgumentUseClient = await browser.elementById('data').text()
+      const match = logs().match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/argument-use-client\/layout","_N_T_\/argument-use-client\/page","_N_T_\/argument-use-client"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyArgumentUseClient = match[0]
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
       const browser = await next.browser(`/argument-use-server`)
       dataArgumentUseServer = await browser.elementById('data').text()
       const match = logs().match(
@@ -107,6 +120,7 @@ async function execute(next: NextInstance, envKey: string, id: string) {
       keyRoot,
       keyNested,
       keyArgumentUseCache,
+      keyArgumentUseClient,
       keyArgumentUseServer,
       keyPrerender,
       keyClient,
@@ -114,6 +128,7 @@ async function execute(next: NextInstance, envKey: string, id: string) {
       dataRoot,
       dataNested,
       dataArgumentUseCache,
+      dataArgumentUseClient,
       dataArgumentUseServer,
       dataPrerender,
       dataClient,
@@ -306,7 +321,7 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
       }
     })
 
-    it('should recompute when client reference changes', async () => {
+    it('should recompute when client reference import changes', async () => {
       const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
       await next.patchFile(
         'app/client/client.tsx',
@@ -330,6 +345,27 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
           // Is different, the client code and async:false->true
           expect(key1.keyClient).not.toBe(key2.keyClient)
           expect(key1.dataClient).not.toBe(key2.dataClient)
+        }
+      )
+    })
+
+    // TODO this seems like a preexisting bug? The reference gets serialized into the cache key as just "$T"
+    it.skip('should recompute when a client reference argument changes', async () => {
+      const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
+      await next.patchFile(
+        'app/argument-use-client/client.tsx',
+        (oldContent) =>
+          oldContent.replace(
+            "'use client'",
+            "'use client'\n\nawait Promise.resolve()"
+          ),
+        async () => {
+          const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')
+
+          expect(key1.keyArgumentUseClient).not.toBe(key2.keyArgumentUseClient)
+          expect(key1.dataArgumentUseClient).not.toBe(
+            key2.dataArgumentUseClient
+          )
         }
       )
     })

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -9,10 +9,12 @@ async function execute(next: NextInstance, envKey: string, id: string) {
     await next.start()
 
     let keyRoot: string,
+      keyNested: string,
       keyPrerender: string,
       keyClient: string,
       keyRoute: string,
       dataRoot: string,
+      dataNested: string,
       dataPrerender: string,
       dataClient: string,
       dataRoute: string
@@ -56,6 +58,17 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 
     {
       const logs = next.getCliOutputFromHere()
+      const browser = await next.browser(`/nested`)
+      dataNested = await browser.elementById('data').text()
+      const match = logs().match(
+        /^CustomCacheHandler::get .* \[\["_N_T_\/layout","_N_T_\/nested\/layout","_N_T_\/nested\/page","_N_T_\/nested"\]\]$/m
+      )
+      expect(match).toBeArray()
+      keyNested = match[0]
+    }
+
+    {
+      const logs = next.getCliOutputFromHere()
       const browser = await next.browser(`/`)
       dataRoot = await browser.elementById('data').text()
       const match = logs().match(
@@ -66,10 +79,12 @@ async function execute(next: NextInstance, envKey: string, id: string) {
     }
     return {
       keyRoot,
+      keyNested,
       keyPrerender,
       keyClient,
       keyRoute,
       dataRoot,
+      dataNested,
       dataPrerender,
       dataClient,
       dataRoute,
@@ -195,6 +210,12 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
         // The env var value should not be leaked into the cache key, only hashes of it.
         expect(key1.keyRoot).not.toContain(foobar1)
         expect(key2.keyRoot).not.toContain(foobar2)
+
+        expect(key1.keyNested).not.toBe(key2.keyNested)
+        expect(key1.dataNested).toEndWith(`:${foobar1}`)
+        expect(key2.dataNested).toEndWith(`:${foobar2}`)
+        expect(key1.keyNested).not.toContain(foobar1)
+        expect(key2.keyNested).not.toContain(foobar2)
 
         expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
         expect(key1.dataPrerender).toEndWith(`:${foobar1}`)

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -167,14 +167,21 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
         expect(key1.keyRoot).not.toBe(key2.keyRoot)
         expect(key1.dataRoot).toEndWith(`:${foobar1}`)
         expect(key2.dataRoot).toEndWith(`:${foobar2}`)
+        // The env var value should not be leaked into the cache key, only hashes of it.
+        expect(key1.keyRoot).not.toContain(foobar1)
+        expect(key2.keyRoot).not.toContain(foobar2)
 
         expect(key1.keyPrerender).not.toBe(key2.keyPrerender)
         expect(key1.dataPrerender).toEndWith(`:${foobar1}`)
         expect(key2.dataPrerender).toEndWith(`:${foobar2}`)
+        expect(key1.keyPrerender).not.toContain(foobar1)
+        expect(key2.keyPrerender).not.toContain(foobar2)
 
         expect(key1.keyClient).not.toBe(key2.keyClient)
         expect(key1.dataClient).toEndWith(`:${foobar1}`)
         expect(key2.dataClient).toEndWith(`:${foobar2}`)
+        expect(key1.keyClient).not.toContain(foobar1)
+        expect(key2.keyClient).not.toContain(foobar2)
       } finally {
         delete next.env['FOOBAR']
       }

--- a/test/production/custom-server/custom-server.test.ts
+++ b/test/production/custom-server/custom-server.test.ts
@@ -115,6 +115,6 @@ function createCacheSetLogRegExp(id: string) {
   // Expect a requestId, that's provided through ALS, to be present in the log
   // message for the cache handler set call.
   return new RegExp(
-    `set cache \\["[A-Za-z0-9_-]+","(?:[0-9a-f]{2})+",\\[{"id":"${id}"}]\\] requestId: \\d+`
+    `set cache \\["(?:[0-9a-f]{2})+",\\[{"id":"${id}"}\\],\\["[A-Za-z0-9_-]+"(?:,"[^"]+")*\\]\\] requestId: \\d+`
   )
 }


### PR DESCRIPTION
Caveats:
- I had to skip `react[-dom][/*]` and `private-next-rsc-server-reference` and `private-next-rsc-cache-wrapper` imports in the code hash and env-var tracking. Because those all end up pulling in app-page-turbo.runtime.prod.js which reads many env vars and would cause constant deopting. But this should still be correct. The code of these imports is included via the Next.js version, and no env vars should change the semantics of any of those imports.
- Static env var reads are collected, but too dynamic accesses are silently ignored and don't lead to deopts (same goes for env var reads in native NAPI addons). This means that this cache reuse is not guaranteed to be 100% guaranteed to never lead to stale caches.
- Code hashing and env var collection happens on a per-module basis. So if you put all use-cache functions into a single file and/or together with react components, then you will see extraneous invalidations. This will be fixed by either generally enabling module splitting for all of Turbopack, or by adding a special transform that does it for use-cache functions.

Followups:
- There are some env var static analysis gaps that will be immediate followups before broader testing. These are the various TODOs added in https://github.com/vercel/next.js/pull/95310
- Client components invalidation is very coarse grained right now (statically imports any client component anywhere -> deopt completely). Followup for the future. But the current setup is correct. This would just improve effectiveness further
- Do this in dev as well. Currently there is no NFT at all in dev (for performance reasons)
- Module splitting for more granular tracking
- Include entropy when serializing server reference arguments for cache key


Todo:

- [x] Use implementation code hash (includes inlined env vars): from #94234
- [x] Include non-inlined runtime env vars: from #95310
- [x] Include client reference manifest (very coarse for now)
- [x] Include Next.js version (for wire format, etc)
- [x] This is now done for all use-cache entries now. Not just for `use cache: remote`. Is that the intended behavior? Yes
- [ ] ~~if `NEXT_DEPLOYMENT_ID` is in the env vars. just deopt and don't care about stringifing and hashing the env vars~~
- [x] Is cache key size a problem? Currently you can get this: (values are always hashed)
`CustomCacheHandler::get ["80e6f6560092f0078775e7e787c1c10ecf6dea0bc4",[],["d984fbaa996274737f3b59345a300a20","16.4.0-canary.5","__NEXT_NO_MIDDLEWARE_URL_NORMALIZE=undefined","NEXT_OTEL_PERFORMANCE_PREFIX=undefined","__NEXT_PRIVATE_ORIGIN=a04f4b9d6a8f42724740a480e9a2bc67c053dc04377be831c0e2c407a1422004","NEXT_PRIVATE_RESPONSE_CACHE_TTL=undefined","NEXT_PRIVATE_RESPONSE_CACHE_MAX_SIZE=undefined","__NEXT_CACHE_COMPONENTS=b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b","__NEXT_ROUTER_BASEPATH=undefined","__NEXT_MANUAL_CLIENT_BASE_PATH=undefined","__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS=undefined","__NEXT_APP_NAV_FAIL_HANDLING=undefined","__NEXT_GESTURE_TRANSITION=undefined","__NEXT_USE_OFFLINE=undefined","NEXT_DEBUG_BUILD=undefined","__NEXT_VERBOSE_LOGGING=undefined...]] [["_N_T_/layout","_N_T_/page","_N_T_/","_N_T_/index"]]`