### PR TITLE
Fix standalone output symlinks resolving outside `.next/standalone` on Windows with pnpm

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1291,8 +1291,31 @@ export async function copyTracedFiles(
           const symlink = await fs.readlink(tracedFilePath).catch(() => null)
 
           if (symlink) {
+            // pnpm on Windows installs packages as junctions with absolute
+            // targets (e.g. <project>\node_modules\.pnpm\...). Remap absolute
+            // targets that resolve inside the tracing root to the equivalent
+            // path in the standalone output so the copied link doesn't
+            // resolve back into the original node_modules.
+            let symlinkTarget = symlink
+            if (path.isAbsolute(symlink)) {
+              const relativeTarget = path.relative(tracingRoot, symlink)
+              if (
+                !relativeTarget.startsWith('..') &&
+                !path.isAbsolute(relativeTarget)
+              ) {
+                symlinkTarget = path.join(outputPath, relativeTarget)
+              }
+            }
+            // A remapped target may not have been copied yet, so Windows
+            // can't infer the link type from it — stat the original target
+            // (readlink resolved through the link) instead.
+            const targetStat = await fs.stat(tracedFilePath).catch(() => null)
             try {
-              await fs.symlink(symlink, fileOutputPath)
+              await fs.symlink(
+                symlinkTarget,
+                fileOutputPath,
+                targetStat?.isDirectory() ? 'dir' : 'file'
+              )
             } catch (err: any) {
               // Windows doesn't support creating symlinks without elevated privileges, unless
               // "Developer Mode" is turned on. If we failed to create a symlink due to EPERM, try
@@ -1305,10 +1328,10 @@ export async function copyTracedFiles(
               if (
                 process.platform === 'win32' &&
                 err.code === 'EPERM' &&
-                path.isAbsolute(symlink)
+                path.isAbsolute(symlinkTarget)
               ) {
                 try {
-                  await fs.symlink(symlink, fileOutputPath, 'junction')
+                  await fs.symlink(symlinkTarget, fileOutputPath, 'junction')
                 } catch (junctionErr: any) {
                   if (junctionErr.code !== 'EEXIST') {
                     throw junctionErr

--- a/test/unit/copy-traced-files.test.ts
+++ b/test/unit/copy-traced-files.test.ts
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+
+import { copyTracedFiles } from 'next/dist/build/utils'
+import { join, relative, isAbsolute } from 'path'
+import fs from 'fs-extra'
+
+const testDir = join(__dirname, 'copy-traced-files-test')
+const projectDir = join(testDir, 'project')
+const outsideDir = join(testDir, 'outside')
+const distDir = join(projectDir, '.next')
+const standaloneDir = join(distDir, 'standalone')
+
+// Mirrors a pnpm-on-Windows install: node_modules/<pkg> is a junction with an
+// absolute target pointing into node_modules/.pnpm (see issue #95450).
+const pnpmPkgDir = join(
+  projectDir,
+  'node_modules/.pnpm/my-pkg@1.0.0/node_modules/my-pkg'
+)
+
+describe('copyTracedFiles', () => {
+  if (process.platform === 'win32') {
+    it('should skip on windows to avoid symlink issues', () => {})
+    return
+  }
+  afterAll(() => fs.remove(testDir))
+
+  it('should remap absolute symlink targets inside the tracing root into the standalone output', async () => {
+    await fs.remove(testDir)
+
+    await fs.outputFile(join(pnpmPkgDir, 'index.js'), 'module.exports = 1')
+    await fs.ensureSymlink(pnpmPkgDir, join(projectDir, 'node_modules/my-pkg'))
+
+    // An absolute symlink target outside the tracing root must be preserved.
+    await fs.outputFile(join(outsideDir, 'index.js'), 'module.exports = 2')
+    await fs.ensureSymlink(
+      outsideDir,
+      join(projectDir, 'node_modules/outside-pkg')
+    )
+
+    await fs.outputJson(join(projectDir, 'package.json'), { name: 'app' })
+    await fs.outputJson(join(distDir, 'next-server.js.nft.json'), {
+      version: 1,
+      files: [
+        '../node_modules/my-pkg',
+        '../node_modules/.pnpm/my-pkg@1.0.0/node_modules/my-pkg/index.js',
+        '../node_modules/outside-pkg',
+      ],
+    })
+
+    await copyTracedFiles(
+      projectDir,
+      distDir,
+      [],
+      undefined,
+      projectDir,
+      {} as any,
+      {
+        version: 3,
+        middleware: {},
+        functions: {},
+        sortedMiddleware: [],
+      } as any,
+      false,
+      false,
+      new Set()
+    )
+
+    const copiedLink = join(standaloneDir, 'node_modules/my-pkg')
+    const target = await fs.readlink(copiedLink)
+    // The link must resolve inside the standalone output, not back into the
+    // original project's node_modules.
+    expect(isAbsolute(target)).toBe(true)
+    expect(relative(standaloneDir, target).startsWith('..')).toBe(false)
+    expect(target).toBe(
+      join(standaloneDir, 'node_modules/.pnpm/my-pkg@1.0.0/node_modules/my-pkg')
+    )
+    // The remapped link resolves to the copied file.
+    expect(await fs.readFile(join(copiedLink, 'index.js'), 'utf8')).toBe(
+      'module.exports = 1'
+    )
+
+    // Targets outside the tracing root are left untouched.
+    expect(
+      await fs.readlink(join(standaloneDir, 'node_modules/outside-pkg'))
+    ).toBe(outsideDir)
+  })
+})


### PR DESCRIPTION
When using Next.js with `output: "standalone"` together with pnpm on Windows, the generated standalone output contains symlinks inside `.next/standalone/node_modules` that resolve to the root `node_modules/.pnpm` directory instead of the standalone directory. This happens because pnpm on Windows installs packages as junctions with absolute targets.

This PR fixes the issue by remapping absolute symlink targets that resolve inside the tracing root to their equivalent path in the standalone output during the `copyTracedFiles` process. It also explicitly sets the symlink type based on the original target's stat to handle cases where the remapped target hasn't been copied yet. A regression test has been added to verify the fix.

Closes #95450