### PR TITLE
Update documentation for the Image component

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -39,8 +39,8 @@ The following props are available:
 | ----------------------------------------- | ---------------------------------------- | --------------- | ---------- |
 | [`src`](#src)                             | `src="/profile.png"`                     | String          | Required   |
 | [`alt`](#alt)                             | `alt="Picture of the author"`            | String          | Required   |
-| [`width`](#width-and-height)                         | `width={500}`                            | Integer (px)    | -   |
-| [`height`](#width-and-height)                       | `height={500}`                           | Integer (px)    | -   |
+| [`width`](#width-and-height)                         | `width={500}`                            | Integer (px)    | Required   |
+| [`height`](#width-and-height)                       | `height={500}`                           | Integer (px)    | Required   |
 | [`fill`](#fill)                           | `fill={true}`                            | Boolean         | -          |
 | [`loader`](#loader)                       | `loader={imageLoader}`                   | Function        | -          |
 | [`sizes`](#sizes)                         | `sizes="(max-width: 768px) 100vw, 33vw"` | String          | -          |


### PR DESCRIPTION
### What?
Updates the document of the Image component

### Why?
In the stable version at the time of writing 16.2.10, the width and height properties are required. This is not reflected in the documentation.

### How?
Updated the markdown to indicate that the width and height properties are still required.

Closes NEXT-
Fixes #

