### PR TITLE
docs: fix WordPress README typos

### DIFF
--- a/examples/cms-wordpress/README.md
+++ b/examples/cms-wordpress/README.md
@@ -8,7 +8,7 @@ This is an example on how you can build a Next.js 14 project (with App Router), 
 - `sitemap.ts`: This automatically gets all paths from the API and generates a sitemap to serve on the `/sitemap.xml` route.
 - `middleware.ts`: This contains a middleware function that checks the users path for stored redirects, and redirects the user if a match is found.
 - `[[...slug]]`: This is the catch-all route that is used to render all pages. It is important that this route is not removed, as it is used to render all pages. It fetches the ContentType and renders the corresponding
-- `not-found.tsx`: This page is used for dynamic 404 handling - adjust the database id to match your decired WordPress page, and make sure the WordPress slug is "not-found", your 404 page will then be editable from your CMS.
+- `not-found.tsx`: This page is used for dynamic 404 handling - adjust the database id to match your desired WordPress page, and make sure the WordPress slug is "not-found", your 404 page will then be editable from your CMS.
 - `codegen.ts`: Automatic type generation for your WordPress installation
 - `Draft Mode`: Seamless Preview / Draft Preview support, using authentication through WPGraphQL JWT Authentication and Next.js Draft Mode
 - `On Demand Cache Revalidation`: Including a bare minimum WordPress theme that implements cache revalidation, WordPress link rewrites and other utils for integrating with Next.js
@@ -116,24 +116,26 @@ Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&ut
 
 | Name                                 | Value                                                                   | Example                  | Description                                                                                                                                                         |
 | ------------------------------------ | ----------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_BASE_URL`               | Insert base url of frontend                                             | http://localhost:3000    | Used for generating sitemap, redirects etc.                                                                                                                         |
-| `NEXT_PUBLIC_WORDPRESS_API_URL`      | Insert base url of your WordPress installation                          | http://wp-domain.com     | Used when requesting wordpress for data                                                                                                                             |
+| `NEXT_PUBLIC_BASE_URL`               | Insert base URL of frontend                                             | http://localhost:3000    | Used for generating sitemap, redirects etc.                                                                                                                         |
+| `NEXT_PUBLIC_WORDPRESS_API_URL`      | Insert base URL of your WordPress installation                          | http://wp-domain.com     | Used when requesting WordPress for data                                                                                                                             |
 | `NEXT_PUBLIC_WORDPRESS_API_HOSTNAME` | The hostname without protocol for your WordPress installation           | wp-domain.com            | Used for dynamically populating the next.config images remotePatterns                                                                                               |
 | `HEADLESS_SECRET`                    | Insert the same random key, that you generated for your `wp-config.php` | INSERT_RANDOM_SECRET_KEY | Used for public exchanges between frontend and backend                                                                                                               |
 | `WP_USER`                            | Insert a valid WordPress username                                       | username                 | Username for a system user created specifically for interacting with your WordPress installation                                                                    |
 | `WP_APP_PASS`                        | Insert application password                                             | 1234 5678 abcd efgh      | [Generate an application password](https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/) for the WordPress user defined in `WP_USER` |
 
-> [!WARNING] > `WP_USER` and `WP_APP_PASS` are critical for making preview and redirection work
+> [!WARNING]
+> `WP_USER` and `WP_APP_PASS` are critical for making preview and redirection work
 
 4. Adjust the ID in `not-found.tsx` to match the post id of your "404 Not Found" page in WordPress
 
 5. `npm run dev` and build an awesome application with WordPress!
 
-> [!NOTE] > Running `npm run dev` will automatically generate typings from the WordPress installation found on the url provided in your environment variable: `NEXT_PUBLIC_WORDPRESS_API_URL`
+> [!NOTE]
+> Running `npm run dev` will automatically generate typings from the WordPress installation found on the URL provided in your environment variable: `NEXT_PUBLIC_WORDPRESS_API_URL`
 
-## GraphQL and typescript types
+## GraphQL and TypeScript types
 
-We are generating typescript types from the provided schema with Codegen.
+We are generating TypeScript types from the provided schema with Codegen.
 
 ### Enabling Auto Completion for graphql queries
 
@@ -154,11 +156,11 @@ module.exports = {
 
 I will recommend building your page content by using the [Flexible Content](https://www.advancedcustomfields.com/resources/flexible-content/) data type in ACF Pro.
 This will make you able to create a "Block Builder" editor experience, but still having everything automatically type generated, and receiving the data in a structured way.
-The default "Gutenberg" editor returns a lot of HTML, which makes you loose a lot of the advantages of using GraphQL with type generation.
+The default "Gutenberg" editor returns a lot of HTML, which makes you lose a lot of the advantages of using GraphQL with type generation.
 
 ## Redirection setup
 
-The example supports the WordPress "Redirection" plugin. the `WP_USER` and `WP_APP_PASS` environment variables are required, for this to work. By implementing this you can manage redirects for your content, through your WordPress CMS
+The example supports the WordPress "Redirection" plugin. The `WP_USER` and `WP_APP_PASS` environment variables are required for this to work. By implementing this you can manage redirects for your content, through your WordPress CMS
 
 ## Draft / Preview support
 


### PR DESCRIPTION
## Summary

Fix several typos and GitHub admonition formatting issues in the WordPress CMS example README.

## Verification

- `rg -n "decired|base url|requesting wordpress|\[!WARNING\] >|\[!NOTE\] >|typescript|loose|plugin\. the|base URL|TypeScript|\[!NOTE\]|\[!WARNING\]" examples/cms-wordpress/README.md`
- `git diff --check -- examples/cms-wordpress/README.md`

<!-- NEXT_JS_LLM_PR -->