### PR TITLE
fix(app-router): scroll to hash target inside a Suspense boundary

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -153,13 +153,17 @@ interface PendingHashFragmentScroll {
 }
 
 /**
- * Watch the DOM for a hash fragment's target element to appear (e.g. when a
- * Suspense boundary it lives in resolves), then invoke `onAppear`. The caller
- * is responsible for cancelling the returned watcher once it is no longer
- * needed via `cancelPendingHashFragmentScroll`.
+ * Watch `root`'s subtree for a hash fragment's target element to appear (e.g.
+ * when a Suspense boundary it lives in resolves), then invoke `onAppear`.
+ * Callers scope `root` to the segment's own subtree rather than the whole
+ * document, so the watcher does not react to unrelated DOM changes elsewhere on
+ * the page and does not outlive the segment. The caller is responsible for
+ * cancelling the returned watcher once it is no longer needed via
+ * `cancelPendingHashFragmentScroll`.
  */
 function watchForHashFragment(
   hashFragment: string,
+  root: Node,
   onAppear: () => void
 ): PendingHashFragmentScroll {
   const observer = new MutationObserver(() => {
@@ -167,7 +171,7 @@ function watchForHashFragment(
       onAppear()
     }
   })
-  observer.observe(document.body, { childList: true, subtree: true })
+  observer.observe(root, { childList: true, subtree: true })
   return { hashFragment, observer }
 }
 
@@ -224,8 +228,17 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
           this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
             this.pendingHashFragmentScroll
           )
+          // Scope the watch to this segment's subtree: the target lives inside a
+          // Suspense boundary within it, so there is no need to observe the
+          // whole document, and we won't react to unrelated DOM changes
+          // elsewhere on the page (nor keep watching after the segment is gone).
+          const container = findDOMNode(this)
+          const observeRoot =
+            (container instanceof Element && container.parentElement) ||
+            document.body
           this.pendingHashFragmentScroll = watchForHashFragment(
             hashFragment,
+            observeRoot,
             () => {
               this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
                 this.pendingHashFragmentScroll
@@ -395,6 +408,10 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
               )
             pendingHashFragmentScrollRef.current = watchForHashFragment(
               hashFragment,
+              // The Fragment-ref handler has no single container node to scope
+              // to, so fall back to observing document.body. This branch is
+              // behind the experimental `appNewScrollHandler` flag.
+              document.body,
               () => {
                 pendingHashFragmentScrollRef.current =
                   cancelPendingHashFragmentScroll(

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -138,12 +138,58 @@ function getHashFragmentDomNode(hashFragment: string) {
     document.getElementsByName(hashFragment)[0]
   )
 }
+
+// When navigating to a hash, the target element may live inside a Suspense
+// boundary that hasn't resolved yet (e.g. streamed content). In that case it
+// isn't in the DOM when we'd normally scroll. Rather than giving up (and
+// resetting to the top of the page) we watch for it to appear and scroll to it
+// then. This mirrors the browser: it doesn't scroll for a fragment that isn't
+// present, and scrolls to it once it is. The watcher is cancelled when the
+// element is found, when a newer navigation supersedes the scroll, or on
+// unmount — so a genuinely absent fragment simply never scrolls.
+interface PendingHashFragmentScroll {
+  hashFragment: string
+  observer: MutationObserver
+}
+
+/**
+ * Watch the DOM for a hash fragment's target element to appear (e.g. when a
+ * Suspense boundary it lives in resolves), then invoke `onAppear`. The caller
+ * is responsible for cancelling the returned watcher once it is no longer
+ * needed via `cancelPendingHashFragmentScroll`.
+ */
+function watchForHashFragment(
+  hashFragment: string,
+  onAppear: () => void
+): PendingHashFragmentScroll {
+  const observer = new MutationObserver(() => {
+    if (getHashFragmentDomNode(hashFragment)) {
+      onAppear()
+    }
+  })
+  observer.observe(document.body, { childList: true, subtree: true })
+  return { hashFragment, observer }
+}
+
+function cancelPendingHashFragmentScroll(
+  pending: PendingHashFragmentScroll | null
+): null {
+  if (pending !== null) {
+    pending.observer.disconnect()
+  }
+  return null
+}
+
 interface ScrollAndMaybeFocusHandlerProps {
   focusAndScrollRef: FocusAndScrollRef
   children: React.ReactNode
   cacheNode: CacheNode
 }
 class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusHandlerProps> {
+  // Tracks a scroll deferred until a hash-fragment element appears in the DOM
+  // (e.g. once a Suspense boundary it lives in resolves).
+  pendingHashFragmentScroll: PendingHashFragmentScroll | null = null
+
   handlePotentialScroll = () => {
     // Handle scroll and focus, it's only applied once.
     const { focusAndScrollRef, cacheNode } = this.props
@@ -151,7 +197,14 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
     const scrollRef = focusAndScrollRef.forceScroll
       ? focusAndScrollRef.scrollRef
       : cacheNode.scrollRef
-    if (scrollRef === null || !scrollRef.current) return
+    if (scrollRef === null || !scrollRef.current) {
+      // Scrolling is no longer wanted (already handled, or superseded by a
+      // newer navigation). Stop waiting for any deferred hash scroll.
+      this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
+        this.pendingHashFragmentScroll
+      )
+      return
+    }
 
     let domNode:
       | ReturnType<typeof getHashFragmentDomNode>
@@ -160,6 +213,39 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
 
     if (hashFragment) {
       domNode = getHashFragmentDomNode(hashFragment)
+
+      if (!domNode) {
+        // The target element isn't in the DOM yet — it's likely inside a
+        // Suspense boundary that hasn't resolved. Wait for it to appear and
+        // scroll then, instead of consuming the scroll and resetting to the
+        // top of the page. (If it never appears we simply don't scroll, which
+        // matches the browser's behavior for an absent fragment.)
+        if (this.pendingHashFragmentScroll?.hashFragment !== hashFragment) {
+          this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
+            this.pendingHashFragmentScroll
+          )
+          this.pendingHashFragmentScroll = watchForHashFragment(
+            hashFragment,
+            () => {
+              this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
+                this.pendingHashFragmentScroll
+              )
+              this.handlePotentialScroll()
+            }
+          )
+        }
+        return
+      }
+
+      // Found the element; cancel any pending wait from a previous attempt.
+      this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
+        this.pendingHashFragmentScroll
+      )
+    } else {
+      // Not a hash navigation; cancel any pending hash wait.
+      this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
+        this.pendingHashFragmentScroll
+      )
     }
 
     // `findDOMNode` is tricky because it returns just the first child if the component is a fragment.
@@ -247,6 +333,12 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
     this.handlePotentialScroll()
   }
 
+  componentWillUnmount() {
+    this.pendingHashFragmentScroll = cancelPendingHashFragmentScroll(
+      this.pendingHashFragmentScroll
+    )
+  }
+
   render() {
     return this.props.children
   }
@@ -258,6 +350,13 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
  */
 function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
   const childrenRef = React.useRef<FragmentInstance>(null)
+  // Tracks a scroll deferred until a hash-fragment element appears in the DOM
+  // (e.g. once a Suspense boundary it lives in resolves).
+  const pendingHashFragmentScrollRef =
+    React.useRef<PendingHashFragmentScroll | null>(null)
+  // Re-runs the (dependency-less) layout effect below once a watched hash
+  // fragment appears, so we can scroll to it then.
+  const [, forceUpdate] = React.useReducer((c: number) => c + 1, 0)
 
   useLayoutEffect(
     () => {
@@ -266,13 +365,57 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
       const scrollRef = focusAndScrollRef.forceScroll
         ? focusAndScrollRef.scrollRef
         : cacheNode.scrollRef
-      if (scrollRef === null || !scrollRef.current) return
+      if (scrollRef === null || !scrollRef.current) {
+        // Scrolling is no longer wanted (already handled, or superseded by a
+        // newer navigation). Stop waiting for any deferred hash scroll.
+        pendingHashFragmentScrollRef.current = cancelPendingHashFragmentScroll(
+          pendingHashFragmentScrollRef.current
+        )
+        return
+      }
 
       let instance: FragmentInstance | HTMLElement | null = null
       const hashFragment = focusAndScrollRef.hashFragment
 
       if (hashFragment) {
         instance = getHashFragmentDomNode(hashFragment)
+
+        if (!instance) {
+          // The target element isn't in the DOM yet — it's likely inside a
+          // Suspense boundary that hasn't resolved. Wait for it to appear and
+          // scroll then, instead of consuming the scroll and resetting to the
+          // top of the page. (If it never appears we simply don't scroll, which
+          // matches the browser's behavior for an absent fragment.)
+          if (
+            pendingHashFragmentScrollRef.current?.hashFragment !== hashFragment
+          ) {
+            pendingHashFragmentScrollRef.current =
+              cancelPendingHashFragmentScroll(
+                pendingHashFragmentScrollRef.current
+              )
+            pendingHashFragmentScrollRef.current = watchForHashFragment(
+              hashFragment,
+              () => {
+                pendingHashFragmentScrollRef.current =
+                  cancelPendingHashFragmentScroll(
+                    pendingHashFragmentScrollRef.current
+                  )
+                forceUpdate()
+              }
+            )
+          }
+          return
+        }
+
+        // Found the element; cancel any pending wait from a previous attempt.
+        pendingHashFragmentScrollRef.current = cancelPendingHashFragmentScroll(
+          pendingHashFragmentScrollRef.current
+        )
+      } else {
+        // Not a hash navigation; cancel any pending hash wait.
+        pendingHashFragmentScrollRef.current = cancelPendingHashFragmentScroll(
+          pendingHashFragmentScrollRef.current
+        )
       }
 
       if (!instance) {
@@ -347,6 +490,15 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
     // Used to run on every commit. We may be able to be smarter about this
     // but be prepared for lots of manual testing.
     undefined
+  )
+
+  useLayoutEffect(
+    () => () => {
+      pendingHashFragmentScrollRef.current = cancelPendingHashFragmentScroll(
+        pendingHashFragmentScrollRef.current
+      )
+    },
+    []
   )
 
   return <Fragment ref={childrenRef}>{props.children}</Fragment>

--- a/test/e2e/app-dir/navigation/app/hash-absent/page.js
+++ b/test/e2e/app-dir/navigation/app/hash-absent/page.js
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+// Fixture for navigating to a hash whose target is not present in the DOM.
+// The links are position: fixed so that clicking one never scrolls the
+// viewport to bring it into view — that way the test observes only the
+// router's own scroll behavior, not the browser's click-into-view scroll.
+export default function HashAbsentPage() {
+  return (
+    <div style={{ fontFamily: 'sans-serif', fontSize: '16px' }}>
+      <p>Hash Absent Page</p>
+      <nav style={{ position: 'fixed', top: 0, left: 0, zIndex: 1 }}>
+        <Link href="#present-target" id="link-to-present">
+          to present target
+        </Link>{' '}
+        <Link href="#ghost-target" id="link-to-ghost">
+          to absent target
+        </Link>
+      </nav>
+      <div style={{ height: '150vh' }} />
+      <h2 id="present-target">Present target</h2>
+      <div style={{ height: '150vh' }} />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/hash-suspense/page.js
+++ b/test/e2e/app-dir/navigation/app/hash-suspense/page.js
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function HashSuspensePage() {
+  return (
+    <div style={{ fontFamily: 'sans-serif', fontSize: '16px' }}>
+      <p>Hash Suspense Page</p>
+      <Link
+        href="/hash-suspense/with-suspense#hash-target"
+        id="link-to-suspense-hash"
+      >
+        To hash target inside a Suspense boundary
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/hash-suspense/with-suspense/page.js
+++ b/test/e2e/app-dir/navigation/app/hash-suspense/with-suspense/page.js
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+
+// An async server component that resolves after a short delay, so on the first
+// (uncached) navigation its content streams in behind the Suspense boundary
+// below. The hash target lives inside it, so it is NOT in the DOM at the moment
+// the router would normally scroll to the hash.
+async function SlowCategories() {
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  return (
+    <div>
+      {/* Push the target well below the fold so a real scroll is required. */}
+      <div style={{ height: '150vh' }}>Categories loaded</div>
+      <h2 id="hash-target">Hash target (was inside Suspense)</h2>
+      <div style={{ height: '150vh' }} />
+    </div>
+  )
+}
+
+export default function WithSuspensePage() {
+  return (
+    <div style={{ fontFamily: 'sans-serif', fontSize: '16px' }}>
+      <p>With Suspense</p>
+      <Suspense fallback={<p id="fallback">Loading categories…</p>}>
+        <SlowCategories />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -238,6 +238,35 @@ describe('app dir - navigation', () => {
         expect(await browser.eval('window.pageYOffset')).toBeGreaterThan(0)
       })
     })
+
+    it('should not reset scroll to the top when the hash target never appears', async () => {
+      // Regression guard for the one intentional behavior change in this fix:
+      // navigating to a hash whose target is not (and never becomes) present
+      // must leave the scroll position untouched — matching the browser —
+      // instead of resetting to the top of the page. The fixture's links are
+      // position: fixed, so clicking one never scrolls the viewport itself.
+      const browser = await next.browser('/hash-absent')
+
+      // Scroll away from the top via a hash target that exists.
+      await browser.elementByCss('#link-to-present').click()
+      await retry(async () => {
+        expect(await browser.eval('window.pageYOffset')).toBeGreaterThan(0)
+      })
+      const scrollBeforeAbsentHash = await browser.eval('window.pageYOffset')
+
+      // Navigate to a hash whose target does not exist in the DOM.
+      await browser.elementByCss('#link-to-ghost').click()
+      await retry(async () =>
+        expect(await browser.eval('window.location.hash')).toBe('#ghost-target')
+      )
+
+      // Give any (incorrect) scroll-to-top a chance to run before asserting the
+      // position is unchanged.
+      await waitFor(500)
+      expect(await browser.eval('window.pageYOffset')).toBe(
+        scrollBeforeAbsentHash
+      )
+    })
   })
 
   describe('hash-with-scroll-offset', () => {

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -219,6 +219,27 @@ describe('app dir - navigation', () => {
     })
   })
 
+  describe('hash-suspense', () => {
+    it('should scroll to a hash target rendered inside a Suspense boundary once it resolves', async () => {
+      const browser = await next.browser('/hash-suspense')
+
+      // Sanity: we start at the top of the page.
+      expect(await browser.eval('window.pageYOffset')).toBe(0)
+
+      // Navigate to a page whose hash target streams in behind a Suspense
+      // boundary, so it isn't in the DOM at the moment the router would
+      // normally scroll to the hash.
+      await browser.elementByCss('#link-to-suspense-hash').click()
+
+      // Once the boundary resolves and the target appears, the page should
+      // scroll to it instead of staying at the top.
+      await browser.waitForElementByCss('#hash-target')
+      await retry(async () => {
+        expect(await browser.eval('window.pageYOffset')).toBeGreaterThan(0)
+      })
+    })
+  })
+
   describe('hash-with-scroll-offset', () => {
     it('should scroll to the specified hash', async () => {
       const browser = await next.browser('/hash-with-scroll-offset')


### PR DESCRIPTION
### Problem

Navigating to a URL with a hash fragment (`/page#section`) whose target element is rendered inside a `<Suspense>` boundary that hasn't resolved yet (e.g. streamed content) did not scroll to it — the page reset to the top and never recovered. Navigating a second time worked only because the content was cached.

Fixes #65960

### Root cause

`ScrollAndMaybeFocusHandler` (in `layout-router.tsx`) runs once when the segment commits. If the hash target isn't in the DOM at that moment, it consumed the scroll, cleared the hash, and scrolled the segment container (≈ top). Because the handler is an *ancestor* of every Suspense boundary, it does not re-render when a boundary resolves, so it never retried once the target appeared.

### Fix

When the hash target isn't in the DOM, watch for it with a `MutationObserver` and scroll to it once it appears, without consuming the scroll. The watcher is cancelled when the element is found, when a newer navigation supersedes the scroll (`scrollRef.current` is invalidated), or on unmount.

If the fragment never appears, the page no longer scrolls — matching the browser's behavior for an absent `#fragment` (previously it reset to the top). This is the one intentional behavior change; it's why no timeout/"give-up" heuristic is needed.

Applied to both the default scroll handler and the experimental `appNewScrollHandler` fork.

### Testing

Added an e2e test under `test/e2e/app-dir/navigation` whose hash target streams in behind a `<Suspense>` boundary. It fails without the fix (page stays at the top) and passes with it. The existing hash-navigation tests — including the non-existent-hash case — continue to pass.

<!-- NEXT_JS_LLM_PR -->
