### PR TITLE
Report cacheHit on router transition commit events

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -106,9 +106,9 @@ import type {
 export function unstable_onRouterTransitionCommit(
   url: string,
   navigationType: RouterTransitionType,
-  { id, timestamp, to }: RouterTransitionCommitEvent
+  { id, timestamp, to, cacheHit }: RouterTransitionCommitEvent
 ) {
-  console.log(id, timestamp, url, navigationType, to.renderedPathname)
+  console.log(id, timestamp, url, navigationType, to.renderedPathname, cacheHit)
 }
 
 export function unstable_onRouterTransitionAbort(
@@ -129,6 +129,7 @@ The hooks receive:
 - `navigationType: 'push' | 'replace' | 'traverse'` - The type of navigation
 - `event.id` - An opaque ID shared by every event for this transition
 - `event.timestamp` - A framework-captured Unix timestamp in milliseconds
+- `event.cacheHit` (commit only) - Whether the router's caches could serve the whole destination (the route tree plus every fresh segment) at dispatch. A partial shell counts, even one that is entirely a dynamic hole: this measures cache coverage, not paint time. It is `false` when the navigation had to reach the network first — the route was not prefetched, a segment's prefetch was pending or evicted, or the commit rode a refresh/retry response. Pair it with the start→commit latency: a `false` is prefetch-fixable, while a slow `cacheHit: true` is waiting on streaming content that prefetching cannot remove. (In development nothing is prefetched, so most navigations report `false`.)
 - `event.replacedBy` (abort only) - The `id` of the transition whose commit replaced this one
 
 The `start` event also carries `event.from` describing the route the navigation left, and the `commit` event carries `event.to`, describing the route that was committed. Both share the `RouterTransitionRoute` type:
@@ -138,7 +139,7 @@ The `start` event also carries `event.from` describing the route the navigation 
 - `routes` - The rendered routes, primary (page) first, then parallel slots. Each entry pairs a `template` (with dynamic segments in their source notation) with the `params` that fill it, keyed by param name: a navigation away from `/blog/hello` reports `{ template: '/blog/[slug]', params: { slug: 'hello' } }`, and a photo modal intercepted over a gallery reports `{ template: '/gallery/@modal/(.)photos/[id]', params: { id: '1' } }`. Params are scoped per template, and catch-all values are arrays of path segments
 - `searchParams` - The post-rewrite search params
 
-A hash-only navigation keeps the same route, so a commit's `to` matches its start's `from` (only the hash-bearing canonical URL differs).
+A hash-only navigation keeps the same route, so a commit's `to` matches its start's `from` (only the hash-bearing canonical URL differs). It reports `cacheHit: true` when the route is already known locally and the on-screen UI is reused, and `false` if the router had to consult the server first (as in development).
 
 Hook errors are isolated and do not affect navigation or other hooks.
 

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -129,7 +129,7 @@ The hooks receive:
 - `navigationType: 'push' | 'replace' | 'traverse'` - The type of navigation
 - `event.id` - An opaque ID shared by every event for this transition
 - `event.timestamp` - A framework-captured Unix timestamp in milliseconds
-- `event.cacheHit` (commit only) - Whether the router's caches could serve the whole destination (the route tree plus every fresh segment) at dispatch. A partial shell counts, even one that is entirely a dynamic hole: this measures cache coverage, not paint time. It is `false` when the navigation had to reach the network first — the route was not prefetched, a segment's prefetch was pending or evicted, or the commit rode a refresh/retry response. Pair it with the start→commit latency: a `false` is prefetch-fixable, while a slow `cacheHit: true` is waiting on streaming content that prefetching cannot remove. (In development nothing is prefetched, so most navigations report `false`.)
+- `event.cacheHit` (commit only) - Whether the router's cache could serve the whole destination at dispatch. `false` marks navigations that prefetching could have made faster; in development nothing is prefetched, so most navigations report `false`
 - `event.replacedBy` (abort only) - The `id` of the transition whose commit replaced this one
 
 The `start` event also carries `event.from` describing the route the navigation left, and the `commit` event carries `event.to`, describing the route that was committed. Both share the `RouterTransitionRoute` type:

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -12,6 +12,10 @@ import {
   NOT_FOUND_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
+import {
+  markRouterTransitionAsCacheMiss,
+  type PendingRouterTransition,
+} from '../router-transition'
 import type { NavigationLockState } from '../segment-cache/navigation-testing-lock'
 import { createHrefFromUrl } from './create-href-from-url'
 import { fetchServerResponse } from './fetch-server-response'
@@ -140,6 +144,19 @@ export type NavigationRequestAccumulation = {
    * during a refresh where the route structure didn't change).
    */
   scrollRef: ScrollRef | null
+  /**
+   * INSTRUMENTATION ONLY — never read by navigation logic. The pending
+   * transition being navigated to (`null` when the navigation is untracked,
+   * e.g. hydration, a server-action redirect, or a retry), threaded through
+   * the segment walk so a fresh segment the cache could NOT serve marks it
+   * as a cache miss (see finishSegmentCacheNode). The question is
+   * deliberately "did the cache have bytes to render right now" — a shell
+   * that is entirely a dynamic hole counts — NOT whether those bytes paint
+   * or how long the commit takes, which keeps the check synchronous and
+   * deterministic. Segments reused from the current UI never run the walk,
+   * matching the transition's cache-hit default.
+   */
+  instrumentationTransition: PendingRouterTransition | null
 }
 
 export type NavigationLock = NavigationLockState | null
@@ -158,6 +175,8 @@ export function createInitialCacheNodeForHydration(
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,
+    // Hydration is not a tracked transition.
+    instrumentationTransition: null,
   }
   const restrictToShell = false
   const task = createCacheNodeOnNavigation(
@@ -397,7 +416,8 @@ function updateCacheNodeOnNavigation(
       oldCacheNode !== undefined
         ? oldCacheNode.bfcacheId
         : generateBFCacheId(freshness),
-      restrictToShell
+      restrictToShell,
+      accumulation
     )
     newCacheNode = result.cacheNode
     needsDynamicRequest = result.needsDynamicRequest
@@ -686,7 +706,8 @@ function createCacheNodeOnNavigation(
     // This segment was not part of the previous route, so mint a fresh
     // bfcacheId.
     generateBFCacheId(freshness),
-    restrictToShell
+    restrictToShell,
+    accumulation
   )
   const newCacheNode = result.cacheNode
   const needsDynamicRequest = result.needsDynamicRequest
@@ -942,6 +963,27 @@ function reuseSharedCacheNode(
   )
 }
 
+// Every return from createCacheNodeForSegment funnels through this helper so
+// that no code path can produce a fresh segment's cache node without
+// answering the instrumentation question: did the cache have bytes to render
+// for this segment right now? `renderedFromCache` is deliberately generous —
+// a partial shell counts even when it is entirely a dynamic hole — because
+// `cacheHit` attributes cache coverage, not paint time: whether those bytes
+// commit instantly or suspend on streaming content is read from the commit
+// event's start→commit latency instead. A new return path fails to compile
+// without answering.
+function finishSegmentCacheNode(
+  accumulation: NavigationRequestAccumulation,
+  renderedFromCache: boolean,
+  cacheNode: CacheNode,
+  needsDynamicRequest: boolean
+): { cacheNode: CacheNode; needsDynamicRequest: boolean } {
+  if (!renderedFromCache) {
+    markRouterTransitionAsCacheMiss(accumulation.instrumentationTransition)
+  }
+  return { cacheNode, needsDynamicRequest }
+}
+
 function createCacheNodeForSegment(
   now: number,
   tree: RouteTree,
@@ -953,7 +995,11 @@ function createCacheNodeForSegment(
   bfcacheId: number,
   // Instant Navigation Testing API only — restricts segment reads to shell
   // entries. Always false outside the testing API. See navigation-testing-lock.
-  restrictToShell: boolean
+  restrictToShell: boolean,
+  // Carries the pending transition so a segment the cache could not serve
+  // can mark it as a miss. See
+  // NavigationRequestAccumulation.instrumentationTransition.
+  accumulation: NavigationRequestAccumulation
 ): { cacheNode: CacheNode; needsDynamicRequest: boolean } {
   // Construct a new CacheNode using data from the BFCache, the client's
   // Segment Cache, or seeded from a server response.
@@ -989,16 +1035,19 @@ function createCacheNodeForSegment(
         // fresh navigation, so we use the caller-supplied bfcacheId — the
         // BFCacheEntry's id is only restored on history-traversal
         // navigations.
-        return {
-          cacheNode: createCacheNode(
+        return finishSegmentCacheNode(
+          accumulation,
+          // A BFCache hit is rendered state we already had.
+          true,
+          createCacheNode(
             bfcacheEntry.rsc,
             bfcacheEntry.prefetchRsc,
             bfcacheEntry.head,
             bfcacheEntry.prefetchHead,
             bfcacheId
           ),
-          needsDynamicRequest: false,
-        }
+          false
+        )
       }
       break
     }
@@ -1043,16 +1092,13 @@ function createCacheNodeForSegment(
           bfcacheId
         )
       }
-      return {
-        cacheNode: createCacheNode(
-          rsc,
-          prefetchRsc,
-          head,
-          prefetchHead,
-          bfcacheId
-        ),
-        needsDynamicRequest: false,
-      }
+      return finishSegmentCacheNode(
+        accumulation,
+        // Seeded from the document already in hand.
+        true,
+        createCacheNode(rsc, prefetchRsc, head, prefetchHead, bfcacheId),
+        false
+      )
     }
     case FreshnessPolicy.HistoryTraversal:
       const bfcacheEntry = readFromBFCache(tree.varyPath)
@@ -1074,16 +1120,19 @@ function createCacheNodeForSegment(
         // Restore the bfcacheId from the cached entry so that back/forward
         // navigations preserve the original id, regardless of whether
         // `cacheComponents` Activity preservation is enabled.
-        return {
-          cacheNode: createCacheNode(
+        return finishSegmentCacheNode(
+          accumulation,
+          // A BFCache hit is rendered state we already had.
+          true,
+          createCacheNode(
             bfcacheEntry.rsc,
             dropPrefetchRsc ? null : bfcacheEntry.prefetchRsc,
             bfcacheEntry.head,
             dropPrefetchRsc ? null : bfcacheEntry.prefetchHead,
             bfcacheEntry.bfcacheId
           ),
-          needsDynamicRequest: false,
-        }
+          false
+        )
       }
       break
     case FreshnessPolicy.RefreshAll:
@@ -1098,6 +1147,16 @@ function createCacheNodeForSegment(
 
   let cachedRsc: React.ReactNode | null = null
   let isCachedRscPartial: boolean = true
+  // Instrumentation classification for the final return below: the cache
+  // served this segment iff its entry is Fulfilled with bytes — partiality
+  // does not matter (even a shell that is entirely a dynamic hole counts as
+  // rendered-from-cache; whether it paints instantly or suspends on the
+  // stream is deliberately not this flag's question). Pending (the prefetch
+  // arrived too late), Empty, Rejected, and a missing entry mean the cache
+  // had nothing to render right now. Every fresh segment (layouts, pages,
+  // parallel slots) passes through here, so one unserved segment marks the
+  // whole navigation.
+  let renderedFromCache = false
 
   const segmentEntry = readSegmentCacheEntryForNavigation(
     now,
@@ -1110,6 +1169,7 @@ function createCacheNodeForSegment(
         // Happy path: a cache hit
         cachedRsc = segmentEntry.rsc
         isCachedRscPartial = segmentEntry.isPartial
+        renderedFromCache = segmentEntry.rsc !== null
         break
       }
       case EntryStatus.Pending: {
@@ -1202,6 +1262,13 @@ function createCacheNodeForSegment(
   let head: React.ReactNode | null = null
   let doesHeadNeedDynamicRequest: boolean = isPage
 
+  // Instrumentation: mirror `renderedFromCache` for the page head. The head
+  // is its own segment-cache entry (metadataVaryPath), so it is classified
+  // exactly like a segment — a Fulfilled entry with bytes counts (partiality
+  // does not matter), anything else is a miss — and folded into `cacheHit`
+  // below. Non-page segments have no head and so never mark on this axis.
+  let renderedHeadFromCache = !isPage
+
   if (isPage) {
     let cachedHead: HeadData | null = null
     let isCachedHeadPartial: boolean = true
@@ -1216,6 +1283,9 @@ function createCacheNodeForSegment(
           case EntryStatus.Fulfilled: {
             cachedHead = metadataEntry.rsc
             isCachedHeadPartial = metadataEntry.isPartial
+            // Generous, like the segment: even a partial head counts as
+            // served. Pending/Empty/Rejected/missing leave this a miss.
+            renderedHeadFromCache = metadataEntry.rsc !== null
             break
           }
           case EntryStatus.Pending: {
@@ -1257,6 +1327,9 @@ function createCacheNodeForSegment(
     }
 
     if (seedHead !== null) {
+      // The head arrived with a server response already in hand, so it is
+      // served even if no cache entry backed it.
+      renderedHeadFromCache = true
       if (isCachedHeadPartial) {
         prefetchHead = cachedHead
         head = seedHead
@@ -1306,14 +1379,24 @@ function createCacheNodeForSegment(
     }
   }
 
-  return {
-    cacheNode: createCacheNode(rsc, prefetchRsc, head, prefetchHead, bfcacheId),
+  return finishSegmentCacheNode(
+    accumulation,
+    // Seed segments (a server response already in hand) belong to
+    // navigations marked at the route level or untracked, so the
+    // `seedRsc !== null` short-circuit covers them. Otherwise the cache
+    // served this segment only if both the segment bytes AND — for a page —
+    // the head were cached. From the client's perspective the head is just
+    // another segment, so a head the cache could not serve is a miss even
+    // though it streams in non-blocking and never stalls the commit: it
+    // means the head was not prefetched, which is exactly the kind of gap
+    // cacheHit exists to surface.
+    seedRsc !== null || (renderedFromCache && renderedHeadFromCache),
+    createCacheNode(rsc, prefetchRsc, head, prefetchHead, bfcacheId),
     // TODO: We should store this field on the CacheNode itself. I think we can
     // probably unify NavigationTask, CacheNode, and DeferredRsc into a
     // single type. Or at least CacheNode and DeferredRsc.
-    needsDynamicRequest:
-      doesSegmentNeedDynamicRequest || doesHeadNeedDynamicRequest,
-  }
+    doesSegmentNeedDynamicRequest || doesHeadNeedDynamicRequest
+  )
 }
 
 function createCacheNode(

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -52,6 +52,7 @@ export function restoreReducer(
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,
+    instrumentationTransition: action.instrumentationTransition,
   }
   const restoreSeed = convertServerPatchToFullTree(
     now,

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -67,6 +67,16 @@ export type PendingRouterTransition = {
    * (see `sweepReplacedRouterTransitions`).
    */
   replaced: boolean
+  /**
+   * Backs the commit event's `cacheHit` field: whether the router had
+   * something cached to render for the whole destination at dispatch — the
+   * route tree plus bytes for every fresh segment, where a shell that is
+   * entirely a dynamic hole still counts (the flag attributes cache
+   * coverage, deliberately not paint time). A one-way latch: starts `true`;
+   * unset by markRouterTransitionAsCacheMiss at the sites where the
+   * navigation needed the network first, never set back.
+   */
+  cacheHit: boolean
 }
 
 let instrumentationModules: readonly ClientInstrumentationHooks[] = []
@@ -178,6 +188,7 @@ export function startRouterTransition(
       url,
       phase: 'pending',
       replaced: false,
+      cacheHit: true,
     }
     pendingTransitions.push(transition)
 
@@ -251,9 +262,10 @@ export function getInstrumentationTransition(
  *   — the carried field is what lets the derived state commit it. This is
  *   safe under either interleaving: if React does not batch, the
  *   navigation's own state commits first and the derived state's commit
- *   no-ops (the transition's phase has already advanced). Because the
- *   carry-over lives in the reducers, these actions need nothing from the
- *   settle point.
+ *   no-ops (the transition's phase has already advanced). What's left for
+ *   the settle point is the `cacheHit` consequence: the derivation rode a
+ *   server response, so a still-pending carried transition is a miss
+ *   (see `retargetRouterTransition`).
  *
  * - Server actions are preserving only when they did not navigate: a
  *   revalidation re-renders the current URL (same reasoning as refresh, and
@@ -289,13 +301,63 @@ export function settleRouterTransition(
       case ACTION_REFRESH:
       case ACTION_SERVER_PATCH:
       case ACTION_HMR_REFRESH:
+        retargetRouterTransition(prevState, nextState)
+        return
       case ACTION_SERVER_ACTION:
-        // Destination-preserving: the reducer carried the base state's
-        // transition onto the derived state (see the class descriptions
-        // above), so there is nothing left to settle here.
+        if (
+          nextState !== prevState &&
+          !nextState.pushRef.mpaNavigation &&
+          nextState.canonicalUrl === prevState.canonicalUrl
+        ) {
+          retargetRouterTransition(prevState, nextState)
+        }
         return
       default:
         payload satisfies never
+    }
+  }
+}
+
+/**
+ * Applies the `cacheHit` consequence when a destination-preserving action
+ * derives a new state from a tracked-but-not-yet-committed one (see
+ * `settleRouterTransition`). The destination identity needs no re-pointing —
+ * the reducer copies `instrumentationTransition` onto the derived state, so
+ * HistoryUpdater finds the transition on whichever state ends up committing.
+ * No-op in the common case where the base state's transition was already
+ * committed (a plain refresh of a settled page) or nothing is in flight.
+ */
+function retargetRouterTransition(
+  prevState: AppRouterState,
+  nextState: AppRouterState
+): void {
+  const transition = nextState.instrumentationTransition
+  if (
+    transition !== null &&
+    transition === prevState.instrumentationTransition &&
+    transition.phase === 'pending'
+  ) {
+    // The commit now rides a state derived from a server response (a
+    // refresh awaited its fetch, a mismatch retry corrects the predicted
+    // tree with the dynamic response, a destination-preserving server
+    // action returned new state), so the navigation needed the network
+    // before this commit could be built.
+    transition.cacheHit = false
+  }
+}
+
+/**
+ * Marks the transition as a cache miss, so its commit reports
+ * `cacheHit: false`. The flag is a one-way latch: a transition starts as a
+ * hit, any single unserved piece flips it to a miss, and nothing (by design)
+ * flips it back.
+ */
+export function markRouterTransitionAsCacheMiss(
+  transition: PendingRouterTransition | null
+): void {
+  if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    if (transition !== null) {
+      transition.cacheHit = false
     }
   }
 }
@@ -424,6 +486,12 @@ export function commitRouterTransition(state: AppRouterState): void {
               id: committed.id,
               timestamp: now,
               to,
+              // `cacheHit` defaults to true and is only unset at the known
+              // miss sites, so a navigation that renders entirely from local
+              // data (including one that reuses the current UI, e.g.
+              // hash-only) reports a hit without any code path having to
+              // say so.
+              cacheHit: committed.cacheHit,
             }
           )
         )

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -40,7 +40,11 @@ import { createCacheKey, type NormalizedSearch } from './cache-key'
 import { schedulePrefetchTask } from './scheduler'
 import { PrefetchPriority, FetchStrategy } from './types'
 import { getLinkForCurrentNavigation } from '../links'
-import type { PendingRouterTransition } from '../router-transition'
+import {
+  markRouterTransitionAsCacheMiss,
+  type PendingRouterTransition,
+} from '../router-transition'
+import { isThenable } from '../../../shared/lib/is-thenable'
 import type { PageVaryPath } from './vary-path'
 import type { AppRouterState } from '../router-reducer/router-reducer-types'
 import { ScrollBehavior } from '../router-reducer/router-reducer-types'
@@ -72,9 +76,11 @@ export function navigate(
   // the pending transition created when this navigation started, or the
   // base state's transition carried through a server-action revalidation
   // (`null` when untracked, e.g. a server-action redirect or gesture). It
-  // is stamped onto the produced state (`instrumentationTransition`), which
-  // is how HistoryUpdater reports the commit for the destination the
-  // navigation actually built.
+  // is stamped onto the produced state (`instrumentationTransition`), and
+  // the `cacheHit` marks need navigation-time data — whether the
+  // destination state is produced synchronously, and whether the segment
+  // walk was served from cache — so the transition is threaded to those
+  // sites too.
   instrumentationTransition: PendingRouterTransition | null
 ): AppRouterState | Promise<AppRouterState> {
   let navigationLock: NavigationLock = null
@@ -107,7 +113,7 @@ export function navigate(
     }
   }
 
-  return navigateImpl(
+  const result = navigateImpl(
     state,
     url,
     currentUrl,
@@ -121,6 +127,16 @@ export function navigate(
     navigationLock,
     instrumentationTransition
   )
+  // Instrumentation: if the destination state could not be produced
+  // synchronously, the navigation waited on the network before that state
+  // could even exist — today the only async path is an unprefetched route
+  // tree, which blocks on the dynamic fetch. Deriving the mark from the
+  // asynchrony itself keeps the tracking exhaustive by construction: a
+  // future async path in navigateImpl is marked automatically.
+  if (isThenable(result)) {
+    markRouterTransitionAsCacheMiss(instrumentationTransition)
+  }
+  return result
 }
 
 function navigateImpl(
@@ -260,11 +276,12 @@ export function navigateToKnownRoute(
   signal: AbortSignal | undefined,
   // INSTRUMENTATION ONLY — the transition the produced state belongs to. It
   // is stamped onto the state (`instrumentationTransition`), which is how
-  // HistoryUpdater reports the commit. For navigations this is the action's
-  // threaded transition; for destination-preserving callers (refresh,
-  // retry, revalidating server action) it is the base state's transition
-  // carried forward. `null` for untracked callers (redirecting server
-  // actions).
+  // HistoryUpdater reports the commit and how the segment walk's
+  // accumulation marks a fresh segment the cache could not serve as a
+  // cache miss. For navigations this is the action's threaded transition;
+  // for destination-preserving callers (refresh, retry, revalidating
+  // server action) it is the base state's transition carried forward.
+  // `null` for untracked callers (redirecting server actions).
   instrumentationTransition: PendingRouterTransition | null
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
@@ -332,6 +349,7 @@ export function navigateToKnownRoute(
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,
+    instrumentationTransition,
   }
   // We special case navigations to the exact same URL as the current location.
   // It's a common UI pattern for apps to refresh when you click a link to the
@@ -1141,7 +1159,7 @@ async function ensurePrefetchThenNavigate(
 
   // Prefetch is complete. Proceed with the normal navigation flow, which
   // will now find the route in the cache.
-  const result = await navigateImpl(
+  const resultOrPromise = navigateImpl(
     state,
     url,
     currentUrl,
@@ -1155,6 +1173,14 @@ async function ensurePrefetchThenNavigate(
     navigationLock,
     instrumentationTransition
   )
+  // Same asynchrony-derived instrumentation mark as in navigate(). The
+  // deliberate prefetch wait above is not marked: this testing path exists
+  // to simulate navigations whose prefetch completed before the
+  // user navigated.
+  if (isThenable(resultOrPromise)) {
+    markRouterTransitionAsCacheMiss(instrumentationTransition)
+  }
+  const result = await resultOrPromise
 
   // Only transition to captured-SPA once the navigation is known to be an SPA.
   // If the result is an MPA navigation, leave the cookie pending and let the new

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -114,6 +114,22 @@ export type RouterTransitionStartEvent = RouterTransitionEvent & {
 export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   /** The route that was committed. */
   to: RouterTransitionRoute
+  /**
+   * Whether the navigation was a cache hit: at the moment it was dispatched,
+   * the router had something in its caches to render for the whole
+   * destination — the route tree, plus bytes for every fresh segment.
+   * "Something to render" is deliberately generous: a partial shell counts
+   * even when it is entirely a dynamic hole, so `cacheHit` attributes cache
+   * coverage, not paint time. `false` when the navigation needed the network
+   * before it had anything to render: the route was not prefetched (the
+   * commit itself blocked on the fetch), a segment's prefetch was still
+   * pending, evicted, or never made, or the commit rode a
+   * refresh/retry-derived tree. Read it together with the start→commit
+   * latency: `false` marks the navigations prefetching could have made
+   * faster, while a slow cache-hit commit is waiting on streaming runtime
+   * content or client-side rendering — costs prefetching cannot remove.
+   */
+  cacheHit: boolean
 }
 
 export type RouterTransitionAbortEvent = RouterTransitionEvent & {

--- a/test/e2e/instrumentation-client-hook/app-router/app/test-controls.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/test-controls.tsx
@@ -11,6 +11,17 @@ export function TestControls() {
         Push hash
       </button>
       <button
+        id="push-no-prefetch"
+        onClick={() => {
+          // A programmatic push with no <Link> in the viewport: nothing was
+          // prefetched, so the router must fetch the route before it has
+          // anything to render — a cache miss by definition.
+          router.push('/no-prefetch')
+        }}
+      >
+        Push without prefetch
+      </button>
+      <button
         id="triple-push"
         onClick={() => {
           // Three navigations in one tick: only the newest one may commit; both

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -224,10 +224,16 @@ describe('Instrumentation Client Hook', () => {
           start.event.timestamp
         )
         expect(Object.keys(commit.event).sort()).toEqual([
+          'cacheHit',
           'id',
           'timestamp',
           'to',
         ])
+        // The value is asserted in the dedicated cacheHit tests below: this
+        // first click races the link's own prefetch (clicking before it
+        // lands is a genuine cache miss), so only the payload shape is
+        // deterministic here.
+        expect(typeof commit.event.cacheHit).toBe('boolean')
         expect(commit.event.to.routes).toEqual([
           { template: '/some-page', params: {} },
         ])
@@ -275,6 +281,99 @@ describe('Instrumentation Client Hook', () => {
         'commit',
       ])
       expect(events.at(-2).event.from.canonicalUrl).toBe('/?shallow=1')
+    })
+
+    it('reports a cache hit when restoring a cached route', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await browser.back()
+      await browser.elementById('home')
+      // Going forward restores /some-page from the BFCache, so there is a fully
+      // rendered shell to navigate into.
+      await browser.forward()
+      await browser.elementById('some-page')
+
+      await retry(async () => {
+        const commit = (await getTransitionEvents(browser))
+          .filter((e) => e.phase === 'commit' && e.url === '/some-page')
+          .at(-1)
+        expect(commit?.event.cacheHit).toBe(true)
+      })
+    })
+
+    it('reports a cache hit for a fully prefetched route', async () => {
+      const browser = await next.browser('/')
+
+      // The /some-page link uses prefetch={true}, so its complete route —
+      // shell and head — is fetched up front. Once that prefetch lands the
+      // click navigates straight through the segment walk (not the BFCache
+      // path the previous test covers), so the cache serving both the
+      // segment bytes AND the head is what makes this a hit: a head the
+      // cache could not serve would mark it a miss. In development nothing is
+      // prefetched, so the same click first fetches the route — a miss.
+      await browser.waitForIdleNetwork()
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+
+      await retry(async () => {
+        const commit = (await getTransitionEvents(browser)).find(
+          (e) => e.phase === 'commit' && e.url === '/some-page'
+        )
+        expect(commit?.event.cacheHit).toBe(isNextDev ? false : true)
+      })
+    })
+
+    it('reports a cache miss when nothing is prefetched for the route', async () => {
+      const browser = await next.browser('/')
+
+      // Without a prefetch the destination state is produced asynchronously
+      // (the router blocks on the dynamic fetch), so the cache could not
+      // serve the navigation.
+      await browser.elementById('push-no-prefetch').click()
+      await browser.elementById('no-prefetch')
+
+      await retry(async () => {
+        const commit = (await getTransitionEvents(browser)).find(
+          (e) => e.phase === 'commit' && e.url === '/no-prefetch'
+        )
+        expect(commit?.event.to.renderedPathname).toBe('/no-prefetch')
+        expect(commit?.event.cacheHit).toBe(false)
+      })
+    })
+
+    it('reports a cache hit for a hash-only navigation', async () => {
+      const browser = await next.browser('/')
+
+      // A hash-only push still resolves its destination through the route
+      // cache, so it is only a hit once the current route's prefetch has
+      // landed. Wait for that before clicking; otherwise the click races the
+      // prefetch — invisible on a fast machine, but a deterministic miss in
+      // slow deploy-mode CI.
+      await browser.waitForIdleNetwork()
+
+      await browser.elementById('push-hash').click()
+      await retry(async () => {
+        const events = await getTransitionEvents(browser)
+        expect(events.some((e) => e.phase === 'commit')).toBe(true)
+      })
+      const commit = lastCommit(await getTransitionEvents(browser))
+      // In production the route tree is known locally and the page UI is
+      // reused, so the cache serves the navigation — a hit. In development
+      // nothing is prefetched, so even a hash-only navigation consults the
+      // server for the route tree before committing — an accurate miss.
+      expect(commit.event.cacheHit).toBe(isNextDev ? false : true)
+
+      // Traversing back across the hash boundary reuses the tree the same
+      // way — a hit in both modes (no fetch ever happens).
+      await browser.back()
+      await retry(async () => {
+        const traverseCommit = (await getTransitionEvents(browser)).find(
+          (e) => e.phase === 'commit' && e.navigateType === 'traverse'
+        )
+        expect(traverseCommit?.event.cacheHit).toBe(true)
+      })
     })
 
     it('describes routes across group, dynamic, catch-all, rewritten, hash, query, and intercepted URLs', async () => {
@@ -598,6 +697,11 @@ describe('Instrumentation Client Hook', () => {
       expect(commits).toHaveLength(1)
       expect(commits[0].event.id).toBe(starts[0].event.id)
       expect(commits[0].event.to.renderedPathname).toBe('/no-prefetch')
+      // A miss twice over: the route wasn't prefetched (the push blocked on
+      // the dynamic fetch), and the committed tree was derived by the
+      // refresh from a second server response (retargetRouterTransition also
+      // marks retargeted transitions as misses).
+      expect(commits[0].event.cacheHit).toBe(false)
       expect(events.filter((e) => e.phase === 'abort')).toHaveLength(0)
 
       // The transition is settled, not starved: before the fix, its entry


### PR DESCRIPTION
## Summary

Stacked on #95328.

Adds a `cacheHit: boolean` field to the `unstable_onRouterTransitionCommit` event. It answers one question about each navigation:

> At dispatch, did the router already have something cached to render the whole destination?

"Something to render" = the prefetched route tree, plus bytes for every fresh segment (the page's head included). It is deliberately generous: even a shell that is entirely a dynamic hole counts. `cacheHit` measures **cache coverage**, not paint time.

### Why a separate flag, not just "instant"

`cacheHit: true` does not mean the navigation was fast. A cache-served navigation can still commit slowly — its shell was prefetched, but its content streams from the server. That wait already shows up in the start→commit latency; it does not belong in this flag.

Read the two signals together and you get an actionable split:

| `cacheHit` | commit | meaning | what to do |
|---|---|---|---|
| `false` | any | went to the network before it had anything to render | **prefetch-fixable** — enable / hoist / retain the prefetch |
| `true` | fast | genuinely instant | — |
| `true` | slow | cache served it; the wait is streaming content or client rendering | **not prefetch-fixable** — add Suspense / restructure |

A `false` has a small, concrete set of causes: the route was not prefetched, a segment's prefetch was pending / evicted / never made, or the commit rode a refresh/retry-derived tree.

This is also why the field is not named `instant`. It and the `export const instant = false` route config measure different things — a route declaring `instant = false` still reports `cacheHit: true` when its shell was prefetched — so they must not share a word.

### How it's computed

`cacheHit` **defaults to `true`** and is only flipped to `false` at the few sites where the router provably reached for the network. Defaulting to true is what lets reuse paths that run no per-segment code — hash-only navigations, BFCache traversals, shared segments — report correctly with no special casing.

The three miss sites are deterministic, synchronous observations:

- **Unprefetched route.** Its destination state is produced asynchronously, so the mark is derived from that asynchrony at the `navigateImpl` call sites. Any future async path is covered automatically.
- **An unserved segment.** Every return of `createCacheNodeForSegment` must classify whether the cache served that segment (compile-enforced): a Fulfilled entry with bytes counts, partial or not; Pending / Empty / Rejected / missing is a miss. Layouts, pages, and a page's **head** are all classified the same way — from the client's perspective the head is just another segment, so a head the cache could not serve is a miss even though it streams in non-blocking (a missing head means it was never prefetched). One unserved segment marks the whole navigation.
- **A retargeted tree.** A transition redirected onto a refresh / retry / server-action-derived tree (`retargetRouterTransition`) needed that response, so it is marked too.

### Why not define it from paint

Paint-based definitions were prototyped and rejected as undecidable on the client. A hole-only shell and a content shell are structurally identical in the cache, and "did the commit wait for content?" races the server's first byte against React's commit — ~10ms apart on a fast network — flipping the answer nondeterministically. Cache coverage is the strongest deterministic observable.

## Verification

- `pnpm test-dev-turbo test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts` and `pnpm test-start-turbo` (same file), each also with `__NEXT_CACHE_COMPONENTS=true`.
- Manual stress matrix: drove a cacheComponents app (headless Chromium against `next start`, viewport-prefetched links) and checked the flag against measured start→commit latency:

  | route | shape | start→commit | `cacheHit` |
  |---|---|---|---|
  | static page declaring `instant = false` | complete prefetch | 9ms | `true` |
  | PPR page (shell + Suspense-wrapped hole) | partial prefetch | 16ms | `true` |
  | blocking `instant = false` page, no boundary | hole-only prefetch shell | 1010ms | `true` — slow commit attributed to streaming content, not prefetching |
  | blocking `instant = false` page behind a boundary | hole-only prefetch shell | 13ms | `true` |
  | instant page + blocking parallel slot page | mixed | 1511ms | `true` — same attribution |
  | `router.push` to an unprefetched route | nothing cached | — | `false` |
  | BFCache back/forward traversals | reuse | ~1ms | `true` |

<!-- NEXT_JS_LLM_PR -->
