### PR TITLE
[test] Give webpack server-action-period-hash tests a larger timeout

### DIFF
--- a/test/production/app-dir/server-action-period-hash/server-action-period-hash-custom-key.test.ts
+++ b/test/production/app-dir/server-action-period-hash/server-action-period-hash-custom-key.test.ts
@@ -7,6 +7,13 @@ async function getServerActionManifestNodeKeys(next: NextInstance) {
   return Object.keys(manifest.node)
 }
 
+// Each test runs two production builds, and webpack builds are much slower than
+// Turbopack, so the default 60s per-test budget is too tight on slower CI
+// runners. Turbopack keeps the default.
+if (process.env.IS_WEBPACK_TEST) {
+  jest.setTimeout(120_000)
+}
+
 describe('app-dir - server-action-period-hash-custom-key', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/production/app-dir/server-action-period-hash/server-action-period-hash.test.ts
+++ b/test/production/app-dir/server-action-period-hash/server-action-period-hash.test.ts
@@ -7,6 +7,13 @@ async function getServerActionManifestNodeKeys(next: NextInstance) {
   return Object.keys(manifest.node)
 }
 
+// Each test runs two production builds, and webpack builds are much slower than
+// Turbopack, so the default 60s per-test budget is too tight on slower CI
+// runners. Turbopack keeps the default.
+if (process.env.IS_WEBPACK_TEST) {
+  jest.setTimeout(120_000)
+}
+
 describe('app-dir - server-action-period-hash', () => {
   const { next } = nextTestSetup({
     files: __dirname,


### PR DESCRIPTION
Both `server-action-period-hash` test files run two production builds per test case, and webpack production builds are considerably slower than Turbopack. On slower CI runners two webpack builds can exceed the default 60s per-test budget, and when the timeout fires mid-build the `next build` child process is orphaned while `NextStartInstance` still tracks it. The `jest.retryTimes(1)` retry then re-runs the body and the next `build()` call throws `can not run export while server is running`, which masks the original timeout.

This raises the per-test timeout to 120s for these files under webpack only, matching the existing precedent of a larger budget on slower platforms. Turbopack keeps the default 60s budget, where two builds fit comfortably.