### PR TITLE
Add lightningcss CSS-modules passthrough config for Turbopack

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -373,7 +373,7 @@ pub async fn get_client_module_options_context(
         css: CssOptionsContext {
             source_maps,
             module_css_condition: Some(module_styles_rule_condition()),
-            lightningcss_features: *next_config.lightningcss_feature_flags().await?,
+            lightningcss: next_config.lightningcss_options().owned().await?,
             ..Default::default()
         },
         static_url_tag: Some(rcstr!("client")),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1415,6 +1415,8 @@ pub struct ExperimentalConfig {
     // turbopack_file_system_cache_for_dev: Option<bool>,
     // turbopack_file_system_cache_for_build: Option<bool>,
     lightning_css_features: Option<LightningCssFeatures>,
+    /// Passthrough configuration for lightningcss (Turbopack only for now).
+    lightning_css: Option<LightningCss>,
 }
 
 #[derive(
@@ -1451,6 +1453,52 @@ pub struct SubResourceIntegrity {
 pub struct LightningCssFeatures {
     pub include: Option<Vec<RcStr>>,
     pub exclude: Option<Vec<RcStr>>,
+}
+
+/// Passthrough configuration for lightningcss, mirroring the subset of
+/// lightningcss options that Next.js exposes via `experimental.lightningCss`.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct LightningCss {
+    /// Feature `include`/`exclude` lists. Takes precedence over the top-level
+    /// `experimental.lightningCssFeatures` when set.
+    pub features: Option<LightningCssFeatures>,
+    /// CSS-modules configuration (class-name renaming).
+    pub css_modules: Option<LightningCssModules>,
+}
+
+/// User-facing subset of lightningcss' `css_modules::Config`.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct LightningCssModules {
+    /// Custom class-name pattern, e.g. `[name]__[hash]__[local]`.
+    pub pattern: Option<RcStr>,
+    /// Whether to rename dashed identifiers (e.g. CSS custom properties).
+    pub dashed_idents: Option<bool>,
 }
 
 #[derive(
@@ -2550,18 +2598,50 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn lightningcss_feature_flags(
-        &self,
-    ) -> Result<Vc<turbopack_css::LightningCssFeatureFlags>> {
-        Ok(turbopack_css::LightningCssFeatureFlags {
-            include: lightningcss_features_field_mask(
-                &self.experimental.lightning_css_features,
-                |f| f.include.as_ref(),
-            )?,
-            exclude: lightningcss_features_field_mask(
-                &self.experimental.lightning_css_features,
-                |f| f.exclude.as_ref(),
-            )?,
+    pub fn lightningcss_options(&self) -> Result<Vc<turbopack_css::LightningCssOptions>> {
+        // `lightningCss.features` takes precedence over the legacy top-level
+        // `lightningCssFeatures`; the whole block wins when set.
+        let features_config = self
+            .experimental
+            .lightning_css
+            .as_ref()
+            .and_then(|c| c.features.as_ref())
+            .or(self.experimental.lightning_css_features.as_ref());
+
+        let features = turbopack_css::LightningCssFeatureFlags {
+            include: lightningcss_features_field_mask(features_config, |f| f.include.as_ref())?,
+            exclude: lightningcss_features_field_mask(features_config, |f| f.exclude.as_ref())?,
+        };
+
+        let css_modules = match self
+            .experimental
+            .lightning_css
+            .as_ref()
+            .and_then(|c| c.css_modules.as_ref())
+        {
+            Some(css_modules) => {
+                if let Some(pattern) = css_modules.pattern.as_deref() {
+                    // Validate the pattern eagerly so an invalid value fails the
+                    // build once, with a clear message, rather than emitting a
+                    // warning per CSS-module file at parse time.
+                    lightningcss::css_modules::Pattern::parse(pattern).map_err(|err| {
+                        anyhow::anyhow!(
+                            "Invalid `experimental.lightningCss.cssModules.pattern` \
+                             ({pattern:?}): {err}"
+                        )
+                    })?;
+                }
+                turbopack_css::LightningCssModulesOptions {
+                    pattern: css_modules.pattern.clone(),
+                    dashed_idents: css_modules.dashed_idents.unwrap_or(false),
+                }
+            }
+            None => turbopack_css::LightningCssModulesOptions::default(),
+        };
+
+        Ok(turbopack_css::LightningCssOptions {
+            features,
+            css_modules,
         }
         .cell())
     }
@@ -2775,11 +2855,10 @@ impl JsConfig {
 /// Extract either the `include` or `exclude` field from `LightningCssFeatures`
 /// and convert the feature names to a bitmask.
 fn lightningcss_features_field_mask(
-    features: &Option<LightningCssFeatures>,
+    features: Option<&LightningCssFeatures>,
     field: impl FnOnce(&LightningCssFeatures) -> Option<&Vec<RcStr>>,
 ) -> Result<u32> {
     features
-        .as_ref()
         .and_then(field)
         .map(|names| lightningcss_feature_names_to_mask(names))
         .unwrap_or(Ok(0))

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -586,7 +586,7 @@ pub async fn get_server_module_options_context(
         css: CssOptionsContext {
             source_maps,
             module_css_condition: Some(module_styles_rule_condition()),
-            lightningcss_features: *next_config.lightningcss_feature_flags().await?,
+            lightningcss: next_config.lightningcss_options().owned().await?,
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/useLightningcss.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/useLightningcss.mdx
@@ -39,6 +39,9 @@ By default, Lightning CSS decides which CSS features to transpile based on your 
 
 This applies to both webpack (when `useLightningcss` is enabled) and Turbopack.
 
+In Turbopack, [`lightningCss.features`](#lightningcss) is the newer equivalent of this option.
+When both are set, `lightningCss.features` takes precedence over `lightningCssFeatures`.
+
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
@@ -117,10 +120,115 @@ Composite groups (shorthand for enabling multiple features at once):
 | `media-queries` | `media-interval-syntax`, `media-range-syntax`, `custom-media-queries`                                                           |
 | `colors`        | `color-function`, `oklab-colors`, `lab-colors`, `p3-colors`, `hex-alpha-colors`, `space-separated-color-notation`, `light-dark` |
 
+## `lightningCss`
+
+Turbopack-only. The `lightningCss` option is a passthrough for configuring Lightning CSS directly.
+It is the home for newer options such as CSS Modules class-name patterns, and it also accepts a `features` field that supersedes the top-level [`lightningCssFeatures`](#lightningcssfeatures).
+
+This option currently only applies to Turbopack. It has no effect with the webpack bundler.
+
+### `lightningCss.cssModules`
+
+By default, Turbopack generates [CSS Modules](/docs/app/getting-started/css#css-modules) class names using the pattern `[name]__[hash]__[local]`.
+The `cssModules` option lets you customize how those class names are generated.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    lightningCss: {
+      cssModules: {
+        // e.g. `.button` in `styles.module.css` -> `styles__a1b2c3__button`
+        pattern: '[name]__[hash]__[local]',
+        dashedIdents: false,
+      },
+    },
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    lightningCss: {
+      cssModules: {
+        // e.g. `.button` in `styles.module.css` -> `styles__a1b2c3__button`
+        pattern: '[name]__[hash]__[local]',
+        dashedIdents: false,
+      },
+    },
+  },
+}
+
+module.exports = nextConfig
+```
+
+#### Options
+
+| Option         | Type      | Description                                                                           |
+| -------------- | --------- | ------------------------------------------------------------------------------------- |
+| `pattern`      | `string`  | The class-name pattern. Defaults to `[name]__[hash]__[local]`.                        |
+| `dashedIdents` | `boolean` | Whether to rename dashed identifiers, such as custom properties. Defaults to `false`. |
+
+The `pattern` accepts the following placeholders. Any other text is treated as a literal, so you can add prefixes or separators.
+
+| Placeholder      | Description                  |
+| ---------------- | ---------------------------- |
+| `[name]`         | The base file name.          |
+| `[local]`        | The original class name.     |
+| `[hash]`         | A hash of the file path.     |
+| `[content-hash]` | A hash of the file contents. |
+
+An invalid `pattern` fails the build with a clear error at config load.
+
+### `lightningCss.features`
+
+The same as [`lightningCssFeatures`](#lightningcssfeatures), but nested under `lightningCss`.
+When both `lightningCss.features` and the top-level `lightningCssFeatures` are set, `lightningCss.features` takes precedence and `lightningCssFeatures` is ignored.
+See [Available features](#available-features) for the list of feature names.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    lightningCss: {
+      features: {
+        include: ['light-dark', 'oklab-colors'],
+        exclude: ['nesting'],
+      },
+    },
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    lightningCss: {
+      features: {
+        include: ['light-dark', 'oklab-colors'],
+        exclude: ['nesting'],
+      },
+    },
+  },
+}
+
+module.exports = nextConfig
+```
+
 ## Version History
 
 | Version  | Changes                                                                                                                                                                                      |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `16.3.0` | `lightningCss` added (`cssModules` and `features`), Turbopack only.                                                                                                                          |
 | `16.2.0` | `lightningCssFeatures` added.                                                                                                                                                                |
 | `15.1.0` | Support for `useSwcCss` was removed from Turbopack.                                                                                                                                          |
 | `14.2.0` | Turbopack's default CSS processor was changed from `@swc/css` to Lightning CSS. `useLightningcss` became ignored on Turbopack, and a legacy `experimental.turbo.useSwcCss` option was added. |

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -418,6 +418,22 @@ export const experimentalSchema = {
       exclude: z.array(z.enum(LIGHTNINGCSS_FEATURE_NAMES)).optional(),
     })
     .optional(),
+  lightningCss: z
+    .object({
+      features: z
+        .object({
+          include: z.array(z.enum(LIGHTNINGCSS_FEATURE_NAMES)).optional(),
+          exclude: z.array(z.enum(LIGHTNINGCSS_FEATURE_NAMES)).optional(),
+        })
+        .optional(),
+      cssModules: z
+        .object({
+          pattern: z.string().optional(),
+          dashedIdents: z.boolean().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
   testProxy: z.boolean().optional(),
   defaultTestRunner: z.enum(SUPPORTED_TEST_RUNNERS_LIST).optional(),
   allowDevelopmentBuild: z.literal(true).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -432,6 +432,40 @@ export interface LightningCssFeatures {
 }
 
 /**
+ * Passthrough configuration for lightningcss CSS modules, mirroring the subset
+ * of lightningcss' CSS-modules options that Next.js exposes.
+ */
+export interface LightningCssModulesConfig {
+  /**
+   * Custom class-name pattern for CSS modules, using lightningcss placeholder
+   * syntax. Recognized placeholders: `[name]`, `[local]`, `[hash]`,
+   * `[content-hash]`. Any other text is treated as a literal.
+   *
+   * @example '[name]__[hash]__[local]'
+   */
+  pattern?: string
+  /**
+   * Whether to rename dashed identifiers (e.g. CSS custom properties).
+   */
+  dashedIdents?: boolean
+}
+
+export interface LightningCssConfig {
+  /**
+   * Which CSS features lightningcss should always transpile (`include`) or
+   * never transpile (`exclude`), regardless of browser targets.
+   *
+   * When set, this takes precedence over the top-level
+   * `experimental.lightningCssFeatures`.
+   */
+  features?: LightningCssFeatures
+  /**
+   * CSS-modules configuration (class-name renaming).
+   */
+  cssModules?: LightningCssModulesConfig
+}
+
+/**
  * Accepted shapes for `experimental.cssChunking`. See [`ExperimentalConfig.cssChunking`] for the
  * accepted values; use [`resolveCssChunkingMode`] to normalize the value at runtime.
  */
@@ -1116,9 +1150,21 @@ export interface ExperimentalConfig {
   /**
    * Configure which CSS features lightningcss should always transpile
    * (include) or never transpile (exclude), regardless of browser targets.
-   * Requires `useLightningcss: true`.
+   * Requires `useLightningcss: true` (webpack only; Turbopack applies it
+   * regardless).
+   *
+   * Superseded by `experimental.lightningCss.features`, which takes precedence
+   * when both are set. Kept for backwards compatibility.
    */
   lightningCssFeatures?: LightningCssFeatures
+
+  /**
+   * Passthrough configuration for lightningcss.
+   *
+   * Currently only applies to Turbopack, where lightningcss is always used to
+   * process CSS (independent of `useLightningcss`).
+   */
+  lightningCss?: LightningCssConfig
 
   /**
    * Enables view transitions by using the {@link https://react.dev/reference/react/ViewTransition ViewTransition} Component.

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2011,6 +2011,26 @@ async function loadConfigImpl(
     }
 
     if (
+      userConfig.experimental?.lightningCss &&
+      bundler !== Bundler.Turbopack
+    ) {
+      curLog.warn(
+        `experimental.lightningCss currently only applies to Turbopack. ` +
+          `It has no effect with the webpack bundler.`
+      )
+    }
+
+    if (
+      userConfig.experimental?.lightningCss?.features &&
+      userConfig.experimental?.lightningCssFeatures
+    ) {
+      curLog.warn(
+        `Both experimental.lightningCss.features and experimental.lightningCssFeatures are set. ` +
+          `experimental.lightningCss.features takes precedence; lightningCssFeatures is ignored.`
+      )
+    }
+
+    if (
       phase !== PHASE_PRODUCTION_SERVER &&
       userConfig.experimental?.useLightningcss
     ) {

--- a/test/e2e/app-dir/experimental-lightningcss-css-modules/app/layout.tsx
+++ b/test/e2e/app-dir/experimental-lightningcss-css-modules/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/experimental-lightningcss-css-modules/app/page.module.css
+++ b/test/e2e/app-dir/experimental-lightningcss-css-modules/app/page.module.css
@@ -1,0 +1,3 @@
+.box {
+  color: red;
+}

--- a/test/e2e/app-dir/experimental-lightningcss-css-modules/app/page.tsx
+++ b/test/e2e/app-dir/experimental-lightningcss-css-modules/app/page.tsx
@@ -1,0 +1,11 @@
+import styles from './page.module.css'
+
+export default function Page() {
+  // Render the compiled class name into an attribute so the test can read it
+  // out of the HTML without a browser.
+  return (
+    <div id="box" className={styles.box}>
+      Hello
+    </div>
+  )
+}

--- a/test/e2e/app-dir/experimental-lightningcss-css-modules/experimental-lightningcss-css-modules.test.ts
+++ b/test/e2e/app-dir/experimental-lightningcss-css-modules/experimental-lightningcss-css-modules.test.ts
@@ -1,0 +1,59 @@
+import { nextTestSetup } from 'e2e-utils'
+
+/** Collect all CSS reachable from a page (inline <style> + linked .css). */
+async function collectPageCss(
+  next: ReturnType<typeof nextTestSetup>['next'],
+  path: string
+): Promise<string> {
+  const html = await (await next.fetch(path)).text()
+  let css = ''
+  // Inline <style> blocks
+  for (const m of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)) {
+    css += m[1]
+  }
+  // External <link> stylesheets (href may contain query strings like ?dpl=...)
+  for (const m of html.matchAll(/<link[^>]*href="([^"]*\.css[^"]*?)"[^>]*>/g)) {
+    const res = await next.fetch(m[1])
+    if (res.ok) css += await res.text()
+  }
+  return css
+}
+
+describe('experimental-lightningcss-css-modules', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    dependencies: { lightningcss: '^1.23.0' },
+    nextConfig: {
+      experimental: {
+        useLightningcss: true,
+        lightningCss: {
+          cssModules: {
+            // Non-default pattern so we can tell it apart from the built-in
+            // `[name]__[hash]__[local]` pattern.
+            pattern: '[local]__custom__[hash]',
+          },
+        },
+      },
+    },
+  })
+
+  it('applies the custom CSS-modules class-name pattern', async () => {
+    const $ = await next.render$('/')
+    const className = $('#box').attr('class')
+
+    // The class is always applied and present in the emitted CSS.
+    expect(className).toBeTruthy()
+    const css = await collectPageCss(next, '/')
+    expect(css).toContain(className)
+
+    if (isTurbopack) {
+      // `experimental.lightningCss.cssModules.pattern` is honored by Turbopack.
+      // `[local]__custom__[hash]` renders the `.box` class as e.g.
+      // `box__custom__<hash>`.
+      expect(className).toMatch(/^box__custom__[^\s]+$/)
+      expect(css).toContain('.box__custom__')
+    }
+    // Webpack does not (yet) honor `experimental.lightningCss`; it keeps its own
+    // class-name pattern, so we only assert the generic behavior above.
+  })
+})

--- a/test/e2e/app-dir/experimental-lightningcss-features/experimental-lightningcss-features.test.ts
+++ b/test/e2e/app-dir/experimental-lightningcss-features/experimental-lightningcss-features.test.ts
@@ -83,4 +83,47 @@ describe('experimental-lightningcss-features', () => {
       expect(css).not.toContain('--lightningcss-dark')
     })
   })
+
+  describe('lightningCss.features precedence', () => {
+    const { next, isTurbopack } = nextTestSetup({
+      files: __dirname,
+      dependencies: { lightningcss: '^1.23.0' },
+      // Chrome 100 does NOT support light-dark() natively.
+      packageJson: {
+        browserslist: ['chrome 100'],
+      },
+      nextConfig: {
+        experimental: {
+          useLightningcss: true,
+          // Legacy config says: do NOT transpile light-dark().
+          lightningCssFeatures: {
+            exclude: ['light-dark'],
+          },
+          // New passthrough says: DO transpile it. This must win.
+          lightningCss: {
+            features: {
+              include: ['light-dark'],
+            },
+          },
+        },
+      },
+    })
+
+    it('lets lightningCss.features override lightningCssFeatures', async () => {
+      const html = await next.render('/')
+      expect(html).toContain('Hello')
+
+      const css = await collectPageCss(next, '/')
+      if (isTurbopack) {
+        // `lightningCss.features.include` wins over `lightningCssFeatures.exclude`,
+        // so light-dark() is transpiled.
+        expect(css).not.toContain('light-dark(')
+        expect(css).toContain('--lightningcss-light')
+      } else {
+        // Webpack ignores `experimental.lightningCss`, so `lightningCssFeatures`
+        // (exclude) applies and light-dark() is preserved.
+        expect(css).toContain('light-dark(')
+      }
+    })
+  })
 })

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
 };
 
 use crate::{
-    CssModuleType, LightningCssFeatureFlags,
+    CssModuleType, LightningCssOptions,
     chunk::{CssChunkItem, CssChunkItemContent, CssChunkPlaceable, CssChunkType, CssImport},
     code_gen::CodeGenerateable,
     process::{
@@ -42,7 +42,7 @@ pub struct CssModule {
     import_context: Option<ResolvedVc<ImportContext>>,
     ty: CssModuleType,
     environment: Option<ResolvedVc<Environment>>,
-    lightningcss_features: LightningCssFeatureFlags,
+    lightningcss: LightningCssOptions,
     /// The path of `source`, precomputed so that `ResolveOrigin::origin_path` is synchronous.
     origin_path: FileSystemPath,
 }
@@ -57,7 +57,7 @@ impl CssModule {
         ty: CssModuleType,
         import_context: Option<ResolvedVc<ImportContext>>,
         environment: Option<ResolvedVc<Environment>>,
-        lightningcss_features: LightningCssFeatureFlags,
+        lightningcss: LightningCssOptions,
     ) -> Result<Vc<Self>> {
         Ok(Self::cell(CssModule {
             origin_path: source.ident().await?.path.clone(),
@@ -66,7 +66,7 @@ impl CssModule {
             import_context,
             ty,
             environment,
-            lightningcss_features,
+            lightningcss,
         }))
     }
 
@@ -89,7 +89,7 @@ impl ParseCss for CssModule {
             this.import_context.map(|v| *v),
             this.ty,
             this.environment.as_deref().copied(),
-            this.lightningcss_features,
+            this.lightningcss.clone(),
         ))
     }
 }
@@ -104,7 +104,7 @@ impl ProcessCss for CssModule {
         Ok(process_css_with_placeholder(
             parse_result,
             this.environment.as_deref().copied(),
-            this.lightningcss_features,
+            this.lightningcss.features,
         ))
     }
 
@@ -128,7 +128,7 @@ impl ProcessCss for CssModule {
             minify_type,
             origin_source_map,
             this.environment.as_deref().copied(),
-            this.lightningcss_features,
+            this.lightningcss.features,
         ))
     }
 }

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod process;
 pub(crate) mod references;
 
 use bincode::{Decode, Encode};
+use turbo_rcstr::RcStr;
 use turbo_tasks::trace::TraceRawVcs;
 
 use crate::references::import::ImportAssetReference;
@@ -38,4 +39,37 @@ pub enum CssModuleType {
 pub struct LightningCssFeatureFlags {
     pub include: u32,
     pub exclude: u32,
+}
+
+/// User-specified lightningcss options that are passed through to lightningcss
+/// when Turbopack processes CSS.
+///
+/// This is the aggregate of the individual `experimental.lightningCss*` config
+/// keys. It is threaded from the module options context down to the CSS parser.
+#[turbo_tasks::value(shared, serialization = "auto", task_input)]
+#[derive(PartialOrd, Ord, Hash, Clone, Debug, Default)]
+pub struct LightningCssOptions {
+    /// Feature `include`/`exclude` bitmasks (from `lightningCssFeatures`).
+    pub features: LightningCssFeatureFlags,
+    /// CSS-modules configuration (from `lightningCss.cssModules`).
+    pub css_modules: LightningCssModulesOptions,
+}
+
+/// Passthrough configuration for lightningcss CSS modules.
+///
+/// Mirrors the relevant fields of lightningcss' [`css_modules::Config`]. Fields
+/// left at their defaults preserve Next.js' built-in behavior.
+///
+/// [`css_modules::Config`]: lightningcss::css_modules::Config
+#[turbo_tasks::value(shared, serialization = "auto", task_input)]
+#[derive(PartialOrd, Ord, Hash, Clone, Debug, Default)]
+pub struct LightningCssModulesOptions {
+    /// The class-name pattern in lightningcss syntax, e.g.
+    /// `[name]__[hash]__[local]`. `None` uses the Next.js default pattern.
+    ///
+    /// Recognized placeholders: `[name]`, `[local]`, `[hash]`,
+    /// `[content-hash]`. Any other text is treated as a literal.
+    pub pattern: Option<RcStr>,
+    /// Whether to rename dashed identifiers (e.g. CSS custom properties).
+    pub dashed_idents: bool,
 }

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, LazyLock, Mutex, RwLock};
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
@@ -36,7 +36,7 @@ use turbopack_core::{
 };
 
 use crate::{
-    CssModuleType, LightningCssFeatureFlags,
+    CssModuleType, LightningCssFeatureFlags, LightningCssModulesOptions, LightningCssOptions,
     lifetime_util::stylesheet_into_static,
     references::{
         analyze_references,
@@ -366,7 +366,7 @@ pub async fn parse_css(
     import_context: Option<ResolvedVc<ImportContext>>,
     ty: CssModuleType,
     environment: Option<ResolvedVc<Environment>>,
-    feature_flags: LightningCssFeatureFlags,
+    lightningcss: LightningCssOptions,
 ) -> Result<Vc<ParseCssResult>> {
     let span = tracing::info_span!(
         "parse css",
@@ -391,7 +391,7 @@ pub async fn parse_css(
                             import_context,
                             ty,
                             environment,
-                            feature_flags,
+                            lightningcss,
                         )
                         .await?
                     }
@@ -427,6 +427,72 @@ fn parse_css_stylesheet<'a, 'o>(
     Ok(ss)
 }
 
+/// The Next.js default CSS-modules class-name pattern (`[name]__[hash]__[local]`),
+/// used when the user does not configure a custom pattern.
+fn default_css_module_pattern() -> Pattern<'static> {
+    Pattern {
+        segments: smallvec![
+            Segment::Name,
+            Segment::Literal("__"),
+            Segment::Hash,
+            Segment::Literal("__"),
+            Segment::Local,
+        ],
+    }
+}
+
+/// Interns a CSS-modules pattern string so it can be used as a `'static`
+/// [`Pattern`]. lightningcss' `Pattern` borrows its literal segments from the
+/// input, but the parsed [`ParserOptions`] must outlive this function, so the
+/// backing string has to be `'static`.
+///
+/// The set of distinct patterns is tiny (typically a single value from
+/// `next.config.js`), so each unique pattern is leaked at most once.
+fn intern_pattern(pattern: &str) -> &'static str {
+    static INTERNED: LazyLock<Mutex<FxHashMap<Box<str>, &'static str>>> =
+        LazyLock::new(|| Mutex::new(FxHashMap::default()));
+
+    let mut interned = INTERNED.lock().unwrap();
+    if let Some(&existing) = interned.get(pattern) {
+        return existing;
+    }
+    let leaked: &'static str = Box::leak(pattern.to_owned().into_boxed_str());
+    interned.insert(pattern.into(), leaked);
+    leaked
+}
+
+/// Resolves the lightningcss CSS-modules class-name pattern from user config,
+/// falling back to the Next.js default when unset. Invalid patterns are
+/// normally rejected earlier (at config load); if one still reaches here we
+/// surface a warning and use the default so the build can proceed.
+fn css_module_pattern(
+    options: &LightningCssModulesOptions,
+    source: ResolvedVc<Box<dyn Source>>,
+) -> Pattern<'static> {
+    let Some(pattern) = options.pattern.as_deref() else {
+        return default_css_module_pattern();
+    };
+
+    match Pattern::parse(intern_pattern(pattern)) {
+        Ok(pattern) => pattern,
+        Err(err) => {
+            ParsingIssue {
+                severity: IssueSeverity::Warning,
+                msg: format!(
+                    "Invalid `experimental.lightningCss.cssModules.pattern` ({pattern:?}): {err}. \
+                     Falling back to the default pattern."
+                )
+                .into(),
+                stage: IssueStage::Transform,
+                source: IssueSource::from_source_only(source),
+            }
+            .resolved_cell()
+            .emit();
+            default_css_module_pattern()
+        }
+    }
+}
+
 async fn process_content(
     content_vc: ResolvedVc<FileContent>,
     code: String,
@@ -436,7 +502,7 @@ async fn process_content(
     import_context: Option<ResolvedVc<ImportContext>>,
     ty: CssModuleType,
     environment: Option<ResolvedVc<Environment>>,
-    feature_flags: LightningCssFeatureFlags,
+    lightningcss: LightningCssOptions,
 ) -> Result<Vc<ParseCssResult>> {
     #[allow(clippy::needless_lifetimes)]
     fn without_warnings<'o, 'i>(config: ParserOptions<'o, 'i>) -> ParserOptions<'o, 'static> {
@@ -453,16 +519,8 @@ async fn process_content(
     let config = ParserOptions {
         css_modules: match ty {
             CssModuleType::Module => Some(lightningcss::css_modules::Config {
-                pattern: Pattern {
-                    segments: smallvec![
-                        Segment::Name,
-                        Segment::Literal("__"),
-                        Segment::Hash,
-                        Segment::Literal("__"),
-                        Segment::Local,
-                    ],
-                },
-                dashed_idents: false,
+                pattern: css_module_pattern(&lightningcss.css_modules, source),
+                dashed_idents: lightningcss.css_modules.dashed_idents,
                 grid: false,
                 container: false,
                 ..Default::default()
@@ -532,7 +590,7 @@ async fn process_content(
                 let targets = *get_lightningcss_browser_targets(
                     environment.as_deref().copied(),
                     true,
-                    feature_flags,
+                    lightningcss.features,
                 )
                 .await?;
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -259,7 +259,7 @@ async fn apply_module_type(
         ModuleType::Css {
             ty,
             environment,
-            lightningcss_features,
+            lightningcss,
         } => ResolvedVc::upcast(
             CssModule::new(
                 *source,
@@ -267,7 +267,7 @@ async fn apply_module_type(
                 *ty,
                 css_import_context.map(|c| *c),
                 environment.as_deref().copied(),
-                *lightningcss_features,
+                lightningcss.clone(),
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -257,7 +257,7 @@ impl ModuleOptions {
                     enable_raw_css,
                     source_maps: css_source_maps,
                     ref module_css_condition,
-                    lightningcss_features,
+                    ref lightningcss,
                     ..
                 },
             ref static_url_tag,
@@ -512,7 +512,7 @@ impl ModuleOptions {
                                     postprocess,
                                     ecmascript_options_vc,
                                     environment,
-                                    lightningcss_features,
+                                    lightningcss.clone(),
                                 )
                                 .await?,
                         )
@@ -843,7 +843,7 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleType::Module,
                         environment,
-                        lightningcss_features,
+                        lightningcss: lightningcss.clone(),
                     })],
                 ),
                 ModuleRule::new(
@@ -854,7 +854,7 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleType::Default,
                         environment,
-                        lightningcss_features,
+                        lightningcss: lightningcss.clone(),
                     })],
                 ),
             ]);
@@ -918,7 +918,7 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleType::Module,
                         environment,
-                        lightningcss_features,
+                        lightningcss: lightningcss.clone(),
                     })],
                 ),
                 // Ecmascript CSS Modules referencing the actual CSS module to include it
@@ -932,7 +932,7 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleType::Module,
                         environment,
-                        lightningcss_features,
+                        lightningcss: lightningcss.clone(),
                     })],
                 ),
                 // Ecmascript CSS Modules referencing the actual CSS module to list the classes
@@ -946,7 +946,7 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleType::Module,
                         environment,
-                        lightningcss_features,
+                        lightningcss: lightningcss.clone(),
                     })],
                 ),
                 ModuleRule::new(
@@ -961,7 +961,7 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleType::Default,
                         environment,
-                        lightningcss_features,
+                        lightningcss: lightningcss.clone(),
                     })],
                 ),
             ]);

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -308,8 +308,8 @@ pub struct CssOptionsContext {
     /// `Any(ResourcePathEndsWith(".module.css"), ContentTypeStartsWith("text/css+module"))`
     pub module_css_condition: Option<RuleCondition>,
 
-    /// User-specified lightningcss feature flags (include/exclude bitmasks).
-    pub lightningcss_features: turbopack_css::LightningCssFeatureFlags,
+    /// User-specified lightningcss options (feature flags + CSS-modules config).
+    pub lightningcss: turbopack_css::LightningCssOptions,
 
     pub placeholder_for_future_extensions: (),
 }

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -142,7 +142,7 @@ pub enum ModuleType {
     Css {
         ty: CssModuleType,
         environment: Option<ResolvedVc<Environment>>,
-        lightningcss_features: turbopack_css::LightningCssFeatureFlags,
+        lightningcss: turbopack_css::LightningCssOptions,
     },
     StaticUrlJs {
         /// The tag that is passed to ChunkingContext::asset_url
@@ -232,7 +232,7 @@ impl ConfiguredModuleType {
         postprocess: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         environment: Option<ResolvedVc<Environment>>,
-        lightningcss_features: turbopack_css::LightningCssFeatureFlags,
+        lightningcss: turbopack_css::LightningCssOptions,
     ) -> Result<ModuleRuleEffect> {
         Ok(match self {
             ConfiguredModuleType::Bytes => {
@@ -266,7 +266,7 @@ impl ConfiguredModuleType {
             ConfiguredModuleType::Css => ModuleRuleEffect::ModuleType(ModuleType::Css {
                 ty: CssModuleType::Default,
                 environment,
-                lightningcss_features,
+                lightningcss,
             }),
             ConfiguredModuleType::CssModule => ModuleRuleEffect::ModuleType(ModuleType::CssModule),
             ConfiguredModuleType::Json => {


### PR DESCRIPTION
Addresses:
- https://github.com/vercel/next.js/discussions/64580
- https://github.com/vercel/next.js/discussions/85869

## Summary

Adds an experimental config surface for customizing how Turbopack invokes lightningcss. Two things Turbopack previously did not expose:

1. **CSS-modules class names** — the class-name pattern was hard-coded as `[name]__[hash]__[local]`.
2. **A single passthrough home** — feature flags now live under `lightningCss` alongside CSS-modules config.

```js
// next.config.js
module.exports = {
  experimental: {
    lightningCss: {
      features: { include: ["nesting"], exclude: [] },
      cssModules: {
        pattern: "[name]__[hash]__[local]", // lightningcss placeholder syntax
        dashedIdents: false,
      },
    },
  },
}
```

- `cssModules.pattern` accepts lightningcss placeholders (`[name]`, `[local]`, `[hash]`, `[content-hash]`) plus literals, validated at config load (invalid values fail the build with a clear message).
- `lightningCss.features` (include/exclude) **takes precedence over the legacy top-level `experimental.lightningCssFeatures`** when both are set; `lightningCssFeatures` is kept for backwards compatibility. A warning is emitted if both are set.
- Turbopack-only for now. `useLightningcss` is unchanged — it remains the webpack-only switch (in Turbopack lightningcss always processes CSS, so it is a no-op there). A warning is emitted if `lightningCss` is set with the webpack bundler. The `lightningCss` object leaves room for webpack parity and broader passthrough (drafts / nonStandard / pseudoClasses) later.

Internally, the existing `LightningCssFeatureFlags` becomes the `features` field of a new `LightningCssOptions` (features + CSS-modules config) threaded through the CSS module pipeline.

## Backwards compatibility

Fully backwards compatible. The config is additive and optional at every layer (`Option` in Rust, `.optional()` in the zod schema). When `experimental.lightningCss` is unset, the code falls back to the exact previous defaults — the hard-coded `[name]__[hash]__[local]` pattern, `dashedIdents: false`, the same `grid`/`container` settings, and the legacy `lightningCssFeatures` for feature flags — so existing projects produce byte-identical class names and CSS output. No migration needed.

## Verification

- `cargo check -p turbopack-css -p turbopack -p next-core` — clean
- `pnpm build-all` (JS + native) — succeeds
- `pnpm test-dev-turbo test/e2e/app-dir/experimental-lightningcss-css-modules/...` — passes (custom pattern renders `.box` as `box__custom__<hash>`)
- `pnpm test-dev-turbo test/e2e/app-dir/experimental-lightningcss-features/...` — passes, including a new case asserting `lightningCss.features` overrides `lightningCssFeatures`
- Backwards-compat check on a real app (~176 `.module.scss` files) with no config: class names remain the default `[name]__[hash]__[local]` (e.g. `styles-module-scss-module__jMmjOa__root`), unchanged from before


## Verification screenshots
<img width="638" height="259" alt="Screenshot 2026-07-03 at 9 59 37 AM" src="https://github.com/user-attachments/assets/0ab2736e-0b0a-44ac-b296-9d32c10aab3d" />
<img width="617" height="290" alt="Screenshot 2026-07-03 at 9 59 10 AM" src="https://github.com/user-attachments/assets/6b286d03-80e0-4e24-b1c5-607a631a2601" />

<!-- NEXT_JS_LLM_PR -->