### PR TITLE
Fix: allow pageExtensions to be configured in no-html-link-for-pages (#53473)

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -107,8 +107,11 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const nextSettings: { rootDir?: string | string[]; pageExtensions?: string[] } = context.settings?.next || {}
+    const pageExtensions = nextSettings.pageExtensions || ['tsx', 'ts', 'jsx', 'js']
+
+    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, pageExtensions)
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, pageExtensions)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,33 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+function getExtensionRegex(pageExtensions: string[]) {
+  const exts = pageExtensions.map((ext) => ext.replace(/\./g, '\\.'))
+  return new RegExp(`(?:\\.(${exts.join('|')}))$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(urlprefix: string, directory: string, pageExtensions: string[]) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = getExtensionRegex(pageExtensions)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (extRegex.test(dirent.name)) {
+      const indexRegex = new RegExp(`^index(?:\\.(${pageExtensions.map((ext) => ext.replace(/\./g, '\\.')).join('|')}))$`)
+      if (indexRegex.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(indexRegex, '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions))
       }
     }
   })
@@ -36,24 +41,25 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(urlprefix: string, directory: string, pageExtensions: string[]) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = getExtensionRegex(pageExtensions)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      const pageRegex = new RegExp(`^page(?:\\.(${pageExtensions.map((ext) => ext.replace(/\./g, '\\.')).join('|')}))$`)
+      const layoutRegex = new RegExp(`^layout(?:\\.(${pageExtensions.map((ext) => ext.replace(/\./g, '\\.')).join('|')}))$`)
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions))
       }
     }
   })
@@ -136,13 +142,14 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, pageExtensions))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +163,14 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, pageExtensions))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -72,6 +72,14 @@ const linterConfigWithNestedContentRootDirDirectory = {
     },
   },
 }
+const linterConfigWithPageExtensions = {
+  ...linterConfig,
+  settings: {
+    next: {
+      pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+    },
+  },
+}
 
 for (const linter of Object.values(linters)) {
   linter.defineRules({
@@ -493,6 +501,31 @@ describe('no-html-link-for-pages', function () {
     assert.equal(
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid static route with custom pageExtensions', function () {
+    const invalidCustomExtensionCode = `
+      import Link from 'next/link';
+      export class Blah extends Head {
+        render() {
+          return (
+            <div>
+              <a href='/hello'>Hello</a>
+              <h1>Hello title</h1>
+            </div>
+          );
+        }
+      }
+    `
+    const [report] = linters.withCustomPages.verify(
+      invalidCustomExtensionCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/hello/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
 })

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -73,7 +73,7 @@ const linterConfigWithNestedContentRootDirDirectory = {
   },
 }
 const linterConfigWithPageExtensions = {
-  ...linterConfig,
+  ...linterConfigWithCustomDirectory,
   settings: {
     next: {
       pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],


### PR DESCRIPTION
### What?\
\
This updates the \@next/next/no-html-link-for-pages\ ESLint rule so that it correctly respects the \pageExtensions\ array instead of strictly defaulting to \.js, .jsx, .ts, .tsx\.\
\
### Why?\
\
Currently, developers using custom page extensions (e.g., \pageExtensions: ['page.tsx']\ in Next.js) experience false positives from the ESLint plugin when linking to their pages. The plugin was hardcoded to only recognize standard extensions. This resulted in legitimate \<Link>\ components to custom-extension pages not being validated, and legitimate uses of \<a>\ tags falling through or triggering errors improperly.\
\
By propagating the custom \pageExtensions\ from \settings.next.pageExtensions\ in \.eslintrc\, the linter behaves identically to Next.js routing.\
\
### How?\
\
- Modified \parseUrlForPages\ and \parseUrlForAppDir\ in \packages/eslint-plugin-next/src/utils/url.ts\ to accept \pageExtensions\ and dynamically build the regex matcher.\
- Updated \
o-html-link-for-pages.ts\ to retrieve \context.settings.next.pageExtensions\. If omitted, it falls back to the default \['tsx', 'ts', 'jsx', 'js']\.\
- Added a unit test in \	est/unit/eslint-plugin-next/no-html-link-for-pages.test.ts\ to verify the rule operates correctly on custom extensions.\
\
Fixes #53473