### PR TITLE
docs(opengraph-image): load assets at module scope to keep route static under Cache Components

### DIFF
--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -416,7 +416,7 @@ import { readFile } from 'node:fs/promises'
 const content = await readFile('./config.json', 'utf-8')
 const items = JSON.parse(content).items ?? []
 
-export default async function Page() {
+export default function Page() {
   return (
     <ul>
       {items.map((item) => (

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -403,12 +403,9 @@ export default async function Page() {
 
 > **Good to know:** This includes queries to embedded databases with synchronous APIs, such as `better-sqlite3` or Node.js's built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html). If you need per-request data from a synchronous source, call [`connection()`](/docs/app/api-reference/functions/connection) before the query.
 
-Asynchronous I/O is the exception: even though the read returns the same result each time, an `await readFile(...)` inside a component defers the route to request time. Request-time rendering is expected when the response should be dynamic. To keep the route prerendered, you have two options:
+Some asynchronous APIs read local resources that don't depend on the incoming request, such as fonts or configuration files. When those resources are expected to be the same for every request, read them once at module scope instead of during rendering
 
-- Read the data once at module scope with a top-level `await`, so it runs when the module loads rather than during render.
-- Wrap the read in [`use cache`](/docs/app/api-reference/directives/use-cache), so Next.js includes the cached result in the static shell.
-
-Module scope fits data that never varies per request, such as a local file, because it avoids caching entirely:
+If the data should instead be computed during rendering and reused across requests, wrap the read in [`use cache`](/docs/app/api-reference/directives/use-cache). If the data depends on the incoming request or is expected to change over time, read it during request-time rendering.
 
 ```tsx filename="page.tsx"
 import { readFile } from 'node:fs/promises'
@@ -427,6 +424,7 @@ export default function Page() {
 }
 ```
 
+In this example, the configuration file is expected to be the same for every request, so it is read once at module scope. Calling `await readFile()` inside the component would be treated as uncached data that work must be either accessed within `use cache` or behind a `<Suspense>` boundary. Since this file does not depend on the request and is not expected to change, module scope is the simplest option.
 ## Prerendering
 
 At build time, Next.js renders your route's component tree. How each component is handled depends on the APIs it uses:

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -403,6 +403,32 @@ export default async function Page() {
 
 > **Good to know:** This includes queries to embedded databases with synchronous APIs, such as `better-sqlite3` or Node.js's built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html). If you need per-request data from a synchronous source, call [`connection()`](/docs/app/api-reference/functions/connection) before the query.
 
+## Asynchronous I/O at module scope
+
+Asynchronous I/O during render, such as `await readFile(...)` inside a component, defers the route to request time. Request-time rendering is expected when the response should be dynamic. To keep the route prerendered, you have two options:
+
+- Read request-independent data once at module scope with a top-level `await`, so it runs when the module loads rather than during render.
+- Wrap the read in [`use cache`](/docs/app/api-reference/directives/use-cache), so Next.js includes the cached result in the static shell.
+
+Module scope fits data that never varies per request, such as a local file, because it avoids caching entirely:
+
+```tsx filename="page.tsx"
+import { readFile } from 'node:fs/promises'
+
+const content = await readFile('./config.json', 'utf-8')
+const items = JSON.parse(content).items ?? []
+
+export default async function Page() {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.value}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
 ## Prerendering
 
 At build time, Next.js renders your route's component tree. How each component is handled depends on the APIs it uses:

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -376,7 +376,7 @@ You don't need to memorize which operations behave this way. The dev overlay sur
   />
 </FixCardGrid>
 
-## I/O and computations
+## Predictable values
 
 Unlike random values and timestamps, which can vary between renders, module imports, synchronous I/O, and pure computations produce the same result every time they run. Components using only these operations are prerendered automatically, and their output becomes part of the static HTML at build time.
 
@@ -425,13 +425,14 @@ export default function Page() {
 ```
 
 In this example, the configuration file is expected to be the same for every request, so it is read once at module scope. Calling `await readFile()` inside the component would be treated as uncached data that work must be either accessed within `use cache` or behind a `<Suspense>` boundary. Since this file does not depend on the request and is not expected to change, module scope is the simplest option.
+
 ## Prerendering
 
 At build time, Next.js renders your route's component tree. How each component is handled depends on the APIs it uses:
 
 - [`use cache`](#usage): the result is cached and included in the static shell
 - [`<Suspense>`](#streaming-uncached-data): fallback UI is included in the static shell while the content streams at request time
-- [I/O and computations](#io-and-computations): module imports, `fs.readFileSync`, and pure computations complete during prerender and are included in the static shell automatically
+- [Predictable values](#predictable-values): module imports, `fs.readFileSync`, and pure computations complete during prerender and are included in the static shell automatically
 - [Random values and timestamps](#random-values-and-timestamps): use `connection()` + `<Suspense>` to get a unique value per request, or `use cache` to share one across users
 
 This generates a static shell consisting of HTML for initial page loads and a serialized [RSC Payload](/docs/app/getting-started/server-and-client-components#on-the-server) for client-side navigation, ensuring the browser receives fully rendered content instantly whether users navigate directly to the URL or transition from another page. This rendering approach is called **Partial Prerendering (PPR)**, the default behavior with Cache Components.

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -376,9 +376,9 @@ You don't need to memorize which operations behave this way. The dev overlay sur
   />
 </FixCardGrid>
 
-## Synchronous I/O and pure computations
+## I/O and computations
 
-Unlike random or time-based APIs, synchronous I/O, module imports, and pure computations are predictable: the same inputs produce the same outputs. Components using only these operations are prerendered automatically, and their output becomes part of the static HTML at build time.
+Unlike random values or timestamps, module imports, synchronous I/O, and pure computations produce the same result every time they run. Components using only these operations are prerendered automatically, and their output becomes part of the static HTML at build time.
 
 ```tsx filename="page.tsx"
 import fs from 'node:fs'
@@ -403,11 +403,9 @@ export default async function Page() {
 
 > **Good to know:** This includes queries to embedded databases with synchronous APIs, such as `better-sqlite3` or Node.js's built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html). If you need per-request data from a synchronous source, call [`connection()`](/docs/app/api-reference/functions/connection) before the query.
 
-## Asynchronous I/O at module scope
+Asynchronous I/O is the exception: even though the read returns the same result each time, an `await readFile(...)` inside a component defers the route to request time. Request-time rendering is expected when the response should be dynamic. To keep the route prerendered, you have two options:
 
-Asynchronous I/O during render, such as `await readFile(...)` inside a component, defers the route to request time. Request-time rendering is expected when the response should be dynamic. To keep the route prerendered, you have two options:
-
-- Read request-independent data once at module scope with a top-level `await`, so it runs when the module loads rather than during render.
+- Read the data once at module scope with a top-level `await`, so it runs when the module loads rather than during render.
 - Wrap the read in [`use cache`](/docs/app/api-reference/directives/use-cache), so Next.js includes the cached result in the static shell.
 
 Module scope fits data that never varies per request, such as a local file, because it avoids caching entirely:
@@ -435,7 +433,7 @@ At build time, Next.js renders your route's component tree. How each component i
 
 - [`use cache`](#usage): the result is cached and included in the static shell
 - [`<Suspense>`](#streaming-uncached-data): fallback UI is included in the static shell while the content streams at request time
-- [Synchronous I/O and pure computations](#synchronous-io-and-pure-computations): module imports, `fs.readFileSync`, and pure computations complete during prerender and are included in the static shell automatically
+- [I/O and computations](#io-and-computations): module imports, `fs.readFileSync`, and pure computations complete during prerender and are included in the static shell automatically
 - [Random values and timestamps](#random-values-and-timestamps): use `connection()` + `<Suspense>` to get a unique value per request, or `use cache` to share one across users
 
 This generates a static shell consisting of HTML for initial page loads and a serialized [RSC Payload](/docs/app/getting-started/server-and-client-components#on-the-server) for client-side navigation, ensuring the browser receives fully rendered content instantly whether users navigate directly to the URL or transition from another page. This rendering approach is called **Partial Prerendering (PPR)**, the default behavior with Cache Components.

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -378,7 +378,7 @@ You don't need to memorize which operations behave this way. The dev overlay sur
 
 ## I/O and computations
 
-Unlike random values or timestamps, module imports, synchronous I/O, and pure computations produce the same result every time they run. Components using only these operations are prerendered automatically, and their output becomes part of the static HTML at build time.
+Unlike random values and timestamps, which can vary between renders, module imports, synchronous I/O, and pure computations produce the same result every time they run. Components using only these operations are prerendered automatically, and their output becomes part of the static HTML at build time.
 
 ```tsx filename="page.tsx"
 import fs from 'node:fs'

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -424,7 +424,7 @@ export default function Page() {
 }
 ```
 
-In this example, the configuration file is expected to be the same for every request, so it is read once at module scope. Calling `await readFile()` inside the component would be treated as uncached data that work must be either accessed within `use cache` or behind a `<Suspense>` boundary. Since this file does not depend on the request and is not expected to change, module scope is the simplest option.
+In this example, the configuration file is expected to be the same for every request, so it is read once at module scope. Calling `await readFile()` inside the component would be treated as uncached data that must be either accessed within `use cache` or behind a `<Suspense>` boundary. Since this file does not depend on the request and is not expected to change, module scope is the simplest option.
 
 ## Prerendering
 

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -416,7 +416,7 @@ export default async function Image({ params }) {
 
 These examples use the Node.js runtime to fetch a local image from the file system and pass it to the `<img>` `src` attribute, either as a base64 string or an `ArrayBuffer`. Place the local asset relative to the project root, not the example source file.
 
-The asset doesn't depend on request data, so read it once at module scope. See [Asynchronous I/O at module scope](/docs/app/getting-started/caching#asynchronous-io-at-module-scope).
+The asset doesn't depend on request data, so read it once at module scope. See [I/O and computations](/docs/app/getting-started/caching#io-and-computations).
 
 ```tsx filename="app/opengraph-image.tsx" switcher
 import { ImageResponse } from 'next/og'

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -108,9 +108,6 @@ export const size = {
 
 export const contentType = 'image/png'
 
-// Load assets at module scope. Reading inside the component would be treated
-// as dynamic I/O under Cache Components and opt the route out of static
-// generation.
 const interSemiBold = await readFile(
   join(process.cwd(), 'assets/Inter-SemiBold.ttf')
 )
@@ -418,6 +415,8 @@ export default async function Image({ params }) {
 #### Using Node.js runtime with local assets
 
 These examples use the Node.js runtime to fetch a local image from the file system and pass it to the `<img>` `src` attribute, either as a base64 string or an `ArrayBuffer`. Place the local asset relative to the project root, not the example source file.
+
+Because the asset doesn't depend on request data, read it once at module scope so the route stays prerenderable. See [Asynchronous I/O at module scope](/docs/app/getting-started/caching#asynchronous-io-at-module-scope).
 
 ```tsx filename="app/opengraph-image.tsx" switcher
 import { ImageResponse } from 'next/og'

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -416,7 +416,7 @@ export default async function Image({ params }) {
 
 These examples use the Node.js runtime to fetch a local image from the file system and pass it to the `<img>` `src` attribute, either as a base64 string or an `ArrayBuffer`. Place the local asset relative to the project root, not the example source file.
 
-The asset doesn't depend on request data, so read it once at module scope. See [I/O and computations](/docs/app/getting-started/caching#io-and-computations).
+The asset doesn't depend on request data, so read it once at module scope. See [Predictable values](/docs/app/getting-started/caching#predictable-values).
 
 ```tsx filename="app/opengraph-image.tsx" switcher
 import { ImageResponse } from 'next/og'

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -416,7 +416,7 @@ export default async function Image({ params }) {
 
 These examples use the Node.js runtime to fetch a local image from the file system and pass it to the `<img>` `src` attribute, either as a base64 string or an `ArrayBuffer`. Place the local asset relative to the project root, not the example source file.
 
-Because the asset doesn't depend on request data, read it once at module scope so the route stays prerenderable. See [Asynchronous I/O at module scope](/docs/app/getting-started/caching#asynchronous-io-at-module-scope).
+The asset doesn't depend on request data, so read it once at module scope. See [Asynchronous I/O at module scope](/docs/app/getting-started/caching#asynchronous-io-at-module-scope).
 
 ```tsx filename="app/opengraph-image.tsx" switcher
 import { ImageResponse } from 'next/og'

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -108,13 +108,15 @@ export const size = {
 
 export const contentType = 'image/png'
 
+// Load the font once at module scope. process.cwd() is the Next.js project
+// directory. Reading it inside the component would be treated as dynamic I/O
+// under Cache Components and opt the route out of static generation.
+const interSemiBold = await readFile(
+  join(process.cwd(), 'assets/Inter-SemiBold.ttf')
+)
+
 // Image generation
 export default async function Image() {
-  // Font loading, process.cwd() is Next.js project directory
-  const interSemiBold = await readFile(
-    join(process.cwd(), 'assets/Inter-SemiBold.ttf')
-  )
-
   return new ImageResponse(
     (
       // ImageResponse JSX element
@@ -164,13 +166,15 @@ export const size = {
 
 export const contentType = 'image/png'
 
+// Load the font once at module scope. process.cwd() is the Next.js project
+// directory. Reading it inside the component would be treated as dynamic I/O
+// under Cache Components and opt the route out of static generation.
+const interSemiBold = await readFile(
+  join(process.cwd(), 'assets/Inter-SemiBold.ttf')
+)
+
 // Image generation
 export default async function Image() {
-  // Font loading, process.cwd() is Next.js project directory
-  const interSemiBold = await readFile(
-    join(process.cwd(), 'assets/Inter-SemiBold.ttf')
-  )
-
   return new ImageResponse(
     (
       // ImageResponse JSX element
@@ -423,10 +427,13 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-export default async function Image() {
-  const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')
-  const logoSrc = `data:image/png;base64,${logoData}`
+// Load the asset once at module scope. Reading it inside the component would
+// be treated as dynamic I/O under Cache Components and opt the route out of
+// static generation.
+const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')
+const logoSrc = `data:image/png;base64,${logoData}`
 
+export default async function Image() {
   return new ImageResponse(
     (
       <div
@@ -448,10 +455,13 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-export default async function Image() {
-  const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')
-  const logoSrc = `data:image/png;base64,${logoData}`
+// Load the asset once at module scope. Reading it inside the component would
+// be treated as dynamic I/O under Cache Components and opt the route out of
+// static generation.
+const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')
+const logoSrc = `data:image/png;base64,${logoData}`
 
+export default async function Image() {
   return new ImageResponse(
     (
       <div
@@ -475,10 +485,13 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-export default async function Image() {
-  const logoData = await readFile(join(process.cwd(), 'logo.png'))
-  const logoSrc = Uint8Array.from(logoData).buffer
+// Load the asset once at module scope. Reading it inside the component would
+// be treated as dynamic I/O under Cache Components and opt the route out of
+// static generation.
+const logoData = await readFile(join(process.cwd(), 'logo.png'))
+const logoSrc = Uint8Array.from(logoData).buffer
 
+export default async function Image() {
   return new ImageResponse(
     (
       <div
@@ -501,10 +514,13 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-export default async function Image() {
-  const logoData = await readFile(join(process.cwd(), 'logo.png'))
-  const logoSrc = Uint8Array.from(logoData).buffer
+// Load the asset once at module scope. Reading it inside the component would
+// be treated as dynamic I/O under Cache Components and opt the route out of
+// static generation.
+const logoData = await readFile(join(process.cwd(), 'logo.png'))
+const logoSrc = Uint8Array.from(logoData).buffer
 
+export default async function Image() {
   return new ImageResponse(
     (
       <div

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -108,9 +108,9 @@ export const size = {
 
 export const contentType = 'image/png'
 
-// Load the font once at module scope. process.cwd() is the Next.js project
-// directory. Reading it inside the component would be treated as dynamic I/O
-// under Cache Components and opt the route out of static generation.
+// Load assets at module scope. Reading inside the component would be treated
+// as dynamic I/O under Cache Components and opt the route out of static
+// generation.
 const interSemiBold = await readFile(
   join(process.cwd(), 'assets/Inter-SemiBold.ttf')
 )
@@ -166,9 +166,6 @@ export const size = {
 
 export const contentType = 'image/png'
 
-// Load the font once at module scope. process.cwd() is the Next.js project
-// directory. Reading it inside the component would be treated as dynamic I/O
-// under Cache Components and opt the route out of static generation.
 const interSemiBold = await readFile(
   join(process.cwd(), 'assets/Inter-SemiBold.ttf')
 )
@@ -427,9 +424,6 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-// Load the asset once at module scope. Reading it inside the component would
-// be treated as dynamic I/O under Cache Components and opt the route out of
-// static generation.
 const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')
 const logoSrc = `data:image/png;base64,${logoData}`
 
@@ -455,11 +449,7 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-// Load the asset once at module scope. Reading it inside the component would
-// be treated as dynamic I/O under Cache Components and opt the route out of
-// static generation.
-const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')
-const logoSrc = `data:image/png;base64,${logoData}`
+const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')const logoSrc = `data:image/png;base64,${logoData}`
 
 export default async function Image() {
   return new ImageResponse(
@@ -485,9 +475,6 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-// Load the asset once at module scope. Reading it inside the component would
-// be treated as dynamic I/O under Cache Components and opt the route out of
-// static generation.
 const logoData = await readFile(join(process.cwd(), 'logo.png'))
 const logoSrc = Uint8Array.from(logoData).buffer
 
@@ -514,9 +501,6 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-// Load the asset once at module scope. Reading it inside the component would
-// be treated as dynamic I/O under Cache Components and opt the route out of
-// static generation.
 const logoData = await readFile(join(process.cwd(), 'logo.png'))
 const logoSrc = Uint8Array.from(logoData).buffer
 

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -449,7 +449,8 @@ import { ImageResponse } from 'next/og'
 import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
-const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')const logoSrc = `data:image/png;base64,${logoData}`
+const logoData = await readFile(join(process.cwd(), 'logo.png'), 'base64')
+const logoSrc = `data:image/png;base64,${logoData}`
 
 export default async function Image() {
   return new ImageResponse(

--- a/docs/01-app/03-api-reference/04-functions/image-response.mdx
+++ b/docs/01-app/03-api-reference/04-functions/image-response.mdx
@@ -158,7 +158,7 @@ export default async function Image() {
 
 ### Custom fonts
 
-You can use custom fonts in your `ImageResponse` by providing a `fonts` array in the options. The font doesn't depend on request data, so read it once at module scope. See [I/O and computations](/docs/app/getting-started/caching#io-and-computations).
+You can use custom fonts in your `ImageResponse` by providing a `fonts` array in the options. The font doesn't depend on request data, so read it once at module scope. See [Predictable values](/docs/app/getting-started/caching#predictable-values).
 
 ```tsx filename="app/opengraph-image.tsx"
 import { ImageResponse } from 'next/og'

--- a/docs/01-app/03-api-reference/04-functions/image-response.mdx
+++ b/docs/01-app/03-api-reference/04-functions/image-response.mdx
@@ -158,7 +158,7 @@ export default async function Image() {
 
 ### Custom fonts
 
-You can use custom fonts in your `ImageResponse` by providing a `fonts` array in the options. The font doesn't depend on request data, so read it once at module scope. See [Asynchronous I/O at module scope](/docs/app/getting-started/caching#asynchronous-io-at-module-scope).
+You can use custom fonts in your `ImageResponse` by providing a `fonts` array in the options. The font doesn't depend on request data, so read it once at module scope. See [I/O and computations](/docs/app/getting-started/caching#io-and-computations).
 
 ```tsx filename="app/opengraph-image.tsx"
 import { ImageResponse } from 'next/og'

--- a/docs/01-app/03-api-reference/04-functions/image-response.mdx
+++ b/docs/01-app/03-api-reference/04-functions/image-response.mdx
@@ -158,7 +158,7 @@ export default async function Image() {
 
 ### Custom fonts
 
-You can use custom fonts in your `ImageResponse` by providing a `fonts` array in the options.
+You can use custom fonts in your `ImageResponse` by providing a `fonts` array in the options. The font doesn't depend on request data, so read it once at module scope. See [Asynchronous I/O at module scope](/docs/app/getting-started/caching#asynchronous-io-at-module-scope).
 
 ```tsx filename="app/opengraph-image.tsx"
 import { ImageResponse } from 'next/og'
@@ -174,9 +174,6 @@ export const size = {
 
 export const contentType = 'image/png'
 
-// Load the font once at module scope. process.cwd() is the Next.js project
-// directory. Reading it inside the component would be treated as dynamic I/O
-// under Cache Components and opt the route out of static generation.
 const interSemiBold = await readFile(
   join(process.cwd(), 'assets/Inter-SemiBold.ttf')
 )


### PR DESCRIPTION
### What?

Document loading request-independent assets at module scope, and update the OG image examples to follow it.

### Why?

Reading a local asset inside the component is async I/O during render, so the route defers to request time. A top-level `await` at module scope keeps the route prerendered without reaching for `use cache`. The pattern previously only lived as an inline snippet in the OG image docs.

### How?

- Add an "Asynchronous I/O at module scope" section to the Cache Components guide as the canonical explanation.
- Load fonts and local assets at module scope in `opengraph-image.mdx` and `image-response.mdx`, and link both to the new section.

<!-- NEXT_JS_LLM_PR -->
