### PR TITLE
fix: support custom pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -17,8 +17,6 @@ const pagesDirWarning = execOnce((pagesDirs) => {
   )
 })
 
-// Cache for fs.existsSync lookup.
-// Prevent multiple blocking IO requests that have already been calculated.
 const fsExistsSyncCache = {}
 
 const memoize = <T = any>(fn: (...args: any[]) => T) => {
@@ -65,14 +63,15 @@ export default defineRule({
     ],
   },
 
-  /**
-   * Creates an ESLint rule listener.
-   */
   create(context) {
     const ruleOptions: (string | string[])[] = context.options
     const [customPagesDirectory] = ruleOptions
 
     const rootDirs = getRootDirs(context)
+
+    const nextSettings: { pageExtensions?: string[] } =
+      context.settings.next || {}
+    const pageExtensions = nextSettings.pageExtensions
 
     const pagesDirs = (
       customPagesDirectory
@@ -101,14 +100,21 @@ export default defineRule({
       return fsExistsSyncCache[dir]
     })
 
-    // warn if there are no pages and app directories
     if (foundPagesDirs.length === 0 && foundAppDirs.length === 0) {
       pagesDirWarning(pagesDirs)
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {
@@ -147,7 +153,6 @@ export default defineRule({
         }
 
         const hrefPath = normalizeURL(href.value.value)
-        // Outgoing links are ignored
         if (/^(https?:\/\/|\/\/)/.test(hrefPath)) {
           return
         }

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,67 +5,85 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
-/**
- * Recursively parse directory for page URLs.
- */
-function parseUrlForPages(urlprefix: string, directory: string) {
+const DEFAULT_PAGE_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
+
+function getExtensionRegex(extensions: string[]) {
+  const escaped = extensions.map((ext) =>
+    ext.startsWith('.') ? ext.replace(/\./g, '\\.') : `\\.${ext}`
+  )
+  return escaped.join('|')
+}
+
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extRegexStr = getExtensionRegex(pageExtensions)
+  const extRegex = new RegExp(`(${extRegexStr})$`)
+  const indexRegex = new RegExp(`^index(${extRegexStr})$`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
   return res
 }
 
-/**
- * Recursively parse app directory for URLs.
- */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extRegexStr = getExtensionRegex(pageExtensions)
+  const extRegex = new RegExp(`(${extRegexStr})$`)
+  const pageRegex = new RegExp(`^page(${extRegexStr})$`)
+  const layoutRegex = new RegExp(`^layout(${extRegexStr})$`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
   return res
 }
 
-/**
- * Takes a URL and does the following things.
- *  - Replaces `index.html` with `/`
- *  - Makes sure all URLs are have a trailing `/`
- *  - Removes query string
- */
 export function normalizeURL(url: string) {
   if (!url) {
     return
@@ -73,7 +91,6 @@ export function normalizeURL(url: string) {
   url = url.split('?', 1)[0]
   url = url.split('#', 1)[0]
   url = url = url.replace(/(\/index\.html)$/, '/')
-  // Empty URLs should not be trailed with `/`, e.g. `#heading`
   if (url === '') {
     return url
   }
@@ -81,70 +98,41 @@ export function normalizeURL(url: string) {
   return url
 }
 
-/**
- * Normalizes an app route so it represents the actual request path. Essentially
- * performing the following transformations:
- *
- * - `/(dashboard)/user/[id]/page` to `/user/[id]`
- * - `/(dashboard)/account/page` to `/account`
- * - `/user/[id]/page` to `/user/[id]`
- * - `/account/page` to `/account`
- * - `/page` to `/`
- * - `/(dashboard)/user/[id]/route` to `/user/[id]`
- * - `/(dashboard)/account/route` to `/account`
- * - `/user/[id]/route` to `/user/[id]`
- * - `/account/route` to `/account`
- * - `/route` to `/`
- * - `/` to `/`
- *
- * @param route the app route to normalize
- * @returns the normalized pathname
- */
 export function normalizeAppPath(route: string) {
   return ensureLeadingSlash(
     route.split('/').reduce((pathname, segment, index, segments) => {
-      // Empty segments are ignored.
       if (!segment) {
         return pathname
       }
-
-      // Groups are ignored.
       if (isGroupSegment(segment)) {
         return pathname
       }
-
-      // Parallel segments are ignored.
       if (segment[0] === '@') {
         return pathname
       }
-
-      // The last segment (if it's a leaf) should be ignored.
       if (
         (segment === 'page' || segment === 'route') &&
         index === segments.length - 1
       ) {
         return pathname
       }
-
       return `${pathname}/${segment}`
     }, '')
   )
 }
 
-/**
- * Gets the possible URLs from a directory.
- */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
-    // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
-          // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
         )
     )
@@ -156,16 +144,17 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
-    // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
-          // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeAppPath(url)}$`
         )
     )
@@ -180,7 +169,6 @@ export function execOnce<TArgs extends any[], TResult>(
 ): (...args: TArgs) => TResult {
   let used = false
   let result: TResult
-
   return (...args: TArgs) => {
     if (!used) {
       used = true


### PR DESCRIPTION
The `@next/next/no-html-link-for-pages` ESLint rule currently only recognizes default page extensions (js, jsx, ts, tsx). When a project configures custom `pageExtensions` in `next.config.js` (e.g. `['page.tsx']`), the rule fails to detect any page files and produces no warnings.

This PR adds support for `pageExtensions` via ESLint settings. Users can configure custom page extensions under `settings.next.pageExtensions`:

```json
{
  "settings": {
    "next": {
      "pageExtensions": ["page.tsx"]
    }
  }
}
```

### Changes

- Added `DEFAULT_PAGE_EXTENSIONS` constant and `getExtensionRegex()` helper in `url.ts`
- `parseUrlForPages()` and `parseUrlForAppDir()` now accept an optional `pageExtensions` parameter and build regex patterns dynamically instead of using hardcoded JS/TS extensions
- `getUrlFromPagesDirectories()` and `getUrlFromAppDirectory()` pass through `pageExtensions`
- The `no-html-link-for-pages` rule reads `pageExtensions` from `context.settings.next.pageExtensions`

Fixes #53473