### PR TITLE
Enable Server Components HMR cancellation by default

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1002,7 +1002,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true
-        export __NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=dev
         export IS_TURBOPACK_TEST=1
@@ -1038,7 +1037,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true
-        export __NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=start
         export IS_TURBOPACK_TEST=1

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -174,7 +174,8 @@ import {
   getClientComponentLoaderMetrics,
   wrapClientComponentLoader,
 } from '../client-component-renderer-logger'
-import { isNodeNextRequest } from '../base-http/helpers'
+import { isNodeNextRequest, isNodeNextResponse } from '../base-http/helpers'
+import { signalFromNodeResponse } from '../web/spec-extension/adapters/next-request'
 import {
   parseRelativeUrl,
   type ParsedRelativeUrl,
@@ -843,6 +844,19 @@ async function generateDynamicFlightRenderResult(
     onFlightDataRenderError
   )
 
+  // With Server Components HMR cancellation enabled, a superseded HMR refresh
+  // aborts its own client fetch, which closes this response. We use that
+  // response-close to abort the discarded render. This is the
+  // non-Cache-Components dev RSC path; unlike the Cache Components staged path
+  // it has no detached validation, so the render is the only work to cancel.
+  const abortSignal =
+    process.env.__NEXT_DEV_SERVER &&
+    renderOpts.experimental.serverComponentsHmrCancellation === true &&
+    requestStore.isHmrRefresh === true &&
+    isNodeNextResponse(ctx.res)
+      ? signalFromNodeResponse(ctx.res.originalResponse)
+      : undefined
+
   if (process.env.__NEXT_USE_NODE_STREAMS) {
     const debugChannel = setReactDebugChannel && createNodeDebugChannel()
 
@@ -870,6 +884,7 @@ async function generateDynamicFlightRenderResult(
         temporaryReferences: options?.temporaryReferences,
         filterStackFrame,
         debugChannel: debugChannel?.serverSide,
+        signal: abortSignal,
       }
     )
 
@@ -905,6 +920,7 @@ async function generateDynamicFlightRenderResult(
         temporaryReferences: options?.temporaryReferences,
         filterStackFrame,
         debugChannel: debugChannel?.serverSide,
+        signal: abortSignal,
       }
     )
 
@@ -1378,6 +1394,34 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       }
     }
 
+    // With Server Components HMR cancellation enabled, a superseded HMR refresh
+    // aborts its own client fetch (see the client-side supersession logic),
+    // which closes this response. We use that response-close as the signal to
+    // stop the server work this refresh started that's now discarded: the
+    // streaming render below is aborted, and the detached validation is skipped
+    // (including aborting the background renders it uses to prepare its
+    // inputs). The render's in-flight `'use cache'` fills are left running,
+    // since they aren't tied to its controller. A superseding refresh can't
+    // reuse those fills today, because each edit changes the HMR hash baked
+    // into the cache key; that becomes useful only once those keys use
+    // implementation-derived hashes instead (see `use-cache-wrapper.ts`).
+    //
+    // The detached validation is Cache Components only: it runs only on this
+    // staged dev render, so there's nothing to skip on the non-Cache Components
+    // dev RSC path. That path (`generateDynamicFlightRenderResult`) aborts its
+    // superseded render the same way; it just has no validation to skip.
+    //
+    // TODO: The gate is `isHmrRefresh` for now because that's the only case we
+    // cancel today. The response-close signal itself is general, so this could
+    // later be relaxed to also cover a browser stop or a devtools "cancel
+    // render" button.
+    const abortSignal =
+      renderOpts.experimental.serverComponentsHmrCancellation === true &&
+      initialRequestStore.isHmrRefresh === true &&
+      isNodeNextResponse(ctx.res)
+        ? signalFromNodeResponse(ctx.res.originalResponse)
+        : undefined
+
     const result = await stagedRenderWithCachesInDev({
       prefetchMode,
       ctx,
@@ -1392,6 +1436,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
         type: 'prefetched-client',
         prefetchStage,
       },
+      abortSignal,
     })
     stream = result.stream
     debugChannel = result.debugChannel
@@ -3475,6 +3520,8 @@ async function renderToStream(
               navigationKind: {
                 type: 'initial-load',
               },
+              // The initial load has no request-abort signal to tear it down.
+              abortSignal: undefined,
             })
 
           reactServerResult = new ReactServerResult(serverStream)
@@ -4413,11 +4460,22 @@ function runDevValidationInBackground(
   getDevRenderDidError: () => boolean,
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
-  onError: (error: unknown) => void
+  onError: (error: unknown) => void,
+  abortSignal: AbortSignal | undefined
 ): void {
   void consoleAsyncStorage
     .run({ dim: true }, async () => {
       const result = await resultPromise
+
+      // If the request was aborted while its render was in flight, skip
+      // validation entirely: the render's result is being discarded, so
+      // re-rendering and analyzing it would only waste server work. In-flight
+      // `'use cache'` fills are left running (we don't await `cacheReady`
+      // below).
+      if (abortSignal?.aborted) {
+        logValidationAborted(ctx)
+        return
+      }
 
       // Read whether the streamed render errored only now that it has fully
       // settled.
@@ -4452,7 +4510,8 @@ function runDevValidationInBackground(
         prerenderResumeDataCache,
         createRequestStore,
         getPayload,
-        onError
+        onError,
+        abortSignal
       )
 
       // If we need to do multiple renders, do them in parallel.
@@ -4474,18 +4533,33 @@ function runDevValidationInBackground(
         return
       }
 
+      // The request may have been aborted while we prepared the validation
+      // inputs above (which can itself render). Skip validation before it
+      // begins rather than run it for a discarded request.
+      if (abortSignal?.aborted) {
+        logValidationAborted(ctx)
+        return
+      }
+
       return runValidationInDev(
         prefetchMode,
         instantInputs,
         staticInputs,
         ctx,
         fallbackRouteParams,
-        devRenderDidError
+        devRenderDidError,
+        abortSignal
       )
     })
     // The catch keeps a failed render, or anything thrown inside validation,
     // from surfacing as an unhandled rejection.
     .catch((err) => {
+      // If this request was aborted, its render and detached validation are
+      // being torn down and their result discarded. We don't want to log these
+      // errors (including the abort signal reason itself).
+      if (abortSignal?.aborted) {
+        return
+      }
       console.error(
         new InvariantError('An unexpected error occurred during validation', {
           cause: err,
@@ -4549,7 +4623,8 @@ async function prepareValidationInputs(
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
-  onError: (error: unknown) => void
+  onError: (error: unknown) => void,
+  abortSignal: AbortSignal | undefined
 ): Promise<PrepareValidationInputsResult> {
   // Check if we can re-use the main render for validation.
   let inputsFromNavigation: DevValidationInputs | null
@@ -4578,7 +4653,8 @@ async function prepareValidationInputs(
       createRequestStore,
       getPayload,
       onError,
-      inputsFromNavigation
+      inputsFromNavigation,
+      abortSignal
     )
   } else {
     return prepareValidationInputsInLegacyPrefetching(
@@ -4587,7 +4663,8 @@ async function prepareValidationInputs(
       createRequestStore,
       getPayload,
       onError,
-      inputsFromNavigation
+      inputsFromNavigation,
+      abortSignal
     )
   }
 }
@@ -4600,7 +4677,8 @@ async function prepareValidationInputsInPartialPrefetching(
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  inputsFromNavigation: DevValidationInputs | null
+  inputsFromNavigation: DevValidationInputs | null,
+  abortSignal: AbortSignal | undefined
 ): Promise<PrepareValidationInputsResult> {
   const loaderTree = ctx.componentMod.routeModule.userland.loaderTree
   const needsInstantValidation =
@@ -4622,7 +4700,8 @@ async function prepareValidationInputsInPartialPrefetching(
       getPayload,
       onError,
       prerenderResumeDataCache,
-      shouldRenderWithAppShell
+      shouldRenderWithAppShell,
+      abortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4636,7 +4715,8 @@ async function prepareValidationInputsInPartialPrefetching(
       createRequestStore,
       getPayload,
       onError,
-      prerenderResumeDataCache
+      prerenderResumeDataCache,
+      abortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4689,7 +4769,8 @@ async function prepareValidationInputsInLegacyPrefetching(
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  inputsFromNavigation: DevValidationInputs | null
+  inputsFromNavigation: DevValidationInputs | null,
+  abortSignal: AbortSignal | undefined
 ): Promise<PrepareValidationInputsResult> {
   const loaderTree = ctx.componentMod.routeModule.userland.loaderTree
   const needsInstantValidation =
@@ -4712,7 +4793,8 @@ async function prepareValidationInputsInLegacyPrefetching(
       getPayload,
       onError,
       prerenderResumeDataCache,
-      shouldRenderWithAppShell
+      shouldRenderWithAppShell,
+      abortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4726,7 +4808,8 @@ async function prepareValidationInputsInLegacyPrefetching(
       createRequestStore,
       getPayload,
       onError,
-      prerenderResumeDataCache
+      prerenderResumeDataCache,
+      abortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4902,6 +4985,10 @@ interface StagedDevRenderOptions {
   requestStore: RequestStore
   onError: (error: unknown) => void
   navigationKind: DevNavigationKind
+  // When this aborts, the staged dev render is torn down (its in-flight `'use
+  // cache'` fills keep running) and the detached validation is skipped.
+  // `undefined` runs both to completion.
+  abortSignal: AbortSignal | undefined
 }
 
 type DevNavigationKind =
@@ -4953,6 +5040,7 @@ async function streamStagedRenderInDev({
   onError,
   debugChannel,
   navigationKind,
+  abortSignal,
 }: StreamStagedRenderInDevOptions): Promise<{
   stream: Readable
   resultPromise: Promise<StagedDevRenderResult>
@@ -5061,13 +5149,15 @@ async function streamStagedRenderInDev({
     }
   }
 
-  // The render runs to completion; it never aborts. The first task starts the
-  // render in the `ShellEarlyStatic` stage and creates the stream (one replay
-  // for the response, one to accumulate the chunks). The later tasks advance
-  // the stages, settle `hadCacheMiss`, and reveal the shell – as soon as a
-  // cache miss is seen, or once the render reaches `revealAfterStage` – then
-  // advance into the dynamic stage a task later. The replayable stays local:
-  // the response is the only reader outside this function.
+  // The render runs to completion unless `abortSignal` fires, in which case
+  // React aborts the Flight render and the accumulation tears down. The first
+  // task starts the render in the `ShellEarlyStatic` stage and creates the
+  // stream (one replay for the response, one to accumulate the chunks). The
+  // later tasks advance the stages, settle `hadCacheMiss`, and reveal the shell
+  // – as soon as a cache miss is seen, or once the render reaches
+  // `revealAfterStage` – then advance into the dynamic stage a task later. The
+  // replayable stays local: the response is the only reader outside this
+  // function.
   const stagesAdvanced = runInSequentialTasks(
     () => {
       stageController.advanceStage(RenderStage.ShellEarlyStatic)
@@ -5086,6 +5176,7 @@ async function streamStagedRenderInDev({
             startTime,
             filterStackFrame,
             debugChannel: debugChannel?.serverSide,
+            signal: abortSignal,
           }
         ) as Readable
       )
@@ -5095,7 +5186,10 @@ async function streamStagedRenderInDev({
         accumulatedChunksPromise: accumulateStreamChunks(
           replayable.createReplayStream(),
           stageController,
-          null
+          // Tear down the chunk accumulation on abort too, so `resultPromise`
+          // settles promptly (instead of waiting out the aborted render) and
+          // the detached validation can see the abort and skip.
+          abortSignal ?? null
         ),
       })
     },
@@ -5184,7 +5278,8 @@ async function renderWithWarmCachesForValidationInDev(
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
-  shouldRenderWithAppShell: boolean
+  shouldRenderWithAppShell: boolean,
+  abortSignal: AbortSignal | undefined
 ): Promise<DevValidationInputs> {
   const { ComponentMod, setReactDebugChannel } = ctx.renderOpts
   const { clientModules } = getClientReferenceManifest()
@@ -5234,10 +5329,15 @@ async function renderWithWarmCachesForValidationInDev(
           startTime,
           filterStackFrame,
           debugChannel: debugChannel?.serverSide,
+          signal: abortSignal,
         }
       ) as Readable
 
-      return accumulateStreamChunks(sourceStream, stageController, null)
+      return accumulateStreamChunks(
+        sourceStream,
+        stageController,
+        abortSignal ?? null
+      )
     },
     () => stageController.advanceStage(RenderStage.ShellStatic),
     () => stageController.advanceStage(RenderStage.EarlyStatic),
@@ -5273,7 +5373,8 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>
+  prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
+  abortSignal: AbortSignal | undefined
 ): Promise<DevValidationInputs> {
   const { ComponentMod, setReactDebugChannel } = ctx.renderOpts
   const { clientModules } = getClientReferenceManifest()
@@ -5283,6 +5384,12 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
   // (we need static chunks and runtime chunks for discriminated errors)
   const finalReactController = new AbortController()
   const finalDataController = new AbortController()
+
+  // Aborting `finalReactController` (the prerender's own controller) on the
+  // signal tears the render down the same way its runtime-stage abort does.
+  if (abortSignal) {
+    abortWhenSignalAborts(abortSignal, finalReactController)
+  }
 
   const stageController = new StagedRenderingController({
     abortSignal: finalDataController.signal,
@@ -5444,6 +5551,7 @@ async function stagedRenderWithCachesInDev({
   fallbackRouteParams,
   getDevRenderDidError,
   navigationKind,
+  abortSignal,
 }: StagedRenderWithCachesInDevOptions): Promise<{
   stream: Readable
   debugChannel: NodeDebugChannelPair | undefined
@@ -5482,6 +5590,7 @@ async function stagedRenderWithCachesInDev({
     onError,
     debugChannel,
     navigationKind,
+    abortSignal,
   })
 
   if (shouldValidate) {
@@ -5498,7 +5607,8 @@ async function stagedRenderWithCachesInDev({
       getDevRenderDidError,
       createRequestStore,
       getPayload,
-      onError
+      onError,
+      abortSignal
     )
   } else {
     logValidationSkipped(ctx)
@@ -5899,6 +6009,18 @@ function logValidationSkipped(ctx: AppRenderContext) {
   }
 }
 
+function logValidationAborted(ctx: AppRenderContext) {
+  if (process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION) {
+    const requestId = ctx.requestId
+    const url = ctx.url.href
+    console.log(
+      '<VALIDATION_MESSAGE>' +
+        JSON.stringify({ type: 'validation_aborted', requestId, url }) +
+        '</VALIDATION_MESSAGE>'
+    )
+  }
+}
+
 async function runValidationInDev(
   ...args: Parameters<typeof runValidationInDevImpl>
 ) {
@@ -5937,7 +6059,8 @@ async function runValidationInDevImpl(
   staticInputs: DevValidationInputs,
   ctx: AppRenderContext,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
-  devRenderDidError: boolean
+  devRenderDidError: boolean,
+  abortSignal: AbortSignal | undefined
 ): Promise<void> {
   const { componentMod: ComponentMod, getDynamicParamFromSegment } = ctx
   const loaderTree = ComponentMod.routeModule.userland.loaderTree
@@ -5997,6 +6120,11 @@ async function runValidationInDevImpl(
   // Static shell validation
   //================================
   {
+    // The request may have been aborted during the client module warmup above.
+    if (abortSignal?.aborted) {
+      return
+    }
+
     const inputs = staticInputs
 
     const debugChunks = inputs.debugChannelClient
@@ -6012,6 +6140,12 @@ async function runValidationInDevImpl(
       debugChunks,
       hmrRefreshHash
     )
+    // The request was aborted while this validation render ran, so its result
+    // is being discarded. Don't surface its validation errors: they're for a
+    // render that won't be shown.
+    if (abortSignal?.aborted) {
+      return
+    }
     if (result.length > 0) {
       return logMessagesAndSendErrorsToBrowser(result, ctx)
     }
@@ -6041,6 +6175,11 @@ async function runValidationInDevImpl(
       devRenderDidError
     )
 
+    // The request was aborted while this render ran; don't surface its stale
+    // validation errors: they're for a render that won't be shown.
+    if (abortSignal?.aborted) {
+      return
+    }
     if (result.length > 0) {
       return logMessagesAndSendErrorsToBrowser(result, ctx)
     }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -849,7 +849,7 @@ async function generateDynamicFlightRenderResult(
   // response-close to abort the discarded render. This is the
   // non-Cache-Components dev RSC path; unlike the Cache Components staged path
   // it has no detached validation, so the render is the only work to cancel.
-  const abortSignal =
+  const requestAbortSignal =
     process.env.__NEXT_DEV_SERVER &&
     renderOpts.experimental.serverComponentsHmrCancellation === true &&
     requestStore.isHmrRefresh === true &&
@@ -884,7 +884,7 @@ async function generateDynamicFlightRenderResult(
         temporaryReferences: options?.temporaryReferences,
         filterStackFrame,
         debugChannel: debugChannel?.serverSide,
-        signal: abortSignal,
+        signal: requestAbortSignal,
       }
     )
 
@@ -920,7 +920,7 @@ async function generateDynamicFlightRenderResult(
         temporaryReferences: options?.temporaryReferences,
         filterStackFrame,
         debugChannel: debugChannel?.serverSide,
-        signal: abortSignal,
+        signal: requestAbortSignal,
       }
     )
 
@@ -1415,7 +1415,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     // cancel today. The response-close signal itself is general, so this could
     // later be relaxed to also cover a browser stop or a devtools "cancel
     // render" button.
-    const abortSignal =
+    const requestAbortSignal =
       renderOpts.experimental.serverComponentsHmrCancellation === true &&
       initialRequestStore.isHmrRefresh === true &&
       isNodeNextResponse(ctx.res)
@@ -1436,7 +1436,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
         type: 'prefetched-client',
         prefetchStage,
       },
-      abortSignal,
+      requestAbortSignal,
     })
     stream = result.stream
     debugChannel = result.debugChannel
@@ -3520,8 +3520,8 @@ async function renderToStream(
               navigationKind: {
                 type: 'initial-load',
               },
-              // The initial load has no request-abort signal to tear it down.
-              abortSignal: undefined,
+              // We currently only abort HMR refresh requests.
+              requestAbortSignal: undefined,
             })
 
           reactServerResult = new ReactServerResult(serverStream)
@@ -4461,7 +4461,7 @@ function runDevValidationInBackground(
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 ): void {
   void consoleAsyncStorage
     .run({ dim: true }, async () => {
@@ -4472,7 +4472,7 @@ function runDevValidationInBackground(
       // re-rendering and analyzing it would only waste server work. In-flight
       // `'use cache'` fills are left running (we don't await `cacheReady`
       // below).
-      if (abortSignal?.aborted) {
+      if (requestAbortSignal?.aborted) {
         logValidationAborted(ctx)
         return
       }
@@ -4511,7 +4511,7 @@ function runDevValidationInBackground(
         createRequestStore,
         getPayload,
         onError,
-        abortSignal
+        requestAbortSignal
       )
 
       // If we need to do multiple renders, do them in parallel.
@@ -4536,7 +4536,7 @@ function runDevValidationInBackground(
       // The request may have been aborted while we prepared the validation
       // inputs above (which can itself render). Skip validation before it
       // begins rather than run it for a discarded request.
-      if (abortSignal?.aborted) {
+      if (requestAbortSignal?.aborted) {
         logValidationAborted(ctx)
         return
       }
@@ -4548,7 +4548,7 @@ function runDevValidationInBackground(
         ctx,
         fallbackRouteParams,
         devRenderDidError,
-        abortSignal
+        requestAbortSignal
       )
     })
     // The catch keeps a failed render, or anything thrown inside validation,
@@ -4557,7 +4557,7 @@ function runDevValidationInBackground(
       // If this request was aborted, its render and detached validation are
       // being torn down and their result discarded. We don't want to log these
       // errors (including the abort signal reason itself).
-      if (abortSignal?.aborted) {
+      if (requestAbortSignal?.aborted) {
         return
       }
       console.error(
@@ -4624,7 +4624,7 @@ async function prepareValidationInputs(
   createRequestStore: () => RequestStore,
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 ): Promise<PrepareValidationInputsResult> {
   // Check if we can re-use the main render for validation.
   let inputsFromNavigation: DevValidationInputs | null
@@ -4654,7 +4654,7 @@ async function prepareValidationInputs(
       getPayload,
       onError,
       inputsFromNavigation,
-      abortSignal
+      requestAbortSignal
     )
   } else {
     return prepareValidationInputsInLegacyPrefetching(
@@ -4664,7 +4664,7 @@ async function prepareValidationInputs(
       getPayload,
       onError,
       inputsFromNavigation,
-      abortSignal
+      requestAbortSignal
     )
   }
 }
@@ -4678,7 +4678,7 @@ async function prepareValidationInputsInPartialPrefetching(
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   inputsFromNavigation: DevValidationInputs | null,
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 ): Promise<PrepareValidationInputsResult> {
   const loaderTree = ctx.componentMod.routeModule.userland.loaderTree
   const needsInstantValidation =
@@ -4701,7 +4701,7 @@ async function prepareValidationInputsInPartialPrefetching(
       onError,
       prerenderResumeDataCache,
       shouldRenderWithAppShell,
-      abortSignal
+      requestAbortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4716,7 +4716,7 @@ async function prepareValidationInputsInPartialPrefetching(
       getPayload,
       onError,
       prerenderResumeDataCache,
-      abortSignal
+      requestAbortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4770,7 +4770,7 @@ async function prepareValidationInputsInLegacyPrefetching(
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   inputsFromNavigation: DevValidationInputs | null,
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 ): Promise<PrepareValidationInputsResult> {
   const loaderTree = ctx.componentMod.routeModule.userland.loaderTree
   const needsInstantValidation =
@@ -4794,7 +4794,7 @@ async function prepareValidationInputsInLegacyPrefetching(
       onError,
       prerenderResumeDataCache,
       shouldRenderWithAppShell,
-      abortSignal
+      requestAbortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4809,7 +4809,7 @@ async function prepareValidationInputsInLegacyPrefetching(
       getPayload,
       onError,
       prerenderResumeDataCache,
-      abortSignal
+      requestAbortSignal
     )
     if (forwardErrorsFromWarmRender(inputs, ctx)) {
       return VALIDATION_BAILOUT
@@ -4988,7 +4988,7 @@ interface StagedDevRenderOptions {
   // When this aborts, the staged dev render is torn down (its in-flight `'use
   // cache'` fills keep running) and the detached validation is skipped.
   // `undefined` runs both to completion.
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 }
 
 type DevNavigationKind =
@@ -5040,7 +5040,7 @@ async function streamStagedRenderInDev({
   onError,
   debugChannel,
   navigationKind,
-  abortSignal,
+  requestAbortSignal,
 }: StreamStagedRenderInDevOptions): Promise<{
   stream: Readable
   resultPromise: Promise<StagedDevRenderResult>
@@ -5149,15 +5149,6 @@ async function streamStagedRenderInDev({
     }
   }
 
-  // The render runs to completion unless `abortSignal` fires, in which case
-  // React aborts the Flight render and the accumulation tears down. The first
-  // task starts the render in the `ShellEarlyStatic` stage and creates the
-  // stream (one replay for the response, one to accumulate the chunks). The
-  // later tasks advance the stages, settle `hadCacheMiss`, and reveal the shell
-  // – as soon as a cache miss is seen, or once the render reaches
-  // `revealAfterStage` – then advance into the dynamic stage a task later. The
-  // replayable stays local: the response is the only reader outside this
-  // function.
   const stagesAdvanced = runInSequentialTasks(
     () => {
       stageController.advanceStage(RenderStage.ShellEarlyStatic)
@@ -5176,7 +5167,7 @@ async function streamStagedRenderInDev({
             startTime,
             filterStackFrame,
             debugChannel: debugChannel?.serverSide,
-            signal: abortSignal,
+            signal: requestAbortSignal,
           }
         ) as Readable
       )
@@ -5186,10 +5177,9 @@ async function streamStagedRenderInDev({
         accumulatedChunksPromise: accumulateStreamChunks(
           replayable.createReplayStream(),
           stageController,
-          // Tear down the chunk accumulation on abort too, so `resultPromise`
-          // settles promptly (instead of waiting out the aborted render) and
-          // the detached validation can see the abort and skip.
-          abortSignal ?? null
+          // Abort accumulation as soon as the signal aborts instead of waiting
+          // for the stream to close.
+          requestAbortSignal ?? null
         ),
       })
     },
@@ -5279,7 +5269,7 @@ async function renderWithWarmCachesForValidationInDev(
   onError: (error: unknown) => void,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   shouldRenderWithAppShell: boolean,
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 ): Promise<DevValidationInputs> {
   const { ComponentMod, setReactDebugChannel } = ctx.renderOpts
   const { clientModules } = getClientReferenceManifest()
@@ -5329,14 +5319,14 @@ async function renderWithWarmCachesForValidationInDev(
           startTime,
           filterStackFrame,
           debugChannel: debugChannel?.serverSide,
-          signal: abortSignal,
+          signal: requestAbortSignal,
         }
       ) as Readable
 
       return accumulateStreamChunks(
         sourceStream,
         stageController,
-        abortSignal ?? null
+        requestAbortSignal ?? null
       )
     },
     () => stageController.advanceStage(RenderStage.ShellStatic),
@@ -5374,7 +5364,7 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
   getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 ): Promise<DevValidationInputs> {
   const { ComponentMod, setReactDebugChannel } = ctx.renderOpts
   const { clientModules } = getClientReferenceManifest()
@@ -5385,10 +5375,8 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
   const finalReactController = new AbortController()
   const finalDataController = new AbortController()
 
-  // Aborting `finalReactController` (the prerender's own controller) on the
-  // signal tears the render down the same way its runtime-stage abort does.
-  if (abortSignal) {
-    abortWhenSignalAborts(abortSignal, finalReactController)
+  if (requestAbortSignal) {
+    abortWhenSignalAborts(requestAbortSignal, finalReactController)
   }
 
   const stageController = new StagedRenderingController({
@@ -5551,7 +5539,7 @@ async function stagedRenderWithCachesInDev({
   fallbackRouteParams,
   getDevRenderDidError,
   navigationKind,
-  abortSignal,
+  requestAbortSignal,
 }: StagedRenderWithCachesInDevOptions): Promise<{
   stream: Readable
   debugChannel: NodeDebugChannelPair | undefined
@@ -5590,7 +5578,7 @@ async function stagedRenderWithCachesInDev({
     onError,
     debugChannel,
     navigationKind,
-    abortSignal,
+    requestAbortSignal,
   })
 
   if (shouldValidate) {
@@ -5608,7 +5596,7 @@ async function stagedRenderWithCachesInDev({
       createRequestStore,
       getPayload,
       onError,
-      abortSignal
+      requestAbortSignal
     )
   } else {
     logValidationSkipped(ctx)
@@ -6060,7 +6048,7 @@ async function runValidationInDevImpl(
   ctx: AppRenderContext,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   devRenderDidError: boolean,
-  abortSignal: AbortSignal | undefined
+  requestAbortSignal: AbortSignal | undefined
 ): Promise<void> {
   const { componentMod: ComponentMod, getDynamicParamFromSegment } = ctx
   const loaderTree = ComponentMod.routeModule.userland.loaderTree
@@ -6121,7 +6109,7 @@ async function runValidationInDevImpl(
   //================================
   {
     // The request may have been aborted during the client module warmup above.
-    if (abortSignal?.aborted) {
+    if (requestAbortSignal?.aborted) {
       return
     }
 
@@ -6143,7 +6131,7 @@ async function runValidationInDevImpl(
     // The request was aborted while this validation render ran, so its result
     // is being discarded. Don't surface its validation errors: they're for a
     // render that won't be shown.
-    if (abortSignal?.aborted) {
+    if (requestAbortSignal?.aborted) {
       return
     }
     if (result.length > 0) {
@@ -6177,7 +6165,7 @@ async function runValidationInDevImpl(
 
     // The request was aborted while this render ran; don't surface its stale
     // validation errors: they're for a render that won't be shown.
-    if (abortSignal?.aborted) {
+    if (requestAbortSignal?.aborted) {
       return
     }
     if (result.length > 0) {

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -551,8 +551,9 @@ export function renderToNodeFlightStream(
 
   // `renderToPipeableStream` has no `signal` option (unlike the Web
   // `renderToReadableStream`), so pull `signal` out of the options and abort
-  // the returned pipeable ourselves when it fires. The listener is removed once
-  // the passthrough closes.
+  // the returned pipeable ourselves when it fires. We drop the listener when
+  // the passthrough closes so a finished render's `pipeable` isn't retained by
+  // the request signal, which can outlive it.
   const { signal, ...renderOptions } = opts ?? {}
 
   const pt = new PassThrough()

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -48,6 +48,11 @@ import {
   atLeastOneTask,
   waitAtLeastOneReactRenderTask,
 } from '../../lib/scheduler'
+import type {
+  FlightPayload,
+  FlightClientModules,
+  FlightRenderOptions,
+} from './stream-ops.web'
 
 // ---------------------------------------------------------------------------
 // Re-export shared types from the web module
@@ -536,21 +541,38 @@ export { renderToWebFlightStream } from './stream-ops.web'
 
 export function renderToNodeFlightStream(
   ComponentMod: FlightComponentMod,
-  payload: any,
-  clientModules: any,
-  opts: any
+  payload: FlightPayload,
+  clientModules: FlightClientModules,
+  opts: FlightRenderOptions
 ): AnyStream {
   if (!ComponentMod.renderToPipeableStream) {
     throw new Error('renderToPipeableStream is not implemented')
   }
 
+  // `renderToPipeableStream` has no `signal` option (unlike the Web
+  // `renderToReadableStream`), so pull `signal` out of the options and abort
+  // the returned pipeable ourselves when it fires. The listener is removed once
+  // the passthrough closes.
+  const { signal, ...renderOptions } = opts ?? {}
+
   const pt = new PassThrough()
   const pipeable = ComponentMod.renderToPipeableStream!(
     payload,
     clientModules,
-    opts
+    renderOptions
   )
   pipeable.pipe(pt)
+
+  if (signal) {
+    if (signal.aborted) {
+      pipeable.abort(signal.reason)
+    } else {
+      const onAbort = () => pipeable.abort(signal.reason)
+      signal.addEventListener('abort', onAbort, { once: true })
+      pt.on('close', () => signal.removeEventListener('abort', onAbort))
+    }
+  }
+
   return pt
 }
 

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -10,6 +10,7 @@
 import type { PostponedState, PrerenderOptions } from 'react-dom/static'
 import { resume, renderToReadableStream } from 'react-dom/server'
 import { prerender } from 'react-dom/static'
+import type { renderToReadableStream as flightRenderToReadableStream } from 'react-server-dom-webpack/server'
 
 import {
   renderToInitialFizzStream,
@@ -32,11 +33,7 @@ import type { AnyStream as AnyStreamType } from './app-render-prerender-utils'
 // Shared types
 // ---------------------------------------------------------------------------
 
-type FlightRenderToReadableStream = (
-  model: any,
-  webpackMap: any,
-  options?: any
-) => ReadableStream<Uint8Array>
+type FlightRenderToReadableStream = typeof flightRenderToReadableStream
 
 export type AnyStream = AnyStreamType
 
@@ -73,7 +70,17 @@ export type ServerPrerenderComponentMod = {
 
 export type FlightPayload = Parameters<FlightRenderToReadableStream>[0]
 export type FlightClientModules = Parameters<FlightRenderToReadableStream>[1]
-export type FlightRenderOptions = Parameters<FlightRenderToReadableStream>[2]
+
+/**
+ * The options our Flight render wrappers accept, taken from React's Flight
+ * `renderToReadableStream`. `signal` aborts the render: the Web wrapper passes
+ * it straight to `renderToReadableStream`, while the Node wrapper aborts the
+ * pipeable returned by `renderToPipeableStream` (which has no `signal` option)
+ * when it fires.
+ */
+export type FlightRenderOptions = NonNullable<
+  Parameters<FlightRenderToReadableStream>[2]
+>
 
 export type FizzStreamResult = {
   stream: AnyStream

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1196,7 +1196,7 @@ export interface ExperimentalConfig {
   serverComponentsHmrCache?: boolean
 
   /**
-   * Cancels the render and validation work for a Server Component HMR refresh
+   * Cancels the render and validation work for a Server Components HMR refresh
    * once a newer refresh supersedes it. Development only.
    */
   serverComponentsHmrCancellation?: boolean

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -2163,7 +2163,7 @@ export const defaultConfig = Object.freeze({
     reactDebugChannel: true,
     staticGenerationRetryCount: undefined,
     serverComponentsHmrCache: true,
-    serverComponentsHmrCancellation: false,
+    serverComponentsHmrCancellation: true,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
     transitionIndicator: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2234,26 +2234,6 @@ function enforceExperimentalFeatures(
     }
   }
 
-  // TODO: Remove this once serverComponentsHmrCancellation is the default.
-  if (
-    process.env.__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION ===
-      'true' &&
-    // We do respect an explicit value in the user config.
-    (config.experimental.serverComponentsHmrCancellation === undefined ||
-      (isDefaultConfig && !config.experimental.serverComponentsHmrCancellation))
-  ) {
-    config.experimental.serverComponentsHmrCancellation = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'serverComponentsHmrCancellation',
-        true,
-        'enabled by `__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION`'
-      )
-    }
-  }
-
   // Enable cachedNavigations by default when cacheComponents is enabled.
   // cachedNavigations relies on Cache Components rendering to do anything
   // useful, so the two features are tied together: we only flip the default

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -240,7 +240,6 @@ declare module 'react-server-dom-webpack/server.node' {
           ) => boolean)
         | undefined
       onError?: (error: unknown) => void
-      signal?: AbortSignal
       // React's Node API expects debugChannel to be a Node.js Writable
       // (has .write()), Duplex (has .read()), or WebSocket (has .send()).
       // This differs from the web API which expects { readable?, writable? }.

--- a/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
+++ b/test/development/app-dir/hmr-rsc-cancellation/app/page.tsx
@@ -1,18 +1,26 @@
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-// Editing any of these constants triggers a Server Component HMR refresh.
+// Editing any of these constants triggers a Server Components HMR refresh.
 // `boundaryKey` is the Suspense boundary's key: changing it remounts the
 // boundary, so the remounted boundary has no prior content and commits its
-// fallback while `DynamicContent` streams — a partially committed tree.
+// fallback while `DynamicContent` streams (a partially committed tree).
 const boundaryKey = 'initial'
 const dynamicMarker = 'initial'
 const dynamicDelayMs = 0
 
+// Logs when React renders it. A superseded refresh's render is aborted while
+// `DynamicContent` is still awaiting, so React never renders this child and no
+// log arrives for that marker; only the refresh that commits logs.
+function DynamicMarker({ marker }: { marker: string }) {
+  console.log(`[hmr-rsc-cancellation] rendered ${marker}`)
+  return <p id="dynamic">{marker}</p>
+}
+
 async function DynamicContent() {
   await connection()
   await new Promise((resolve) => setTimeout(resolve, dynamicDelayMs))
-  return <p id="dynamic">{dynamicMarker}</p>
+  return <DynamicMarker marker={dynamicMarker} />
 }
 
 export default function Page() {

--- a/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
+++ b/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
@@ -1,11 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry, assertNoConsoleErrors } from 'next-test-utils'
+import { parseValidationMessages } from 'e2e-utils/instant-validation'
 import type { Playwright } from 'next-webdriver'
+
+const cacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
 describe('hmr-rsc-cancellation', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Emit `<VALIDATION_MESSAGE>` markers so the server-side validation-skip
+    // can be asserted.
+    env: { NEXT_TEST_LOG_VALIDATION: '1' },
   })
 
   let pristinePage: string
@@ -79,7 +85,21 @@ describe('hmr-rsc-cancellation', () => {
     expect(output).not.toContain('unhandledRejection')
   }
 
-  it('cancels a superseded Server Component HMR request', async () => {
+  // The markers `DynamicMarker` logs when React renders it. The dev server
+  // forwards server-component logs to the browser console, so we read them from
+  // there. A render aborted before React reaches the child logs nothing for its
+  // marker.
+  async function renderedMarkers(browser: Playwright): Promise<string[]> {
+    const logs = await browser.log()
+    return logs.flatMap((entry) => {
+      const match = entry.message.match(
+        /\[hmr-rsc-cancellation\] rendered (\w+)/
+      )
+      return match ? [match[1]] : []
+    })
+  }
+
+  it('cancels a superseded Server Components HMR request', async () => {
     await next.start()
     const browser = await next.browser('/', { pushErrorAsConsoleLog: true })
     await retry(async () => {
@@ -219,12 +239,10 @@ describe('hmr-rsc-cancellation', () => {
         )
         .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 0')
     )
-    await retry(async () => {
-      expect(await browser.elementById('dynamic').text()).toBe('latest')
-    })
-
     // With cancellation disabled, neither refresh is aborted; both run to
-    // completion like before.
+    // completion. Which marker ends up committed is a race (the superseded
+    // refresh can still finish and clobber the newest), so we assert only that
+    // both requests ran, unaborted, rather than the final DOM.
     await retry(async () => {
       const { requests } = await readResult(browser)
       expect(requests).toMatchObject([
@@ -232,5 +250,70 @@ describe('hmr-rsc-cancellation', () => {
         { aborted: false, settled: true },
       ])
     })
+  })
+
+  it("aborts the superseded refresh's render server-side", async () => {
+    await next.start()
+    const browser = await next.browser('/', { pushErrorAsConsoleLog: true })
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('initial')
+    })
+    await instrumentBrowser(browser)
+    const cliStart = next.cliOutput.length
+
+    // Request A: a slow refresh that stays in flight until B supersedes it.
+    await next.patchFile('app/page.tsx', (src) =>
+      src
+        .replace(
+          /const dynamicMarker = '[^']*'/,
+          "const dynamicMarker = 'slow'"
+        )
+        .replace(/const dynamicDelayMs = \d+/, 'const dynamicDelayMs = 5000')
+    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => (window as any).__hmrRequests.length)
+      ).toBe(1)
+    })
+
+    // Request B changes only the marker, so it keeps A's slow delay while
+    // superseding it. By the time B commits, A's delay has elapsed: had A's
+    // render not been aborted, `DynamicMarker` would already have rendered and
+    // logged `slow`.
+    await next.patchFile('app/page.tsx', (src) =>
+      src.replace(
+        /const dynamicMarker = '[^']*'/,
+        "const dynamicMarker = 'latest'"
+      )
+    )
+    await retry(async () => {
+      expect(await browser.elementById('dynamic').text()).toBe('latest')
+    }, 10000)
+
+    await retry(async () => {
+      const markers = await renderedMarkers(browser)
+      // The superseding refresh rendered; the superseded refresh's render was
+      // aborted before React reached `DynamicMarker`, so it never logged.
+      expect(markers).toContain('latest')
+      expect(markers).not.toContain('slow')
+    }, 10000)
+
+    if (cacheComponentsEnabled) {
+      // On the Cache Components staged render the superseded refresh also skips
+      // its detached validation: it emits `validation_aborted` and never a
+      // start/end pair, while the committed refresh validates normally.
+      await retry(async () => {
+        const events = parseValidationMessages(next.cliOutput.slice(cliStart))
+        expect(events).toMatchObject([
+          { type: 'validation_aborted' },
+          { type: 'validation_start' },
+          { type: 'validation_end' },
+        ])
+        expect(events[0].requestId).not.toBe(events[1].requestId)
+      }, 10000)
+    }
+
+    await assertNoConsoleErrors(browser)
+    expectCleanCliOutput(next.cliOutput.slice(cliStart))
   })
 })

--- a/test/development/app-dir/hmr-rsc-cancellation/next.config.js
+++ b/test/development/app-dir/hmr-rsc-cancellation/next.config.js
@@ -2,7 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  cacheComponents: true,
   experimental: {
     serverComponentsHmrCancellation: true,
   },

--- a/test/lib/e2e-utils/instant-validation.ts
+++ b/test/lib/e2e-utils/instant-validation.ts
@@ -2,7 +2,10 @@ import { retry } from '../next-test-utils'
 import { getDeterministicOutput } from '../../e2e/app-dir/cache-components-errors/utils'
 import { inspect } from 'util'
 
-export type ValidationEvent = ValidationStartEvent | ValidationEndEvent
+export type ValidationEvent =
+  | ValidationStartEvent
+  | ValidationEndEvent
+  | ValidationAbortedEvent
 
 type ValidationStartEvent = {
   type: 'validation_start'
@@ -11,6 +14,13 @@ type ValidationStartEvent = {
 }
 type ValidationEndEvent = {
   type: 'validation_end'
+  requestId: string
+  url: string
+}
+// Emitted instead of a start/end pair when a request is aborted before its
+// detached validation runs (e.g. Server Components HMR cancellation).
+type ValidationAbortedEvent = {
+  type: 'validation_aborted'
   requestId: string
   url: string
 }

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -23,7 +23,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
-               ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)
                · staticGenerationMaxConcurrency: 1"
             `)
           } else if (isRspack) {
@@ -153,7 +152,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                · staticGenerationMaxConcurrency: 1
                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
@@ -358,8 +356,7 @@ describe('build-output-prerender', () => {
              ▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
-               ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)"
+               ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
@@ -429,7 +426,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ cachedNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ serverComponentsHmrCancellation (enabled by \`__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)


### PR DESCRIPTION
The `experimental.serverComponentsHmrCancellation` flag now defaults to `true`, and the `__NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION` env-var opt-in is removed, along with the two Cache Components test shards that exported it. The flag remains available for opting out.

Because the feature is now a default rather than an env-enabled experiment, it no longer appears in the build output's list of configured experiments, so the `build-output-prerender` snapshots drop the `serverComponentsHmrCancellation` line.