### PR TITLE
docs: document Sanity API version env

### DIFF
--- a/examples/cms-sanity/.env.local.example
+++ b/examples/cms-sanity/.env.local.example
@@ -1,4 +1,5 @@
 # https://github.com/vercel/next.js/tree/canary/examples/cms-sanity#using-the-sanity-cli
 NEXT_PUBLIC_SANITY_PROJECT_ID=
 NEXT_PUBLIC_SANITY_DATASET=
+NEXT_PUBLIC_SANITY_API_VERSION=
 SANITY_API_READ_TOKEN=

--- a/examples/cms-sanity/README.md
+++ b/examples/cms-sanity/README.md
@@ -143,6 +143,7 @@ Your `.env.local` file should look something like this:
 ```bash
 NEXT_PUBLIC_SANITY_PROJECT_ID="r0z1eifg"
 NEXT_PUBLIC_SANITY_DATASET="blog-vercel"
+NEXT_PUBLIC_SANITY_API_VERSION="2024-02-28"
 SANITY_API_READ_TOKEN="sk..."
 ```
 


### PR DESCRIPTION
## Summary

Document the optional `NEXT_PUBLIC_SANITY_API_VERSION` environment variable in the `cms-sanity` example. The example code already reads this variable and falls back to `2024-02-28`, so the README and `.env.local.example` now surface the configurable value.

## Verification

- `rg -n --hidden "NEXT_PUBLIC_SANITY_API_VERSION|NEXT_PUBLIC_SANITY_PROJECT_ID|NEXT_PUBLIC_SANITY_DATASET" examples/cms-sanity/.env.local.example examples/cms-sanity/README.md examples/cms-sanity/sanity/lib/api.ts`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->