### PR TITLE
feat(create-next-app): detect nub package manager

### DIFF
--- a/packages/create-next-app/helpers/get-pkg-manager.ts
+++ b/packages/create-next-app/helpers/get-pkg-manager.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process'
 
-export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'nub'
 
 export function getPkgManager(): PackageManager {
   const userAgent = process.env.npm_config_user_agent || ''
@@ -15,6 +15,10 @@ export function getPkgManager(): PackageManager {
 
   if (userAgent.startsWith('bun')) {
     return 'bun'
+  }
+
+  if (userAgent.startsWith('nub')) {
+    return 'nub'
   }
 
   return 'npm'

--- a/packages/create-next-app/helpers/typegen.ts
+++ b/packages/create-next-app/helpers/typegen.ts
@@ -27,6 +27,10 @@ export async function runTypegen(
         command = 'pnpm'
         args = ['exec', 'next', '--', 'typegen']
         break
+      case 'nub':
+        command = 'nub'
+        args = ['exec', 'next', '--', 'typegen']
+        break
       case 'bun':
         command = 'bun'
         // Bun only has `bun x` which is not the same thing.

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -788,6 +788,7 @@ async function notifyUpdate(): Promise<void> {
         yarn: 'yarn global add',
         pnpm: 'pnpm add -g',
         bun: 'bun add -g',
+        nub: 'nub add -g',
       }
       const distTag = getDistTag(packageJson.version)
       const pkgTag = distTag === 'latest' ? '' : `@${distTag}`


### PR DESCRIPTION
When invoked through nub, create-next-app misdetects the package manager as npm and prints npm hints. It infers the PM from `npm_config_user_agent`, matching `yarn`/`pnpm`/`bun` and defaulting to npm otherwise; [nub](https://nubjs.com) advertises `nub/<version>` in that string, so it falls through to the default.

nub is a Rust CLI with a pnpm-compatible command grammar. This adds it to the detection in `get-pkg-manager.ts` and to the update-notice map in `index.ts`. Nothing else changes: `install()` already spawns `<pm> install`, and the post-scaffold output prints `nub run dev`.
