### PR TITLE
[docs] Update progressive web apps documentation for new service worker syntax

### DIFF
--- a/docs/01-app/02-guides/progressive-web-apps.mdx
+++ b/docs/01-app/02-guides/progressive-web-apps.mdx
@@ -157,7 +157,7 @@ function PushNotificationManager() {
 
   async function registerServiceWorker() {
     const registration = await navigator.serviceWorker.register(
-      new URL('../lib/service-worker.js', import.meta.url), 
+      new URL('../lib/service-worker.js', import.meta.url),
       {
         scope: '/',
         updateViaCache: 'none',
@@ -238,7 +238,7 @@ function PushNotificationManager() {
 
   async function registerServiceWorker() {
     const registration = await navigator.serviceWorker.register(
-      new URL('../lib/service-worker.js', import.meta.url), 
+      new URL('../lib/service-worker.js', import.meta.url),
       {
         scope: '/',
         updateViaCache: 'none',
@@ -633,7 +633,7 @@ module.exports = {
         ],
       },
       {
-        source: '/service-worker.js',
+        source: '/sw.js',
         headers: [
           {
             key: 'Content-Type',

--- a/docs/01-app/02-guides/progressive-web-apps.mdx
+++ b/docs/01-app/02-guides/progressive-web-apps.mdx
@@ -156,10 +156,13 @@ function PushNotificationManager() {
   }, [])
 
   async function registerServiceWorker() {
-    const registration = await navigator.serviceWorker.register('/sw.js', {
-      scope: '/',
-      updateViaCache: 'none',
-    })
+    const registration = await navigator.serviceWorker.register(
+      new URL('../lib/service-worker.js', import.meta.url), 
+      {
+        scope: '/',
+        updateViaCache: 'none',
+      }
+    )
     const sub = await registration.pushManager.getSubscription()
     setSubscription(sub)
   }
@@ -234,10 +237,13 @@ function PushNotificationManager() {
   }, []);
 
   async function registerServiceWorker() {
-    const registration = await navigator.serviceWorker.register('/sw.js', {
-      scope: '/',
-      updateViaCache: 'none',
-    });
+    const registration = await navigator.serviceWorker.register(
+      new URL('../lib/service-worker.js', import.meta.url), 
+      {
+        scope: '/',
+        updateViaCache: 'none',
+      }
+    )
     const sub = await registration.pushManager.getSubscription();
     setSubscription(sub);
   }
@@ -544,9 +550,9 @@ VAPID_PRIVATE_KEY=your_private_key_here
 
 ### 5. Creating a Service Worker
 
-Create a `public/sw.js` file for your service worker:
+Create a `lib/service-worker.js` file for your service worker:
 
-```js filename="public/sw.js"
+```js filename="lib/service-worker.js"
 self.addEventListener('push', function (event) {
   if (event.data) {
     const data = event.data.json()
@@ -627,7 +633,7 @@ module.exports = {
         ],
       },
       {
-        source: '/sw.js',
+        source: '/service-worker.js',
         headers: [
           {
             key: 'Content-Type',


### PR DESCRIPTION
We recently rolled out this new syntax for bundling service workers with Turbopack:

```
await navigator.serviceWorker.register(new URL('../lib/service-workers/1.js', import.meta.url), ...)
```

This PR updates the documentation that previously mentioned service workers.