### PR TITLE
Abort superseded Server Components HMR requests on the client

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -53,6 +53,7 @@ import {
   NEXT_IS_PRERENDER_HEADER,
   NEXT_DID_POSTPONE_HEADER,
   RSC_CONTENT_TYPE_HEADER,
+  NEXT_HMR_REFRESH_HEADER,
 } from '../../client/components/app-router-headers' with { 'turbopack-transition': 'next-server-utility' }
 import {
   getBotType,
@@ -1576,9 +1577,21 @@ export async function handler(
         )
       }
 
-      // In dev, we should not cache pages for any reason.
+      // Dev responses use `no-cache` so the browser can restore them from the
+      // HTTP cache on back/forward instead of reloading. HMR refresh responses
+      // opt out into `no-store` because a superseded refresh's fetch is aborted
+      // mid-write: under `no-cache` the response is stored, so the abort leaves
+      // the cache entry shared with the superseding refresh (same URL)
+      // half-written; Chromium then discards it and reissues the superseding
+      // refresh on a second connection as a duplicate request. `no-store` keeps
+      // that entry from being created.
       if (routeModule.isDev) {
-        res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        res.setHeader(
+          'Cache-Control',
+          req.headers[NEXT_HMR_REFRESH_HEADER] === '1'
+            ? 'no-store'
+            : 'no-cache, must-revalidate'
+        )
       }
 
       if (!cacheEntry) {

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -380,6 +380,10 @@ function gesturePush(href: string, options?: NavigateOptions): void {
   }
 }
 
+// Tracks the newest HMR refresh generation so that a newer refresh can abort
+// the request of the one it supersedes. Development only.
+let activeHmrRefreshController: AbortController | null = null
+
 /**
  * The app router that is exposed through `useRouter`. These are public API
  * methods. Internal Next.js code should call the lower level methods directly
@@ -486,9 +490,19 @@ export const publicAppRouterInstance: AppRouterInstance = {
       // Reset the known routes table so that route predictions are cleared
       // when routes change during development.
       resetKnownRoutes()
+      let signal: AbortSignal | undefined
+      if (process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION) {
+        // Abort the superseded generation before scheduling the new one, so its
+        // request is torn down as early as possible. Halting (not rejecting)
+        // makes the abort safe regardless of order.
+        activeHmrRefreshController?.abort()
+        activeHmrRefreshController = new AbortController()
+        signal = activeHmrRefreshController.signal
+      }
       startTransition(() => {
         dispatchAppRouterAction({
           type: ACTION_HMR_REFRESH,
+          signal,
         })
       })
     }

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -66,6 +66,7 @@ export interface FetchServerResponseOptions {
   readonly flightRouterState: FlightRouterState
   readonly nextUrl: string | null
   readonly isHmrRefresh?: boolean
+  readonly signal?: AbortSignal
 }
 
 export type StaticStageData<
@@ -198,7 +199,8 @@ export async function fetchServerResponse(
       url,
       headers,
       'auto',
-      shouldImmediatelyDecode
+      shouldImmediatelyDecode,
+      options.signal
     )
 
     // If the fetch succeeds while we're in the offline state, notify the
@@ -313,6 +315,13 @@ export async function fetchServerResponse(
       revealAfter: flightResponse._revealAfter ?? null,
     }
   } catch (err) {
+    if (options.signal?.aborted) {
+      // A newer HMR refresh superseded this one and aborted its request.
+      // Rethrow so the caller treats it as canceled, rather than logging a
+      // failure or falling back to an MPA navigation.
+      throw err
+    }
+
     // If the fetch rejected due to a network error, wait for connectivity
     // to be restored and then retry. checkOfflineError returns true for
     // network errors (and starts the polling loop); returns false for
@@ -549,6 +558,123 @@ export async function decodeStageUntilBoundary<T>(
   })
 }
 
+// When an HMR refresh can be superseded, we decode its Flight response through
+// a wrapper stream we can close on abort. Closing the stream (rather than
+// letting the aborted fetch error it) makes React's Flight client mark
+// unresolved rows as halted: they suspend during render instead of rejecting,
+// so a superseded request never surfaces an error on an already-committed tree.
+// Because the stream is closed, there's also no unclosed-stream GC-root leak
+// (see #89610). The wrapper is created synchronously here so that the decode
+// starts at the same point `createFromNextFetch` would, preserving the
+// server-latency debug timing.
+function createHaltingFlightResponse<T>(
+  fetchPromise: Promise<Response>,
+  headers: RequestHeaders,
+  signal: AbortSignal
+): Promise<T> & { _debugInfo?: Array<any> } {
+  let closed = false
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+  const wrapper = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const onAbort = () => {
+        closed = true
+        try {
+          controller.close()
+        } catch {
+          // The controller may already be closed; nothing to do.
+        }
+        if (reader !== null) {
+          reader.cancel().catch(() => {})
+        }
+      }
+      if (signal.aborted) {
+        onAbort()
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+    },
+    async pull(controller) {
+      if (closed) {
+        return
+      }
+      if (reader === null) {
+        let response: Response
+        try {
+          response = await fetchPromise
+        } catch (err) {
+          // We don't inspect `err`. If the request was superseded, `onAbort`
+          // already ran synchronously (abort listeners fire during
+          // `signal.abort()`, before this rejection microtask), so `closed` is
+          // true and the controller is already closed — erroring it would
+          // throw, and a superseded request's failure is moot regardless of its
+          // cause. Only a genuine, non-superseded failure reaches here with
+          // `closed` still false; that is the case we surface.
+          if (!closed) {
+            controller.error(err)
+          }
+          return
+        }
+        if (closed) {
+          // Aborted while awaiting the response. The `fetch` abort tears down
+          // an in-flight request, but if it had already completed we still hold
+          // an unread body; release it so it isn't left dangling.
+          response.body?.cancel().catch(() => {})
+          return
+        }
+        const body = response.body
+        if (body === null) {
+          controller.close()
+          return
+        }
+        reader = body.getReader()
+      }
+      try {
+        const { done, value } = await reader.read()
+        if (closed) {
+          return
+        }
+        if (done) {
+          controller.close()
+        } else {
+          controller.enqueue(value)
+        }
+      } catch (err) {
+        // Same as the fetch catch above: once superseded (`closed`) the
+        // controller is already closed and the outcome is moot, so we swallow
+        // the rejection unconditionally; only a real, non-superseded read
+        // failure (`closed` still false) is surfaced.
+        if (!closed) {
+          controller.error(err)
+        }
+      }
+    },
+  })
+
+  // React attaches `_debugInfo` to the returned promise at runtime.
+  return createFromNextReadableStream<T>(wrapper, headers, {
+    allowPartialStream: true,
+  }) as Promise<T> & { _debugInfo?: Array<any> }
+}
+
+// Selects the Flight decode strategy: a halting wrapper for cancellable HMR
+// refreshes, otherwise the standard fetch-based decode. Gated to the dev server
+// (where HMR runs) so the wrapper is eliminated from production and
+// `--debug-prerender` bundles regardless of the flag.
+function decodeFlightResponse<T>(
+  fetchPromise: Promise<Response>,
+  headers: RequestHeaders,
+  signal: AbortSignal | undefined
+): Promise<T> & { _debugInfo?: Array<any> } {
+  if (
+    process.env.__NEXT_DEV_SERVER &&
+    process.env.__NEXT_SERVER_COMPONENTS_HMR_CANCELLATION &&
+    signal
+  ) {
+    return createHaltingFlightResponse<T>(fetchPromise, headers, signal)
+  }
+  return createFromNextFetch<T>(fetchPromise, headers)
+}
+
 export async function createFetch<T>(
   url: URL,
   headers: RequestHeaders,
@@ -606,7 +732,7 @@ export async function createFetch<T>(
   // been written into the cache by the time the navigation happens, the router
   // will go straight to a dynamic request.
   let flightResponsePromise = shouldImmediatelyDecode
-    ? createFromNextFetch<T>(fetchPromise, headers)
+    ? decodeFlightResponse<T>(fetchPromise, headers, signal)
     : null
   let browserResponse = await fetchPromise
 
@@ -667,7 +793,7 @@ export async function createFetch<T>(
       processed = fetch(fetchUrl, fetchOptions).then(processFetch)
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
-        ? createFromNextFetch<T>(fetchPromise, headers)
+        ? decodeFlightResponse<T>(fetchPromise, headers, signal)
         : null
       browserResponse = await fetchPromise
       // We just performed a manual redirect, so this is now true.

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -104,6 +104,11 @@ const enum NavigationTaskStatus {
  */
 const enum NavigationTaskExitStatus {
   /**
+   * The request was superseded by a newer navigation and aborted. No retry is
+   * needed; the newer request owns the tree from here.
+   */
+  Canceled = -1,
+  /**
    * No additional navigation is required.
    */
   Done = 0,
@@ -1411,7 +1416,8 @@ export function spawnDynamicRequests(
   // server-patch retry logic so it can inherit the intent if the original
   // transition hasn't committed yet.
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  signal: AbortSignal | undefined
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
   if (dynamicRequestTree === null) {
@@ -1436,7 +1442,8 @@ export function spawnDynamicRequests(
     nextUrl,
     freshnessPolicy,
     routeCacheEntry,
-    navigationLock
+    navigationLock,
+    signal
   )
 
   const separateRefreshUrls = accumulation.separateRefreshUrls
@@ -1489,7 +1496,8 @@ export function spawnDynamicRequests(
             nextUrl,
             freshnessPolicy,
             routeCacheEntry,
-            navigationLock
+            navigationLock,
+            signal
           )
         )
       }
@@ -1538,6 +1546,14 @@ async function finishNavigationTask(
   }
 
   switch (exitStatus) {
+    case NavigationTaskExitStatus.Canceled: {
+      // This navigation was superseded and its request aborted. Its cache nodes
+      // may already be reused by the newer navigation, so leave them untouched
+      // for the newer request to fulfill. If the tree was abandoned entirely,
+      // it can be garbage collected along with its unresolved promises. We do
+      // not retry or hard-navigate.
+      return
+    }
     case NavigationTaskExitStatus.Done: {
       // The task has completely finished. There's no missing data. Exit.
       previousNavigationDidMismatch = false
@@ -1758,7 +1774,8 @@ async function fetchMissingDynamicData(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock,
+  signal: AbortSignal | undefined
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
   url: URL
@@ -1769,6 +1786,7 @@ async function fetchMissingDynamicData(
       flightRouterState: dynamicRequestTree,
       nextUrl,
       isHmrRefresh: freshnessPolicy === FreshnessPolicy.HMRRefresh,
+      signal,
     })
     if (typeof result === 'string') {
       // fetchServerResponse will return an href to indicate that the SPA
@@ -1913,6 +1931,17 @@ async function fetchMissingDynamicData(
       seed,
     }
   } catch {
+    if (signal?.aborted) {
+      // A newer HMR refresh superseded this one and aborted its request. Treat
+      // it as canceled rather than a failure, so we don't retry or
+      // hard-navigate.
+      return {
+        exitStatus: NavigationTaskExitStatus.Canceled,
+        url,
+        seed: null,
+      }
+    }
+
     // This shouldn't happen because fetchServerResponse's entire body is
     // wrapped in a try/catch. If it does, though, it implies the server failed
     // to respond with any tree at all. So we must fall back to a hard retry.

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -1,10 +1,21 @@
 import type {
+  HmrRefreshAction,
   ReadonlyReducerState,
   ReducerState,
 } from '../router-reducer-types'
 import { refreshDynamicData } from './refresh-reducer'
 import { FreshnessPolicy } from '../ppr-navigations'
 
-export function hmrRefreshReducer(state: ReadonlyReducerState): ReducerState {
-  return refreshDynamicData(state, FreshnessPolicy.HMRRefresh)
+export function hmrRefreshReducer(
+  state: ReadonlyReducerState,
+  action: HmrRefreshAction
+): ReducerState {
+  // HMR actions may wait behind a Server Action in the router queue. If a newer
+  // generation superseded this one before it started, don't install a refresh
+  // tree whose request is already canceled.
+  if (action.signal?.aborted) {
+    return state
+  }
+
+  return refreshDynamicData(state, FreshnessPolicy.HMRRefresh, action.signal)
 }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -35,12 +35,14 @@ export function refreshReducer(
     const currentRouterState = state.tree
     invalidateSegmentCacheEntries(currentNextUrl, currentRouterState)
   }
-  return refreshDynamicData(state, FreshnessPolicy.RefreshAll)
+  // A full refresh has no HMR generation to cancel.
+  return refreshDynamicData(state, FreshnessPolicy.RefreshAll, undefined)
 }
 
 export function refreshDynamicData(
   state: ReadonlyReducerState,
-  freshnessPolicy: FreshnessPolicy.RefreshAll | FreshnessPolicy.HMRRefresh
+  freshnessPolicy: FreshnessPolicy.RefreshAll | FreshnessPolicy.HMRRefresh,
+  signal: AbortSignal | undefined
 ): ReducerState {
   // During a refresh, invalidate the BFCache, which may contain dynamic data.
   invalidateBfCache()
@@ -103,6 +105,7 @@ export function refreshDynamicData(
     // cache entry to mark as having a dynamic rewrite on mismatch. If a
     // mismatch occurs, the retry handler will traverse the known route tree
     // to find and mark the entry.
-    null
+    null,
+    signal
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -94,7 +94,9 @@ export function restoreReducer(
     null,
     // History traversal always uses 'replace'.
     'replace',
-    navigationLock
+    navigationLock,
+    // Not an HMR refresh, so there's no request generation to cancel.
+    undefined
   )
   return completeTraverseNavigation(
     state,

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -518,7 +518,9 @@ export function serverActionReducer(
           // have the route tree from the server response. If a mismatch occurs
           // during dynamic data fetch, the retry handler will traverse the
           // known route tree to mark the entry as having a dynamic rewrite.
-          null
+          null,
+          // Not an HMR refresh, so there's no request generation to cancel.
+          undefined
         )
       }
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -69,6 +69,8 @@ export function serverPatchReducer(
     // Server patch (retry) navigations don't use route prediction. This is
     // typically a retry after a previous mismatch, so the route was already
     // marked as having a dynamic rewrite when the mismatch was detected.
-    null
+    null,
+    // Not an HMR refresh, so there's no request generation to cancel.
+    undefined
   )
 }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -38,6 +38,7 @@ export interface RefreshAction {
 
 export interface HmrRefreshAction {
   type: typeof ACTION_HMR_REFRESH
+  signal?: AbortSignal
 }
 
 export type ServerActionDispatcher = (

--- a/packages/next/src/client/components/router-reducer/router-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer.ts
@@ -41,7 +41,7 @@ function clientReducer(
       if (process.env.NODE_ENV === 'development') {
         const { hmrRefreshReducer } =
           require('./reducers/hmr-refresh-reducer') as typeof import('./reducers/hmr-refresh-reducer')
-        return hmrRefreshReducer(state)
+        return hmrRefreshReducer(state, action)
       } else {
         throw new Error(
           'hmrRefresh can only be used in development mode. Please use refresh instead.'

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -239,7 +239,8 @@ export function navigateToKnownRoute(
   // In these cases, if a mismatch occurs, we still mark the route as having a
   // dynamic rewrite by traversing the known route tree (see
   // dispatchRetryDueToTreeMismatch).
-  routeCacheEntry: FulfilledRouteCacheEntry | null
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  signal: AbortSignal | undefined
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
@@ -352,7 +353,8 @@ export function navigateToKnownRoute(
         accumulation,
         routeCacheEntry,
         navigateType,
-        navigationLock
+        navigationLock,
+        signal
       )
     }
     return completeSoftNavigation(
@@ -415,7 +417,9 @@ function navigateUsingPrefetchedRouteTree(
     navigateType,
     navigationLock,
     null,
-    route
+    route,
+    // Not an HMR refresh, so there's no request generation to cancel.
+    undefined
   )
 }
 
@@ -631,7 +635,9 @@ async function navigateToUnknownRoute(
     // came directly from the server. If a mismatch occurs during dynamic data
     // fetch, the retry handler will traverse the known route tree to mark the
     // entry as having a dynamic rewrite.
-    null
+    null,
+    // Not an HMR refresh, so there's no request generation to cancel.
+    undefined
   )
 }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -90,6 +90,7 @@ import {
   NEXT_URL,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_INSTANT_TEST_COOKIE,
+  NEXT_HMR_REFRESH_HEADER,
 } from '../client/components/app-router-headers'
 import type {
   MatchOptions,
@@ -1818,9 +1819,21 @@ export default abstract class Server<
     if (!res.sent) {
       const { generateEtags, poweredByHeader } = this.renderOpts
 
-      // In dev, we should not cache pages for any reason.
+      // Dev responses use `no-cache` so the browser can restore them from the
+      // HTTP cache on back/forward instead of reloading. HMR refresh responses
+      // opt out into `no-store` because a superseded refresh's fetch is aborted
+      // mid-write: under `no-cache` the response is stored, so the abort leaves
+      // the cache entry shared with the superseding refresh (same URL)
+      // half-written; Chromium then discards it and reissues the superseding
+      // refresh on a second connection as a duplicate request. `no-store` keeps
+      // that entry from being created.
       if (this.dev) {
-        res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        res.setHeader(
+          'Cache-Control',
+          req.headers[NEXT_HMR_REFRESH_HEADER] === '1'
+            ? 'no-store'
+            : 'no-cache, must-revalidate'
+        )
         cacheControl = undefined
       }
 

--- a/test/development/app-dir/hmr-rsc-cancellation/app/layout.tsx
+++ b/test/development/app-dir/hmr-rsc-cancellation/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
+++ b/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
@@ -1,0 +1,27 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+// Editing any of these constants triggers a Server Component HMR refresh.
+// `boundaryKey` is the Suspense boundary's key: changing it remounts the
+// boundary, so the remounted boundary has no prior content and commits its
+// fallback while `DynamicContent` streams — a partially committed tree.
+const boundaryKey = 'initial'
+const dynamicMarker = 'initial'
+const dynamicDelayMs = 0
+
+async function DynamicContent() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, dynamicDelayMs))
+  return <p id="dynamic">{dynamicMarker}</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="shell">shell</p>
+      <Suspense key={boundaryKey} fallback={<p id="dynamic">loading</p>}>
+        <DynamicContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
+++ b/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { retry, assertNoConsoleErrors } from 'next-test-utils'
 import type { Playwright } from 'next-webdriver'
 
 describe('hmr-rsc-cancellation', () => {
@@ -81,7 +81,7 @@ describe('hmr-rsc-cancellation', () => {
 
   it('cancels a superseded Server Component HMR request', async () => {
     await next.start()
-    const browser = await next.browser('/')
+    const browser = await next.browser('/', { pushErrorAsConsoleLog: true })
     await retry(async () => {
       expect(await browser.elementById('dynamic').text()).toBe('initial')
     })
@@ -125,12 +125,13 @@ describe('hmr-rsc-cancellation', () => {
         { aborted: false, settled: true },
       ])
     })
+    await assertNoConsoleErrors(browser)
     expectCleanCliOutput(next.cliOutput.slice(cliStart))
   })
 
   it('does not surface an error when a partially committed render is superseded', async () => {
     await next.start()
-    const browser = await next.browser('/')
+    const browser = await next.browser('/', { pushErrorAsConsoleLog: true })
     await retry(async () => {
       expect(await browser.elementById('dynamic').text()).toBe('initial')
     })
@@ -178,6 +179,7 @@ describe('hmr-rsc-cancellation', () => {
         { aborted: false, settled: true },
       ])
     })
+    await assertNoConsoleErrors(browser)
     expectCleanCliOutput(next.cliOutput.slice(cliStart))
   })
 
@@ -189,7 +191,7 @@ describe('hmr-rsc-cancellation', () => {
       )
     )
     await next.start()
-    const browser = await next.browser('/')
+    const browser = await next.browser('/', { pushErrorAsConsoleLog: true })
     await retry(async () => {
       expect(await browser.elementById('dynamic').text()).toBe('initial')
     })

--- a/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
+++ b/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
@@ -1,0 +1,234 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type { Playwright } from 'next-webdriver'
+
+describe('hmr-rsc-cancellation', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  let pristinePage: string
+  let pristineConfig: string
+
+  beforeAll(async () => {
+    pristinePage = await next.readFile('app/page.tsx')
+    pristineConfig = await next.readFile('next.config.js')
+  })
+
+  afterEach(async () => {
+    await next.stop()
+    // Restore the fixture so each test starts from the same baseline.
+    await next.patchFile('app/page.tsx', pristinePage)
+    await next.patchFile('next.config.js', pristineConfig)
+  })
+
+  // Records each HMR RSC request's aborted/settled state, and a sentinel that
+  // is cleared if the page hard-reloads (so we can assert cancellation never
+  // triggers a reload).
+  async function instrumentBrowser(browser: Playwright) {
+    await browser.eval(() => {
+      const requests: Array<{ aborted: boolean; settled: boolean }> = []
+      ;(window as any).__hmrRequests = requests
+      ;(window as any).__reloadSentinel = true
+      const originalFetch = window.fetch
+      window.fetch = (input: any, init: any) => {
+        const headers = new Headers(init?.headers)
+        if (headers.get('next-hmr-refresh') === '1') {
+          const record = {
+            aborted: init?.signal?.aborted ?? false,
+            settled: false,
+          }
+          requests.push(record)
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              record.aborted = true
+            },
+            { once: true }
+          )
+          const result = originalFetch(input, init)
+          result.then(
+            () => {
+              record.settled = true
+            },
+            () => {
+              record.settled = true
+            }
+          )
+          return result
+        }
+        return originalFetch(input, init)
+      }
+    })
+  }
+
+  function readResult(browser: Playwright) {
+    return browser.eval(() => ({
+      requests: (window as any).__hmrRequests as Array<{
+        aborted: boolean
+        settled: boolean
+      }>,
+      reloaded: (window as any).__reloadSentinel !== true,
+    }))
+  }
+
+  function expectCleanCliOutput(output: string) {
+    expect(output).not.toContain('Failed to fetch RSC payload')
+    expect(output).not.toContain('Cannot write to a closing writable stream')
+    expect(output).not.toContain('unhandledRejection')
+  }
+
+  it('cancels a superseded Server Component HMR request', async () => {
+    await next.start()
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('initial')
+    })
+    await instrumentBrowser(browser)
+    const cliStart = next.cliOutput.length
+
+    // Request A: a slow refresh whose dynamic content keeps streaming.
+    await next.patchFile('app/page.tsx', (src) =>
+      src
+        .replace(
+          /const dynamicMarker = '[^']*'/,
+          "const dynamicMarker = 'slow'"
+        )
+        .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 5000')
+    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => (window as any).__hmrRequests.length)
+      ).toBe(1)
+    })
+
+    // Request B supersedes A, aborting it.
+    await next.patchFile('app/page.tsx', (src) =>
+      src
+        .replace(
+          /const dynamicMarker = '[^']*'/,
+          "const dynamicMarker = 'latest'"
+        )
+        .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 0')
+    )
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('latest')
+    })
+
+    await retry(async () => {
+      const { requests, reloaded } = await readResult(browser)
+      expect(reloaded).toBe(false)
+      // Two refreshes: the superseded one was aborted, the newest committed.
+      expect(requests).toMatchObject([
+        { aborted: true, settled: true },
+        { aborted: false, settled: true },
+      ])
+    })
+    expectCleanCliOutput(next.cliOutput.slice(cliStart))
+  })
+
+  it('does not surface an error when a partially committed render is superseded', async () => {
+    await next.start()
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('initial')
+    })
+    await instrumentBrowser(browser)
+    const cliStart = next.cliOutput.length
+
+    // Request A: remount the Suspense boundary (new key) with a slow dynamic.
+    // The remounted boundary has no prior content, so React commits it showing
+    // its fallback while the dynamic row streams — the tree is partially
+    // committed and on screen.
+    await next.patchFile('app/page.tsx', (src) =>
+      src
+        .replace(/const boundaryKey = '[^']*'/, "const boundaryKey = 'a'")
+        .replace(
+          /const dynamicMarker = '[^']*'/,
+          "const dynamicMarker = 'slow'"
+        )
+        .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 5000')
+    )
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('loading')
+    })
+
+    // Request B supersedes A, keeping the same boundary key so B reuses the
+    // committed boundary that is showing A's fallback. A's aborted dynamic row
+    // must halt (suspend) rather than reject into that mounted boundary.
+    await next.patchFile('app/page.tsx', (src) =>
+      src
+        .replace(
+          /const dynamicMarker = '[^']*'/,
+          "const dynamicMarker = 'latest'"
+        )
+        .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 0')
+    )
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('latest')
+    })
+
+    await retry(async () => {
+      const { requests, reloaded } = await readResult(browser)
+      expect(reloaded).toBe(false)
+      // Two refreshes: the superseded one was aborted, the newest committed.
+      expect(requests).toMatchObject([
+        { aborted: true, settled: true },
+        { aborted: false, settled: true },
+      ])
+    })
+    expectCleanCliOutput(next.cliOutput.slice(cliStart))
+  })
+
+  it('preserves existing behavior when cancellation is disabled', async () => {
+    await next.patchFile('next.config.js', (src) =>
+      src.replace(
+        'serverComponentsHmrCancellation: true',
+        'serverComponentsHmrCancellation: false'
+      )
+    )
+    await next.start()
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('initial')
+    })
+    await instrumentBrowser(browser)
+
+    await next.patchFile('app/page.tsx', (src) =>
+      src
+        .replace(
+          /const dynamicMarker = '[^']*'/,
+          "const dynamicMarker = 'slow'"
+        )
+        .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 1000')
+    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => (window as any).__hmrRequests.length)
+      ).toBe(1)
+    })
+
+    await next.patchFile('app/page.tsx', (src) =>
+      src
+        .replace(
+          /const dynamicMarker = '[^']*'/,
+          "const dynamicMarker = 'latest'"
+        )
+        .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 0')
+    )
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('latest')
+    })
+
+    // With cancellation disabled, neither refresh is aborted; both run to
+    // completion like before.
+    await retry(async () => {
+      const { requests } = await readResult(browser)
+      expect(requests).toMatchObject([
+        { aborted: false, settled: true },
+        { aborted: false, settled: true },
+      ])
+    })
+  })
+})

--- a/test/development/app-dir/hmr-rsc-cancellation/next.config.js
+++ b/test/development/app-dir/hmr-rsc-cancellation/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    serverComponentsHmrCancellation: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
In `next dev`, rapid edits can start overlapping Server Components HMR refreshes, but only the newest can commit. When a newer refresh supersedes an older one, we abort the older request on the client so it stops transferring and decoding RSC data, and we keep the browser from reissuing the superseding request as a duplicate. Everything here is gated on the `serverComponentsHmrCancellation` flag.

On the client, the router's `hmrRefresh` method tracks the newest refresh generation in an `AbortController` and aborts the previous one before scheduling the new one, threading the abort signal through the HMR action down to the `fetch` call. An aborted request becomes a `NavigationTaskExitStatus.Canceled` rather than a failure, so `finishNavigationTask` leaves its cache nodes for the newer navigation to fulfill and does not retry or fall back to an MPA navigation. `hmrRefreshReducer` also bails out when its generation was aborted before it ran, which happens when an HMR action waits behind a Server Action in the router queue.

The subtle part is how an aborted request's partially received response is handled. A superseded refresh can already have committed part of its tree with a Suspense boundary still streaming. Rather than letting the aborted fetch reject the still-pending rows, which a committed boundary would throw on, we decode the response through a wrapper stream that we close, so React marks the unresolved rows as halted: they suspend during render instead of rejecting, and the superseded boundary keeps its fallback until the newer response commits. Closing the stream also avoids the unclosed-stream memory leak that #89610 fixed for prefetch streams.

Aborting the superseded fetch exposed a Chromium-only side effect. In development, App Router responses are served with `Cache-Control: no-cache, must-revalidate` so the browser can restore them on back and forward navigation, which keeps each response stored and keyed by URL. Successive refreshes of the same page share one cache entry, and aborting the superseded refresh mid-write leaves that entry half-written; Chromium discards it and reissues another superseding refresh on a second connection. The dev server then renders it twice and emits its debug channel twice under the same request id, producing `Cannot write to a CLOSED writable stream` errors on the client. Firefox and Safari do not reissue. To prevent this we serve HMR refresh responses, identified by the `next-hmr-refresh` request header, with `Cache-Control: no-store`, so no shared entry exists for an aborted refresh to leave half-written. All other dev responses keep `no-cache`, so their restore behavior is unchanged.

A development test suite covers a superseded request being aborted while the newest commits without a hard reload, a partially committed render whose Suspense boundary is left streaming not surfacing an error when superseded, and disabling the flag preserving the previous behavior. The supersession tests also assert no browser console errors, which guards against the duplicate debug channel regression.

Cancelling the superseded request's server-side render and validation, so the dev server also stops the discarded work, is left to a follow-up.