### PR TITLE
docs: clarify query param behavior in URL composition

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -433,6 +433,7 @@ export const metadata = {
 URL composition favors developer intent over default directory traversal semantics.
 
 - Trailing slashes between `metadataBase` and `metadata` fields are normalized.
+- Query parameters in relative fields are not altered by trailing slash normalization. Use absolute URLs if precise control over query parameters is needed.
 - An "absolute" path in a `metadata` field (that typically would replace the whole URL path) is treated as a "relative" path (starting from the end of `metadataBase`).
 
 For example, given the following `metadataBase`:


### PR DESCRIPTION
## Description

Updated the URL Composition section in generate-metadata docs to clarify that query parameters in relative fields are not affected by trailing slash normalization.

Fixes #68272

## Changes
- Added note that query params are not altered by trailing slash normalization
- Suggested using absolute URLs when precise control over query params is needed