### PR TITLE
[ci] Skip apt-installed dependencies in playwright install step

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -367,7 +367,13 @@ jobs:
 
       - name: Install Playwright browsers
         if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' }}
-        run: pnpm playwright install --with-deps --only-shell ${{ inputs.browser }}
+        env:
+          PLAYWRIGHT_BROWSERS: ${{ inputs.browser }}
+          WITH_DEPS: ${{ inputs.browser != 'chromium' && '--with-deps' || '' }}
+        run: |
+          # PLAYWRIGHT_BROWSERS can be a space-separated list, should expand
+          # into multiple arguments
+          pnpm playwright install --only-shell $WITH_DEPS $PLAYWRIGHT_BROWSERS
 
       - name: Download pre-built test timings
         if: ${{ inputs.testTimingsArtifact != '' }}

--- a/test/development/pages-dir/client-navigation/scroll-position.util.ts
+++ b/test/development/pages-dir/client-navigation/scroll-position.util.ts
@@ -1,0 +1,32 @@
+import type { Playwright } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+/**
+ * Asserts that the window has scrolled to the element returned by
+ * `getElementJs` (a JS expression evaluated in the browser). The expected
+ * offset is computed from the element's live layout position rather than a
+ * hardcoded pixel value, so the assertion is independent of font metrics,
+ * which vary with the fonts installed on the host.
+ */
+export async function expectScrolledTo(
+  browser: Playwright,
+  getElementJs: string
+) {
+  await retry(async () => {
+    const { expected, actual } = await browser.eval<{
+      expected: number
+      actual: number
+    }>(`(() => {
+      const el = ${getElementJs}
+      // Scrolling to an anchor near the bottom of the page is clamped to the
+      // maximum scroll position.
+      const expected = Math.min(
+        el.getBoundingClientRect().top + window.pageYOffset,
+        document.documentElement.scrollHeight - window.innerHeight
+      )
+      return { expected, actual: window.pageYOffset }
+    })()`)
+    expect(expected).toBeGreaterThan(0)
+    expect(Math.abs(actual - expected)).toBeLessThanOrEqual(1)
+  })
+}

--- a/test/development/pages-dir/client-navigation/scroll.test.ts
+++ b/test/development/pages-dir/client-navigation/scroll.test.ts
@@ -3,6 +3,7 @@
 import { check } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
+import { expectScrolledTo } from './scroll-position.util'
 
 describe('Client navigation scroll', () => {
   const { next } = nextTestSetup({
@@ -22,8 +23,7 @@ describe('Client navigation scroll', () => {
         .elementByCss('#scroll-to-item-400')
         .click()
 
-      const scrollPosition = await browser.eval('window.pageYOffset')
-      expect(scrollPosition).toBe(7208)
+      await expectScrolledTo(browser, "document.getElementById('item-400')")
 
       // Go to snap scroll page
       await browser
@@ -46,8 +46,7 @@ describe('Client navigation scroll', () => {
         .elementByCss('#scroll-to-item-400')
         .click()
 
-      const scrollPosition = await browser.eval('window.pageYOffset')
-      expect(scrollPosition).toBe(7208)
+      await expectScrolledTo(browser, "document.getElementById('item-400')")
 
       // Go to snap scroll page
       await browser
@@ -70,8 +69,8 @@ describe('Client navigation scroll', () => {
         .elementByCss('#scroll-to-item-400')
         .click()
 
+      await expectScrolledTo(browser, "document.getElementById('item-400')")
       const scrollPosition = await browser.eval('window.pageYOffset')
-      expect(scrollPosition).toBe(7208)
 
       // Go to snap scroll page
       await browser
@@ -83,7 +82,9 @@ describe('Client navigation scroll', () => {
         'document.getElementById("scroll-pos-y").innerText'
       )
       expect(snappedScrollPosition).not.toBe('0')
-      expect(Number(snappedScrollPosition)).toBeGreaterThanOrEqual(7208)
+      expect(Number(snappedScrollPosition)).toBeGreaterThanOrEqual(
+        scrollPosition
+      )
     })
   })
 

--- a/test/development/pages-dir/client-navigation/url-hash.test.ts
+++ b/test/development/pages-dir/client-navigation/url-hash.test.ts
@@ -3,6 +3,7 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import { expectScrolledTo } from './scroll-position.util'
 
 describe('Client navigation with URL hash', () => {
   const { next } = nextTestSetup({
@@ -47,9 +48,7 @@ describe('Client navigation with URL hash', () => {
         // Scrolls to item 400 on the page
         await browser.elementByCss('#scroll-to-item-400').click()
 
-        await retry(async () => {
-          expect(await browser.eval('window.pageYOffset')).toBe(7258)
-        })
+        await expectScrolledTo(browser, "document.getElementById('item-400')")
 
         // Scrolls back to top when scrolling to `#` with no value.
         await browser.elementByCss('#via-empty-hash').click()
@@ -61,9 +60,7 @@ describe('Client navigation with URL hash', () => {
         // Scrolls to item 400 on the page
         await browser.elementByCss('#scroll-to-item-400').click()
 
-        await retry(async () => {
-          expect(await browser.eval('window.pageYOffset')).toBe(7258)
-        })
+        await expectScrolledTo(browser, "document.getElementById('item-400')")
 
         // Scrolls back to top when clicking link with href `#top`.
         await browser.elementByCss('#via-top-hash').click()
@@ -75,9 +72,7 @@ describe('Client navigation with URL hash', () => {
         // Scrolls to cjk anchor on the page
         await browser.elementByCss('#scroll-to-cjk-anchor').click()
 
-        await retry(async () => {
-          expect(await browser.eval('window.pageYOffset')).toBe(17436)
-        })
+        await expectScrolledTo(browser, "document.getElementById('中文')")
       })
 
       it('should not scroll to hash when scroll={false} is set', async () => {
@@ -100,9 +95,10 @@ describe('Client navigation with URL hash', () => {
         // Scrolls to item 400 with name="name-item-400" on the page
         await browser.elementByCss('#scroll-to-name-item-400').click()
 
-        await retry(async () => {
-          expect(await browser.eval('window.pageYOffset')).toBe(16258)
-        })
+        await expectScrolledTo(
+          browser,
+          "document.getElementsByName('name-item-400')[0]"
+        )
 
         // Scrolls back to top when scrolling to `#` with no value.
         await browser.elementByCss('#via-empty-hash').click()
@@ -121,9 +117,7 @@ describe('Client navigation with URL hash', () => {
           .click()
           .waitForElementByCss('#hash-changes-page')
 
-        await retry(async () => {
-          expect(await browser.eval('window.pageYOffset')).toBe(7258)
-        })
+        await expectScrolledTo(browser, "document.getElementById('item-400')")
       })
 
       it('should scroll to the specified CJK position to a new page', async () => {
@@ -135,9 +129,7 @@ describe('Client navigation with URL hash', () => {
           .click()
           .waitForElementByCss('#hash-changes-page')
 
-        await retry(async () => {
-          expect(await browser.eval('window.pageYOffset')).toBe(17436)
-        })
+        await expectScrolledTo(browser, "document.getElementById('中文')")
       })
 
       it('Should update asPath', async () => {


### PR DESCRIPTION
The hypothesis is that this is just installing some font stuff that isn't actually needed for Chromium to work:

```
The following additional packages will be installed:
  libnss3-tools xfonts-encodings xfonts-utils
Recommended packages:
  fonts-ipafont-mincho fonts-liberation-sans-narrow fonts-tlwg-loma
The following NEW packages will be installed:
  fonts-freefont-ttf fonts-ipafont-gothic fonts-liberation fonts-tlwg-loma-otf
  fonts-unifont fonts-wqy-zenhei xfonts-cyrillic xfonts-encodings
  xfonts-scalable xfonts-utils
The following packages will be upgraded:
  libnss3 libnss3-tools
2 upgraded, 10 newly installed, 0 to remove and 35 not upgraded.
```

`apt` is very slow, so skipping this step should significantly reduce setup time per test shard.

It seems like this isn't always true for other browsers, so only skip this for Chromium (that's fine, that's what most of our jobs use anyways).

On 16 core arm runners, "Install Playwright Browsers" typically took 18-24 seconds. Now it takes 5-6s.

Let's estimate that saves about 15s per Linux job that installs Chromium. Claude estimates that there are 73 chromium-only Linux jobs on this PR:

<img width="891" height="148" alt="Screenshot 2026-07-06 at 10 30 16 PM" src="https://github.com/user-attachments/assets/725893fa-9f6f-4806-a3b4-9858ab0ebe66" />

So that's 15*73/60=18.25 minutes saved per PR push (the average PR gets many pushes). At the public (before any volume discounts) price of $0.026/minute for the 16 core arm runners, that comes out to $0.4745 per PR push saved.

This workflow has had 3,894 runs in the last 30 days, so that could be $1,847/mo saved, but many of those workflow runs were canceled, and some likely failed before getting to these jobs, so the actual savings are probably somewhere around half of that -- scroll through https://github.com/vercel/next.js/actions/workflows/.github/workflows/build_and_test.yml and see that a little less than half of the workflow runs end up canceled.