### PR TITLE
Unify appShells flag with Partial Prefetching

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -392,7 +392,6 @@ export function getDefineEnv({
       config.experimental.optimisticRouting ?? false,
     'process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS':
       config.experimental.instrumentationClientRouterTransitionEvents ?? false,
-    'process.env.__NEXT_APP_SHELLS': config.experimental.appShells ?? false,
     'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_EXPOSE_TESTING_API':
       dev || config.experimental.exposeTestingApiInProductionBuild === true,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -929,7 +929,6 @@ export async function handler(
             useCacheTimeout: nextConfig.experimental.useCacheTimeout,
             cachedNavigations:
               nextConfig.experimental.cachedNavigations ?? false,
-            appShells: nextConfig.experimental.appShells,
             clientTraceMetadata:
               nextConfig.experimental.clientTraceMetadata || ([] as any),
             clientParamParsingOrigins:

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -179,7 +179,6 @@ async function requestHandler(
         serverComponentsHmrCancellation: false,
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
         cachedNavigations: nextConfig.experimental.cachedNavigations ?? false,
-        appShells: nextConfig.experimental.appShells,
         clientTraceMetadata:
           nextConfig.experimental.clientTraceMetadata || ([] as any),
         clientParamParsingOrigins:

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2629,10 +2629,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // staleAt that corresponds to whatever payload the spawned entries get
     // filled with below.
     let staleAtForSpawnedEntries = staleAt
-    if (!process.env.__NEXT_APP_SHELLS || cacheData === null) {
-      // NOTE: cacheData is always set when Cached Navigations is enabled, and
-      // therefore when App Shells is enabled. This null check can be removed
-      // when those flags fully land.
+    if (cacheData === null) {
+      // No shell can be extracted without cache metadata (only present when
+      // Cached Navigations is enabled). For routes without a distinct App Shell
+      // the extraction below is a no-op anyway (`resolveShellStageData` returns
+      // null), so this just short-circuits that case.
       serverDataThatSatisfiesSpawnedEntries = serverData
     } else {
       const shellStageData = await resolveShellStageData(

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -10,6 +10,7 @@ import {
 import { matchSegment } from '../match-segments'
 import {
   readOrCreateRouteCacheEntry,
+  readRouteCacheEntry,
   readOrCreateSegmentCacheEntry,
   fetchRouteOnCacheMiss,
   fetchSegmentsOnCacheMiss,
@@ -575,9 +576,24 @@ function processQueueInMicrotask() {
         continue
       case PrefetchTaskExitStatus.Done:
         if (task.phase === PrefetchPhase.RouteTree) {
-          // Finished prefetching the route tree. If App Shells are enabled,
-          // run the Shell phase next; otherwise go straight to Speculative.
-          task.phase = process.env.__NEXT_APP_SHELLS
+          // Finished prefetching the route tree. The two-phase (Shell then
+          // Speculative) flow only applies to routes that have opted into
+          // Partial Prefetching — either globally via the `partialPrefetching`
+          // config or per segment (`instant`, `prefetch: 'partial'`,
+          // `'unstable_eager'`, or `'allow-runtime'`), all surfaced as the
+          // `SubtreeHasPartialPrefetching` hint on the route tree. Every other
+          // route skips the Shell phase and goes straight to Speculative.
+          //
+          // The route entry is fulfilled at this point (the RouteTree phase
+          // just completed), so its prefetch hints are available.
+          const route = readRouteCacheEntry(now, task.key)
+          const routeHasPartialPrefetching =
+            route !== null &&
+            route.status === EntryStatus.Fulfilled &&
+            (route.tree.prefetchHints &
+              PrefetchHint.SubtreeHasPartialPrefetching) !==
+              0
+          task.phase = routeHasPartialPrefetching
             ? PrefetchPhase.Shell
             : PrefetchPhase.Speculative
           heapResift(taskHeap, task)
@@ -2051,17 +2067,13 @@ export function subtreeHasSpeculativePrefetch(
   fetchStrategy: FetchStrategy,
   prefetchHints: number
 ): boolean {
-  if (!process.env.__NEXT_APP_SHELLS) {
-    // When App Shells is disabled, all prefetches implicitly include the
-    // speculative (non-shell) part of the target.
-    return true
-  }
-
   return (
     // Check if this is a "full" prefetch (<Link prefetch={true}>).
     fetchStrategy === FetchStrategy.Full ||
     // Check if something in this subtree is configured to be eagerly
-    // prefetched at the route level.
+    // prefetched at the route level. Segments that don't opt into Partial
+    // Prefetching are marked eager, so a route without any Partial Prefetching
+    // still speculatively prefetches everything.
     (prefetchHints & PrefetchHint.SubtreeHasEagerPrefetch) !== 0
   )
 }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -519,7 +519,6 @@ async function exportAppImpl(
       authInterrupts: !!nextConfig.experimental.authInterrupts,
       useCacheTimeout: nextConfig.experimental.useCacheTimeout,
       cachedNavigations: nextConfig.experimental.cachedNavigations ?? false,
-      appShells: nextConfig.experimental.appShells,
       maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
         nextConfig.experimental.maxPostponedStateSize
       ),

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -947,7 +947,6 @@ async function generateStagedDynamicFlightRenderResultNode(
   const { routeModule } = componentMod
   const { loaderTree } = routeModule.userland
   const { onInstrumentationRequestError, experimental } = renderOpts
-  const { appShells } = experimental
 
   function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
@@ -995,9 +994,7 @@ async function generateStagedDynamicFlightRenderResultNode(
     selectStaleTime
   )
 
-  const shellByteLengthDeferred = appShells
-    ? createPromiseWithResolvers<number | null>()
-    : null
+  const shellByteLengthDeferred = createPromiseWithResolvers<number | null>()
   const staticStageByteLengthDeferred = createPromiseWithResolvers<number>()
 
   let runtimePrefetchStream: ReadableStream<Uint8Array> | undefined
@@ -1052,7 +1049,7 @@ async function generateStagedDynamicFlightRenderResultNode(
     {
       staleTimeIterable,
       staticStageByteLengthPromise: staticStageByteLengthDeferred.promise,
-      shellByteLengthPromise: shellByteLengthDeferred?.promise,
+      shellByteLengthPromise: shellByteLengthDeferred.promise,
       runtimePrefetchStream,
     }
   )
@@ -1079,7 +1076,7 @@ async function generateStagedDynamicFlightRenderResultNode(
       void countShellAndStaticStageBytes(staticStream, stageController).then(
         (byteLengths) => {
           staticStageByteLengthDeferred.resolve(byteLengths[RenderStage.Static])
-          shellByteLengthDeferred?.resolve(byteLengths[RenderStage.ShellStatic])
+          shellByteLengthDeferred.resolve(byteLengths[RenderStage.ShellStatic])
         }
       )
 
@@ -1120,22 +1117,18 @@ async function spawnRuntimePrefetchWithFilledCaches(
   onError: (err: unknown) => string | undefined
 ): Promise<void> {
   try {
-    const { componentMod, getDynamicParamFromSegment, renderOpts } = ctx
+    const { componentMod, getDynamicParamFromSegment } = ctx
     const { loaderTree } = componentMod.routeModule.userland
-    const { appShells } = renderOpts.experimental
 
     const rootParams = getRootParams(loaderTree, getDynamicParamFromSegment)
     const staleTimeIterable = new StaleTimeIterable()
 
-    const mode: RuntimePrerenderMode = appShells
-      ? // If appShells is on, we want to be able to rewind the result to a session shell.
-        {
-          type: 'rewindable-session-shell',
-          shellUsedSessionDataDeferred: createPromiseWithResolvers(),
-          shellByteLengthDeferred: createPromiseWithResolvers(),
-        }
-      : // Otherwise, render everything without considering shells.
-        { type: 'runtime-only' }
+    // We want to be able to rewind the result to a session shell.
+    const mode: RuntimePrerenderMode = {
+      type: 'rewindable-session-shell',
+      shellUsedSessionDataDeferred: createPromiseWithResolvers(),
+      shellByteLengthDeferred: createPromiseWithResolvers(),
+    }
 
     const { result } = await finalRuntimeServerPrerender(
       mode,
@@ -1146,10 +1139,7 @@ async function spawnRuntimePrefetchWithFilledCaches(
           mode.type === 'rewindable-session-shell'
             ? mode.shellByteLengthDeferred.promise
             : undefined,
-        shellUsedSessionDataPromise:
-          mode.type !== 'runtime-only'
-            ? mode.shellUsedSessionDataDeferred.promise
-            : undefined,
+        shellUsedSessionDataPromise: mode.shellUsedSessionDataDeferred.promise,
       }),
       prerenderResumeDataCache,
       rootParams,
@@ -1479,7 +1469,6 @@ async function generateRuntimePrefetchResult(
     onInstrumentationRequestError,
     setReactDebugChannel,
   } = renderOpts
-  const { appShells } = renderOpts.experimental
 
   function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
@@ -1525,18 +1514,16 @@ async function generateRuntimePrefetchResult(
     requestStore.draftMode
   )
 
-  const mode: RuntimePrerenderMode = appShells
-    ? isShellPrefetch
-      ? {
-          type: 'session-shell-only',
-          shellUsedSessionDataDeferred: createPromiseWithResolvers(),
-        }
-      : {
-          type: 'rewindable-session-shell',
-          shellUsedSessionDataDeferred: createPromiseWithResolvers(),
-          shellByteLengthDeferred: createPromiseWithResolvers(),
-        }
-    : { type: 'runtime-only' }
+  const mode: RuntimePrerenderMode = isShellPrefetch
+    ? {
+        type: 'session-shell-only',
+        shellUsedSessionDataDeferred: createPromiseWithResolvers(),
+      }
+    : {
+        type: 'rewindable-session-shell',
+        shellUsedSessionDataDeferred: createPromiseWithResolvers(),
+        shellByteLengthDeferred: createPromiseWithResolvers(),
+      }
 
   const debugChannel = setReactDebugChannel
     ? createWebDebugChannel()
@@ -1554,10 +1541,7 @@ async function generateRuntimePrefetchResult(
         mode.type === 'rewindable-session-shell'
           ? mode.shellByteLengthDeferred.promise
           : undefined,
-      shellUsedSessionDataPromise:
-        mode.type !== 'runtime-only'
-          ? mode.shellUsedSessionDataDeferred.promise
-          : undefined,
+      shellUsedSessionDataPromise: mode.shellUsedSessionDataDeferred.promise,
     }),
     prerenderResumeDataCache,
     rootParams,
@@ -1731,7 +1715,6 @@ function prependIsPartialByteToChunks(
 }
 
 type RuntimePrerenderMode =
-  | { type: 'runtime-only' }
   | {
       type: 'session-shell-only'
       shellUsedSessionDataDeferred: PromiseWithResolvers<boolean>
@@ -1821,20 +1804,14 @@ async function finalRuntimeServerPrerender(
 
   const streamState = createStreamPendingState()
   const collectedChunks = createPrerenderChunksAccumulator()
-  const stageByteLengths =
-    mode.type === 'rewindable-session-shell' ||
-    mode.type === 'session-shell-only'
-      ? createStageByteLengths()
-      : null
+  const stageByteLengths = createStageByteLengths()
   const collectChunk = (chunk: Uint8Array) => {
     collectPrerenderChunk(collectedChunks, finalServerController.signal, chunk)
-    if (stageByteLengths) {
-      increaseChunkByteLengths(
-        stageByteLengths,
-        finalStageController.currentStage,
-        chunk.byteLength
-      )
-    }
+    increaseChunkByteLengths(
+      stageByteLengths,
+      finalStageController.currentStage,
+      chunk.byteLength
+    )
   }
 
   let didHandleUnexpectedAbort = false
@@ -1921,20 +1898,12 @@ async function finalRuntimeServerPrerender(
       // (fast immediates will be drained at the end of the task, so in the next task we know we're done flushing)
 
       // Check if session data unblocked new content in the shell.
-      if (
-        (mode.type === 'rewindable-session-shell' ||
-          mode.type === 'session-shell-only') &&
-        stageByteLengths
-      ) {
-        const didSessionDataUnblockNewContent =
-          stageByteLengths[RenderStage.ShellRuntime] >
-          stageByteLengths[RenderStage.Static]
-        mode.shellUsedSessionDataDeferred.resolve(
-          didSessionDataUnblockNewContent
-        )
-      }
+      const didSessionDataUnblockNewContent =
+        stageByteLengths[RenderStage.ShellRuntime] >
+        stageByteLengths[RenderStage.Static]
+      mode.shellUsedSessionDataDeferred.resolve(didSessionDataUnblockNewContent)
 
-      if (mode.type === 'rewindable-session-shell' && stageByteLengths) {
+      if (mode.type === 'rewindable-session-shell') {
         // If advancing to the runtime stage didn't unblock new content,
         // then the result does not depend on link data and can be used as a shell (indicated via `null`).
         // Otherwise, send a byte length to indicate where the shell content ends.
@@ -3281,7 +3250,7 @@ async function renderToStream(
     cacheComponents,
   } = renderOpts
 
-  const { cachedNavigations, appShells } = renderOpts.experimental
+  const { cachedNavigations } = renderOpts.experimental
 
   const { ServerInsertedHTMLProvider, renderServerInsertedHTML } =
     createServerInsertedHTML()
@@ -3587,9 +3556,9 @@ async function renderToStream(
           selectStaleTime
         )
 
-        const shellByteLengthDeferred = appShells
-          ? createPromiseWithResolvers<number | null>()
-          : null
+        const shellByteLengthDeferred = createPromiseWithResolvers<
+          number | null
+        >()
         const staticStageByteLengthDeferred =
           createPromiseWithResolvers<number>()
 
@@ -3639,7 +3608,7 @@ async function renderToStream(
           {
             is404: res.statusCode === 404,
             staleTimeIterable,
-            shellByteLengthPromise: shellByteLengthDeferred?.promise,
+            shellByteLengthPromise: shellByteLengthDeferred.promise,
             staticStageByteLengthPromise: staticStageByteLengthDeferred.promise,
             runtimePrefetchStream,
           }
@@ -3672,7 +3641,7 @@ async function renderToStream(
               staticStageByteLengthDeferred.resolve(
                 byteLengths[RenderStage.Static]
               )
-              shellByteLengthDeferred?.resolve(
+              shellByteLengthDeferred.resolve(
                 byteLengths[RenderStage.ShellStatic]
               )
             })
@@ -7754,7 +7723,7 @@ async function prerenderToStream(
     cacheComponents,
   } = renderOpts
 
-  const { cachedNavigations, appShells } = renderOpts.experimental
+  const { cachedNavigations } = renderOpts.experimental
 
   const renderFlightStream = process.env.__NEXT_USE_NODE_STREAMS
     ? renderToNodeFlightStream
@@ -8278,9 +8247,9 @@ async function prerenderToStream(
         varyParamsAccumulator,
       }
 
-      const shellByteLengthDeferred = appShells
-        ? createPromiseWithResolvers<number | null>()
-        : null
+      const shellByteLengthDeferred = createPromiseWithResolvers<
+        number | null
+      >()
 
       const finalServerPayload = await workUnitAsyncStorage.run(
         finalServerPayloadPrerenderStore,
@@ -8289,7 +8258,7 @@ async function prerenderToStream(
         ctx,
         {
           is404: res.statusCode === 404,
-          shellByteLengthPromise: shellByteLengthDeferred?.promise,
+          shellByteLengthPromise: shellByteLengthDeferred.promise,
         }
       )
 
@@ -8335,22 +8304,18 @@ async function prerenderToStream(
 
       const streamState = createStreamPendingState()
       const collectedChunks = createPrerenderChunksAccumulator()
-      const collectedChunksByStage = appShells
-        ? createStageChunksAccumulator()
-        : null
+      const collectedChunksByStage = createStageChunksAccumulator()
       const collectChunk = (chunk: Uint8Array) => {
         collectPrerenderChunk(
           collectedChunks,
           finalServerReactController.signal,
           chunk
         )
-        if (collectedChunksByStage) {
-          collectStageChunk(
-            collectedChunksByStage,
-            finalStageController.currentStage,
-            chunk
-          )
-        }
+        collectStageChunk(
+          collectedChunksByStage,
+          finalStageController.currentStage,
+          chunk
+        )
       }
 
       let didHandleUnexpectedAbort = false
@@ -8456,11 +8421,9 @@ async function prerenderToStream(
           // then the prerender uses link data.
           // NOTE: we must capture this *before* resolving staleTime/varyParams,
           // which always emit new static chunks.
-          if (collectedChunksByStage) {
-            didLinkDataUnblockNewContent =
-              collectedChunksByStage.staticChunks.length >
-              collectedChunksByStage.shellStaticChunks.length
-          }
+          didLinkDataUnblockNewContent =
+            collectedChunksByStage.staticChunks.length >
+            collectedChunksByStage.shellStaticChunks.length
 
           // Now that the prerendering is complete, we know the final stale
           // time and vary params. Close the stale time iterable and resolve
@@ -8473,16 +8436,14 @@ async function prerenderToStream(
           }
           finishAccumulatingVaryParams(varyParamsAccumulator)
 
-          if (shellByteLengthDeferred && collectedChunksByStage) {
-            shellByteLengthDeferred.resolve(
-              didLinkDataUnblockNewContent
-                ? collectedChunksByStage.shellStaticChunks.reduce(
-                    (acc, chunk) => acc + chunk.byteLength,
-                    0
-                  )
-                : null
-            )
-          }
+          shellByteLengthDeferred.resolve(
+            didLinkDataUnblockNewContent
+              ? collectedChunksByStage.shellStaticChunks.reduce(
+                  (acc, chunk) => acc + chunk.byteLength,
+                  0
+                )
+              : null
+          )
         },
         () => {
           if (checkUnexpectedAbort()) return
@@ -8536,24 +8497,22 @@ async function prerenderToStream(
           ctx.pagePath,
           metadata
         )
-        if (appShells && collectedChunksByStage) {
-          // If link data (static params) unblocked new content, then the shell has to be partial.
-          // If not, then the shell prerender and the static prerender are the same except for staleTime/varyParams.
-          const shellIsPartial = didLinkDataUnblockNewContent
-            ? true
-            : resultIsPartial
+        // If link data (static params) unblocked new content, then the shell has to be partial.
+        // If not, then the shell prerender and the static prerender are the same except for staleTime/varyParams.
+        const shellIsPartial = didLinkDataUnblockNewContent
+          ? true
+          : resultIsPartial
 
-          metadata.segmentData ??= new Map()
-          metadata.segmentData.set(
-            '/_shell',
-            Buffer.concat(
-              prependIsPartialByteToChunks(
-                collectedChunksByStage.shellStaticChunks,
-                shellIsPartial
-              )
+        metadata.segmentData ??= new Map()
+        metadata.segmentData.set(
+          '/_shell',
+          Buffer.concat(
+            prependIsPartialByteToChunks(
+              collectedChunksByStage.shellStaticChunks,
+              shellIsPartial
             )
           )
-        }
+        )
       }
 
       const clientDynamicTracking = createDynamicTrackingState(

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -123,7 +123,12 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   } else if (prefetchConfig === 'force-disabled') {
     prefetchHints |= PrefetchHint.PrefetchDisabled
   } else if (prefetchConfig === 'allow-runtime') {
-    prefetchHints |= PrefetchHint.HasRuntimePrefetch
+    // 'allow-runtime' participates in the two-phase (Shell then Speculative)
+    // prefetch flow, so it counts as Partial Prefetching. HasRuntimePrefetch
+    // additionally marks it as needing a runtime request pass.
+    prefetchHints |=
+      PrefetchHint.HasRuntimePrefetch |
+      PrefetchHint.SubtreeHasPartialPrefetching
   }
 
   // Mark the segment as "eager" unless its effective prefetch strategy is

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -916,7 +916,7 @@ export enum ValidationPrefetchKind {
   Shell = 1,
   // TODO(app-shells): validate speculative prefetches
   // Speculative = 2,
-  /** Pre-appShells behavior. */
+  /** Behavior when Partial Prefetching is not enabled. */
   LegacySpeculative = 3,
 }
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -170,7 +170,6 @@ export interface RenderOptsPartial {
     serverComponentsHmrCancellation?: boolean
     useCacheTimeout: number
     cachedNavigations: boolean | 'allow-runtime'
-    appShells: ExperimentalConfig['appShells']
 
     /**
      * The maximum size (in bytes) of the postponed state body for PPR resume

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -602,7 +602,6 @@ export default abstract class Server<
         useCacheTimeout: this.nextConfig.experimental.useCacheTimeout,
         cachedNavigations:
           this.nextConfig.experimental.cachedNavigations ?? false,
-        appShells: this.nextConfig.experimental.appShells,
         maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
           this.nextConfig.experimental.maxPostponedStateSize
         ),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -229,7 +229,6 @@ export const experimentalSchema = {
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   instrumentationClientRouterTransitionEvents: z.boolean().optional(),
-  appShells: z.boolean().optional(),
   varyParams: z.boolean().optional(),
   prefetchInlining: z
     .union([

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -512,14 +512,6 @@ export interface ExperimentalConfig {
   useOffline?: boolean
   optimisticRouting?: boolean
   instrumentationClientRouterTransitionEvents?: boolean
-  /**
-   * Enables App Shell prefetching: a route's reusable, param-free loading
-   * state is prefetched once per session and served instantly for any
-   * concrete navigation. Routes marked as fully static (no per-request
-   * server work) are unaffected; the App Shell phase only runs for
-   * runtime-prefetchable routes.
-   */
-  appShells?: boolean
   varyParams?: boolean
   prefetchInlining?:
     | boolean
@@ -2286,7 +2278,6 @@ export interface NextConfigRuntime {
     | 'dynamicOnHover'
     | 'useOffline'
     | 'optimisticRouting'
-    | 'appShells'
     | 'inlineCss'
     | 'prefetchInlining'
     | 'authInterrupts'
@@ -2356,7 +2347,6 @@ export function getNextConfigRuntime(
     dynamicOnHover: ex.dynamicOnHover,
     useOffline: ex.useOffline,
     optimisticRouting: ex.optimisticRouting,
-    appShells: ex.appShells,
     inlineCss: ex.inlineCss,
     prefetchInlining: ex.prefetchInlining,
     authInterrupts: ex.authInterrupts,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -570,35 +570,6 @@ function assignDefaultsAndValidate(
     )
   }
 
-  if (result.experimental.appShells) {
-    // App Shells is tested in combination with the experimental flags it
-    // expects to ship alongside. All of these are on track to become
-    // defaults, so we don't support enabling App Shells against arbitrary
-    // subsets of them — the validation goes away once each becomes a
-    // default.
-    // Note: `prefetchInlining` is intentionally NOT required. App Shells works
-    // correctly whether or not prefetch inlining is enabled, so disabling it
-    // (e.g. to exercise non-inlined prefetch paths) must not force App Shells off.
-    const missing: string[] = []
-    if (!result.cacheComponents) {
-      missing.push('`cacheComponents`')
-    }
-    if (!result.experimental.varyParams) {
-      missing.push('`experimental.varyParams`')
-    }
-    if (!result.experimental.optimisticRouting) {
-      missing.push('`experimental.optimisticRouting`')
-    }
-    if (!result.experimental.cachedNavigations) {
-      missing.push('`experimental.cachedNavigations`')
-    }
-    if (missing.length > 0) {
-      throw new Error(
-        `\`experimental.appShells\` requires the following to also be enabled: ${missing.join(', ')}. Please update your ${configFileName} accordingly.`
-      )
-    }
-  }
-
   if (result.experimental.ppr) {
     throw new HardDeprecatedConfigError(
       `\`experimental.ppr\` has been merged into \`cacheComponents\`. The Partial Prerendering feature is still available, but is now enabled via \`cacheComponents\`. Please update your ${configFileName} accordingly.`
@@ -2325,32 +2296,6 @@ function enforceExperimentalFeatures(
       (isDefaultConfig && !config.experimental.cachedNavigations))
   ) {
     config.experimental.cachedNavigations = true
-  }
-
-  // Enable appShells by default when cacheComponents is enabled, unless
-  // explicitly disabled. App Shells builds on Cache Components rendering, so
-  // the two features are tied together: we only flip the default for projects
-  // that are already using Cache Components. Done silently for the same reasons
-  // as the cachedNavigations default above.
-  //
-  // We only auto-enable when App Shells's required dependencies are satisfied.
-  // If a project has explicitly disabled one of them, we leave App Shells off
-  // rather than force it on — otherwise the validation in
-  // `assignDefaultsAndValidate` would turn a previously-valid config into a
-  // hard error. Users who want App Shells in that situation can still enable it
-  // explicitly and get the actionable validation message. `prefetchInlining` is
-  // intentionally not part of this gate (App Shells works without it). This runs
-  // after the cachedNavigations default above so that dependency is already set.
-  // TODO: Remove this once appShells is unconditionally the default.
-  if (
-    config.cacheComponents &&
-    config.experimental.varyParams !== false &&
-    config.experimental.optimisticRouting !== false &&
-    config.experimental.cachedNavigations !== false &&
-    (config.experimental.appShells === undefined ||
-      (isDefaultConfig && !config.experimental.appShells))
-  ) {
-    config.experimental.appShells = true
   }
 
   // appNewScrollHandler defaults to `true`. The env var lets us opt back out to

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -358,7 +358,7 @@ function createStaticPrerenderParams(
       // All params are static.
 
       const { stagedRendering } = prerenderStore
-      if (process.env.__NEXT_APP_SHELLS && stagedRendering) {
+      if (stagedRendering) {
         // Even if all params are static, we need to exclude them from the app shell
         // by delaying them to the static stage. However, root params are allowed in shells,
         // so if all the params are root params, they can be included as well.
@@ -458,8 +458,8 @@ function createRuntimePrerenderParams(
   // We don't have fallbackParams in runtime prerenders, so we don't know
   // when params are static. However, root params are static by definition,
   // so we can at least check for that.
-  // Note that resolving them without a delay is also valid in `appShells`,
-  // because root params are allowed in shells.
+  // Note that resolving them without a delay is valid because root params are
+  // allowed in shells.
   if (allParamsAreRootParams(underlyingParams, workUnitStore.rootParams)) {
     return makeUntrackedParams(userspaceParams)
   }
@@ -583,10 +583,7 @@ function createStagedRenderParamsImpl(
 
   // If we're rendering with shells, even static params must be delayed to exclude them from the shell.
   // However, root params are allowed in shells, so if all the params are root params, they can be included as well.
-  if (
-    process.env.__NEXT_APP_SHELLS &&
-    !allParamsAreRootParams(underlyingParams, workUnitStore.rootParams)
-  ) {
+  if (!allParamsAreRootParams(underlyingParams, workUnitStore.rootParams)) {
     // For a dynamic request we generally want to recover a static shell,
     // so static params can resolve in the static stage, because session
     // shells are handled with a separate render.

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -204,11 +204,6 @@ export default class ResponseCache implements ResponseCacheBase {
       routeKind: RouteKind
       isOnDemandRevalidate?: boolean
       isPrefetch?: boolean
-      /**
-       * Whether the `appShells` experimental flag is enabled. Gates the
-       * prefetch-miss-serves-fallback-shell behavior in `handleGet`.
-       */
-      appShells?: boolean
       incrementalCache: IncrementalResponseCache
       isRoutePPREnabled?: boolean
       isFallback?: boolean
@@ -270,7 +265,6 @@ export default class ResponseCache implements ResponseCacheBase {
       isFallback = false,
       isRoutePPREnabled = false,
       isPrefetch = false,
-      appShells = false,
       waitUntil,
       routeKind,
       invocationID,
@@ -288,7 +282,6 @@ export default class ResponseCache implements ResponseCacheBase {
             isFallback,
             isRoutePPREnabled,
             isPrefetch,
-            appShells,
             routeKind,
             invocationID,
           },
@@ -331,7 +324,6 @@ export default class ResponseCache implements ResponseCacheBase {
       isFallback: boolean
       isRoutePPREnabled: boolean
       isPrefetch: boolean
-      appShells: boolean
       routeKind: RouteKind
       invocationID: string | undefined
     },
@@ -381,13 +373,8 @@ export default class ResponseCache implements ResponseCacheBase {
       // wins would depend purely on request timing. Running the generator
       // directly lets every prefetch segment take the same fallback-shell path,
       // independent of any concurrent background upgrade.
-      //
-      // Gated on `appShells`: with the flag off, prefetch misses keep the
-      // previous batch-join behavior so existing suites are unaffected.
       const incrementalResponseCacheEntry =
-        context.isPrefetch &&
-        context.appShells &&
-        previousIncrementalCacheEntry === null
+        context.isPrefetch && previousIncrementalCacheEntry === null
           ? await this.handleRevalidate(
               key,
               context.incrementalCache,

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -1136,28 +1136,20 @@ export abstract class RouteModule<
     isMinimalMode: boolean
   }) {
     const responseCache = this.getResponseCache(req)
-    // The prefetch-serves-fallback-shell behavior is gated behind the
-    // `appShells` experimental flag. When it's off, Next.js Segment Cache
-    // prefetches keep the previous (non-prefetch) response-cache behavior so
-    // existing suites that incidentally depend on it are unaffected.
-    const appShells = nextConfig.experimental.appShells === true
     const cacheEntry = await responseCache.get(cacheKey, responseGenerator, {
       routeKind,
       isFallback,
       isRoutePPREnabled,
       isOnDemandRevalidate,
-      appShells,
       // A Next.js Segment Cache prefetch uses the `Next-Router-Prefetch`
       // header (surfaced as the `isPrefetchRSCRequest` request meta), not the
       // standard browser `purpose: prefetch` header. Recognize both so the
       // response cache treats segment prefetches as prefetches — most
       // importantly, so a prefetch that misses serves a fallback shell rather
-      // than joining an in-flight background (concrete) revalidation. The
-      // Next.js-prefetch arm is gated on `appShells`; with the flag off, only
-      // the standard browser prefetch header is recognized (unchanged).
+      // than joining an in-flight background (concrete) revalidation.
       isPrefetch:
         req.headers.purpose === 'prefetch' ||
-        (appShells && getRequestMeta(req, 'isPrefetchRSCRequest') === true),
+        getRequestMeta(req, 'isPrefetchRSCRequest') === true,
       // Use x-invocation-id header to scope the in-memory cache to a single
       // revalidation request in minimal mode.
       invocationID: req.headers['x-invocation-id'] as string | undefined,

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -184,10 +184,11 @@ export const enum PrefetchHint {
   // This segment has a runtime prefetch enabled (via instant with
   // prefetch: 'runtime'). Per-segment only, does not propagate to ancestors.
   HasRuntimePrefetch = 0b00001,
-  // This segment or one of its descendants opts into Partial Prefetching.
-  // Currently set when a truthy instant config is present on any
-  // segment in the subtree (regardless of prefetch mode). Propagates upward
-  // so the root segment reflects the entire subtree.
+  // This segment or one of its descendants opts into Partial Prefetching, i.e.
+  // uses the two-phase (Shell then Speculative) prefetch flow. Set when a
+  // truthy instant config is present, or `prefetch` is 'partial',
+  // 'unstable_eager', or 'allow-runtime'. Propagates upward so the root segment
+  // reflects the entire subtree.
   SubtreeHasPartialPrefetching = 0b00010,
   // This segment itself has a loading.tsx boundary.
   SegmentHasLoadingBoundary = 0b00100,

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/next.config.js
@@ -9,10 +9,6 @@ const nextConfig = {
   // shell.
   partialPrefetching: true,
   experimental: {
-    // App Shells must be enabled for the shell restriction to apply — with it
-    // off, every prefetch implicitly includes the speculative (non-shell) part
-    // of the target, so there is nothing to restrict.
-    appShells: true,
     // Enable the testing API in production builds for these tests.
     exposeTestingApiInProductionBuild: true,
     prefetchInlining: false,

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/root-params/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/root-params/next.config.js
@@ -4,9 +4,6 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    // TODO(appShells): migrate this test to the two-phase (app shell +
-    // per-page data) prefetch behavior, then remove this override. See #94516.
-    appShells: false,
     exposeTestingApiInProductionBuild: true,
     prefetchInlining: false,
   },

--- a/test/e2e/app-dir/parallel-route-navigations/next.config.js
+++ b/test/e2e/app-dir/parallel-route-navigations/next.config.js
@@ -1,12 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    // TODO(appShells): migrate this test to the two-phase (app shell +
-    // per-page data) prefetch behavior, then remove this override. See #94516.
-    appShells: false,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-global-eager/next.config.ts
@@ -11,7 +11,6 @@ const nextConfig: NextConfig = {
     prefetchInlining: true,
     optimisticRouting: true,
     cachedNavigations: true,
-    appShells: true,
     varyParams: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/static-posts/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/static-posts/[id]/page.tsx
@@ -2,6 +2,11 @@ import { Suspense } from 'react'
 
 type Params = { id: string }
 
+// Opt into Partial Prefetching so the fully-static route participates in the
+// App Shell flow: its shell prefix is extracted and cached at the Fallback
+// vary path, reusable for any param.
+export const prefetch = 'partial'
+
 // This page is fully static: no cookies, no `connection()`, no other dynamic
 // data. All params are statically known via `generateStaticParams`, so the
 // page is prerendered for every URL at build time. With default prefetch

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/static-short-stale/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/static-short-stale/[id]/page.tsx
@@ -3,6 +3,11 @@ import { cacheLife } from 'next/cache'
 
 type Params = { id: string }
 
+// Opt into Partial Prefetching so the fully-static route participates in the
+// App Shell flow: its shell prefix is extracted and cached at the Fallback
+// vary path, reusable for any param.
+export const prefetch = 'partial'
+
 // This page is fully static: all params are statically known via
 // `generateStaticParams`, so the page is prerendered for every URL at build
 // time. It mixes cached content with different stale times. Cached content

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/with-root-param/[lang]/static-posts/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/with-root-param/[lang]/static-posts/[id]/page.tsx
@@ -3,6 +3,11 @@ import { Suspense } from 'react'
 
 type Params = { id: string }
 
+// Opt into Partial Prefetching so the fully-static route participates in the
+// App Shell flow: its shell prefix is extracted and cached at the Fallback
+// vary path, reusable for any param.
+export const prefetch = 'partial'
+
 // This page is fully static: no cookies, no `connection()`, no other dynamic
 // data. All params are statically known via `generateStaticParams`, so the
 // page is prerendered for every URL at build time. With default prefetch

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/next.config.ts
@@ -6,7 +6,6 @@ const nextConfig: NextConfig = {
     prefetchInlining: true,
     optimisticRouting: true,
     cachedNavigations: true,
-    appShells: true,
     varyParams: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -253,21 +253,16 @@ describe('App Shell prefetching', () => {
     })
     const act = createRouterAct(page, { includeAppShellRequests: true })
 
-    // Reveal the LinkAccordion for /static-posts/1. Two prefetch responses
-    // fire: one for the per-segment static prefetch of /static-posts/1
-    // (which contains the resolved page content + the shell above the
-    // params boundary), and one for the runtime shell prefetch (which the
-    // server may return either as a truncated shell or as the full
-    // prerender that the client extracts a shell prefix from). Both
-    // responses contain the "App shell for static posts" substring.
+    // Reveal the LinkAccordion for /static-posts/1. The route is fully static
+    // and doesn't opt into Partial Prefetching, so there's no separate runtime
+    // shell prefetch — a single per-segment static prefetch fires, carrying the
+    // resolved page content plus the shell prefix above the params boundary
+    // (with a byte offset the client uses to extract and cache the shell).
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/static-posts/1"]')
         .click()
-    }, [
-      { includes: 'App shell for static posts' },
-      { includes: 'App shell for static posts' },
-    ])
+    }, [{ includes: 'App shell for static posts' }])
 
     // Click the link to /static-posts/124 — a different param than what
     // was prefetched, rendered with prefetch={false}. The cached App
@@ -363,16 +358,14 @@ describe('App Shell prefetching', () => {
     const act = createRouterAct(page, { includeAppShellRequests: true })
 
     // Reveal the LinkAccordion for /static-short-stale/1. Like the
-    // static-posts route, two prefetch responses fire: the per-segment static
-    // prefetch of /static-short-stale/1 and the runtime shell prefetch.
+    // static-posts route, it's fully static and opts into Partial Prefetching,
+    // so a single per-segment static prefetch fires, carrying the shell prefix
+    // that the client extracts and caches at the Fallback vary path.
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/static-short-stale/1"]')
         .click()
-    }, [
-      { includes: 'App shell for static short-stale posts' },
-      { includes: 'App shell for static short-stale posts' },
-    ])
+    }, [{ includes: 'App shell for static short-stale posts' }])
 
     await act(async () => {
       // Click the link to /static-short-stale/124 — a different param than
@@ -484,23 +477,18 @@ describe('App Shell prefetching', () => {
       })
       const act = createRouterAct(page, { includeAppShellRequests: true })
 
-      // Reveal the LinkAccordion for /with-root-param/en/static-posts/1. Two prefetch responses
-      // fire: one for the per-segment static prefetch of /with-root-param/en/static-posts/1
-      // (which contains the resolved page content + the shell above the
-      // params boundary), and one for the runtime shell prefetch (which the
-      // server may return either as a truncated shell or as the full
-      // prerender that the client extracts a shell prefix from). Both
-      // responses contain the "App shell for static posts" substring.
+      // Reveal the LinkAccordion for /with-root-param/en/static-posts/1. The
+      // route is fully static and opts into Partial Prefetching, so a single
+      // per-segment static prefetch fires, carrying the resolved page content
+      // plus the shell prefix above the params boundary (which the client
+      // extracts and caches at the Fallback vary path).
       await act(async () => {
         await browser
           .elementByCss(
             'input[data-link-accordion="/with-root-param/en/static-posts/1"]'
           )
           .click()
-      }, [
-        { includes: 'App shell for static posts with root param: en' },
-        { includes: 'App shell for static posts with root param: en' },
-      ])
+      }, [{ includes: 'App shell for static posts with root param: en' }])
 
       // Click the link to /with-root-param/en/static-posts/124 — a different param than what
       // was prefetched, rendered with prefetch={false}. The cached App
@@ -743,23 +731,18 @@ describe('App Shell prefetching', () => {
       })
       const act = createRouterAct(page, { includeAppShellRequests: true })
 
-      // Reveal the LinkAccordion for /with-root-param/en/static-posts/1. Two prefetch responses
-      // fire: one for the per-segment static prefetch of /with-root-param/en/static-posts/1
-      // (which contains the resolved page content + the shell above the
-      // params boundary), and one for the runtime shell prefetch (which the
-      // server may return either as a truncated shell or as the full
-      // prerender that the client extracts a shell prefix from). Both
-      // responses contain the "App shell for static posts" substring.
+      // Reveal the LinkAccordion for /with-root-param/en/static-posts/1. The
+      // route is fully static and opts into Partial Prefetching, so a single
+      // per-segment static prefetch fires, carrying the resolved page content
+      // plus the shell prefix above the params boundary (which the client
+      // extracts and caches at the Fallback vary path).
       await act(async () => {
         await browser
           .elementByCss(
             'input[data-link-accordion="/with-root-param/en/static-posts/1"]'
           )
           .click()
-      }, [
-        { includes: 'App shell for static posts with root param: en' },
-        { includes: 'App shell for static posts with root param: en' },
-      ])
+      }, [{ includes: 'App shell for static posts with root param: en' }])
 
       await act(async () => {
         const startingUrl = await browser.url()

--- a/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/next.config.ts
@@ -3,9 +3,6 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
-    // `appShells` gates the prefetch-serves-fallback-shell behavior that this
-    // suite exercises. It requires the following flags to also be enabled.
-    appShells: true,
     prefetchInlining: true,
     varyParams: true,
     optimisticRouting: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/page.tsx
@@ -8,29 +8,47 @@ export default async function Page() {
       <h2>thrown errors</h2>
       <ul>
         <li>
-          <DebugLinkAccordion href="/errors/error-after-cookies" />
+          <DebugLinkAccordion href="/errors/error-after-cookies" prefetch />
         </li>
       </ul>
 
       <h2>sync IO</h2>
       <ul>
         <li>
-          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/cookies" />
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/cookies"
+            prefetch
+          />
         </li>
         <li>
-          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/headers" />
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/headers"
+            prefetch
+          />
         </li>
         <li>
-          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/dynamic-params/123" />
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/dynamic-params/123"
+            prefetch
+          />
         </li>
         <li>
-          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/search-params?foo=bar" />
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/search-params?foo=bar"
+            prefetch
+          />
         </li>
         <li>
-          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/private-cache" />
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/private-cache"
+            prefetch
+          />
         </li>
         <li>
-          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/quickly-expiring-public-cache" />
+          <DebugLinkAccordion
+            href="/errors/sync-io-after-runtime-api/quickly-expiring-public-cache"
+            prefetch
+          />
         </li>
       </ul>
     </main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
@@ -11,7 +11,7 @@ export default async function Page() {
           cookies + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-page/cookies" />
+              <DebugLinkAccordion href="/in-page/cookies" prefetch />
             </li>
           </ul>
         </li>
@@ -20,7 +20,7 @@ export default async function Page() {
           headers + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-page/headers" />
+              <DebugLinkAccordion href="/in-page/headers" prefetch />
             </li>
           </ul>
         </li>
@@ -29,10 +29,16 @@ export default async function Page() {
           search params + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-page/search-params?searchParam=123" />
+              <DebugLinkAccordion
+                href="/in-page/search-params?searchParam=123"
+                prefetch
+              />
             </li>
             <li>
-              <DebugLinkAccordion href="/in-page/search-params?searchParam=456" />
+              <DebugLinkAccordion
+                href="/in-page/search-params?searchParam=456"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -40,10 +46,10 @@ export default async function Page() {
           dynamic params + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-page/dynamic-params/123" />
+              <DebugLinkAccordion href="/in-page/dynamic-params/123" prefetch />
             </li>
             <li>
-              <DebugLinkAccordion href="/in-page/dynamic-params/456" />
+              <DebugLinkAccordion href="/in-page/dynamic-params/456" prefetch />
             </li>
           </ul>
         </li>
@@ -51,7 +57,7 @@ export default async function Page() {
           only cookies
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-page/cookies-only" />
+              <DebugLinkAccordion href="/in-page/cookies-only" prefetch />
             </li>
           </ul>
         </li>
@@ -65,7 +71,7 @@ export default async function Page() {
           cookies in private cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/cookies" />
+              <DebugLinkAccordion href="/in-private-cache/cookies" prefetch />
             </li>
           </ul>
         </li>
@@ -73,7 +79,7 @@ export default async function Page() {
           headers in private cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/headers" />
+              <DebugLinkAccordion href="/in-private-cache/headers" prefetch />
             </li>
           </ul>
         </li>
@@ -81,10 +87,16 @@ export default async function Page() {
           dynamic params in private cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/dynamic-params/123" />
+              <DebugLinkAccordion
+                href="/in-private-cache/dynamic-params/123"
+                prefetch
+              />
             </li>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/dynamic-params/456" />
+              <DebugLinkAccordion
+                href="/in-private-cache/dynamic-params/456"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -92,10 +104,16 @@ export default async function Page() {
           search params in private cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/search-params?searchParam=123" />
+              <DebugLinkAccordion
+                href="/in-private-cache/search-params?searchParam=123"
+                prefetch
+              />
             </li>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/search-params?searchParam=456" />
+              <DebugLinkAccordion
+                href="/in-private-cache/search-params?searchParam=456"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -103,7 +121,10 @@ export default async function Page() {
           only cookies in private cache
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/cookies-only" />
+              <DebugLinkAccordion
+                href="/in-private-cache/cookies-only"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -111,7 +132,7 @@ export default async function Page() {
           Date.now() in private cache
           <ul>
             <li>
-              <DebugLinkAccordion href="/in-private-cache/date-now" />
+              <DebugLinkAccordion href="/in-private-cache/date-now" prefetch />
             </li>
           </ul>
         </li>
@@ -125,7 +146,10 @@ export default async function Page() {
           cookies() promise passed to public cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/passed-to-public-cache/cookies" />
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/cookies"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -133,7 +157,10 @@ export default async function Page() {
           headers() promise passed to public cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/passed-to-public-cache/headers" />
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/headers"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -141,10 +168,16 @@ export default async function Page() {
           dynamic params promise passed to public cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/passed-to-public-cache/dynamic-params/123" />
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/dynamic-params/123"
+                prefetch
+              />
             </li>
             <li>
-              <DebugLinkAccordion href="/passed-to-public-cache/dynamic-params/456" />
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/dynamic-params/456"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -152,10 +185,16 @@ export default async function Page() {
           search params promise passed to public cache + dynamic content
           <ul>
             <li>
-              <DebugLinkAccordion href="/passed-to-public-cache/search-params?searchParam=123" />
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/search-params?searchParam=123"
+                prefetch
+              />
             </li>
             <li>
-              <DebugLinkAccordion href="/passed-to-public-cache/search-params?searchParam=456" />
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/search-params?searchParam=456"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -163,7 +202,10 @@ export default async function Page() {
           only cookies passed to public cache (no dynamic content)
           <ul>
             <li>
-              <DebugLinkAccordion href="/passed-to-public-cache/cookies-only" />
+              <DebugLinkAccordion
+                href="/passed-to-public-cache/cookies-only"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -175,7 +217,7 @@ export default async function Page() {
           private, short stale
           <ul>
             <li>
-              <DebugLinkAccordion href="/caches/private-short-stale" />
+              <DebugLinkAccordion href="/caches/private-short-stale" prefetch />
             </li>
           </ul>
         </li>
@@ -183,7 +225,10 @@ export default async function Page() {
           public, short expire, long enough stale
           <ul>
             <li>
-              <DebugLinkAccordion href="/caches/public-short-expire-long-stale" />
+              <DebugLinkAccordion
+                href="/caches/public-short-expire-long-stale"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -191,7 +236,10 @@ export default async function Page() {
           public, short expire, short stale
           <ul>
             <li>
-              <DebugLinkAccordion href="/caches/public-short-expire-short-stale" />
+              <DebugLinkAccordion
+                href="/caches/public-short-expire-short-stale"
+                prefetch
+              />
             </li>
           </ul>
         </li>
@@ -199,7 +247,7 @@ export default async function Page() {
           public, cacheLife("seconds")
           <ul>
             <li>
-              <DebugLinkAccordion href="/caches/public-seconds" />
+              <DebugLinkAccordion href="/caches/public-seconds" prefetch />
             </li>
           </ul>
         </li>
@@ -207,7 +255,7 @@ export default async function Page() {
           private, cacheLife("seconds")
           <ul>
             <li>
-              <DebugLinkAccordion href="/caches/private-seconds" />
+              <DebugLinkAccordion href="/caches/private-seconds" prefetch />
             </li>
           </ul>
         </li>
@@ -216,7 +264,7 @@ export default async function Page() {
       <h2>misc</h2>
       <ul>
         <li>
-          <DebugLinkAccordion href="/fully-static" />
+          <DebugLinkAccordion href="/fully-static" prefetch />
         </li>
       </ul>
     </main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/page.tsx
@@ -16,11 +16,13 @@ export default async function Page() {
             <li>
               <DebugLinkAccordion
                 href={`/with-root-param/${currentLang}/in-page/root-params`}
+                prefetch
               />
             </li>
             <li>
               <DebugLinkAccordion
                 href={`/with-root-param/${otherLang}/in-page/root-params`}
+                prefetch
               />
             </li>
           </ul>
@@ -37,11 +39,13 @@ export default async function Page() {
             <li>
               <DebugLinkAccordion
                 href={`/with-root-param/${currentLang}/in-private-cache/root-params`}
+                prefetch
               />
             </li>
             <li>
               <DebugLinkAccordion
                 href={`/with-root-param/${otherLang}/in-private-cache/root-params`}
+                prefetch
               />
             </li>
           </ul>
@@ -58,11 +62,13 @@ export default async function Page() {
             <li>
               <DebugLinkAccordion
                 href={`/with-root-param/${currentLang}/passed-to-public-cache/root-params`}
+                prefetch
               />
             </li>
             <li>
               <DebugLinkAccordion
                 href={`/with-root-param/${otherLang}/passed-to-public-cache/root-params`}
+                prefetch
               />
             </li>
           </ul>

--- a/test/e2e/app-dir/segment-cache/search-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/search-params/next.config.js
@@ -4,9 +4,6 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    // TODO(appShells): migrate this test to the two-phase (app shell +
-    // per-page data) prefetch behavior, then remove this override. See #94516.
-    appShells: false,
     // TODO: This test asserts on the pre-`optimisticRouting` prefetch and
     // search-param-rewrite behavior. Pin the fixture to the old default
     // until the test is updated (or until the flag is removed).

--- a/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
@@ -21,12 +21,12 @@ export default function Page() {
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-stale-2-minutes">
+          <LinkAccordion href="/runtime-stale-2-minutes" prefetch>
             Page whose runtime prefetch has a stale time of 2 minutes
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-stale-4-minutes">
+          <LinkAccordion href="/runtime-stale-4-minutes" prefetch>
             Page whose runtime prefetch has a stale time of 4 minutes
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/staleness/next.config.js
+++ b/test/e2e/app-dir/segment-cache/staleness/next.config.js
@@ -4,11 +4,6 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    // The "runtime prefetch" stale-time test relies on a runtime prefetch
-    // firing when a link is revealed. App Shells defers a non-eager route's
-    // dynamic content to navigation rather than prefetching it speculatively,
-    // so keep App Shells off here to exercise runtime-prefetch staleness.
-    appShells: false,
     staleTimes: {
       dynamic: 30,
     },

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/page.tsx
@@ -6,17 +6,26 @@ export default function RuntimePrefetchAllVaryIndexPage() {
       <h1>Runtime Prefetch - All Params in Static Portion</h1>
       <ul>
         <li>
-          <LinkAccordion href="/runtime-prefetch-all-vary/electronics/phone">
+          <LinkAccordion
+            href="/runtime-prefetch-all-vary/electronics/phone"
+            prefetch
+          >
             Electronics: Phone
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-all-vary/electronics/tablet">
+          <LinkAccordion
+            href="/runtime-prefetch-all-vary/electronics/tablet"
+            prefetch
+          >
             Electronics: Tablet
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-all-vary/clothing/shirt">
+          <LinkAccordion
+            href="/runtime-prefetch-all-vary/clothing/shirt"
+            prefetch
+          >
             Clothing: Shirt
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/page.tsx
@@ -6,17 +6,26 @@ export default function RuntimePrefetchLayoutSplitIndexPage() {
       <h1>Runtime Prefetch - Layout/Page Param Split</h1>
       <ul>
         <li>
-          <LinkAccordion href="/runtime-prefetch-layout-split/electronics/phone">
+          <LinkAccordion
+            href="/runtime-prefetch-layout-split/electronics/phone"
+            prefetch
+          >
             Electronics: Phone
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-layout-split/electronics/tablet">
+          <LinkAccordion
+            href="/runtime-prefetch-layout-split/electronics/tablet"
+            prefetch
+          >
             Electronics: Tablet
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-layout-split/clothing/shirt">
+          <LinkAccordion
+            href="/runtime-prefetch-layout-split/clothing/shirt"
+            prefetch
+          >
             Clothing: Shirt
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/page.tsx
@@ -6,12 +6,12 @@ export default function RuntimePrefetchMetadataIndexPage() {
       <h1>Runtime Prefetch - Metadata Param Access</h1>
       <ul>
         <li>
-          <LinkAccordion href="/runtime-prefetch-metadata/aaa">
+          <LinkAccordion href="/runtime-prefetch-metadata/aaa" prefetch>
             Slug: aaa
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-metadata/bbb">
+          <LinkAccordion href="/runtime-prefetch-metadata/bbb" prefetch>
             Slug: bbb
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/page.tsx
@@ -6,17 +6,26 @@ export default function RuntimePrefetchNoVaryIndexPage() {
       <h1>Runtime Prefetch - No Params in Static Portion</h1>
       <ul>
         <li>
-          <LinkAccordion href="/runtime-prefetch-no-vary/electronics/phone">
+          <LinkAccordion
+            href="/runtime-prefetch-no-vary/electronics/phone"
+            prefetch
+          >
             Electronics: Phone
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-no-vary/electronics/tablet">
+          <LinkAccordion
+            href="/runtime-prefetch-no-vary/electronics/tablet"
+            prefetch
+          >
             Electronics: Tablet
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-no-vary/clothing/shirt">
+          <LinkAccordion
+            href="/runtime-prefetch-no-vary/clothing/shirt"
+            prefetch
+          >
             Clothing: Shirt
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/page.tsx
@@ -6,17 +6,26 @@ export default function RuntimePrefetchSearchParamsIndexPage() {
       <h1>Runtime Prefetch - SearchParams Not Accessed</h1>
       <ul>
         <li>
-          <LinkAccordion href="/runtime-prefetch-search-params/target-page?q=1">
+          <LinkAccordion
+            href="/runtime-prefetch-search-params/target-page?q=1"
+            prefetch
+          >
             Target q=1
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-search-params/target-page?q=2">
+          <LinkAccordion
+            href="/runtime-prefetch-search-params/target-page?q=2"
+            prefetch
+          >
             Target q=2
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch-search-params/target-page?q=3">
+          <LinkAccordion
+            href="/runtime-prefetch-search-params/target-page?q=3"
+            prefetch
+          >
             Target q=3
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/page.tsx
@@ -30,27 +30,30 @@ export default function RuntimePrefetchIndexPage() {
       </p>
       <ul>
         <li>
-          <LinkAccordion href="/runtime-prefetch/electronics/phone">
+          <LinkAccordion href="/runtime-prefetch/electronics/phone" prefetch>
             Electronics: Phone
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch/electronics/tablet">
+          <LinkAccordion href="/runtime-prefetch/electronics/tablet" prefetch>
             Electronics: Tablet
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch/electronics/laptop">
+          <LinkAccordion href="/runtime-prefetch/electronics/laptop" prefetch>
             Electronics: Laptop
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch/electronics/headphones">
+          <LinkAccordion
+            href="/runtime-prefetch/electronics/headphones"
+            prefetch
+          >
             Electronics: Headphones
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-prefetch/clothing/shirt">
+          <LinkAccordion href="/runtime-prefetch/clothing/shirt" prefetch>
             Clothing: Shirt
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/page.tsx
@@ -28,22 +28,22 @@ export default function SearchParamsIndexPage() {
       <h2>Target (accesses searchParams)</h2>
       <ul>
         <li>
-          <LinkAccordion href="/search-params/target-page">
+          <LinkAccordion href="/search-params/target-page" prefetch>
             Target with no search params
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/search-params/target-page?foo=1">
+          <LinkAccordion href="/search-params/target-page?foo=1" prefetch>
             Target with foo=1
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/search-params/target-page?foo=2">
+          <LinkAccordion href="/search-params/target-page?foo=2" prefetch>
             Target with foo=2
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/search-params/target-page?foo=3">
+          <LinkAccordion href="/search-params/target-page?foo=3" prefetch>
             Target with foo=3
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/vary-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params/next.config.js
@@ -4,12 +4,6 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    // These tests assert on per-link/runtime prefetch responses to verify
-    // varyParams cache-key behavior. App Shells skips the per-link Speculative
-    // prefetch for non-eager routes (deferring param-dependent content to
-    // navigation), which makes that behavior unobservable via prefetch. Keep
-    // App Shells off here so the varyParams feature is exercised in isolation.
-    appShells: false,
     optimisticRouting: true,
     prefetchInlining: false,
     varyParams: true,

--- a/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
@@ -3,9 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    // TODO(appShells): migrate this test to the two-phase (app shell +
-    // per-page data) prefetch behavior, then remove this override. See #94516.
-    appShells: false,
     prefetchInlining: false,
     useCache: true,
   },

--- a/test/production/app-dir/use-cache-non-deterministic-args/app/[slug]/page.tsx
+++ b/test/production/app-dir/use-cache-non-deterministic-args/app/[slug]/page.tsx
@@ -3,6 +3,11 @@ import { Suspense, cacheSignal } from 'react'
 import { setTimeout } from 'timers/promises'
 import { cookies } from 'next/headers'
 
+// `allow-runtime` opts the route into Partial Prefetching (the two-phase Shell
+// then Speculative flow) and marks it as needing a runtime request pass. A full
+// prefetch (the Link below uses prefetch={true}) resolves the params-dependent
+// content via a per-request runtime prefetch (PPRRuntime), which is what
+// exercises the non-deterministic cache args during a runtime prefetch.
 export const prefetch = 'allow-runtime'
 
 const callCounts = new Map<string, number>()
@@ -67,7 +72,14 @@ export default async function Page({
   const { slug } = await params
 
   if (slug === 'with-runtime-prefetch') {
-    return <Link href="/known">Go to runtime-prefetchable page</Link>
+    // Use a full prefetch so the per-request runtime prefetch (PPRRuntime)
+    // fires during the Speculative phase. An auto prefetch of an allow-runtime
+    // route only warms the reusable shell (RuntimeShell) instead.
+    return (
+      <Link href="/known" prefetch={true}>
+        Go to runtime-prefetchable page
+      </Link>
+    )
   }
 
   return (

--- a/test/production/app-dir/use-cache-non-deterministic-args/next.config.ts
+++ b/test/production/app-dir/use-cache-non-deterministic-args/next.config.ts
@@ -1,12 +1,6 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  experimental: {
-    // TODO(appShells): migrate this test to the two-phase (app shell +
-    // per-page data) prefetch behavior, then remove this override. See #94516.
-    appShells: false,
-  },
-
   cacheComponents: true,
 }
 


### PR DESCRIPTION
The experimental `appShells` flag was added while the feature was being developed. It was not meant to be a public-facing flag.

Some of the behavior that was gated behind the `appShells` flag is purely an optimization and can be landed without any gate.

There are also some behaviors that we don't want to turn on unless you've opted into the new prefetching model via Partial Prefetching. Arguably these too are internal optimizations, but because they can change the number of requests that are made to the server (e.g. one request for the shell, another for the page data), we will gate these behind Partial Prefetching to minimize the impact on existing applications.

The result is that until you opt into Partial Prefetching, you should not see any meaningfully detrimental impact to prefetching costs, regardless of how your app is structured.
