### PR TITLE
Run instrumentation for Node.js Middleware without Adapter

### DIFF
--- a/packages/next/src/build/templates/middleware.ts
+++ b/packages/next/src/build/templates/middleware.ts
@@ -74,7 +74,27 @@ function errorHandledHandler(fn: AdapterOptions['handler']) {
   }
 }
 
-const internalHandler: EdgeHandler = (opts) => {
+const internalHandler: EdgeHandler = async (opts) => {
+  if (process.env.NEXT_RUNTIME !== 'edge') {
+    // This mirrors what `RouteModule#prepare` does for routes
+    // edge runtime handles loading instrumentation at the edge adapter level
+    const { join, relative } =
+      require('node:path') as typeof import('node:path')
+    const { ensureInstrumentationRegistered } =
+      require('../../server/lib/router-utils/instrumentation-globals.external') as typeof import('../../server/lib/router-utils/instrumentation-globals.external')
+    const absoluteProjectDir = join(
+      /* turbopackIgnore: true */
+      process.cwd(),
+      opts.request.requestMeta?.relativeProjectDir || ''
+    )
+    const absoluteDistDir = opts.request.requestMeta?.distDir
+    const distDir = absoluteDistDir
+      ? relative(absoluteProjectDir, absoluteDistDir)
+      : '.next'
+
+    await ensureInstrumentationRegistered(absoluteProjectDir, distDir)
+  }
+
   return adapter({
     ...opts,
     IncrementalCache,
@@ -92,26 +112,6 @@ export async function handler(
     requestMeta?: RequestMeta
   }
 ): Promise<Response> {
-  if (process.env.NEXT_RUNTIME !== 'edge') {
-    // This mirrors what `RouteModule#prepare` does for routes
-    // edge runtime handles loading instrumentation at the edge adapter level
-    const { join, relative } =
-      require('node:path') as typeof import('node:path')
-    const { ensureInstrumentationRegistered } =
-      require('../../server/lib/router-utils/instrumentation-globals.external') as typeof import('../../server/lib/router-utils/instrumentation-globals.external')
-    const absoluteProjectDir = join(
-      /* turbopackIgnore: true */
-      process.cwd(),
-      ctx.requestMeta?.relativeProjectDir || ''
-    )
-    const absoluteDistDir = ctx.requestMeta?.distDir
-    const distDir = absoluteDistDir
-      ? relative(absoluteProjectDir, absoluteDistDir)
-      : '.next'
-
-    await ensureInstrumentationRegistered(absoluteProjectDir, distDir)
-  }
-
   const result = await internalHandler({
     request: {
       url: request.url,
@@ -148,5 +148,5 @@ export async function handler(
   return result.response
 }
 
-// backwards compat
+// backwards compat for non-adapter setups
 export default internalHandler

--- a/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
+++ b/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import path from 'path'
 
 const describeCase = (
@@ -17,6 +17,7 @@ const describeCase = (
     callback(context)
   })
 }
+
 describe('Instrumentation Hook', () => {
   describeCase('with-esm-import', ({ next }) => {
     it('with-esm-import should run the instrumentation hook', async () => {
@@ -103,6 +104,7 @@ describe('Instrumentation Hook', () => {
       const page = await next.render('/instrumentation')
       expect(page).toContain('Hello')
     })
+
     if (isNextDev) {
       // TODO: Implement handling for changing the instrument file.
       it.skip('should reload the server when the instrumentation hook changes', async () => {
@@ -111,14 +113,15 @@ describe('Instrumentation Hook', () => {
           './instrumentation.js',
           `export function register() {console.log('toast')}`
         )
-        await check(() => next.cliOutput, /toast/)
+        await retry(() => expect(next.cliOutput).toContain('toast'))
         await next.renameFile(
           './instrumentation.js',
           './instrumentation.js.bak'
         )
-        await check(
-          () => next.cliOutput,
-          /The instrumentation file has been removed/
+        await retry(() =>
+          expect(next.cliOutput).toContain(
+            'The instrumentation file has been removed'
+          )
         )
         await next.patchFile(
           './instrumentation.js.bak',
@@ -128,8 +131,10 @@ describe('Instrumentation Hook', () => {
           './instrumentation.js.bak',
           './instrumentation.js'
         )
-        await check(() => next.cliOutput, /The instrumentation file was added/)
-        await check(() => next.cliOutput, /bread/)
+        await retry(() => {
+          expect(next.cliOutput).toContain('The instrumentation file was added')
+          expect(next.cliOutput).toContain('bread')
+        })
       })
     }
   })


### PR DESCRIPTION
Fixup for #95357

`.handler()` is used by adapters
but `.default()` (=`internalHandler`) is the legacy entrypoint and used by the non-adapter setup

Also needs https://github.com/vercel/vercel/pull/16944