### PR TITLE
Better error message for invalid `generateStaticParams`

### DIFF
--- a/errors/generate-static-params-export.mdx
+++ b/errors/generate-static-params-export.mdx
@@ -9,7 +9,7 @@ Your application is configured with `output: 'export'` in `next.config.js`, whic
 This error occurs when a dynamic route:
 
 - does not export a `generateStaticParams` function, or
-- exports a `generateStaticParams` function that returned no params (for example, an empty array), leaving Next.js with no paths to prerender for the route.
+- exports a `generateStaticParams` function that returned an empty array `[]` with no params, leaving Next.js with no paths to prerender for the route.
 
 ## Possible Ways to Fix It
 
@@ -25,7 +25,7 @@ This error occurs when a dynamic route:
    }
    ```
 
-   Note that `generateStaticParams` must return an array of params objects.
+   Note that `generateStaticParams` must return an array of params objects, where each object provides a value for every dynamic segment of the route, e.g. `[{ slug: 'post-1' }, { slug: 'post-2' }]` for `app/blog/[slug]/page.tsx`. See the [`generateStaticParams` return value documentation](/docs/app/api-reference/functions/generate-static-params#returns) for the expected shape.
 
 2. If the paths cannot be known at build time, the route cannot be statically exported and you should disable static export.
 

--- a/errors/generate-static-params-export.mdx
+++ b/errors/generate-static-params-export.mdx
@@ -1,0 +1,36 @@
+---
+title: '`generateStaticParams` Export Error'
+---
+
+## Why This Error Occurred
+
+Your application is configured with `output: 'export'` in `next.config.js`, which generates a fully static site. Every [Dynamic Route](/docs/app/api-reference/file-conventions/dynamic-routes) (e.g. `app/blog/[slug]/page.tsx`) must therefore be rendered to static HTML at build time, and Next.js relies on [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) to know which paths to prerender.
+
+This error occurs when a dynamic route:
+
+- does not export a `generateStaticParams` function, or
+- exports a `generateStaticParams` function that returned no params (for example, an empty array), leaving Next.js with no paths to prerender for the route.
+
+## Possible Ways to Fix It
+
+1. Export a `generateStaticParams` function from the dynamic route and make sure it returns a non-empty array of params, one entry for each path that should be generated:
+
+   ```tsx filename="app/blog/[slug]/page.tsx"
+   export async function generateStaticParams() {
+     const posts = await fetch('https://.../posts').then((res) => res.json())
+
+     return posts.map((post) => ({
+       slug: post.slug,
+     }))
+   }
+   ```
+
+   Note that `generateStaticParams` must return an array of params objects.
+
+2. If the paths cannot be known at build time, the route cannot be statically exported and you should disable static export.
+
+## Useful Links
+
+- [`generateStaticParams` documentation](/docs/app/api-reference/functions/generate-static-params)
+- [Static Exports documentation](/docs/app/guides/static-exports)
+- [Dynamic Routes documentation](/docs/app/api-reference/file-conventions/dynamic-routes)

--- a/errors/generate-static-params-export.mdx
+++ b/errors/generate-static-params-export.mdx
@@ -8,7 +8,8 @@ Your application is configured with `output: 'export'` in `next.config.js`, whic
 
 This error occurs when a dynamic route:
 
-- does not export a `generateStaticParams` function, or
+- does not export a `generateStaticParams` function,
+- exports a `generateStaticParams` function whose returned params do not provide a value for every dynamic segment of the route (for example, returning `[{ id: 'foo' }]` for `app/blog/[slug]/page.tsx`, which never provides `slug`), or
 - exports a `generateStaticParams` function that returned an empty array `[]` with no params, leaving Next.js with no paths to prerender for the route.
 
 ## Possible Ways to Fix It

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1423,5 +1423,6 @@
   "1422": "MIN_PREFETCHABLE_STALE must not exceed MIN_SHELL_STALE.",
   "1423": "Invalid value returned from \"generateStaticParams\" in \"%s\". Expected an array of params objects, e.g. %s, received %s. See more info here: https://nextjs.org/docs/app/api-reference/functions/generate-static-params#returns",
   "1424": "Page \"%s\" has \"generateStaticParams()\" but it returned an empty array [] with no params, so it cannot be used with \"output: export\" config. \"generateStaticParams()\" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export",
-  "1425": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export"
+  "1425": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export",
+  "1426": "Page \"%s\" has \"generateStaticParams()\" but it did not provide the required params (%s), so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1420,5 +1420,8 @@
   "1419": "TypeScript CLI interrupted by %s",
   "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s",
   "1421": "The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed.",
-  "1422": "MIN_PREFETCHABLE_STALE must not exceed MIN_SHELL_STALE."
+  "1422": "MIN_PREFETCHABLE_STALE must not exceed MIN_SHELL_STALE.",
+  "1423": "Invalid value returned from \"generateStaticParams\" in \"%s\". Expected an array of params objects, e.g. %s, received %s. See more info here: https://nextjs.org/docs/app/api-reference/functions/generate-static-params#returns",
+  "1424": "Page \"%s\" has \"generateStaticParams()\" but it returned an empty array [] with no params, so it cannot be used with \"output: export\" config. \"generateStaticParams()\" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export",
+  "1425": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2430,17 +2430,23 @@ export default async function build(
 
                           const appConfig = workerResult.appConfig || {}
                           if (appConfig.revalidate !== 0) {
-                            const hasGenerateStaticParams =
-                              workerResult.prerenderedRoutes &&
+                            const hasPrerenderedRoutes =
+                              !!workerResult.prerenderedRoutes &&
                               workerResult.prerenderedRoutes.length > 0
 
                             if (
                               config.output === 'export' &&
                               isDynamic &&
-                              !hasGenerateStaticParams
+                              !hasPrerenderedRoutes
                             ) {
+                              if (!workerResult.hasGenerateStaticParams) {
+                                throw new Error(
+                                  `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
+                                )
+                              }
+
                               throw new Error(
-                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
+                                `Page "${page}" has "generateStaticParams()" but it returned no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
                               )
                             }
 
@@ -2463,7 +2469,7 @@ export default async function build(
                               ])
                               isStatic = true
                             } else if (
-                              !hasGenerateStaticParams &&
+                              !hasPrerenderedRoutes &&
                               (appConfig.dynamic === 'error' ||
                                 appConfig.dynamic === 'force-static')
                             ) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2446,7 +2446,7 @@ export default async function build(
                               }
 
                               throw new Error(
-                                `Page "${page}" has "generateStaticParams()" but it returned no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
+                                `Page "${page}" has "generateStaticParams()" but it returned an empty array [] with no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
                               )
                             }
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2445,6 +2445,18 @@ export default async function build(
                                 )
                               }
 
+                              // "generateStaticParams()" returned a non-empty
+                              // result, but some of the route's params were
+                              // not provided in every entry, so no paths could
+                              // be prerendered.
+                              if (workerResult.missingRouteParams?.length) {
+                                throw new Error(
+                                  `Page "${page}" has "generateStaticParams()" but it did not provide the required params (${workerResult.missingRouteParams.join(
+                                    ', '
+                                  )}), so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
+                                )
+                              }
+
                               throw new Error(
                                 `Page "${page}" has "generateStaticParams()" but it returned an empty array [] with no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
                               )

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -1321,6 +1321,43 @@ describe('generateRouteStaticParams', () => {
       ).rejects.toThrow('Tech not allowed')
     })
 
+    it('should throw when generateStaticParams returns a non-array value', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => ({ id: '1' }) as any),
+      ]
+      const store = createMockWorkStore()
+      await expect(
+        generateRouteStaticParams(
+          segments,
+          store,
+
+          false,
+          []
+        )
+      ).rejects.toThrow(
+        'Invalid value returned from "generateStaticParams" in "/test-page". Expected an array of params objects, received object.'
+      )
+    })
+
+    it('should throw when a child generateStaticParams returns a non-array value', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ category: 'tech' }]),
+        createMockSegment(async () => undefined as any),
+      ]
+      const store = createMockWorkStore()
+      await expect(
+        generateRouteStaticParams(
+          segments,
+          store,
+
+          false,
+          []
+        )
+      ).rejects.toThrow(
+        'Invalid value returned from "generateStaticParams" in "/test-page". Expected an array of params objects, received undefined.'
+      )
+    })
+
     it('should throw error when generateStaticParams returns empty array with isRoutePPREnabled=true', async () => {
       const segments: TestAppSegment[] = [
         createMockSegment(async () => [{ lang: 'en' }]),

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -927,7 +927,11 @@ describe('generateParamPrefixCombinations', () => {
 
 type TestAppSegment = Pick<
   AppSegment,
-  'config' | 'generateStaticParams' | 'createEmptyParamsError'
+  | 'config'
+  | 'generateStaticParams'
+  | 'createEmptyParamsError'
+  | 'paramName'
+  | 'paramType'
 >
 
 // Mirrors the factory the SWC transform injects for pages exporting
@@ -949,11 +953,14 @@ const createMockWorkStore = (fetchCache?: WorkStore['fetchCache']) => ({
 const createMockSegment = (
   generateStaticParams?: (options: { params?: Params }) => Promise<Params[]>,
   config?: TestAppSegment['config'],
-  emptyParamsError?: TestAppSegment['createEmptyParamsError']
+  emptyParamsError?: TestAppSegment['createEmptyParamsError'],
+  param?: Pick<TestAppSegment, 'paramName' | 'paramType'>
 ): TestAppSegment => ({
   config,
   generateStaticParams,
   createEmptyParamsError: emptyParamsError,
+  paramName: param?.paramName,
+  paramType: param?.paramType,
 })
 
 describe('generateRouteStaticParams', () => {
@@ -1323,7 +1330,12 @@ describe('generateRouteStaticParams', () => {
 
     it('should throw when generateStaticParams returns a non-array value', async () => {
       const segments: TestAppSegment[] = [
-        createMockSegment(async () => ({ id: '1' }) as any),
+        createMockSegment(
+          async () => ({ id: '1' }) as any,
+          undefined,
+          undefined,
+          { paramName: 'id', paramType: 'dynamic' }
+        ),
       ]
       const store = createMockWorkStore()
       await expect(
@@ -1335,7 +1347,7 @@ describe('generateRouteStaticParams', () => {
           []
         )
       ).rejects.toThrow(
-        'Invalid value returned from "generateStaticParams" in "/test-page". Expected an array of params objects, received object.'
+        'Invalid value returned from "generateStaticParams" in "/test-page". Expected an array of params objects, e.g. [{ id: \'...\' }], received object.'
       )
     })
 
@@ -1354,7 +1366,30 @@ describe('generateRouteStaticParams', () => {
           []
         )
       ).rejects.toThrow(
-        'Invalid value returned from "generateStaticParams" in "/test-page". Expected an array of params objects, received undefined.'
+        // Without a param name on the segment, the example falls back to a
+        // generic "slug" param.
+        'Invalid value returned from "generateStaticParams" in "/test-page". Expected an array of params objects, e.g. [{ slug: \'...\' }], received undefined.'
+      )
+    })
+
+    it('should use an array example when a catch-all generateStaticParams returns a non-array value', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => 'invalid' as any, undefined, undefined, {
+          paramName: 'slug',
+          paramType: 'catchall',
+        }),
+      ]
+      const store = createMockWorkStore()
+      await expect(
+        generateRouteStaticParams(
+          segments,
+          store,
+
+          false,
+          []
+        )
+      ).rejects.toThrow(
+        'Invalid value returned from "generateStaticParams" in "/test-page". Expected an array of params objects, e.g. [{ slug: [\'...\'] }], received string.'
       )
     })
 

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -603,6 +603,7 @@ export function assignStaticShellMetadata(
  * making root param getters available during static param generation.
  */
 async function callGenerateStaticParams(
+  page: string,
   generateStaticParams: NonNullable<AppSegment['generateStaticParams']>,
   parentParams: Params,
   rootParamKeys: readonly string[],
@@ -622,9 +623,21 @@ async function callGenerateStaticParams(
     rootParams,
   }
 
-  return workUnitAsyncStorage.run(workUnitStore, generateStaticParams, {
-    params: parentParams,
-  })
+  const result = await workUnitAsyncStorage.run(
+    workUnitStore,
+    generateStaticParams,
+    { params: parentParams }
+  )
+
+  if (!Array.isArray(result)) {
+    throw new Error(
+      `Invalid value returned from "generateStaticParams" in "${page}". Expected an array of params objects, received ${
+        result === null ? 'null' : typeof result
+      }.`
+    )
+  }
+
+  return result
 }
 
 /**
@@ -695,6 +708,7 @@ export async function generateRouteStaticParams(
       // Process each parent parameter combination
       for (const parentParams of params) {
         const result = await callGenerateStaticParams(
+          store.page,
           current.generateStaticParams,
           parentParams,
           rootParamKeys,
@@ -716,6 +730,7 @@ export async function generateRouteStaticParams(
     } else {
       // No parent params, call generateStaticParams with empty object
       const result = await callGenerateStaticParams(
+        store.page,
         current.generateStaticParams,
         {},
         rootParamKeys,

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -599,11 +599,40 @@ export function assignStaticShellMetadata(
 }
 
 /**
+ * Builds an example params entry for the invalid-return-value error message,
+ * using the segment's own param name and type when available so the example
+ * matches the user's actual route.
+ */
+function formatExampleParams(
+  segment: Readonly<Pick<AppSegment, 'paramName' | 'paramType'>>
+): string {
+  const paramName = segment.paramName ?? 'slug'
+
+  let paramValue: string
+  switch (segment.paramType) {
+    // Catch-all params (including intercepted variants) are arrays of strings.
+    case 'catchall':
+    case 'optional-catchall':
+    case 'catchall-intercepted-(..)(..)':
+    case 'catchall-intercepted-(.)':
+    case 'catchall-intercepted-(..)':
+    case 'catchall-intercepted-(...)':
+      paramValue = "['...']"
+      break
+    default:
+      paramValue = "'...'"
+  }
+
+  return `[{ ${paramName}: ${paramValue} }]`
+}
+
+/**
  * Calls a single generateStaticParams function within a WorkUnitStore context,
  * making root param getters available during static param generation.
  */
 async function callGenerateStaticParams(
   page: string,
+  segment: Readonly<Pick<AppSegment, 'paramName' | 'paramType'>>,
   generateStaticParams: NonNullable<AppSegment['generateStaticParams']>,
   parentParams: Params,
   rootParamKeys: readonly string[],
@@ -631,9 +660,11 @@ async function callGenerateStaticParams(
 
   if (!Array.isArray(result)) {
     throw new Error(
-      `Invalid value returned from "generateStaticParams" in "${page}". Expected an array of params objects, received ${
+      `Invalid value returned from "generateStaticParams" in "${page}". Expected an array of params objects, e.g. ${formatExampleParams(
+        segment
+      )}, received ${
         result === null ? 'null' : typeof result
-      }.`
+      }. See more info here: https://nextjs.org/docs/app/api-reference/functions/generate-static-params#returns`
     )
   }
 
@@ -657,7 +688,11 @@ export async function generateRouteStaticParams(
     Readonly<
       Pick<
         AppSegment,
-        'config' | 'generateStaticParams' | 'createEmptyParamsError'
+        | 'config'
+        | 'generateStaticParams'
+        | 'createEmptyParamsError'
+        | 'paramName'
+        | 'paramType'
       >
     >
   >,
@@ -709,6 +744,7 @@ export async function generateRouteStaticParams(
       for (const parentParams of params) {
         const result = await callGenerateStaticParams(
           store.page,
+          current,
           current.generateStaticParams,
           parentParams,
           rootParamKeys,
@@ -731,6 +767,7 @@ export async function generateRouteStaticParams(
       // No parent params, call generateStaticParams with empty object
       const result = await callGenerateStaticParams(
         store.page,
+        current,
         current.generateStaticParams,
         {},
         rootParamKeys,

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -608,19 +608,23 @@ function formatExampleParams(
 ): string {
   const paramName = segment.paramName ?? 'slug'
 
+  // Catch-all params (including intercepted variants) are arrays of strings.
+  //
+  // A switch with a default case would read better here, but
+  // @typescript-eslint/switch-exhaustiveness-check would not be
+  // happy, so we use if/else instead.
   let paramValue: string
-  switch (segment.paramType) {
-    // Catch-all params (including intercepted variants) are arrays of strings.
-    case 'catchall':
-    case 'optional-catchall':
-    case 'catchall-intercepted-(..)(..)':
-    case 'catchall-intercepted-(.)':
-    case 'catchall-intercepted-(..)':
-    case 'catchall-intercepted-(...)':
-      paramValue = "['...']"
-      break
-    default:
-      paramValue = "'...'"
+  if (
+    segment.paramType === 'catchall' ||
+    segment.paramType === 'optional-catchall' ||
+    segment.paramType === 'catchall-intercepted-(..)(..)' ||
+    segment.paramType === 'catchall-intercepted-(.)' ||
+    segment.paramType === 'catchall-intercepted-(..)' ||
+    segment.paramType === 'catchall-intercepted-(...)'
+  ) {
+    paramValue = "['...']"
+  } else {
+    paramValue = "'...'"
   }
 
   return `[{ ${paramName}: ${paramValue} }]`

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -954,6 +954,19 @@ export async function buildAppStaticPaths({
     })
   )
 
+  // The pathname params that weren't provided in every generated entry. When
+  // any of these exist, no routes can be prerendered even though
+  // `generateStaticParams` returned a non-empty result, so they're reported
+  // to make error messages accurate (e.g. with `output: export`).
+  const missingRouteParams =
+    routeParams.length > 0
+      ? pathnameRouteParamSegments
+          .filter(({ paramName }) =>
+            routeParams.some((params) => !(paramName in params))
+          )
+          .map(({ paramName }) => paramName)
+      : []
+
   await afterRunner.executeAfter()
 
   let lastDynamicSegmentHadGenerateStaticParams = false
@@ -1176,5 +1189,5 @@ export async function buildAppStaticPaths({
     assignStaticShellMetadata(prerenderedRoutes, prerenderablePathSegments)
   }
 
-  return { fallbackMode, prerenderedRoutes }
+  return { fallbackMode, prerenderedRoutes, missingRouteParams }
 }

--- a/packages/next/src/build/static-paths/types.ts
+++ b/packages/next/src/build/static-paths/types.ts
@@ -57,4 +57,10 @@ export type PrerenderedRoute = StaticPrerenderedRoute | FallbackPrerenderedRoute
 export type StaticPathsResult = {
   fallbackMode: FallbackMode | undefined
   prerenderedRoutes: PrerenderedRoute[] | undefined
+  /**
+   * The pathname params that `generateStaticParams` did not provide values
+   * for in every returned entry. Only populated for app routes when
+   * `generateStaticParams` returned a non-empty result.
+   */
+  missingRouteParams?: readonly string[]
 }

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -673,6 +673,11 @@ type PageIsStaticResult = {
   isStatic?: boolean
   hasServerProps?: boolean
   hasStaticProps?: boolean
+  /**
+   * Whether any of the app route's segments export a `generateStaticParams`
+   * function. Only relevant for app pages/routes; always `false` for pages.
+   */
+  hasGenerateStaticParams: boolean
   prerenderedRoutes: PrerenderedRoute[] | undefined
   prerenderFallbackMode: FallbackMode | undefined
   rootParamKeys: readonly string[] | undefined
@@ -749,6 +754,7 @@ export async function isPageStatic({
       rootParamKeys: undefined,
       hasStaticProps: false,
       hasServerProps: false,
+      hasGenerateStaticParams: false,
       isNextImageImported: false,
       appConfig: {},
     }
@@ -829,6 +835,7 @@ export async function isPageStatic({
       const Comp = Component as NextComponentType | undefined
 
       let isRoutePPREnabled: boolean = false
+      let hasGenerateStaticParams = false
 
       if (pageType === 'app') {
         // @ts-expect-error pageType is app, so we can assume AppPageModule | AppRouteModule
@@ -852,6 +859,10 @@ export async function isPageStatic({
           originalAppPath === UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY
             ? {}
             : reduceAppConfig(segments)
+
+        hasGenerateStaticParams = segments.some(
+          (segment) => typeof segment.generateStaticParams === 'function'
+        )
 
         if (appConfig.dynamic === 'force-static' && pathIsEdgeRuntime) {
           Log.warn(
@@ -991,6 +1002,7 @@ export async function isPageStatic({
         rootParamKeys,
         hasStaticProps,
         hasServerProps,
+        hasGenerateStaticParams,
         isNextImageImported,
         appConfig,
       }

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -678,6 +678,11 @@ type PageIsStaticResult = {
    * function. Only relevant for app pages/routes; always `false` for pages.
    */
   hasGenerateStaticParams: boolean
+  /**
+   * The pathname params that `generateStaticParams` returned entries for but
+   * did not provide values for in every entry. Only populated for app routes.
+   */
+  missingRouteParams?: readonly string[]
   prerenderedRoutes: PrerenderedRoute[] | undefined
   prerenderFallbackMode: FallbackMode | undefined
   rootParamKeys: readonly string[] | undefined
@@ -778,6 +783,7 @@ export async function isPageStatic({
 
       let componentsResult: LoadComponentsReturnType
       let prerenderedRoutes: PrerenderedRoute[] | undefined
+      let missingRouteParams: readonly string[] | undefined
       let prerenderFallbackMode: FallbackMode | undefined
       let appConfig: AppSegmentConfig = {}
       let rootParamKeys: readonly string[] | undefined
@@ -904,29 +910,32 @@ export async function isPageStatic({
             ;({ prerenderedRoutes, fallbackMode: prerenderFallbackMode } =
               buildStaticMetadataStaticPaths(page))
           } else {
-            ;({ prerenderedRoutes, fallbackMode: prerenderFallbackMode } =
-              await buildAppStaticPaths({
-                dir,
-                page,
-                route,
-                cacheComponents,
-                authInterrupts,
-                useCacheTimeout,
-                staticPageGenerationTimeout,
-                segments,
-                distDir,
-                requestHeaders: {},
-                isrFlushToDisk,
-                cacheMaxMemorySize,
-                cacheHandler,
-                cacheLifeProfiles,
-                ComponentMod,
-                nextConfigOutput,
-                isRoutePPREnabled,
-                buildId,
-                deploymentId,
-                rootParamKeys,
-              }))
+            ;({
+              prerenderedRoutes,
+              missingRouteParams,
+              fallbackMode: prerenderFallbackMode,
+            } = await buildAppStaticPaths({
+              dir,
+              page,
+              route,
+              cacheComponents,
+              authInterrupts,
+              useCacheTimeout,
+              staticPageGenerationTimeout,
+              segments,
+              distDir,
+              requestHeaders: {},
+              isrFlushToDisk,
+              cacheMaxMemorySize,
+              cacheHandler,
+              cacheLifeProfiles,
+              ComponentMod,
+              nextConfigOutput,
+              isRoutePPREnabled,
+              buildId,
+              deploymentId,
+              rootParamKeys,
+            }))
           }
         }
       } else {
@@ -1003,6 +1012,7 @@ export async function isPageStatic({
         hasStaticProps,
         hasServerProps,
         hasGenerateStaticParams,
+        missingRouteParams,
         isNextImageImported,
         appConfig,
       }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -853,7 +853,7 @@ export default class DevServer extends Server {
           if (this.nextConfig.output === 'export') {
             if (!prerenderedRoutes) {
               throw new Error(
-                `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config.`
+                `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
               )
             }
 
@@ -861,7 +861,7 @@ export default class DevServer extends Server {
               !prerenderedRoutes.some((item) => item.pathname === urlPathname)
             ) {
               throw new Error(
-                `Page "${page}" is missing param "${pathname}" in "generateStaticParams()", which is required with "output: export" config.`
+                `Page "${page}" is missing param "${urlPathname}" in "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
               )
             }
           }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -852,8 +852,10 @@ export default class DevServer extends Server {
         if (isAppPath) {
           if (this.nextConfig.output === 'export') {
             if (!prerenderedRoutes) {
+              // Keep this message identical to the equivalent build-time error
+              // in build/index.ts so both share a single error code.
               throw new Error(
-                `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
+                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
               )
             }
 
@@ -861,7 +863,7 @@ export default class DevServer extends Server {
               !prerenderedRoutes.some((item) => item.pathname === urlPathname)
             ) {
               throw new Error(
-                `Page "${page}" is missing param "${urlPathname}" in "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export`
+                `Page "${page}" is missing param "${urlPathname}" in "generateStaticParams()", which is required with "output: export" config.`
               )
             }
           }

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -115,6 +115,7 @@
       "test/e2e/app-dir/app-compilation/index.test.ts",
       "test/e2e/app-dir/app-css/index.test.ts",
       "test/e2e/app-dir/app-custom-cache-handler/index.test.ts",
+      "test/e2e/app-dir/app-dir-export-invalid-gsp/app-dir-export-invalid-gsp.test.ts",
       "test/e2e/app-dir/app-edge-root-layout/index.test.ts",
       "test/e2e/app-dir/app-edge/app-edge.test.ts",
       "test/e2e/app-dir/app-esm-js/index.test.ts",

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -7,7 +7,7 @@ describe('app dir - with output export - dynamic missing gsp', () => {
       dynamicPage: 'undefined',
       generateStaticParamsOpt: 'set noop',
       expectedErrMsg: isNextDev
-        ? 'Page "/another/[slug]/page" is missing exported function "generateStaticParams()", which is required with "output: export" config.'
+        ? 'Page "/another/[slug]/page" is missing "generateStaticParams()" so it cannot be used with "output: export" config.'
         : 'Page "/another/[slug]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.',
     })
   })

--- a/test/e2e/app-dir/app-dir-export-invalid-gsp/app-dir-export-invalid-gsp.test.ts
+++ b/test/e2e/app-dir/app-dir-export-invalid-gsp/app-dir-export-invalid-gsp.test.ts
@@ -1,0 +1,75 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+// These tests don't need a browser: in production mode the error is emitted
+// by `next build`, and in dev mode it is logged to the terminal when the
+// dynamic route is requested. Each case runs against its own isolated
+// Next.js instance so the cases stay independent.
+function runTest({
+  gspReturnStatement,
+  expectedErrMsg,
+}: {
+  // Replaces the `return []` statement in the fixture's
+  // `generateStaticParams`. When omitted, the fixture is used as-is.
+  gspReturnStatement?: string
+  expectedErrMsg: { dev: string; build: string }
+}) {
+  const { next, skipped, isNextDev } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+  if (skipped) {
+    return
+  }
+
+  beforeAll(async () => {
+    if (gspReturnStatement) {
+      await next.patchFile('app/another/[slug]/page.tsx', (content) =>
+        content.replace('return []', gspReturnStatement)
+      )
+    }
+
+    if (isNextDev) {
+      await next.start()
+    }
+  })
+
+  it('should fail with an error describing the invalid return value', async () => {
+    if (isNextDev) {
+      await retry(async () => {
+        await next.fetch('/another/first')
+        expect(next.cliOutput).toContain(expectedErrMsg.dev)
+      })
+    } else {
+      const { exitCode, cliOutput } = await next.build()
+      expect(cliOutput).toContain(expectedErrMsg.build)
+      expect(exitCode).toBe(1)
+    }
+  })
+}
+
+describe('app-dir-export-invalid-gsp', () => {
+  describe('should error when generateStaticParams returns an empty array', () => {
+    runTest({
+      expectedErrMsg: {
+        dev: 'Page "/another/[slug]/page" is missing param "/another/first" in "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export',
+        build:
+          'Page "/another/[slug]" has "generateStaticParams()" but it returned no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export',
+      },
+    })
+  })
+
+  describe('should error when generateStaticParams returns a non-array value', () => {
+    const expectedErrMsg =
+      'Invalid value returned from "generateStaticParams" in "/another/[slug]". Expected an array of params objects, received object.'
+
+    runTest({
+      gspReturnStatement: [
+        `// @ts-expect-error -- deliberately return a non-array value: the type error is suppressed so the runtime validation being tested here is what fails the build`,
+        `  return { slug: 'first' }`,
+      ].join('\n'),
+      expectedErrMsg: { dev: expectedErrMsg, build: expectedErrMsg },
+    })
+  })
+})

--- a/test/e2e/app-dir/app-dir-export-invalid-gsp/app-dir-export-invalid-gsp.test.ts
+++ b/test/e2e/app-dir/app-dir-export-invalid-gsp/app-dir-export-invalid-gsp.test.ts
@@ -53,16 +53,16 @@ describe('app-dir-export-invalid-gsp', () => {
   describe('should error when generateStaticParams returns an empty array', () => {
     runTest({
       expectedErrMsg: {
-        dev: 'Page "/another/[slug]/page" is missing param "/another/first" in "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export',
+        dev: 'Page "/another/[slug]/page" is missing param "/another/first" in "generateStaticParams()", which is required with "output: export" config.',
         build:
-          'Page "/another/[slug]" has "generateStaticParams()" but it returned no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export',
+          'Page "/another/[slug]" has "generateStaticParams()" but it returned an empty array [] with no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export',
       },
     })
   })
 
   describe('should error when generateStaticParams returns a non-array value', () => {
     const expectedErrMsg =
-      'Invalid value returned from "generateStaticParams" in "/another/[slug]". Expected an array of params objects, received object.'
+      'Invalid value returned from "generateStaticParams" in "/another/[slug]". Expected an array of params objects, e.g. [{ slug: \'...\' }], received object. See more info here: https://nextjs.org/docs/app/api-reference/functions/generate-static-params#returns'
 
     runTest({
       gspReturnStatement: [

--- a/test/e2e/app-dir/app-dir-export-invalid-gsp/app-dir-export-invalid-gsp.test.ts
+++ b/test/e2e/app-dir/app-dir-export-invalid-gsp/app-dir-export-invalid-gsp.test.ts
@@ -8,11 +8,15 @@ import { retry } from 'next-test-utils'
 function runTest({
   gspReturnStatement,
   expectedErrMsg,
+  notExpectedErrMsg,
 }: {
   // Replaces the `return []` statement in the fixture's
   // `generateStaticParams`. When omitted, the fixture is used as-is.
   gspReturnStatement?: string
   expectedErrMsg: { dev: string; build: string }
+  // Asserted to be absent from the build output, to guard against a
+  // misleading error being reported for the scenario.
+  notExpectedErrMsg?: string
 }) {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
@@ -44,6 +48,9 @@ function runTest({
     } else {
       const { exitCode, cliOutput } = await next.build()
       expect(cliOutput).toContain(expectedErrMsg.build)
+      if (notExpectedErrMsg) {
+        expect(cliOutput).not.toContain(notExpectedErrMsg)
+      }
       expect(exitCode).toBe(1)
     }
   })
@@ -57,6 +64,23 @@ describe('app-dir-export-invalid-gsp', () => {
         build:
           'Page "/another/[slug]" has "generateStaticParams()" but it returned an empty array [] with no params, so it cannot be used with "output: export" config. "generateStaticParams()" must return a non-empty array of params. See more info here: https://nextjs.org/docs/messages/generate-static-params-export',
       },
+    })
+  })
+
+  describe('should error when generateStaticParams returns params that are missing the required params', () => {
+    runTest({
+      gspReturnStatement: [
+        `// @ts-expect-error -- deliberately return a wrong param name: the type error is suppressed so the runtime behavior being tested here is what fails the build`,
+        `  return [{ id: 'foo' }]`,
+      ].join('\n'),
+      expectedErrMsg: {
+        dev: 'Page "/another/[slug]/page" is missing param "/another/first" in "generateStaticParams()", which is required with "output: export" config.',
+        build:
+          'Page "/another/[slug]" has "generateStaticParams()" but it did not provide the required params (slug), so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params-export',
+      },
+      // The params were not empty, so the empty-array error must not be
+      // reported for this scenario.
+      notExpectedErrMsg: 'returned an empty array',
     })
   })
 

--- a/test/e2e/app-dir/app-dir-export-invalid-gsp/app/another/[slug]/page.tsx
+++ b/test/e2e/app-dir/app-dir-export-invalid-gsp/app/another/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams(): Array<{ slug: string }> {
+  return []
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>{slug}</p>
+}

--- a/test/e2e/app-dir/app-dir-export-invalid-gsp/app/layout.tsx
+++ b/test/e2e/app-dir/app-dir-export-invalid-gsp/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-dir-export-invalid-gsp/next.config.js
+++ b/test/e2e/app-dir/app-dir-export-invalid-gsp/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
The PR fixes https://github.com/vercel/next.js/discussions/56731

Currently, invalid `generateStaticParams` is being treated as missing `generateStaticParams`, resulting in a misleading error message and bad DX.

The PR introduced better error messages for invalid `generateStaticParams`.

e2e tests added, documentation added and referenced.
