### PR TITLE
[test] Enable deploy tests for the Instant Navigation Testing API suite

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -305,6 +305,7 @@ export default defineConfig([
         {
           additionalTestBlockFunctions: [
             'retry',
+            'itSkipDeploy',
             'itCI',
             'itHeaded',
             'itTurbopack',

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/[scope]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/[scope]/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers'
+import { connection } from 'next/server'
 
 // The deeper, blocking segment of the fallback route: awaits the uncovered
 // `scope` param and reads request-time `cookies()`, and has no <Suspense> of
@@ -31,6 +32,14 @@ export default async function ScopePage({
 }
 
 async function Secret() {
+  // `await connection()` makes the segment strictly dynamic so no prefetch can
+  // render it, which is what keeps it deferred under the instant lock.
+  // `cookies()` alone would not suffice: the app-shell prefetch carries cookies
+  // and could render the segment, while the empty static speculative prefetch
+  // renders nothing here, so whichever reaches the segment cache first would
+  // decide whether the content appears. `connection()` resolves only with a
+  // real request, which no prefetch has.
+  await connection()
   const cookieStore = await cookies()
   return (
     <div data-testid="blocking-secret">

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
@@ -39,13 +39,8 @@ export default function HomePage() {
           </Link>
         </li>
         <li>
-          <Link href="/dynamic-params/unknown" id="link-to-dynamic-params">
-            Go to dynamic params page
-          </Link>
-        </li>
-        <li>
-          <Link href="/dynamic-params/hello" id="link-to-static-dynamic-params">
-            Go to static dynamic params page
+          <Link href="/static-params/hello" id="link-to-static-params">
+            Go to static params page
           </Link>
         </li>
         <li>
@@ -96,16 +91,16 @@ export default function HomePage() {
           </a>
         </li>
         <li>
-          <a href="/dynamic-params/unknown" id="plain-link-to-dynamic-params">
-            Go to dynamic params page (MPA)
+          <a
+            href="/ungenerated-params/anything"
+            id="plain-link-to-ungenerated-params"
+          >
+            Go to ungenerated params page (MPA)
           </a>
         </li>
         <li>
-          <a
-            href="/dynamic-params/hello"
-            id="plain-link-to-static-dynamic-params"
-          >
-            Go to static dynamic params page (MPA)
+          <a href="/static-params/hello" id="plain-link-to-static-params">
+            Go to static params page (MPA)
           </a>
         </li>
         <li>

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/static-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/static-params/[slug]/page.tsx
@@ -4,16 +4,18 @@ export function generateStaticParams() {
   return [{ slug: 'hello' }]
 }
 
-export default function DynamicParamsPage({
+export default function StaticParamsPage({
   params,
 }: {
   params: Promise<{ slug: string }>
 }) {
   return (
     <div>
-      <h1 data-testid="dynamic-params-title">Dynamic Params Page</h1>
+      <h1 data-testid="static-params-title">Static Params Page</h1>
       <Suspense
-        fallback={<div data-testid="params-fallback">Loading params...</div>}
+        fallback={
+          <div data-testid="static-params-fallback">Loading params...</div>
+        }
       >
         <ParamContent params={params} />
       </Suspense>
@@ -24,5 +26,5 @@ export default function DynamicParamsPage({
 async function ParamContent({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
 
-  return <div data-testid="param-value">slug: {slug}</div>
+  return <div data-testid="static-param-value">slug: {slug}</div>
 }

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -22,8 +22,15 @@
  * API in production mode for testing purposes.
  */
 
-import { NextInstance, nextTestSetup, isNextDev } from 'e2e-utils'
+import {
+  NextInstance,
+  nextTestSetup,
+  isNextDev,
+  isNextDeploy,
+  type Playwright as NextBrowser,
+} from 'e2e-utils'
 import { instant } from '@next/playwright'
+import { assertNoConsoleErrors } from 'next-test-utils'
 import type * as Playwright from 'playwright'
 import { join } from 'node:path'
 
@@ -35,15 +42,33 @@ import { join } from 'node:path'
  * Next.js test infra wraps Playwright with its own BrowserInterface, but
  * the Instant Navigation Testing API is designed to work with native Playwright.
  */
+// The browser and full-document navigation requests for the currently running
+// test. openPage populates these so a shared afterEach can assert there were no
+// console errors (e.g. a failed hydration) and individual tests can assert that
+// releasing the instant lock resolves client-side instead of hard reloading.
+let activeBrowser: NextBrowser | undefined
+let navigationRequests: string[] = []
+
 async function openPage(
   next: NextInstance,
   url: string,
   options?: { cookies?: Array<{ name: string; value: string }> }
 ): Promise<Playwright.Page> {
   let page: Playwright.Page
-  await next.browser(url, {
+  navigationRequests = []
+  activeBrowser = await next.browser(url, {
+    // Surface uncaught page errors (e.g. a failed hydration) as console logs so
+    // assertNoConsoleErrors fails the test on them.
+    pushErrorAsConsoleLog: true,
     beforePageLoad(p) {
       page = p
+      // Record full-document navigations so tests can assert that releasing the
+      // instant lock does not trigger a hard reload.
+      p.on('request', (request) => {
+        if (request.isNavigationRequest()) {
+          navigationRequests.push(new URL(request.url()).pathname)
+        }
+      })
       if (options?.cookies) {
         const { hostname } = new URL(next.url)
         p.context().addCookies(
@@ -63,12 +88,35 @@ async function openPage(
   return page
 }
 
+afterEach(async () => {
+  if (activeBrowser) {
+    // Console-error checking targets production minified React errors (e.g. a
+    // failed hydration on deploy, which is how the instant bootstrap regression
+    // surfaced). Development legitimately logs warnings here (such as a
+    // blocking-route prerender insight), so only assert in production.
+    if (!isNextDev) {
+      // TODO: Hydration is currently broken on deploy, so skip this check until
+      // it is fixed.
+      if (!isNextDeploy) {
+        await assertNoConsoleErrors(activeBrowser)
+      }
+    }
+    activeBrowser = undefined
+  }
+})
+
+// The Instant Navigation lock re-engages on a freshly loaded document via the
+// prerendered-shell bootstrap (`self.__next_instant_test`). That bootstrap is
+// embedded into the prelude in #95222; until then it is missing from the
+// deploy-served document, so any test that drives a full-page load under the
+// lock (a plain-anchor MPA navigation or a reload) engages the lock unreliably
+// on deploy. We skip those in deploy mode and un-skip them in #95222 by turning
+// this back into a plain `it`.
+const itSkipDeploy = isNextDeploy ? it.skip : it
+
 describe('instant-navigation-testing-api', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'default'),
-    // Skip deployment tests because the exposeTestingApiInProductionBuild flag
-    // doesn't exist in the production version of Next.js yet
-    skipDeployment: true,
   })
 
   it('renders prefetched loading shell instantly during navigation', async () => {
@@ -89,12 +137,16 @@ describe('instant-navigation-testing-api', () => {
       expect(await dynamicContent.count()).toBe(0)
     })
 
-    // After exiting the instant scope, dynamic content streams in
+    // After exiting the instant scope, dynamic content streams in. Releasing
+    // the lock must resolve client-side rather than hard reloading the
+    // document.
+    const navigationsAtUnlock = navigationRequests.length
     const dynamicContent = page.locator('[data-testid="dynamic-content"]')
     await dynamicContent.waitFor({ state: 'visible' })
     expect(await dynamicContent.textContent()).toContain(
       'Dynamic content loaded'
     )
+    expect(navigationRequests.length).toBe(navigationsAtUnlock)
   })
 
   it('renders runtime-prefetched content instantly during navigation', async () => {
@@ -299,7 +351,8 @@ describe('instant-navigation-testing-api', () => {
     }
   })
 
-  it('renders shell on page reload', async () => {
+  // prettier-ignore
+  itSkipDeploy('renders shell on page reload', async () => {
     const page = await openPage(next, '/target-page')
 
     // Wait for the page to fully load with dynamic content
@@ -319,16 +372,30 @@ describe('instant-navigation-testing-api', () => {
 
       // Dynamic content has not streamed in yet
       expect(await dynamicContent.count()).toBe(0)
+
+      // Wait for the instant-mode hydration to finish before releasing the
+      // lock. This mirrors real usage, where the cookie is cleared (e.g. via
+      // DevTools) after the page is interactive, so the unlock resolves
+      // client-side. Releasing before hydration completes intentionally falls
+      // back to a hard reload (see refreshOnInstantNavigationUnlock).
+      await page.waitForFunction(
+        () => (globalThis as any).__NEXT_HYDRATED === true
+      )
     })
 
-    // After exiting the instant scope, dynamic content streams in
+    // After exiting the instant scope, dynamic content streams in. Releasing
+    // the lock must resolve client-side rather than hard reloading the
+    // document.
+    const navigationsAtUnlock = navigationRequests.length
     await dynamicContent.waitFor({ state: 'visible' })
     expect(await dynamicContent.textContent()).toContain(
       'Dynamic content loaded'
     )
+    expect(navigationRequests.length).toBe(navigationsAtUnlock)
   })
 
-  it('renders shell on MPA navigation via plain anchor', async () => {
+  // prettier-ignore
+  itSkipDeploy('renders shell on MPA navigation via plain anchor', async () => {
     const page = await openPage(next, '/')
 
     await instant(page, async () => {
@@ -355,7 +422,8 @@ describe('instant-navigation-testing-api', () => {
     )
   })
 
-  it('reload followed by MPA navigation, both block dynamic data', async () => {
+  // prettier-ignore
+  itSkipDeploy('reload followed by MPA navigation, both block dynamic data', async () => {
     const page = await openPage(next, '/')
 
     await instant(page, async () => {
@@ -386,7 +454,7 @@ describe('instant-navigation-testing-api', () => {
     )
   })
 
-  it('successive MPA navigations within instant scope', async () => {
+  itSkipDeploy('successive MPA navigations within instant scope', async () => {
     const page = await openPage(next, '/')
 
     await instant(page, async () => {
@@ -432,13 +500,13 @@ describe('instant-navigation-testing-api', () => {
   // (withheld) param before it reaches the cookie. On a full page load the
   // document render defers the cookie regardless.
   describe('cookies in the instant shell', () => {
-    // Marked failing: `/cookies-page` is a non-partial route (it opts into
-    // neither `partialPrefetching` nor a per-route `prefetch`/`instant`
-    // config), so its speculative static prefetch is fuller than the app-shell
-    // render and supersedes it in the segment cache. The cookie that only the
-    // app shell carries is dropped before it reaches the instant shell, and
-    // #95150's shell handling only engages under partial prefetching, so it
-    // does not cover this case.
+    // Skipped: `/cookies-page` is a non-partial route (it opts into neither
+    // `partialPrefetching` nor a per-route `prefetch`/`instant` config), so its
+    // speculative static prefetch is fuller than the app-shell render and
+    // supersedes it in the segment cache if it's applied last. The cookie that
+    // only the app shell carries is dropped before it reaches the instant
+    // shell, and #95150's shell handling only engages under partial
+    // prefetching, so it does not cover this case.
     //
     // If we later detect that a route reads cookies during app-shell
     // generation, we should opt it into either partial prefetching, so that
@@ -447,31 +515,28 @@ describe('instant-navigation-testing-api', () => {
     // initially showed, and cookie-dependent content is not removed once a
     // speculative prefetch (for a link whose instant app shell we already
     // displayed) has settled.
-    it.failing(
-      'includes app-shell cookie values in the instant shell during client navigation',
-      async () => {
-        const page = await openPage(next, '/', {
-          cookies: [{ name: 'testCookie', value: 'hello' }],
-        })
+    it.skip('includes app-shell cookie values in the instant shell during client navigation', async () => {
+      const page = await openPage(next, '/', {
+        cookies: [{ name: 'testCookie', value: 'hello' }],
+      })
 
-        await instant(page, async () => {
-          await page.click('#link-to-cookies-page')
+      await instant(page, async () => {
+        await page.click('#link-to-cookies-page')
 
-          const title = page.locator('[data-testid="cookies-page-title"]')
-          await title.waitFor({ state: 'visible' })
+        const title = page.locator('[data-testid="cookies-page-title"]')
+        await title.waitFor({ state: 'visible' })
 
-          // Cookies are session data in the app shell, and nothing gates them,
-          // so the value should be available inside the instant scope.
-          const cookieValue = page.locator('[data-testid="cookie-value"]')
-          // Expected-failing today (see the note above): the cookie never reaches
-          // the shell, so cap the wait rather than spend the default 60s on a
-          // known timeout. A real fix puts the cookie in the same captured shell
-          // as the title above, so it surfaces well within this.
-          await cookieValue.waitFor({ state: 'visible', timeout: 3000 })
-          expect(await cookieValue.textContent()).toContain('testCookie: hello')
-        })
-      }
-    )
+        // Cookies are session data in the app shell, and nothing gates them,
+        // so the value should be available inside the instant scope.
+        const cookieValue = page.locator('[data-testid="cookie-value"]')
+        // Expected-failing today (see the note above): the cookie never reaches
+        // the shell, so cap the wait rather than spend the default 60s on a
+        // known timeout. A real fix puts the cookie in the same captured shell
+        // as the title above, so it surfaces well within this.
+        await cookieValue.waitFor({ state: 'visible', timeout: 3000 })
+        expect(await cookieValue.textContent()).toContain('testCookie: hello')
+      })
+    })
 
     it('excludes a cookie read after a param access from the instant shell during client navigation', async () => {
       const page = await openPage(next, '/', {
@@ -500,7 +565,8 @@ describe('instant-navigation-testing-api', () => {
       expect(await cookieValue.textContent()).toContain('testCookie: hello')
     })
 
-    it('does not include cookie values in instant shell during page load', async () => {
+    // prettier-ignore
+    itSkipDeploy('does not include cookie values in instant shell during page load', async () => {
       const page = await openPage(next, '/', {
         cookies: [{ name: 'testCookie', value: 'hello' }],
       })
@@ -525,43 +591,17 @@ describe('instant-navigation-testing-api', () => {
     })
   })
 
-  // Verifies that dynamic route params and search params are excluded from the
-  // instant navigation shell. The shell should only contain static content —
-  // these runtime values should be blocked behind a Suspense boundary until the
-  // instant lock is released. (Cookies are session data carried by the app
-  // shell and are covered separately below.)
+  // Verifies that search params are excluded from the instant navigation shell.
+  // The shell should only contain static content — these runtime values should
+  // be blocked behind a Suspense boundary until the instant lock is released.
+  // (Cookies are session data carried by the app shell, and dynamic route
+  // params without `generateStaticParams` are covered separately below.)
   //
-  // Each test route reads a different runtime param inside a <Suspense>
-  // boundary without opting into `instant: { prefetch: 'runtime' }`.
-  // During the instant scope, the static page title should be visible and the
-  // Suspense fallback should be shown, but the resolved param value should
-  // NOT be present.
-  describe('runtime params are excluded from instant shell', () => {
-    it('does not include dynamic param values in instant shell during client navigation', async () => {
-      const page = await openPage(next, '/')
-
-      await instant(page, async () => {
-        await page.click('#link-to-dynamic-params')
-
-        // Static page title is visible
-        const title = page.locator('[data-testid="dynamic-params-title"]')
-        await title.waitFor({ state: 'visible' })
-
-        // Suspense fallback is visible
-        const fallback = page.locator('[data-testid="params-fallback"]')
-        await fallback.waitFor({ state: 'visible' })
-
-        // Param value is NOT in the shell
-        const paramValue = page.locator('[data-testid="param-value"]')
-        expect(await paramValue.count()).toBe(0)
-      })
-
-      // After exiting instant scope, param value streams in
-      const paramValue = page.locator('[data-testid="param-value"]')
-      await paramValue.waitFor({ state: 'visible' })
-      expect(await paramValue.textContent()).toContain('slug: unknown')
-    })
-
+  // The route reads the search param inside a <Suspense> boundary without
+  // opting into `instant: { prefetch: 'runtime' }`. During the instant scope,
+  // the static page title should be visible and the Suspense fallback should be
+  // shown, but the resolved value should NOT be present.
+  describe('search params are excluded from instant shell', () => {
     it('does not include search param values in instant shell during client navigation', async () => {
       const page = await openPage(next, '/')
 
@@ -591,32 +631,8 @@ describe('instant-navigation-testing-api', () => {
       expect(await searchParamContent.textContent()).toContain('foo: bar')
     })
 
-    it('does not include dynamic param values in instant shell during page load', async () => {
-      const page = await openPage(next, '/')
-
-      await instant(page, async () => {
-        await page.click('#plain-link-to-dynamic-params')
-
-        // Static page title is visible
-        const title = page.locator('[data-testid="dynamic-params-title"]')
-        await title.waitFor({ state: 'visible' })
-
-        // Suspense fallback is visible
-        const fallback = page.locator('[data-testid="params-fallback"]')
-        await fallback.waitFor({ state: 'visible' })
-
-        // Param value is NOT in the shell
-        const paramValue = page.locator('[data-testid="param-value"]')
-        expect(await paramValue.count()).toBe(0)
-      })
-
-      // After exiting instant scope, param value streams in
-      const paramValue = page.locator('[data-testid="param-value"]')
-      await paramValue.waitFor({ state: 'visible', timeout: 10000 })
-      expect(await paramValue.textContent()).toContain('slug: unknown')
-    })
-
-    it('does not include search param values in instant shell during page load', async () => {
+    // prettier-ignore
+    itSkipDeploy('does not include search param values in instant shell during page load', async () => {
       const page = await openPage(next, '/')
 
       await instant(page, async () => {
@@ -651,66 +667,144 @@ describe('instant-navigation-testing-api', () => {
       const page = await openPage(next, '/')
 
       await instant(page, async () => {
-        await page.click('#link-to-static-dynamic-params')
+        await page.click('#link-to-static-params')
 
         // Static page title is visible
-        const title = page.locator('[data-testid="dynamic-params-title"]')
+        const title = page.locator('[data-testid="static-params-title"]')
         await title.waitFor({ state: 'visible' })
 
         // Param value IS in the shell (slug 'hello' is in generateStaticParams)
-        const paramValue = page.locator('[data-testid="param-value"]')
+        const paramValue = page.locator('[data-testid="static-param-value"]')
         await paramValue.waitFor({ state: 'visible' })
         expect(await paramValue.textContent()).toContain('slug: hello')
 
         // Suspense fallback is NOT visible
-        const fallback = page.locator('[data-testid="params-fallback"]')
+        const fallback = page.locator('[data-testid="static-params-fallback"]')
         expect(await fallback.count()).toBe(0)
       })
     })
 
-    it('includes statically generated param values in instant shell during page load', async () => {
+    // prettier-ignore
+    itSkipDeploy('includes statically generated param values in instant shell during page load', async () => {
       const page = await openPage(next, '/')
 
       await instant(page, async () => {
-        await page.click('#plain-link-to-static-dynamic-params')
+        await page.click('#plain-link-to-static-params')
 
         // Static page title is visible
-        const title = page.locator('[data-testid="dynamic-params-title"]')
+        const title = page.locator('[data-testid="static-params-title"]')
         await title.waitFor({ state: 'visible' })
 
         // Param value IS in the shell (slug 'hello' is in generateStaticParams)
-        const paramValue = page.locator('[data-testid="param-value"]')
+        const paramValue = page.locator('[data-testid="static-param-value"]')
         await paramValue.waitFor({ state: 'visible' })
         expect(await paramValue.textContent()).toContain('slug: hello')
 
         // Suspense fallback is NOT visible
-        const fallback = page.locator('[data-testid="params-fallback"]')
+        const fallback = page.locator('[data-testid="static-params-fallback"]')
         expect(await fallback.count()).toBe(0)
       })
     })
   })
 
-  it('does not bake dynamic route params into the instant shell when no generateStaticParams is defined', async () => {
-    const page = await openPage(next, '/')
+  // A route with no `generateStaticParams` is never fallback-upgradeable, so a
+  // concrete param render is never cached back into the static prefetch shell.
+  // The param read therefore stays a dynamic write behind the Suspense boundary
+  // and is gated by the instant lock — it must never appear in the instant
+  // shell, regardless of how the navigation is triggered. (A route that does
+  // define `generateStaticParams` is exercised above; there a non-listed param
+  // legitimately upgrades to static after its first render, so it is not a
+  // reliable runtime value to assert exclusion on.)
+  describe('dynamic route params without generateStaticParams are excluded from instant shell', () => {
+    it('during client navigation', async () => {
+      const page = await openPage(next, '/')
 
-    await instant(page, async () => {
-      await page.click('#link-to-ungenerated-params')
+      await instant(page, async () => {
+        await page.click('#link-to-ungenerated-params')
 
-      // Suspense fallback is visible in the instant shell
-      const fallback = page.locator(
-        '[data-testid="ungenerated-params-fallback"]'
-      )
-      await fallback.waitFor({ state: 'visible' })
+        // Suspense fallback is visible in the instant shell
+        const fallback = page.locator(
+          '[data-testid="ungenerated-params-fallback"]'
+        )
+        await fallback.waitFor({ state: 'visible' })
 
-      // The resolved param value must not be present in the shell
+        // The resolved param value must not be present in the shell
+        const paramValue = page.locator(
+          '[data-testid="ungenerated-param-value"]'
+        )
+        expect(await paramValue.count()).toBe(0)
+      })
+
+      // After the instant scope exits, the param value streams in normally
       const paramValue = page.locator('[data-testid="ungenerated-param-value"]')
-      expect(await paramValue.count()).toBe(0)
+      await paramValue.waitFor({ state: 'visible' })
+      expect(await paramValue.textContent()).toContain('slug: anything')
     })
 
-    // After the instant scope exits, the param value streams in normally
-    const paramValue = page.locator('[data-testid="ungenerated-param-value"]')
-    await paramValue.waitFor({ state: 'visible' })
-    expect(await paramValue.textContent()).toContain('slug: anything')
+    itSkipDeploy('during page load', async () => {
+      const page = await openPage(next, '/')
+
+      await instant(page, async () => {
+        await page.click('#plain-link-to-ungenerated-params')
+
+        // Static page title is visible
+        const title = page.locator('[data-testid="ungenerated-params-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // Suspense fallback is visible
+        const fallback = page.locator(
+          '[data-testid="ungenerated-params-fallback"]'
+        )
+        await fallback.waitFor({ state: 'visible' })
+
+        // The resolved param value must not be present in the shell
+        const paramValue = page.locator(
+          '[data-testid="ungenerated-param-value"]'
+        )
+        expect(await paramValue.count()).toBe(0)
+      })
+
+      // After exiting instant scope, the param value streams in
+      const paramValue = page.locator('[data-testid="ungenerated-param-value"]')
+      await paramValue.waitFor({ state: 'visible', timeout: 10000 })
+      expect(await paramValue.textContent()).toContain('slug: anything')
+    })
+
+    // A hover/intent prefetch must not cache resolved runtime data that then
+    // leaks into the shell once the instant lock is acquired.
+    it('does not leak runtime data from a hover prefetch', async () => {
+      const page = await openPage(next, '/')
+
+      // Hover over the link to trigger an intent prefetch, then wait for it.
+      await page.hover('#link-to-ungenerated-params')
+      await page.waitForTimeout(3000)
+
+      await instant(page, async () => {
+        await page.click('#link-to-ungenerated-params')
+
+        // Static page title is visible
+        const title = page.locator('[data-testid="ungenerated-params-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // Suspense fallback is visible
+        const fallback = page.locator(
+          '[data-testid="ungenerated-params-fallback"]'
+        )
+        await fallback.waitFor({ state: 'visible' })
+
+        // Param value is NOT in the shell, even though a hover prefetch ran
+        // before the instant lock was acquired
+        const paramValue = page.locator(
+          '[data-testid="ungenerated-param-value"]'
+        )
+        expect(await paramValue.count()).toBe(0)
+      })
+
+      // After exiting instant scope, the param value streams in
+      const paramValue = page.locator('[data-testid="ungenerated-param-value"]')
+      await paramValue.waitFor({ state: 'visible' })
+      expect(await paramValue.textContent()).toContain('slug: anything')
+    })
   })
 
   it('does include dynamic route params in the instant shell when runtime prefetching is enabled', async () => {
@@ -829,44 +923,8 @@ describe('instant-navigation-testing-api', () => {
     ).toContain('slug: anything')
   })
 
-  // In dev mode, hover/intent-based prefetches should not send requests
-  // that produce stale segment data. If a hover prefetch caches the route
-  // with resolved runtime data before the instant lock is acquired, params
-  // will leak into the shell when instant mode is later enabled.
-  it('does not leak runtime data from hover prefetch into instant shell', async () => {
-    const page = await openPage(next, '/')
-
-    // Hover over the dynamic params link to trigger an intent prefetch
-    await page.hover('#link-to-dynamic-params')
-
-    // Wait for the prefetch to complete
-    await page.waitForTimeout(3000)
-
-    // Now enable instant mode and navigate
-    await instant(page, async () => {
-      await page.click('#link-to-dynamic-params')
-
-      // Static page title is visible
-      const title = page.locator('[data-testid="dynamic-params-title"]')
-      await title.waitFor({ state: 'visible' })
-
-      // Suspense fallback is visible
-      const fallback = page.locator('[data-testid="params-fallback"]')
-      await fallback.waitFor({ state: 'visible' })
-
-      // Param value is NOT in the shell — even though a hover prefetch
-      // ran before the instant lock was acquired
-      const paramValue = page.locator('[data-testid="param-value"]')
-      expect(await paramValue.count()).toBe(0)
-    })
-
-    // After exiting instant scope, param value streams in
-    const paramValue = page.locator('[data-testid="param-value"]')
-    await paramValue.waitFor({ state: 'visible' })
-    expect(await paramValue.textContent()).toContain('slug: unknown')
-  })
-
-  it('subsequent navigations after instant scope are not locked', async () => {
+  // prettier-ignore
+  itSkipDeploy('subsequent navigations after instant scope are not locked', async () => {
     const page = await openPage(next, '/')
 
     // First, do an MPA navigation within an instant scope
@@ -996,7 +1054,7 @@ describe('instant-navigation-testing-api', () => {
     }
   })
 
-  it('clears cookie after instant scope exits', async () => {
+  itSkipDeploy('clears cookie after instant scope exits', async () => {
     const page = await openPage(next, '/')
 
     await instant(page, async () => {
@@ -1038,7 +1096,8 @@ describe('instant-navigation-testing-api', () => {
     expect(await fetchedData.textContent()).toContain('api response')
   })
 
-  it('blocks out-of-band client fetch during instant scope (MPA)', async () => {
+  // prettier-ignore
+  itSkipDeploy('blocks out-of-band client fetch during instant scope (MPA)', async () => {
     const page = await openPage(next, '/')
 
     await instant(page, async () => {
@@ -1086,14 +1145,22 @@ describe('instant-navigation-testing-api', () => {
   // would be a blank document with no DevTools — leaving the user unable to
   // release the instant navigation lock. Instead the server clears the instant
   // cookie (so the next reload renders normally) and surfaces an error page.
-  it('clears the instant cookie and serves an error when the static shell is empty', async () => {
+  //
+  // TODO: This is skipped on deploy. There, the empty prelude is served
+  // straight from the platform cache before this code runs, so the Set-Cookie
+  // that clears the instant cookie never takes effect and the user stays on a
+  // blank shell. A follow-up serves a client-side cookie-clearing recovery
+  // document so the next reload renders the route normally on deploy too.
+  // prettier-ignore
+  itSkipDeploy('clears the instant cookie and serves an error when the static shell is empty', async () => {
     const res = await next.fetch('/root-blocking-page', {
       headers: { cookie: 'next-instant-navigation-testing=[0]' },
     })
 
-    // An error response is served instead of a blank document. (The exact body
-    // differs by mode — a dev error overlay vs. a minimal production error —
-    // but the 500 status is what distinguishes it from the empty 200 shell.)
+    // An error response is served instead of a blank document. (The exact
+    // body differs by mode — a dev error overlay vs. a minimal production
+    // error — but the 500 status is what distinguishes it from the empty 200
+    // shell.)
     expect(res.status).toBe(500)
 
     // The instant cookie is cleared so the next reload renders normally.
@@ -1111,10 +1178,9 @@ describe('instant-navigation-testing-api', () => {
 describe('instant-navigation-testing-api - root params', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'root-params'),
-    skipDeployment: true,
   })
 
-  it('includes root param in instant shell', async () => {
+  itSkipDeploy('includes root param in instant shell', async () => {
     const page = await openPage(next, '/en')
 
     const langValue = page.locator('[data-testid="lang-value"]')
@@ -1134,7 +1200,6 @@ describe('instant-navigation-testing-api - root params', () => {
 describe('instant-navigation-testing-api - partial prefetching (App Shells)', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'partial-prefetch'),
-    skipDeployment: true,
     // Skew protection (deployment-id asset versioning) is orthogonal to the
     // shell-restriction behavior under test. Disable it so the suite exercises
     // only the navigation-lock behavior.


### PR DESCRIPTION
The Instant Navigation Testing API suite set `skipDeployment: true`, so it only ran under `next dev` and `next start`, which never exercise the real `instant()` flow against a deployment, where the prefetched shell is served from the ISR or edge cache rather than rendered per request. This removes `skipDeployment` so the suite runs on deploy and can catch regressions that are invisible locally.

Running the suite on a deployment surfaced that the `runtime params are excluded from instant shell` tests, which asserted that `/dynamic-params/unknown` keeps its param out of the instant shell, do not hold there. That route defines `generateStaticParams` (for `hello`), which makes its fallback shell upgradeable: on a deployment the first concrete navigation to a non-listed param triggers a background prerender of the upgraded shell with that param, whose result (HTML and all segments) is written into the ISR cache. Subsequent prefetches then read those upgraded segments, so the prefetch the instant shell reads already contains the resolved param and the Suspense fallback never appears. The same fallback-shell upgrade is expected under `next start`, which is meant to persist the background prerender to disk, but for reasons to be investigated separately it does not currently affect these prefetches there, so the assertion held under `next dev` and `next start` but broke on a deployment.

This upgrade is correct behavior, because a non-listed route param legitimately becomes static once the route has been prerendered for it, so it is not a reliable runtime value to assert exclusion on. The exclusion tests now run against a route that defines no `generateStaticParams` and is never upgradeable
(`ungenerated-params/[slug]`), so its param never enters the prefetched shell: under the instant lock the Suspense fallback is shown, and the resolved value appears only after the lock is released. The client-navigation, page-load, and hover-prefetch variants share that route with a stable param and are grouped with the existing ungenerated-params case, whose duplicate client-navigation test is removed.

With the exclusion tests moved off it, the `dynamic-params/[slug]` route only serves the statically generated `hello` slug, so it is renamed to `static-params/[slug]` and continues to back the `statically generated params are included in instant shell` tests. The `runtime params are excluded from instant shell` describe now holds only the search-param cases and is renamed to `search params are excluded from instant shell`.

A larger set of tests now stays skipped on deploy. Any test that drives a full-page load under the instant lock, whether a plain-anchor MPA navigation or a reload, relies on the lock re-engaging on the freshly loaded document through the prerendered-shell bootstrap (`self.__next_instant_test`), which is only embedded into the deploy-served prelude in #95222. Without it the lock engages unreliably on a deployment, so the out-of-band client fetch is not blocked and the deferred data never streams back, and these tests time out or fail. The `clears the instant cookie and serves an error when the static shell is empty` test stays skipped for a separate reason, a blocking route whose empty static shell would otherwise leave the user stuck, which #95227 fixes.