### PR TITLE
fix(turbopack): support parent-directory traversal in import.meta.glob

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -316,11 +316,32 @@ pub fn parse_import_meta_glob(
 // Helpers for collecting files from ReadGlobResult
 // ---------------------------------------------------------------------------
 
-/// Strip the `./` prefix from a Vite-style glob pattern to produce a pattern
-/// compatible with Turbopack's `Glob` (which operates relative to the scan
-/// directory, without a leading `./`).
-fn strip_relative_prefix(pattern: &str) -> &str {
-    pattern.strip_prefix("./").unwrap_or(pattern)
+/// Consume leading `./` and `../` segments from a Vite-style glob pattern.
+///
+/// Returns the number of `..` (parent-directory traversals) and the remaining
+/// pattern, which is relative to the origin directory walked up by that many
+/// parents.
+///
+/// # Examples
+///
+/// - `"./foo/*.js"` → `(0, "foo/*.js")`
+/// - `"../lib/**/*.js"` → `(1, "lib/**/*.js")`
+/// - `"../../a/./b/*.ts"` → `(2, "a/./b/*.ts")`
+/// - `"foo/*.js"` → `(0, "foo/*.js")`
+fn extract_leading_relative_parts(pattern: &str) -> (usize, &str) {
+    let mut rest = pattern;
+    let mut up = 0;
+    loop {
+        if let Some(r) = rest.strip_prefix("./") {
+            rest = r;
+        } else if let Some(r) = rest.strip_prefix("../") {
+            up += 1;
+            rest = r;
+        } else {
+            break;
+        }
+    }
+    (up, rest)
 }
 
 /// Flatten a nested `ReadGlobResult` into a sorted list of
@@ -596,12 +617,75 @@ impl ImportMetaGlobAsset {
         let origin = *self.origin;
         let origin_dir = origin.into_trait_ref().await?.origin_path().parent();
 
-        // Compute the base directory for glob scanning.
+        // Compute the effective origin directory for glob scanning.
         // With `base`, patterns are resolved relative to origin + base.
-        let base_dir = if let Some(ref b) = self.base {
+        let effective_dir = if let Some(ref b) = self.base {
             origin_dir.join(b)?
         } else {
             origin_dir
+        };
+
+        // Determine the maximum parent-directory traversal (`../`) count across
+        // all positive and negative patterns. Vite-compatible semantics allow
+        // patterns to reference files above the origin directory by prefixing
+        // one or more `../` segments.
+        let max_parent = self
+            .patterns
+            .iter()
+            .map(|p| {
+                let raw = p.strip_prefix('!').unwrap_or(p);
+                extract_leading_relative_parts(raw).0
+            })
+            .max()
+            .unwrap_or(0);
+
+        // Walk up from `effective_dir` by `max_parent` levels to produce the
+        // `scan_base` — the single directory from which we do the actual glob
+        // scan. All patterns are then rewritten relative to this base.
+        //
+        // `FileSystemPath::parent()` clamps at the filesystem root, so patterns
+        // whose `../` count exceeds the depth of `effective_dir` are effectively
+        // clamped as well (matching Node's/Vite's behavior of not escaping the
+        // filesystem root).
+        let effective_dir_path = effective_dir.path.clone();
+        let effective_dir_segments: Vec<&str> = effective_dir_path
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+        let clamped_parent = max_parent.min(effective_dir_segments.len());
+
+        let mut scan_base = effective_dir.clone();
+        for _ in 0..clamped_parent {
+            scan_base = scan_base.parent();
+        }
+
+        // Path segments between `scan_base` and `effective_dir`. To rewrite a
+        // pattern with `k` `../`s (k ≤ clamped_parent), we prepend the first
+        // `clamped_parent - k` of these segments to the pattern remainder.
+        let inner_segments: Vec<&str> = if clamped_parent == 0 {
+            Vec::new()
+        } else {
+            effective_dir_segments[effective_dir_segments.len() - clamped_parent..].to_vec()
+        };
+
+        // Rewrite a Vite-style pattern to be relative to `scan_base`.
+        //
+        // Turbopack's `Glob` operates on paths relative to the scan directory
+        // (no leading `./`), so we strip any leading `./`/`../` segments and
+        // prepend the appropriate `inner_segments` prefix so the resulting
+        // pattern targets the same files when matched from `scan_base`.
+        let rewrite = |raw: &str| -> RcStr {
+            let (k, rest) = extract_leading_relative_parts(raw);
+            // Clamp `k` in case the pattern tries to traverse above the
+            // filesystem root; `parent()` clamped `scan_base` at the root, so
+            // we clamp the prefix accordingly.
+            let k = k.min(inner_segments.len());
+            let prefix_count = inner_segments.len() - k;
+            let mut parts: Vec<&str> = inner_segments[..prefix_count].to_vec();
+            if !rest.is_empty() {
+                parts.push(rest);
+            }
+            parts.join("/").into()
         };
 
         // Separate positive (matching) and negative (exclusion) patterns.
@@ -609,12 +693,11 @@ impl ImportMetaGlobAsset {
         let (positive_raw, negative_raw): (Vec<_>, Vec<_>) =
             self.patterns.iter().partition(|p| !p.starts_with('!'));
 
-        // Build the positive Glob. Turbopack's Glob operates on paths relative
-        // to the scan directory (no leading `./`), so strip that prefix. For
-        // multiple patterns, use `Glob::alternatives` to combine them.
+        // Build the positive Glob. For multiple patterns, use
+        // `Glob::alternatives` to combine them into a single alternation glob.
         let positive_globs: Vec<Vc<Glob>> = positive_raw
             .iter()
-            .map(|p| Glob::new(strip_relative_prefix(p).into(), GlobOptions::default()))
+            .map(|p| Glob::new(rewrite(p), GlobOptions::default()))
             .collect();
 
         let positive_glob = if positive_globs.len() == 1 {
@@ -623,15 +706,13 @@ impl ImportMetaGlobAsset {
             Glob::alternatives(positive_globs)
         };
 
-        // Build the negative Glob (if any). Negative patterns also need `./`
-        // stripped and are combined into a single alternation glob.
+        // Build the negative Glob (if any).
         let negative_glob = if !negative_raw.is_empty() {
             let neg_globs: Vec<Vc<Glob>> = negative_raw
                 .iter()
                 .map(|p| {
                     let stripped = p.strip_prefix('!').unwrap_or(p);
-                    let stripped = strip_relative_prefix(stripped);
-                    Glob::new(stripped.into(), GlobOptions::default())
+                    Glob::new(rewrite(stripped), GlobOptions::default())
                 })
                 .collect();
 
@@ -647,7 +728,7 @@ impl ImportMetaGlobAsset {
 
         Ok(ImportMetaGlobMap::generate(
             origin,
-            base_dir,
+            scan_base,
             positive_glob,
             negative_glob,
             self.query.clone(),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/index.js
@@ -114,6 +114,8 @@ it('should include dotfile directories with wildcard patterns', () => {
     './.foo/hidden.js',
     './dir/bar.js',
     './dir/foo.js',
+    './nested/parent-glob.js',
+    './nested/sibling/local.js',
     './other/baz.js',
   ])
 })
@@ -124,4 +126,39 @@ const dotfileExplicit = import.meta.glob('./.foo/*.js', { eager: true })
 it('should include dotfile directories when explicitly targeted', () => {
   const keys = Object.keys(dotfileExplicit)
   expect(keys).toEqual(['./.foo/hidden.js'])
+})
+
+// Parent-directory traversal (`../`) — verifies that `import.meta.glob`
+// supports Vite-compatible parent-relative paths in Turbopack.
+import {
+  parentDir,
+  parentAndLocal,
+  parentNamed,
+  parentWithNegative,
+} from './nested/parent-glob.js'
+
+it('should resolve `../` patterns from the calling file', () => {
+  const keys = Object.keys(parentDir).sort()
+  expect(keys).toEqual(['../dir/bar.js', '../dir/foo.js'])
+  expect(parentDir['../dir/foo.js'].default).toBe('foo')
+  expect(parentDir['../dir/bar.js'].default).toBe('bar')
+})
+
+it('should mix parent-relative and local patterns in the same call', () => {
+  const keys = Object.keys(parentAndLocal).sort()
+  expect(keys).toEqual(['../other/baz.js', './sibling/local.js'])
+  expect(parentAndLocal['./sibling/local.js'].default).toBe('nested-local')
+  expect(parentAndLocal['../other/baz.js'].default).toBe('baz')
+})
+
+it('should honor the `import` option for `../` patterns', () => {
+  const keys = Object.keys(parentNamed).sort()
+  expect(keys).toEqual(['../dir/bar.js', '../dir/foo.js'])
+  expect(parentNamed['../dir/foo.js']).toBe('foo')
+  expect(parentNamed['../dir/bar.js']).toBe('bar')
+})
+
+it('should apply negative patterns to parent-relative matches', () => {
+  const keys = Object.keys(parentWithNegative)
+  expect(keys).toEqual(['../dir/foo.js'])
 })

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/nested/parent-glob.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/nested/parent-glob.js
@@ -1,0 +1,26 @@
+// This file lives in `input/nested/` and exercises `import.meta.glob` patterns
+// that traverse to the parent directory using `../`. It is imported by the
+// top-level `index.js` so that the test assertions live next to the other
+// `import.meta.glob` cases.
+
+// Single-level parent traversal (matches ../dir/*.js — i.e. bar.js and foo.js).
+export const parentDir = import.meta.glob('../dir/*.js', { eager: true })
+
+// Parent traversal combined with a local pattern in the same call. This is the
+// specific shape reported in the issue reproduction.
+export const parentAndLocal = import.meta.glob(
+  ['./sibling/*.js', '../other/*.js'],
+  { eager: true }
+)
+
+// Parent traversal with a globstar and named import.
+export const parentNamed = import.meta.glob('../dir/*.js', {
+  eager: true,
+  import: 'default',
+})
+
+// Negative pattern applied across parent-relative results.
+export const parentWithNegative = import.meta.glob(
+  ['../dir/*.js', '!../dir/bar.js'],
+  { eager: true }
+)

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/nested/sibling/local.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/nested/sibling/local.js
@@ -1,0 +1,1 @@
+export default 'nested-local'


### PR DESCRIPTION
## Summary

`import.meta.glob` in Turbopack silently returned no matches for any pattern
that traversed above the calling file's directory (`../foo/*.js`,
`../../lib/**/*.ts`, etc.). Local patterns (`./foo/*.js`) worked, so this only
affected parent-relative imports, which Vite documents as supported.

Root cause: in `packages/next/../import_meta_glob.rs`, `map()` compiled each
pattern into a `Glob` after stripping only a leading `./` and then called
`base_dir.read_glob(...)` on the origin directory. `read_glob` walks
*downward*, so a leading `../` never gets resolved and the pattern can't match
anything.

Fix: rewrite each pattern to be relative to a common `scan_base`. `map()` now:

1. Computes `max_parent` — the highest `../` count across all positive and
   negative patterns.
2. Walks the effective origin directory up by that many levels (clamped at the
   filesystem root by `FileSystemPath::parent()`).
3. Rewrites every pattern to be relative to that `scan_base`, prepending the
   appropriate slice of the origin's inner segments so `Glob::alternatives`
   still finds matches.

Result mapping (`origin_path.get_relative_path_to(path)`) was already correct,
so the JS keys and resolved imports come out as `../../lib/modules/foo.js`
without further changes.

## Verification

- `cargo test -p turbopack-tests --test execution -- test_tests__execution__turbopack__resolving__import_meta_glob`
  (3 execution fixtures pass, including four new `../`-traversal cases:
  parent-only, mixed local + parent, `import: 'default'` with `../`, and
  negatives applied to `../` matches).

New fixture files:

- `turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/nested/parent-glob.js`
- `turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/nested/sibling/local.js`

Fixes the reproduction at
https://github.com/chitwitgit/turbopack-import-meta-glob.

<!-- NEXT_JS_LLM_PR -->
