### PR TITLE
fix: work around SWC compress bug

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -204,6 +204,12 @@ module.exports = ({ dev, turbo, bundleType, experimental, ...rest }) => {
             minimizer: [
               new webpack.SwcJsMinimizerRspackPlugin({
                 minimizerOptions: {
+                  compress: {
+                    defaults: true,
+                    // FIXME: compiler bug: wrongly merging two conditionals with different return values into one
+                    // (in `prepareValidationInputsInPartialPrefetching`)
+                    conditionals: false,
+                  },
                   mangle:
                     dev || process.env.NEXT_SERVER_NO_MANGLE ? false : true,
                 },


### PR DESCRIPTION
Works around a compiler bug in `SwcJsMinimizerRspackPlugin` that we found in #95394

Some conditionals were getting miscompiled, from this:
```ts
if (inputsFromNavigation) {
  if (areStagesCompatible) {
    const instantInputs = needsInstantValidation ? inputsFromNavigation : null
    const staticInputs = inputsFromNavigation
    return { instantInputs, staticInputs }
  }

  if (navigationHasAppShell(navigationKind)) {
    const instantInputs = needsInstantValidation ? inputsFromNavigation : null
    const staticInputs = LAZY_RUNTIME_PRERENDER
    return { instantInputs, staticInputs }
  }

  const instantInputs = needsInstantValidation ? LAZY_FULL_RENDER : null
  const staticInputs = inputsFromNavigation
  return { instantInputs, staticInputs }
}
```
into this (in `packages/next/dist/compiled/next-server/app-page-turbo.runtime.dev.js`)
```js
if (inputsFromNavigation)
  return areStagesCompatible || navigationHasAppShell(navigationKind)
    ? {
        instantInputs: needsInstantValidation
          ? inputsFromNavigation
          : null,
        staticInputs: inputsFromNavigation,
      }
    : {
        instantInputs: needsInstantValidation ? LAZY_FULL_RENDER : null,
        staticInputs: inputsFromNavigation,
      }
```
In the compiled version, the three branches get incorrectly merged into two: if `navigationHasAppShell(navigationKind)`, static inputs are `inputsFromNavigation` instead of `LAZY_RUNTIME_PRERENDER`. We're guessing that this is a bug in some optimization of conditional returns; disabling `compress.conditionals` in the minimizer seems to work around it.