### PR TITLE
Revert "[ci] Move some test suites back to x86-64 runners to reduce pressure on our currently-limited pool of arm runners (#95332)"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -399,7 +399,6 @@ jobs:
           -g ${{ matrix.group }}
       testTimingsArtifact: 'test-timings'
       stepName: 'test-turbopack-dev-react-${{ matrix.react }}-${{ matrix.group }}'
-      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-turbopack-production:
@@ -437,7 +436,6 @@ jobs:
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} --type production
       testTimingsArtifact: 'test-timings'
       stepName: 'test-turbopack-production-react-${{ matrix.react }}-${{ matrix.group }}'
-      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-rspack-dev:
@@ -811,7 +809,6 @@ jobs:
           --type development
       testTimingsArtifact: 'test-timings'
       stepName: 'test-dev-react-${{ matrix.react }}-${{ matrix.group }}'
-      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-dev-windows:
@@ -919,7 +916,6 @@ jobs:
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} --type production
       testTimingsArtifact: 'test-timings'
       stepName: 'test-prod-react-${{ matrix.react }}-${{ matrix.group }}'
-      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
     secrets: inherit
 
   test-firefox-safari:


### PR DESCRIPTION
There was a bug in this PR (https://github.com/vercel/next.js/pull/95332#discussion_r3502904527) but it "passed" CI and auto-merged because `fetch test timings` failed causing downstream jobs to end up in a skipped state. I'll fix that in a separate PR.