### PR TITLE
docs: fix Agility CMS preview link punctuation

### DIFF
--- a/examples/cms-agilitycms/README.md
+++ b/examples/cms-agilitycms/README.md
@@ -328,7 +328,7 @@ Alternatively, you can deploy using our template by clicking on the Deploy butto
 
 ### Step 18. Try preview mode
 
-Now that you've deployed your app to Vercel, take note of the URL of your deployed site. This will be registered in Agility CMS so that when editors click the `Preview` button within Agility CMS, your app is loaded in **Preview Mode**. Learn more about [Next.js Preview Mode](https://nextjs.org/docs/advanced-features/preview-mode)).
+Now that you've deployed your app to Vercel, take note of the URL of your deployed site. This will be registered in Agility CMS so that when editors click the `Preview` button within Agility CMS, your app is loaded in **Preview Mode**. Learn more about [Next.js Preview Mode](https://nextjs.org/docs/advanced-features/preview-mode).
 
 To enable the Preview Mode, you'll need to add your site to **Domain Configuration** in Agility CMS:
 


### PR DESCRIPTION
## Summary

Remove an extra closing parenthesis after the Agility CMS example README link to the Next.js Preview Mode docs.

## Verification

- `rg -n "Preview Mode\)\)|Preview Mode\)\." examples/cms-agilitycms/README.md`
- `git diff --check -- examples/cms-agilitycms/README.md`

<!-- NEXT_JS_LLM_PR -->