### PR TITLE
[ci] Move some test suites back to x86-64 runners to reduce pressure on our currently-limited pool of arm runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -399,6 +399,7 @@ jobs:
           -g ${{ matrix.group }}
       testTimingsArtifact: 'test-timings'
       stepName: 'test-turbopack-dev-react-${{ matrix.react }}-${{ matrix.group }}'
+      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-turbopack-production:
@@ -436,6 +437,7 @@ jobs:
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} --type production
       testTimingsArtifact: 'test-timings'
       stepName: 'test-turbopack-production-react-${{ matrix.react }}-${{ matrix.group }}'
+      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-rspack-dev:
@@ -809,6 +811,7 @@ jobs:
           --type development
       testTimingsArtifact: 'test-timings'
       stepName: 'test-dev-react-${{ matrix.react }}-${{ matrix.group }}'
+      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-dev-windows:
@@ -916,6 +919,7 @@ jobs:
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} --type production
       testTimingsArtifact: 'test-timings'
       stepName: 'test-prod-react-${{ matrix.react }}-${{ matrix.group }}'
+      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-firefox-safari:


### PR DESCRIPTION
https://vercel.slack.com/archives/C0B0LKK5QD7/p1782838752523649

This is a mitigation until we can get IT to increase the concurrency limit on `ubuntu-latest-16-core-arm-oss` runners.