### PR TITLE
[ci] Migrate webpack tests back to arm runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -119,18 +119,6 @@ jobs:
       uploadNativeArtifact: true
     secrets: inherit
 
-  build-native-x64:
-    name: build-native-x64
-    uses: ./.github/workflows/build_reusable.yml
-    needs: ['changes']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
-    with:
-      skipInstallBuild: 'yes'
-      stepName: 'build-native-x64'
-      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
-      uploadNativeArtifact: true
-    secrets: inherit
-
   build-native-windows:
     name: build-native-windows
     uses: ./.github/workflows/build_reusable.yml
@@ -802,7 +790,7 @@ jobs:
       [
         'optimize-ci',
         'changes',
-        'build-native-x64',
+        'build-native',
         'build-next',
         'fetch-test-timings',
       ]
@@ -833,7 +821,7 @@ jobs:
           --type development
       testTimingsArtifact: 'test-timings'
       stepName: 'test-dev-react-${{ matrix.react }}-${{ matrix.group }}'
-      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
+      runs_on_labels: '["ubuntu-latest-16-core-arm-oss"]'
     secrets: inherit
 
   test-dev-windows:
@@ -915,7 +903,7 @@ jobs:
       [
         'optimize-ci',
         'changes',
-        'build-native-x64',
+        'build-native',
         'build-next',
         'fetch-test-timings',
       ]
@@ -942,7 +930,7 @@ jobs:
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} --type production
       testTimingsArtifact: 'test-timings'
       stepName: 'test-prod-react-${{ matrix.react }}-${{ matrix.group }}'
-      runs_on_labels: '["ubuntu-latest-16-core-oss"]'
+      runs_on_labels: '["ubuntu-latest-16-core-arm-oss"]'
     secrets: inherit
 
   test-firefox-safari:
@@ -1065,7 +1053,6 @@ jobs:
       - optimize-ci
       - changes
       - build-native
-      - build-native-x64
       - build-next
       - fetch-test-timings
       - lint


### PR DESCRIPTION
I partially rolled back CI jobs because we ran out of runners. IT increased the concurrency from 50 to 100, so I've been slowly migrating back to arm runners while watching that we don't end up with long queue times again.

Thread: https://vercel.slack.com/archives/C0B0LKK5QD7/p1782838752523649

Average job queue time in the last day has been 59 seconds:
https://github.com/vercel/next.js/actions/metrics/performance?dateRangeType=DATE_RANGE_TYPE_CUSTOM&range=1783296000000-1783296000000