### PR TITLE
[fragment-scroll] Enable new scroll handler by default

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -406,6 +406,7 @@ jobs:
         export NEXT_TEST_MODE=dev
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         export RUST_BACKTRACE=1
 
         node run-tests.js \
@@ -448,6 +449,7 @@ jobs:
         export NEXT_TEST_MODE=start
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         export RUST_BACKTRACE=1
 
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} --type production
@@ -484,6 +486,7 @@ jobs:
         export NEXT_TEST_MODE=dev
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
 
         # rspack flags
         export NEXT_RSPACK=1
@@ -530,6 +533,7 @@ jobs:
         export NEXT_TEST_MODE=start
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
 
         # rspack flags
         export NEXT_RSPACK=1
@@ -692,6 +696,7 @@ jobs:
     with:
       afterBuild: |
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         node scripts/test-new-tests.mjs \
           --flake-detection \
           --mode dev \
@@ -718,6 +723,7 @@ jobs:
     with:
       afterBuild: |
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         node scripts/test-new-tests.mjs \
           --flake-detection \
           --mode start \
@@ -747,6 +753,7 @@ jobs:
         export NEXT_ENABLE_ADAPTER=1
         export NEXT_E2E_TEST_TIMEOUT=240000
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         node scripts/test-new-tests.mjs \
           --mode deploy \
           --group ${{ matrix.group }} \
@@ -778,7 +785,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true
-        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export NEXT_ENABLE_ADAPTER=1
         export NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json,test/cache-components-tests-manifest.json"
         export NEXT_E2E_TEST_TIMEOUT=240000
@@ -818,6 +824,7 @@ jobs:
         export NEXT_TEST_MODE=dev
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
 
         node run-tests.js \
           --timings \
@@ -839,6 +846,7 @@ jobs:
       afterBuild: |
         export NEXT_TEST_MODE=dev
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_DEV=1
 
@@ -862,6 +870,7 @@ jobs:
       afterBuild: |
         export NEXT_TEST_MODE=start
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_BUILD=1
 
@@ -886,6 +895,7 @@ jobs:
       afterBuild: |
         export NEXT_TEST_MODE=start
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_BUILD=1
 
@@ -927,6 +937,7 @@ jobs:
         export NEXT_TEST_MODE=start
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
 
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} --type production
       testTimingsArtifact: 'test-timings'
@@ -946,6 +957,7 @@ jobs:
         # these all run without concurrency because they're heavier
         export TEST_CONCURRENCY=1
         export IS_TURBOPACK_TEST=1
+        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=false
         TURBOPACK_BUILD=1 NEXT_TEST_MODE=start BROWSER_NAME=firefox node run-tests.js \
           test/production/pages-dir/production/test/index.test.ts \
           test/production/chunk-load-failure/chunk-load-failure.test.ts
@@ -990,7 +1002,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true
-        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export __NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=dev
@@ -1027,7 +1038,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true
-        export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export __NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=start

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "with-rspack": "cross-env NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1",
     "with-turbo": "cross-env IS_TURBOPACK_TEST=1",
     "with-webpack": "cross-env IS_WEBPACK_TEST=1",
-    "with-experimental": "cross-env __NEXT_CACHE_COMPONENTS=true __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true"
+    "with-experimental": "cross-env __NEXT_CACHE_COMPONENTS=true"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -2087,7 +2087,7 @@ export const defaultConfig = Object.freeze({
   },
   adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
   experimental: {
-    appNewScrollHandler: false,
+    appNewScrollHandler: true,
     coldCacheBadge: false,
     useSkewCookie: false,
     cssChunking: true,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2286,23 +2286,19 @@ function enforceExperimentalFeatures(
     config.experimental.appShells = true
   }
 
-  // TODO: Remove this once appNewScrollHandler is the default.
+  // appNewScrollHandler defaults to `true`. The env var lets us opt back out to
+  // keep test coverage of the old scroll handler on the non-experimental CI
+  // shards. Done silently, matching the cachedNavigations/appShells defaults
+  // above, so opting out doesn't add a line to build-output snapshots.
+  // TODO: Remove this once the appNewScrollHandler opt-out is no longer needed
+  // for test coverage.
   if (
-    process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER === 'true' &&
+    process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER === 'false' &&
     // We do respect an explicit value in the user config.
     (config.experimental.appNewScrollHandler === undefined ||
-      (isDefaultConfig && !config.experimental.appNewScrollHandler))
+      (isDefaultConfig && config.experimental.appNewScrollHandler))
   ) {
-    config.experimental.appNewScrollHandler = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'appNewScrollHandler',
-        true,
-        'enabled by `__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER`'
-      )
-    }
+    config.experimental.appNewScrollHandler = false
   }
 
   // TODO: Remove this once strictRouteTypes is the default.

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2288,8 +2288,8 @@ function enforceExperimentalFeatures(
 
   // appNewScrollHandler defaults to `true`. The env var lets us opt back out to
   // keep test coverage of the old scroll handler on the non-experimental CI
-  // shards. Done silently, matching the cachedNavigations/appShells defaults
-  // above, so opting out doesn't add a line to build-output snapshots.
+  // shards. Like the other env-var experimental toggles, opting out is surfaced
+  // in the reported experimental features.
   // TODO: Remove this once the appNewScrollHandler opt-out is no longer needed
   // for test coverage.
   if (
@@ -2299,6 +2299,15 @@ function enforceExperimentalFeatures(
       (isDefaultConfig && config.experimental.appNewScrollHandler))
   ) {
     config.experimental.appNewScrollHandler = false
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'appNewScrollHandler',
+        false,
+        'disabled by `__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER`'
+      )
+    }
   }
 
   // TODO: Remove this once strictRouteTypes is the default.

--- a/scripts/run-jest.sh
+++ b/scripts/run-jest.sh
@@ -15,6 +15,8 @@
 
 set -eo pipefail
 
+experimental=false
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --mode=dev|--mode=start|--mode=deploy)
@@ -39,8 +41,8 @@ while [ $# -gt 0 ]; do
       exit 1
       ;;
     --experimental)
+      experimental=true
       export __NEXT_CACHE_COMPONENTS=true
-      export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
       ;;
     --headless)
       export HEADLESS=true
@@ -56,6 +58,14 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+# appNewScrollHandler defaults to `true`. Non-experimental runs opt out so
+# local runs mirror the non-experimental CI shards and keep coverage of the old
+# scroll handler; experimental runs leave it on via the default. An explicit
+# value in the environment is respected either way.
+if [ "$experimental" != true ]; then
+  export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER="${__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER:-false}"
+fi
 
 # Resolves to `node_modules/.bin/jest` via `$PATH`. This relies on being
 # invoked through pnpm (or another package runner), which prepends the

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -5,7 +5,7 @@ import { retry } from 'next-test-utils'
 
 const bundlerName = process.env.IS_TURBOPACK_TEST ? 'Turbopack' : 'Webpack'
 const enableNewScrollHandler =
-  process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER === 'true'
+  process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER !== 'false'
 const innerScrollAndMaybeFocusHandlerName = enableNewScrollHandler
   ? 'InnerScrollHandlerNew'
   : 'InnerScrollAndFocusHandlerOld'

--- a/test/development/server-side-dev-errors/server-side-dev-errors.test.ts
+++ b/test/development/server-side-dev-errors/server-side-dev-errors.test.ts
@@ -25,6 +25,12 @@ describe('server-side dev errors', () => {
         // with the test capturing `cliOutputIdx`.
         if (trimmed.startsWith('- ')) return false
         if (/^[✓⚠△] /.test(trimmed)) return false
+        // Individual entries under the `- Experiments` header are indented and
+        // use status glyphs (✓ enabled, ⨯ disabled, · value), e.g.
+        // `  ⨯ appNewScrollHandler (disabled by ...)`. Only these banner entries
+        // are indented; real dev errors start at column 0 (`⨯ ReferenceError:
+        // ...`), so key off the leading indentation to avoid dropping them.
+        if (/^\s+[✓⚠△⨯·] /.test(item)) return false
         // Drop compiling indicator lines (e.g. "○ Compiling /gsp ...").
         if (trimmed.startsWith('○ ')) return false
         return true

--- a/test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+++ b/test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 const enableNewScrollHandler =
-  process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER === 'true'
+  process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER !== 'false'
 
 describe('navigation-focus', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { check, assertNoConsoleErrors, retry } from 'next-test-utils'
 
 const enableNewScrollHandler =
-  process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER === 'true'
+  process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER !== 'false'
 
 describe('router autoscrolling on navigation', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/config-experimental-warning/config-experimental-warning.test.ts
+++ b/test/e2e/config-experimental-warning/config-experimental-warning.test.ts
@@ -37,8 +37,10 @@ describe('Config Experimental Warning', () => {
         nextConfig: {
           images: {},
           experimental: {
-            // We enable this by default in CI
+            // We enable this in some CI shards
             strictRouteTypes: false,
+            // We disable this in some CI shards
+            appNewScrollHandler: true,
           },
         },
       })
@@ -99,8 +101,10 @@ describe('Config Experimental Warning', () => {
             module.exports = (phase) => ({
               experimental: {
                 workerThreads: false,
-                // We enable this by default in CI
+                // We enable this in some CI shards
                 strictRouteTypes: false,
+                // We disable this in some CI shards
+                appNewScrollHandler: true,
               }
             })
           `,

--- a/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
+++ b/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
@@ -31,9 +31,12 @@ function extractErrorBlock(output: string, errorTitle: string): string {
 
   const beforeTitle = output.substring(0, titleIdx)
 
-  // In dev mode, errors start with a `⨯` marker on the same line as the file path.
-  // In prod mode, errors start with a bare file-path line above the title.
-  const markerIdx = beforeTitle.lastIndexOf('⨯ ')
+  // In dev mode, errors start with a `⨯` marker on the same line as the file
+  // path (e.g. `⨯ ./app/file.js`). In prod mode, errors start with a bare
+  // file-path line above the title. Match `⨯ ./` specifically so we don't latch
+  // onto unrelated `⨯` markers in the startup output, such as the experimental
+  // features list (e.g. `⨯ appNewScrollHandler (disabled by ...)`).
+  const markerIdx = beforeTitle.lastIndexOf('⨯ ./')
   let startIdx: number
   if (markerIdx !== -1) {
     startIdx = markerIdx

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -52,6 +52,7 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                · staticGenerationMaxConcurrency: 1
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
@@ -61,6 +62,7 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                · staticGenerationMaxConcurrency: 1
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
@@ -70,6 +72,7 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                · staticGenerationMaxConcurrency: 1
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
@@ -193,6 +196,7 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                · staticGenerationMaxConcurrency: 1
@@ -207,6 +211,7 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
@@ -221,6 +226,7 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
@@ -378,6 +384,7 @@ describe('build-output-prerender', () => {
              "✓ Running next.config took N
              ▲ Next.js x.y.z (Turbopack)
              - Experiments (use with caution):
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
           } else if (isRspack) {
@@ -385,6 +392,7 @@ describe('build-output-prerender', () => {
              "✓ Running next.config took N
              ▲ Next.js x.y.z (Rspack)
              - Experiments (use with caution):
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
           } else {
@@ -392,6 +400,7 @@ describe('build-output-prerender', () => {
              "✓ Running next.config took N
              ▲ Next.js x.y.z (webpack)
              - Experiments (use with caution):
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)"
             `)
           }
@@ -459,6 +468,7 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Turbopack)
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                ✓ strictRouteTypes (enabled by \`__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES\`)
@@ -471,6 +481,7 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Rspack)
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
@@ -483,6 +494,7 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (webpack)
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
+               ⨯ appNewScrollHandler (disabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -22,7 +22,6 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)
                · staticGenerationMaxConcurrency: 1"
@@ -33,7 +32,6 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                · staticGenerationMaxConcurrency: 1"
             `)
@@ -43,7 +41,6 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                · staticGenerationMaxConcurrency: 1"
             `)
@@ -151,7 +148,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)
@@ -167,7 +163,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
@@ -182,7 +177,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
@@ -358,7 +352,6 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)"
             `)
@@ -368,7 +361,6 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)"
             `)
           } else {
@@ -377,7 +369,6 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)"
             `)
           }
@@ -427,7 +418,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)
@@ -442,7 +432,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
@@ -456,7 +445,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)


### PR DESCRIPTION
This enables the new scroll handler by default. We consider the changed behavior a bug fix. 

Segments where their first, top level DOM element was focusable, are no longer focused on soft-navigation (e.g. in `<><button /><main></main></>` the `button` is no longer focused on soft-navigation). This matches default browser behavior on hard-navigation.

`experimental.appNewScrollhandler` is kept during the preview period as an opt-out to unblock yourself. Please file an issue and ping me if the new behavior is undesired. We plan to remove the opt-out before 16.3.