### PR TITLE
[DO NOT MERGE] debug: queue tracing for popstate-revalidate CI flake

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -65,27 +65,33 @@ export type ActionQueueNode = {
   discarded?: boolean
 }
 
+// Called when `action` settles, to run the next action in the queue.
 function runRemainingActions(
   actionQueue: AppRouterActionQueue,
+  action: ActionQueueNode,
   setState: DispatchStatePromise
 ) {
-  if (actionQueue.pending !== null) {
-    actionQueue.pending = actionQueue.pending.next
+  // Only the settlement of the action at the head of the queue may advance the
+  // queue. A discarded action settles while the navigation that discarded it
+  // is the head; advancing from here would start the next queued action
+  // against router state that doesn't include that navigation yet.
+  if (actionQueue.pending === action) {
+    actionQueue.pending = action.next
     if (actionQueue.pending !== null) {
       runAction({
         actionQueue,
         action: actionQueue.pending,
         setState,
       })
+      return
     }
-  } else {
-    // Check for refresh when pending is already null
-    // This handles the case where a discarded server action completes
-    // after the navigation has already finished and the queue is empty
-    if (actionQueue.needsRefresh) {
-      actionQueue.needsRefresh = false
-      actionQueue.dispatch({ type: ACTION_REFRESH }, setState)
-    }
+  }
+
+  if (actionQueue.pending === null && actionQueue.needsRefresh) {
+    // The queue is idle; flush the refresh requested by a discarded server
+    // action that revalidated data.
+    actionQueue.needsRefresh = false
+    actionQueue.dispatch({ type: ACTION_REFRESH }, setState)
   }
 }
 
@@ -117,22 +123,22 @@ async function runAction({
         // mark that we need to refresh after all actions complete
         actionQueue.needsRefresh = true
       }
-      // Still need to run remaining actions even for discarded actions
-      // to potentially trigger the refresh
-      runRemainingActions(actionQueue, setState)
+      // This can't advance the queue (this action is no longer its head), but
+      // if the queue has already drained, it flushes the refresh now.
+      runRemainingActions(actionQueue, action, setState)
       return
     }
 
     actionQueue.state = nextState
 
-    runRemainingActions(actionQueue, setState)
+    runRemainingActions(actionQueue, action, setState)
     action.resolve(nextState)
   }
 
   // if the action is a promise, set up a callback to resolve it
   if (isThenable(actionResult)) {
     actionResult.then(handleResult, (err) => {
-      runRemainingActions(actionQueue, setState)
+      runRemainingActions(actionQueue, action, setState)
       action.reject(err)
     })
   } else {

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -65,6 +65,24 @@ export type ActionQueueNode = {
   discarded?: boolean
 }
 
+// TEMP DEBUG (do not merge): action queue tracing for a CI-only
+// navigation.test.ts flake. Logs go to the browser console, which the test
+// harness echoes into CI output.
+let __queueTraceId = 0
+function traceLabel(action: ActionQueueNode | null): string {
+  if (action === null) return 'null'
+  const anyAction = action as any
+  if (anyAction.__traceId === undefined) {
+    anyAction.__traceId = ++__queueTraceId
+  }
+  return `#${anyAction.__traceId}:${action.payload.type}${
+    action.discarded ? '(discarded)' : ''
+  }`
+}
+function traceQueue(message: string) {
+  console.log(`[q] ${message}`)
+}
+
 // Called when `action` settles, to run the next action in the queue.
 function runRemainingActions(
   actionQueue: AppRouterActionQueue,
@@ -77,6 +95,10 @@ function runRemainingActions(
   // against router state that doesn't include that navigation yet.
   if (actionQueue.pending === action) {
     actionQueue.pending = action.next
+    traceQueue(
+      `advance: ${traceLabel(action)} -> ${traceLabel(action.next)}` +
+        ` needsRefresh=${!!actionQueue.needsRefresh}`
+    )
     if (actionQueue.pending !== null) {
       runAction({
         actionQueue,
@@ -85,9 +107,15 @@ function runRemainingActions(
       })
       return
     }
+  } else {
+    traceQueue(
+      `no advance: ${traceLabel(action)} settled but head is ` +
+        `${traceLabel(actionQueue.pending)} needsRefresh=${!!actionQueue.needsRefresh}`
+    )
   }
 
   if (actionQueue.pending === null && actionQueue.needsRefresh) {
+    traceQueue('flushing deferred refresh')
     // The queue is idle; flush the refresh requested by a discarded server
     // action that revalidated data.
     actionQueue.needsRefresh = false
@@ -109,9 +137,13 @@ async function runAction({
   actionQueue.pending = action
 
   const payload = action.payload
+  traceQueue(`run: ${traceLabel(action)}`)
   const actionResult = actionQueue.action(prevState, payload)
 
   function handleResult(nextState: AppRouterState) {
+    traceQueue(
+      `settled: ${traceLabel(action)} isHead=${actionQueue.pending === action}`
+    )
     // if we discarded this action, the state should also be discarded
     if (action.discarded) {
       // Check if the discarded server action revalidated data
@@ -138,6 +170,11 @@ async function runAction({
   // if the action is a promise, set up a callback to resolve it
   if (isThenable(actionResult)) {
     actionResult.then(handleResult, (err) => {
+      traceQueue(
+        `rejected: ${traceLabel(action)} isHead=${
+          actionQueue.pending === action
+        } err=${err instanceof Error ? err.message : String(err)}`
+      )
       runRemainingActions(actionQueue, action, setState)
       action.reject(err)
     })
@@ -186,6 +223,7 @@ function dispatchAction(
     // Mark this action as the last in the queue
     actionQueue.last = newAction
 
+    traceQueue(`dispatch (idle): ${traceLabel(newAction)}`)
     runAction({
       actionQueue,
       action: newAction,
@@ -195,6 +233,12 @@ function dispatchAction(
     payload.type === ACTION_NAVIGATE ||
     payload.type === ACTION_RESTORE
   ) {
+    traceQueue(
+      `dispatch (discards ${traceLabel(actionQueue.pending)}): ` +
+        `${traceLabel(newAction)} inherits next=${traceLabel(
+          actionQueue.pending.next
+        )} last=${traceLabel(actionQueue.last)}`
+    )
     // Navigations (including back/forward) take priority over any pending actions.
     // Mark the pending action as discarded (so the state is never applied) and start the navigation action immediately.
     actionQueue.pending.discarded = true
@@ -209,6 +253,10 @@ function dispatchAction(
       setState,
     })
   } else {
+    traceQueue(
+      `dispatch (enqueued behind ${traceLabel(actionQueue.last)}): ` +
+        `${traceLabel(newAction)} head=${traceLabel(actionQueue.pending)}`
+    )
     // The queue is not empty, so add the action to the end of the queue
     // It will be started by runRemainingActions after the previous action finishes
     if (actionQueue.last !== null) {

--- a/test/e2e/app-dir/actions-discarded-segment-drop/actions-discarded-segment-drop.test.ts
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/actions-discarded-segment-drop.test.ts
@@ -1,0 +1,73 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+;(process.env.__NEXT_CACHE_COMPONENTS ? describe.skip : describe)(
+  'segment-drop on a boundary-gated nested navigation (#86151)',
+  () => {
+    const { next } = nextTestSetup({ files: __dirname })
+
+    // Each navigation discards a Server Action that is still in flight. A
+    // discarded action's settlement must not advance the action queue while
+    // another action is pending: queued actions would run against stale router
+    // state, and their responses revert the /mid/leaf navigation back to /mid
+    // shortly after the leaf renders.
+    async function navigateAndAssertLeafSticks(startPath: string) {
+      const browser = await next.browser(startPath)
+      await browser.elementByCss('[data-testid="start"]')
+
+      await browser.elementByCss('[data-testid="to-mid"]').click()
+      await browser.elementByCss('[data-testid="mid"]')
+
+      // The root layout stamp only changes when the router refreshes.
+      const stamp = await browser.elementByCss('[data-testid="stamp"]').text()
+
+      await browser.elementByCss('[data-testid="to-leaf"]').click()
+      await browser.waitForElementByCss('[data-testid="leaf"]', 10_000)
+
+      // The broken behavior is a revert ~200ms after the leaf renders, so the
+      // assertion above can false-pass on that flash. Wait through the window
+      // in which the discarded action settles and assert the state stuck.
+      await waitFor(2000)
+      expect(await browser.url()).toContain('/mid/leaf')
+      expect(
+        await browser.hasElementByCssSelector('[data-testid="leaf"]')
+      ).toBe(true)
+
+      return { browser, stamp }
+    }
+
+    it('keeps the destination segment when a discarded action settles mid-navigation', async () => {
+      const { browser, stamp } = await navigateAndAssertLeafSticks('/')
+
+      // The discarded action didn't revalidate, so there must be no refresh.
+      expect(await browser.elementByCss('[data-testid="stamp"]').text()).toBe(
+        stamp
+      )
+    })
+
+    // Rejection of a discarded action goes through a separate code path.
+    it('keeps the destination segment when a discarded action rejects mid-navigation', async () => {
+      const { browser, stamp } = await navigateAndAssertLeafSticks('/reject')
+
+      expect(await browser.elementByCss('[data-testid="stamp"]').text()).toBe(
+        stamp
+      )
+    })
+
+    it('still refreshes after a discarded action that revalidated settles mid-navigation', async () => {
+      const { browser, stamp } =
+        await navigateAndAssertLeafSticks('/revalidate')
+
+      // The refresh is deferred while the queue is busy; it must still be
+      // delivered once the queue is idle, without disturbing the navigation.
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('[data-testid="stamp"]').text()
+        ).not.toBe(stamp)
+      }, 10_000)
+      expect(await browser.url()).toContain('/mid/leaf')
+      expect(
+        await browser.hasElementByCssSelector('[data-testid="leaf"]')
+      ).toBe(true)
+    })
+  }
+)

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/actions.ts
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/actions.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+export async function fast() {
+  await sleep(60)
+  return true
+}
+
+export async function slow(ms: number) {
+  await sleep(ms)
+  return true
+}
+
+export async function slowReject(ms: number) {
+  await sleep(ms)
+  throw new Error('intentional test error')
+}
+
+export async function slowRevalidate(ms: number) {
+  await sleep(ms)
+  revalidatePath('/', 'layout')
+  return true
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/client.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/client.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { fast, slow, slowReject, slowRevalidate } from './actions'
+
+export function Start({ kind }: { kind?: 'reject' | 'revalidate' }) {
+  // The slow action is still in flight when a navigation discards it.
+  useEffect(() => {
+    fast().catch(() => {})
+    if (kind === 'reject') {
+      slowReject(1500).catch(() => {})
+    } else if (kind === 'revalidate') {
+      slowRevalidate(1500).catch(() => {})
+    } else {
+      slow(1500).catch(() => {})
+    }
+  }, [kind])
+  return (
+    <div data-testid="start">
+      <Link href="/mid" data-testid="to-mid">
+        mid
+      </Link>
+    </div>
+  )
+}
+
+export function Mid() {
+  // Delay the link so the next navigation happens while the slow action —
+  // which the queue starts once the navigation to /mid settles — is still in
+  // flight. Deliberately not a Server Action: that would queue behind the slow
+  // action and not appear until it already settled.
+  const [ready, setReady] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setReady(true), 200)
+    return () => clearTimeout(t)
+  }, [])
+  if (!ready) return <div data-testid="mid-loading">loading…</div>
+  return (
+    <div data-testid="mid">
+      <Link href="/mid/leaf" data-testid="to-leaf">
+        leaf
+      </Link>
+    </div>
+  )
+}
+
+export function Leaf() {
+  // These queue up behind the discarded action; when the bug is present, their
+  // responses are computed against /mid and revert the navigation.
+  useEffect(() => {
+    slow(50).catch(() => {})
+    slow(50).catch(() => {})
+  }, [])
+  return <div data-testid="leaf">leaf content</div>
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/layout.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/layout.tsx
@@ -1,0 +1,18 @@
+// Dynamic so the stamp changes whenever the router refreshes. Navigations
+// preserve the root layout, so a changed stamp means a refresh happened.
+export const dynamic = 'force-dynamic'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <div data-testid="stamp">{Date.now()}</div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/mid/leaf/loading.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/mid/leaf/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div data-testid="leaf-loading">loading…</div>
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/mid/leaf/page.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/mid/leaf/page.tsx
@@ -1,0 +1,10 @@
+import { slow } from '../../actions'
+import { Leaf } from '../../client'
+
+export const dynamic = 'force-dynamic'
+
+export default async function LeafPage() {
+  // Stream long enough for the discarded action to settle before the reveal.
+  await slow(1200)
+  return <Leaf />
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/mid/page.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/mid/page.tsx
@@ -1,0 +1,7 @@
+import { Mid } from '../client'
+
+export const dynamic = 'force-dynamic'
+
+export default function MidPage() {
+  return <Mid />
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/page.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/page.tsx
@@ -1,0 +1,5 @@
+import { Start } from './client'
+
+export default function Page() {
+  return <Start />
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/reject/page.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/reject/page.tsx
@@ -1,0 +1,5 @@
+import { Start } from '../client'
+
+export default function Page() {
+  return <Start kind="reject" />
+}

--- a/test/e2e/app-dir/actions-discarded-segment-drop/app/revalidate/page.tsx
+++ b/test/e2e/app-dir/actions-discarded-segment-drop/app/revalidate/page.tsx
@@ -1,0 +1,5 @@
+import { Start } from '../client'
+
+export default function Page() {
+  return <Start kind="revalidate" />
+}

--- a/test/e2e/app-dir/navigation/popstate-race-repro.test.ts
+++ b/test/e2e/app-dir/navigation/popstate-race-repro.test.ts
@@ -1,0 +1,68 @@
+/**
+ * TEMP DEBUG (do not merge): repro attempt for the CI-only failure of
+ * "browser back to a revalidated page > should load the page".
+ * CPU-throttles the browser so back() lands while the server action's router
+ * work is still in flight, forcing the discard path like on slow CI machines.
+ */
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('popstate-revalidate race repro', () => {
+  const { next } = nextTestSetup({ files: __dirname })
+
+  for (let i = 0; i < 5; i++) {
+    it(`immediate back() after submit, iteration ${i}`, async () => {
+      const browser = await next.browser('/popstate-revalidate', {
+        cpuThrottleRate: 10,
+      })
+      await browser.waitForElementByCss('h1', 30_000)
+      await browser.elementByCss("[href='/popstate-revalidate/foo']").click()
+      await browser.waitForElementByCss('#submit-button', 30_000)
+      await browser.elementById('submit-button').click()
+      await browser.back()
+
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('h1').text()).toBe('Home')
+        },
+        20_000,
+        undefined,
+        `iteration ${i}`
+      )
+    })
+
+    it(`back() after Form Submitted appears, iteration ${i}`, async () => {
+      const browser = await next.browser('/popstate-revalidate', {
+        cpuThrottleRate: 10,
+      })
+      await browser.waitForElementByCss('h1', 30_000)
+      await browser.elementByCss("[href='/popstate-revalidate/foo']").click()
+      await browser.waitForElementByCss('#submit-button', 30_000)
+      await browser.elementById('submit-button').click()
+      // Tight poll (no 500ms retry interval) so back() lands right after the
+      // action value resolves, while the router action is still pending.
+      await browser.eval(
+        `new Promise((resolve) => {
+          const check = () => {
+            if (document.body.textContent.includes('Form Submitted.')) {
+              resolve()
+            } else {
+              setTimeout(check, 5)
+            }
+          }
+          check()
+        })`
+      )
+      await browser.back()
+
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('h1').text()).toBe('Home')
+        },
+        20_000,
+        undefined,
+        `iteration ${i}`
+      )
+    })
+  }
+})


### PR DESCRIPTION
Debugging branch for the CI-only failure of `app dir - navigation > browser back to a revalidated page > should load the page` seen on #95381 ([failing job](https://github.com/vercel/next.js/actions/runs/28552750725/job/84654270421)).

This is #95381 plus:

- Temporary `console.log` tracing of the router action queue (dispatch/run/settle/reject/advance/flush, with per-action ids). The test harness echoes browser logs into CI output, so a CI repro will include the exact action interleaving.
- A temporary CPU-throttled test that forces `back()` to discard the in-flight revalidating server action, to give CI more samples of the discard path.

In the failing runs, the server log shows no requests at all after the action `POST` — the client router appears to freeze with no console errors. Locally the failure does not reproduce (including with forced discards under 10x CPU throttling), so this collects the interleaving from CI directly.

Do not merge.

<!-- NEXT_JS_LLM_PR -->