### PR TITLE
Turbopack: don't replace single-arg calls with argument in analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10145,6 +10145,7 @@ dependencies = [
  "mockito",
  "quick_cache",
  "reqwest",
+ "rustc-hash 2.1.1",
  "rustls",
  "serde",
  "tokio",

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/mod.rs
@@ -42,19 +42,6 @@ pub async fn replace_well_known<'a>(
                 Modified::Yes,
             )
         }
-        JsValue::Call(total, call) => {
-            // var fs = require('fs'), fs = __importStar(fs);
-            // TODO(WEB-552) this is not correct and has many false positives!
-            if call.args().len() == 1
-                && let JsValue::WellKnownObject(_) = &call.args()[0]
-            {
-                return Ok((
-                    call.args()[0].clone_in(arena.get_or_default()),
-                    Modified::Yes,
-                ));
-            }
-            (JsValue::Call(total, call), Modified::No)
-        }
         JsValue::Member(_, mut obj, mut prop) if matches!(&*obj, JsValue::WellKnownObject(_)) => {
             let JsValue::WellKnownObject(kind) = take(&mut *obj) else {
                 unreachable!()

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/env-vars.codegen.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/env-vars.codegen.snapshot
@@ -1,3 +1,1 @@
-runtime: [
-    "DECOY",
-]
+runtime: []

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/env-vars.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/env-vars.snapshot
@@ -1,3 +1,1 @@
-runtime: [
-    "DECOY",
-]
+runtime: []

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/env-vars.tracing.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/env-vars.tracing.snapshot
@@ -1,3 +1,1 @@
-runtime: [
-    "DECOY",
-]
+runtime: []

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/fn-map/input.js
@@ -1,5 +1,5 @@
+// TODO track arguments and mark FOOBAR as read
 globalThis.blackbox = (v) => ({ DECOY: v.FOOBAR })
 
-// TODO fix this
 const v = blackbox(process.env).DECOY
 console.log(v)


### PR DESCRIPTION
This was a hack added a long time ago. And it can lead to correctness issues