### PR TITLE
Increase the code frame width used when logging to a file.

### DIFF
--- a/crates/next-napi-bindings/src/code_frame.rs
+++ b/crates/next-napi-bindings/src/code_frame.rs
@@ -5,7 +5,15 @@ use next_code_frame::{
 };
 
 /// Default max width when the caller doesn't provide one (e.g., no terminal).
-const DEFAULT_MAX_WIDTH: u32 = 100;
+///
+/// When output is captured to a log file or build container, there is no
+/// terminal width to read. A log/build-log viewer can soft-wrap or scroll, so
+/// the cost of wrapping too narrow (scattering the caret line away from the
+/// code) is worse than being a bit wide. We pick a generous value — roughly 2x
+/// a typical editor width — that fits nearly all hand-written source, while
+/// still bounding per-frame output so a minified/generated line can't dump
+/// kilobytes into the log.
+const DEFAULT_MAX_WIDTH: u32 = 240;
 
 #[napi(object)]
 pub struct NapiLocation {
@@ -52,7 +60,7 @@ pub struct NapiCodeFrameOptions {
     pub lines_above: Option<u32>,
     /// Number of lines to show below the error (default: 3)
     pub lines_below: Option<u32>,
-    /// Maximum width of the output in columns (default: 100)
+    /// Maximum width of the output in columns (default: 240)
     pub max_width: Option<u32>,
     /// Whether to use ANSI colors (default: false)
     pub color: Option<Either<NapiCodeFrameColorMode, bool>>,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -77,7 +77,7 @@ export interface NapiCodeFrameOptions {
   linesAbove?: number
   /** Number of lines to show below the error (default: 3) */
   linesBelow?: number
-  /** Maximum width of the output in columns (default: 100) */
+  /** Maximum width of the output in columns (default: 240) */
   maxWidth?: number
   /** Whether to use ANSI colors (default: false) */
   color?: NapiCodeFrameColorMode | boolean

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -1593,7 +1593,7 @@ describe('Cache Components Errors', () => {
                  TypeError: <module-function>().get is not a function
                      at CookiesReadingComponent (app/sync-cookies/page.tsx:18:36)
                    16 | async function CookiesReadingComponent() {
-                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync...
+                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const token = (cookies() as any).get('token')
                       |                                    ^
                    19 |
@@ -1611,7 +1611,7 @@ describe('Cache Components Errors', () => {
                  TypeError: <module-function>().get is not a function
                      at CookiesReadingComponent (webpack:///app/sync-cookies/page.tsx:18:36)
                    16 | async function CookiesReadingComponent() {
-                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync...
+                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const token = (cookies() as any).get('token')
                       |                                    ^
                    19 |
@@ -1631,7 +1631,7 @@ describe('Cache Components Errors', () => {
                  TypeError: <module-function>().get is not a function
                      at a (app/sync-cookies/page.tsx:18:36)
                    16 | async function CookiesReadingComponent() {
-                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync...
+                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const token = (cookies() as any).get('token')
                       |                                    ^
                    19 |
@@ -1925,7 +1925,7 @@ describe('Cache Components Errors', () => {
                  TypeError: <module-function>().get is not a function
                      at HeadersReadingComponent (app/sync-headers/page.tsx:18:40)
                    16 | async function HeadersReadingComponent() {
-                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync...
+                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const userAgent = (headers() as any).get('user-agent')
                       |                                        ^
                    19 |   return (
@@ -1943,7 +1943,7 @@ describe('Cache Components Errors', () => {
                  TypeError: <module-function>().get is not a function
                      at HeadersReadingComponent (webpack:///app/sync-headers/page.tsx:18:40)
                    16 | async function HeadersReadingComponent() {
-                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync...
+                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const userAgent = (headers() as any).get('user-agent')
                       |                                        ^
                    19 |   return (
@@ -1963,7 +1963,7 @@ describe('Cache Components Errors', () => {
                  TypeError: <module-function>().get is not a function
                      at a (app/sync-headers/page.tsx:18:40)
                    16 | async function HeadersReadingComponent() {
-                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync...
+                   17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const userAgent = (headers() as any).get('user-agent')
                       |                                        ^
                    19 |   return (


### PR DESCRIPTION
### What?

Bump the default code frame width (used when stdout isn't a terminal) from 100 to 240 columns.

### Why?

When code frames are captured to a log file or build container, there's no terminal width to read, so we fall back to a default. 100 columns is too narrow for log output — build-log viewers soft-wrap or scroll, so the cost of wrapping too narrow (scattering the caret line away from the code) is worse than being a bit wide. 240 fits nearly all hand-written source while still bounding per-frame output so a minified/generated line can't dump kilobytes into the log.

<!-- NEXT_JS_LLM_PR -->
