### PR TITLE
Fix/next info experimental analyze with graph css chunking

### DIFF
--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -43,6 +43,9 @@ export default async function analyze({
   port = 4000,
 }: AnalyzeOptions): Promise<void> {
   try {
+    // analyze is Turbopack-only. Mirror what parseBundlerArgs does for build/dev
+    // so every process.env.TURBOPACK consumer in this run agrees with the bundler choice.
+    process.env.TURBOPACK ??= '1'
     const config: NextConfigComplete = await loadConfig(PHASE_ANALYZE, dir, {
       silent: false,
       reactProductionProfiling,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -1,4 +1,4 @@
-import { PHASE_PRODUCTION_BUILD } from '../api/constants'
+import { PHASE_INFO, PHASE_PRODUCTION_BUILD } from '../api/constants'
 
 describe('loadConfig', () => {
   let loadConfig: typeof import('./config').default
@@ -231,6 +231,15 @@ describe('loadConfig', () => {
       expect(result.cacheHandlers?.['abc']).toBeDefined()
       expect(result.cacheHandlers?.['valid-handler']).toBeDefined()
       expect(result.cacheHandlers?.['abc-def']).toBeDefined()
+    })
+  })
+
+  describe('experimental.cssChunking bundler validation', () => {
+    it('should not validate `cssChunking` during `next info`', async () => {
+      const result = await loadConfig(PHASE_INFO, __dirname, {
+        customConfig: { experimental: { cssChunking: 'graph' } },
+      })
+      expect(result.experimental.cssChunking).toBe('graph')
     })
   })
 })

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -10,6 +10,7 @@ import {
   PHASE_EXPORT,
   PHASE_PRODUCTION_BUILD,
   PHASE_PRODUCTION_SERVER,
+  PHASE_INFO,
   type PHASE_TYPE,
 } from '../shared/lib/constants'
 import {
@@ -489,7 +490,7 @@ function assignDefaultsAndValidate(
   // Turbopack-only; strict mode and `false` (single-chunk-per-module) are webpack-only.
   // Only validate during build/dev — `next start` doesn't pick a bundler and would otherwise
   // see `process.env.TURBOPACK` unset and reject a valid `cssChunking: "graph"` config.
-  if (phase !== PHASE_PRODUCTION_SERVER) {
+  if (phase !== PHASE_PRODUCTION_SERVER && phase !== PHASE_INFO) {
     const cssChunkingValue = result.experimental.cssChunking
     const cssChunkingMode = resolveCssChunkingMode(cssChunkingValue)
     if (cssChunkingMode === 'graph' && !process.env.TURBOPACK) {


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/95530

- Make sure analyze sets `process.env.TURBOPACK ??= '1'`
- Gate the validation - do not run it for `next info` phase

To be honest, I am not sure about the unit test, I had also modified `test/e2e/next-analyze/next.config.js` to include the `cssChunking` graph option, but didn't feel like it was the right direction. 

Just minimally added a unit test for the regression.