### PR TITLE
docs: fix MQTT example env variable names

### DIFF
--- a/examples/with-mqtt-js/README.md
+++ b/examples/with-mqtt-js/README.md
@@ -30,9 +30,9 @@ cp .env.local.example .env.local
 
 Then set each variable on `.env.local`:
 
-- `NEXT_MQTT_URI`: The URI of the broker. For example `wss://test.mosquitto.org:8081/mqtt`
-- `NEXT_MQTT_CLIENTID`: An arbitrary string of max. 23 characters.
-- `NEXT_MQTT_USERNAME`: The username for the connection to the broker.
-- `NEXT_MQTT_PASSWORD`: The password for the connection to the broker.
+- `NEXT_PUBLIC_MQTT_URI`: The URI of the broker. For example `wss://test.mosquitto.org:8081/mqtt`
+- `NEXT_PUBLIC_MQTT_CLIENTID`: An arbitrary string of max. 23 characters.
+- `NEXT_PUBLIC_MQTT_USERNAME`: The username for the connection to the broker.
+- `NEXT_PUBLIC_MQTT_PASSWORD`: The password for the connection to the broker.
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).


### PR DESCRIPTION
## Summary

Update the `with-mqtt-js` example README to use the `NEXT_PUBLIC_MQTT_*` environment variable names that the example code and `.env.local.example` already expect. This avoids users copying private `NEXT_MQTT_*` names that are never read by the client-side example.

## Verification

- `rg -n "NEXT_MQTT|NEXT_PUBLIC_MQTT" examples/with-mqtt-js`
- `git diff --check`
- Not run: `pnpm prettier --with-node-modules --ignore-path .prettierignore --write examples/with-mqtt-js/README.md` (`pnpm` attempted to bootstrap dependencies and failed fetching internal package `@next/swc` from npm)

<!-- NEXT_JS_LLM_PR -->