### PR TITLE
[ci] Migrate Turbopack build_and_test jobs back to arm64, leave webpack jobs as x86-64

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -379,7 +379,7 @@ jobs:
         'optimize-ci',
         'changes',
         'build-next',
-        'build-native-x64',
+        'build-native',
         'fetch-test-timings',
       ]
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
@@ -420,7 +420,7 @@ jobs:
         'optimize-ci',
         'changes',
         'build-next',
-        'build-native-x64',
+        'build-native',
         'fetch-test-timings',
       ]
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}


### PR DESCRIPTION
IT increased the concurrency limit from 50 to 100. This ramps back up the `build_and_test` job. I'll keep an eye out for long queue times before migrating us all the way back to arm64.

https://vercel.slack.com/archives/C0B0LKK5QD7/p1782910263667649?thread_ts=1782838752.523649&cid=C0B0LKK5QD7