### PR TITLE
Fix stale data after navigation despite revalidation

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -49,6 +49,7 @@ export type AppRouterActionQueue = {
 
   pending: ActionQueueNode | null
   needsRefresh?: boolean
+  wasPreempted?: boolean
   last: ActionQueueNode | null
 }
 
@@ -86,11 +87,23 @@ function runRemainingActions(
     }
   }
 
-  if (actionQueue.pending === null && actionQueue.needsRefresh) {
-    // The queue is idle; flush the refresh requested by a discarded server
-    // action that revalidated data.
-    actionQueue.needsRefresh = false
-    actionQueue.dispatch({ type: ACTION_REFRESH }, setState)
+  if (actionQueue.pending === null) {
+    if (actionQueue.wasPreempted) {
+      // React renders the state promise from the latest dispatch — the
+      // navigation's, since it jumped ahead of actions that were already
+      // waiting in the queue. Those actions ran after it, so the states they
+      // produced were never rendered. Now that the queue is idle, render the
+      // state we ended up with.
+      actionQueue.wasPreempted = false
+      startTransition(() => setState(actionQueue.state))
+    }
+
+    if (actionQueue.needsRefresh) {
+      // The queue is idle; flush the refresh requested by a discarded server
+      // action that revalidated data.
+      actionQueue.needsRefresh = false
+      actionQueue.dispatch({ type: ACTION_REFRESH }, setState)
+    }
   }
 }
 
@@ -197,6 +210,7 @@ function dispatchAction(
     // Navigations (including back/forward) take priority over any pending actions.
     // Mark the pending action as discarded (so the state is never applied) and start the navigation action immediately.
     actionQueue.pending.discarded = true
+    actionQueue.wasPreempted = true
 
     // The rest of the current queue should still execute after this navigation.
     // (Note that it can't contain any earlier navigations, because we always put those into `actionQueue.pending` by calling `runAction`)

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -49,6 +49,7 @@ export type AppRouterActionQueue = {
 
   pending: ActionQueueNode | null
   needsRefresh?: boolean
+  wasPreempted?: boolean
   last: ActionQueueNode | null
 }
 
@@ -86,11 +87,20 @@ function runRemainingActions(
     }
   }
 
-  if (actionQueue.pending === null && actionQueue.needsRefresh) {
-    // The queue is idle; flush the refresh requested by a discarded server
-    // action that revalidated data.
-    actionQueue.needsRefresh = false
-    actionQueue.dispatch({ type: ACTION_REFRESH }, setState)
+  if (actionQueue.pending === null) {
+    if (actionQueue.wasPreempted) {
+      actionQueue.wasPreempted = false
+      // When an action is preempted, later actions can update the queue's state without React rendering it.
+      // Once the queue is empty, publish the final state so the UI catches up.
+      startTransition(() => setState(actionQueue.state))
+    }
+
+    if (actionQueue.needsRefresh) {
+      // The queue is idle; flush the refresh requested by a discarded server
+      // action that revalidated data.
+      actionQueue.needsRefresh = false
+      actionQueue.dispatch({ type: ACTION_REFRESH }, setState)
+    }
   }
 }
 
@@ -197,6 +207,7 @@ function dispatchAction(
     // Navigations (including back/forward) take priority over any pending actions.
     // Mark the pending action as discarded (so the state is never applied) and start the navigation action immediately.
     actionQueue.pending.discarded = true
+    actionQueue.wasPreempted = true
 
     // The rest of the current queue should still execute after this navigation.
     // (Note that it can't contain any earlier navigations, because we always put those into `actionQueue.pending` by calling `runAction`)

--- a/test/e2e/app-dir/actions-discarded-navigation-revert/actions-discarded-navigation-revert.test.ts
+++ b/test/e2e/app-dir/actions-discarded-navigation-revert/actions-discarded-navigation-revert.test.ts
@@ -153,6 +153,59 @@ describe('discarded action settling while a navigation is pending (#86151)', () 
     expect(await browser.elementById('dest').text()).toBe('Destination page')
   })
 
+  // An action queued behind the navigation runs after it — but running is
+  // not enough: the state it produces must also render. B revalidates here,
+  // so its settlement must repaint the layout stamp without any
+  // further interaction.
+  it('renders the state produced by an action that settles after the navigation', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    const initialRender = await browser
+      .elementById('stamp')
+      .getAttribute('data-render')
+
+    await act(
+      async () => {
+        // Start server action A. Its response is withheld, so it stays in
+        // flight throughout this scope.
+        await act(async () => {
+          await browser.elementById('dispatch-resolve').click()
+        }, 'block')
+
+        // Start server action B, which revalidates. It queues behind A.
+        await act(async () => {
+          await browser.elementById('dispatch-b-revalidate').click()
+        }, 'no-requests')
+
+        // Navigate before A or B finished. This discards A. The navigation
+        // response is withheld too.
+        await act(
+          async () => {
+            await browser.elementById('go-dest').click()
+          },
+          { includes: 'Destination page', block: true }
+        )
+      },
+      // B ran after the navigation and returned its result.
+      { includes: 'revalidated' }
+    )
+
+    await browser.waitForElementByCss('#status-b[data-status="revalidated"]')
+
+    // B revalidated, so the layout stamp it produced must render.
+    await browser.waitForElementByCss(
+      `#stamp:not([data-render="${initialRender}"])`
+    )
+    expect(new URL(await browser.url()).pathname).toBe('/dest')
+    expect(await browser.elementById('dest').text()).toBe('Destination page')
+  })
+
   it('defers the refresh from a discarded revalidating action until the queue drains', async () => {
     const { browser, initialRender } = await interleave('dispatch-revalidate')
 

--- a/test/e2e/app-dir/actions-discarded-navigation-revert/app/controls.tsx
+++ b/test/e2e/app-dir/actions-discarded-navigation-revert/app/controls.tsx
@@ -48,6 +48,15 @@ export function Controls() {
     }
   }
 
+  async function dispatchBRevalidate() {
+    setB('pending')
+    try {
+      setB(await revalidate())
+    } catch {
+      setB('rejected')
+    }
+  }
+
   async function dispatchC() {
     setC('pending')
     try {
@@ -70,6 +79,9 @@ export function Controls() {
       </button>
       <button id="dispatch-b" onClick={dispatchB}>
         dispatch queued action
+      </button>
+      <button id="dispatch-b-revalidate" onClick={dispatchBRevalidate}>
+        dispatch revalidating queued action
       </button>
       <button id="go-dest" onClick={() => router.push('/dest')}>
         go to destination


### PR DESCRIPTION
Claude noticed this while working on https://github.com/vercel/next.js/pull/95391.

Basically, the queue's React state always gets updated in the order of dispatching. So if a navigation displaced pending actions, it's the *navigation's* promise that was last. So when the pending action runs after it, that action's state is no longer taken into account, even if it revalidated. This is why the new data won't reflect on the screen.

With the fix, the final state is properly reflected.

## Test Plan

New test, which was red before the fix.

Also tried it on a mini-app.

Before:

https://github.com/user-attachments/assets/2235b116-82c4-4ef4-a63c-78e157c90470

After:

https://github.com/user-attachments/assets/d7b685c7-d0a5-4b91-8da7-78bb14011313

## How

We re-render at the end with the final queue state — if we know it was preempted.