### PR TITLE
Fix workers on thread to not crash with napi-rs

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -58,7 +58,7 @@ export interface NapiTaskMessage {
 export declare function recvTaskMessageInWorker(
   workerId: number
 ): Promise<NapiTaskMessage>
-export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
+export declare function sendTaskMessage(message: NapiTaskMessage): void
 export interface NapiLocation {
   line: number
   column?: number

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -374,7 +374,7 @@ export const experimentalSchema = {
     .union([z.literal(false), z.literal('full')])
     .optional(),
   turbopackPluginRuntimeStrategy: z
-    .enum(['workerThreads', 'childProcesses', 'forceWorkerThreads'])
+    .enum(['workerThreads', 'childProcesses'])
     .optional(),
   turbopackMinify: z.boolean().optional(),
   turbopackFileSystemCacheForDev: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -723,26 +723,11 @@ export interface ExperimentalConfig {
    * This defaults to `'childProcesses'`, which creates a pool of child node.js
    * processes and communciates with them over sockets.
    *
-   * `'workerThreads'` should use less memory and CPU. It may become the default
-   * in a future version of Next.js.
-   *
-   * Node.js 24.13.1+ or 25.4.0+ is required for `'workerThreads'` due to memory
-   * safety bugs in older versions. If you use this option with an older Node.js
-   * version, the setting is ignored and a warning is emitted. Bun and Deno are
-   * assumed safe, and are not checked for compatibility.
-   *
-   * - Fix for memory safety issue: <https://github.com/nodejs/node/pull/55877>
-   * - Backported to 25.4.0: <https://github.com/nodejs/node/pull/61400>
-   * - Backported to 24.13.1: <https://github.com/nodejs/node/pull/61661>
-   *
-   * `'forceWorkerThreads'` behaves like `'workerThreads'` but skips the
-   * version-gated downgrade. You should not use this option unless you're
-   * confident that the version check in Next.js is wrong.
+   * `'workerThreads'` runs the same work in worker threads instead, which should
+   * use less memory and CPU. It may become the default in a future version of
+   * Next.js.
    */
-  turbopackPluginRuntimeStrategy?:
-    | 'workerThreads'
-    | 'childProcesses'
-    | 'forceWorkerThreads'
+  turbopackPluginRuntimeStrategy?: 'workerThreads' | 'childProcesses'
 
   /**
    * Enable minification. Defaults to true in build mode and false in dev mode.

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2,7 +2,6 @@ import { existsSync } from 'fs'
 import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import findUp from 'next/dist/compiled/find-up'
-import semver from 'next/dist/compiled/semver'
 import * as Log from '../build/output/log'
 import * as ciEnvironment from '../server/ci-info'
 import {
@@ -1580,52 +1579,6 @@ function assignDefaultsAndValidate(
   // backwards compatibility.
   if (result.experimental.useCache === undefined) {
     result.experimental.useCache = result.cacheComponents
-  }
-
-  // Node.js version gate for turbopackPluginRuntimeStrategy: 'workerThreads'.
-  // Older Node.js versions have memory safety bugs in worker threads. Bun and
-  // Deno are not affected by this check.
-  {
-    const strategy = result.experimental.turbopackPluginRuntimeStrategy
-    const isForced = strategy === 'forceWorkerThreads'
-    if (strategy === 'workerThreads' || isForced) {
-      // Normalize 'forceWorkerThreads' → 'workerThreads' for Rust/serde
-      result.experimental.turbopackPluginRuntimeStrategy = 'workerThreads'
-
-      const isBun = !!process.versions.bun
-      const isDeno = !!process.versions.deno
-      if (!isBun && !isDeno) {
-        const nodeVersion = process.versions.node
-        const WORKER_THREADS_SAFE_RANGE = '>=24.13.1 <25.0.0 || >=25.4.0'
-        if (
-          !semver.satisfies(nodeVersion, WORKER_THREADS_SAFE_RANGE, {
-            includePrerelease: true,
-          })
-        ) {
-          if (isForced) {
-            Log.warn(
-              `\`experimental.turbopackPluginRuntimeStrategy = ` +
-                `'forceWorkerThreads'\` has been enabled, but you're using ` +
-                `Node.js ${nodeVersion}, which has known memory safety bugs ` +
-                `with worker threads used from the Node-API. You may ` +
-                `experience crashes, segmentation faults, or other ` +
-                `instability. Upgrade to Node.js ${WORKER_THREADS_SAFE_RANGE}.`
-            )
-          } else {
-            Log.warn(
-              `\`experimental.turbopackPluginRuntimeStrategy = ` +
-                `'workerThreads'\` is set but has been ` +
-                `ignored because you're using Node.js ${nodeVersion}, which ` +
-                `has memory safety bugs in worker threads. Falling back to ` +
-                `'childProcesses'. Upgrade to Node.js ` +
-                `${WORKER_THREADS_SAFE_RANGE}.`
-            )
-            result.experimental.turbopackPluginRuntimeStrategy =
-              'childProcesses'
-          }
-        }
-      }
-    }
   }
 
   // Store the distDirRoot in the config before it is modified for development mode

--- a/test/production/turbopack-node-backend/turbopack-node-backend.test.ts
+++ b/test/production/turbopack-node-backend/turbopack-node-backend.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe.each([
-  ['forceWorkerThreads', true],
+  ['workerThreads', true],
   ['childProcesses', false],
 ] as const)(
   'turbopack-node-backend (%s)',

--- a/turbopack/crates/turbopack-node/js/src/worker_thread/taskChannel.ts
+++ b/turbopack/crates/turbopack-node/js/src/worker_thread/taskChannel.ts
@@ -10,7 +10,7 @@ export interface TaskMessage {
 
 export interface Binding {
   recvTaskMessageInWorker(workerId: number): Promise<TaskMessage>
-  sendTaskMessage(msg: TaskMessage): Promise<void>
+  sendTaskMessage(msg: TaskMessage): void
   workerCreated(workerId: number): void
 }
 
@@ -44,14 +44,17 @@ export class TaskChannel {
       reject = rej
     })
     TaskChannel.requests.set(id, { resolve, reject })
-    return await this.binding
-      .sendTaskMessage({
-        taskId: this.taskId,
-        data: TEXT_ENCODER.encode(
-          JSON.stringify({ type: 'request', id, data: message })
-        ),
-      })
-      .then(() => promise)
+    // sendTaskMessage used to be async, but ran into issues with
+    // napi-rs#3357.
+    // Now we send this message sync.
+    // But the resolve still happens async.
+    this.binding.sendTaskMessage({
+      taskId: this.taskId,
+      data: TEXT_ENCODER.encode(
+        JSON.stringify({ type: 'request', id, data: message })
+      ),
+    })
+    return await promise
   }
 
   async sendError(error: Error) {

--- a/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
@@ -42,6 +42,14 @@ impl<T: Send + Sync + 'static> MessageChannel<T> {
             .map_err(|_| anyhow::anyhow!("failed to send message"))
     }
 
+    /// Synchronous, non-blocking send (the channel is unbounded). Lets callers
+    /// on the napi env thread enqueue without going async.
+    pub(crate) fn send_sync(&self, message: T) -> Result<()> {
+        self.sender
+            .send(message)
+            .map_err(|_| anyhow::anyhow!("failed to send message"))
+    }
+
     pub(crate) async fn recv(&self) -> Result<T> {
         let mut rx = self.receiver.lock().await;
         rx.recv()
@@ -165,7 +173,7 @@ impl WorkerPoolOperation {
             .with_context(|| format!("failed to recv message in worker {worker_id}"))
     }
 
-    pub(crate) async fn send_task_message(&self, message: TaskMessage) -> Result<()> {
+    pub(crate) fn send_task_message(&self, message: TaskMessage) -> Result<()> {
         let channel = {
             let mut map = self.task_routed_channel.lock();
             map.entry(message.task_id)
@@ -173,9 +181,8 @@ impl WorkerPoolOperation {
                 .clone()
         };
         channel
-            .send(message.data)
-            .await
-            .with_context(|| format!("failed to send  response for task {}", message.task_id))
+            .send_sync(message.data)
+            .with_context(|| format!("failed to send response for task {}", message.task_id))
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/worker_pool/worker_thread.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/worker_thread.rs
@@ -155,7 +155,14 @@ impl From<NapiTaskMessage> for TaskMessage {
         let NapiTaskMessage { task_id, data } = message;
         TaskMessage {
             task_id,
-            data: Bytes::from_owner(data),
+            // Copy out of the JS Buffer rather than retaining a napi reference
+            // (`Bytes::from_owner`). Because `send_task_message` is a *sync*
+            // `#[napi]` fn, this runs on the env thread, so the `Buffer` is
+            // dropped here via a direct `napi_reference_unref`. It never crosses
+            // to a tokio/turbo-tasks thread, so the global CustomGC
+            // ThreadsafeFunction (napi-rs#3357) is never
+            // invoked for our task payloads.
+            data: Bytes::copy_from_slice(&data),
         }
     }
 }
@@ -176,8 +183,6 @@ pub async fn recv_task_message_in_worker(worker_id: u32) -> napi::Result<NapiTas
 // Allow dead_code for test builds where napi exports are not entry points
 #[allow(dead_code)]
 #[napi]
-pub async fn send_task_message(message: NapiTaskMessage) -> napi::Result<()> {
-    Ok(WORKER_POOL_OPERATION
-        .send_task_message(message.into())
-        .await?)
+pub fn send_task_message(message: NapiTaskMessage) -> napi::Result<()> {
+    Ok(WORKER_POOL_OPERATION.send_task_message(message.into())?)
 }


### PR DESCRIPTION
We believed the workers were crashing due to issues related to node. We had code that guarded on which version of node you were using and warned that it was unstable. I was able to recreate the crashes regardless of node version or napi-rs version. I filed an issue with napi-rs https://github.com/napi-rs/napi-rs/issues/3357. 

This gets around the crashes we were seeing by making sure we don't drop things off isolate causing these bugs. I did explore writing some tests here, but I wasn't sure a good way to do that. I did make [jimmym/turbopack-loader-worker-changes-stress-test](https://github.com/vercel/next.js/tree/jimmym/turbopack-loader-worker-changes-stress-test) which has  a nice little reproducing stress test that now passes. I wasn't sure if we'd want something like this checked in or not. But figure it is good for people to see.

I probably do need to validate this with some existing apps out there that trigger the crash. But I did keep the default to the process workers for now, so impact should be minimal.