### PR TITLE
Ignore-list internal frames whose source maps chain to original sources

### DIFF
--- a/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
@@ -187,9 +187,42 @@ export default class EvalSourceMapDevToolPlugin {
               }
             )
             sourceMap.sources = moduleFilenames
+            // The vendored `webpack-sources` drops the source map's
+            // `ignoreList` when it combines a module's input source map with
+            // the generated mappings, so we recompute it from
+            // `shouldIgnorePath` here. That matches on the emitted source path,
+            // which is fine while a source resolves back to its module. But a
+            // module that ships an input source map (Next's compiled files,
+            // whose `.js.map` marks every source ignore-listed) resolves its
+            // sources to the original files instead. For example, for the Proxy
+            // adapter, `modules[index]` is then the unresolved string
+            // `.../src/server/web/adapter.ts` while `moduleResource` (the
+            // module's own resource) is
+            // `.../node_modules/next/dist/.../adapter.js`. The emitted `src`
+            // path has lost the `node_modules`/`next/dist` marker, so for such
+            // unresolved sources we fall back to `moduleResource`.
+            //
+            // This is only sound for a `NormalModule`, whose sources all belong
+            // to that one module. A `ConcatenatedModule` merges several
+            // modules' sources under one map, so no single resource identifies
+            // them all; those are left to the path check alone. The dev
+            // `eval-source-map` devtool never concatenates (a production-only
+            // optimization), so this is not hit in practice.
+            const moduleResource =
+              m instanceof NormalModule ? m.resource : undefined
+            const moduleIsIgnored =
+              moduleResource !== undefined &&
+              this.shouldIgnorePath(moduleResource)
             sourceMap.ignoreList = []
             for (let index = 0; index < moduleFilenames.length; index++) {
-              if (this.shouldIgnorePath(moduleFilenames[index])) {
+              // A string entry in `modules` (built above) is a source that did
+              // not resolve back to a module, i.e. an original file such as the
+              // `.ts` above rather than the compiled `.js` module.
+              const sourceIsUnresolved = typeof modules[index] === 'string'
+              if (
+                this.shouldIgnorePath(moduleFilenames[index]) ||
+                (moduleIsIgnored && sourceIsUnresolved)
+              ) {
                 sourceMap.ignoreList.push(index)
               }
             }

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -25,11 +25,7 @@ describe('middleware - development errors', () => {
       await next.start()
     })
 
-    // TODO(veil): Skipped because a source-map ignore-list bug leaks internal
-    // proxy adapter frames into the error output (fixed in a follow-up). We'd
-    // normally assert the leaked `src/...` frames, but their relative-path
-    // depth is environment-dependent and drifts, so it's too flaky to pin.
-    it.skip('logs the error correctly', async () => {
+    it('logs the error correctly', async () => {
       await next.fetch('/')
 
       await retry(() => {
@@ -130,11 +126,7 @@ describe('middleware - development errors', () => {
       await next.start()
     })
 
-    // TODO(veil): Skipped because a source-map ignore-list bug leaks internal
-    // proxy adapter frames into the error output (fixed in a follow-up). We'd
-    // normally assert the leaked `src/...` frames, but their relative-path
-    // depth is environment-dependent and drifts, so it's too flaky to pin.
-    it.skip('logs the error correctly', async () => {
+    it('logs the error correctly', async () => {
       await next.fetch('/')
 
       await retry(() => {
@@ -188,11 +180,7 @@ describe('middleware - development errors', () => {
       await next.start()
     })
 
-    // TODO(veil): Skipped because a source-map ignore-list bug leaks internal
-    // proxy adapter frames into the error output (fixed in a follow-up). We'd
-    // normally assert the leaked `src/...` frames, but their relative-path
-    // depth is environment-dependent and drifts, so it's too flaky to pin.
-    it.skip('logs the error correctly', async () => {
+    it('logs the error correctly', async () => {
       await next.fetch('/')
 
       await retry(() => {


### PR DESCRIPTION
Next's dev error output (terminal logs and the browser overlay) ignore-lists framework-internal stack frames. The forked `EvalSourceMapDevToolPlugin` recomputes this ignore-list per module because the vendored `webpack-sources` has no runtime `ignoreList` support, so it drops the field when it combines a module's input source map with the generated mappings. `shouldIgnorePath` matches on the emitted source path, which works while a source resolves back to its module. But a Next-internal module that ships an input source map (its `.js.map`, which taskfile-swc marks entirely ignore-listed) resolves its sources to the original files such as `src/server/web/adapter.ts`, which no longer contain the `node_modules`/`next/dist` marker and no longer resolve back to a module. Those frames then escape ignore-listing and leak into both the terminal output and the overlay.

For such unresolved sources this falls back to the module's own resource path, so a frame whose module lives in `node_modules`/`next/dist` stays ignore-listed even when its source map points at the original source. The fallback applies only to a `NormalModule`, whose sources all belong to that one module; a `ConcatenatedModule` merges several modules' sources under one map and is left to the path check, which the dev `eval-source-map` devtool never produces anyway.