### PR TITLE
Ignore onAllReady after a fatal shell error in the Node Fizz stream

### DIFF
--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -565,6 +565,7 @@ export async function renderToNodeFizzStream(
   const shellReady = new DetachedPromise<void>()
   const allReady = new DetachedPromise<void>()
   const deferPipe = options?.waitForAllReady === true
+  let shellErrored = false
 
   const pipeable = getTracer().trace(AppRenderSpan.renderToReadableStream, () =>
     renderToPipeableStream(element, {
@@ -575,10 +576,16 @@ export async function renderToNodeFizzStream(
         shellReady.resolve()
       },
       onShellError(error: unknown) {
+        shellErrored = true
         streamOptions?.onShellError?.(error)
         shellReady.reject(error)
       },
       onAllReady() {
+        // React still fires onAllReady after a fatal shell error
+        // (facebook/react#36890). onShellError is terminal, so ignore it.
+        if (shellErrored) {
+          return
+        }
         streamOptions?.onAllReady?.()
         if (deferPipe) {
           pipeable.pipe(pt)
@@ -617,6 +624,7 @@ export async function resumeToFizzStream(
   const pt = new PassThrough()
   const shellReady = new DetachedPromise<void>()
   const allReady = new DetachedPromise<void>()
+  let shellErrored = false
 
   const pipeable = await run(() =>
     resumeToPipeableStream(element, postponedState, {
@@ -626,10 +634,16 @@ export async function resumeToFizzStream(
         shellReady.resolve()
       },
       onShellError(error: unknown) {
+        shellErrored = true
         streamOptions?.onShellError?.(error)
         shellReady.reject(error)
       },
       onAllReady() {
+        // React still fires onAllReady after a fatal shell error
+        // (facebook/react#36890). onShellError is terminal, so ignore it.
+        if (shellErrored) {
+          return
+        }
         streamOptions?.onAllReady?.()
         allReady.resolve()
       },


### PR DESCRIPTION
React still invokes the `onAllReady` callback after `onShellError` has fired for a fatal shell error, even though the render never completed (facebook/react#36890). Because `onShellError` is terminal, treating a subsequent `onAllReady` as a successful completion is incorrect: it resolves the `allReady` promise as if the render had succeeded, and in the `waitForAllReady` path it would pipe a stream whose shell had already errored.

This change tracks whether the shell errored in both `renderToNodeFizzStream` and `resumeToFizzStream` in `stream-ops.node.ts` and ignores the late `onAllReady` so that a fatal shell error stays terminal. The web path is unaffected because it consumes `renderToReadableStream` (whose returned `allReady` promise already rejects on shell error) rather than the callback form.