### PR TITLE
fix: params/searchParams in client page crashing dev instant validation

### DIFF
--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -69,12 +69,6 @@ export function createParamsFromClient(
           workUnitStore,
           varyParamsAccumulator
         )
-      case 'validation-client':
-        return createClientParamsInInstantValidation(
-          underlyingParams,
-          workStore,
-          workUnitStore.validationSamples
-        )
       case 'cache':
       case 'private-cache':
       case 'unstable-cache':
@@ -89,6 +83,16 @@ export function createParamsFromClient(
         throw new InvariantError(
           'createParamsFromClient should not be called inside generateStaticParams.'
         )
+      case 'validation-client': {
+        if (workUnitStore.validationSamples) {
+          return createClientParamsInInstantValidation(
+            underlyingParams,
+            workStore,
+            workUnitStore.validationSamples
+          )
+        }
+        return makeUntrackedParams(underlyingParams)
+      }
       case 'request': {
         if (workUnitStore.validationSamples) {
           return createClientParamsInInstantValidation(

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -62,13 +62,6 @@ export function createSearchParamsFromClient(
       case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderSearchParams(workStore, workUnitStore)
-      case 'validation-client': {
-        return createClientSearchParamsInValidation(
-          underlyingSearchParams,
-          workStore,
-          workUnitStore
-        )
-      }
       case 'prerender-runtime':
         throw new InvariantError(
           'createSearchParamsFromClient should not be called in a runtime prerender.'
@@ -83,6 +76,16 @@ export function createSearchParamsFromClient(
         throw new InvariantError(
           'createSearchParamsFromClient should not be called inside generateStaticParams.'
         )
+      case 'validation-client': {
+        if (workUnitStore.validationSamples) {
+          return createClientSearchParamsInValidation(
+            underlyingSearchParams,
+            workStore,
+            workUnitStore
+          )
+        }
+        return makeUntrackedSearchParams(underlyingSearchParams)
+      }
       case 'request':
         // Client searchParams are not runtime prefetchable
         const isRuntimePrefetchable = false

--- a/test/e2e/app-dir/instant-validation/app/shared.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shared.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react'
 import { setTimeout } from 'timers/promises'
 
 export function HackilyPreventFullyStaticServerPrerender() {
+  // FIXME(NAR-800)
   return <Suspense>{connection().then(() => null)}</Suspense>
 }
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -124,6 +124,12 @@ export default async function Page() {
           <DebugLinks href="/suspense-in-root/static/valid-client-api-in-parent/search-params" />
         </li>
         <li>
+          <DebugLinks href="/suspense-in-root/static/valid-client-params/123" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/static/valid-client-search-params?query=foo" />
+        </li>
+        <li>
           <DebugLinks href="/suspense-in-root/static/valid-client-data-does-not-block-validation" />
         </li>
         <li>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-params/[slug]/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-params/[slug]/layout.tsx
@@ -1,0 +1,18 @@
+import { Instant } from 'next'
+import { ReactNode } from 'react'
+import { HackilyPreventFullyStaticServerPrerender } from '../../../../shared'
+
+// We need a layout to export an instant config. Client components cannot have one
+export const instant: Instant = {
+  level: 'experimental-error',
+  unstable_samples: [{ params: { slug: '123' } }],
+}
+
+export default function DummyLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <HackilyPreventFullyStaticServerPrerender />
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-params/[slug]/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { use } from 'react'
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = use(params)
+  return (
+    <main>
+      <h1>Slug: {slug}</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-search-params/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-search-params/layout.tsx
@@ -1,0 +1,18 @@
+import { Instant } from 'next'
+import { ReactNode } from 'react'
+import { HackilyPreventFullyStaticServerPrerender } from '../../../shared'
+
+// We need a layout to export an instant config. Client components cannot have one
+export const instant: Instant = {
+  level: 'experimental-error',
+  unstable_samples: [{ searchParams: { query: 'foo' } }],
+}
+
+export default function DummyLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <HackilyPreventFullyStaticServerPrerender />
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-search-params/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { use } from 'react'
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[]>>
+}) {
+  const { query } = use(searchParams)
+  return (
+    <main>
+      <h1>Query {query}</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -1787,6 +1787,34 @@ describe('instant validation', () => {
           expectNoBuildValidationErrors(result)
         }
       })
+
+      it('valid - unguarded params in client page', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/suspense-in-root/static/valid-client-params/123'
+          )
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/static/valid-client-params/[slug]'
+          )
+          expectNoBuildValidationErrors(result)
+        }
+      })
+
+      it('valid - unguarded searchParams in client page', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/suspense-in-root/static/valid-client-search-params?query=foo'
+          )
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/static/valid-client-search-params'
+          )
+          expectNoBuildValidationErrors(result)
+        }
+      })
     })
 
     describe('client errors', () => {


### PR DESCRIPTION
Fixes an oversight where `params`/`searchParams` in client pages would cause dev instant validation to go down a codepath intended for build-time instant validation. We'd end up unintentionally wrapping params with an excaustive proxy which would then crash because the store is not set up as expected:
```
## Error Message
Route "/store/[slug]": Could not validate `instant` because an error prevented the target segment from rendering.

Next.js version: 16.3.0-preview.5 (Turbopack)

  [cause]: Error [InvariantError]: Invariant: Expected to have a workUnitStore that provides validationSampleTracking. This is a bug in Next.js.
      at Page (app/store/[slug]/page.tsx:6:11)
    4 |
    5 | export default function Page(props: PageProps<"/store/[slug]">) {
  > 6 |   const { slug } = use(props.params);
      |           ^
    7 |   return (
    8 |     <>
    9 |       <h1>Store {slug}</h1>
}
```
The proxy code should've been gated on `workUnitStore.validationSamples` like we do in other places that care about samples.