### PR TITLE
docs: Update FormEvent to SubmitEvent in form handling example (deprecated in React 19.2.10+)

### DIFF
--- a/docs/02-pages/02-guides/forms.mdx
+++ b/docs/02-pages/02-guides/forms.mdx
@@ -36,10 +36,10 @@ export default function handler(req, res) {
 Then, call the API Route from the client with an event handler:
 
 ```tsx filename="pages/index.tsx" switcher
-import { FormEvent } from 'react'
+import { SubmitEvent } from 'react'
 
 export default function Page() {
-  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault()
 
     const formData = new FormData(event.currentTarget)
@@ -133,13 +133,13 @@ export default async function handler(req, res) {
 You can use React state to show an error message when a form submission fails:
 
 ```tsx filename="pages/index.tsx" switcher
-import React, { useState, FormEvent } from 'react'
+import React, { useState, SubmitEvent } from 'react'
 
 export default function Page() {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
 
-  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault()
     setIsLoading(true)
     setError(null) // Clear previous errors when a new request starts
@@ -235,12 +235,12 @@ export default function Page() {
 You can use React state to show a loading state when a form is submitting on the server:
 
 ```tsx filename="pages/index.tsx" switcher
-import React, { useState, FormEvent } from 'react'
+import React, { useState, SubmitEvent } from 'react'
 
 export default function Page() {
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault()
     setIsLoading(true) // Set loading to true when the request starts
 


### PR DESCRIPTION
**Description:**
Since React v19.2.10, `FormEvent` and `FormEventHandler` are deprecated in favor of `SubmitEvent` and `SubmitEventHandler` for form `onSubmit` handlers. The current docs example still imports and uses the deprecated `FormEvent` type, which now triggers a TypeScript deprecation warning (`TS6385`) for anyone following the guide with an up-to-date React version.

**Why:** 
`FormEvent` still works but is marked deprecated as of React 19.2.10, so following the current docs produces a TypeScript warning out of the box. Updating to `SubmitEvent` keeps the example aligned with the current React types and avoids confusing new users who copy the snippet verbatim.

**Reference:** [React TypeScript Cheatsheet – Forms and Events](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forms_and_events/)