### PR TITLE
docs: document Redis cache example env vars

### DIFF
--- a/examples/cache-handler-redis/.env.local.example
+++ b/examples/cache-handler-redis/.env.local.example
@@ -1,0 +1,2 @@
+REDIS_URL=redis://localhost:6379
+REDIS_INSIGHT_URL=http://localhost:8001

--- a/examples/cache-handler-redis/README.md
+++ b/examples/cache-handler-redis/README.md
@@ -26,6 +26,17 @@ Once you have installed the dependencies, you can begin running the example Redi
 docker compose up -d
 ```
 
+Copy the local environment example:
+
+```bash
+cp .env.local.example .env.local
+```
+
+The default values point to the Redis Stack server from `compose.yaml`:
+
+- `REDIS_URL`: The Redis connection URL used by the cache handler.
+- `REDIS_INSIGHT_URL`: The RedisInsight URL linked from the example UI.
+
 Then, build and start the Next.js app as usual.
 
 To see the cache logs use NEXT_PRIVATE_DEBUG_CACHE=1 [troubleshooting](https://caching-tools.github.io/next-shared-cache/troubleshooting)


### PR DESCRIPTION
## Summary

Add a `.env.local.example` file for the `cache-handler-redis` example and document the Redis-related environment variables used by the cache handler and RedisInsight link. The defaults match the ports exposed by the example `compose.yaml`.

## Verification

- `rg -n --hidden "REDIS_URL|REDIS_INSIGHT_URL|NEXT_PUBLIC_REDIS_INSIGHT_URL|\.env.local.example" examples/cache-handler-redis`
- `git diff --check`
- Not run: full example runtime (`cache-handler-redis` requires running Redis Stack with Docker)

<!-- NEXT_JS_LLM_PR -->