### PR TITLE
Turbopack: support turbopackChunkName/webpackChunkName magic comments

### DIFF
--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -532,7 +532,7 @@ pub async fn analyze_module_graphs(module_graph: Vc<ModuleGraph>) -> Result<Vc<F
             };
 
             match reference.chunking_type {
-                ChunkingType::Async => {
+                ChunkingType::Async { .. } => {
                     all_async_edges.insert((parent_node, node));
                 }
                 _ => {

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -367,6 +367,7 @@ pub async fn get_client_module_options_context(
             enable_import_as_text: *next_config.turbopack_import_type_text().await?,
             source_maps,
             infer_module_side_effects: *next_config.turbopack_infer_module_side_effects().await?,
+            enable_chunk_names: *next_config.turbopack_chunk_names().await?,
             preset_env_config,
             ..Default::default()
         },

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1383,6 +1383,9 @@ pub struct ExperimentalConfig {
     turbopack_worker_asset_prefix: Option<RcStr>,
     turbopack_client_side_nested_async_chunking: Option<bool>,
     turbopack_server_side_nested_async_chunking: Option<bool>,
+    /// Apply `turbopackChunkName`/`webpackChunkName` magic comments on dynamic imports,
+    /// including the specified name in the emitted chunk file names. Defaults to false.
+    turbopack_chunk_names: Option<bool>,
     turbopack_import_type_bytes: Option<bool>,
     turbopack_import_type_text: Option<bool>,
     /// Disable automatic configuration of the sass loader.
@@ -2538,6 +2541,11 @@ impl NextConfig {
                 .turbopack_import_type_bytes
                 .unwrap_or(false),
         )
+    }
+
+    #[turbo_tasks::function]
+    pub async fn turbopack_chunk_names(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.turbopack_chunk_names.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -579,6 +579,7 @@ pub async fn get_server_module_options_context(
             ignore_dynamic_requests: true,
             source_maps,
             infer_module_side_effects: *next_config.turbopack_infer_module_side_effects().await?,
+            enable_chunk_names: *next_config.turbopack_chunk_names().await?,
             ..Default::default()
         },
         execution_context: Some(execution_context),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -396,6 +396,7 @@ export const experimentalSchema = {
   turbopackWorkerAssetPrefix: z.string().optional(),
   turbopackClientSideNestedAsyncChunking: z.boolean().optional(),
   turbopackServerSideNestedAsyncChunking: z.boolean().optional(),
+  turbopackChunkNames: z.boolean().optional(),
   turbopackImportTypeBytes: z.boolean().optional(),
   turbopackImportTypeText: z.boolean().optional(),
   turbopackUseBuiltinBabel: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -826,6 +826,16 @@ export interface ExperimentalConfig {
   turbopackServerSideNestedAsyncChunking?: boolean
 
   /**
+   * Apply `turbopackChunkName` (or `webpackChunkName`) magic comments on dynamic imports,
+   * e.g. `import(/* turbopackChunkName: "my-chunk" *\/ './module')`. The specified name is
+   * included in the file names of the chunks emitted for the dynamic import, in addition to
+   * the usual content hash.
+   *
+   * Defaults to `false`.
+   */
+  turbopackChunkNames?: boolean
+
+  /**
    * Enable filesystem cache for the turbopack dev server.
    *
    * Defaults to `true`.

--- a/test/e2e/app-dir/turbopack-chunk-names-disabled/app/layout.tsx
+++ b/test/e2e/app-dir/turbopack-chunk-names-disabled/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/turbopack-chunk-names-disabled/app/page.tsx
+++ b/test/e2e/app-dir/turbopack-chunk-names-disabled/app/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function Page() {
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    import(/* turbopackChunkName: "my-widget" */ './widget').then((mod) =>
+      setMessage(mod.default)
+    )
+  }, [])
+
+  return (
+    <main>
+      <p>hello world</p>
+      <p id="widget">{message}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/turbopack-chunk-names-disabled/app/widget.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names-disabled/app/widget.ts
@@ -1,0 +1,1 @@
+export default 'my widget loaded'

--- a/test/e2e/app-dir/turbopack-chunk-names-disabled/next.config.js
+++ b/test/e2e/app-dir/turbopack-chunk-names-disabled/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/turbopack-chunk-names-disabled/turbopack-chunk-names-disabled.test.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names-disabled/turbopack-chunk-names-disabled.test.ts
@@ -1,0 +1,39 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { listClientChunks, retry } from 'next-test-utils'
+
+describe('turbopack-chunk-names-disabled', () => {
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should load the dynamically imported module', async () => {
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await browser.elementByCss('#widget').text()).toBe(
+        'my widget loaded'
+      )
+    })
+  })
+
+  if (isTurbopack) {
+    it('should not apply the chunk name magic comment when the flag is not enabled', async () => {
+      if (isNextDev) {
+        const browser = await next.browser('/')
+        await retry(async () => {
+          expect(await browser.elementByCss('#widget').text()).toBe(
+            'my widget loaded'
+          )
+        })
+
+        const urls: string[] = await browser.eval(
+          `performance.getEntriesByType('resource').map((entry) => entry.name)`
+        )
+        expect(urls.some((url) => url.includes('my-widget'))).toBe(false)
+      } else {
+        const chunks = await listClientChunks(path.join(next.testDir, '.next'))
+        expect(chunks.some((chunk) => chunk.includes('my-widget'))).toBe(false)
+      }
+    })
+  }
+})

--- a/test/e2e/app-dir/turbopack-chunk-names/app/dynamic/dyn-widget.tsx
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/dynamic/dyn-widget.tsx
@@ -1,0 +1,3 @@
+export default function DynWidget() {
+  return <p id="dyn-widget">dyn widget loaded</p>
+}

--- a/test/e2e/app-dir/turbopack-chunk-names/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/dynamic/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const DynWidget = dynamic(
+  () => import(/* turbopackChunkName: "dyn-widget" */ './dyn-widget')
+)
+
+export default function Page() {
+  return (
+    <main>
+      <DynWidget />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/turbopack-chunk-names/app/layout.tsx
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/turbopack-chunk-names/app/legacy-widget.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/legacy-widget.ts
@@ -1,0 +1,1 @@
+export default 'legacy widget loaded'

--- a/test/e2e/app-dir/turbopack-chunk-names/app/page.tsx
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function Page() {
+  const [messages, setMessages] = useState<string[]>([])
+
+  useEffect(() => {
+    Promise.all([
+      import(/* turbopackChunkName: "my-widget" */ './widget'),
+      import(/* webpackChunkName: "legacy-widget" */ './legacy-widget'),
+      import(
+        /* turbopackChunkName: "wins" */
+        /* webpackChunkName: "loses" */
+        './precedence-widget'
+      ),
+      import(/* turbopackChunkName: "lazy-[request]" */ './request-widget'),
+      import(/* turbopackChunkName: "[request]" */ './pure-request-widget'),
+    ]).then((modules) => setMessages(modules.map((mod) => mod.default)))
+  }, [])
+
+  return (
+    <main>
+      <p>hello world</p>
+      <ul id="widgets">
+        {messages.map((message) => (
+          <li key={message}>{message}</li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/turbopack-chunk-names/app/precedence-widget.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/precedence-widget.ts
@@ -1,0 +1,1 @@
+export default 'precedence widget loaded'

--- a/test/e2e/app-dir/turbopack-chunk-names/app/pure-request-widget.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/pure-request-widget.ts
@@ -1,0 +1,1 @@
+export default 'pure request widget loaded'

--- a/test/e2e/app-dir/turbopack-chunk-names/app/request-widget.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/request-widget.ts
@@ -1,0 +1,1 @@
+export default 'request widget loaded'

--- a/test/e2e/app-dir/turbopack-chunk-names/app/widget.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names/app/widget.ts
@@ -1,0 +1,1 @@
+export default 'my widget loaded'

--- a/test/e2e/app-dir/turbopack-chunk-names/next.config.js
+++ b/test/e2e/app-dir/turbopack-chunk-names/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    turbopackChunkNames: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/turbopack-chunk-names/turbopack-chunk-names.test.ts
+++ b/test/e2e/app-dir/turbopack-chunk-names/turbopack-chunk-names.test.ts
@@ -1,0 +1,131 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { listClientChunks, retry } from 'next-test-utils'
+
+// The 13-character base38 content hash appended to production chunk names.
+const HASH = '[0-9a-z_-]{13}'
+// The test harness may enable immutable assets, which moves client chunks
+// from `static/chunks/` to `static/immutable/chunks/`.
+const CHUNK_DIR = 'static/(?:immutable/)?chunks'
+
+async function loadedResourceUrls(browser: any): Promise<string[]> {
+  return browser.eval(
+    `performance.getEntriesByType('resource').map((entry) => entry.name)`
+  )
+}
+
+describe('turbopack-chunk-names', () => {
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should load all dynamically imported modules', async () => {
+    const browser = await next.browser('/')
+    await retry(async () => {
+      const text = await browser.elementByCss('#widgets').text()
+      expect(text).toContain('my widget loaded')
+      expect(text).toContain('legacy widget loaded')
+      expect(text).toContain('precedence widget loaded')
+      expect(text).toContain('request widget loaded')
+      expect(text).toContain('pure request widget loaded')
+    })
+  })
+
+  it('should load a next/dynamic component', async () => {
+    const browser = await next.browser('/dynamic')
+    await retry(async () => {
+      expect(await browser.elementByCss('#dyn-widget').text()).toBe(
+        'dyn widget loaded'
+      )
+    })
+  })
+
+  if (isTurbopack) {
+    if (isNextDev) {
+      it('should include the chunk name in dev chunk URLs', async () => {
+        const browser = await next.browser('/')
+        await retry(async () => {
+          const text = await browser.elementByCss('#widgets').text()
+          expect(text).toContain('request widget loaded')
+        })
+
+        const urls = await loadedResourceUrls(browser)
+        expect(urls.some((url) => url.includes('/my-widget-'))).toBe(true)
+        expect(urls.some((url) => url.includes('/legacy-widget-'))).toBe(true)
+        // `turbopackChunkName` takes precedence over `webpackChunkName`
+        expect(urls.some((url) => url.includes('/wins-'))).toBe(true)
+        expect(urls.some((url) => url.includes('/loses-'))).toBe(false)
+        // `[request]` is substituted with the sanitized import request
+        expect(urls.some((url) => url.includes('/lazy-request-widget-'))).toBe(
+          true
+        )
+        // a bare `[request]` name derives the chunk name from the imported file
+        expect(urls.some((url) => url.includes('/pure-request-widget-'))).toBe(
+          true
+        )
+      })
+
+      it('should include the chunk name in dev chunk URLs for next/dynamic', async () => {
+        const browser = await next.browser('/dynamic')
+        await retry(async () => {
+          expect(await browser.elementByCss('#dyn-widget').text()).toBe(
+            'dyn widget loaded'
+          )
+        })
+
+        const urls = await loadedResourceUrls(browser)
+        expect(urls.some((url) => url.includes('/dyn-widget-'))).toBe(true)
+      })
+    } else {
+      it('should emit chunk files that carry the chunk name and retain the content hash', async () => {
+        const chunks = (
+          await listClientChunks(path.join(next.testDir, '.next'))
+        ).filter((chunk) => chunk.endsWith('.js'))
+
+        expect(chunks).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/my-widget-${HASH}\\.js$`)
+            ),
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/legacy-widget-${HASH}\\.js$`)
+            ),
+            // `turbopackChunkName` takes precedence over `webpackChunkName`
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/wins-${HASH}\\.js$`)
+            ),
+            // `[request]` is substituted with the sanitized import request
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/lazy-request-widget-${HASH}\\.js$`)
+            ),
+            // a bare `[request]` name derives the chunk name from the imported file
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/pure-request-widget-${HASH}\\.js$`)
+            ),
+            // next/dynamic loaders support the magic comment as well
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/dyn-widget-${HASH}\\.js$`)
+            ),
+          ])
+        )
+
+        // The losing `webpackChunkName` must not be used
+        expect(chunks.some((chunk) => chunk.includes('loses-'))).toBe(false)
+      })
+
+      it('should load the named chunk files in the browser', async () => {
+        const browser = await next.browser('/')
+        await retry(async () => {
+          const text = await browser.elementByCss('#widgets').text()
+          expect(text).toContain('my widget loaded')
+        })
+
+        const urls = await loadedResourceUrls(browser)
+        // Note: no `$` anchor, the chunk URL may carry a query string (e.g. `?dpl=...`).
+        expect(
+          urls.some((url) => new RegExp(`/my-widget-${HASH}\\.js`).test(url))
+        ).toBe(true)
+      })
+    }
+  }
+})

--- a/test/e2e/turbopack-chunk-names-pages/AGENTS.md
+++ b/test/e2e/turbopack-chunk-names-pages/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+
+**Keep this block, including in commits.** It is part of the project's agent setup, maintained by `next dev` for every agent that works here. If it appears as an uncommitted change, that is intentional — commit it as-is. Do not remove it to clean up a diff; it will be regenerated.
+
+<!-- END:nextjs-agent-rules -->

--- a/test/e2e/turbopack-chunk-names-pages/CLAUDE.md
+++ b/test/e2e/turbopack-chunk-names-pages/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test/e2e/turbopack-chunk-names-pages/lib/dyn-widget.tsx
+++ b/test/e2e/turbopack-chunk-names-pages/lib/dyn-widget.tsx
@@ -1,0 +1,3 @@
+export default function DynWidget() {
+  return <p id="dyn-widget">pages dyn widget loaded</p>
+}

--- a/test/e2e/turbopack-chunk-names-pages/lib/legacy-widget.ts
+++ b/test/e2e/turbopack-chunk-names-pages/lib/legacy-widget.ts
@@ -1,0 +1,1 @@
+export default 'pages legacy widget loaded'

--- a/test/e2e/turbopack-chunk-names-pages/lib/widget.ts
+++ b/test/e2e/turbopack-chunk-names-pages/lib/widget.ts
@@ -1,0 +1,1 @@
+export default 'pages widget loaded'

--- a/test/e2e/turbopack-chunk-names-pages/next.config.js
+++ b/test/e2e/turbopack-chunk-names-pages/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    turbopackChunkNames: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/turbopack-chunk-names-pages/pages/dynamic.tsx
+++ b/test/e2e/turbopack-chunk-names-pages/pages/dynamic.tsx
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic'
+
+const DynWidget = dynamic(
+  () => import(/* turbopackChunkName: "pages-dyn-widget" */ '../lib/dyn-widget')
+)
+
+export default function Page() {
+  return (
+    <main>
+      <DynWidget />
+    </main>
+  )
+}

--- a/test/e2e/turbopack-chunk-names-pages/pages/index.tsx
+++ b/test/e2e/turbopack-chunk-names-pages/pages/index.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+
+export default function Page() {
+  const [messages, setMessages] = useState<string[]>([])
+
+  useEffect(() => {
+    Promise.all([
+      import(/* turbopackChunkName: "pages-widget" */ '../lib/widget'),
+      import(
+        /* webpackChunkName: "pages-legacy-widget" */ '../lib/legacy-widget'
+      ),
+    ]).then((modules) => setMessages(modules.map((mod) => mod.default)))
+  }, [])
+
+  return (
+    <main>
+      <p>hello world</p>
+      <ul id="widgets">
+        {messages.map((message) => (
+          <li key={message}>{message}</li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/turbopack-chunk-names-pages/turbopack-chunk-names-pages.test.ts
+++ b/test/e2e/turbopack-chunk-names-pages/turbopack-chunk-names-pages.test.ts
@@ -1,0 +1,91 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { listClientChunks, retry } from 'next-test-utils'
+
+// The 13-character base38 content hash appended to production chunk names.
+const HASH = '[0-9a-z_-]{13}'
+// The test harness may enable immutable assets, which moves client chunks
+// from `static/chunks/` to `static/immutable/chunks/`.
+const CHUNK_DIR = 'static/(?:immutable/)?chunks'
+
+async function loadedResourceUrls(browser: any): Promise<string[]> {
+  return browser.eval(
+    `performance.getEntriesByType('resource').map((entry) => entry.name)`
+  )
+}
+
+describe('turbopack-chunk-names-pages', () => {
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should load all dynamically imported modules', async () => {
+    const browser = await next.browser('/')
+    await retry(async () => {
+      const text = await browser.elementByCss('#widgets').text()
+      expect(text).toContain('pages widget loaded')
+      expect(text).toContain('pages legacy widget loaded')
+    })
+  })
+
+  it('should load a next/dynamic component', async () => {
+    const browser = await next.browser('/dynamic')
+    await retry(async () => {
+      expect(await browser.elementByCss('#dyn-widget').text()).toBe(
+        'pages dyn widget loaded'
+      )
+    })
+  })
+
+  if (isTurbopack) {
+    if (isNextDev) {
+      it('should include the chunk name in dev chunk URLs', async () => {
+        const browser = await next.browser('/')
+        await retry(async () => {
+          const text = await browser.elementByCss('#widgets').text()
+          expect(text).toContain('pages widget loaded')
+        })
+
+        const urls = await loadedResourceUrls(browser)
+        expect(urls.some((url) => url.includes('/pages-widget-'))).toBe(true)
+        expect(urls.some((url) => url.includes('/pages-legacy-widget-'))).toBe(
+          true
+        )
+      })
+
+      it('should include the chunk name in dev chunk URLs for next/dynamic', async () => {
+        const browser = await next.browser('/dynamic')
+        await retry(async () => {
+          expect(await browser.elementByCss('#dyn-widget').text()).toBe(
+            'pages dyn widget loaded'
+          )
+        })
+
+        const urls = await loadedResourceUrls(browser)
+        expect(urls.some((url) => url.includes('/pages-dyn-widget-'))).toBe(
+          true
+        )
+      })
+    } else {
+      it('should emit chunk files that carry the chunk name and retain the content hash', async () => {
+        const chunks = (
+          await listClientChunks(path.join(next.testDir, '.next'))
+        ).filter((chunk) => chunk.endsWith('.js'))
+
+        expect(chunks).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/pages-widget-${HASH}\\.js$`)
+            ),
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/pages-legacy-widget-${HASH}\\.js$`)
+            ),
+            expect.stringMatching(
+              new RegExp(`^${CHUNK_DIR}/pages-dyn-widget-${HASH}\\.js$`)
+            ),
+          ])
+        )
+      })
+    }
+  }
+})

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -465,12 +465,13 @@ impl BrowserChunkingContext {
     async fn generate_chunk(
         self: Vc<Self>,
         chunk: ResolvedVc<Box<dyn Chunk>>,
+        chunk_name: Option<RcStr>,
     ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
         Ok(
             if let Some(ecmascript_chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk)
             {
                 ResolvedVc::upcast(
-                    EcmascriptBrowserChunk::new(self, *ecmascript_chunk)
+                    EcmascriptBrowserChunk::new(self, *ecmascript_chunk, chunk_name)
                         .to_resolved()
                         .await?,
                 )
@@ -790,6 +791,21 @@ impl ChunkingContext for BrowserChunkingContext {
         let span = tracing::info_span!("chunking", name = display(ident.to_string().await?));
         async move {
             let input_availability_info = availability_info;
+
+            // Async chunk groups can be given a user-specified name via a
+            // `turbopackChunkName`/`webpackChunkName` magic comment, which is included in the
+            // file names of the emitted chunks.
+            let chunk_name = if let ChunkGroup::Async(entry_module) = &chunk_group {
+                module_graph
+                    .chunk_group_info()
+                    .await?
+                    .async_chunk_group_names
+                    .get(entry_module)
+                    .cloned()
+            } else {
+                None
+            };
+
             let MakeChunkGroupResult {
                 chunks,
                 references,
@@ -806,7 +822,22 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let assets = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(*chunk))
+                .map(|chunk| {
+                    let chunk_name = chunk_name.clone();
+                    async move {
+                        // Only chunks that are exclusive to this chunk group may carry the
+                        // user-specified name; see `chunk_is_exclusive_to_single_chunk_group`.
+                        let chunk_name = match chunk_name {
+                            Some(name) => {
+                                chunk_is_exclusive_to_single_chunk_group(*chunk, *module_graph)
+                                    .await?
+                                    .then_some(name)
+                            }
+                            None => None,
+                        };
+                        self.generate_chunk(*chunk, chunk_name).await
+                    }
+                })
                 .try_join()
                 .await?;
 
@@ -856,7 +887,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let mut assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(*chunk))
+                .map(|chunk| self.generate_chunk(*chunk, None))
                 .try_join()
                 .await?;
 
@@ -1177,6 +1208,49 @@ struct ChunkPathInfo {
     root_path: FileSystemPath,
     chunk_root_path: FileSystemPath,
     chunk_content_hashing: Option<ContentHashing>,
+}
+
+/// Whether every module in the chunk belongs to exactly one chunk group.
+///
+/// Only such chunks may carry a user-specified chunk group name: a chunk containing modules
+/// shared across chunk groups is emitted byte-identically from each of those groups and
+/// deduplicated into a single output file via its group-independent name. Giving it a per-group
+/// name would fork it into duplicate output files (and duplicate downloads).
+///
+/// Synthetic modules that are not part of the module graph (e.g. async loaders) are ignored for
+/// this check.
+async fn chunk_is_exclusive_to_single_chunk_group(
+    chunk: ResolvedVc<Box<dyn Chunk>>,
+    module_graph: Vc<ModuleGraph>,
+) -> Result<bool> {
+    let module_chunk_groups = module_graph.chunk_group_info().module_chunk_groups();
+    let chunk_items = chunk.chunk_items().await?;
+    for item in chunk_items.iter() {
+        let module = item.module().to_resolved().await?;
+        let chunk_groups = match module_chunk_groups.get(&module).await? {
+            Some(chunk_groups) => chunk_groups,
+            None => {
+                // Merged modules don't have a chunk group in chunk_group_info, so look up the
+                // original module instead.
+                let Some(original_module) = module_graph
+                    .merged_modules()
+                    .await?
+                    .get_original_module(module)
+                    .await?
+                else {
+                    continue;
+                };
+                let Some(chunk_groups) = module_chunk_groups.get(&original_module).await? else {
+                    continue;
+                };
+                chunk_groups
+            }
+        };
+        if chunk_groups.len() != 1 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -22,6 +22,10 @@ use crate::{BrowserChunkingContext, ecmascript::content::EcmascriptBrowserChunkC
 pub struct EcmascriptBrowserChunk {
     chunking_context: ResolvedVc<BrowserChunkingContext>,
     chunk: ResolvedVc<EcmascriptChunk>,
+    /// A user-specified name for the chunk group this chunk belongs to, from a
+    /// `turbopackChunkName`/`webpackChunkName` magic comment. Used as a prefix in the output
+    /// file name.
+    chunk_name: Option<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
@@ -31,10 +35,12 @@ impl EcmascriptBrowserChunk {
     pub fn new(
         chunking_context: ResolvedVc<BrowserChunkingContext>,
         chunk: ResolvedVc<EcmascriptChunk>,
+        chunk_name: Option<RcStr>,
     ) -> Vc<Self> {
         EcmascriptBrowserChunk {
             chunking_context,
             chunk,
+            chunk_name,
         }
         .cell()
     }
@@ -46,6 +52,7 @@ impl EcmascriptBrowserChunk {
             Vc::upcast(*this.chunking_context),
             this.ident_for_path().await?,
             Vc::upcast(self),
+            this.chunk_name.clone(),
         ))
     }
 }
@@ -128,9 +135,12 @@ impl OutputAsset for EcmascriptBrowserChunk {
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
         let ident = this.ident_for_path().await?;
-        Ok(this
-            .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, None, rcstr!(".js")))
+        Ok(this.chunking_context.chunk_path(
+            Some(Vc::upcast(self)),
+            ident,
+            this.chunk_name.clone(),
+            rcstr!(".js"),
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -249,6 +249,7 @@ impl EcmascriptBrowserEvaluateChunk {
             Vc::upcast(*this.chunking_context),
             self.ident_for_path(),
             Vc::upcast(self),
+            None,
         ))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/single_entry_chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/single_entry_chunk.rs
@@ -74,7 +74,7 @@ impl EcmascriptBrowserSingleEntryChunk {
             *this.chunking_context.debug_ids_enabled().await?,
         );
 
-        let module_chunk = EcmascriptBrowserChunk::new(*this.chunking_context, *this.chunk);
+        let module_chunk = EcmascriptBrowserChunk::new(*this.chunking_context, *this.chunk, None);
         code.push_code(&*module_chunk.own_content().code().await?);
 
         let evaluate_chunk = EcmascriptBrowserEvaluateChunk::new(

--- a/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
@@ -82,6 +82,7 @@ impl EcmascriptBrowserWorkerEntrypoint {
             *this.chunking_context,
             self.ident_for_path(),
             Vc::upcast(self),
+            None,
         ))
     }
 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -298,7 +298,7 @@ async fn chunk_group_content_operation(
                             GraphTraversalAction::Exclude
                         }
                     }
-                    ChunkingType::Async => {
+                    ChunkingType::Async { .. } => {
                         if can_split_async {
                             let chunkable_module =
                                 ResolvedVc::try_downcast(edge.module.unwrap())

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -356,7 +356,12 @@ pub enum ChunkingType {
     },
     /// An async loader is placed into the referencing chunk and loads the
     /// separate chunk group in which the module is placed.
-    Async,
+    Async {
+        /// A user-specified name for the chunk group, from a `turbopackChunkName` or
+        /// `webpackChunkName` magic comment. Only affects the file names of the emitted chunks,
+        /// not how modules are grouped into chunk groups.
+        name: Option<RcStr>,
+    },
     /// Create a new chunk group in a separate context, merging references with the same tag into a
     /// single chunk group. It does not inherit the available modules from the parent.
     // TODO this is currently skipped in chunking
@@ -392,7 +397,8 @@ impl Display for ChunkingType {
                     "Parallel(inherit_async: {inherit_async}, hoisted: {hoisted})",
                 )
             }
-            ChunkingType::Async => write!(f, "Async"),
+            ChunkingType::Async { name: Some(name) } => write!(f, "Async(name: {name})"),
+            ChunkingType::Async { name: None } => write!(f, "Async"),
             ChunkingType::Isolated {
                 _ty,
                 merge_tag: Some(merge_tag),
@@ -466,7 +472,7 @@ impl ChunkingType {
                 hoisted: *hoisted,
                 inherit_async: false,
             },
-            ChunkingType::Async => ChunkingType::Async,
+            ChunkingType::Async { name } => ChunkingType::Async { name: name.clone() },
             ChunkingType::Isolated { _ty, merge_tag } => ChunkingType::Isolated {
                 _ty: *_ty,
                 merge_tag: merge_tag.clone(),

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -78,7 +78,7 @@ pub async fn children_from_module_references(
                     parallel_reference_ty()
                 }
             }
-            Some(ChunkingType::Async) => async_reference_ty(),
+            Some(ChunkingType::Async { .. }) => async_reference_ty(),
             Some(ChunkingType::Isolated { .. }) => isolated_reference_ty(),
             Some(ChunkingType::Shared { .. }) => shared_reference_ty(),
             Some(ChunkingType::Traced { .. }) => traced_reference_ty(),

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -4,20 +4,23 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use either::Either;
 use indexmap::map::Entry;
 use roaring::RoaringBitmap;
 use rustc_hash::FxHashMap;
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString,
     Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbofmt,
 };
+use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     chunk::ChunkingType,
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     module::Module,
     module_graph::{GraphTraversalAction, ModuleGraph, RefData},
 };
@@ -95,6 +98,11 @@ pub struct ChunkGroupInfo {
     #[bincode(with = "turbo_bincode::indexset")]
     pub chunk_group_keys: FxIndexSet<ChunkGroupKey>,
     pub chunking_heuristics: ChunkingHeuristicsInfo,
+    /// User-specified names for async chunk groups, keyed by the chunk group's entry module.
+    /// Names come from `turbopackChunkName`/`webpackChunkName` magic comments on `import()`
+    /// expressions. They only affect the file names of the emitted chunks, not how modules are
+    /// grouped.
+    pub async_chunk_group_names: FxHashMap<ResolvedVc<Box<dyn Module>>, RcStr>,
 }
 
 /// Chunking heuristics computed by [`compute_chunk_group_info`]. `priority_routes` is a set of
@@ -466,6 +474,13 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
         let mut module_chunk_groups: FxHashMap<ResolvedVc<Box<dyn Module>>, RoaringBitmapWrapper> =
             FxHashMap::default();
 
+        // All user-specified chunk names seen per async chunk group entry module. Reduced to a
+        // single name (plus a warning on conflicts) after the traversal.
+        let mut async_chunk_group_name_candidates: FxHashMap<
+            ResolvedVc<Box<dyn Module>>,
+            FxIndexSet<RcStr>,
+        > = FxHashMap::default();
+
         let module_count = graph
             .graphs
             .iter()
@@ -596,9 +611,17 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                 let chunk_groups = if let Some((parent, ref_data, _)) = parent_info {
                     match &ref_data.chunking_type {
                         ChunkingType::Parallel { .. } => ChunkGroupInheritance::Inherit(parent),
-                        ChunkingType::Async => ChunkGroupInheritance::ChunkGroup(Either::Left(
-                            std::iter::once(ChunkGroupKey::Async(node)),
-                        )),
+                        ChunkingType::Async { name } => {
+                            if let Some(name) = name {
+                                async_chunk_group_name_candidates
+                                    .entry(node)
+                                    .or_default()
+                                    .insert(name.clone());
+                            }
+                            ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
+                                ChunkGroupKey::Async(node),
+                            )))
+                        }
                         ChunkingType::Isolated {
                             merge_tag: None, ..
                         } => ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
@@ -773,6 +796,30 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
         span.record("visit_count", visit_count);
         span.record("chunk_group_count", chunk_groups_map.len());
 
+        // Reduce the collected chunk name candidates to a single name per entry module. Multiple
+        // imports of the same module end up in the same chunk group, so only one name can apply;
+        // pick the lexicographically smallest to be deterministic (independent of traversal
+        // order) and warn so conflicting names don't go unnoticed.
+        let mut async_chunk_group_names: FxHashMap<ResolvedVc<Box<dyn Module>>, RcStr> =
+            FxHashMap::with_capacity_and_hasher(
+                async_chunk_group_name_candidates.len(),
+                Default::default(),
+            );
+        for (module, names) in async_chunk_group_name_candidates {
+            let mut names: Vec<RcStr> = names.into_iter().collect();
+            names.sort_unstable();
+            if names.len() > 1 {
+                ConflictingChunkNamesIssue {
+                    path: module.ident().await?.path.clone(),
+                    module: module.ident().to_string().owned().await?,
+                    names: names.clone(),
+                }
+                .resolved_cell()
+                .emit();
+            }
+            async_chunk_group_names.insert(module, names.swap_remove(0));
+        }
+
         #[cfg(debug_assertions)]
         {
             use std::sync::LazyLock;
@@ -865,6 +912,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
 
         Ok(ChunkGroupInfo {
             module_chunk_groups: ResolvedVc::cell(module_chunk_groups),
+            async_chunk_group_names,
             chunk_group_keys: chunk_groups_map.keys().cloned().collect(),
             chunking_heuristics: ChunkingHeuristicsInfo {
                 priority_routes: chunk_group_priority_routes,
@@ -896,4 +944,55 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
     }
     .instrument(span_outer)
     .await
+}
+
+/// Emitted when multiple dynamic imports of the same module specify different chunk names via
+/// `turbopackChunkName`/`webpackChunkName` magic comments. They all end up in the same chunk
+/// group, so only one name can apply.
+#[turbo_tasks::value(shared)]
+struct ConflictingChunkNamesIssue {
+    path: FileSystemPath,
+    module: RcStr,
+    names: Vec<RcStr>,
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl Issue for ConflictingChunkNamesIssue {
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Warning
+    }
+
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
+    }
+
+    fn stage(&self) -> IssueStage {
+        IssueStage::Analysis
+    }
+
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Conflicting chunk names for dynamically imported module"
+        )))
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(
+            format!(
+                "The module {} is dynamically imported with multiple different chunk names ({}). \
+                 All imports of a module share a single chunk group, so only one name can be \
+                 used: \"{}\". Use the same `turbopackChunkName`/`webpackChunkName` comment on \
+                 all dynamic imports of this module to remove this warning.",
+                self.module,
+                self.names
+                    .iter()
+                    .map(|name| format!("\"{name}\""))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                self.names[0],
+            )
+            .into(),
+        )))
+    }
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1927,7 +1927,7 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
                     let _span = span.entered();
                     span = tracing::info_span!("traced reference");
                 }
-                ChunkingType::Async => {
+                ChunkingType::Async { .. } => {
                     let _span = span.entered();
                     span = tracing::info_span!("async reference");
                 }

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -24,6 +24,9 @@ enum PathType {
     FromIdent {
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         ident_for_path: ResolvedVc<AssetIdent>,
+        /// Passed through to `ChunkingContext::chunk_path`, so the source map path gets the same
+        /// prefix as the asset it belongs to (e.g. a user-specified chunk name).
+        prefix: Option<RcStr>,
     },
 }
 
@@ -41,11 +44,13 @@ impl SourceMapAsset {
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         ident_for_path: ResolvedVc<AssetIdent>,
         generate_source_map: ResolvedVc<Box<dyn GenerateSourceMap>>,
+        prefix: Option<RcStr>,
     ) -> Vc<Self> {
         SourceMapAsset {
             path_ty: PathType::FromIdent {
                 chunking_context,
                 ident_for_path,
+                prefix,
             },
             generate_source_map,
         }
@@ -79,11 +84,12 @@ impl OutputAsset for SourceMapAsset {
             PathType::FromIdent {
                 chunking_context,
                 ident_for_path,
+                prefix,
             } => chunking_context
                 .chunk_path(
                     Some(Vc::upcast(self)),
                     **ident_for_path,
-                    None,
+                    prefix.clone(),
                     rcstr!(".js"),
                 )
                 .await?

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -461,6 +461,20 @@ pub struct ImportAttributes {
     /// const a = require(/* turbopackChunkingType: parallel */ "a");
     /// ```
     pub chunking_type: Option<SpecifiedChunkingType>,
+    /// A user-specified name for the chunk group created by a dynamic import. The name is
+    /// included in the file names of the emitted chunks (in addition to the usual hash).
+    ///
+    /// This is set by using either a `turbopackChunkName` or `webpackChunkName` comment. When
+    /// both are present, `turbopackChunkName` wins.
+    ///
+    /// Only applied when chunk names are enabled via `EcmascriptOptions::chunk_names`.
+    ///
+    /// Example:
+    /// ```js
+    /// const a = import(/* turbopackChunkName: "my-chunk" */ "a");
+    /// const b = import(/* webpackChunkName: "legacy-chunk" */ "b");
+    /// ```
+    pub chunk_name: Option<RcStr>,
 }
 
 impl ImportAttributes {
@@ -470,6 +484,7 @@ impl ImportAttributes {
             optional: false,
             export_names: None,
             chunking_type: None,
+            chunk_name: None,
         }
     }
 
@@ -1377,6 +1392,8 @@ fn parse_directives(
     let mut optional = None;
     let mut export_names = None;
     let mut chunking_type = None;
+    let mut turbopack_chunk_name = None;
+    let mut webpack_chunk_name = None;
 
     // Process all comments, last one wins for each directive type
     for comment in leading_comments.iter() {
@@ -1399,22 +1416,59 @@ fn parse_directives(
                 "turbopackChunkingType" => {
                     chunking_type = parse_chunking_type_annotation(value.span(), val);
                 }
+                "turbopackChunkName" => {
+                    turbopack_chunk_name = parse_chunk_name(val);
+                }
+                "webpackChunkName" => {
+                    webpack_chunk_name = parse_chunk_name(val);
+                }
                 _ => {} // ignore anything else
             }
         }
     }
 
+    // `turbopackChunkName` takes precedence over the webpack fallback
+    let chunk_name = turbopack_chunk_name.or(webpack_chunk_name);
+
     // Return Some only if at least one directive was found
-    if ignore.is_some() || optional.is_some() || export_names.is_some() || chunking_type.is_some() {
+    if ignore.is_some()
+        || optional.is_some()
+        || export_names.is_some()
+        || chunking_type.is_some()
+        || chunk_name.is_some()
+    {
         Some(ImportAttributes {
             ignore: ignore.unwrap_or(false),
             optional: optional.unwrap_or(false),
             export_names,
             chunking_type,
+            chunk_name,
         })
     } else {
         None
     }
+}
+
+/// Parse a chunk name from a `turbopackChunkName` or `webpackChunkName` comment value.
+///
+/// Supports a JSON string (`"name"`) or a bare token (`name`). Returns `None` for empty values.
+fn parse_chunk_name(val: &str) -> Option<RcStr> {
+    let val = val.trim();
+
+    // Try parsing as a JSON string first (the common `/* webpackChunkName: "name" */` form)
+    if let Ok(name) = serde_json::from_str::<String>(val) {
+        if name.is_empty() {
+            return None;
+        }
+        return Some(name.into());
+    }
+
+    // Bare identifier (no quotes)
+    if !val.is_empty() {
+        return Some(val.into());
+    }
+
+    None
 }
 
 /// Parse export names from a `webpackExports` or `turbopackExports` comment value.
@@ -1559,5 +1613,92 @@ mod tests {
     fn test_parse_empty_with() {
         let annotations = ImportAnnotations::parse(None);
         assert!(annotations.is_none());
+    }
+
+    /// Helper to run `parse_directives` against a call argument that has the given leading
+    /// (block) comments, i.e. `import(/* comment */ "./module")`.
+    fn parse_directives_from_comments(comment_texts: &[&str]) -> Option<ImportAttributes> {
+        use swc_core::common::{
+            BytePos, Span,
+            comments::{Comment, CommentKind, Comments, SingleThreadedComments},
+        };
+
+        let comments = SingleThreadedComments::default();
+        let pos = BytePos(10);
+        for text in comment_texts {
+            comments.add_leading(
+                pos,
+                Comment {
+                    kind: CommentKind::Block,
+                    span: DUMMY_SP,
+                    text: Atom::from(*text).into(),
+                },
+            );
+        }
+        let value = ExprOrSpread {
+            spread: None,
+            expr: Box::new(Expr::Lit(Lit::Str(Str {
+                span: Span::new(pos, BytePos(20)),
+                value: Atom::from("./module").into(),
+                raw: None,
+            }))),
+        };
+        parse_directives(&comments, Some(&value))
+    }
+
+    #[test]
+    fn test_parse_turbopack_chunk_name() {
+        let attributes =
+            parse_directives_from_comments(&[r#" turbopackChunkName: "my-chunk" "#]).unwrap();
+        assert_eq!(attributes.chunk_name.as_deref(), Some("my-chunk"));
+    }
+
+    #[test]
+    fn test_parse_webpack_chunk_name_fallback() {
+        let attributes =
+            parse_directives_from_comments(&[r#" webpackChunkName: "legacy-chunk" "#]).unwrap();
+        assert_eq!(attributes.chunk_name.as_deref(), Some("legacy-chunk"));
+    }
+
+    #[test]
+    fn test_turbopack_chunk_name_takes_precedence() {
+        // ... regardless of comment order
+        let attributes = parse_directives_from_comments(&[
+            r#" webpackChunkName: "loses" "#,
+            r#" turbopackChunkName: "wins" "#,
+        ])
+        .unwrap();
+        assert_eq!(attributes.chunk_name.as_deref(), Some("wins"));
+
+        let attributes = parse_directives_from_comments(&[
+            r#" turbopackChunkName: "wins" "#,
+            r#" webpackChunkName: "loses" "#,
+        ])
+        .unwrap();
+        assert_eq!(attributes.chunk_name.as_deref(), Some("wins"));
+    }
+
+    #[test]
+    fn test_parse_bare_chunk_name() {
+        let attributes =
+            parse_directives_from_comments(&[" turbopackChunkName: my-chunk "]).unwrap();
+        assert_eq!(attributes.chunk_name.as_deref(), Some("my-chunk"));
+    }
+
+    #[test]
+    fn test_parse_empty_chunk_name() {
+        assert!(parse_directives_from_comments(&[" turbopackChunkName: "]).is_none());
+        assert!(parse_directives_from_comments(&[r#" turbopackChunkName: "" "#]).is_none());
+    }
+
+    #[test]
+    fn test_chunk_name_combines_with_other_directives() {
+        let attributes = parse_directives_from_comments(&[
+            r#" webpackChunkName: "my-chunk" "#,
+            " turbopackOptional: true ",
+        ])
+        .unwrap();
+        assert_eq!(attributes.chunk_name.as_deref(), Some("my-chunk"));
+        assert!(attributes.optional);
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -259,6 +259,10 @@ pub struct EcmascriptOptions {
     pub inline_helpers: bool,
     /// Whether to infer side effect free modules via local analysis. Defaults to true.
     pub infer_module_side_effects: bool,
+    /// Whether to apply `turbopackChunkName`/`webpackChunkName` magic comments on dynamic
+    /// imports. When enabled, the specified name is included in the file names of the emitted
+    /// chunks (in addition to the usual hash). Defaults to false.
+    pub chunk_names: bool,
 }
 
 #[turbo_tasks::value(task_input)]

--- a/turbopack/crates/turbopack-ecmascript/src/references/chunk_name.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/chunk_name.rs
@@ -1,0 +1,112 @@
+use turbo_rcstr::RcStr;
+
+const REQUEST_PLACEHOLDER: &str = "[request]";
+/// Chunk names end up in output file names, so keep them reasonably short. The usual ident hash
+/// is still appended, so truncation cannot cause collisions.
+const MAX_CHUNK_NAME_LEN: usize = 64;
+
+/// Resolves a user-specified chunk name (from a `turbopackChunkName`/`webpackChunkName` magic
+/// comment) into a string that is safe to use in an output file name.
+///
+/// The `[request]` placeholder is replaced with the sanitized import request. When the request
+/// is not statically known, a name containing `[request]` is dropped entirely.
+pub fn resolve_chunk_name(name: &str, request: Option<&str>) -> Option<RcStr> {
+    let name = if name.contains(REQUEST_PLACEHOLDER) {
+        name.replace(REQUEST_PLACEHOLDER, &sanitize_request(request?))
+    } else {
+        name.to_string()
+    };
+
+    // Restrict to characters that are safe in file names and URLs on all platforms. This
+    // intentionally does not allow `/` (which webpack uses to create nested directories) to keep
+    // chunk paths flat and predictable.
+    let mut sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    sanitized.truncate(MAX_CHUNK_NAME_LEN);
+
+    if sanitized.is_empty() {
+        None
+    } else {
+        Some(sanitized.into())
+    }
+}
+
+/// Sanitizes an import request for use in the `[request]` placeholder, similar to webpack:
+/// strips a leading `./` and collapses runs of unsafe characters into a single `-`.
+fn sanitize_request(request: &str) -> String {
+    let request = request.trim_start_matches("./");
+    let mut out = String::with_capacity(request.len());
+    let mut last_was_replacement = false;
+    for c in request.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+            out.push(c);
+            last_was_replacement = false;
+        } else if !last_was_replacement {
+            out.push('-');
+            last_was_replacement = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_name_is_kept() {
+        assert_eq!(resolve_chunk_name("my-chunk", None).unwrap(), "my-chunk");
+        assert_eq!(
+            resolve_chunk_name("my_chunk123", Some("./foo")).unwrap(),
+            "my_chunk123"
+        );
+    }
+
+    #[test]
+    fn unsafe_characters_are_replaced() {
+        assert_eq!(
+            resolve_chunk_name("my/chunk name", None).unwrap(),
+            "my_chunk_name"
+        );
+        assert_eq!(
+            resolve_chunk_name("../../evil", None).unwrap(),
+            "______evil"
+        );
+    }
+
+    #[test]
+    fn request_placeholder_is_substituted() {
+        assert_eq!(
+            resolve_chunk_name("[request]", Some("./components/Abc.tsx")).unwrap(),
+            "components-Abc-tsx"
+        );
+        assert_eq!(
+            resolve_chunk_name("lazy-[request]", Some("lodash/debounce")).unwrap(),
+            "lazy-lodash-debounce"
+        );
+    }
+
+    #[test]
+    fn request_placeholder_without_static_request_drops_name() {
+        assert_eq!(resolve_chunk_name("lazy-[request]", None), None);
+    }
+
+    #[test]
+    fn empty_name_is_dropped() {
+        assert_eq!(resolve_chunk_name("", None), None);
+    }
+
+    #[test]
+    fn long_names_are_truncated() {
+        let long = "a".repeat(100);
+        assert_eq!(resolve_chunk_name(&long, None).unwrap().len(), 64);
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -5,6 +5,7 @@ use swc_core::{
     ecma::ast::{CallExpr, Callee, Expr, ExprOrSpread, Lit},
     quote_expr,
 };
+use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
@@ -46,6 +47,10 @@ pub struct EsmAsyncAssetReference {
     /// callback destructuring, or webpackExports/turbopackExports comments.
     pub export_usage: ExportUsage,
     pub resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
+    /// A user-specified name for the async chunk group, from a
+    /// `turbopackChunkName`/`webpackChunkName` magic comment. Already sanitized for use in file
+    /// names.
+    pub chunk_name: Option<RcStr>,
 }
 
 impl EsmAsyncAssetReference {
@@ -59,6 +64,7 @@ impl EsmAsyncAssetReference {
         import_externals: bool,
         export_usage: ExportUsage,
         resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
+        chunk_name: Option<RcStr>,
     ) -> Result<Self> {
         // Apply any annotation-driven transition eagerly so the stored origin is final and the
         // `annotations` don't need to be retained on the reference.
@@ -79,6 +85,7 @@ impl EsmAsyncAssetReference {
             import_externals,
             export_usage,
             resolve_override,
+            chunk_name,
         })
     }
 }
@@ -102,7 +109,9 @@ impl ModuleReference for EsmAsyncAssetReference {
     }
 
     fn chunking_type(&self) -> Option<ChunkingType> {
-        Some(ChunkingType::Async)
+        Some(ChunkingType::Async {
+            name: self.chunk_name.clone(),
+        })
     }
 
     fn binding_usage(&self) -> BindingUsage {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1,5 +1,6 @@
 pub mod amd;
 pub mod async_module;
+pub mod chunk_name;
 pub mod cjs;
 pub mod constant_condition;
 pub mod constant_value;
@@ -461,6 +462,9 @@ struct AnalysisState<'a> {
     tree_shaking_mode: Option<TreeShakingMode>,
     import_externals: bool,
     ignore_dynamic_requests: bool,
+    // Whether to apply `turbopackChunkName`/`webpackChunkName` magic comments on dynamic
+    // imports.
+    enable_chunk_names: bool,
     url_rewrite_behavior: Option<UrlRewriteBehavior>,
     // Whether we should collect affecting sources from referenced files. Only usedful when
     // tracing.
@@ -856,6 +860,7 @@ async fn analyze_ecmascript_module_internal(
             tree_shaking_mode: options.tree_shaking_mode,
             import_externals: options.import_externals,
             ignore_dynamic_requests: options.ignore_dynamic_requests,
+            enable_chunk_names: options.chunk_names,
             url_rewrite_behavior: options.url_rewrite_behavior,
             collect_affecting_sources: options.analyze_mode.is_tracing_assets(),
             tracing_only: !options.analyze_mode.is_code_gen(),
@@ -1662,8 +1667,15 @@ async fn handle_dynamic_import<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>
         origin,
         source,
         ignore_dynamic_requests,
+        enable_chunk_names,
         ..
     } = state;
+
+    let chunk_name = if enable_chunk_names {
+        attributes.chunk_name.clone()
+    } else {
+        None
+    };
 
     let error_mode = if attributes.optional {
         ResolveErrorMode::Ignore
@@ -1708,10 +1720,12 @@ async fn handle_dynamic_import<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>
         error_mode,
         state.import_externals,
         export_usage,
+        chunk_name,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_dynamic_import_with_linked_args(
     ast_path: &[AstParentKind],
     span: Span,
@@ -1725,6 +1739,7 @@ async fn handle_dynamic_import_with_linked_args(
     error_mode: ResolveErrorMode,
     import_externals: bool,
     export_usage: ExportUsage,
+    chunk_name: Option<RcStr>,
 ) -> Result<()> {
     if linked_args.len() == 1 || linked_args.len() == 2 {
         let pat = js_value_to_pattern(&linked_args[0]);
@@ -1773,6 +1788,10 @@ async fn handle_dynamic_import_with_linked_args(
             None
         };
 
+        let chunk_name = chunk_name.and_then(|name| {
+            chunk_name::resolve_chunk_name(&name, pat.as_constant_string().map(|s| s.as_str()))
+        });
+
         analysis.add_reference_code_gen(
             EsmAsyncAssetReference::new(
                 origin,
@@ -1783,6 +1802,7 @@ async fn handle_dynamic_import_with_linked_args(
                 import_externals,
                 export_usage,
                 resolve_override,
+                chunk_name,
             )
             .await?,
             ast_path.to_vec().into(),
@@ -2074,6 +2094,11 @@ where
                 Some(names) => ExportUsage::PartialNamespaceObject(names.clone()),
                 None => ExportUsage::All,
             };
+            let chunk_name = if state.enable_chunk_names {
+                attributes.chunk_name.clone()
+            } else {
+                None
+            };
             handle_dynamic_import_with_linked_args(
                 ast_path,
                 span,
@@ -2087,6 +2112,7 @@ where
                 error_mode,
                 state.import_externals,
                 export_usage,
+                chunk_name,
             )
             .await?;
         }

--- a/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
@@ -33,6 +33,7 @@ impl SingleFileEcmascriptOutput {
             *this.chunking_context,
             this.source.ident(),
             Vc::upcast(self),
+            None,
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -51,6 +51,7 @@ impl EcmascriptBuildNodeChunk {
                 .with_modifier(modifier())
                 .into_vc(),
             Vc::upcast(self),
+            None,
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -152,6 +152,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
             Vc::upcast(*this.chunking_context),
             self.ident_for_path(),
             Vc::upcast(self),
+            None,
         ))
     }
 }

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -33,7 +33,7 @@ pub async fn get_global_module_id_strategy(
             if let Some((
                 _,
                 &RefData {
-                    chunking_type: ChunkingType::Async,
+                    chunking_type: ChunkingType::Async { .. },
                     ..
                 },
             )) = parent

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -247,6 +247,7 @@ impl ModuleOptions {
                     source_maps: ecmascript_source_maps,
                     inline_helpers,
                     infer_module_side_effects,
+                    enable_chunk_names,
                     ref preset_env_config,
                     ..
                 },
@@ -337,6 +338,7 @@ impl ModuleOptions {
             enable_exports_info_inlining,
             inline_helpers,
             infer_module_side_effects,
+            chunk_names: enable_chunk_names,
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.resolved_cell();

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -284,6 +284,10 @@ pub struct EcmascriptOptionsContext {
     /// Whether to infer side effect free modules via local analysis. Defaults to true.
     pub infer_module_side_effects: bool,
 
+    /// Whether to apply `turbopackChunkName`/`webpackChunkName` magic comments on dynamic
+    /// imports. Defaults to false.
+    pub enable_chunk_names: bool,
+
     /// Additional SWC preset-env options (mode, coreJs, include, exclude, etc.).
     pub preset_env_config: Option<ResolvedVc<PresetEnvConfig>>,
 


### PR DESCRIPTION
Adds opt-in support for naming dynamic-import chunks in Turbopack via magic comments, behind a new `experimental.turbopackChunkNames` flag:

```js
const mod = await import(/* turbopackChunkName: "my-widget" */ './widget')
```

- `turbopackChunkName` functions similarly to `webpackChunkName` (both are supported for easy migration)
- The name is included in the emitted browser chunk file names while retaining the usual content hash: `static/chunks/my-widget-<13-char-content-hash>.js` in production, `my-widget-<ident>_<hash>._.js` in dev. Named chunks therefore show up readably in browser network logs.

Names deliberately do **not** affect chunking decisions:

- Chunk group identity (`ChunkGroupKey::Async`) stays keyed by entry module only; grouping, availability, batching, and production merge heuristics are untouched. The name is applied purely at output-asset naming time.
- A chunk only carries the name if every module in it is exclusive to the named chunk group. Chunks shared across groups keep their group-independent hash names so they remain deduplicated across groups (matching webpack, where `splitChunks` still extracts shared code out of named chunks).
- If multiple dynamic imports of the same module specify different names, the lexicographically smallest wins deterministically and a build warning (`ConflictingChunkNamesIssue`) is emitted.

With the flag off (default) there is no behavior change; magic-comment application is gated by `EcmascriptOptions::chunk_names`, and the directive parsing itself is a single extra match arm over leading comments that are already scanned for `webpackIgnore`.

Implementation: `ImportAttributes.chunk_name` (analyzer) → `EsmAsyncAssetReference` → `ChunkingType::Async { name }` (graph edge) → `ChunkGroupInfo.async_chunk_group_names` side map → `BrowserChunkingContext::chunk_group()` applies it as the `chunk_path` prefix on `EcmascriptBrowserChunk` (and its source map). Server (`NodeJsChunkingContext`) chunk names are unchanged.

## Verification

- `cargo test -p turbopack-ecmascript --lib chunk_name` (12 unit tests: directive parsing incl. precedence/bare/empty values, `[request]` substitution, sanitization, truncation)
- `pnpm test-start-turbo` / `pnpm test-dev-turbo` for the three new e2e suites (`test/e2e/app-dir/turbopack-chunk-names`, `test/e2e/app-dir/turbopack-chunk-names-disabled`, `test/e2e/turbopack-chunk-names-pages`): named files emitted with hash retained, chunks load in the browser with named URLs, `webpackChunkName` fallback and precedence, `[request]` (bare and combined), `next/dynamic`, and no behavior change with the flag off
- `pnpm test-start-webpack test/e2e/app-dir/turbopack-chunk-names/turbopack-chunk-names.test.ts` (webpack builds unaffected; naming assertions are turbopack-gated)

<!-- NEXT_JS_LLM_PR -->