### PR TITLE
Turbopack: fix split_module correctness for app-router

### DIFF
--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
     output::OutputAssetsReference,
     reference::{ModuleReference, ModuleReferences},
     reference_type::ReferenceType,
-    resolve::ModuleResolveResult,
+    resolve::{ModulePart, ModuleResolveResult},
     source::OptionSource,
     virtual_source::VirtualSource,
 };
@@ -152,20 +152,29 @@ impl EcmascriptClientReferenceModule {
         let proxy_module_content =
             AssetContent::file(FileContent::Content(File::from(code.source_code().clone())).cell());
 
-        let proxy_source = VirtualSource::new(
-            self.server_ident.await?.path.join(
-                // We choose the extension based on the original file because we're placing the
-                // virtual module next to the original code, so its parsing will be
-                // affected by `type` fields in package.json -- a bare `proxy.js`
-                // may end up being unexpectedly parsed as the wrong format.
-                // The name special cased later to always ignore-list this module.
-                &format!(
-                    "__nextjs-internal-proxy.{}",
-                    if is_esm { "mjs" } else { "cjs" }
-                ),
-            )?,
-            proxy_module_content,
-        );
+        let proxy_path = self.server_ident.await?.path.join(
+            // We choose the extension based on the original file because we're placing the
+            // virtual module next to the original code, so its parsing will be
+            // affected by `type` fields in package.json -- a bare `proxy.js`
+            // may end up being unexpectedly parsed as the wrong format.
+            // The name special cased later to always ignore-list this module.
+            &format!(
+                "__nextjs-internal-proxy.{}",
+                if is_esm { "mjs" } else { "cjs" }
+            ),
+        )?;
+
+        // Tag the ident with a `ModulePart::Exports` part so tree-shaking's
+        // `split_module` opt-out (`!ident.parts.is_empty()`) skips this module.
+        // The proxy is a codegen delegate whose exports are all used, so
+        // splitting yields no benefit; splitting it also duplicates its
+        // `<exports>` part in the module graph (the proxy is reached via two
+        // paths), tripping the duplicate-ident check in
+        // `ModuleGraph::from_graphs`.
+        let proxy_ident = AssetIdent::from_path(proxy_path)
+            .with_part(ModulePart::Exports)
+            .into_vc();
+        let proxy_source = VirtualSource::new_with_ident(proxy_ident, proxy_module_content);
 
         let proxy_module = self
             .server_asset_context

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -166,11 +166,11 @@ impl EcmascriptClientReferenceModule {
 
         // Tag the ident with a `ModulePart::Exports` part so tree-shaking's
         // `split_module` opt-out (`!ident.parts.is_empty()`) skips this module.
-        // The proxy is a codegen delegate whose exports are all used, so
-        // splitting yields no benefit; splitting it also duplicates its
-        // `<exports>` part in the module graph (the proxy is reached via two
-        // paths), tripping the duplicate-ident check in
-        // `ModuleGraph::from_graphs`.
+        // Because of the state of this feature, it is unclear if this is competely
+        // the right course of action. Not skipping this causes "Duplicate module idents"
+        // errors.
+        // TODO: Understand more deeply why these occur and if skipping here is the best
+        // course of action or if there is a way to avoid these duplicates without skipping.
         let proxy_ident = AssetIdent::from_path(proxy_path)
             .with_part(ModulePart::Exports)
             .into_vc();

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -152,20 +152,23 @@ impl EcmascriptClientReferenceModule {
         let proxy_module_content =
             AssetContent::file(FileContent::Content(File::from(code.source_code().clone())).cell());
 
-        let proxy_source = VirtualSource::new(
-            self.server_ident.await?.path.join(
-                // We choose the extension based on the original file because we're placing the
-                // virtual module next to the original code, so its parsing will be
-                // affected by `type` fields in package.json -- a bare `proxy.js`
-                // may end up being unexpectedly parsed as the wrong format.
-                // The name special cased later to always ignore-list this module.
-                &format!(
-                    "__nextjs-internal-proxy.{}",
-                    if is_esm { "mjs" } else { "cjs" }
-                ),
-            )?,
-            proxy_module_content,
-        );
+        let proxy_path = self.server_ident.await?.path.join(
+            // We choose the extension based on the original file because we're placing the
+            // virtual module next to the original code, so its parsing will be
+            // affected by `type` fields in package.json -- a bare `proxy.js`
+            // may end up being unexpectedly parsed as the wrong format.
+            // The name special cased later to always ignore-list this module.
+            &format!(
+                "__nextjs-internal-proxy.{}",
+                if is_esm { "mjs" } else { "cjs" }
+            ),
+        )?;
+
+        // Proxy contents include the part-specific server ident, so it must affect identity.
+        let proxy_ident = AssetIdent::from_path(proxy_path)
+            .with_asset(rcstr!("server"), self.server_ident)
+            .into_vc();
+        let proxy_source = VirtualSource::new_with_ident(proxy_ident, proxy_module_content);
 
         let proxy_module = self
             .server_asset_context

--- a/test/e2e/turbopack-tree-shaking-pages/next.config.js
+++ b/test/e2e/turbopack-tree-shaking-pages/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = { experimental: { turbopackTreeShaking: true } }
+module.exports = nextConfig

--- a/test/e2e/turbopack-tree-shaking-pages/next.config.js
+++ b/test/e2e/turbopack-tree-shaking-pages/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = { experimental: { turbopackModuleFragments: true } }
+module.exports = nextConfig

--- a/test/e2e/turbopack-tree-shaking-pages/pages/index.tsx
+++ b/test/e2e/turbopack-tree-shaking-pages/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>tree shaking pages</h1>
+}

--- a/test/e2e/turbopack-tree-shaking-pages/turbopack-tree-shaking-pages.test.ts
+++ b/test/e2e/turbopack-tree-shaking-pages/turbopack-tree-shaking-pages.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Companion to the app-router #93424 regression: verify tree-shaking builds
+// succeed for a pages-router app (no app-router global-error sharing).
+describe('turbopack-tree-shaking-pages', () => {
+  const { next } = nextTestSetup({ files: __dirname })
+
+  it('builds and renders without a tree-shaking panic', async () => {
+    const $ = await next.render$('/')
+    expect($('h1').text()).toContain('tree shaking pages')
+  })
+})

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -19,8 +19,9 @@ pub fn add_default_ignore_list(map: &mut swc_sourcemap::SourceMap) {
         if source.starts_with(concatcp!(SOURCE_URL_PROTOCOL_STR, "///[next]"))
             || source.starts_with(concatcp!(SOURCE_URL_PROTOCOL_STR, "///[turbopack]"))
             || source.contains("/node_modules/")
-            || source.ends_with("__nextjs-internal-proxy.cjs")
-            || source.ends_with("__nextjs-internal-proxy.mjs")
+            // The proxy module's ident may carry a trailing part suffix (e.g.
+            // ` <exports>`), so match the base name rather than the extension.
+            || source.contains("__nextjs-internal-proxy.")
         {
             ignored_ids.insert(source_id);
         }

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -19,8 +19,10 @@ pub fn add_default_ignore_list(map: &mut swc_sourcemap::SourceMap) {
         if source.starts_with(concatcp!(SOURCE_URL_PROTOCOL_STR, "///[next]"))
             || source.starts_with(concatcp!(SOURCE_URL_PROTOCOL_STR, "///[turbopack]"))
             || source.contains("/node_modules/")
-            || source.ends_with("__nextjs-internal-proxy.cjs")
-            || source.ends_with("__nextjs-internal-proxy.mjs")
+            // The proxy module's ident carries a nested-asset suffix (e.g.
+            // ` { server => "..." }`), so it does not end with the extension.
+            // Match the base name instead.
+            || source.contains("__nextjs-internal-proxy.")
         {
             ignored_ids.insert(source_id);
         }

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
@@ -491,6 +491,20 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
         .cell());
     }
 
+    // Don't split the generated client-reference proxy module. It is a codegen
+    // delegate for `EcmascriptClientReferenceModule` whose exports are all used,
+    // so splitting yields no benefit. Splitting it duplicates its `<exports>`
+    // part in the module graph (the proxy is used for codegen but reached via
+    // two paths), which trips the duplicate-ident check in
+    // `ModuleGraph::from_graphs`. See `BindingUsageInfo::used_exports` in
+    // `binding_usage_info.rs` for a similar workaround.
+    if name.contains("__nextjs-internal-proxy.") {
+        return Ok(SplitResult::Failed {
+            parse_result: parsed,
+        }
+        .cell());
+    }
+
     let parse_result = parsed.await?;
 
     match &*parse_result {
@@ -571,7 +585,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                             eval_context.unresolved_mark,
                             eval_context.top_level_mark,
                             eval_context.force_free_values.clone(),
-                            None,
+                            Some(&**comments as &dyn Comments),
                         )
                     });
 

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
@@ -491,20 +491,6 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
         .cell());
     }
 
-    // Don't split the generated client-reference proxy module. It is a codegen
-    // delegate for `EcmascriptClientReferenceModule` whose exports are all used,
-    // so splitting yields no benefit. Splitting it duplicates its `<exports>`
-    // part in the module graph (the proxy is used for codegen but reached via
-    // two paths), which trips the duplicate-ident check in
-    // `ModuleGraph::from_graphs`. See `BindingUsageInfo::used_exports` in
-    // `binding_usage_info.rs` for a similar workaround.
-    if name.contains("__nextjs-internal-proxy.") {
-        return Ok(SplitResult::Failed {
-            parse_result: parsed,
-        }
-        .cell());
-    }
-
     let parse_result = parsed.await?;
 
     match &*parse_result {

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
@@ -571,7 +571,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                             eval_context.unresolved_mark,
                             eval_context.top_level_mark,
                             eval_context.force_free_values.clone(),
-                            None,
+                            Some(&**comments as &dyn Comments),
                         )
                     });
 


### PR DESCRIPTION
Turbopack: fix split_module correctness for app-router

- Don't split the generated __nextjs-internal-proxy. client-reference
  proxy module. Its exports are all used, so splitting yields no benefit
  and duplicates its <exports> part in the module graph, tripping the
  duplicate-ident check in ModuleGraph::from_graphs.
- Pass the original comments to each fragment so magic-comment
  annotations (turbopackChunkingType, turbopackExports) are still
  parsed. Fragment ASTs keep their original spans, so comments resolve
  at the same byte positions. Without this, references fall back to
  defaults (ChunkingType::Shared -> Parallel), breaking app-router
  layout-segment chunk groups.