### PR TITLE
docs: fix Kontent.ai deploy link

### DIFF
--- a/examples/cms-kontent-ai/README.md
+++ b/examples/cms-kontent-ai/README.md
@@ -218,4 +218,4 @@ To deploy your local project to Vercel, push it to GitHub/GitLab/Bitbucket and [
 
 Alternatively, you can deploy using our template by clicking on the Deploy button below.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/cms-kontent&project-name=cms-kontent&repository-name=cms-kontent&env=KONTENT_PROJECT_ID,KONTENT_PREVIEW_API_KEY,KONTENT_PREVIEW_SECRET&envDescription=Required%20to%20connect%20the%20app%20with%20Kontent&envLink=https://github.com/vercel/next.js/tree/canary/examples/cms-kontent%23step-3-set-up-environment-variables)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/cms-kontent-ai&project-name=cms-kontent-ai&repository-name=cms-kontent-ai&env=KONTENT_PROJECT_ID,KONTENT_PREVIEW_API_KEY,KONTENT_PREVIEW_SECRET&envDescription=Required%20to%20connect%20the%20app%20with%20Kontent.ai&envLink=https://github.com/vercel/next.js/tree/canary/examples/cms-kontent-ai%23step-3-set-up-environment-variables)


### PR DESCRIPTION
## Summary

Update the lower deploy button in the `cms-kontent-ai` README so it points to the current `examples/cms-kontent-ai` path and uses the matching project, repository, and Kontent.ai description. The top deploy button already used the current path.

## Verification

- `rg -n "cms-kontent($|[^-])|cms-kontent-ai|Kontent.ai|Kontent&" examples/cms-kontent-ai/README.md`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->