### PR TITLE
examples: remove stale GraphCMS env log

### DIFF
--- a/examples/cms-graphcms/lib/graphcms.js
+++ b/examples/cms-graphcms/lib/graphcms.js
@@ -17,7 +17,6 @@ async function fetchAPI(query, { variables, preview } = {}) {
   const json = await res.json();
 
   if (json.errors) {
-    console.log(process.env.NEXT_EXAMPLE_CMS_GCMS_PROJECT_ID);
     console.error(json.errors);
     throw new Error("Failed to fetch API");
   }


### PR DESCRIPTION
## Summary

Remove a stale debug log from the `cms-graphcms` example that printed `process.env.NEXT_EXAMPLE_CMS_GCMS_PROJECT_ID` when GraphCMS returned errors. That variable is not configured by the example, so the log only emitted `undefined`; the actual GraphCMS errors are still logged.

## Verification

- `rg -n "NEXT_EXAMPLE_CMS_GCMS_PROJECT_ID|console\.error\(json\.errors\)" examples/cms-graphcms/lib/graphcms.js examples/cms-graphcms/README.md examples/cms-graphcms/.env.local.example`
- `git diff --check`
- Not run: full example runtime (`cms-graphcms` requires GraphCMS credentials)

<!-- NEXT_JS_LLM_PR -->