### PR TITLE
Add Geist Pixel to next/font/google

### DIFF
--- a/packages/font/src/google/font-data.json
+++ b/packages/font/src/google/font-data.json
@@ -5815,6 +5815,19 @@
       "vietnamese"
     ]
   },
+  "Geist Pixel": {
+    "weights": ["400", "variable"],
+    "styles": ["normal"],
+    "axes": [
+      {
+        "tag": "ELSH",
+        "min": 0,
+        "max": 100,
+        "defaultValue": 0
+      }
+    ],
+    "subsets": ["latin", "latin-ext"]
+  },
   "Gelasio": {
     "weights": ["400", "500", "600", "700", "variable"],
     "styles": ["normal", "italic"],

--- a/packages/font/src/google/index.ts
+++ b/packages/font/src/google/index.ts
@@ -8899,6 +8899,19 @@ export declare function Geist_Mono<
     | 'vietnamese'
   >
 }): T extends undefined ? NextFont : NextFontWithVariable
+export declare function Geist_Pixel<
+  T extends CssVariable | undefined = undefined,
+>(options?: {
+  weight?: '400' | 'variable' | Array<'400'>
+  style?: 'normal' | Array<'normal'>
+  display?: Display
+  variable?: T
+  preload?: boolean
+  fallback?: string[]
+  adjustFontFallback?: boolean
+  subsets?: Array<'latin' | 'latin-ext'>
+  axes?: 'ELSH'[]
+}): T extends undefined ? NextFont : NextFontWithVariable
 export declare function Gelasio<
   T extends CssVariable | undefined = undefined,
 >(options?: {


### PR DESCRIPTION
### What

Adds [Geist Pixel](https://fonts.google.com/specimen/Geist+Pixel) to `next/font/google` so it can be imported like the other Geist families:

```ts
import { Geist_Pixel } from 'next/font/google'
```

### Why

Geist Pixel was recently published on Google Fonts and now appears in the Google Fonts metadata API (`https://fonts.google.com/metadata/fonts`), alongside the existing `Geist` and `Geist Mono` entries. Until the next automated `Update font data` regen runs, it isn't importable.

### How

Adds the `Geist Pixel` entry to `packages/font/src/google/font-data.json` and the matching generated `Geist_Pixel` type declaration to `packages/font/src/google/index.ts`. Both match the output of `scripts/update-google-fonts.js` for the current metadata (verified by running the generator against the live API), so this is consistent with what the periodic bulk regen would produce:

- Variable font, single `ELSH` axis (`0`–`100`, default `0`)
- Weights: `400`, `variable`
- Style: `normal`
- Subsets: `latin`, `latin-ext`

Scoped to just Geist Pixel to keep the diff reviewable rather than sweeping in every unrelated font change since the last `Update font data` PR.