### PR TITLE
Fix next/font preload lookup for custom pageExtensions

### DIFF
--- a/packages/next/src/server/app-render/get-preloadable-fonts.tsx
+++ b/packages/next/src/server/app-render/get-preloadable-fonts.tsx
@@ -20,7 +20,11 @@ export function getPreloadableFonts(
   const fontFiles = new Set<string>()
   let foundFontUsage = false
 
-  const preloadedFontFiles = nextFontManifest.app[filepathWithoutExtension]
+  let preloadedFontFiles = nextFontManifest.app[filepathWithoutExtension]
+  if (!preloadedFontFiles) {
+    const fallbackPath = filepathWithoutExtension.replace(/\.[^.]+$/, '')
+    preloadedFontFiles = nextFontManifest.app[fallbackPath]
+  }
   if (preloadedFontFiles) {
     foundFontUsage = true
     for (const fontFile of preloadedFontFiles) {

--- a/test/e2e/next-font/custom-page-extensions.test.ts
+++ b/test/e2e/next-font/custom-page-extensions.test.ts
@@ -1,0 +1,39 @@
+import cheerio from 'cheerio'
+import { nextTestSetup } from 'e2e-utils'
+import { renderViaHTTP } from 'next-test-utils'
+import { join } from 'path'
+
+const mockedGoogleFontResponses = require.resolve(
+  './google-font-mocked-responses.js'
+)
+
+describe('next/font/google custom-page-extensions', () => {
+  if ((global as any).isNextDeploy) {
+    it('should skip next deploy for now', () => {})
+    return
+  }
+
+  const { next } = nextTestSetup({
+    files: join(__dirname, 'custom-page-extensions'),
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
+  })
+
+  test('preload correct files at /', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    const $ = cheerio.load(html)
+
+    // Preload should exist and point to the font file
+    expect($('link[as="font"]').length).toBe(1)
+    expect($('link[as="font"]').get(0).attribs).toEqual({
+      as: 'font',
+      crossorigin: '',
+      href: expect.stringMatching(
+        /\/_next\/static\/(immutable\/)?media\/.*-s\.p(\..*)?\.woff2/
+      ),
+      rel: 'preload',
+      type: 'font/woff2',
+    })
+  })
+})

--- a/test/e2e/next-font/custom-page-extensions/app/layout.page.tsx
+++ b/test/e2e/next-font/custom-page-extensions/app/layout.page.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/next-font/custom-page-extensions/app/page.page.tsx
+++ b/test/e2e/next-font/custom-page-extensions/app/page.page.tsx
@@ -1,0 +1,7 @@
+import { Inter } from 'next/font/google'
+
+const inter = Inter({ subsets: ['latin'], weight: '900' })
+
+export default function Page() {
+  return <h1 className={inter.className}>Hello World</h1>
+}

--- a/test/e2e/next-font/custom-page-extensions/next.config.js
+++ b/test/e2e/next-font/custom-page-extensions/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+}


### PR DESCRIPTION
### Problem

When a project uses custom `pageExtensions` (e.g., `['page.tsx', 'page.ts', 'page.jsx', 'page.js']`), the files inside the `app/` directory are named with these custom extensions, such as `app/page.page.tsx` and `app/layout.page.tsx`.

During rendering, `filepathWithoutExtension` retains the intermediate `.page` suffix (e.g. `app/page.page`). However, the `next-font-manifest` generated during the build maps routes using standard paths (e.g. `app/page`). As a result, the lookup `nextFontManifest.app[filepathWithoutExtension]` fails, preventing fonts from being preloaded on pages with custom page extensions.

### Root Cause

The manifest lookup uses `filepathWithoutExtension` directly, which does not strip custom page extension suffixes (like `.page`), causing a key mismatch in `nextFontManifest.app` where the keys are stored without the custom suffix.

### Solution

Implement a fallback lookup path in `getPreloadableFonts` by stripping the trailing segment before the extension (e.g., removing `.page` from `app/page.page` to get `app/page`) if the direct lookup fails.

### Testing

Added an end-to-end integration test in `test/e2e/next-font/custom-page-extensions.test.ts` to verify that fonts are correctly preloaded when custom `pageExtensions` are used.