### PR TITLE
[ci] Display correct test commands when Cache Component test fail

### DIFF
--- a/scripts/pr-ci-comment.mjs
+++ b/scripts/pr-ci-comment.mjs
@@ -810,9 +810,10 @@ function datadogSearchQuery(values) {
 
 function getTestCommand(suite) {
   const jobName = suite.job.name.toLowerCase()
-  const isTurbopack = jobName.includes('turbopack')
+  const isCacheComponents = jobName.includes('cache components')
+  const isTurbopack = jobName.includes('turbopack') || isCacheComponents
   const isRspack = jobName.includes('rspack')
-  const isExperimental = jobName.includes('experimental')
+  const isExperimental = jobName.includes('experimental') || isCacheComponents
   const isPPR = jobName.includes('ppr')
   const script = suite.mode
     ? `test-${suite.mode}${isExperimental ? '-experimental' : ''}${


### PR DESCRIPTION
The PR CI comment derives a local reproduction command from each failing job's name. The cache components jobs are named `test cache components dev`/`test cache components prod` and carry neither a `turbopack` nor `experimental` marker, so the suggested command was a plain `pnpm test-start <path>` that omits the cache components experimental flags and Turbopack those jobs actually run with.

This detects cache components jobs by name and treats them as both experimental and Turbopack, so the comment now suggests `pnpm test-start-experimental-turbo <path>` (and the dev equivalent). The existing `experimental` shard detection is preserved so older release branches are unaffected.

<!-- NEXT_JS_LLM_PR -->