### PR TITLE
Await reused in-flight prefetch entries under Instant Navigation lock

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -881,10 +881,30 @@ export function readOrCreateSegmentCacheEntry(
       // reused like normal; otherwise the prefetch would discard the entry it
       // just fetched on every scheduler pass and refetch forever. See
       // navigation-testing-lock.ts.
-      const { getCurrentNavigationLock } =
+      const { getCurrentNavigationLock, trackNavigationLockPrefetchEntry } =
         require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
       const lock = getCurrentNavigationLock()
       if (lock !== null && lock.ownedEntries.has(existingEntry)) {
+        // Track-on-reuse: when this navigation reuses an in-flight (Pending)
+        // entry it didn't spawn — e.g. a runtime-prefetch (PPRRuntime) upgrade
+        // started by an earlier prefetch in the scope — register it on this
+        // navigation's prefetch so the navigation awaits it before reading.
+        // Without this, the navigation can read while that upgrade is still
+        // pending and fall back to a less-specific fulfilled entry (the shell),
+        // never surfacing the resolved value.
+        //
+        // This is content-neutral: the entry is found by the concrete vary-path
+        // (not by strategy), so it's whatever the navigation would read at this
+        // key anyway. Tracking only controls whether we await it now versus
+        // suspend on it during the render, so it can't surface an entry the
+        // navigation wouldn't otherwise read. Tracking is deduped, so it's a
+        // no-op if we already spawned/tracked this entry.
+        if (existingEntry.status === EntryStatus.Pending) {
+          trackNavigationLockPrefetchEntry(
+            navigationLockPrefetch,
+            existingEntry
+          )
+        }
         return existingEntry
       }
     } else {

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -56,7 +56,11 @@ async function openPage(
       }
     },
   })
-  return page!
+  // Lower the per-action timeout below jest's 60s test timeout so a stalling
+  // waitFor fails with its own locator (naming the element that never appeared)
+  // instead of a bare test-level timeout that hides which assertion hung.
+  page.setDefaultTimeout(20_000)
+  return page
 }
 
 describe('instant-navigation-testing-api', () => {


### PR DESCRIPTION
A locked instant() navigation could time out flakily on routes that use runtime prefetching (e.g. `allow-runtime` pages). The navigation reads the segment cache only after its prefetch drains, but the prefetch only awaits the entries it spawned itself. When an earlier prefetch in the scope had already started a more-specific runtime upgrade (a `PPRRuntime` page entry) that was still in flight, the navigation reused that entry without tracking it, drained without waiting for it, and read while it was still pending. The read then fell back to the less-specific fulfilled `RuntimeShell` entry (the static shell with no resolved value), so the awaited content never surfaced and the test timed out. The race only lost under CPU contention, which is why it reproduced in the prod flake-detection job on slow containers but almost never locally.

This change tracks an in-flight entry at the point the navigation reuses it. In `readOrCreateSegmentCacheEntry`, when a locked navigation reuses an existing `Pending` entry it did not spawn, it now registers that entry on the navigation's prefetch via `trackNavigationLockPrefetchEntry`, so the prefetch awaits it before the navigation reads. The read then finds the resolved entry rather than the shell.

The fix is content-neutral: the entry is looked up by the concrete vary path, so it is whatever the navigation would read at that key regardless. Tracking only controls whether the navigation awaits the entry now versus suspends on it during render, so it cannot surface an entry the navigation would not otherwise read, and it leaves session ownership untouched (so reads still never miss). Tracking is deduped, so reusing an entry the navigation already spawned is a no-op.

This also lowers the per-action timeout in the `instant-navigation-testing-api` test suite to below jest's test timeout, so a future stalling `waitFor` fails with its own locator (naming the element that never appeared) instead of a bare test-level timeout that hides which assertion hung. That edit also marks the suite as changed, so CI's flake-detection job re-runs the previously flaky runtime-prefetch tests and confirms they are now stable.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>