### PR TITLE
[turbopack] Rename `rscEndpoint` to `rscHmrEndpoint`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1061,10 +1061,10 @@ pub fn app_entry_point_to_route(
                         }
                         .resolved_cell(),
                     ),
-                    rsc_endpoint: ResolvedVc::upcast(
+                    rsc_hmr_endpoint: ResolvedVc::upcast(
                         AppEndpoint {
                             ty: AppEndpointType::Page {
-                                ty: AppPageEndpointType::Rsc,
+                                ty: AppPageEndpointType::RscHmr,
                                 loader_tree,
                             },
                             app_project,
@@ -1109,7 +1109,7 @@ pub fn app_entry_point_to_route(
 #[derive(Copy, Clone, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue, Encode, Decode)]
 enum AppPageEndpointType {
     Html,
-    Rsc,
+    RscHmr,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue, Encode, Decode)]
@@ -2048,10 +2048,10 @@ impl Endpoint for AppEndpoint {
                 tracing::info_span!("app endpoint HTML", name = page_name)
             }
             AppEndpointType::Page {
-                ty: AppPageEndpointType::Rsc,
+                ty: AppPageEndpointType::RscHmr,
                 ..
             } => {
-                tracing::info_span!("app endpoint RSC", name = page_name)
+                tracing::info_span!("app endpoint RSC HMR", name = page_name)
             }
             AppEndpointType::Route { .. } => {
                 tracing::info_span!("app endpoint route", name = page_name)

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -93,9 +93,9 @@ fn pick_route(entrypoints: OperationVc<Entrypoints>, key: RcStr, route: &Route) 
                         entrypoints,
                         EndpointSelector::RouteAppPageHtml(key.clone(), i),
                     ),
-                    rsc_endpoint: pick_endpoint(
+                    rsc_hmr_endpoint: pick_endpoint(
                         entrypoints,
-                        EndpointSelector::RouteAppPageRsc(key.clone(), i),
+                        EndpointSelector::RouteAppPageRscHmr(key.clone(), i),
                     ),
                 })
                 .collect(),
@@ -117,7 +117,7 @@ enum EndpointSelector {
     RoutePageData(RcStr),
     RoutePageApi(RcStr),
     RouteAppPageHtml(RcStr, usize),
-    RouteAppPageRsc(RcStr, usize),
+    RouteAppPageRscHmr(RcStr, usize),
     RouteAppRoute(RcStr),
     InstrumentationNodeJs,
     InstrumentationEdge,
@@ -176,9 +176,9 @@ async fn pick_endpoint(
                 None
             }
         }
-        EndpointSelector::RouteAppPageRsc(name, i) => {
+        EndpointSelector::RouteAppPageRscHmr(name, i) => {
             if let Some(Route::AppPage(pages)) = endpoints.routes.get(&name) {
-                pages.get(i).as_ref().map(|p| p.rsc_endpoint)
+                pages.get(i).as_ref().map(|p| p.rsc_hmr_endpoint)
             } else {
                 None
             }
@@ -230,5 +230,5 @@ pub enum RouteOperation {
 pub struct AppPageRouteOperation {
     pub original_name: RcStr,
     pub html_endpoint: OperationVc<OptionEndpoint>,
-    pub rsc_endpoint: OperationVc<OptionEndpoint>,
+    pub rsc_hmr_endpoint: OperationVc<OptionEndpoint>,
 }

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -21,7 +21,7 @@ use crate::{operation::OptionEndpoint, paths::AssetPath, project::Project};
 pub struct AppPageRoute {
     pub original_name: RcStr,
     pub html_endpoint: ResolvedVc<Box<dyn Endpoint>>,
-    pub rsc_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    pub rsc_hmr_endpoint: ResolvedVc<Box<dyn Endpoint>>,
 }
 
 #[turbo_tasks::value(shared)]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -800,7 +800,7 @@ pub struct AppPageNapiRoute {
     pub original_name: Option<RcStr>,
 
     pub html_endpoint: Option<External<ExternalEndpoint>>,
-    pub rsc_endpoint: Option<External<ExternalEndpoint>>,
+    pub rsc_hmr_endpoint: Option<External<ExternalEndpoint>>,
 }
 
 #[napi(object)]
@@ -819,7 +819,7 @@ pub struct NapiRoute {
     // Different representations of the endpoint
     pub endpoint: Option<External<ExternalEndpoint>>,
     pub html_endpoint: Option<External<ExternalEndpoint>>,
-    pub rsc_endpoint: Option<External<ExternalEndpoint>>,
+    pub rsc_hmr_endpoint: Option<External<ExternalEndpoint>>,
     pub data_endpoint: Option<External<ExternalEndpoint>>,
 }
 
@@ -861,7 +861,7 @@ impl NapiRoute {
                         .map(|page_route| AppPageNapiRoute {
                             original_name: Some(page_route.original_name),
                             html_endpoint: convert_endpoint(page_route.html_endpoint),
-                            rsc_endpoint: convert_endpoint(page_route.rsc_endpoint),
+                            rsc_hmr_endpoint: convert_endpoint(page_route.rsc_hmr_endpoint),
                         })
                         .collect(),
                 ),

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -364,7 +364,7 @@ export interface AppPageNapiRoute {
   /** The relative path from project_path to the route file */
   originalName?: RcStr
   htmlEndpoint?: ExternalObject<ExternalEndpoint>
-  rscEndpoint?: ExternalObject<ExternalEndpoint>
+  rscHmrEndpoint?: ExternalObject<ExternalEndpoint>
 }
 export interface NapiRoute {
   /** The router path */
@@ -376,7 +376,7 @@ export interface NapiRoute {
   pages?: Array<AppPageNapiRoute>
   endpoint?: ExternalObject<ExternalEndpoint>
   htmlEndpoint?: ExternalObject<ExternalEndpoint>
-  rscEndpoint?: ExternalObject<ExternalEndpoint>
+  rscHmrEndpoint?: ExternalObject<ExternalEndpoint>
   dataEndpoint?: ExternalObject<ExternalEndpoint>
 }
 export interface NapiMiddleware {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -550,7 +550,7 @@ function bindingToApi(
         pages: {
           originalName: string
           htmlEndpoint: NapiEndpoint
-          rscEndpoint: NapiEndpoint
+          rscHmrEndpoint: NapiEndpoint
         }[]
       }
     | {
@@ -1210,7 +1210,7 @@ function bindingToApi(
             pages: nativeRoute.pages.map((page) => ({
               originalName: page.originalName,
               htmlEndpoint: new EndpointImpl(page.htmlEndpoint),
-              rscEndpoint: new EndpointImpl(page.rscEndpoint),
+              rscHmrEndpoint: new EndpointImpl(page.rscHmrEndpoint),
             })),
           }
           break

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -368,7 +368,7 @@ export type Route =
       pages: {
         originalName: string
         htmlEndpoint: Endpoint
-        rscEndpoint: Endpoint
+        rscHmrEndpoint: Endpoint
       }[]
     }
   | {
@@ -514,7 +514,7 @@ export type AppRoute =
   | {
       type: 'app-page'
       htmlEndpoint: Endpoint
-      rscEndpoint: Endpoint
+      rscHmrEndpoint: Endpoint
     }
   | {
       type: 'app-route'

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -355,7 +355,7 @@ export async function handleRouteType({
         hooks?.subscribeToChanges(
           key,
           /** includeIssues=*/ true,
-          route.rscEndpoint,
+          route.rscHmrEndpoint,
           (change, hash) => {
             if (change.issues.some((issue) => issue.severity === 'error')) {
               // Ignore any updates that has errors

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -500,7 +500,7 @@ describe('next.rs api', () => {
           expect(result.config).toEqual(config)
           expect(normalizeIssues(result.issues)).toMatchSnapshot('issues')
 
-          const result2 = await route.pages[0].rscEndpoint.writeToDisk()
+          const result2 = await route.pages[0].rscHmrEndpoint.writeToDisk()
           expect(result2.type).toBe(runtime)
           expect(result2.config).toEqual(config)
           expect(normalizeIssues(result2.issues)).toMatchSnapshot('rsc issues')
@@ -610,7 +610,7 @@ describe('next.rs api', () => {
           case 'app-page': {
             await route.pages[0].htmlEndpoint.writeToDisk()
             serverSideSubscription =
-              await route.pages[0].rscEndpoint.serverChanged(false)
+              await route.pages[0].rscHmrEndpoint.serverChanged(false)
             break
           }
           default: {


### PR DESCRIPTION
I'm introducing a new endpoint that doesn't compile SSR when doing a page navigation, I'd like to call it a `rscEndpoint` but currently this name is taken. `rscEndpoint` appears to be used for detecting changes for HMR so I've renamed it to `rscHmrEndpoint` so I can use that name for the new `rscEndpoint`.