### PR TITLE
Disable `supportsImmutableAssets` with `config.output`

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1624,6 +1624,17 @@ function finalizeConfig(config: NextConfigComplete): NextConfigComplete {
     config.experimental.supportsImmutableAssets = true
   }
 
+  if (
+    config.experimental.supportsImmutableAssets &&
+    (config.output === 'export' || config.output === 'standalone')
+  ) {
+    // supportsImmutableAssets is designed to work with adapters. Disable it for output=export and
+    // output=standalone, which are currently using a non-adapter codepath.
+    // Particularly output=export should just run through the adapter, with only static assets.
+    // TODO remove again once output=export (and output=standalone) are using adapters.
+    config.experimental.supportsImmutableAssets = false
+  }
+
   return config
 }
 

--- a/test/production/export-immutable-assets/app/layout.tsx
+++ b/test/production/export-immutable-assets/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/export-immutable-assets/app/page.tsx
+++ b/test/production/export-immutable-assets/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/export-immutable-assets/export-immutable-assets.test.ts
+++ b/test/production/export-immutable-assets/export-immutable-assets.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+import { listClientChunks } from 'next-test-utils'
+
+// Immutable static files are only supported with Turbopack anywy
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'output: export - immutable assets disabled',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      // `next start` does not work with `output: 'export'`.
+      skipStart: true,
+      disableAutoSkewProtection: true,
+    })
+
+    // supportsImmutableAssets is designed to work with adapters. It must be
+    // force-disabled for `output: 'export'`, so even though it is requested here
+    // the build should not emit any `_next/static/immutable` assets.
+    // We can loosen this requirement in the future when using output=export together with an adapter
+    it('does not emit any _next/static/immutable files', async () => {
+      const { exitCode } = await next.build()
+      expect(exitCode).toBe(0)
+
+      const files = await listClientChunks(join(next.testDir, next.distDir))
+
+      expect(files).not.toBeEmpty()
+      expect(files).toSatisfyAll((f) => f.includes('static/'))
+      expect(files).toSatisfyAll((f) => !f.includes('static/immutable/'))
+    })
+  }
+)

--- a/test/production/export-immutable-assets/next.config.js
+++ b/test/production/export-immutable-assets/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  deploymentId: 'test-deployment-id',
+  experimental: {
+    supportsImmutableAssets: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
`output=export` and `output=standalone` don't use adapters.
But for `supportsImmutableAssets`, you really want the adapter to get all necessary data.

Disable immutable assets for now in this case. Once `output=export` runs the adapter (as it should), we can remove this override again