### PR TITLE
fix(eslint-plugin-next): respect pageExtensions in no-html-link-for-pages fixes 53473

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -60,6 +60,19 @@ export default defineRule({
               type: 'string',
             },
           },
+          {
+            type: 'object',
+            properties: {
+              pageExtensions: {
+                type: 'array',
+                uniqueItems: true,
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+            additionalProperties: false,
+          },
         ],
       },
     ],
@@ -69,8 +82,11 @@ export default defineRule({
    * Creates an ESLint rule listener.
    */
   create(context) {
-    const ruleOptions: (string | string[])[] = context.options
-    const [customPagesDirectory] = ruleOptions
+    const ruleOptions = context.options
+    const [customPagesDirectory, ruleSettings = {}] = ruleOptions
+    const pageExtensions = Array.isArray((ruleSettings as any)?.pageExtensions)
+      ? (ruleSettings as { pageExtensions: string[] }).pageExtensions
+      : []
 
     const rootDirs = getRootDirs(context)
 
@@ -107,8 +123,12 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, pageExtensions)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,63 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+function getPageExtensionRegex(pageExtensions: string[]) {
+  const supportedExtensions = [...pageExtensions]
+    .map((extension) => extension.replace(/^\./, ''))
+    .sort((a, b) => b.length - a.length)
+    .map((extension) => extension.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')
+
+  return new RegExp(`\\.(${supportedExtensions})$`)
+}
+
+function getPageRouteName(pathname: string, pageExtensions: string[]) {
+  const extensionMatch = pathname.match(getPageExtensionRegex(pageExtensions))
+  if (!extensionMatch) {
+    return undefined
+  }
+
+  const extension = extensionMatch[1]
+  return pathname.slice(0, -`.${extension}`.length)
+}
+
+const defaultPageExtensions = ['js', 'jsx', 'ts', 'tsx']
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
+  const validExtensions = pageExtensions.length
+    ? pageExtensions
+    : defaultPageExtensions
+
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    const routeName = getPageRouteName(dirent.name, validExtensions)
+
+    if (routeName) {
+      if (routeName === 'index') {
+        res.push(urlprefix)
+      } else {
+        res.push(`${urlprefix}${routeName}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +71,36 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
+  const validExtensions = pageExtensions.length
+    ? pageExtensions
+    : defaultPageExtensions
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    const routeName = getPageRouteName(dirent.name, validExtensions)
+    if (routeName) {
+      if (/^page$/.test(routeName)) {
+        res.push(`${urlprefix}${routeName.replace(/^page$/, '')}`)
+      } else if (!/^layout$/.test(routeName)) {
+        res.push(`${urlprefix}${routeName}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForAppDir(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +183,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = defaultPageExtensions
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +206,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = defaultPageExtensions
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -52,6 +52,18 @@ const linterConfigWithCustomDirectory: any = {
     ],
   },
 }
+const linterConfigWithCustomDirectoryAndPageExtensions: any = {
+  ...linterConfig,
+  rules: {
+    'no-html-link-for-pages': [
+      2,
+      path.join(withCustomPagesDir, 'custom-pages'),
+      {
+        pageExtensions: ['page.tsx', 'ts', 'tsx', 'js', 'jsx'],
+      },
+    ],
+  },
+}
 const linterConfigWithMultipleDirectories = {
   ...linterConfig,
   rules: {
@@ -307,6 +319,18 @@ describe('no-html-link-for-pages', function () {
     )
     assert.deepEqual(report, [])
   })
+  it('invalid static route with custom pageExtensions', function () {
+    const [report] = linters.withCustomPages.verify(
+      invalidStaticCode,
+      linterConfigWithCustomDirectoryAndPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
   it('valid anchor element', function () {
     const report = linters.withCustomPages.verify(
       validAnchorCode,
@@ -443,6 +467,32 @@ describe('no-html-link-for-pages', function () {
     assert.equal(
       report.message,
       'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid about route with custom pageExtensions', function () {
+    const code = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/about'>About</a>
+        <h1>Hello title</h1>
+      </div>
+    )
+  }
+}
+`
+    const [report] = linters.withCustomPages.verify(
+      code,
+      linterConfigWithCustomDirectoryAndPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/about/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
   it('invalid dynamic route with appDir', function () {

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/about.page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <h1>About</h1>
+}

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/index.page.tsx
@@ -1,0 +1,3 @@
+export default function RootPage() {
+  return <h1>Root</h1>
+}


### PR DESCRIPTION
## Why
The ESLint rule `@next/next/no-html-link-for-pages` misses routes when projects use custom `pageExtensions`, so it can fail to flag `<a href="...">` for pages like `index.page.tsx`.

## What changed
- Added optional rule option `{ pageExtensions }` in `no-html-link-for-pages`.
- Threaded `pageExtensions` through URL discovery for both `pages/` and `app/` directory parsing.
- Updated filename extension matching to use configured extensions while preserving default behavior.
- Added regression coverage for `.page.tsx` page extension and additional fixtures.

## Validation
- `pnpm install`
- `pnpm run -s build --filter next` (to ensure local workspace artifacts are available)
- `pnpm --filter @next/eslint-plugin-next run build` (to validate plugin TS compilation)
- `pnpm jest test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts` (passes locally)

## Issue
Fixes #53473
