### PR TITLE
Fix Navigation Inspector in Safari

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -44,14 +44,31 @@ function parseCookieValue(raw: string): InstantNavCookieState {
   return 'pending'
 }
 
+function writeDocumentCookie(
+  value: InstantCookie,
+  options: { domain?: string | null; path?: string | null }
+): void {
+  if (typeof document === 'undefined') {
+    return
+  }
+  let cookie = `${NEXT_INSTANT_TEST_COOKIE}=${JSON.stringify(value)}; Path=${
+    options.path ?? '/'
+  }`
+  if (options.domain) {
+    cookie += `; Domain=${options.domain}`
+  }
+  document.cookie = cookie
+}
+
 function writeCookieValue(value: InstantCookie): void {
   if (typeof cookieStore === 'undefined') {
     return
   }
-  // Read the existing cookie to preserve its attributes (domain, path),
-  // then write back with the new value. This updates the same cookie
-  // entry that the external actor created, regardless of how it was
-  // scoped.
+  // Read the existing cookie to preserve its attributes (domain, path), then
+  // write back with the new value. This updates the same cookie entry that the
+  // external actor created, regardless of how it was scoped. Use document.cookie
+  // for the write because WebKit exposes Cookie Store on localhost but does not
+  // commit cookies written through cookieStore.set() there.
   //
   // Capture the current lockState and compare it in the callback so we
   // only write if the lock we observed at call time is still held. This
@@ -63,15 +80,7 @@ function writeCookieValue(value: InstantCookie): void {
   const lockAtCall = lockState
   cookieStore.get(NEXT_INSTANT_TEST_COOKIE).then((existing: any) => {
     if (existing && lockState === lockAtCall && lockAtCall !== null) {
-      const options: any = {
-        name: NEXT_INSTANT_TEST_COOKIE,
-        value: JSON.stringify(value),
-        path: existing.path ?? '/',
-      }
-      if (existing.domain) {
-        options.domain = existing.domain
-      }
-      cookieStore.set(options)
+      writeDocumentCookie(value, existing)
     }
   })
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -93,14 +93,45 @@ function createPendingInstantNavCookie(): InstantCookie {
   return [0, `p${Math.random()}`]
 }
 
-function setPendingInstantNavCookie(): void {
+function setInstantNavCookie(value: InstantCookie): void {
+  if (typeof document === 'undefined') {
+    return
+  }
+  document.cookie = `${COOKIE_NAME}=${JSON.stringify(value)}; Path=/`
+}
+
+function deleteInstantNavCookie(): void {
+  if (typeof document === 'undefined') {
+    return
+  }
+  document.cookie = `${COOKIE_NAME}=; Path=/; Max-Age=0`
+}
+
+function waitForInstantNavCookieDeleted(): Promise<void> {
   if (typeof cookieStore !== 'undefined') {
-    cookieStore.set({
-      name: COOKIE_NAME,
-      value: JSON.stringify(createPendingInstantNavCookie()),
-      path: '/',
+    return new Promise((resolve) => {
+      function done(): void {
+        cookieStore.removeEventListener('change', handler)
+        resolve()
+      }
+
+      function handler(event: CookieChangeEvent): void {
+        for (const cookie of event.deleted) {
+          if (cookie.name === COOKIE_NAME) {
+            done()
+            return
+          }
+        }
+      }
+
+      cookieStore.addEventListener('change', handler)
     })
   }
+  return Promise.resolve()
+}
+
+function setPendingInstantNavCookie(): void {
+  setInstantNavCookie(createPendingInstantNavCookie())
 }
 
 function getCurrentLocationUrl(): string {
@@ -114,9 +145,7 @@ function getCurrentLocationUrl(): string {
 // navigation-testing-lock.ts, which releases the lock and soft-refreshes to real data.
 function clearInstantNavCaptureCookie(): void {
   setInstantNavTransientStatus('idle')
-  if (typeof cookieStore !== 'undefined') {
-    cookieStore.delete(COOKIE_NAME)
-  }
+  deleteInstantNavCookie()
 }
 
 export function InstantNavsPanel() {
@@ -199,23 +228,16 @@ export function InstantNavsPanel() {
   const spaToUrl = currentSpaToUrl ?? lastSpaToUrl
 
   async function resume(): Promise<void> {
-    if (typeof cookieStore !== 'undefined') {
-      // Resume: delete the cookie (which releases the
-      // lock and triggers a soft refresh for real data via the lock
-      // listener), then restart capture for the next navigation by
-      // writing a fresh pending cookie. Chaining the writes keeps
-      // them as two ordered cookie events (delete -> refresh, then
-      // restart) rather than coalescing into one, so the refresh runs
-      // and snapshots the released lock before the restart re-acquires it.
-      setInstantNavTransientStatus('restarting')
-      const pendingCookie: InstantCookie = [0, `p${Math.random()}`]
-      await cookieStore.delete(COOKIE_NAME)
-      cookieStore.set({
-        name: COOKIE_NAME,
-        value: JSON.stringify(pendingCookie),
-        path: '/',
-      })
-    }
+    // Resume: delete the cookie (which releases the lock and triggers a soft
+    // refresh for real data via the lock listener), then restart capture for
+    // the next navigation by writing a fresh pending cookie. Waiting for the
+    // delete event keeps this as two ordered cookie transitions.
+    setInstantNavTransientStatus('restarting')
+    const pendingCookie = createPendingInstantNavCookie()
+    const deleted = waitForInstantNavCookieDeleted()
+    deleteInstantNavCookie()
+    await deleted
+    setInstantNavCookie(pendingCookie)
   }
 
   function togglePaused(): void {

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -58,6 +58,17 @@ describe('instant-nav-panel', () => {
       .click()
   }
 
+  async function disableCookieStoreSet(browser: Playwright) {
+    await browser.eval(() => {
+      if (typeof cookieStore !== 'undefined') {
+        const prototype = Object.getPrototypeOf(cookieStore) as {
+          set: typeof cookieStore.set
+        }
+        prototype.set = async () => undefined
+      }
+    })
+  }
+
   async function clickLink(browser: Playwright, href: string) {
     await browser.eval((page) => {
       document.querySelector<HTMLAnchorElement>(`[href="${page}"]`)!.click()
@@ -555,6 +566,21 @@ describe('instant-nav-panel', () => {
       await expectSpaPanel(browser)
 
       // Clean up
+      await clearInstantModeCookie(browser)
+    })
+
+    it('should capture when CookieStore writes are not reflected in document.cookie', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+      await disableCookieStoreSet(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+      await expectTargetPageSpaShell(browser)
+
       await clearInstantModeCookie(browser)
     })
 


### PR DESCRIPTION
Fixes the Navigation Inspector in Safari/WebKit on localhost.

Safari 18.6 exposes the Cookie Store API, but WebKit on localhost can resolve `cookieStore.set()` and emit a change event without committing a cookie that is visible to `document.cookie` or sent with requests. Since the instant navigation lock depends on a real request cookie, the inspector was not working correctly.

This switches instant-nav cookie writes/deletes to `document.cookie`, keeps Cookie Store for observing changes, and makes Resume wait for the delete event before starting the next pending capture.
