### PR TITLE
[ci] Add optimize-ci, changes, and fetch-test-timings jobs to the needs list for the tests-pass job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1025,8 +1025,15 @@ jobs:
       stepName: 'test-cache-components-prod-${{ matrix.group }}'
     secrets: inherit
 
+  # We block merging unless this job passes. This is enforced by a "require
+  # status checks to pass" rule on the canary branch.
+  # <https://github.com/vercel/next.js/settings/rules/15507172>
   tests-pass:
     needs:
+      # Note: Some of these jobs are dependencies of other test jobs. If they
+      # fail, they'll cause the dependent test job to be skipped, which could
+      # cause this aggregation job to incorrectly pass if the dependency job is
+      # not listed here.
       - optimize-ci
       - changes
       - build-native

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1027,36 +1027,36 @@ jobs:
 
   tests-pass:
     needs:
-      [
-        'build-native',
-        'build-next',
-        'lint',
-        'validate-docs-links',
-        'check-types-precompiled',
-        'test-unit',
-        'test-next-config-ts-native-ts-dev',
-        'test-next-config-ts-native-ts-prod',
-        'test-dev',
-        'test-prod',
-        'test-firefox-safari',
-        'test-cache-components-dev',
-        'test-cache-components-prod',
-        'test-cargo-unit',
-        'rust-check',
-        'rustdoc-check',
-        'test-next-swc-wasm',
-        'test-turbopack-dev',
-        'test-new-tests-dev',
-        'test-new-tests-start',
-        'test-new-tests-deploy',
-        'test-new-tests-deploy-cache-components',
-        'test-turbopack-production',
-        'test-unit-windows',
-        'test-dev-windows',
-        'test-integration-windows',
-        'test-prod-windows',
-      ]
-
+      - optimize-ci
+      - changes
+      - build-native
+      - build-next
+      - fetch-test-timings
+      - lint
+      - validate-docs-links
+      - check-types-precompiled
+      - test-unit
+      - test-next-config-ts-native-ts-dev
+      - test-next-config-ts-native-ts-prod
+      - test-dev
+      - test-prod
+      - test-firefox-safari
+      - test-cache-components-dev
+      - test-cache-components-prod
+      - test-cargo-unit
+      - rust-check
+      - rustdoc-check
+      - test-next-swc-wasm
+      - test-turbopack-dev
+      - test-new-tests-dev
+      - test-new-tests-start
+      - test-new-tests-deploy
+      - test-new-tests-deploy-cache-components
+      - test-turbopack-production
+      - test-unit-windows
+      - test-dev-windows
+      - test-integration-windows
+      - test-prod-windows
     if: always()
     runs-on: ubuntu-latest
     # Coupled with retry logic in retry_test.yml

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -73,9 +73,12 @@ on:
         required: false
         type: string
         default: ''
-
       testTimingsArtifact:
-        description: 'Name of an uploaded artifact containing test-timings.json. When set, download it instead of fetching via turbo.'
+        description: >
+          Name of an uploaded artifact containing test-timings.json. When set,
+          download it instead of fetching via turbo. This can be useful in
+          ensuring that when failed jobs are retried, they end up with exactly
+          the same set of timings, and therefore run the same set of tests.
         required: false
         type: string
         default: ''


### PR DESCRIPTION
On #95332, the `fetch-test-timings` job failed. That caused downstream jobs to get a "skip" state, instead of a failure state, which then caused `tests-pass` to succeed. This is because if a dependency job fails, GitHub's default behavior is for the downstream job to skip, and to not cascade the failure.

Depending on all of these helper jobs seems like the simplest way to prevent this from happening in the future.