### PR TITLE
Re-query deploy-test build logs until id markers appear

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra'
 import { NextInstance } from './base'
 import * as projectEnv from '../../../scripts/reset-project.mjs'
 import { Span } from 'next/dist/trace'
+import { setTimeout } from 'timers/promises'
 
 export class NextDeployInstance extends NextInstance {
   private _cliOutput: string
@@ -183,6 +184,54 @@ export class NextDeployInstance extends NextInstance {
     require('console').log(
       `Got buildId: ${this._buildId}, deploymentId: ${this._deploymentId}, supportsImmutableAssets: ${this._supportsImmutableAssets}`
     )
+  }
+
+  private async fetchBuildLogsUntilComplete(
+    url: string,
+    vercelEnv: NodeJS.ProcessEnv,
+    vercelFlags: string[]
+  ): Promise<string> {
+    // The fixture's `post-build` script prints the BUILD_ID, DEPLOYMENT_ID and
+    // NEXT_SUPPORTS_IMMUTABLE_ASSETS markers (in that order) as the final lines
+    // of the build (see `base.ts`). A deployment can report `Ready` before that
+    // tail has propagated to the log query API, so `vercel inspect --logs` can
+    // return a truncated prefix that stops before the markers. Gate on the
+    // last-printed marker so a partial read can't slip into the parser, and
+    // re-query until it appears.
+    const maxAttempts = 20
+    const retryDelayMs = 3000
+    let output = ''
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const buildLogs = await execa(
+        'vercel',
+        ['inspect', '--logs', url, ...vercelFlags],
+        {
+          env: vercelEnv,
+          reject: false,
+        }
+      )
+      if (buildLogs.exitCode !== 0) {
+        throw new Error(`Failed to get build output logs: ${buildLogs.stderr}`)
+      }
+      // Build logs are piped to stderr, so combine both streams.
+      output = buildLogs.stdout + buildLogs.stderr
+
+      if (/NEXT_SUPPORTS_IMMUTABLE_ASSETS: (.+)/.test(output)) {
+        return output
+      }
+
+      if (attempt < maxAttempts) {
+        require('console').log(
+          `Build log markers not yet propagated for ${url} (attempt ${attempt}/${maxAttempts}); the build log tail likely hasn't propagated yet. Retrying in ${retryDelayMs}ms...`
+        )
+        await setTimeout(retryDelayMs)
+      }
+    }
+
+    // The markers never appeared within the retry window; return the last
+    // output so `parseIdsFromCliOuput` throws a descriptive error including it.
+    return output
   }
 
   public async setup(parentSpan: Span) {
@@ -432,25 +481,19 @@ export class NextDeployInstance extends NextInstance {
 
     require('console').log(`Deployment URL: ${this._url}`)
 
-    // Use the vercel inspect command to get the CLI output from the build.
-    const buildLogs = await execa(
-      'vercel',
-      ['inspect', '--logs', this._url, ...vercelFlags],
-      {
-        env: vercelEnv,
-        reject: false,
-      }
+    // Fetch the build logs to extract the build/deployment id markers that the
+    // fixture's `post-build` script prints. The deployment can report `Ready`
+    // (and `vercel deploy` can return) before its full build-log tail has
+    // propagated to the log query API, so re-query until the markers appear
+    // rather than failing on the first incomplete read. TODO: Combine with
+    // runtime logs (via `vercel logs`)
+    this._cliOutput = await this.fetchBuildLogsUntilComplete(
+      this._url,
+      vercelEnv,
+      vercelFlags
     )
-    if (buildLogs.exitCode !== 0) {
-      throw new Error(`Failed to get build output logs: ${buildLogs.stderr}`)
-    }
-    // TODO: Combine with runtime logs (via `vercel logs`)
-    // Build logs seem to be piped to stderr, so we'll combine them to make sure we get all the logs.
-    this._cliOutput = buildLogs.stdout + buildLogs.stderr
 
     this.parseIdsFromCliOuput()
-    // Use the stdout from the logs command as the CLI output. The CLI will
-    // output other unrelated logs to stderr.
   }
 
   private async configureProxyAddress(): Promise<void> {


### PR DESCRIPTION
Deploy tests recover the `BUILD_ID`, `DEPLOYMENT_ID` and `NEXT_SUPPORTS_IMMUTABLE_ASSETS` values by scraping them out of the deployment's build logs, where the test fixture's `post-build` script prints them as the final lines of the build. We fetch those logs with `vercel inspect --logs` after `vercel deploy` returns, but a deployment can report `Ready` before its full build-log tail has propagated to the log query API, so a single call sometimes returns a truncated prefix that stops before the markers. When that happens `parseIdsFromCliOuput` throws "Failed to get buildId from logs" and fails the whole suite during setup, which is the intermittent failure we have been seeing across the deploy jobs.

This change wraps the log fetch in `fetchBuildLogsUntilComplete`, which re-queries `vercel inspect --logs` until the last-printed marker (`NEXT_SUPPORTS_IMMUTABLE_ASSETS`) appears before parsing, bounded to twenty attempts three seconds apart. Gating on the final marker rather than the first ensures a partial read cannot slip past the loop into the parser. Streaming the logs from `vercel deploy --logs` as part of the deploy itself was considered, but it has the same race: the CLI stops streaming once the deployment reports `Ready`, before the `post-build` tail flushes, and a single stream cannot re-query for the missing lines.