### PR TITLE
Turbopack: preserve import `with` clauses when direct-binding

### DIFF
--- a/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/app/layout.tsx
+++ b/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/app/page.tsx
+++ b/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>tree shaking app</h1>
+}

--- a/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/next.config.js
+++ b/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import("next").NextConfig} */
+const nextConfig = { experimental: { turbopackTreeShaking: true } }
+module.exports = nextConfig

--- a/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/next.config.js
+++ b/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import("next").NextConfig} */
+const nextConfig = { experimental: { turbopackModuleFragments: true } }
+module.exports = nextConfig

--- a/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/turbopack-tree-shaking-chunkgroup.test.ts
+++ b/test/e2e/app-dir/turbopack-tree-shaking-chunkgroup/turbopack-tree-shaking-chunkgroup.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('turbopack-tree-shaking-chunkgroup', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('builds an app-router app with tree-shaking enabled and renders', async () => {
+    const $ = await next.render$('/')
+    expect($('h1').text()).toContain('tree shaking app')
+  })
+})

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
@@ -142,7 +142,7 @@ pub(crate) struct ItemData {
     /// [ItemId].
     ///
     /// Used to optimize `ImportBinding`.
-    pub binding_source: Option<(Str, ImportSpecifier)>,
+    pub binding_source: Option<(Str, ImportSpecifier, Option<Box<ObjectLit>>)>,
 
     /// Explicit dependencies of this item.
     ///
@@ -528,7 +528,7 @@ impl DepGraph {
                     let dep_item_id = &dep_item_ids[0];
                     let dep_item_data = data.get(dep_item_id).unwrap();
 
-                    if let Some((module_specifier, import_specifier)) =
+                    if let Some((module_specifier, import_specifier, with_clause)) =
                         &dep_item_data.binding_source
                     {
                         // Preserve the order of the side effects by importing the
@@ -567,7 +567,7 @@ impl DepGraph {
                                 specifiers,
                                 src: Box::new(module_specifier.clone()),
                                 type_only: false,
-                                with: None,
+                                with: with_clause.clone(),
                                 phase: Default::default(),
                             })));
                         continue;
@@ -1226,12 +1226,11 @@ impl DepGraph {
                                     specifiers: vec![s.clone()],
                                     ..item.clone()
                                 })),
-                                binding_source: if item.with.is_none() {
-                                    // Optimize by directly binding to the source
-                                    Some((*item.src.clone(), s.clone()))
-                                } else {
-                                    None
-                                },
+                                binding_source: Some((
+                                    *item.src.clone(),
+                                    s.clone(),
+                                    item.with.clone(),
+                                )),
                                 explicit_deps: vec![import_id.clone()],
                                 ..Default::default()
                             },

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/import-with-clause/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/import-with-clause/input.js
@@ -1,0 +1,7 @@
+import { createTransition } from "./transition" with {
+    "turbopack-transition": "next-ssr"
+};
+
+export function useTransition() {
+    return createTransition();
+}

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/import-with-clause/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/import-with-clause/output.md
@@ -1,0 +1,214 @@
+# Items
+
+Count: 4
+
+## Item 1: Stmt 0, `ImportOfModule`
+
+```js
+import { createTransition } from "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+
+```
+
+- Hoisted
+- Side effects
+
+## Item 2: Stmt 0, `ImportBinding(0)`
+
+```js
+import { createTransition } from "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+
+```
+
+- Hoisted
+- Declares: `createTransition`
+
+## Item 3: Stmt 1, `Normal`
+
+```js
+export function useTransition() {
+    return createTransition();
+}
+
+```
+
+- Hoisted
+- Declares: `useTransition`
+- Reads (eventual): `createTransition`
+- Write: `useTransition`
+
+# Phase 1
+```mermaid
+graph TD
+    Item1;
+    Item2;
+    Item3;
+    Item4;
+    Item4["export useTransition"];
+```
+# Phase 2
+```mermaid
+graph TD
+    Item1;
+    Item2;
+    Item3;
+    Item4;
+    Item4["export useTransition"];
+    Item4 --> Item3;
+```
+# Phase 3
+```mermaid
+graph TD
+    Item1;
+    Item2;
+    Item3;
+    Item4;
+    Item4["export useTransition"];
+    Item4 --> Item3;
+    Item3 --> Item2;
+```
+# Phase 4
+```mermaid
+graph TD
+    Item1;
+    Item2;
+    Item3;
+    Item4;
+    Item4["export useTransition"];
+    Item4 --> Item3;
+    Item3 --> Item2;
+```
+# Final
+```mermaid
+graph TD
+    N0["Items: [ItemId(0, ImportOfModule), ItemId(1, Normal), ItemId(Export((&quot;useTransition&quot;, #2), &quot;useTransition&quot;))]"];
+    N1["Items: [ItemId(0, ImportBinding(0))]"];
+    N0 --> N1;
+```
+# Entrypoints
+
+```
+{
+    ModuleEvaluation: 0,
+    Export(
+        "useTransition",
+    ): 0,
+    Exports: 2,
+}
+```
+
+
+# Modules (dev)
+## Part 0
+```js
+import { createTransition } from "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+import "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+function useTransition() {
+    return createTransition();
+}
+export { useTransition };
+export { useTransition as a } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+export { };
+
+```
+## Part 1
+```js
+export { };
+
+```
+## Part 2
+```js
+export { useTransition } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export useTransition"
+};
+
+```
+## Merged (module eval)
+```js
+import { createTransition } from "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+import "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+function useTransition() {
+    return createTransition();
+}
+export { useTransition };
+export { useTransition as a } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+export { };
+
+```
+# Entrypoints
+
+```
+{
+    ModuleEvaluation: 0,
+    Export(
+        "useTransition",
+    ): 0,
+    Exports: 2,
+}
+```
+
+
+# Modules (prod)
+## Part 0
+```js
+import { createTransition } from "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+import "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+function useTransition() {
+    return createTransition();
+}
+export { useTransition };
+export { useTransition as a } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+export { };
+
+```
+## Part 1
+```js
+export { };
+
+```
+## Part 2
+```js
+export { useTransition } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export useTransition"
+};
+
+```
+## Merged (module eval)
+```js
+import { createTransition } from "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+import "./transition" assert {
+    "turbopack-transition": "next-ssr"
+};
+function useTransition() {
+    return createTransition();
+}
+export { useTransition };
+export { useTransition as a } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+export { };
+
+```


### PR DESCRIPTION
binding_source now carries the import's `with` clause (Option<Box<ObjectLit>>) so re-emitting the import in the consuming fragment keeps the same resolution semantics. Dropping it made transition imports (e.g. turbopack-transition) resolve to undefined at evaluation under tree-shaking.