### PR TITLE
fix: use data properties for named exports in eslint plugin

### DIFF
--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -125,3 +125,18 @@ Object.assign(plugin.configs, {
 
 export default plugin
 export const { rules, configs } = plugin
+
+// Override getter-based named exports with data properties
+// for proper CJS/ESM interop. Node.js ignores getter-based
+// synthetic named exports when importing CJS as ESM.
+Object.defineProperty(module.exports, 'rules', {
+  enumerable: true,
+  value: rules,
+  writable: false,
+})
+
+Object.defineProperty(module.exports, 'configs', {
+  enumerable: true,
+  value: configs,
+  writable: false,
+})


### PR DESCRIPTION
The @next/eslint-plugin-next package defines its named exports (rules and configs) via destructured re-exports. When compiled to CJS, these become getter-based Object.defineProperty calls. Node.js ignores top-level getters for synthetic named exports when importing CJS as ESM.

This PR adds explicit Object.defineProperty calls with data properties (value instead of get) after the existing exports, ensuring Node.js can properly detect both rules and configs as named exports.

Fixes #86504