### PR TITLE
fix(dev-overlay): increase fix card grid row gap to clear floating Copy prompt button

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance.tsx
@@ -381,9 +381,10 @@ export const INSTANT_GUIDANCE_STYLES = css`
   }
 
   [data-nextjs-card-grid] {
+    --copy-prompt-offset: 10px;
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 12px;
+    gap: calc(12px + var(--copy-prompt-offset)) 12px;
   }
 
   [data-nextjs-fix-card] {
@@ -607,7 +608,7 @@ export const INSTANT_GUIDANCE_STYLES = css`
     padding: 5px 10px;
     position: absolute;
     right: 10px;
-    top: -10px;
+    top: calc(-1 * var(--copy-prompt-offset));
     transition:
       background 120ms ease,
       border-color 120ms ease,


### PR DESCRIPTION
### What?

Gives the instant guidance panel's fix card grid a larger row gap than column gap, derived from the Copy prompt button's overhang: `--copy-prompt-offset: 10px`, row gap `calc(12px + var(--copy-prompt-offset))`, column gap unchanged at 12px. The button's `top: -10px` now reads from the same variable.

### Why?

Each fix card's **Copy prompt** button floats above the card's top border by `--copy-prompt-offset`. When an insight has enough cards to wrap to a second row, the floating buttons of the second row ate 10 of the uniform 12px gap, leaving them ~2px from the cards above.

### How?

The row gap is the column gap plus the button overhang, so the two can't drift apart. The docs mirror of this grid (`FixCardGrid` on nextjs.org) already uses a larger row gap for the same reason.

<!-- NEXT_JS_LLM_PR -->