### PR TITLE
fix(create-next-app): pin both axes on logo Images to silence aspect-ratio warning under Tailwind Preflight

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -5,7 +5,7 @@ export default function Home() {
     <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <Image
-          className="dark:invert"
+          className="dark:invert h-5 w-[100px]"
           src="/next.svg"
           alt="Next.js logo"
           width={100}
@@ -42,7 +42,7 @@ export default function Home() {
             rel="noopener noreferrer"
           >
             <Image
-              className="dark:invert"
+              className="dark:invert h-[14px] w-4"
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}

--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -5,7 +5,7 @@ export default function Home() {
     <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <Image
-          className="dark:invert h-5 w-[100px]"
+          className="dark:invert h-[20px] w-[100px]"
           src="/next.svg"
           alt="Next.js logo"
           width={100}
@@ -42,7 +42,7 @@ export default function Home() {
             rel="noopener noreferrer"
           >
             <Image
-              className="dark:invert h-[14px] w-4"
+              className="dark:invert h-[14px] w-[16px]"
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <Image
-          className="dark:invert"
+          className="dark:invert h-5 w-[100px]"
           src="/next.svg"
           alt="Next.js logo"
           width={100}
@@ -42,7 +42,7 @@ export default function Home() {
             rel="noopener noreferrer"
           >
             <Image
-              className="dark:invert"
+              className="dark:invert h-[14px] w-4"
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <Image
-          className="dark:invert h-5 w-[100px]"
+          className="dark:invert h-[20px] w-[100px]"
           src="/next.svg"
           alt="Next.js logo"
           width={100}
@@ -42,7 +42,7 @@ export default function Home() {
             rel="noopener noreferrer"
           >
             <Image
-              className="dark:invert h-[14px] w-4"
+              className="dark:invert h-[14px] w-[16px]"
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}


### PR DESCRIPTION
### What?

Pin both axes with Tailwind classes on the two `next/image` logo instances in the `app-tw` (Tailwind) templates so the browser doesn't compute either axis from the asset's intrinsic aspect ratio.

### Why?

Tailwind v4 Preflight ships `img, video { height: auto }`. That overrides the `height` attribute `next/image` writes, so the browser sizes height from `width × natural-ratio`. For `vercel.svg` declared at `width={16} height={14}` the rendered height is 13.87px; for `next.svg` declared at `width={100} height={20}` the rendered height is 20.30px. On Retina / fractional DPRs, those snap to a different integer than the declared height, and `next/image`'s `onLoad` check flags `width or height modified, but not the other` (rauchg reported this on the default `create-next-app` home page).

Adding `style={{ width: "auto", height: "auto" }}` (the warning's own advice) doesn't help — `height: auto` is already in effect, and width still resolves to the intrinsic value, leaving exactly one axis CSS-modified.

### How?

`className="h-5 w-[100px]"` on the `next.svg` Image and `className="h-[14px] w-4"` on the `vercel.svg` Image. Both axes are now explicit CSS, neither falls back to `auto`, and the rendered size matches the declared `width`/`height` props on all DPRs.

Only the `app-tw` (TS + JS) templates are affected — the non-Tailwind `app` template has no `img { height: auto }` reset.

<!-- NEXT_JS_LLM_PR -->
