### PR TITLE
fix(next-devtools): use null-prototype object for segment explorer trie children

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.test.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.test.tsx
@@ -261,4 +261,54 @@ describe('Segment Explorer', () => {
       value: undefined,
     })
   })
+
+  // See https://github.com/vercel/next.js/issues/95395
+  // A route segment literally named "constructor" (or another
+  // Object.prototype member) used to resolve to the inherited prototype
+  // value instead of `undefined`, causing the trie to treat the node as
+  // already existing and then crash on the next segment lookup.
+  test('handles route segments that collide with Object.prototype members', () => {
+    insertSegmentNode(
+      createSegmentNode({ pagePath: '/constructor/page.js', type: 'page' })
+    )
+    insertSegmentNode(
+      createSegmentNode({ pagePath: '/__proto__/page.js', type: 'page' })
+    )
+    insertSegmentNode(
+      createSegmentNode({ pagePath: '/toString/page.js', type: 'page' })
+    )
+    insertSegmentNode(
+      createSegmentNode({ pagePath: '/hasOwnProperty/page.js', type: 'page' })
+    )
+
+    const { result } = renderHook(useSegmentTree)
+
+    const rootChildren = result.current.children[''].children
+    expect(Object.keys(rootChildren).sort()).toEqual([
+      '__proto__',
+      'constructor',
+      'hasOwnProperty',
+      'toString',
+    ])
+    expect(rootChildren['constructor'].children['page.js'].value).toEqual({
+      pagePath: '/constructor/page.js',
+      type: 'page',
+      boundaryType: null,
+      setBoundaryType: expect.anything(),
+    })
+    expect(rootChildren['__proto__'].children['page.js'].value).toEqual({
+      pagePath: '/__proto__/page.js',
+      type: 'page',
+      boundaryType: null,
+      setBoundaryType: expect.anything(),
+    })
+
+    // Removal must also work correctly for these segment names.
+    removeSegmentNode(
+      createSegmentNode({ pagePath: '/constructor/page.js', type: 'page' })
+    )
+    expect(
+      result.current.children[''].children['constructor']
+    ).toBeUndefined()
+  })
 })

--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
@@ -25,6 +25,18 @@ type TrieNode<Value = string> = {
   }
 }
 
+// Creates a children map with no prototype, so segment names that collide
+// with inherited Object.prototype members (e.g. "constructor", "__proto__",
+// "toString", "hasOwnProperty") are treated as plain missing keys instead of
+// resolving to those inherited values. See Next.js issue #95395: a route
+// segment literally named "constructor" would resolve `children['constructor']`
+// to the native Object constructor function (truthy, so treated as an
+// existing node) instead of undefined, and the next segment lookup would
+// then crash trying to read `.children` off that function.
+function createEmptyChildren<Value>(): TrieNode<Value>['children'] {
+  return Object.create(null)
+}
+
 type Trie<Value = string> = {
   insert: (value: Value) => void
   remove: (value: Value) => void
@@ -64,7 +76,7 @@ function createTrie<Value = string>({
 }): Trie<Value> {
   let root: TrieNode<Value> = {
     value: undefined,
-    children: {},
+    children: createEmptyChildren(),
   }
 
   function markUpdated() {
@@ -82,7 +94,7 @@ function createTrie<Value = string>({
         currentNode.children[segment] = {
           value: undefined,
           // Skip value for intermediate nodes
-          children: {},
+          children: createEmptyChildren(),
         }
       }
       currentNode = currentNode.children[segment]


### PR DESCRIPTION
### What?

Segment explorer trie used a plain object literal for its children map. Route segments that collide with inherited Object.prototype members, most notably `constructor`, resolved to the inherited value instead of undefined.

### Why?

`children[segment]` on a plain object returns `Object.prototype.constructor` when segment equals `constructor`, since every plain object inherits that property. The code treats this as a truthy existing node and walks into it. The next segment lookup then does `Object.children`, which is undefined, and throws. This matches the crash in the linked issue exactly.

### How?

Replaced `children: {}` with `children: Object.create(null)` everywhere a trie node is created. A null-prototype object has no inherited properties, so `constructor`, `__proto__`, `toString`, `hasOwnProperty` etc are treated as ordinary missing keys. All existing consumers use `Object.keys`, `Object.values`, or bracket indexing, all of which work identically on a null-prototype object, so no other files needed changes.

Added a test covering route segments named `constructor`, `__proto__`, `toString`, and `hasOwnProperty`, for both insert and remove.

Fixes NEXT- #95395