### PR TITLE
[test] Unflake `cache-components-dev-streaming` test suite

### DIFF
--- a/test/development/app-dir/cache-components-dev-streaming/cache-components-dev-streaming.test.ts
+++ b/test/development/app-dir/cache-components-dev-streaming/cache-components-dev-streaming.test.ts
@@ -51,12 +51,12 @@ describe('cache-components-dev-streaming', () => {
         .text()
     ).toBe('Loading...')
 
-    // Eventually, the private cache content should be streamed in.
-    await retry(async () => {
-      expect(
-        await browser.elementByCssInstant('#private').text()
-      ).toBeDateString()
-    })
+    // Eventually, the private cache content streams in. Waiting for the element
+    // (without waiting for "load") is enough; the boundary reveals `#private`
+    // atomically with its final content, so no retry is needed.
+    expect(
+      await browser.elementByCss('#private', { waitUntil: false }).text()
+    ).toBeDateString()
   })
 
   it('streams dynamic content immediately while a sibling cache is still filling', async () => {
@@ -70,27 +70,25 @@ describe('cache-components-dev-streaming', () => {
     // away, in parallel with the sibling's long-running cache fill, rather than
     // being withheld until the cache finishes filling.
     //
-    // Use instant checks throughout: `elementByCss`/`elementById` also wait for
-    // the page "load" event, which (with `waitUntil: 'commit'`) only fires once
-    // the slow cache has filled, which would advance past the very window this
-    // test inspects.
-    await retry(async () => {
-      expect(await browser.elementByCssInstant('#dynamic').text()).toBe(
-        'dynamic content'
-      )
-    })
+    // Read with `waitUntil: false` so we don't wait for the page "load" event,
+    // which (with `waitUntil: 'commit'`) only fires once the slow cache has
+    // filled, advancing past the very window this test inspects.
+    expect(
+      await browser.elementByCss('#dynamic', { waitUntil: false }).text()
+    ).toBe('dynamic content')
 
     // The slow cache is still filling at this point, so its fallback is shown
     // and its content hasn't streamed in yet.
     expect(await browser.hasElementByCss('#cached-fallback')).toBe(true)
     expect(await browser.hasElementByCss('#cached')).toBe(false)
 
-    // Eventually the cache fills and its content streams in.
-    await retry(async () => {
-      expect(
-        await browser.elementByCssInstant('#cached').text()
-      ).toBeDateString()
-    }, 10000)
+    // Eventually the cache fills and its content streams in. The fill takes
+    // ~5s, so allow a longer wait than the default 5s selector timeout.
+    expect(
+      await browser
+        .elementByCss('#cached', { waitUntil: false, timeout: 10000 })
+        .text()
+    ).toBeDateString()
   })
 
   it('does not show a Suspense fallback for runtime-prefetchable content on a client navigation', async () => {
@@ -108,14 +106,12 @@ describe('cache-components-dev-streaming', () => {
     await browser.elementByCss('a[href="/runtime-prefetch"]').click()
 
     // Wait for the navigation to fully settle.
-    await retry(async () => {
-      expect(await browser.elementByCssInstant('#runtime').text()).toBe(
-        'runtime content'
-      )
-      expect(await browser.elementByCssInstant('#dynamic').text()).toBe(
-        'dynamic content'
-      )
-    })
+    expect(
+      await browser.elementByCss('#runtime', { waitUntil: false }).text()
+    ).toBe('runtime content')
+    expect(
+      await browser.elementByCss('#dynamic', { waitUntil: false }).text()
+    ).toBe('dynamic content')
 
     const appearanceCounts = await fallbackObserver.getResult()
     // The runtime-prefetchable content was resolved before the response started
@@ -391,14 +387,12 @@ describe('cache-components-dev-streaming', () => {
         .click()
 
       // Wait for the navigation to fully settle.
-      await retry(async () => {
-        expect(await browser.elementByCssInstant('#session-data').text()).toBe(
-          'session content'
-        )
-        expect(await browser.elementByCssInstant('#dynamic-data').text()).toBe(
-          'dynamic content'
-        )
-      })
+      expect(
+        await browser.elementByCss('#session-data', { waitUntil: false }).text()
+      ).toBe('session content')
+      expect(
+        await browser.elementByCss('#dynamic-data', { waitUntil: false }).text()
+      ).toBe('dynamic content')
 
       const appearanceCounts = await fallbackObserver.getResult()
       // The runtime shell was resolved before the response started
@@ -433,14 +427,14 @@ describe('cache-components-dev-streaming', () => {
           .click()
 
         // Wait for the navigation to fully settle.
-        await retry(async () => {
-          expect(await browser.elementByCssInstant('#link-data').text()).toBe(
-            'link content'
-          )
-          expect(
-            await browser.elementByCssInstant('#dynamic-data').text()
-          ).toBe('dynamic content')
-        })
+        expect(
+          await browser.elementByCss('#link-data', { waitUntil: false }).text()
+        ).toBe('link content')
+        expect(
+          await browser
+            .elementByCss('#dynamic-data', { waitUntil: false })
+            .text()
+        ).toBe('dynamic content')
 
         const appearanceCounts = await fallbackObserver.getResult()
         expect(appearanceCounts).toEqual({


### PR DESCRIPTION
[Flakiness metrics](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22%20%40test.suite%3Acache-components-dev-streaming&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1782496431626&end=1783101231626&paused=false)

<img width="425" height="170" alt="Screenshot 2026-07-03 at 19 55 48" src="https://github.com/user-attachments/assets/7751d204-1ceb-4cc0-b90e-8f8f70adb803" />

The streaming assertions in this suite used `elementByCssInstant`, which runs `page.waitForSelector` with a 10ms timeout. That budget is below the floor of a Playwright selector query under CI load: the call is a cross-process round-trip to the browser, and in a streaming render the page's main thread is busy processing chunks, so the injected visibility poll frequently cannot complete within 10ms even when the element is already present and visible. Playwright then rejects with a timeout, and the surrounding `retry()` only hides this behind a coarse 500ms poll, leaving the tests racy. We have observed the instant selector throwing immediately after a prior assertion had already confirmed the same element was present.

This change replaces those `elementByCssInstant` and `retry` blocks with `elementByCss(selector, { waitUntil: false })`. That gives the selector query Playwright's default 5s budget and its efficient built-in waiting, while still skipping the page `load` event, which (with `waitUntil: 'commit'`) only fires once the slowest cache has filled. The `retry()` wrappers become redundant because every target here is a distinct id from its fallback (for example `#dynamic` versus `#dynamic-fallback`), and the Suspense boundary reveals the content subtree in a single commit, so the moment the element exists its text is already final.

The `#cached` assertion keeps an explicit `timeout: 10000` because its cache fill takes about 5s, which would race the default 5s selector timeout. The `retry()` around the bare `<p>` in the `use-cache` test is left in place: there the fallback and the content are both an id-less `<p>`, so the same element's text changes from `Loading...` to a date, and only a retry can observe that transition.