### PR TITLE
Turbopack: fix empty tree-shake chunks desyncing part ids (#93424)

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
@@ -714,7 +714,21 @@ impl DepGraph {
             }
 
             if chunk.body.is_empty() {
-                continue;
+                // The rest of this code assumes ids match indexes
+                // so I am putting this placeholder here of an empty
+                // export so that nothing errors later on because
+                // of this mismatch
+                chunk
+                    .body
+                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
+                        NamedExport {
+                            span: DUMMY_SP,
+                            specifiers: Default::default(),
+                            src: None,
+                            type_only: false,
+                            with: None,
+                        },
+                    )));
             }
 
             modules.push(chunk);

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
@@ -80,7 +80,7 @@ graph TD
 ```
 {
     ModuleEvaluation: 0,
-    Exports: 1,
+    Exports: 2,
 }
 ```
 
@@ -97,6 +97,11 @@ export { };
 
 ```
 ## Part 1
+```js
+export { };
+
+```
+## Part 2
 ```js
 
 ```
@@ -115,7 +120,7 @@ export { };
 ```
 {
     ModuleEvaluation: 0,
-    Exports: 1,
+    Exports: 2,
 }
 ```
 
@@ -132,6 +137,11 @@ export { };
 
 ```
 ## Part 1
+```js
+export { };
+
+```
+## Part 2
 ```js
 
 ```

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
@@ -423,7 +423,7 @@ graph TD
     Export(
         "NextResponse",
     ): 0,
-    Exports: 1,
+    Exports: 7,
 }
 ```
 
@@ -569,6 +569,36 @@ export { };
 
 ```
 ## Part 1
+```js
+export { };
+
+```
+## Part 2
+```js
+export { };
+
+```
+## Part 3
+```js
+export { };
+
+```
+## Part 4
+```js
+export { };
+
+```
+## Part 5
+```js
+export { };
+
+```
+## Part 6
+```js
+export { };
+
+```
+## Part 7
 ```js
 export { NextResponse } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export NextResponse"
@@ -722,7 +752,7 @@ export { };
     Export(
         "NextResponse",
     ): 0,
-    Exports: 1,
+    Exports: 7,
 }
 ```
 
@@ -868,6 +898,36 @@ export { };
 
 ```
 ## Part 1
+```js
+export { };
+
+```
+## Part 2
+```js
+export { };
+
+```
+## Part 3
+```js
+export { };
+
+```
+## Part 4
+```js
+export { };
+
+```
+## Part 5
+```js
+export { };
+
+```
+## Part 6
+```js
+export { };
+
+```
+## Part 7
 ```js
 export { NextResponse } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export NextResponse"

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
@@ -123,7 +123,7 @@ graph TD
     Export(
         "runtime",
     ): 2,
-    Exports: 2,
+    Exports: 3,
 }
 ```
 
@@ -147,6 +147,11 @@ export { };
 ```
 ## Part 1
 ```js
+export { };
+
+```
+## Part 2
+```js
 const runtime = "edge";
 export { runtime };
 export { runtime as b } from "__TURBOPACK_VAR__" assert {
@@ -154,7 +159,7 @@ export { runtime as b } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 2
+## Part 3
 ```js
 export { GET } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export GET"
@@ -191,7 +196,7 @@ export { };
     Export(
         "runtime",
     ): 2,
-    Exports: 2,
+    Exports: 3,
 }
 ```
 
@@ -215,6 +220,11 @@ export { };
 ```
 ## Part 1
 ```js
+export { };
+
+```
+## Part 2
+```js
 const runtime = "edge";
 export { runtime };
 export { runtime as b } from "__TURBOPACK_VAR__" assert {
@@ -222,7 +232,7 @@ export { runtime as b } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 2
+## Part 3
 ```js
 export { GET } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export GET"

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
@@ -168,7 +168,7 @@ graph TD
     Export(
         "GET",
     ): 0,
-    Exports: 1,
+    Exports: 4,
 }
 ```
 
@@ -196,6 +196,21 @@ export { };
 
 ```
 ## Part 1
+```js
+export { };
+
+```
+## Part 2
+```js
+export { };
+
+```
+## Part 3
+```js
+export { };
+
+```
+## Part 4
 ```js
 export { GET } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export GET"
@@ -231,7 +246,7 @@ export { };
     Export(
         "GET",
     ): 0,
-    Exports: 1,
+    Exports: 4,
 }
 ```
 
@@ -259,6 +274,21 @@ export { };
 
 ```
 ## Part 1
+```js
+export { };
+
+```
+## Part 2
+```js
+export { };
+
+```
+## Part 3
+```js
+export { };
+
+```
+## Part 4
 ```js
 export { GET } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export GET"


### PR DESCRIPTION
split_module skipped chunks whose body ended up empty, but the group index is used directly as a part id by outputs (Key::Export/Key::ModuleEvaluation), part_deps, and the PartId::Internal asserts embedded in the emitted chunk ASTs. Skipping shifted every later module's position and desynced those indices, causing out-of-bounds panics in split_module and wrong-fragment selection in part_of_module. Always push a module for every group; use a well-formed side-effect-free `export {}` placeholder when the body is empty.

Update tree-shaker analyzer snapshots to include the placeholder parts.
