### PR TITLE
Reuse last-good source when a dev static-info read is torn

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -452,6 +452,56 @@ function tryToReadFile(filePath: string, shouldThrow: boolean) {
   }
 }
 
+const lastGoodStaticInfoSource = new Map<string, string>()
+
+/**
+ * Reads a route file's source for static-info analysis, tolerating a read that
+ * races with an in-progress write.
+ *
+ * In the dev server the same file is read out-of-band on every on-demand
+ * `ensure` and every webpack compilation, and these reads race with writers we
+ * don't control (editors, git checkouts, codemods, the test harness). A read
+ * that lands in a writer's truncate window comes back empty. Acting on that
+ * empty read would derive `runtime: undefined`, drop the route from its
+ * compiler's entrypoints, and wipe it from the regenerated manifest, while its
+ * on-demand entry stayed marked built, so `ensure` would not recompile it and,
+ * with no watcher event for the settle, nothing would repair it: a stuck 404.
+ *
+ * To avoid that, an empty read is treated as never-legitimate route source and
+ * the last good source is reused instead. This keeps the route in its
+ * compiler's entrypoints and thus in the regenerated manifest, consistent with
+ * its still-built entry, so the built-and-not-recompiled state that would
+ * otherwise strand it is here the correct steady state rather than a trap. The
+ * reuse is transient: last good is only returned for an empty read and is
+ * overwritten by the next non-empty read (which every compilation and every
+ * request performs), so the classification returns to fresh the moment the
+ * write settles. A genuine runtime switch writes non-empty content, so it is
+ * read and classified from its own source rather than reused. A file that is
+ * genuinely emptied is invalid however it is classified and simply rebuilds
+ * (and errors) once real content returns.
+ *
+ * The reuse is limited to the dev server; a production build reads a static
+ * source tree with nothing racing it.
+ */
+function readStaticInfoSource(
+  pageFilePath: string,
+  isDev: boolean
+): string | undefined {
+  const content = tryToReadFile(pageFilePath, !isDev)
+  if (!isDev) {
+    return content
+  }
+  if (content) {
+    lastGoodStaticInfoSource.set(pageFilePath, content)
+    return content
+  }
+  const lastGood = lastGoodStaticInfoSource.get(pageFilePath)
+  if (lastGood !== undefined) {
+    return lastGood
+  }
+  return content
+}
+
 /**
  * @internal - required to exclude zod types from the build
  */
@@ -633,7 +683,7 @@ export async function getAppPageStaticInfo({
   isDev,
   page,
 }: GetPageStaticInfoParams): Promise<AppPageStaticInfo> {
-  const content = tryToReadFile(pageFilePath, !isDev)
+  const content = readStaticInfoSource(pageFilePath, isDev)
   if (!content || !PARSE_PATTERN.test(content)) {
     return {
       type: PAGE_TYPES.APP,
@@ -771,7 +821,7 @@ export async function getPagesPageStaticInfo({
   isDev,
   page,
 }: GetPageStaticInfoParams): Promise<PagesPageStaticInfo> {
-  const content = tryToReadFile(pageFilePath, !isDev)
+  const content = readStaticInfoSource(pageFilePath, isDev)
   if (!content || !PARSE_PATTERN.test(content)) {
     return {
       type: PAGE_TYPES.PAGES,


### PR DESCRIPTION
The `edge-runtime-module-errors` development-mode tests intermittently fail with a 404 on an edge route that should exist ([flakiness metrics](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22%20%40test.suite%3A%22Edge%20runtime%20module%20errors%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1781616736084&end=1782912736084&paused=false)). Each case rewrites `pages/api/route.js` and `afterEach` restores it, and under load the route occasionally answers 404 for the rest of the run.

The cause is a race between reading a route file for its static info and a writer rewriting it. In webpack dev the pages and middleware manifests are regenerated from scratch on every compilation from that compilation's entrypoints, and both the on-demand entry handler and `config.entry` read each route file out-of-band to derive its static info, most importantly the runtime that decides which compiler owns the entry. Editors, git checkouts, formatters, codemods, and the test harness all rewrite files with a non-atomic truncate-then-write, which briefly leaves the file empty. A read that lands in that truncate window comes back empty and parses the runtime as `undefined`. Misread as a plain Node route, an edge entry takes the `onServer` branch, which no-ops in the edge compilation, and the edge-keyed entry is skipped by the Node compilation too, so it is emitted by neither and drops out of the regenerated manifest. Because its on-demand entry is still marked built, `ensure` short-circuits without recompiling it, and the write settling fires no watcher event, so nothing repairs it and the route answers 404 until the file changes again.

This change reuses the last good source instead of acting on such a read. A new `readStaticInfoSource` wrapper remembers the last non-empty source read for each file and, in the dev server, returns that source when a subsequent read comes back empty or momentarily absent. That keeps the route in its compiler's entrypoints and therefore in the manifest, consistent with its still-built entry. An empty read is never legitimate route source, so preferring the last good source is always the safe choice: a genuine runtime switch writes non-empty content and is read and classified from its own source, and a file that is genuinely emptied is invalid regardless of how it is classified and simply rebuilds and errors once real content is read again. The reuse is transient, since the cache is overwritten by the next non-empty read that any compilation or request performs, and it is limited to the dev server, since a production build reads a static source tree with nothing racing it.

It is worth being precise about what this guarantees. The fix eliminates the diagnosed failure, where the static-info read alone being torn drops the route and produces a stuck 404. It does so by keeping the route in the entrypoints, which is also what lets webpack build the module at all: in the old behavior the dropped entry means webpack never builds the route in that compilation, so it is simply absent. Webpack's own build read happens later in the compilation than `config.entry`, so in practice it observes the settled content and builds fresh. The remaining theoretical window is narrower and softer: only if webpack's later build read also lands in a truncate window would the module build empty, producing a 500 (a present-but-empty route) rather than a 404, recoverable on the next write the same way. That read is webpack's own and is not touched here. Across 2500 rapid rewrite iterations the served status stayed 200 throughout, where the same churn without the fix stuck at iteration 112, so the change strictly narrows the failure window (from one torn read to two, at different points of the compilation) and softens the worst-case symptom.

The fix is scoped to empty and absent reads, which are the torn states a single writer produces: a truncate window, or the brief gap of an atomic rename. Non-empty but corrupt reads require two writers racing the same file, which normal editing, git, and branch switches do not do, and covering them would mean reusing last-good when a non-empty read fails to parse, which could not be distinguished from a genuine syntax error the user just typed.