### PR TITLE
fix parent-relative import.meta.glob patterns

### DIFF
--- a/test/e2e/import-meta-glob/app/api/glob/route.js
+++ b/test/e2e/import-meta-glob/app/api/glob/route.js
@@ -1,0 +1,10 @@
+const modules = import.meta.glob('../../../lib/modules/*.ts')
+
+export async function GET() {
+  const values = []
+  for (const loader of Object.values(modules)) {
+    const mod = await loader()
+    values.push(mod.name)
+  }
+  return Response.json({ values: values.sort() })
+}

--- a/test/e2e/import-meta-glob/app/page.tsx
+++ b/test/e2e/import-meta-glob/app/page.tsx
@@ -11,12 +11,20 @@ const defaultExports = import.meta.glob('./modules/*.ts', {
 })
 
 // Negative pattern
-const filteredModules = import.meta.glob(['./modules/*.ts', '!**/skip.ts'], {
-  eager: true,
-})
+const filteredModules = import.meta.glob(
+  ['./modules/*.ts', '!./modules/skip.ts'],
+  {
+    eager: true,
+  }
+)
 
 // Multiple patterns (modules + other)
 const multiModules = import.meta.glob(['./modules/*.ts', './other/*.ts'], {
+  eager: true,
+})
+
+// Parent-relative pattern
+const parentModules = import.meta.glob('../lib/modules/*.ts', {
   eager: true,
 })
 
@@ -57,6 +65,13 @@ export default async function Page() {
     multiResults[key] = (multiModules[key] as any).name
   }
 
+  // Get parent-relative module names
+  const parentKeys = Object.keys(parentModules).sort()
+  const parentResults: Record<string, string> = {}
+  for (const key of parentKeys) {
+    parentResults[key] = (parentModules[key] as any).name
+  }
+
   return (
     <div>
       <div id="lazy-keys">{JSON.stringify(lazyKeys)}</div>
@@ -68,6 +83,8 @@ export default async function Page() {
       <div id="filtered-results">{JSON.stringify(filteredResults)}</div>
       <div id="multi-keys">{JSON.stringify(multiKeys)}</div>
       <div id="multi-results">{JSON.stringify(multiResults)}</div>
+      <div id="parent-keys">{JSON.stringify(parentKeys)}</div>
+      <div id="parent-results">{JSON.stringify(parentResults)}</div>
     </div>
   )
 }

--- a/test/e2e/import-meta-glob/app/page.tsx
+++ b/test/e2e/import-meta-glob/app/page.tsx
@@ -11,12 +11,9 @@ const defaultExports = import.meta.glob('./modules/*.ts', {
 })
 
 // Negative pattern
-const filteredModules = import.meta.glob(
-  ['./modules/*.ts', '!./modules/skip.ts'],
-  {
-    eager: true,
-  }
-)
+const filteredModules = import.meta.glob(['./modules/*.ts', '!**/skip.ts'], {
+  eager: true,
+})
 
 // Multiple patterns (modules + other)
 const multiModules = import.meta.glob(['./modules/*.ts', './other/*.ts'], {

--- a/test/e2e/import-meta-glob/import-meta-glob.test.ts
+++ b/test/e2e/import-meta-glob/import-meta-glob.test.ts
@@ -88,4 +88,22 @@ testFn('import-meta-glob', () => {
       './other/baz.ts': 'baz',
     })
   })
+
+  it('should resolve parent-relative glob patterns in server components', async () => {
+    const $ = await next.render$('/')
+    const parentKeys = JSON.parse($('#parent-keys').text())
+    expect(parentKeys).toEqual(['../lib/modules/example.ts'])
+
+    const parentResults = JSON.parse($('#parent-results').text())
+    expect(parentResults).toEqual({
+      '../lib/modules/example.ts': 'example-module',
+    })
+  })
+
+  it('should resolve parent-relative glob patterns', async () => {
+    const res = await next.fetch('/api/glob')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ values: ['example-module'] })
+  })
 })

--- a/test/e2e/import-meta-glob/lib/modules/example.ts
+++ b/test/e2e/import-meta-glob/lib/modules/example.ts
@@ -1,0 +1,1 @@
+export const name = 'example-module'

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -323,6 +323,74 @@ fn strip_relative_prefix(pattern: &str) -> &str {
     pattern.strip_prefix("./").unwrap_or(pattern)
 }
 
+/// Split a glob pattern into a static directory prefix and a glob suffix.
+///
+/// The directory prefix may contain `..` segments and is resolved against the
+/// importer's directory via [`FileSystemPath::join`]. The glob suffix is passed
+/// to `read_glob` relative to the resolved scan directory.
+fn split_glob_pattern(pattern: &str) -> (&str, &str) {
+    let glob_start = pattern.find(['*', '?', '[', '{']).unwrap_or(pattern.len());
+
+    if glob_start == 0 {
+        return ("", pattern);
+    }
+
+    if let Some(slash_pos) = pattern[..glob_start].rfind('/') {
+        (&pattern[..slash_pos], &pattern[slash_pos + 1..])
+    } else {
+        ("", pattern)
+    }
+}
+
+/// Resolve a Vite-style glob pattern into a scan directory and a glob pattern
+/// relative to that directory.
+fn resolve_glob_scan(pattern: &str, root_dir: &FileSystemPath) -> Result<(FileSystemPath, RcStr)> {
+    let (dir_prefix, glob_suffix) = split_glob_pattern(pattern);
+    let scan_dir = if dir_prefix.is_empty() || dir_prefix == "." {
+        root_dir.clone()
+    } else {
+        root_dir.join(dir_prefix)?
+    };
+    let glob_pattern: RcStr = strip_relative_prefix(glob_suffix).into();
+    Ok((scan_dir, glob_pattern))
+}
+
+fn join_scan_path(dir_prefix: &str, scan_relative: &str) -> RcStr {
+    if dir_prefix.is_empty() || dir_prefix == "." {
+        scan_relative.into()
+    } else {
+        format!("{}/{scan_relative}", strip_relative_prefix(dir_prefix)).into()
+    }
+}
+
+/// Scan all positive glob patterns and return matched files.
+///
+/// Each pattern is resolved independently so that patterns containing `..`
+/// segments scan the correct directory.
+async fn collect_glob_files(
+    root_dir: &FileSystemPath,
+    positive_patterns: &[&RcStr],
+) -> Result<Vec<(RcStr, FileSystemPath)>> {
+    let mut files = Vec::new();
+
+    for pattern in positive_patterns {
+        let (dir_prefix, _) = split_glob_pattern(pattern);
+        let (scan_dir, glob_pattern) = resolve_glob_scan(pattern, root_dir)?;
+        let glob_result = scan_dir
+            .read_glob(Glob::new(glob_pattern, GlobOptions::default()))
+            .await?;
+        files.extend(
+            flatten_read_glob(&glob_result)
+                .await?
+                .into_iter()
+                .map(|(scan_relative, path)| (join_scan_path(dir_prefix, &scan_relative), path)),
+        );
+    }
+
+    files.sort_by(|a: &(RcStr, _), b: &(RcStr, _)| a.0.cmp(&b.0));
+    Ok(files)
+}
+
 /// Flatten a nested `ReadGlobResult` into a sorted list of
 /// `(base_relative_path, FileSystemPath)` pairs.
 ///
@@ -398,15 +466,13 @@ pub struct ImportMetaGlobMap(
 impl ImportMetaGlobMap {
     /// Discover files matching glob patterns and resolve them as ESM imports.
     ///
-    /// `base_dir` is the directory to scan (origin dir, or origin + base).
-    /// `positive_glob` is a `Glob` matching the wanted files (relative to
-    /// base_dir). `negative_glob` optionally excludes files. Both globs
-    /// operate on paths *relative to base_dir*.
+    /// `files` contains paths relative to the glob's base directory paired with
+    /// their absolute filesystem paths. `negative_glob` optionally excludes
+    /// files by matching against those base-relative paths.
     #[turbo_tasks::function]
     pub(crate) async fn generate(
         origin: Vc<Box<dyn ResolveOrigin>>,
-        base_dir: FileSystemPath,
-        positive_glob: Vc<Glob>,
+        files: Vec<(RcStr, FileSystemPath)>,
         negative_glob: Option<Vc<Glob>>,
         query: Option<RcStr>,
         eager: bool,
@@ -414,10 +480,6 @@ impl ImportMetaGlobMap {
         error_mode: ResolveErrorMode,
     ) -> Result<Vc<Self>> {
         let origin_path = origin.into_trait_ref().await?.origin_path().parent();
-
-        // Use read_glob for efficient directory-pruning file discovery.
-        let glob_result = base_dir.read_glob(positive_glob).await?;
-        let files = flatten_read_glob(&glob_result).await?;
 
         // Pre-resolve the negative glob (if any) once, outside the loop.
         let negative = if let Some(neg) = negative_glob {
@@ -436,7 +498,6 @@ impl ImportMetaGlobMap {
         let entries: Vec<_> = files
             .iter()
             .filter(|(base_relative, _)| {
-                // Apply negative pattern filtering on the base-relative path.
                 if let Some(ref neg) = negative {
                     !neg.matches(base_relative)
                 } else {
@@ -609,19 +670,7 @@ impl ImportMetaGlobAsset {
         let (positive_raw, negative_raw): (Vec<_>, Vec<_>) =
             self.patterns.iter().partition(|p| !p.starts_with('!'));
 
-        // Build the positive Glob. Turbopack's Glob operates on paths relative
-        // to the scan directory (no leading `./`), so strip that prefix. For
-        // multiple patterns, use `Glob::alternatives` to combine them.
-        let positive_globs: Vec<Vc<Glob>> = positive_raw
-            .iter()
-            .map(|p| Glob::new(strip_relative_prefix(p).into(), GlobOptions::default()))
-            .collect();
-
-        let positive_glob = if positive_globs.len() == 1 {
-            positive_globs.into_iter().next().unwrap()
-        } else {
-            Glob::alternatives(positive_globs)
-        };
+        let files = collect_glob_files(&base_dir, &positive_raw).await?;
 
         // Build the negative Glob (if any). Negative patterns also need `./`
         // stripped and are combined into a single alternation glob.
@@ -647,8 +696,7 @@ impl ImportMetaGlobAsset {
 
         Ok(ImportMetaGlobMap::generate(
             origin,
-            base_dir,
-            positive_glob,
+            files,
             negative_glob,
             self.query.clone(),
             self.eager,
@@ -971,5 +1019,42 @@ impl ImportMetaGlobAssetReferenceCodeGen {
             }
         ));
         Ok(CodeGeneration::visitors(visitors))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_glob_pattern_handles_current_directory_prefix() {
+        assert_eq!(split_glob_pattern("./dir/*.js"), ("./dir", "*.js"));
+    }
+
+    #[test]
+    fn split_glob_pattern_handles_parent_directory_prefix() {
+        assert_eq!(
+            split_glob_pattern("../../../lib/modules/*.js"),
+            ("../../../lib/modules", "*.js")
+        );
+    }
+
+    #[test]
+    fn split_glob_pattern_handles_rootless_globs() {
+        assert_eq!(split_glob_pattern("**/*.js"), ("", "**/*.js"));
+        assert_eq!(split_glob_pattern("*.js"), ("", "*.js"));
+    }
+
+    #[test]
+    fn join_scan_path_reconstructs_base_relative_paths() {
+        assert_eq!(
+            join_scan_path("", "modules/foo.js").as_str(),
+            "modules/foo.js"
+        );
+        assert_eq!(join_scan_path("./dir", "foo.js").as_str(), "dir/foo.js");
+        assert_eq!(
+            join_scan_path("../lib/modules", "example.js").as_str(),
+            "../lib/modules/example.js"
+        );
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -316,79 +316,25 @@ pub fn parse_import_meta_glob(
 // Helpers for collecting files from ReadGlobResult
 // ---------------------------------------------------------------------------
 
-/// Strip the `./` prefix from a Vite-style glob pattern to produce a pattern
-/// compatible with Turbopack's `Glob` (which operates relative to the scan
-/// directory, without a leading `./`).
-fn strip_relative_prefix(pattern: &str) -> &str {
-    pattern.strip_prefix("./").unwrap_or(pattern)
-}
-
-/// Split a glob pattern into a static directory prefix and a glob suffix.
+/// Consume leading `./` and `../` segments from a Vite-style glob pattern.
 ///
-/// The directory prefix may contain `..` segments and is resolved against the
-/// importer's directory via [`FileSystemPath::join`]. The glob suffix is passed
-/// to `read_glob` relative to the resolved scan directory.
-fn split_glob_pattern(pattern: &str) -> (&str, &str) {
-    let glob_start = pattern.find(['*', '?', '[', '{']).unwrap_or(pattern.len());
-
-    if glob_start == 0 {
-        return ("", pattern);
+/// Returns the number of `..` (parent-directory traversals) and the remaining
+/// pattern, which is relative to the origin directory walked up by that many
+/// parents.
+fn extract_leading_relative_parts(pattern: &str) -> (usize, &str) {
+    let mut rest = pattern;
+    let mut up = 0;
+    loop {
+        if let Some(r) = rest.strip_prefix("./") {
+            rest = r;
+        } else if let Some(r) = rest.strip_prefix("../") {
+            up += 1;
+            rest = r;
+        } else {
+            break;
+        }
     }
-
-    if let Some(slash_pos) = pattern[..glob_start].rfind('/') {
-        (&pattern[..slash_pos], &pattern[slash_pos + 1..])
-    } else {
-        ("", pattern)
-    }
-}
-
-/// Resolve a Vite-style glob pattern into a scan directory and a glob pattern
-/// relative to that directory.
-fn resolve_glob_scan(pattern: &str, root_dir: &FileSystemPath) -> Result<(FileSystemPath, RcStr)> {
-    let (dir_prefix, glob_suffix) = split_glob_pattern(pattern);
-    let scan_dir = if dir_prefix.is_empty() || dir_prefix == "." {
-        root_dir.clone()
-    } else {
-        root_dir.join(dir_prefix)?
-    };
-    let glob_pattern: RcStr = strip_relative_prefix(glob_suffix).into();
-    Ok((scan_dir, glob_pattern))
-}
-
-fn join_scan_path(dir_prefix: &str, scan_relative: &str) -> RcStr {
-    if dir_prefix.is_empty() || dir_prefix == "." {
-        scan_relative.into()
-    } else {
-        format!("{}/{scan_relative}", strip_relative_prefix(dir_prefix)).into()
-    }
-}
-
-/// Scan all positive glob patterns and return matched files.
-///
-/// Each pattern is resolved independently so that patterns containing `..`
-/// segments scan the correct directory.
-async fn collect_glob_files(
-    root_dir: &FileSystemPath,
-    positive_patterns: &[&RcStr],
-) -> Result<Vec<(RcStr, FileSystemPath)>> {
-    let mut files = Vec::new();
-
-    for pattern in positive_patterns {
-        let (dir_prefix, _) = split_glob_pattern(pattern);
-        let (scan_dir, glob_pattern) = resolve_glob_scan(pattern, root_dir)?;
-        let glob_result = scan_dir
-            .read_glob(Glob::new(glob_pattern, GlobOptions::default()))
-            .await?;
-        files.extend(
-            flatten_read_glob(&glob_result)
-                .await?
-                .into_iter()
-                .map(|(scan_relative, path)| (join_scan_path(dir_prefix, &scan_relative), path)),
-        );
-    }
-
-    files.sort_by(|a: &(RcStr, _), b: &(RcStr, _)| a.0.cmp(&b.0));
-    Ok(files)
+    (up, rest)
 }
 
 /// Flatten a nested `ReadGlobResult` into a sorted list of
@@ -466,13 +412,15 @@ pub struct ImportMetaGlobMap(
 impl ImportMetaGlobMap {
     /// Discover files matching glob patterns and resolve them as ESM imports.
     ///
-    /// `files` contains paths relative to the glob's base directory paired with
-    /// their absolute filesystem paths. `negative_glob` optionally excludes
-    /// files by matching against those base-relative paths.
+    /// `base_dir` is the directory to scan (origin dir, or origin + base).
+    /// `positive_glob` is a `Glob` matching the wanted files (relative to
+    /// base_dir). `negative_glob` optionally excludes files. Both globs
+    /// operate on paths *relative to base_dir*.
     #[turbo_tasks::function]
     pub(crate) async fn generate(
         origin: Vc<Box<dyn ResolveOrigin>>,
-        files: Vec<(RcStr, FileSystemPath)>,
+        base_dir: FileSystemPath,
+        positive_glob: Vc<Glob>,
         negative_glob: Option<Vc<Glob>>,
         query: Option<RcStr>,
         eager: bool,
@@ -480,6 +428,10 @@ impl ImportMetaGlobMap {
         error_mode: ResolveErrorMode,
     ) -> Result<Vc<Self>> {
         let origin_path = origin.into_trait_ref().await?.origin_path().parent();
+
+        // Use read_glob for efficient directory-pruning file discovery.
+        let glob_result = base_dir.read_glob(positive_glob).await?;
+        let files = flatten_read_glob(&glob_result).await?;
 
         // Pre-resolve the negative glob (if any) once, outside the loop.
         let negative = if let Some(neg) = negative_glob {
@@ -498,6 +450,7 @@ impl ImportMetaGlobMap {
         let entries: Vec<_> = files
             .iter()
             .filter(|(base_relative, _)| {
+                // Apply negative pattern filtering on the base-relative path.
                 if let Some(ref neg) = negative {
                     !neg.matches(base_relative)
                 } else {
@@ -657,12 +610,60 @@ impl ImportMetaGlobAsset {
         let origin = *self.origin;
         let origin_dir = origin.into_trait_ref().await?.origin_path().parent();
 
-        // Compute the base directory for glob scanning.
+        // Compute the effective origin directory for glob scanning.
         // With `base`, patterns are resolved relative to origin + base.
-        let base_dir = if let Some(ref b) = self.base {
+        let effective_dir = if let Some(ref b) = self.base {
             origin_dir.join(b)?
         } else {
             origin_dir
+        };
+
+        // Determine the maximum parent-directory traversal (`../`) count across
+        // all positive and negative patterns.
+        let max_parent = self
+            .patterns
+            .iter()
+            .map(|p| {
+                let raw = p.strip_prefix('!').unwrap_or(p);
+                extract_leading_relative_parts(raw).0
+            })
+            .max()
+            .unwrap_or(0);
+
+        // Walk up from `effective_dir` by `max_parent` levels to produce the
+        // `scan_base` — the single directory from which we do the actual glob
+        // scan. All patterns are then rewritten relative to this base.
+        let effective_dir_path = effective_dir.path.clone();
+        let effective_dir_segments: Vec<&str> = effective_dir_path
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+        let clamped_parent = max_parent.min(effective_dir_segments.len());
+
+        let mut scan_base = effective_dir.clone();
+        for _ in 0..clamped_parent {
+            scan_base = scan_base.parent();
+        }
+
+        // Path segments between `scan_base` and `effective_dir`. To rewrite a
+        // pattern with `k` `../`s (k ≤ clamped_parent), we prepend the first
+        // `clamped_parent - k` of these segments to the pattern remainder.
+        let inner_segments: Vec<&str> = if clamped_parent == 0 {
+            Vec::new()
+        } else {
+            effective_dir_segments[effective_dir_segments.len() - clamped_parent..].to_vec()
+        };
+
+        // Rewrite a Vite-style pattern to be relative to `scan_base`.
+        let rewrite = |raw: &str| -> RcStr {
+            let (k, rest) = extract_leading_relative_parts(raw);
+            let k = k.min(inner_segments.len());
+            let prefix_count = inner_segments.len() - k;
+            let mut parts: Vec<&str> = inner_segments[..prefix_count].to_vec();
+            if !rest.is_empty() {
+                parts.push(rest);
+            }
+            parts.join("/").into()
         };
 
         // Separate positive (matching) and negative (exclusion) patterns.
@@ -670,17 +671,26 @@ impl ImportMetaGlobAsset {
         let (positive_raw, negative_raw): (Vec<_>, Vec<_>) =
             self.patterns.iter().partition(|p| !p.starts_with('!'));
 
-        let files = collect_glob_files(&base_dir, &positive_raw).await?;
+        // Build the positive Glob. For multiple patterns, use
+        // `Glob::alternatives` to combine them into a single alternation glob.
+        let positive_globs: Vec<Vc<Glob>> = positive_raw
+            .iter()
+            .map(|p| Glob::new(rewrite(p), GlobOptions::default()))
+            .collect();
 
-        // Build the negative Glob (if any). Negative patterns also need `./`
-        // stripped and are combined into a single alternation glob.
+        let positive_glob = if positive_globs.len() == 1 {
+            positive_globs.into_iter().next().unwrap()
+        } else {
+            Glob::alternatives(positive_globs)
+        };
+
+        // Build the negative Glob (if any).
         let negative_glob = if !negative_raw.is_empty() {
             let neg_globs: Vec<Vc<Glob>> = negative_raw
                 .iter()
                 .map(|p| {
                     let stripped = p.strip_prefix('!').unwrap_or(p);
-                    let stripped = strip_relative_prefix(stripped);
-                    Glob::new(stripped.into(), GlobOptions::default())
+                    Glob::new(rewrite(stripped), GlobOptions::default())
                 })
                 .collect();
 
@@ -696,7 +706,8 @@ impl ImportMetaGlobAsset {
 
         Ok(ImportMetaGlobMap::generate(
             origin,
-            files,
+            scan_base,
+            positive_glob,
             negative_glob,
             self.query.clone(),
             self.eager,
@@ -1027,34 +1038,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn split_glob_pattern_handles_current_directory_prefix() {
-        assert_eq!(split_glob_pattern("./dir/*.js"), ("./dir", "*.js"));
-    }
-
-    #[test]
-    fn split_glob_pattern_handles_parent_directory_prefix() {
+    fn extract_leading_relative_parts_handles_current_directory_prefix() {
         assert_eq!(
-            split_glob_pattern("../../../lib/modules/*.js"),
-            ("../../../lib/modules", "*.js")
+            extract_leading_relative_parts("./foo/*.js"),
+            (0, "foo/*.js")
         );
     }
 
     #[test]
-    fn split_glob_pattern_handles_rootless_globs() {
-        assert_eq!(split_glob_pattern("**/*.js"), ("", "**/*.js"));
-        assert_eq!(split_glob_pattern("*.js"), ("", "*.js"));
+    fn extract_leading_relative_parts_handles_parent_directory_prefix() {
+        assert_eq!(
+            extract_leading_relative_parts("../lib/**/*.js"),
+            (1, "lib/**/*.js")
+        );
+        assert_eq!(
+            extract_leading_relative_parts("../../a/./b/*.ts"),
+            (2, "a/./b/*.ts")
+        );
     }
 
     #[test]
-    fn join_scan_path_reconstructs_base_relative_paths() {
-        assert_eq!(
-            join_scan_path("", "modules/foo.js").as_str(),
-            "modules/foo.js"
-        );
-        assert_eq!(join_scan_path("./dir", "foo.js").as_str(), "dir/foo.js");
-        assert_eq!(
-            join_scan_path("../lib/modules", "example.js").as_str(),
-            "../lib/modules/example.js"
-        );
+    fn extract_leading_relative_parts_handles_rootless_globs() {
+        assert_eq!(extract_leading_relative_parts("foo/*.js"), (0, "foo/*.js"));
     }
 }


### PR DESCRIPTION
## Summary

Fix `import.meta.glob` parent-relative patterns in Turbopack by resolving each positive glob against its own scan directory.

Adds focused coverage for parent-relative patterns in both a Server Component and an App Route.

Closes #95496.

## Verification

- `pnpm test-dev-turbo test/e2e/import-meta-glob/import-meta-glob.test.ts`
