### PR TITLE
test: Fix immutable static asset deployment tests

### DIFF
--- a/test/e2e/app-dir/next-image/next-image.test.ts
+++ b/test/e2e/app-dir/next-image/next-image.test.ts
@@ -1,6 +1,6 @@
 import { isNextDeploy, nextTestSetup } from 'e2e-utils'
 import fs from 'fs-extra'
-import { join } from 'path'
+import path from 'path'
 
 describe('app dir - next-image', () => {
   const { next } = nextTestSetup({
@@ -10,7 +10,7 @@ describe('app dir - next-image', () => {
   describe('ssr content', () => {
     if (!isNextDeploy) {
       it('should handle HEAD requests for uncached images', async () => {
-        const imagesDir = join(next.testDir, '.next/cache/images')
+        const imagesDir = path.join(next.testDir, '.next/cache/images')
         await fs.remove(imagesDir).catch(() => {})
 
         const $ = await next.render$('/')

--- a/test/e2e/app-dir/worker/worker.test.ts
+++ b/test/e2e/app-dir/worker/worker.test.ts
@@ -12,7 +12,7 @@ describe('app dir - workers', () => {
   })
 
   function beforePageLoad(page: Page) {
-    // TODO fix deployment id for webpack
+    // TODO Webpack doesn't pass the ?dpl query param for the worker chunk request.
     if (isTurbopack && (isNextDeploy || isNextStart)) {
       page.on('request', (request) => {
         const url = request.url()

--- a/test/e2e/app-dir/worker/worker.test.ts
+++ b/test/e2e/app-dir/worker/worker.test.ts
@@ -18,7 +18,9 @@ describe('app dir - workers', () => {
         const url = request.url()
         if (url.includes('/_next/')) {
           let parsed = new URL(url, next.url)
-          expect(parsed.searchParams.get('dpl')).toBe(next.assetToken)
+          expect(parsed.searchParams.get('dpl') ?? undefined).toBe(
+            next.assetToken
+          )
         }
       })
     }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -310,7 +310,7 @@ export class NextInstance {
                     ? // since we can't get the build id as a build artifact,
                       // add it in build logs
                       {
-                        'post-build': `node -e 'console.log("BUILD" + "_ID: " + fs.readFileSync("${this.distDir}/BUILD_ID") + "\\nDEPLOYMENT" + "_ID: " + process.env.NEXT_DEPLOYMENT_ID + "\\nNEXT_SUPPORTS_IMMUTABLE" + "_ASSETS: " + (process.env.NEXT_SUPPORTS_IMMUTABLE_ASSETS ? 1 : 0))'`,
+                        'post-build': `node -e 'console.log("BUILD" + "_ID: " + fs.readFileSync("${this.distDir}/BUILD_ID") + "\\nDEPLOYMENT" + "_ID: " + process.env.NEXT_DEPLOYMENT_ID + "\\nNEXT_SUPPORTS_IMMUTABLE" + "_ASSETS: " + (process.env.VERCEL_IMMUTABLE_STATIC_FILES_ENABLED ? 1 : 0))'`,
                       }
                     : {}),
                   ...pkgScripts,


### PR DESCRIPTION
1. The env var ended up having a different name than I foresaw months ago. Now `next.assetToken` is correctly `undefined` if the deployment used immutable static assets.
2. `expect(searchParams.get(...)).toBe(undefined)` was failing because `.get()` returns null for unknown keys

Failures:
- https://github.com/vercel/next.js/actions/runs/28831699621/job/85515363446
- https://github.com/vercel/next.js/actions/runs/28831699621/job/85515363310