### PR TITLE
codemod: non-interactive upgrade for agents and CI

### DIFF
--- a/docs/01-app/02-guides/upgrading/codemods.mdx
+++ b/docs/01-app/02-guides/upgrading/codemods.mdx
@@ -34,6 +34,7 @@ npx @next/codemod upgrade [revision]
 
 - `revision` (optional): Specify the upgrade type (`patch`, `minor`, `major`), an NPM dist tag (e.g. `latest`, `canary`, `rc`), or an exact version (e.g. `15.0.0`). Defaults to `minor` for stable versions.
 - `--verbose`: Show more detailed output during the upgrade process.
+- `-y, --yes`: Skip every interactive prompt and accept its default (upgrade React past 18, enable Turbopack, apply all recommended codemods, run the React 19 codemods). Also auto-enabled when stdin is not a TTY (CI, an AI coding agent, or any non-interactive shell), so you usually don't need to pass it explicitly.
 
 For example:
 
@@ -52,12 +53,16 @@ npx @next/codemod upgrade 16
 
 # Upgrade to the canary release
 npx @next/codemod upgrade canary
+
+# Run from an agent or CI: skip every prompt
+npx @next/codemod upgrade canary --yes
 ```
 
 > **Good to know**:
 >
 > - If the target version is the same as or lower than your current version, the command exits without making changes.
 > - During the upgrade, you may be prompted to choose which Next.js codemods to apply and run React 19 codemods if upgrading React.
+> - When invoked by an AI coding agent or in CI (anywhere stdin isn't a TTY), the upgrade runs non-interactively and accepts every default. Pass `--yes` to force this behavior even from a terminal.
 
 ## Codemods
 

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -65,6 +65,11 @@ program
   )
   .usage('[revision] [options]')
   .option('--verbose', 'Verbose output', false)
+  .option(
+    '-y, --yes',
+    'Skip every interactive prompt and accept its default. Also auto-enabled when stdin is not a TTY (e.g. running under an agent or in CI).',
+    false
+  )
   .action(async (revision, options) => {
     try {
       await runUpgrade(revision, options)

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -116,7 +116,7 @@ export async function runUpgrade(
 ): Promise<void> {
   const { verbose } = options
   const nonInteractive = options.yes === true || !process.stdin.isTTY
-  if (nonInteractive && verbose) {
+  if (nonInteractive) {
     console.log(
       `  Running in non-interactive mode. Every prompt will accept its default.`
     )

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -112,9 +112,15 @@ function resolveSemanticRevision(
 
 export async function runUpgrade(
   revision: string | undefined,
-  options: { verbose: boolean }
+  options: { verbose: boolean; yes?: boolean }
 ): Promise<void> {
   const { verbose } = options
+  const nonInteractive = options.yes === true || !process.stdin.isTTY
+  if (nonInteractive && verbose) {
+    console.log(
+      `  Running in non-interactive mode. Every prompt will accept its default.`
+    )
+  }
   const appPackageJsonPath = path.resolve(cwd, 'package.json')
   let appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8'))
 
@@ -221,22 +227,27 @@ export async function runUpgrade(
     // We'll recommend to upgrade in the prompt but users can decide to try 18.
     !isPureAppRouter
   ) {
-    const shouldStayOnReact18Res = await prompts(
-      {
-        type: 'confirm',
-        name: 'shouldStayOnReact18',
-        message:
-          `Do you prefer to stay on React 18?` +
-          (isMixedApp
-            ? " Since you're using both pages/ and app/, we recommend upgrading React to use a consistent version throughout your app."
-            : ''),
-        initial: false,
-        active: 'Yes',
-        inactive: 'No',
-      },
-      { onCancel }
-    )
-    shouldStayOnReact18 = shouldStayOnReact18Res.shouldStayOnReact18
+    if (nonInteractive) {
+      // Default: upgrade React past 18.
+      shouldStayOnReact18 = false
+    } else {
+      const shouldStayOnReact18Res = await prompts(
+        {
+          type: 'confirm',
+          name: 'shouldStayOnReact18',
+          message:
+            `Do you prefer to stay on React 18?` +
+            (isMixedApp
+              ? " Since you're using both pages/ and app/, we recommend upgrading React to use a consistent version throughout your app."
+              : ''),
+          initial: false,
+          active: 'Yes',
+          inactive: 'No',
+        },
+        { onCancel }
+      )
+      shouldStayOnReact18 = shouldStayOnReact18Res.shouldStayOnReact18
+    }
   }
 
   // We're resolving a specific version here to avoid including "ugly" version queries
@@ -254,12 +265,13 @@ export async function runUpgrade(
     compareVersions(targetNextVersion, '15.0.0-canary') >= 0 &&
     compareVersions(targetNextVersion, '16.0.0-canary') < 0
   ) {
-    await suggestTurbopack(appPackageJson, targetNextVersion)
+    await suggestTurbopack(appPackageJson, targetNextVersion, nonInteractive)
   }
 
   const codemods = await suggestCodemods(
     installedNextVersion,
-    targetNextVersion
+    targetNextVersion,
+    nonInteractive
   )
   const packageManager: PackageManager = getPkgManager(cwd)
 
@@ -272,8 +284,9 @@ export async function runUpgrade(
     compareVersions(targetReactVersion, '19.0.0-0') >= 0 &&
     compareVersions(installedReactVersion, '19.0.0-0') < 0
   ) {
-    shouldRunReactCodemods = await suggestReactCodemods()
-    shouldRunReactTypesCodemods = await suggestReactTypesCodemods()
+    shouldRunReactCodemods = await suggestReactCodemods(nonInteractive)
+    shouldRunReactTypesCodemods =
+      await suggestReactTypesCodemods(nonInteractive)
 
     execCommand = getNpxCommand(packageManager)
   }
@@ -486,7 +499,8 @@ function isUsingAppDir(projectPath: string): boolean {
  */
 async function suggestTurbopack(
   packageJson: any,
-  targetNextVersion: string
+  targetNextVersion: string,
+  nonInteractive: boolean
 ): Promise<void> {
   const devScript: string | undefined = packageJson.scripts?.['dev']
   // Turbopack flag was changed from `--turbo` to `--turbopack` in v15.0.1-canary.3
@@ -518,17 +532,21 @@ async function suggestTurbopack(
       return
     }
 
-    const responseTurbopack = await prompts(
-      {
-        type: 'confirm',
-        name: 'enable',
-        message: `Enable Turbopack for ${pc.bold('next dev')}?`,
-        initial: true,
-      },
-      { onCancel }
-    )
+    let enable = true
+    if (!nonInteractive) {
+      const responseTurbopack = await prompts(
+        {
+          type: 'confirm',
+          name: 'enable',
+          message: `Enable Turbopack for ${pc.bold('next dev')}?`,
+          initial: true,
+        },
+        { onCancel }
+      )
+      enable = responseTurbopack.enable
+    }
 
-    if (!responseTurbopack.enable) {
+    if (!enable) {
       return
     }
 
@@ -542,6 +560,12 @@ async function suggestTurbopack(
   console.log(
     `${pc.yellow('⚠')} Could not find "${pc.bold('next dev')}" in your dev script.`
   )
+
+  if (nonInteractive) {
+    // Without a TTY we can't ask the user for a replacement script.
+    // Keep the existing dev script untouched.
+    return
+  }
 
   const responseCustomDevScript = await prompts(
     {
@@ -559,7 +583,8 @@ async function suggestTurbopack(
 
 async function suggestCodemods(
   initialNextVersion: string,
-  targetNextVersion: string
+  targetNextVersion: string,
+  nonInteractive: boolean
 ): Promise<string[]> {
   // example:
   // codemod version: 15.0.0-canary.45
@@ -594,6 +619,16 @@ async function suggestCodemods(
     return []
   }
 
+  if (nonInteractive) {
+    // Default: apply every recommended codemod, matching `selected: true` below.
+    const all = relevantCodemods.map(({ value }) => value)
+    console.log(
+      `  Applying all ${pc.blue('codemods')} recommended for your upgrade:\n` +
+        all.map((value) => `    - ${value}`).join('\n')
+    )
+    return all
+  }
+
   const { codemods } = await prompts(
     {
       type: 'multiselect',
@@ -614,7 +649,10 @@ async function suggestCodemods(
   return codemods
 }
 
-async function suggestReactCodemods(): Promise<boolean> {
+async function suggestReactCodemods(nonInteractive: boolean): Promise<boolean> {
+  if (nonInteractive) {
+    return true
+  }
   const { runReactCodemod } = await prompts(
     {
       type: 'confirm',
@@ -628,7 +666,12 @@ async function suggestReactCodemods(): Promise<boolean> {
   return runReactCodemod
 }
 
-async function suggestReactTypesCodemods(): Promise<boolean> {
+async function suggestReactTypesCodemods(
+  nonInteractive: boolean
+): Promise<boolean> {
+  if (nonInteractive) {
+    return true
+  }
   const { runReactTypesCodemod } = await prompts(
     {
       type: 'confirm',

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -413,10 +413,12 @@ export async function runUpgrade(
   // understanding of the codemods, we run all of the applicable codemods.
   if (shouldRunReactCodemods) {
     // https://react.dev/blog/2024/04/25/react-19-upgrade-guide#run-all-react-19-codemods
+    // `--no-interactive` skips the interactive prompt that asks for confirmation
+    // https://github.com/codemod-com/codemod/blob/c0cf00d13161a0ec0965b6cc6bc5d54076839cc8/apps/cli/src/flags.ts#L160
+    // `--allow-dirty` is required because the upgrade above modified package.json
+    // and the lockfile; the recipe refuses to run on a dirty tree otherwise.
     execSync(
-      // `--no-interactive` skips the interactive prompt that asks for confirmation
-      // https://github.com/codemod-com/codemod/blob/c0cf00d13161a0ec0965b6cc6bc5d54076839cc8/apps/cli/src/flags.ts#L160
-      `${execCommand} codemod@latest react/19/migration-recipe --no-interactive`,
+      `${execCommand} codemod@latest react/19/migration-recipe --no-interactive --allow-dirty`,
       { stdio: 'inherit' }
     )
   }


### PR DESCRIPTION
## Why

Sokra flagged in Slack that \`pnpm dlx @next/codemod@canary upgrade preview\` hangs forever when an agent invokes it: the recommended-codemods multiselect blocks waiting for keyboard input. Same hazard for any CI that pipes the command. Agents end up choosing the manual non-interactive path, which defeats the codemod entirely.

## What

- Adds \`-y, --yes\` to \`@next/codemod upgrade\`.
- Auto-detects \`!process.stdin.isTTY\` so agents and CI get non-interactive mode without needing to know the flag.
- In non-interactive mode every prompt accepts its existing default:
  - React 18-or-19 -> upgrade (existing \`initial: false\` stays-on-18).
  - Turbopack enable -> yes (\`initial: true\`).
  - Custom-dev-script fallback -> leave the script untouched (we can't ask for a replacement without a TTY).
  - Recommended codemods multiselect -> apply all (matches \`selected: true\` on every choice). Logged to stdout so the agent sees what ran.
  - React 19 + React 19 Types codemod confirms -> yes.

## How

Single \`nonInteractive\` flag plumbed into the four \`suggest*\` helpers, each short-circuits before its \`prompts(...)\` call and returns the default. Type-check clean.

<!-- NEXT_JS_LLM_PR -->