### PR TITLE
turbo-persistence: skip directory fsync on Windows

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -879,6 +879,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         // Sync the directory to ensure the new directory entries (file name → inode mappings)
         // are durable before we update CURRENT. Without this, a crash could leave CURRENT pointing
         // to files whose directory entries were lost even though their data was flushed.
+        // Skipped on Windows: `sync_data` calls `FlushFileBuffers`, which needs a handle with
+        // write access and always fails with ERROR_ACCESS_DENIED on the read-only handle that
+        // `File::open` returns for a directory. Other storage engines (LevelDB, SQLite) also
+        // skip directory syncing on Windows.
+        #[cfg(not(windows))]
         File::open(&self.path)?.sync_data()?;
         drop(sync_span);
 


### PR DESCRIPTION
Fixes #95495

### What

`TurboPersistence::commit()` syncs the database directory (`File::open(&self.path)?.sync_data()?`) before updating CURRENT. On Windows, `sync_data` calls `FlushFileBuffers`, which requires a handle with write access and always fails with `ERROR_ACCESS_DENIED` on the read-only directory handle `File::open` produces. Every commit fails, persistence is disabled for the session, and dev memory eviction never engages (details and a syscall-level demonstration are in #95495).

This skips the directory sync on Windows with `#[cfg(not(windows))]`. The per-file `sync_data` calls are unaffected. If an equivalent directory-entry durability guarantee is wanted on Windows it would need a directory handle opened with write access; I kept this to the minimal fix and can adjust if you prefer that approach. Skipping matches prior art: LevelDB and SQLite do not sync directories on Windows either.

### Tests

No new test added: the failure is platform-specific and already covered by the existing suite. On Windows, `cargo test -p turbo-persistence` fails 30 of 60 tests before this change, all with `Access is denied. (os error 5)`, and passes 60 of 60 with it (toolchain: nightly-2026-06-24, x86_64-pc-windows-gnu, Windows 11). The directory sync was introduced in #90542.

