### PR TITLE
[turbopack] Add public manifests for remote components

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -25,7 +25,9 @@ use next_core::{
     next_edge::route_regex::get_named_middleware_regex,
     next_manifests::{
         AppPathsManifest, BuildManifest, EdgeFunctionDefinition, MiddlewaresManifestV2,
-        PagesManifest, ProxyMatcher, Regions, client_reference_manifest::ClientReferenceManifest,
+        PagesManifest, ProxyMatcher, Regions,
+        client_reference_manifest::ClientReferenceManifest,
+        remote_components::{ModuleIdManifest, RemoteModuleManifest},
     },
     next_server::{
         ServerContextType, get_server_module_options_context, get_server_resolve_options_context,
@@ -1517,27 +1519,54 @@ impl AppEndpoint {
         let mut client_reference_manifest = None;
 
         if emit_rsc_manifests {
-            let entry_manifest = ResolvedVc::upcast(
-                ClientReferenceManifest {
-                    node_root: node_root.clone(),
-                    client_relative_path: client_relative_path.clone(),
-                    entry_name: app_entry.original_name.clone(),
-                    client_references,
-                    client_references_chunks,
-                    client_chunking_context,
-                    ssr_chunking_context,
-                    async_module_info: module_graphs.full.async_module_info().to_resolved().await?,
-                    next_config: project.next_config().to_resolved().await?,
-                    runtime,
-                    mode: *project.next_mode().await?,
-                }
-                .resolved_cell(),
-            );
+            let cref_manifest = ClientReferenceManifest {
+                node_root: node_root.clone(),
+                client_relative_path: client_relative_path.clone(),
+                entry_name: app_entry.original_name.clone(),
+                client_references,
+                client_references_chunks,
+                client_chunking_context,
+                ssr_chunking_context,
+                async_module_info: module_graphs.full.async_module_info().to_resolved().await?,
+                next_config: project.next_config().to_resolved().await?,
+                runtime,
+                mode: *project.next_mode().await?,
+            }
+            .resolved_cell();
+            let entry_manifest = ResolvedVc::upcast(cref_manifest);
             server_assets.insert(entry_manifest);
             if runtime == NextRuntime::Edge {
                 middleware_assets.insert(entry_manifest);
             }
             client_reference_manifest = Some(entry_manifest);
+
+            if *project
+                .next_config()
+                .turbopack_remote_modules_manifests()
+                .await?
+            {
+                server_assets.insert(ResolvedVc::upcast(
+                    RemoteModuleManifest {
+                        node_root: node_root.clone(),
+                        entry_name: app_entry.original_name.clone(),
+                        client_reference_manifest: cref_manifest,
+                    }
+                    .resolved_cell(),
+                ));
+
+                server_assets.insert(ResolvedVc::upcast(
+                    ModuleIdManifest {
+                        node_root: node_root.clone(),
+                        entry_name: app_entry.original_name.clone(),
+                        module_graph: module_graphs.full,
+                        client_chunking_context,
+                        ssr_chunking_context,
+                        output_path: None,
+                        page_loader_module: None,
+                    }
+                    .resolved_cell(),
+                ));
+            }
         }
         if emit_manifests == EmitManifests::Full {
             let next_font_manifest_output = ResolvedVc::upcast(

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -16,7 +16,7 @@ use next_core::{
     next_edge::route_regex::get_named_middleware_regex,
     next_manifests::{
         BuildManifest, ClientBuildManifest, EdgeFunctionDefinition, MiddlewaresManifestV2,
-        PagesManifest, ProxyMatcher, Regions,
+        PagesManifest, ProxyMatcher, Regions, remote_components::ModuleIdManifest,
     },
     next_pages::create_page_ssr_entry_module,
     next_server::{
@@ -1332,6 +1332,34 @@ impl PageEndpoint {
                 client_assets.push(page_loader);
                 server_assets.push(build_manifest);
                 server_assets.push(client_build_manifest);
+
+                let project = this.pages_project.project();
+                if *project
+                    .next_config()
+                    .turbopack_remote_modules_manifests()
+                    .await?
+                {
+                    let pages_node_root = project.node_root().owned().await?;
+                    let module_ids_prefix = get_asset_prefix_from_pathname(&this.pathname);
+                    let module_ids_manifest = ResolvedVc::upcast(
+                        ModuleIdManifest {
+                            node_root: pages_node_root.clone(),
+                            entry_name: this.pathname.clone(),
+                            module_graph: self.client_module_graph().to_resolved().await?,
+                            client_chunking_context: project
+                                .client_chunking_context()
+                                .to_resolved()
+                                .await?,
+                            ssr_chunking_context: None,
+                            output_path: Some(pages_node_root.join(&format!(
+                                "server/pages{module_ids_prefix}/module-ids-manifest.json",
+                            ))?),
+                            page_loader_module: Some(self.client_module().to_resolved().await?),
+                        }
+                        .resolved_cell(),
+                    );
+                    server_assets.push(module_ids_manifest);
+                }
 
                 self.ssr_chunk(emit_manifests)
             }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1290,6 +1290,7 @@ pub struct ExperimentalConfig {
     turbopack_input_source_maps: Option<bool>,
     turbopack_tree_shaking: Option<bool>,
     turbopack_scope_hoisting: Option<bool>,
+    turbopack_remote_modules_manifests: Option<bool>,
     /// Custom URL prefix for Web Worker URLs (the entrypoint and the module
     /// chunks loaded inside the worker) produced by
     /// `new Worker(new URL(..., import.meta.url))`. Mirrors webpack's
@@ -2230,6 +2231,18 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_blocking_ssr(&self) -> Vc<bool> {
         Vc::cell(self.experimental.blocking_ssr.unwrap_or(false))
+    }
+
+    /// Whether to emit the public Remote Components manifests
+    /// (`turbopack.remote-modules`, `turbopack.module-ids`), gated by
+    /// `experimental.turbopackRemoteModulesManifests`.
+    #[turbo_tasks::function]
+    pub fn turbopack_remote_modules_manifests(&self) -> Vc<bool> {
+        Vc::cell(
+            self.experimental
+                .turbopack_remote_modules_manifests
+                .unwrap_or(false),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -28,6 +28,7 @@ use crate::{
     util::NextRuntime,
 };
 
+#[turbo_tasks::value(serialization = "skip")]
 #[derive(Serialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SerializedClientReferenceManifest {
@@ -55,7 +56,8 @@ pub struct SerializedClientReferenceManifest {
     pub entry_js_files: FxIndexMap<RcStr, FxIndexSet<RcStr>>,
 }
 
-#[derive(Serialize, Debug, Clone, Eq, Hash, PartialEq)]
+#[turbo_tasks::value(serialization = "skip")]
+#[derive(Serialize, Debug, Clone, Hash)]
 pub struct CssResource {
     pub path: RcStr,
     pub inlined: bool,
@@ -63,13 +65,16 @@ pub struct CssResource {
     pub content: Option<RcStr>,
 }
 
+#[turbo_tasks::value(serialization = "skip")]
 #[derive(Serialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ModuleLoading {
     pub prefix: RcStr,
+    #[turbo_tasks(trace_ignore)]
     pub cross_origin: CrossOrigin,
 }
 
+#[turbo_tasks::value(serialization = "skip")]
 #[derive(Serialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ManifestNode {
@@ -78,6 +83,7 @@ pub struct ManifestNode {
     pub module_exports: FxIndexMap<RcStr, ManifestNodeEntry>,
 }
 
+#[turbo_tasks::value(serialization = "skip")]
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ManifestNodeEntry {
@@ -139,13 +145,16 @@ impl Asset for ClientReferenceManifest {
 }
 
 #[turbo_tasks::value(shared)]
-struct ClientReferenceManifestResult {
+pub(crate) struct ClientReferenceManifestResult {
     content: ResolvedVc<AssetContent>,
     references: ResolvedVc<OutputAssets>,
+    /// The assembled manifest, exposed so the public remote components
+    /// generator can reuse it.
+    pub(crate) manifest: ResolvedVc<SerializedClientReferenceManifest>,
 }
 
 #[turbo_tasks::function]
-async fn build_manifest(
+pub(crate) async fn build_manifest(
     manifest: Vc<ClientReferenceManifest>,
 ) -> Result<Vc<ClientReferenceManifestResult>> {
     let ClientReferenceManifest {
@@ -506,6 +515,7 @@ async fn build_manifest(
             .to_resolved()
             .await?,
             references: ResolvedVc::cell(references.into_iter().collect()),
+            manifest: entry_manifest.resolved_cell(),
         }
         .cell())
     }

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod client_reference_manifest;
 mod encode_uri_component;
+pub mod remote_components;
 
 use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
@@ -479,7 +480,8 @@ pub enum ActionLayer {
     ActionBrowser,
 }
 
-#[derive(Serialize, Debug, Eq, PartialEq, Hash, Clone)]
+#[turbo_tasks::value(serialization = "skip")]
+#[derive(Serialize, Debug, Hash, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum ModuleId {

--- a/crates/next-core/src/next_manifests/remote_components/mod.rs
+++ b/crates/next-core/src/next_manifests/remote_components/mod.rs
@@ -1,0 +1,23 @@
+//! Public, versioned Turbopack manifests for the Remote Components integration.
+//!
+//!
+//! - Manifest #1 (`turbopack.remote-modules`): maps each React Flight client reference to stable
+//!   module ids, chunk urls, exports, and per-variant (browser/ssr/edge/rsc) metadata.
+//! - Manifest #2 (`turbopack.module-ids`): a manifest-level mapping from remote module IDs to
+//!   shared specifiers.
+
+mod remote_module_manifest;
+mod shared_modules_manifest;
+
+pub use remote_module_manifest::RemoteModuleManifest;
+use serde::Serialize;
+pub use shared_modules_manifest::ModuleIdManifest;
+
+#[derive(Serialize, Clone, Copy, Eq, PartialEq, Hash, Debug, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum RuntimeKind {
+    #[default]
+    Browser,
+    NodeJs,
+    Edge,
+}

--- a/crates/next-core/src/next_manifests/remote_components/remote_module_manifest.rs
+++ b/crates/next-core/src/next_manifests/remote_components/remote_module_manifest.rs
@@ -1,0 +1,220 @@
+use anyhow::Result;
+use serde::Serialize;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, Vc};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
+use turbopack_browser::BrowserChunkingContext;
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    chunk::CrossOrigin,
+    output::{OutputAsset, OutputAssetsReference},
+};
+
+use super::RuntimeKind;
+use crate::{
+    next_manifests::{
+        ModuleId,
+        client_reference_manifest::{
+            ClientReferenceManifest, CssResource, ManifestNode, build_manifest,
+        },
+    },
+    util::NextRuntime,
+};
+
+pub const REMOTE_MODULE_MANIFEST_PROTOCOL: &str = "turbopack.remote-modules";
+pub const REMOTE_MODULE_MANIFEST_VERSION: u32 = 1;
+
+/// Remote Module Manifest (`turbopack.remote-modules`)
+///
+/// This is a public manifest that maps React Flight client references
+/// and remote chunks to stable module IDs, chunk URLs, exports,
+/// runtime kind, and any SSR/client variant metadata required
+/// to load the module later.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoteModuleManifestData {
+    protocol: &'static str,
+    version: u32,
+    route: RcStr,
+    module_loading: ModuleLoadingData,
+    chunk_loading_global: RcStr,
+    client_references: Vec<RemoteClientReference>,
+    #[serde(skip_serializing_if = "FxIndexMap::is_empty")]
+    entry_css: FxIndexMap<RcStr, FxIndexSet<CssResource>>,
+    #[serde(skip_serializing_if = "FxIndexMap::is_empty")]
+    entry_js: FxIndexMap<RcStr, FxIndexSet<RcStr>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ModuleLoadingData {
+    prefix: RcStr,
+    cross_origin: Option<&'static str>,
+}
+
+/// Maps Turbopack's `CrossOrigin` to the React/HTML `crossOrigin` vocabulary.
+fn normalize_cross_origin(value: CrossOrigin) -> Option<&'static str> {
+    match value {
+        CrossOrigin::None => None,
+        CrossOrigin::Anonymous => Some(""),
+        CrossOrigin::UseCredentials => Some("use-credentials"),
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoteClientReference {
+    key: RcStr,
+    export_name: RcStr,
+    variants: RemoteModuleVariants,
+}
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct RemoteModuleVariants {
+    browser: RemoteModuleVariant,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nodejs: Option<RemoteModuleVariant>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    edge: Option<RemoteModuleVariant>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rsc: Option<RemoteModuleVariant>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    edge_rsc: Option<RemoteModuleVariant>,
+}
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct RemoteModuleVariant {
+    id: ModuleId,
+    name: RcStr,
+    chunks: Vec<RcStr>,
+    r#async: bool,
+    runtime_kind: RuntimeKind,
+}
+
+impl Default for ModuleId {
+    fn default() -> Self {
+        ModuleId::String(RcStr::default())
+    }
+}
+
+fn variant_from_node(node: &ManifestNode, kind: RuntimeKind) -> Option<RemoteModuleVariant> {
+    let (_, entry) = node.module_exports.iter().next()?;
+    Some(RemoteModuleVariant {
+        id: entry.id.clone(),
+        name: entry.name.clone(),
+        chunks: entry.chunks.clone(),
+        r#async: entry.r#async,
+        runtime_kind: kind,
+    })
+}
+
+#[turbo_tasks::value(shared)]
+pub struct RemoteModuleManifest {
+    pub node_root: FileSystemPath,
+    pub entry_name: RcStr,
+    pub client_reference_manifest: ResolvedVc<ClientReferenceManifest>,
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAssetsReference for RemoteModuleManifest {}
+
+#[turbo_tasks::value_impl]
+impl OutputAsset for RemoteModuleManifest {
+    #[turbo_tasks::function]
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
+        let normalized = self.entry_name.replace("%5F", "_");
+        Ok(self
+            .node_root
+            .join(&format!(
+                "server/app{normalized}_remote-module-manifest.json",
+            ))?
+            .cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for RemoteModuleManifest {
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<Vc<AssetContent>> {
+        let cref = self.client_reference_manifest.await?;
+        let runtime = cref.runtime;
+        let result = build_manifest(*self.client_reference_manifest).await?;
+        let manifest = result.manifest.await?;
+
+        let chunk_loading_global = if let Some(browser) =
+            ResolvedVc::try_downcast_type::<BrowserChunkingContext>(cref.client_chunking_context)
+        {
+            browser.chunk_loading_global().owned().await?
+        } else {
+            rcstr!("TURBOPACK")
+        };
+
+        let mut client_references = Vec::new();
+        for (key, browser_entry) in &manifest.client_modules.module_exports {
+            let client_id = &browser_entry.id;
+            let nodejs = manifest
+                .ssr_module_mapping
+                .get(client_id)
+                .and_then(|n| variant_from_node(n, RuntimeKind::NodeJs));
+            let edge = manifest
+                .edge_ssr_module_mapping
+                .get(client_id)
+                .and_then(|n| variant_from_node(n, RuntimeKind::Edge));
+            let rsc = manifest
+                .rsc_module_mapping
+                .get(client_id)
+                .and_then(|n| variant_from_node(n, RuntimeKind::NodeJs));
+            let edge_rsc = manifest
+                .edge_rsc_module_mapping
+                .get(client_id)
+                .and_then(|n| variant_from_node(n, RuntimeKind::Edge));
+
+            client_references.push(RemoteClientReference {
+                key: key.clone(),
+                export_name: browser_entry.name.clone(),
+                variants: RemoteModuleVariants {
+                    browser: RemoteModuleVariant {
+                        id: browser_entry.id.clone(),
+                        name: browser_entry.name.clone(),
+                        chunks: browser_entry.chunks.clone(),
+                        r#async: browser_entry.r#async,
+                        runtime_kind: RuntimeKind::Browser,
+                    },
+                    nodejs: if runtime == NextRuntime::NodeJs {
+                        nodejs
+                    } else {
+                        None
+                    },
+                    edge: if runtime == NextRuntime::Edge {
+                        edge
+                    } else {
+                        None
+                    },
+                    rsc,
+                    edge_rsc,
+                },
+            });
+        }
+
+        let data = RemoteModuleManifestData {
+            protocol: REMOTE_MODULE_MANIFEST_PROTOCOL,
+            version: REMOTE_MODULE_MANIFEST_VERSION,
+            route: self.entry_name.clone(),
+            module_loading: ModuleLoadingData {
+                prefix: manifest.module_loading.prefix.clone(),
+                cross_origin: normalize_cross_origin(manifest.module_loading.cross_origin),
+            },
+            chunk_loading_global,
+            client_references,
+            entry_css: manifest.entry_css_files.clone(),
+            entry_js: manifest.entry_js_files.clone(),
+        };
+
+        let json = serde_json::to_string(&data)?;
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(json)).cell(),
+        ))
+    }
+}

--- a/crates/next-core/src/next_manifests/remote_components/shared_modules_manifest.rs
+++ b/crates/next-core/src/next_manifests/remote_components/shared_modules_manifest.rs
@@ -1,0 +1,145 @@
+use anyhow::Result;
+use serde::Serialize;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    chunk::{ChunkingContext, ModuleChunkItemIdExt},
+    module::Module,
+    module_graph::ModuleGraph,
+    output::{OutputAsset, OutputAssetsReference},
+};
+
+use super::RuntimeKind;
+use crate::next_manifests::ModuleId;
+
+pub const MODULE_ID_MANIFEST_PROTOCOL: &str = "turbopack.module-ids";
+pub const MODULE_ID_MANIFEST_VERSION: u32 = 1;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ModuleIdManifestData {
+    protocol: &'static str,
+    version: u32,
+    route: RcStr,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page_loader_id: Option<ModuleId>,
+    modules: Vec<ModuleIdEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ModuleIdEntry {
+    id: ModuleId,
+    path: RcStr,
+    layer: RcStr,
+    runtime_kind: RuntimeKind,
+}
+
+/// Module ID Map (`turbopack.module-ids`)
+///
+/// A manifest that maps from remote module IDs to shared specifiers.
+/// One per route is emitted.
+#[turbo_tasks::value(shared)]
+pub struct ModuleIdManifest {
+    pub node_root: FileSystemPath,
+    pub entry_name: RcStr,
+    pub module_graph: ResolvedVc<ModuleGraph>,
+    pub client_chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    pub ssr_chunking_context: Option<ResolvedVc<Box<dyn ChunkingContext>>>,
+    pub output_path: Option<FileSystemPath>,
+    /// Pages router only: this route's page-loader entry module.
+    pub page_loader_module: Option<ResolvedVc<Box<dyn Module>>>,
+}
+
+fn runtime_kind_for_layer(layer: &str) -> RuntimeKind {
+    if layer.contains("client") || layer.contains("browser") {
+        RuntimeKind::Browser
+    } else if layer.contains("edge") {
+        RuntimeKind::Edge
+    } else {
+        RuntimeKind::NodeJs
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAssetsReference for ModuleIdManifest {}
+
+#[turbo_tasks::value_impl]
+impl OutputAsset for ModuleIdManifest {
+    #[turbo_tasks::function]
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
+        if let Some(output_path) = &self.output_path {
+            return Ok(output_path.clone().cell());
+        }
+        let normalized = self.entry_name.replace("%5F", "_");
+        Ok(self
+            .node_root
+            .join(&format!("server/app{normalized}_module-ids-manifest.json"))?
+            .cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for ModuleIdManifest {
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<Vc<AssetContent>> {
+        let graphs = self.module_graph.iter_graphs().await?;
+        let mut modules = Vec::new();
+
+        for layer in graphs.iter() {
+            let layer = layer.connect().await?;
+            for module in layer.iter_nodes() {
+                let ident = module.ident().await?;
+                let layer: RcStr = ident
+                    .layer
+                    .as_ref()
+                    .map(|l| l.name().clone())
+                    .unwrap_or_default();
+                let runtime_kind = runtime_kind_for_layer(&layer);
+
+                let chunking_context = match runtime_kind {
+                    RuntimeKind::Browser => *self.client_chunking_context,
+                    _ => match self.ssr_chunking_context {
+                        Some(ctx) => *ctx,
+                        None => *self.client_chunking_context,
+                    },
+                };
+
+                let id: ModuleId = match module.chunk_item_id(chunking_context).await {
+                    Ok(id) => (&id).into(),
+                    Err(_) => continue,
+                };
+
+                modules.push(ModuleIdEntry {
+                    id,
+                    path: ident.path.path.clone(),
+                    layer,
+                    runtime_kind,
+                });
+            }
+        }
+
+        let page_loader_id: Option<ModuleId> = match self.page_loader_module {
+            Some(module) => match module.chunk_item_id(*self.client_chunking_context).await {
+                Ok(id) => Some((&id).into()),
+                Err(_) => None,
+            },
+            None => None,
+        };
+
+        let data = ModuleIdManifestData {
+            protocol: MODULE_ID_MANIFEST_PROTOCOL,
+            version: MODULE_ID_MANIFEST_VERSION,
+            route: self.entry_name.clone(),
+            page_loader_id,
+            modules,
+        };
+
+        let json = serde_json::to_string(&data)?;
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(json)).cell(),
+        ))
+    }
+}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -377,6 +377,7 @@ export const experimentalSchema = {
     .enum(['workerThreads', 'childProcesses', 'forceWorkerThreads'])
     .optional(),
   turbopackMinify: z.boolean().optional(),
+  turbopackRemoteModulesManifests: z.boolean().optional(),
   turbopackFileSystemCacheForDev: z.boolean().optional(),
   turbopackFileSystemCacheForBuild: z.boolean().optional(),
   turbopackSourceMaps: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -750,6 +750,12 @@ export interface ExperimentalConfig {
   turbopackMinify?: boolean
 
   /**
+   * Emit the public Remote Components manifests (`turbopack.remote-modules`,
+   * `turbopack.module-ids`) during a Turbopack build.
+   */
+  turbopackRemoteModulesManifests?: boolean
+
+  /**
    * Enable support for `with {type: "bytes"}` for ESM imports.
    */
   turbopackImportTypeBytes?: boolean


### PR DESCRIPTION
This PR adds two manifests to better support remote components w/ Turbopack. The goal here is to provide stability because previously remote-components has been Regex-ing chunks to reverse engineer Turbopack.

This implementation is based on "Turbopack support we need" in [Shared Runtime Provider Layer and Turbopack Federation Support](https://app.notion.com/p/vercel/Shared-Runtime-Provider-Layer-and-Turbopack-Federation-Support-36ce06b059c480c69e3dcc8098397aee):

- **Stable remote module manifest**:
    - Emit a public manifest that maps React Flight client references and remote chunks to stable module IDs, chunk URLs, exports, runtime kind, and any SSR/client variant metadata required to load the module later.
- **Shared module manifest mapping**:
    - Expose or consume a manifest-level mapping from remote module IDs to shared specifiers. This is the public equivalent of the `remote-components.shared.v1` data that drives the Remote Components provider plan.

The two manifests added are: `turbopack.remote-modules` and `turbopack.module-ids`. These are emitted when `experimental.turbopackRemoteModulesManifests` is true which will be set by `withRemoteComponentsConfig`. They are emitted at:

| Manifest | Router | Path (relative to dist dir) |
|---|---|---|
| `turbopack.remote-modules` | App only | `server/app{route}_remote-module-manifest.json` |
| `turbopack.module-ids` | App | `server/app{route}_module-ids-manifest.json` |
| `turbopack.module-ids` | Pages | `server/pages{prefix}/module-ids-manifest.json` |

### Manifest 1 — `turbopack.remote-modules`

```ts
interface RemoteModuleManifest {
  protocol: "turbopack.remote-modules";
  version: 1;
  route: string;                       // e.g. "/" or "/products/[id]"
  moduleLoading: {
    prefix: string;                    // asset prefix for chunk URLs
    crossOrigin: null | "" | "use-credentials";  // React/HTML crossOrigin
  };
  chunkLoadingGlobal: string;          // e.g. "TURBOPACK" or a scoped global
  clientReferences: RemoteClientReference[];
  entryCss?: { [serverComponentPath: string]: CssResource[] };  // omitted when empty
  entryJs?:  { [serverComponentPath: string]: string[] };       // omitted when empty
}

interface RemoteClientReference {
  key: string;                         // stable client-reference key
  exportName: string;                  // exported symbol name
  variants: {
    browser: RemoteModuleVariant;      // always present
    nodejs?: RemoteModuleVariant;      // present when route runtime = nodejs
    edge?: RemoteModuleVariant;        // present when route runtime = edge
    rsc?: RemoteModuleVariant;         // server-component variant
    edgeRsc?: RemoteModuleVariant;     // edge server-component variant
  };
}

interface RemoteModuleVariant {
  id: ModuleId;
  name: string;                        // export name for this variant
  chunks: string[];                    // chunk URLs to load
  async: boolean;
  runtimeKind: RuntimeKind;
}

interface CssResource {
  path: string;
  inlined: boolean;
  content?: string;                    // present only when inlined
}
```

#### Example

```json
{
  "protocol": "turbopack.remote-modules",
  "version": 1,
  "route": "/",
  "moduleLoading": { "prefix": "/_next/", "crossOrigin": "" },
  "chunkLoadingGlobal": "TURBOPACK",
  "clientReferences": [
    {
      "key": "[project]/components/Button.tsx <module evaluation>",
      "exportName": "Button",
      "variants": {
        "browser": {
          "id": 67554,
          "name": "Button",
          "chunks": ["static/chunks/components_Button_tsx_abc.js"],
          "async": false,
          "runtimeKind": "browser"
        },
        "nodejs": {
          "id": "[project]/components/Button.tsx",
          "name": "Button",
          "chunks": [],
          "async": false,
          "runtimeKind": "nodejs"
        }
      }
    }
  ],
  "entryCss": {
    "[project]/app/page.tsx": [
      { "path": "static/css/app_page.css", "inlined": false }
    ]
  }
}
```

### Manifest 2 — `turbopack.module-ids`

```ts
interface ModuleIdManifest {
  protocol: "turbopack.module-ids";
  version: 1;
  route: string;
  pageLoaderId?: ModuleId;   // Pages Router only: this route's
                             // [next]/entry/page-loader.ts module id
                             // (the module that registers the route into __NEXT_P).
                             // Absent for App Router.
  modules: ModuleIdEntry[];
}

interface ModuleIdEntry {
  id: ModuleId;
  path: string;              // resolved module path (primary join key)
  layer: string;            // e.g. "app-client", "app-ssr", "app-rsc", "client"
  runtimeKind: RuntimeKind; // derived from layer
}
```

#### Example (Pages Router)

```json
{
  "protocol": "turbopack.module-ids",
  "version": 1,
  "route": "/remote-components/barrel-reexport",
  "pageLoaderId": 16759,
  "modules": [
    {
      "id": 67554,
      "path": "[project]/node_modules/.pnpm/react@19.2.3/node_modules/react/index.js",
      "layer": "client",
      "runtimeKind": "browser"
    }
  ]
}
```

#### Example (App Router)

```json
{
  "protocol": "turbopack.module-ids",
  "version": 1,
  "route": "/page",
  "modules": [
    {
      "id": 67554,
      "path": "node_modules/.pnpm/next@.../node_modules/next/dist/compiled/react/index.js",
      "layer": "app-client",
      "runtimeKind": "browser"
    },
    {
      "id": 73391,
      "path": "node_modules/.pnpm/next@.../node_modules/next/dist/compiled/react/index.js",
      "layer": "app-ssr",
      "runtimeKind": "nodejs"
    },
    {
      "id": 26030,
      "path": "app/page.tsx",
      "layer": "app-rsc",
      "runtimeKind": "nodejs"
    }
  ]
}
```

## Testing

To test this change, I had Claude generate a re-implementation of the Turbopack integration in `vercel/remote-components` that used these manifests and made metadata scraping a legacy implementation. All E2E tests appear to be passing locally so I believe these two manifests have sufficient implementation - let me know though if there's more I should add!