### PR TITLE
docs: fix Builder.io env variable name

### DIFF
--- a/examples/cms-builder-io/README.md
+++ b/examples/cms-builder-io/README.md
@@ -42,7 +42,7 @@ builder create -k [private-key] -n [space-name] -d
 This command when done it'll print your new space's public api key, copy it and add as the value for `NEXT_PUBLIC_BUILDER_API_KEY` into the .env files (`.env.production` and `.env.development`)
 
 ```
-BUILDER_PUBLIC_KEY=...
+NEXT_PUBLIC_BUILDER_API_KEY=...
 ```
 
 ### Step 3 Run Next.js in development mode
@@ -79,7 +79,7 @@ To deploy your local project to Vercel, push it to GitHub/GitLab/Bitbucket and [
 
 Alternatively, you can deploy using our template by clicking on the Deploy button below.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/cms-builder-io&project-name=cms-builder-io&repository-name=cms-builder-io&env=BUILDER_PUBLIC_KEY&envDescription=Required%20to%20connect%20the%20app%20with%20Builder.io&envLink=https://www.builder.io/c/docs/custom-react-components#api-key)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/cms-builder-io&project-name=cms-builder-io&repository-name=cms-builder-io&env=NEXT_PUBLIC_BUILDER_API_KEY&envDescription=Required%20to%20connect%20the%20app%20with%20Builder.io&envLink=https://www.builder.io/c/docs/custom-react-components#api-key)
 
 ### Related examples
 


### PR DESCRIPTION
## Summary

Update the `cms-builder-io` README so its environment variable example and deploy button use `NEXT_PUBLIC_BUILDER_API_KEY`, matching the variable read by the example code and the setup text.

## Verification

- `rg -n "BUILDER_PUBLIC_KEY|NEXT_PUBLIC_BUILDER_API_KEY|process\.env\.NEXT_PUBLIC_BUILDER_API_KEY" examples/cms-builder-io/README.md examples/cms-builder-io/lib/constants.js`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->