### PR TITLE
fix(middleware): exclude _writableState from replaceRequestBody() to fix Readable.toWeb() on POST routes

### DIFF
--- a/packages/next/src/server/body-streams.ts
+++ b/packages/next/src/server/body-streams.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'http'
 import type { Readable } from 'stream'
-import { PassThrough } from 'stream'
+import { PassThrough, Writable } from 'stream'
 import bytes from 'next/dist/compiled/bytes'
 
 const DEFAULT_BODY_CLONE_SIZE_LIMIT = 10 * 1024 * 1024 // 10MB
@@ -20,11 +20,27 @@ export function requestToBodyStream(
   })
 }
 
+// Keys that belong exclusively to the Writable/Duplex interface and must not
+// be copied onto an IncomingMessage (which is a pure Readable). In particular,
+// copying `_writableState` causes `Readable.toWeb()` to hang on POST routes
+// that pass through middleware: Node.js sees `_writableState.finished ===
+// false` on what it expects to be a plain Readable and waits for a writable
+// side that will never close.
+const WRITABLE_ONLY_KEYS = new Set<string>([
+  '_writableState',
+  ...Object.getOwnPropertyNames(Writable.prototype),
+])
+
 function replaceRequestBody<T extends IncomingMessage>(
   base: T,
   stream: Readable
 ): T {
   for (const key in stream) {
+    // Skip Writable-specific internals and prototype methods so that the
+    // resulting IncomingMessage stays a pure Readable and does not confuse
+    // APIs such as Readable.toWeb() that inspect _writableState.
+    if (WRITABLE_ONLY_KEYS.has(key)) continue
+
     let v = stream[key as keyof Readable] as any
     if (typeof v === 'function') {
       v = v.bind(base)


### PR DESCRIPTION
### What?

In `replaceRequestBody()` inside `body-streams.ts`, replace the bare `for...in` property copy with a filtered copy that excludes `_writableState` and `Writable.prototype` methods when merging a PassThrough back into an IncomingMessage.

### Why?

When middleware calls `NextResponse.next()` on a POST route, `cloneBodyStream()` creates a `PassThrough` (a Duplex stream) and `replaceRequestBody()` copies its properties onto the `IncomingMessage` (a pure Readable) using `for...in`. This also copies `_writableState` and 39+ Writable prototype methods.

`Readable.toWeb()` inspects `_writableState.finished` on the object and hangs indefinitely when it is `false` — it waits for a writable side that will never close. The timing is deterministic: `_writableState.finished` only becomes `true` via `process.nextTick()`, but `replaceRequestBody()` runs in a microtask (after `await endPromise`), so microtasks always execute before the nextTick callback, meaning `finished === false` is always copied.

GET requests and `NextResponse.rewrite()` are unaffected. Only POST (or PUT/PATCH) through `NextResponse.next()` is affected.

### How?

Build a module-level `WRITABLE_ONLY_KEYS` set from `_writableState` plus `Object.getOwnPropertyNames(Writable.prototype)` and `continue` on those keys inside the `for...in` loop. This keeps all Readable-compatible properties (`_readableState`, event emitter methods, readable methods) while preventing Writable internals from leaking onto the IncomingMessage.

Fixes #95335