### PR TITLE
fix: allow `cssChunking: "graph"` in `next experimental-analyze` and `next info`

### DIFF
--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -270,6 +270,19 @@ describe('loadConfig', () => {
       expect(result.experimental.cssChunking).toBe('graph')
     })
 
+    it('should reject `cssChunking: "strict"` when the Turbopack bundler is passed explicitly', async () => {
+      delete process.env.TURBOPACK
+
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: { cssChunking: 'strict' },
+          },
+          bundler: Bundler.Turbopack,
+        })
+      ).rejects.toThrow(/only supported with webpack/)
+    })
+
     it('should accept `cssChunking: "graph"` during `next info` (no bundler selected)', async () => {
       delete process.env.TURBOPACK
 

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -1,4 +1,5 @@
-import { PHASE_PRODUCTION_BUILD } from '../api/constants'
+import { PHASE_INFO, PHASE_PRODUCTION_BUILD } from '../api/constants'
+import { Bundler } from '../lib/bundler'
 
 describe('loadConfig', () => {
   let loadConfig: typeof import('./config').default
@@ -231,6 +232,53 @@ describe('loadConfig', () => {
       expect(result.cacheHandlers?.['abc']).toBeDefined()
       expect(result.cacheHandlers?.['valid-handler']).toBeDefined()
       expect(result.cacheHandlers?.['abc-def']).toBeDefined()
+    })
+  })
+
+  describe('experimental.cssChunking bundler validation', () => {
+    const originalTurbopackEnv = process.env.TURBOPACK
+
+    afterEach(() => {
+      if (originalTurbopackEnv === undefined) {
+        delete process.env.TURBOPACK
+      } else {
+        process.env.TURBOPACK = originalTurbopackEnv
+      }
+    })
+
+    it('should reject `cssChunking: "graph"` when building without Turbopack', async () => {
+      delete process.env.TURBOPACK
+
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: { cssChunking: 'graph' },
+          },
+        })
+      ).rejects.toThrow(/only supported with Turbopack/)
+    })
+
+    it('should accept `cssChunking: "graph"` when the Turbopack bundler is passed explicitly', async () => {
+      delete process.env.TURBOPACK
+
+      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+        customConfig: {
+          experimental: { cssChunking: 'graph' },
+        },
+        bundler: Bundler.Turbopack,
+      })
+      expect(result.experimental.cssChunking).toBe('graph')
+    })
+
+    it('should accept `cssChunking: "graph"` during `next info` (no bundler selected)', async () => {
+      delete process.env.TURBOPACK
+
+      const result = await loadConfig(PHASE_INFO, __dirname, {
+        customConfig: {
+          experimental: { cssChunking: 'graph' },
+        },
+      })
+      expect(result.experimental.cssChunking).toBe('graph')
     })
   })
 })

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -505,7 +505,7 @@ function assignDefaultsAndValidate(
           `Please remove the option or run Next.js with Turbopack in ${configFileName}.`
       )
     }
-    if (cssChunkingMode === 'strict' && process.env.TURBOPACK) {
+    if (cssChunkingMode === 'strict' && isTurbopack) {
       throw new Error(
         `\`experimental.cssChunking: "strict"\` is only supported with webpack. ` +
           `Please remove the option or run Next.js with webpack in ${configFileName}.`
@@ -513,7 +513,7 @@ function assignDefaultsAndValidate(
     }
     // Only error when `false` was set explicitly. `undefined` (the default) also resolves to
     // `'off'` but that's the implicit default and must not error on Turbopack.
-    if (cssChunkingValue === false && process.env.TURBOPACK) {
+    if (cssChunkingValue === false && isTurbopack) {
       throw new Error(
         `\`experimental.cssChunking: false\` is only supported with webpack. ` +
           `Please remove the option or run Next.js with webpack in ${configFileName}.`

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -8,6 +8,7 @@ import {
   CONFIG_FILES,
   PHASE_DEVELOPMENT_SERVER,
   PHASE_EXPORT,
+  PHASE_INFO,
   PHASE_PRODUCTION_BUILD,
   PHASE_PRODUCTION_SERVER,
   type PHASE_TYPE,
@@ -296,7 +297,8 @@ function assignDefaultsAndValidate(
   dir: string,
   userConfig: NextConfig & { configFileName: string },
   silent: boolean,
-  phase: PHASE_TYPE
+  phase: PHASE_TYPE,
+  bundler?: Bundler
 ): NextConfigComplete {
   const configFileName = userConfig.configFileName
   if (typeof (userConfig as any).exportTrailingSlash !== 'undefined') {
@@ -487,12 +489,17 @@ function assignDefaultsAndValidate(
 
   // Validate experimental.cssChunking compatibility with the active bundler. Graph mode is
   // Turbopack-only; strict mode and `false` (single-chunk-per-module) are webpack-only.
-  // Only validate during build/dev — `next start` doesn't pick a bundler and would otherwise
-  // see `process.env.TURBOPACK` unset and reject a valid `cssChunking: "graph"` config.
-  if (phase !== PHASE_PRODUCTION_SERVER) {
+  // Only validate during phases that pick a bundler — `next start` and `next info` don't
+  // and would otherwise see `process.env.TURBOPACK` unset and reject a valid
+  // `cssChunking: "graph"` config.
+  if (phase !== PHASE_PRODUCTION_SERVER && phase !== PHASE_INFO) {
+    // Commands like `next experimental-analyze` always use Turbopack but don't set
+    // `process.env.TURBOPACK`; they declare the bundler via the `bundler` option instead.
+    const isTurbopack =
+      Boolean(process.env.TURBOPACK) || bundler === Bundler.Turbopack
     const cssChunkingValue = result.experimental.cssChunking
     const cssChunkingMode = resolveCssChunkingMode(cssChunkingValue)
-    if (cssChunkingMode === 'graph' && !process.env.TURBOPACK) {
+    if (cssChunkingMode === 'graph' && !isTurbopack) {
       throw new Error(
         `\`experimental.cssChunking: "graph"\` is only supported with Turbopack. ` +
           `Please remove the option or run Next.js with Turbopack in ${configFileName}.`
@@ -513,10 +520,7 @@ function assignDefaultsAndValidate(
       )
     }
 
-    if (
-      result.experimental.turbopackRustReactCompiler &&
-      !process.env.TURBOPACK
-    ) {
+    if (result.experimental.turbopackRustReactCompiler && !isTurbopack) {
       throw new Error(
         `\`experimental.turbopackRustReactCompiler\` is only supported with Turbopack. ` +
           `Please remove the option or run Next.js with Turbopack in ${configFileName}.`
@@ -1845,7 +1849,8 @@ async function loadConfigImpl(
             ...customConfig,
           },
           silent,
-          phase
+          phase,
+          bundler
         ),
         phase,
         silent,
@@ -2050,7 +2055,8 @@ async function loadConfigImpl(
         ...userConfig,
       },
       silent,
-      phase
+      phase,
+      bundler
     )
 
     const finalConfig = finalizeConfig(
@@ -2107,7 +2113,8 @@ async function loadConfigImpl(
     dir,
     { ...clonedDefaultConfig, configFileName },
     silent,
-    phase
+    phase,
+    bundler
   )
 
   setHttpClientAndAgentOptions(completeConfig)


### PR DESCRIPTION
## Summary

`next experimental-analyze` and `next info` failed with `` `experimental.cssChunking: "graph"` is only supported with Turbopack `` even though analyze always uses Turbopack and `next info` selects no bundler at all. The validation only checked `process.env.TURBOPACK`, which is set exclusively by `next build`/`next dev`.

The validation now also honors the `bundler` option that `analyze` already passes to `loadConfig`, and is skipped for `PHASE_INFO` (matching the existing `PHASE_PRODUCTION_SERVER` exemption). The `experimental.turbopackRustReactCompiler` check gets the same treatment.

Fixes #95530

## Verification

- `next info` and `next experimental-analyze --output` now succeed on a repro app with `cssChunking: "graph"` using the locally built binary
- `next build --webpack` on the same app still fails with the expected error (no regression)
- Added unit tests in `packages/next/src/server/config.test.ts` covering all three cases

<!-- NEXT_JS_LLM_PR -->