### PR TITLE
Improve typing of `decodeReply`

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -780,7 +780,7 @@ export async function handleAction({
                 return handleUnrecognizedFetchAction(err)
               }
 
-              boundActionArguments = await decodeReply(
+              boundActionArguments = await decodeReply<unknown[]>(
                 formData,
                 serverModuleMap,
                 { temporaryReferences }
@@ -861,7 +861,7 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
+            boundActionArguments = await decodeReply<unknown[]>(
               actionData,
               serverModuleMap,
               { temporaryReferences }
@@ -954,7 +954,7 @@ export async function handleAction({
                   pipeline(body, sizeLimitTransform, busboy, {
                     signal: abortController.signal,
                   }),
-                  decodeReplyFromBusboy(busboy, serverModuleMap, {
+                  decodeReplyFromBusboy<unknown[]>(busboy, serverModuleMap, {
                     temporaryReferences,
                   }),
                 ])
@@ -1070,7 +1070,7 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
+            boundActionArguments = await decodeReply<unknown[]>(
               actionData,
               serverModuleMap,
               { temporaryReferences }

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -117,9 +117,13 @@ export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
     const temporaryReferences = createTemporaryReferenceSet()
     let decoded: CacheKeyParts
     if (msg.encodedArguments.kind === 'string') {
-      decoded = (await decodeReply(msg.encodedArguments.data, serverModuleMap, {
-        temporaryReferences,
-      })) as CacheKeyParts
+      decoded = await decodeReply<CacheKeyParts>(
+        msg.encodedArguments.data,
+        serverModuleMap,
+        {
+          temporaryReferences,
+        }
+      )
     } else {
       const entries = msg.encodedArguments.entries.map<[string, string | File]>(
         ([key, value]) => {
@@ -130,7 +134,7 @@ export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
           return [key, new File([bytes], '', { type: value.type })]
         }
       )
-      decoded = (await decodeReplyFromAsyncIterable(
+      decoded = await decodeReplyFromAsyncIterable<CacheKeyParts>(
         {
           async *[Symbol.asyncIterator]() {
             for (const pair of entries) {
@@ -140,7 +144,7 @@ export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
         },
         serverModuleMap,
         { temporaryReferences }
-      )) as CacheKeyParts
+      )
     }
 
     const args = decoded[2]

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -279,17 +279,17 @@ declare module 'react-server-dom-webpack/server.node' {
     ...args: unknown[]
   ): TemporaryReferenceSet
 
-  export function decodeReplyFromBusboy(
+  export function decodeReplyFromBusboy<T>(
     busboyStream: Busboy,
     webpackMap: ServerManifest,
     options?: { temporaryReferences?: TemporaryReferenceSet }
-  ): Promise<unknown[]>
+  ): Promise<T>
 
   export function decodeReply<T>(
     body: string | FormData,
     webpackMap: ServerManifest,
     options?: { temporaryReferences?: TemporaryReferenceSet }
-  ): Promise<T[]>
+  ): Promise<T>
 
   export function decodeAction(
     body: FormData,


### PR DESCRIPTION
The types were unnecessarily specific (it doesn't always return a `T[]`)