### PR TITLE
[ci] Disable mid-stack PR optimization for native PR stacks

### DIFF
--- a/.github/workflows/pr_stack_optimizer.yml
+++ b/.github/workflows/pr_stack_optimizer.yml
@@ -56,10 +56,12 @@ jobs:
       #
       # We skip if either Graphite's optimizer says to skip, or the PR is a mid-stack PR in a
       # GitHub native stack. The bypass label overrides both.
-      skip: |-
-        ${{ env.HAS_BYPASS_LABEL == 'false' && (
-          steps.check-skip.outputs.skip == 'true' || env.IS_MID_STACK_NATIVE == 'true'
-        ) }}
+      skip: ${{ env.HAS_BYPASS_LABEL == 'false' && steps.check-skip.outputs.skip == 'true' }}
+      # Note: IS_MID_STACK_NATIVE is disabled for now because it doesn't
+      # understand if we're not on the bottom of the stack, but all the PRs
+      # below us are merged.
+      # <https://vercel.slack.com/archives/C04KC8A53T7/p1783018076576349>
+      #  || env.IS_MID_STACK_NATIVE == 'true'
     steps:
       - name: Optimize CI
         id: check-skip


### PR DESCRIPTION
https://vercel.slack.com/archives/C04KC8A53T7/p1783018076576349

<img width="1015" height="347" alt="Screenshot 2026-07-02 at 11 57 05 AM" src="https://github.com/user-attachments/assets/74d99079-d165-435a-aece-161862795ef6" />

If we're in the middle of a stack, but the PRs below us in the stack are already merged, we should not skip CI jobs. This logic isn't smart enough to handle that.