### PR TITLE
[test] Park the blocking-fallback segment on a withheld param

### DIFF
--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/[scope]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/blocking-fallback/[lang]/[scope]/page.tsx
@@ -1,10 +1,27 @@
 import { cookies } from 'next/headers'
 
-// The deeper, blocking segment of the fallback route: reads request-time
-// `cookies()` and has no <Suspense> of its own, so it has no static shell.
-// Under instant() the navigation here must stay parked on the committed parent;
-// the cookie value must not commit while the lock is held.
-export default function ScopePage() {
+// The deeper, blocking segment of the fallback route: awaits the uncovered
+// `scope` param and reads request-time `cookies()`, and has no <Suspense> of
+// its own, so it has no static shell. Under instant() the navigation here must
+// stay parked on the committed parent; neither the title nor the cookie value
+// may commit while the lock is held.
+export default async function ScopePage({
+  params,
+}: {
+  params: Promise<{ lang: string; scope: string }>
+}) {
+  // Await the uncovered `scope` fallback param to keep this segment parked
+  // under instant(). The app shell is allowed to read `cookies()` without
+  // blocking, so gating only on cookies would make parking depend on a race:
+  // the title leaks when the cookie-bearing app-shell prefetch commits this
+  // segment, but stays hidden when the empty static speculative prefetch
+  // commits first. Awaiting the withheld param removes the title from both
+  // prefetches, so it stays parked until the lock releases no matter which one
+  // wins. This app-shell-versus-speculative-prefetch race is a known, likely
+  // temporary limitation; see the note on the `cookies in the instant shell`
+  // describe block for the related case and the planned fix.
+  await params
+
   return (
     <div>
       <h1 data-testid="blocking-scope-title">Scope</h1>

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -136,10 +136,13 @@ describe('instant-navigation-testing-api', () => {
   // Navigate deeper under the lock. Loading `/blocking-fallback/en` commits the
   // parent layout (which owns the only <Suspense> boundary) and the landing
   // page. `/blocking-fallback/en/s1` is a fallback route (`[scope]` has no
-  // generateStaticParams) whose deeper page blocks on `cookies()`. Navigating
-  // into it must stay parked: the committed parent and landing page stay on
-  // screen, the deeper page and its cookie value must not commit while the lock
-  // is held, and they stream in only after release.
+  // generateStaticParams) whose deeper page awaits the uncovered `scope` param
+  // and reads `cookies()`. Awaiting the withheld param is what keeps the
+  // segment out of the app shell (the app shell is allowed to read cookies, so
+  // a cookie read alone would not park it). Navigating into it must stay
+  // parked: the committed parent and landing page stay on screen, the deeper
+  // page (its title and its cookie value) must not commit while the lock is
+  // held, and they stream in only after release.
   it('keeps the committed layout and defers a deeper blocking segment under instant()', async () => {
     const page = await openPage(next, '/blocking-fallback/en', {
       cookies: [{ name: 'testCookie', value: 'hello' }],


### PR DESCRIPTION
The `blocking-fallback/[lang]/[scope]` fixture's deeper page previously rendered a static title and gated its only dynamic work on a `cookies( ` read. Under instant() the committed app shell is allowed to read reque t cookies without blocking, which is exactly what the cookie assertions  n this suite rely on, so a segment gated only on cookies renders into th shell and its title commits while the lock is held. Under CPU load thi surfaced as a flaky leak of `blocking-scope-title` during the parke navigation, and instrumenting the lock's read path confirmed the cause  the test failed precisely when the app-shell (RuntimeShell) entry committe  the deeper segment and passed when the speculative static prefetch (PPR) e try committed, a commit-order race between the two prefetch responses 

This change makes `ScopePage` await `params` before rendering anything. Because `scope` is an uncovered fallback param (the route has no `generateStaticParams`), awaiting it suspends the whole segment during the app-shell prerender and keeps both the title and the cookie value out of the committed shell regardless of which prefetch wins. The segment streams in only after the lock releases, when the real dynamic render resolves `params`.

The underlying app-shell-versus-speculative-prefetch race is a known, likely temporary limitation; the `cookies in the instant shell` describe block documents the related case and the planned fix of opting cookie-reading routes into partial or runtime prefetching. The test comment is updated to describe this param-gated parking instead of the previous cookie-based description.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>