### PR TITLE
Render a code frame for build errors thrown collecting page data

### DIFF
--- a/packages/next/src/build/worker.ts
+++ b/packages/next/src/build/worker.ts
@@ -2,13 +2,26 @@ import '../server/require-hook'
 // Import cpu-profile to start profiling early if enabled
 import '../server/lib/cpu-profile'
 
+import { installBindings } from './swc/install-bindings'
+import { installCodeFrameSupport } from '../server/lib/install-code-frame'
+import { isPageStatic as isPageStaticImpl } from './utils'
+
 // Set the global asset suffix for Turbopack compiled code to use during prerendering
 ;(globalThis as any).NEXT_CLIENT_ASSET_SUFFIX =
   process.env.__NEXT_PRERENDER_CLIENT_ASSET_SUFFIX
 
-export {
-  getDefinedNamedExports,
-  hasCustomGetInitialProps,
-  isPageStatic,
-} from './utils'
+export { getDefinedNamedExports, hasCustomGetInitialProps } from './utils'
+
+// Install native bindings and code-frame support before collecting page data so
+// errors thrown there (e.g. an empty `generateStaticParams`) render a code
+// frame in the build output, matching prerender errors. Both are idempotent.
+// This is done in the worker entry rather than in `./utils`, which is reachable
+// from `next-server` and would otherwise pull the devtools code-frame renderer
+// into the production server's file trace.
+export const isPageStatic: typeof isPageStaticImpl = async (params) => {
+  await installBindings()
+  installCodeFrameSupport()
+  return isPageStaticImpl(params)
+}
+
 export { exportPages } from '../export/worker'

--- a/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -11,9 +11,6 @@ describe('empty-generate-static-params', () => {
     return
   }
 
-  // TODO: The build error has no code frame because generateStaticParams runs
-  // in the page-data worker, which lacks code-frame support. Surface one to
-  // match prerender errors in a follow-up.
   function errorBlock(cliOutput: string) {
     return cliOutput.slice(
       cliOutput.indexOf('When using Cache Components'),
@@ -82,6 +79,12 @@ describe('empty-generate-static-params', () => {
 
          Learn more: https://nextjs.org/docs/messages/empty-generate-static-params
              at generateStaticParams (app/[slug]/page.tsx:10:10)
+            8 |
+            9 | export async function generateStaticParams() {
+         > 10 |   return []
+              |          ^
+           11 | }
+           12 |
 
          > "
         `)
@@ -91,6 +94,12 @@ describe('empty-generate-static-params', () => {
 
          Learn more: https://nextjs.org/docs/messages/empty-generate-static-params
              at generateStaticParams (webpack:///app/[slug]/page.tsx:10:10)
+            8 |
+            9 | export async function generateStaticParams() {
+         > 10 |   return []
+              |          ^
+           11 | }
+           12 |
 
          > "
         `)
@@ -105,6 +114,13 @@ describe('empty-generate-static-params', () => {
 
          Learn more: https://nextjs.org/docs/messages/empty-generate-static-params
              at generateStaticParams (app/computed/[slug]/page.tsx:9:8)
+            7 | }
+            8 |
+         >  9 | export async function generateStaticParams() {
+              |        ^
+           10 |   // Empty at runtime but not statically analyzable, so it falls back to the
+           11 |   // factory stack anchored at the declaration.
+           12 |   const items: string[] = []
 
          > "
         `)
@@ -114,6 +130,13 @@ describe('empty-generate-static-params', () => {
 
          Learn more: https://nextjs.org/docs/messages/empty-generate-static-params
              at generateStaticParams (webpack:///app/computed/[slug]/page.tsx:9:8)
+            7 | }
+            8 |
+         >  9 | export async function generateStaticParams() {
+              |        ^
+           10 |   // Empty at runtime but not statically analyzable, so it falls back to the
+           11 |   // factory stack anchored at the declaration.
+           12 |   const items: string[] = []
 
          > "
         `)


### PR DESCRIPTION
Errors thrown while collecting page data, such as an empty `generateStaticParams` under Cache Components, printed a source-mapped stack in the build output but no code frame, unlike prerender errors from the export worker which show the offending source lines. The static worker exposes both `isPageStatic` and `exportPages`, but only `exportPages` called `installCodeFrameSupport`, so when `isPageStatic` ran the code-frame renderer was never registered and the frame was dropped even though the stack itself was already source-mapped.

This installs the native bindings and code-frame support in the static worker entry (`build/worker.ts`) by wrapping the exposed `isPageStatic`, mirroring what `exportPages` already does. It is deliberately not done in `build/utils.ts`: that module is reachable from `next-server` through the dev server, so importing the code-frame installer there pulls the devtools renderer (`next-devtools/server/shared`) into the production server's file trace, which the `next-server-nft` test rightly rejects. The worker entry is only loaded by build workers, so the renderer stays out of the runtime server. Both installs are idempotent.

With the renderer registered, a build error thrown from `generateStaticParams` now prints the same code frame as a prerender error, pointing at the offending line. The frame is only rendered when the source map carries source content, which happens under `--debug-prerender` (and otherwise `serverSourceMaps`), so normal minified production builds are unaffected. The `empty-generate-static-params` end-to-end test is updated to assert the code frame that now appears in the build error for both the literal and the computed empty array cases.