### PR TITLE
examples: fix Payload video media URL env

### DIFF
--- a/examples/cms-payload/components/Media/Video/index.tsx
+++ b/examples/cms-payload/components/Media/Video/index.tsx
@@ -31,7 +31,7 @@ export const Video: React.FC<Props> = (props) => {
         onClick={onClick}
         ref={videoRef}
       >
-        <source src={`${process.env.NEXT_PUBLIC_API_URL}/media/${filename}`} />
+        <source src={`${process.env.NEXT_PUBLIC_APP_URL}/media/${filename}`} />
       </video>
     );
   }


### PR DESCRIPTION
## Summary

Update the `cms-payload` video media component to use `NEXT_PUBLIC_APP_URL`, matching the existing `.env.example`. The previous `NEXT_PUBLIC_API_URL` variable was not documented or provided by the example, so video media URLs could be built with an undefined base URL.

## Verification

- `rg -n "NEXT_PUBLIC_API_URL|NEXT_PUBLIC_APP_URL" examples/cms-payload/components/Media/Video/index.tsx examples/cms-payload/.env.example examples/cms-payload/README.md`
- `git diff --check`
- Not run: full example runtime (`cms-payload` requires MongoDB and optional S3 setup)

<!-- NEXT_JS_LLM_PR -->