### PR TITLE
Don't drop a pending history push when a later router state supersedes it

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -780,7 +780,16 @@ export function completeSoftNavigation(
     canonicalUrl,
     renderedSearch,
     pushRef: {
-      pendingPush: navigateType === 'push',
+      // Carry forward an unconsumed push from the previous state. The history
+      // push for a navigation only happens when React commits the state that
+      // requested it; if this update supersedes that state before it ever
+      // commits (e.g. a refresh or HMR refresh settling right behind a
+      // navigation), dropping the flag here would turn the navigation's push
+      // into a replace, destroying the previous page's history entry (so the
+      // back button breaks). HistoryUpdater consumes the flag by mutating the
+      // committed pushRef, and its same-URL check turns an already-performed
+      // push into a replace, so carrying the flag forward can't double-push.
+      pendingPush: navigateType === 'push' || oldState.pushRef.pendingPush,
       mpaNavigation: false,
       preserveCustomHistoryState: false,
     },

--- a/test/e2e/app-dir/navigation/app/push-and-refresh/page.tsx
+++ b/test/e2e/app-dir/navigation/app/push-and-refresh/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <div>
+      <h1>Home</h1>
+      <button
+        id="push-and-refresh"
+        onClick={() => {
+          // Refresh in the same tick so the refresh state can supersede the
+          // navigation's state before React commits it.
+          router.push('/push-and-refresh/target')
+          router.refresh()
+        }}
+      >
+        Push and refresh
+      </button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -948,6 +948,33 @@ describe('app dir - navigation', () => {
     })
   })
 
+  describe('browser back after a navigation followed by a refresh', () => {
+    it('should push a new history entry', async () => {
+      const browser = await next.browser('/push-and-refresh')
+      expect(await browser.elementByCss('h1').text()).toBe('Home')
+      const historyLength = await browser.eval('window.history.length')
+
+      await browser.elementById('push-and-refresh').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('Target')
+      })
+      // If the refresh state superseded the navigation before it committed,
+      // the push was dropped and the current entry was replaced instead.
+      await retry(async () => {
+        expect(await browser.eval('window.history.length')).toBe(
+          historyLength + 1
+        )
+      })
+
+      await browser.back()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('Home')
+      })
+    })
+  })
+
   describe('middleware redirect', () => {
     it('should change browser location when router.refresh() gets a redirect response', async () => {
       const browser = await next.browser('/redirect-on-refresh/auth')


### PR DESCRIPTION
will resubmit
