### PR TITLE
refactor: remove unnecessary switches from StagedRenderingController

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1417,5 +1417,6 @@
   "1416": "Invalid \"%s\" provided, expected a finite number of seconds or Infinity, received %s",
   "1417": "Could not parse output from TypeScript's --showConfig.",
   "1418": "TypeScript %s does not provide the compiler API required by Next.js. Enable %s in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
-  "1419": "TypeScript CLI interrupted by %s"
+  "1419": "TypeScript CLI interrupted by %s",
+  "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s"
 }

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -184,13 +184,15 @@ export class StagedRenderingController {
     }
   }
 
+  /** Note: only call this if `shouldTrackSyncInterrupt()` returned true */
   syncInterruptCurrentStageWithReason(reason: Error) {
-    if (this.currentStage === RenderStage.Before) {
-      return
-    }
-
-    // If the render has already been abandoned, there's nothing to interrupt.
-    if (this.currentStage === RenderStage.Abandoned) {
+    const { currentStage } = this
+    if (
+      currentStage === RenderStage.Before ||
+      currentStage === RenderStage.Dynamic ||
+      currentStage === RenderStage.Abandoned
+    ) {
+      // Not interruptible. Defensive noop.
       return
     }
 
@@ -214,35 +216,8 @@ export class StagedRenderingController {
     // If we're in a non-abandonable & non-abortable render,
     // we need to advance to the Dynamic stage and capture the interruption reason.
     // (in dev, this will be the restarted render)
-    switch (this.currentStage) {
-      case RenderStage.ShellEarlyStatic:
-      case RenderStage.ShellStatic:
-      case RenderStage.EarlyStatic:
-      case RenderStage.Static:
-      case RenderStage.ShellEarlyRuntime:
-      case RenderStage.EarlyRuntime: {
-        // EarlyRuntime is for runtime-prefetchable segments. Sync IO here
-        // means the prefetch would be aborted too early.
-        this.syncInterruptReason = reason
-        this.advanceStage(RenderStage.Dynamic)
-        return
-      }
-      case RenderStage.ShellRuntime:
-      case RenderStage.Runtime: {
-        // `shouldTrackSyncInterrupt` returns false for [Shell]Runtime, so we should
-        // never get here. Defensive no-op.
-        break
-      }
-      case RenderStage.Dynamic: {
-        // `shouldTrackSyncInterrupt` returns false for Dynamic, so we should
-        // never get here. Defensive no-op.
-
-        break
-      }
-      default: {
-        this.currentStage satisfies never
-      }
-    }
+    this.syncInterruptReason = reason
+    this.advanceStage(RenderStage.Dynamic)
   }
 
   getSyncInterruptReason() {
@@ -275,40 +250,30 @@ export class StagedRenderingController {
     // unblocking the dynamic stage would likely lead to wasted (uncached) IO.
 
     const { currentStage } = this
-    switch (currentStage) {
-      case RenderStage.Before: {
-        throw new InvariantError(
-          "A render that hasn't started yet cannot be abandoned"
-        )
-      }
-      case RenderStage.ShellEarlyStatic:
-      case RenderStage.EarlyStatic:
-      case RenderStage.ShellStatic:
-      case RenderStage.Static:
-      case RenderStage.ShellEarlyRuntime:
-      case RenderStage.EarlyRuntime:
-      case RenderStage.ShellRuntime:
-      case RenderStage.Runtime: {
-        // Resolve all stages after the current one, up to runtime (excluding dynamic)
-        const nextStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(currentStage) + 1
-        const dynamicStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(
-          RenderStage.Dynamic
-        )
-        for (let i = nextStageIx; i < dynamicStageIx; i++) {
-          this.resolveStage(RENDER_STAGE_ADVANCE_ORDER[i])
-        }
 
-        this.currentStage = RenderStage.Abandoned
-        break
-      }
-      case RenderStage.Dynamic:
-      case RenderStage.Abandoned: {
-        break
-      }
-      default: {
-        currentStage satisfies never
-      }
+    if (currentStage === RenderStage.Before) {
+      throw new InvariantError(
+        "A render that hasn't started yet cannot be abandoned"
+      )
     }
+    if (
+      currentStage === RenderStage.Dynamic ||
+      currentStage === RenderStage.Abandoned
+    ) {
+      // We shouldn't ever trigger an abandon in these. Defensive noop.
+      return
+    }
+
+    // Resolve all stages after the current one, up to runtime (excluding dynamic)
+    const nextStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(currentStage) + 1
+    const dynamicStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(
+      RenderStage.Dynamic
+    )
+    for (let i = nextStageIx; i < dynamicStageIx; i++) {
+      this.resolveStage(RENDER_STAGE_ADVANCE_ORDER[i])
+    }
+
+    this.currentStage = RenderStage.Abandoned
   }
 
   advanceStage(targetStage: AdvanceableRenderStage) {
@@ -317,43 +282,31 @@ export class StagedRenderingController {
         `Attempted to advance to stage ${RenderStage[targetStage]} but the render is limited to ${RenderStage[this.finalStage]}`
       )
     }
-    // If we're already at the target stage or beyond, do nothing.
-    // (this can happen e.g. if sync IO advanced us to the dynamic stage)
-    if (targetStage <= this.currentStage) {
+    const { currentStage } = this
+
+    if (
+      currentStage === RenderStage.Dynamic ||
+      currentStage === RenderStage.Abandoned
+    ) {
+      // Terminal stages, nowhere left to advance.
       return
     }
 
-    const { currentStage } = this
+    // If we're already at the target stage or beyond, do nothing.
+    if (targetStage <= currentStage) {
+      return
+    }
+
     this.currentStage = targetStage
 
-    switch (currentStage) {
-      case RenderStage.Before:
-      case RenderStage.ShellEarlyStatic:
-      case RenderStage.EarlyStatic:
-      case RenderStage.ShellStatic:
-      case RenderStage.Static:
-      case RenderStage.ShellEarlyRuntime:
-      case RenderStage.EarlyRuntime:
-      case RenderStage.ShellRuntime:
-      case RenderStage.Runtime: {
-        // Resolve all stages between the current stage and the target.
-        const nextStageIx =
-          currentStage === RenderStage.Before
-            ? 0
-            : RENDER_STAGE_ADVANCE_ORDER.indexOf(currentStage) + 1
-        const targetStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(targetStage)
-        for (let i = nextStageIx; i <= targetStageIx; i++) {
-          this.resolveStage(RENDER_STAGE_ADVANCE_ORDER[i])
-        }
-        break
-      }
-      case RenderStage.Dynamic:
-      case RenderStage.Abandoned: {
-        break
-      }
-      default: {
-        currentStage satisfies never
-      }
+    // Resolve all stages between the current stage and the target.
+    const nextStageIx =
+      currentStage === RenderStage.Before
+        ? 0
+        : RENDER_STAGE_ADVANCE_ORDER.indexOf(currentStage) + 1
+    const targetStageIx = RENDER_STAGE_ADVANCE_ORDER.indexOf(targetStage)
+    for (let i = nextStageIx; i <= targetStageIx; i++) {
+      this.resolveStage(RENDER_STAGE_ADVANCE_ORDER[i])
     }
   }
 

--- a/packages/next/src/server/node-environment-extensions/io-utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/io-utils.tsx
@@ -9,6 +9,7 @@ import {
   createSyncIORuntimeError,
   type SyncIOApiType,
 } from '../app-render/sync-io-messages'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 export function io(expression: string, type: SyncIOApiType) {
   const workUnitStore = workUnitAsyncStorage.getStore()
@@ -56,21 +57,36 @@ export function io(expression: string, type: SyncIOApiType) {
       const stageController = workUnitStore.stagedRendering
       if (stageController && stageController.shouldTrackSyncInterrupt()) {
         let syncIOError: Error
-        if (
-          stageController.currentStage === RenderStage.Static ||
-          stageController.currentStage === RenderStage.EarlyStatic
-        ) {
-          syncIOError = createSyncIOError(workStore.route, expression, type)
-        } else {
-          // We're in the Runtime stage.
-          // We only error for Sync IO in the Runtime stage if the route has a runtime prefetch config.
-          // This check is implemented in `stageController.canSyncInterrupt()` --
-          // if runtime prefetching isn't enabled, then we won't get here.
-          syncIOError = createSyncIORuntimeError(
-            workStore.route,
-            expression,
-            type
-          )
+        // NOTE: keep stages where we can interrupt in sync with
+        // `shouldTrackSyncInterrupt`/`syncInterruptCurrentStageWithReason`
+        switch (stageController.currentStage) {
+          case RenderStage.ShellEarlyStatic:
+          case RenderStage.ShellStatic:
+          case RenderStage.EarlyStatic:
+          case RenderStage.Static: {
+            syncIOError = createSyncIOError(workStore.route, expression, type)
+            break
+          }
+          case RenderStage.ShellEarlyRuntime:
+          case RenderStage.EarlyRuntime: {
+            // We only error for Sync IO in the Runtime stage if the segment has a runtime prefetch config.
+            // Only Runtime prefetchable segments are rendered in the "early" runtime stages.
+            syncIOError = createSyncIORuntimeError(
+              workStore.route,
+              expression,
+              type
+            )
+            break
+          }
+          case RenderStage.Before:
+          case RenderStage.ShellRuntime:
+          case RenderStage.Runtime:
+          case RenderStage.Dynamic:
+          case RenderStage.Abandoned: {
+            throw new InvariantError(
+              `shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: ${RenderStage[stageController.currentStage]}`
+            )
+          }
         }
 
         syncIOError = applyOwnerStack(syncIOError)


### PR DESCRIPTION
We have a couple switches in `StagedRenderingController` where the main purpose ends up being eliminating `Before/Dynamic/Abandoned` (i.e. the start and the end stages). Since we migrated everything to `RENDER_STAGE_ORDER` loops, we no longer really need to list all the intermediate stages out explicitly in these switches. It's enough to rule out the "special" stages  and let the rest of the code be generic. This saves some work when adding/removing intermediate stages.

View with "hide whitespace", otherwise it looks messy.