### PR TITLE
Rename ErrorFallback to CustomErrorBoundary

### DIFF
--- a/docs/01-app/01-getting-started/10-error-handling.mdx
+++ b/docs/01-app/01-getting-started/10-error-handling.mdx
@@ -285,7 +285,7 @@ For component-level error recovery, the [`catchError`](/docs/app/api-reference/f
 
 import { catchError, type ErrorInfo } from 'next/error'
 
-function ErrorFallback(props: { title: string }, { error, retry }: ErrorInfo) {
+function CustomErrorBoundary(props: { title: string }, { error, retry }: ErrorInfo) {
   return (
     <div>
       <h2>{props.title}</h2>
@@ -295,7 +295,7 @@ function ErrorFallback(props: { title: string }, { error, retry }: ErrorInfo) {
   )
 }
 
-export default catchError(ErrorFallback)
+export default catchError(CustomErrorBoundary)
 ```
 
 ```jsx filename="app/custom-error-boundary.js" switcher
@@ -303,7 +303,7 @@ export default catchError(ErrorFallback)
 
 import { catchError } from 'next/error'
 
-function ErrorFallback(props, { error, retry }) {
+function CustomErrorBoundary(props, { error, retry }) {
   return (
     <div>
       <h2>{props.title}</h2>
@@ -313,24 +313,24 @@ function ErrorFallback(props, { error, retry }) {
   )
 }
 
-export default catchError(ErrorFallback)
+export default catchError(CustomErrorBoundary)
 ```
 
 Then use the returned component as a wrapper in any layout or page:
 
 ```tsx filename="app/some-component.tsx" switcher
-import ErrorBoundary from './custom-error-boundary'
+import CustomErrorBoundary from './custom-error-boundary'
 
 export default function Component({ children }: { children: React.ReactNode }) {
-  return <ErrorBoundary title="Dashboard Error">{children}</ErrorBoundary>
+  return <CustomErrorBoundary title="Dashboard Error">{children}</CustomErrorBoundary>
 }
 ```
 
 ```jsx filename="app/some-component.js" switcher
-import ErrorBoundary from './custom-error-boundary'
+import CustomErrorBoundary from './custom-error-boundary'
 
 export default function Component({ children }) {
-  return <ErrorBoundary title="Dashboard Error">{children}</ErrorBoundary>
+  return <CustomErrorBoundary title="Dashboard Error">{children}</CustomErrorBoundary>
 }
 ```
 


### PR DESCRIPTION
## For Contributors
### Improving Documentation
- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### What?

Renames the example component in the "Handling uncaught exceptions" section of the Error Handling doc (`app/getting-started/error-handling.mdx`) from `ErrorFallback` to `CustomErrorBoundary` for consistency.

### Why?

The component passed to `unstable_catchError` is defined as `ErrorFallback`, but immediately imported and used under a different name, `ErrorBoundary`, in the following example:

```tsx
export default catchError(ErrorFallback)
```
```tsx
import ErrorBoundary from './custom-error-boundary'
```

While this is valid code since the default export can be imported under any local name, but having two different names for the same component in adjacent code samples is confusing for readers trying to follow the example, especially since the file is named `custom-error-boundary.tsx`. This PR uses one consistent name, `CustomErrorBoundary`, matching the filename, throughout both the definition and usage examples.

### How?

Renamed `ErrorFallback` → `CustomErrorBoundary` in both the `.tsx` and `.jsx` code blocks, and updated the import/usage in the following `some-component` examples to match. No behavioral or API changes.

Closes NEXT-
Fixes #