### PR TITLE
test: Really use pnpm on deploy tests

### DIFF
--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -35,26 +35,25 @@ module.exports = {
 `
 
 describe('404-page-router', () => {
-  const { next } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: {
       pages: new FileRef(path.join(__dirname, 'app/pages')),
       components: new FileRef(path.join(__dirname, 'app/components')),
     },
     skipStart: true,
+    // TODO: investigate condensing these tests to avoid 5 separate deploys for this one test
+    skipDeployment: true,
     patchFileDelay: 500,
   })
+
+  if (skipped) {
+    return
+  }
 
   describe.each(table)(
     '404-page-router with basePath of $basePath and i18n of $i18n and middleware $middleware',
     (options) => {
       const isDev = (global as any).isNextDev
-
-      if ((global as any).isNextDeploy) {
-        // TODO: investigate condensing these tests to avoid
-        // 5 separate deploys for this one test
-        it('should skip for deploy', () => {})
-        return
-      }
 
       beforeAll(async () => {
         // Only add in the middleware if we're testing with middleware enabled.

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -494,7 +494,7 @@ export class NextInstance {
               path.join(this.testDir, 'vercel.json'),
               JSON.stringify({
                 installCommand:
-                  'mv node_modules node_modules.bak && npm i && cp -r node_modules.bak/* node_modules',
+                  'mv node_modules node_modules.bak && pnpm i && cp -r node_modules.bak/* node_modules',
               })
             )
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -518,7 +518,7 @@ export class NextInstance {
               path.join(this.testDir, 'vercel.json'),
               JSON.stringify({
                 installCommand:
-                  'mv node_modules node_modules.bak && npm i && cp -r node_modules.bak/* node_modules',
+                  'mv node_modules node_modules.bak && pnpm i && cp -r node_modules.bak/* node_modules',
               })
             )
 

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -409,6 +409,8 @@ export class NextDeployInstance extends NextInstance {
       `VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION || 'vercel@latest'}`
     )
 
+    additionalEnv.push(`ENABLE_EXPERIMENTAL_COREPACK=1`)
+
     // Add experimental feature flags
 
     if (process.env.__NEXT_CACHE_COMPONENTS) {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -424,6 +424,9 @@ export class NextDeployInstance extends NextInstance {
       `VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION || 'vercel@latest'}`
     )
 
+    // So that our `package.json#packageManager` field is respected when building on Vercel
+    additionalEnv.push(`ENABLE_EXPERIMENTAL_COREPACK=1`)
+
     // Route the build to a named hive, and to a specific build-container image.
     // The dispatcher reads the image version only for a build on a forced hive.
     // A version without a hive falls back to the default image and reports no


### PR DESCRIPTION
We already set `package.json#packageManager`

<img width="539" height="388" alt="Bildschirmfoto 2026-07-01 um 16 26 30" src="https://github.com/user-attachments/assets/8f6f3e8f-60a6-484d-ac57-f8dc261f8b85" />

But the Vercel deployment tests still used npm to install dependencies because you need to set `ENABLE_EXPERIMENTAL_COREPACK` so that `packageManager` applies.

npm takes 14s in a minimal project: https://vercel.com/vtest314-next-adapter-e2e-tests/vtest314-e2e-tests/HMrxJAB3UidJ7SHnftfDgeL5jKav
pnpm takes 6.7s with more dependencices: https://vercel.com/vtest314-next-adapter-e2e-tests/vtest314-e2e-tests/8hWsBpV3P5Gmu4ep3s83BWWq427H#

So pnpm should be hopefully faster, and also improves consistency across the test environments

Full deploy test run:
~~https://github.com/vercel/next.js/actions/runs/28528683809~~ ~~https://github.com/vercel/next.js/actions/runs/28531873334~~ ~~https://github.com/vercel/next.js/actions/runs/28542029071~~ ~~https://github.com/vercel/next.js/actions/runs/29311003094~~ https://github.com/vercel/next.js/actions/runs/32731722428