### PR TITLE
[test] Recover from a leftover build process on test retry in `build()`

### DIFF
--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -65,24 +65,31 @@ export class NextStartInstance extends NextInstance {
     })
   }
 
+  // When a previous test attempt was interrupted (typically by exceeding the
+  // per-test timeout) while `next build` was still running, the build process
+  // is still tracked here. Since `jest.retryTimes` re-runs the test body in the
+  // same process, stop the orphaned build so the caller can continue instead of
+  // failing the retry. If a server is genuinely running, throw
+  // `serverRunningError` instead.
+  private async stopLeftoverBuildOrThrow(serverRunningError: string) {
+    if (!this.childProcess) {
+      return
+    }
+
+    if (this._phase === 'building') {
+      require('console').warn(
+        'Found a leftover `next build` process from an interrupted test attempt; stopping it before continuing.'
+      )
+      await this.stop()
+    } else {
+      throw new Error(serverRunningError)
+    }
+  }
+
   public async start(
     options: { skipBuild?: boolean; env?: Record<string, string> } = {}
   ) {
-    if (this.childProcess) {
-      if (this._phase === 'building') {
-        // A previous test attempt was interrupted (typically by exceeding the
-        // per-test timeout) while `next build` was still running, so the build
-        // process is still tracked here. Since `jest.retryTimes` re-runs the
-        // test body in the same process, stop the orphaned build and continue
-        // instead of failing the retry with `next already started`.
-        require('console').warn(
-          'Found a leftover `next build` process from an interrupted test attempt; stopping it before starting again.'
-        )
-        await this.stop()
-      } else {
-        throw new Error('next already started')
-      }
-    }
+    await this.stopLeftoverBuildOrThrow('next already started')
 
     this._cliOutput = ''
     const spawnOpts = this.getSpawnOpts(options.env)
@@ -270,11 +277,9 @@ export class NextStartInstance extends NextInstance {
   public async build(
     options: { env?: Record<string, string>; args?: string[] } = {}
   ) {
-    if (this.childProcess) {
-      throw new Error(
-        `can not run export while server is running, use next.stop() first`
-      )
-    }
+    await this.stopLeftoverBuildOrThrow(
+      'can not run export while server is running, use next.stop() first'
+    )
 
     let result = await new Promise<{
       exitCode: NodeJS.Signals | number | null


### PR DESCRIPTION
PR #94797 taught `NextStartInstance.start()` to recover from a leftover `next build` process left behind when a previous test attempt was interrupted mid-build by the per-test timeout, but `build()` kept throwing `can not run export while server is running` unconditionally whenever a child process was still tracked. Tests that only call `next.build()` (and never `start()`) therefore still failed their `jest.retryTimes` retry with that misleading error, masking the original timeout.

This extracts the recovery logic into a shared `stopLeftoverBuildOrThrow` helper and routes both `start()` and `build()` through it. When a leftover `next build` process from an interrupted attempt is found, it is stopped so the retry can continue from a clean state; a genuinely running server still throws, preserving the existing guard. Sharing one helper keeps the two call sites in sync.