### PR TITLE
Refresh outdated agent-rules blocks on next dev and codemod upgrade

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -18,6 +18,7 @@ import {
 } from '../lib/handle-package'
 import { runTransform } from './transform'
 import { onCancel, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
+import { refreshAgentRulesBlock } from '../lib/agents-md'
 import { BadInput } from './shared'
 
 type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
@@ -474,6 +475,16 @@ export async function runUpgrade(
   console.log() // new line
   if (codemods.length > 0) {
     console.log(`${pc.green('✔')} Codemods have been applied successfully.`)
+  }
+
+  try {
+    if (refreshAgentRulesBlock(cwd) === 'refreshed') {
+      console.log(
+        `${pc.green('✔')} Refreshed the managed agent-rules block in AGENTS.md / CLAUDE.md to match the upgraded Next.js.`
+      )
+    }
+  } catch {
+    // The block refresh is best-effort — never fail the upgrade over it.
   }
 
   warnDependenciesOutOfRange(appPackageJson, versionMapping)

--- a/packages/next-codemod/lib/agents-md.ts
+++ b/packages/next-codemod/lib/agents-md.ts
@@ -15,6 +15,54 @@ interface NextjsVersionResult {
   error?: string
 }
 
+const AGENT_RULES_START_MARKER = '<!-- BEGIN:nextjs-agent-rules -->'
+
+/**
+ * After an upgrade, refresh the managed agent-rules block in
+ * AGENTS.md / CLAUDE.md so its content matches the Next.js version
+ * that is now installed.
+ *
+ * Delegates to the installed package's own generator
+ * (`next/dist/server/lib/generate-agent-files`), so the block text is
+ * always the one shipped with that version — this codemod never
+ * carries its own copy. Returns `'refreshed'` when a file was
+ * rewritten, `'current'` when the block was already up to date, and
+ * `'skipped'` when there is nothing to do: the project never adopted
+ * the managed block, or the installed Next.js predates the generator
+ * (< 16.3).
+ */
+export function refreshAgentRulesBlock(
+  cwd: string
+): 'refreshed' | 'current' | 'skipped' {
+  const hostsBlock = ['AGENTS.md', 'CLAUDE.md'].some((file) => {
+    try {
+      return fs
+        .readFileSync(path.join(cwd, file), 'utf-8')
+        .includes(AGENT_RULES_START_MARKER)
+    } catch {
+      return false
+    }
+  })
+  if (!hostsBlock) return 'skipped'
+
+  let writeAgentFiles: (dir: string) => { agentsMd: string; claudeMd: string }
+  try {
+    const generatorPath = require.resolve(
+      'next/dist/server/lib/generate-agent-files',
+      { paths: [cwd] }
+    )
+    writeAgentFiles = require(generatorPath).writeAgentFiles
+    if (typeof writeAgentFiles !== 'function') return 'skipped'
+  } catch {
+    return 'skipped'
+  }
+
+  const result = writeAgentFiles(cwd)
+  return result.agentsMd === 'updated' || result.claudeMd === 'updated'
+    ? 'refreshed'
+    : 'current'
+}
+
 export function getNextjsVersion(cwd: string): NextjsVersionResult {
   try {
     const nextPkgPath = require.resolve('next/package.json', { paths: [cwd] })

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -6,7 +6,7 @@ import type { ConfiguredExperimentalFeature } from '../config'
 import { experimentalSchema } from '../config-schema'
 import { detectAgent } from '../../telemetry/detect-agent'
 import {
-  hasAgentRulesInstalled,
+  hasCurrentAgentRules,
   writeAgentFiles,
   type AgentFilesResult,
 } from './generate-agent-files'
@@ -129,17 +129,18 @@ export function logExperimentalInfo({
 
 /**
  * When `next dev` detects an AI coding agent but the managed
- * agent-rules block is missing from AGENTS.md / CLAUDE.md,
- * auto-generate the files so the agent has access to version-matched
- * docs. Returns the write result when files were generated, or `null`
- * when no action was needed.
+ * agent-rules block is missing from AGENTS.md / CLAUDE.md — or an
+ * outdated version of it is installed — auto-generate or refresh the
+ * files so the agent has access to version-matched docs. Returns the
+ * write result when files were touched, or `null` when no action was
+ * needed.
  *
  * Callers gate this on `config.agentRules !== false` — opt-out is
  * declarative in next.config, not inside this function.
  */
 export function ensureAgentRulesForDev(dir: string): AgentFilesResult | null {
   if (detectAgent() === null) return null
-  if (hasAgentRulesInstalled(dir)) return null
+  if (hasCurrentAgentRules(dir)) return null
 
   return writeAgentFiles(dir)
 }

--- a/packages/next/src/server/lib/generate-agent-files.ts
+++ b/packages/next/src/server/lib/generate-agent-files.ts
@@ -41,16 +41,33 @@ export interface AgentFilesResult {
 }
 
 /**
- * Returns true when `AGENTS.md` or `CLAUDE.md` at `dir` contains the
- * managed agent-rules marker.
+ * Returns the managed block (markers included) found in `content`, or
+ * `null` when the markers are absent or malformed.
  */
-export function hasAgentRulesInstalled(dir: string): boolean {
-  const agentsContent = tryReadFile(path.join(dir, 'AGENTS.md'))
-  if (agentsContent?.includes(AGENT_RULES_START_MARKER)) return true
+function extractAgentRulesBlock(content: string): string | null {
+  const start = content.indexOf(AGENT_RULES_START_MARKER)
+  if (start === -1) return null
+  const end = content.indexOf(AGENT_RULES_END_MARKER, start)
+  if (end === -1) return null
+  return content.slice(start, end + AGENT_RULES_END_MARKER.length)
+}
 
-  const claudeContent = tryReadFile(path.join(dir, 'CLAUDE.md'))
-  if (claudeContent?.includes(AGENT_RULES_START_MARKER)) return true
-
+/**
+ * Returns true when `AGENTS.md` or `CLAUDE.md` at `dir` already
+ * contains the current agent-rules block. A block from an earlier
+ * Next.js version (older wording, legacy markers) returns false so
+ * callers know to upsert the current one over it.
+ */
+export function hasCurrentAgentRules(dir: string): boolean {
+  const block = buildAgentRulesBlock()
+  for (const file of ['AGENTS.md', 'CLAUDE.md']) {
+    const content = tryReadFile(path.join(dir, file))
+    if (!content) continue
+    const installed = extractAgentRulesBlock(content)
+    if (installed !== null && normalizeEol(installed, '\n') === block) {
+      return true
+    }
+  }
   return false
 }
 
@@ -58,6 +75,8 @@ export function hasAgentRulesInstalled(dir: string): boolean {
  * Write the agent-rules block into `projectDir`, respecting whichever
  * file the user already uses:
  *
+ *   - A file already hosting the managed block → upsert into it, so
+ *     upgrades rewrite the block in place instead of adding a copy.
  *   - `AGENTS.md` exists → upsert into it, leave `CLAUDE.md` alone.
  *   - `CLAUDE.md` exists (but not `AGENTS.md`) → upsert into it.
  *   - Neither exists → create both (`AGENTS.md` + `CLAUDE.md` with
@@ -74,7 +93,14 @@ export function writeAgentFiles(projectDir: string): AgentFilesResult {
   const agentsMdExists = fs.existsSync(agentsMdPath)
   const claudeMdExists = fs.existsSync(claudeMdPath)
 
-  if (agentsMdExists) {
+  const claudeMdHostsBlock =
+    claudeMdExists &&
+    (tryReadFile(claudeMdPath)?.includes(AGENT_RULES_START_MARKER) ?? false)
+  const agentsMdHostsBlock =
+    agentsMdExists &&
+    (tryReadFile(agentsMdPath)?.includes(AGENT_RULES_START_MARKER) ?? false)
+
+  if (agentsMdExists && (agentsMdHostsBlock || !claudeMdHostsBlock)) {
     return {
       agentsMd: upsertFile(agentsMdPath, block),
       claudeMd: 'skipped',

--- a/test/development/app-dir/agent-rules-auto-generate/agent-rules-auto-generate.test.ts
+++ b/test/development/app-dir/agent-rules-auto-generate/agent-rules-auto-generate.test.ts
@@ -1,8 +1,21 @@
 import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
+import { writeAgentFiles } from 'next/dist/server/lib/generate-agent-files'
 
 const AGENT_RULES_MARKER = '<!-- BEGIN:nextjs-agent-rules -->'
+
+/**
+ * The canonical block as the version under test generates it,
+ * obtained by running the real generator into a temp dir — the test
+ * never hardcodes the wording.
+ */
+function currentAgentRulesBlock(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-rules-'))
+  writeAgentFiles(dir)
+  return fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8').trimEnd()
+}
 
 describe('agent-rules auto-generate on next dev (agent detected)', () => {
   const { next } = nextTestSetup({
@@ -81,28 +94,56 @@ describe('agent-rules auto-generate on next dev (agentRules: false)', () => {
   })
 })
 
-describe('agent-rules auto-generate on next dev (AGENTS.md already has marker)', () => {
+describe('agent-rules auto-generate on next dev (AGENTS.md has an outdated managed block)', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     env: { CLAUDECODE: '1' },
     skipStart: true,
   })
 
+  // A block written by a different Next.js version — the content
+  // between the markers should be upgraded in place while everything
+  // around it is preserved. Uses synthetic body text so this test does
+  // not depend on any particular shipped wording.
+  const OUTDATED_BLOCK = `${AGENT_RULES_MARKER}
+# Stale heading from an older Next.js
+
+Stale body from an older Next.js.
+<!-- END:nextjs-agent-rules -->`
+
   beforeAll(async () => {
-    // Pre-populate AGENTS.md WITH the managed marker before the dev
-    // server starts, so the auto-gen sees it as already installed.
-    await next.patchFile('AGENTS.md', `${AGENT_RULES_MARKER}\n`)
+    await next.patchFile(
+      'AGENTS.md',
+      `# Team rules\n\nUse tabs, not spaces.\n\n${OUTDATED_BLOCK}\n`
+    )
     await next.start()
   })
 
-  it('leaves the file untouched and does not create CLAUDE.md', async () => {
+  it('refreshes the block in place and preserves surrounding content', async () => {
     await next.fetch('/')
     const content = fs.readFileSync(
       path.join(next.testDir, 'AGENTS.md'),
       'utf-8'
     )
-    expect(content).toBe(`${AGENT_RULES_MARKER}\n`)
+    expect(content).toContain('Use tabs, not spaces.')
+    expect(content).not.toContain('Stale body from an older Next.js.')
+    expect(content).toContain(currentAgentRulesBlock())
+    // Exactly one managed block — upgraded, not duplicated.
+    expect(content.split(AGENT_RULES_MARKER).length - 1).toBe(1)
     expect(fs.existsSync(path.join(next.testDir, 'CLAUDE.md'))).toBe(false)
+  })
+
+  it('is idempotent across dev server restarts', async () => {
+    await next.fetch('/')
+    const before = fs.readFileSync(
+      path.join(next.testDir, 'AGENTS.md'),
+      'utf-8'
+    )
+    await next.stop()
+    await next.start()
+    await next.fetch('/')
+    const after = fs.readFileSync(path.join(next.testDir, 'AGENTS.md'), 'utf-8')
+    expect(after).toBe(before)
   })
 })
 


### PR DESCRIPTION
Once the managed agent-rules block is installed, `next dev` never touches it again — `ensureAgentRulesForDev` gates on marker presence — and `@next/codemod upgrade` doesn't refresh it either, so changes to the block's content (like the wording fix in #95467) never reach existing projects.

`next dev` now gates on `hasCurrentAgentRules` and re-upserts a block whose content differs from canonical, targeting whichever file already hosts it so an upgrade rewrites the block in place instead of duplicating it into a second file; legacy `NEXT-AGENTS-MD` blocks migrate the same way, and CRLF files keep their line endings. `@next/codemod upgrade` refreshes the block after the version bump by delegating to the installed package's own generator (`next/dist/server/lib/generate-agent-files`), so the codemod never carries a copy of the wording and no-ops below 16.3 or when the project never adopted the block. A malformed block (start marker without end) converges to a single canonical block within two runs rather than growing unboundedly.

The e2e test now covers the in-place upgrade (surrounding content preserved, exactly one block, no `CLAUDE.md` created when `AGENTS.md` hosts it) and idempotence across dev-server restarts, using the real generator's output rather than hardcoded wording.