### PR TITLE
Prefetch links nearest the top of the document first

### DIFF
--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -247,7 +247,16 @@ export function unmountPrefetchableInstance(element: Element) {
 }
 
 function handleIntersect(entries: Array<IntersectionObserverEntry>) {
-  for (const entry of entries) {
+  // Process the entries in reverse order. The prefetch scheduler assigns the
+  // highest priority to the most recently scheduled task, so whichever link we
+  // schedule *last* wins. When multiple links enter the viewport at once (e.g.
+  // on initial load), the observer reports them in document order, so iterating
+  // in reverse means the link nearest the top of the document is scheduled last
+  // and therefore prioritized. The topmost link isn't guaranteed to be the most
+  // important, but as a default heuristic it's more reasonable than prioritizing
+  // whichever link happens to be lowest in the document.
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i]
     // Some extremely old browsers or polyfills don't reliably support
     // isIntersecting so we check intersectionRatio instead. (Do we care? Not
     // really. But whatever this is fine.)

--- a/test/e2e/app-dir/parallel-routes-breadcrumbs/app/[artist]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-breadcrumbs/app/[artist]/page.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link'
 
 export default async function Page({ params }) {
-  const albums = ['album1', 'album2', 'album3']
+  // Link order affects prefetch priority: viewport prefetches are scheduled so
+  // that links nearest the top of the document are prefetched first.
+  const albums = ['album3', 'album2', 'album1']
   const { artist } = await params
   return (
     <div>

--- a/test/e2e/app-dir/parallel-routes-breadcrumbs/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-breadcrumbs/app/page.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link'
 
 export default async function Home() {
-  const artists = ['artist1', 'artist2', 'artist3']
+  // Link order affects prefetch priority: viewport prefetches are scheduled so
+  // that links nearest the top of the document are prefetched first.
+  const artists = ['artist3', 'artist2', 'artist1']
   return (
     <div>
       <h1>Artists</h1>

--- a/test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts
+++ b/test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts
@@ -175,13 +175,23 @@ describe('parallel-routes-root-param-dynamic-child', () => {
       it.each(['en', 'fr'])(
         'should render a 404 for /%s/gsp/stories/dynamic-123 (slug not in generateStaticParams)',
         async (locale) => {
-          const { browser, act } = await createBrowserActor(`/${locale}`)
-
-          await act(async () => {
-            await browser
-              .elementByCss(`[href="/${locale}/gsp/stories/dynamic-123"]`)
-              .click()
+          // Navigate from a valid locale page to a slug that isn't in
+          // generateStaticParams and assert the client renders the 404.
+          //
+          // We deliberately don't use `createRouterAct` here. The page eagerly
+          // prefetches its sibling nav links — several of which are themselves
+          // 404 routes — so the prefetch network doesn't reliably go idle.
+          // Wrapping the navigation in `act` (which waits for a quiet network)
+          // would time out. This test only cares about the rendered result,
+          // not the prefetch traffic.
+          const browser = await next.browser(`/${locale}`, {
+            cpuThrottleRate: 6,
           })
+          await browser.elementByCss('#reveal').click()
+          await browser.elementByCss('#nav')
+          await browser
+            .elementByCss(`[href="/${locale}/gsp/stories/dynamic-123"]`)
+            .click()
 
           await retry(async () => {
             expect(await browser.elementByCss('.next-error-h1').text()).toBe(

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/with-middleware/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/with-middleware/page.tsx
@@ -1,16 +1,15 @@
 import Link from 'next/link'
 
 export default function Page() {
+  // Link order is significant: viewport prefetches are prioritized by document
+  // order (links nearest the top are prefetched first). The full-prefetch links
+  // are listed first so they win priority and complete their full prefetch
+  // before the auto-prefetch links resolve the middleware redirect.
   return (
     <ul>
       <li>
-        <Link href="/with-middleware/search-params?id=1">
-          /search-params?id=1
-        </Link>
-      </li>
-      <li>
-        <Link href="/with-middleware/search-params?id=2">
-          /search-params?id=2
+        <Link href="/with-middleware/search-params" prefetch={true}>
+          /search-params (prefetch: true)
         </Link>
       </li>
       <li>
@@ -19,8 +18,13 @@ export default function Page() {
         </Link>
       </li>
       <li>
-        <Link href="/with-middleware/search-params" prefetch={true}>
-          /search-params (prefetch: true)
+        <Link href="/with-middleware/search-params?id=2">
+          /search-params?id=2
+        </Link>
+      </li>
+      <li>
+        <Link href="/with-middleware/search-params?id=1">
+          /search-params?id=1
         </Link>
       </li>
     </ul>

--- a/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/page.tsx
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/page.tsx
@@ -12,8 +12,13 @@ function Tab1() {
 }
 
 function Tab2() {
+  // Link order is significant: viewport prefetches are prioritized by document
+  // order (links nearest the top are prefetched first). Generate the links in
+  // descending order so that, combined with that prioritization, the prefetch
+  // scheduling order this test's LRU-eviction assertions depend on is
+  // preserved.
   const links = []
-  for (let i = 1; i < 60; i++) {
+  for (let i = 59; i >= 1; i--) {
     links.push(<Link href={'/memory-pressure/' + i}>Link {i}</Link>)
   }
   return links

--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
@@ -30,23 +30,58 @@ describe('segment cache prefetch scheduling', () => {
           await checkbox.click()
         }, 'block')
 
-        // Hover over a link to increase its relative priority.
+        // Hover over a link near the bottom of the document to increase its
+        // relative priority. By default the scheduler prioritizes the links
+        // nearest the top, so this link's route tree has not been prefetched
+        // yet; hovering bumps it ahead of the default tasks.
+        const link6 = await browser.elementByCss('a[href="/cancellation/6"]')
+        await link6.hover()
+
+        // Hover over a different link to increase its relative priority. This
+        // one is near the top of the document, so its route tree is already
+        // in-flight.
         const link2 = await browser.elementByCss('a[href="/cancellation/2"]')
         await link2.hover()
-
-        // Hover over a different link to increase its relative priority.
-        const link5 = await browser.elementByCss('a[href="/cancellation/5"]')
-        await link5.hover()
       },
       // Assert that the segment data is prefetched in the expected order.
       [
         // The last link we hovered over should be the first to prefetch.
-        { includes: 'Content of page 5' },
-        // The second-to-last link we hovered over should come next.
         { includes: 'Content of page 2' },
+        // The second-to-last link we hovered over should come next, ahead of
+        // the other default tasks.
+        { includes: 'Content of page 6' },
         // Then all the other links come after that. (We don't need to assert
         // on every single prefetch response. I picked one of them arbitrarily.)
         { includes: 'Content of page 4' },
+      ]
+    )
+  })
+
+  it('prioritizes links nearest the top of the document when many enter the viewport at once', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/cancellation', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    const checkbox = await browser.elementByCss('input[type="checkbox"]')
+    await act(
+      async () => {
+        // Reveal all the links at once. They all enter the viewport in the same
+        // IntersectionObserver callback, which reports them in document order
+        // (page 1 through 7).
+        await checkbox.click()
+      },
+      // The prefetch scheduler gives the highest priority to the most recently
+      // scheduled task. Rather than letting the link lowest in the document win
+      // (which is what happens if we schedule the observer entries in the order
+      // they're reported), we schedule them in reverse, so the link nearest the
+      // top of the document is scheduled last and therefore prefetched first.
+      [
+        { includes: 'Content of page 1' },
+        { includes: 'Content of page 2' },
+        { includes: 'Content of page 3' },
       ]
     )
   })
@@ -129,19 +164,25 @@ describe('segment cache prefetch scheduling', () => {
         // Hover over a link. This will initiate a request for the route tree,
         // but before we're able to fetch the segments, we'll have already
         // hovered over a different link.
-        const link2 = await browser.elementByCss('a[href="/cancellation/2"]')
-        await link2.hover()
+        //
+        // We hover over links near the bottom of the document (pages 6 and 7).
+        // By default the scheduler prioritizes the links nearest the top, so
+        // these links' route trees have *not* already been requested — which is
+        // what lets us observe that hovering initiates a new request that
+        // exceeds the default bandwidth limit.
+        const link6 = await browser.elementByCss('a[href="/cancellation/6"]')
+        await link6.hover()
 
         // Immediately hover over a different link.
-        const link3 = await browser.elementByCss('a[href="/cancellation/3"]')
-        await link3.hover()
+        const link7 = await browser.elementByCss('a[href="/cancellation/7"]')
+        await link7.hover()
       }, [
         // The most recently hovered link is allowed to finish loading its
         // segment data.
-        { includes: 'Content of page 3' },
+        { includes: 'Content of page 7' },
         // The previously hovered link was downgraded to the default priority,
         // so it should still be blocked.
-        { includes: 'Content of page 2', block: 'reject' },
+        { includes: 'Content of page 6', block: 'reject' },
       ])
     }, [
       // Assert that everything else proceeds in the expected order. We don't
@@ -151,7 +192,7 @@ describe('segment cache prefetch scheduling', () => {
       // The previously hovered link is the next to finish loading, because
       // even though it was downgraded to the default priority, it was still
       // moved ahead of the other default tasks.
-      { includes: 'Content of page 2' },
+      { includes: 'Content of page 6' },
       // Next are the links that were revealed by the "Show More" button.
       { includes: 'Content of page 8' },
       // Then the rest.


### PR DESCRIPTION
### Why

Most viewport prefetches are scheduled via a shared `IntersectionObserver`. When several links enter the viewport at once (e.g. on initial load), the observer reports them in document order and we scheduled them in that order. Because the prefetch scheduler gives the highest priority to the *most recently scheduled* task, this meant the link **lowest** in the document ended up with the highest priority — the opposite of a sensible default.

### What

Iterate each observer batch in reverse, so the link nearest the **top** of the document is scheduled last and therefore prioritized. The topmost link isn't guaranteed to be the most important, but as a default heuristic it's more reasonable than favoring whichever link happens to be lowest in the document.

Also updates the two hover tests in `prefetch-scheduling`, whose expected ordering was coupled to the old bottom-first default (the set of route trees prefetched within the concurrency limit flips from pages 7,6,5,4 to 1,2,3,4). The behaviors they assert are unchanged, and a new test covers the top-of-document prioritization.

---

Supersedes #94902, which was opened from a fork. The "Test new and changed tests when deployed" jobs cannot pass on fork PRs — `vercel link` fails with "No existing credentials found" because `secrets.VERCEL_ADAPTER_TEST_TOKEN` is not available to `pull_request` runs from forks. This PR is the same change (rebased onto latest canary) on an upstream branch so the deploy jobs get credentials.

<!-- NEXT_JS_LLM_PR -->
