### PR TITLE
[turbopack] print Turbopack warnings after SSG

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -202,6 +202,7 @@ import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot
 import type { UseCacheTrackerKey } from './webpack/plugins/telemetry-plugin/use-cache-tracker-utils'
 
 import { turbopackBuild } from './turbopack-build'
+import { formatWarningsHeader } from './print-build-errors'
 import { inlineStaticEnv } from '../lib/inline-static-env'
 import { populateStaticEnv } from '../lib/static-env'
 import { durationToString, hrtimeDurationToString } from './duration-to-string'
@@ -947,6 +948,21 @@ export default async function build(
 
   let loadedConfig: NextConfigComplete | undefined
   let staticWorker: StaticWorker
+
+  // Turbopack compile warnings are deferred until after static generation.
+  let deferredTurbopackWarnings: string[] | undefined
+  const flushTurbopackWarnings = () => {
+    if (deferredTurbopackWarnings && deferredTurbopackWarnings.length > 0) {
+      console.warn(
+        `${formatWarningsHeader(deferredTurbopackWarnings.length)}\n${deferredTurbopackWarnings.join('\n')}`
+      )
+    }
+    deferredTurbopackWarnings = undefined
+  }
+
+  // A failing static generation worker exits the process directly (`prerenderEarlyExit`), skipping the flush points below.
+  process.once('exit', () => flushTurbopackWarnings())
+
   try {
     const nextBuildSpan = trace('next-build', undefined, {
       buildMode: experimentalBuildMode,
@@ -1639,6 +1655,7 @@ export default async function build(
           const {
             duration: compilerDuration,
             shutdownPromise: p,
+            warnings,
             ...rest
           } = await turbopackBuild(
             process.env.NEXT_TURBOPACK_USE_WORKER === undefined ||
@@ -1646,6 +1663,7 @@ export default async function build(
             telemetry
           )
           shutdownPromise = p
+          deferredTurbopackWarnings = warnings
           traceMemoryUsage('Finished build', nextBuildSpan)
 
           buildTraceContext = rest.buildTraceContext
@@ -3922,6 +3940,8 @@ export default async function build(
           .traceAsyncFn(() => writeManifest(routesManifestPath, routesManifest))
       }
 
+      flushTurbopackWarnings()
+
       const finalizingPageOptimizationStart = process.hrtime()
       const postBuildSpinner = createSpinner('Finalizing page optimization')
       let buildTracesSpinner
@@ -4326,6 +4346,9 @@ export default async function build(
     }
     // Ensure we wait for lockfile patching if present
     await lockfilePatchPromise.cur
+
+    // Backstop for builds that never reach the post-static-generation flush.
+    flushTurbopackWarnings()
 
     // Flush telemetry before finishing (waits for async operations like setTimeout in debug mode)
     const telemetry: Telemetry | undefined = traceGlobals.get('telemetry')

--- a/packages/next/src/build/print-build-errors.ts
+++ b/packages/next/src/build/print-build-errors.ts
@@ -1,19 +1,26 @@
 import { formatIssue, isRelevantWarning } from '../shared/lib/turbopack/utils'
 import type { TurbopackResult } from './swc/types'
 
+export function formatWarningsHeader(count: number): string {
+  return `Turbopack build encountered ${count} ${count === 1 ? 'warning' : 'warnings'}:`
+}
+
 /**
  * Processes and reports build issues from Turbopack entrypoints.
  *
  * @param entrypoints - The result object containing build issues to process.
  * @param isDev - A flag indicating if the build is running in development mode.
- * @return This function does not return a value but logs or throws errors based on the issues.
+ * @param opts.deferWarnings - When true, warnings are returned instead of
+ *                             printed so the caller can print them later.
+ * @return The formatted warnings when `deferWarnings` is set and nothing threw.
  * @throws {Error} If a fatal issue is encountered, this function throws an error. In development mode, we only throw on
  *                 'fatal' and 'bug' issues. In production mode, we also throw on 'error' issues.
  */
 export function printBuildErrors(
   entrypoints: TurbopackResult,
-  isDev: boolean
-): void {
+  isDev: boolean,
+  opts?: { deferWarnings?: boolean }
+): { warnings: string[] } {
   // Issues that we want to stop the server from executing
   const topLevelFatalIssues = []
   // Issues that are true errors, but we believe we can keep running and allow the user to address the issue
@@ -60,11 +67,11 @@ export function printBuildErrors(
     }
   }
   // TODO: print in order by source location so issues from the same file are displayed together and then add a summary at the end about the number of warnings/errors
-  if (topLevelWarnings.length > 0) {
+  const deferWarnings =
+    (opts?.deferWarnings ?? false) && topLevelFatalIssues.length === 0
+  if (topLevelWarnings.length > 0 && !deferWarnings) {
     console.warn(
-      `Turbopack build encountered ${
-        topLevelWarnings.length
-      } ${topLevelWarnings.length === 1 ? 'warning' : 'warnings'}:\n${topLevelWarnings.join('\n')}`
+      `${formatWarningsHeader(topLevelWarnings.length)}\n${topLevelWarnings.join('\n')}`
     )
   }
 
@@ -83,4 +90,6 @@ export function printBuildErrors(
       } ${topLevelFatalIssues.length === 1 ? 'error' : 'errors'}:\n${topLevelFatalIssues.join('\n')}`
     )
   }
+
+  return { warnings: deferWarnings ? topLevelWarnings : [] }
 }

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -39,6 +39,7 @@ export async function turbopackBuild(telemetry: Telemetry): Promise<{
   duration: number
   buildTraceContext: undefined
   shutdownPromise: Promise<void>
+  warnings: string[]
 }> {
   await validateTurboNextConfig({
     dir: NextBuildContext.dir!,
@@ -174,7 +175,11 @@ export async function turbopackBuild(telemetry: Telemetry): Promise<{
     let appDirOnly = NextBuildContext.appDirOnly!
 
     const entrypoints = await project.writeAllEntrypointsToDisk(appDirOnly)
-    printBuildErrors(entrypoints, dev)
+    // Defer warnings so the caller can print them after static generation,
+    // keeping SSG errors more prominent than compile warnings.
+    const { warnings } = printBuildErrors(entrypoints, dev, {
+      deferWarnings: true,
+    })
 
     // Skip when telemetry is fully off — featureUsage() isn't free.
     if (telemetry.isEnabled || process.env.NEXT_TELEMETRY_DEBUG) {
@@ -296,6 +301,7 @@ export async function turbopackBuild(telemetry: Telemetry): Promise<{
       duration: time[0] + time[1] / 1e9,
       buildTraceContext: undefined,
       shutdownPromise,
+      warnings,
     }
   } catch (err) {
     await project.shutdown()
@@ -347,11 +353,13 @@ export async function workerMain(workerData: {
       shutdownPromise: resultShutdownPromise,
       buildTraceContext,
       duration,
+      warnings,
     } = await turbopackBuild(telemetry)
     shutdownPromise = resultShutdownPromise
     return {
       buildTraceContext,
       duration,
+      warnings,
     }
   } finally {
     // Always flush telemetry before worker exits (waits for async operations like setTimeout in debug mode)

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -36,7 +36,7 @@ async function turbopackBuildWithWorker(): ReturnType<
       config: _config,
       ...prunedBuildContext
     } = NextBuildContext
-    const { buildTraceContext, duration } = await worker.workerMain({
+    const { buildTraceContext, duration, warnings } = await worker.workerMain({
       buildContext: prunedBuildContext,
       traceState: {
         ...exportTraceState(),
@@ -56,6 +56,7 @@ async function turbopackBuildWithWorker(): ReturnType<
       }),
       buildTraceContext,
       duration,
+      warnings,
     }
   } catch (err: any) {
     // When the error is a serialized `Error` object we need to recreate the `Error` instance

--- a/test/production/build-tracing-message/index.test.ts
+++ b/test/production/build-tracing-message/index.test.ts
@@ -15,14 +15,22 @@ import stripAnsi from 'strip-ansi'
         const { exitCode } = await next.build()
         expect(exitCode).toBe(0)
 
-        let output = next.cliOutput
+        const cliOutput = stripAnsi(next.cliOutput)
+
+        // Warnings are deferred until after static generation so that
+        // prerender errors are more prominent than compile warnings.
+        expect(
+          cliOutput.indexOf('Turbopack build encountered')
+        ).toBeGreaterThan(cliOutput.indexOf('✓ Compiled successfully'))
+
+        const output = cliOutput
           .slice(
-            next.cliOutput.indexOf('Turbopack build encountered'),
-            next.cliOutput.indexOf('✓ Compiled successfully')
+            cliOutput.indexOf('Turbopack build encountered'),
+            cliOutput.indexOf('Finalizing page optimization')
           )
           .trim()
 
-        expect(stripAnsi(output)).toMatchInlineSnapshot(`
+        expect(output).toMatchInlineSnapshot(`
        "Turbopack build encountered 1 warning:
        ./app/join-cwd.js:4:10
        Warning: Dynamic filesystem access causes tracing of the whole project
@@ -47,6 +55,84 @@ import stripAnsi from 'strip-ansi'
            ./app/join-cwd.js
            ./app/page.js"
       `)
+      })
+    })
+
+    describe('with a prerender error', () => {
+      const { next } = nextTestSetup({
+        files: __dirname,
+        skipStart: true,
+        overrideFiles: {
+          'app/boom/page.js': `export default function Page() {
+            throw new Error('boom during prerender')
+          }`,
+        },
+      })
+
+      it('should print warnings after prerender errors', async () => {
+        const { exitCode } = await next.build()
+        expect(exitCode).not.toBe(0)
+
+        const cliOutput = stripAnsi(next.cliOutput)
+
+        const prerenderErrorIndex = cliOutput.indexOf(
+          'Error occurred prerendering page "/boom"'
+        )
+        const exitingBuildIndex = cliOutput.indexOf(
+          'Export encountered an error on /boom/page: /boom, exiting the build.'
+        )
+        const warningIndex = cliOutput.indexOf(
+          'Turbopack build encountered 1 warning'
+        )
+
+        expect(prerenderErrorIndex).not.toBe(-1)
+        expect(exitingBuildIndex).not.toBe(-1)
+        expect(warningIndex).not.toBe(-1)
+
+        // The prerender error comes first, the deferred compile warnings
+        // after.
+        expect(warningIndex).toBeGreaterThan(prerenderErrorIndex)
+        expect(warningIndex).toBeGreaterThan(exitingBuildIndex)
+      })
+    })
+
+    describe('with a prerender error and prerenderEarlyExit disabled', () => {
+      const { next } = nextTestSetup({
+        files: __dirname,
+        skipStart: true,
+        overrideFiles: {
+          'app/boom/page.js': `export default function Page() {
+            throw new Error('boom during prerender')
+          }`,
+          'next.config.js': `/** @type {import('next').NextConfig} */
+          module.exports = {
+            experimental: { prerenderEarlyExit: false },
+          }`,
+        },
+      })
+
+      it('should print warnings after prerender errors and before the failure summary', async () => {
+        const { exitCode } = await next.build()
+        expect(exitCode).not.toBe(0)
+
+        const cliOutput = stripAnsi(next.cliOutput)
+
+        const prerenderErrorIndex = cliOutput.indexOf(
+          'Error occurred prerendering page "/boom"'
+        )
+        const warningIndex = cliOutput.indexOf(
+          'Turbopack build encountered 1 warning'
+        )
+        const exportErrorIndex = cliOutput.indexOf('Export encountered errors')
+
+        expect(prerenderErrorIndex).not.toBe(-1)
+        expect(warningIndex).not.toBe(-1)
+        expect(exportErrorIndex).not.toBe(-1)
+
+        // Prerender errors come first, then the deferred compile warnings,
+        // and the failure summary is printed last.
+        expect(warningIndex).toBeGreaterThan(prerenderErrorIndex)
+        expect(exportErrorIndex).toBeGreaterThan(warningIndex)
       })
     })
 


### PR DESCRIPTION
Picked up this from "Turbopack Work Ideas 2026":

> 4. (S) Turbopack Warnings are before SSG Errors
>    - Solution: print Turbopack warnings after SSG

I think this is a pretty bare-bones fix for this - let me know if the idea was to do something different!

See an example output:


```
✓ Running next.config.js took 6ms
▲ Next.js 16.3.0-canary.75 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 889ms
  Running TypeScript ...
  Finished TypeScript in 38ms ...
  Collecting page data using 5 workers ...
  Generating static pages using 5 workers (0/4) ...
Error occurred prerendering page "/boom". Read more: https://nextjs.org/docs/messages/prerender-error
Error: boom during prerender
    at <unknown> (app/boom/page.js:2:9)
  1 | export default function Page() {
> 2 |   throw new Error("boom during prerender")
    |         ^
  3 | }
  4 | {
  digest: '1942497547'
}
Export encountered an error on /boom/page: /boom, exiting the build.
⨯ Next.js build worker exited with code: 1 and signal: null
Turbopack build encountered 1 warning:
./app/join-cwd.js:4:10
Warning: Dynamic filesystem access causes tracing of the whole project
  [90m2 |[0m
  [90m3 |[0m [36mexport[0m [36mdefault[0m [36mfunction[0m (f) {
[33m[1m>[0m [90m4 |[0m   [36mreturn[0m path.join(process.cwd(), f)
  [90m  |[0m          [33m[1m^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
  [90m5 |[0m }
  [90m6 |[0m

Static analysis determined that this filesystem access causes the whole project to be traced and included in the output.
This is usually unintentional and leads to all source files (including the public folder) to be deployed as part of the server code.
This can slow down deployments or lead to failures when size limits are exceeded.
To resolve this, you can
- make sure they are statically scoped to some subfolder: path.join(process.cwd(), 'data', bar), or
- only use them in development, or
- add ignore comments: path.join(/*turbopackIgnore: true*/ process.cwd(), bar), or
- remove them.

Import trace:
  Server Component:
    ./app/join-cwd.js
    ./app/page.js
```