### PR TITLE
Fix cache components dynamic route 404 status

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -2057,9 +2057,9 @@ export async function handler(
       }
 
       // Perform the render again, but this time, provide the postponed state.
-      // We don't await because we want the result to start streaming now, and
-      // we've already chained the transformer's readable to the render result.
-      doRender({
+      // Await the resumed render before sending the response so errors such as
+      // notFound() can update the HTTP status before headers are committed.
+      const resumeResult = await doRender({
         span,
         postponed: cachedData.postponed,
         // This is a resume render, not a fallback render. Fallback params
@@ -2067,27 +2067,31 @@ export async function handler(
         fallbackRouteParams: null,
         forceStaticRender: false,
       })
-        .then(async (result) => {
-          if (!result) {
-            throw new Error('Invariant: expected a result to be returned')
-          }
 
-          if (result.value?.kind !== CachedRouteKind.APP_PAGE) {
-            throw new Error(
-              `Invariant: expected a page response, got ${result.value?.kind}`
-            )
-          }
+      if (!resumeResult) {
+        throw new Error('Invariant: expected a result to be returned')
+      }
 
-          // Pipe the resume result to the transformer.
-          await result.value.html.pipeTo(transformer.writable)
+      if (resumeResult.value?.kind !== CachedRouteKind.APP_PAGE) {
+        throw new Error(
+          `Invariant: expected a page response, got ${resumeResult.value?.kind}`
+        )
+      }
+
+      const resumeData = resumeResult.value
+      if (resumeData.status) {
+        res.statusCode = resumeData.status
+      }
+
+      // Pipe the resume result to the transformer after the status has been
+      // applied. The actual body can still stream to the client.
+      resumeData.html.pipeTo(transformer.writable).catch((err) => {
+        // An error occurred during piping, abort the transformer's writer so we
+        // can terminate the stream.
+        transformer.writable.abort(err).catch((e) => {
+          console.error("couldn't abort transformer", e)
         })
-        .catch((err) => {
-          // An error occurred during piping or preparing the render, abort
-          // the transformers writer so we can terminate the stream.
-          transformer.writable.abort(err).catch((e) => {
-            console.error("couldn't abort transformer", e)
-          })
-        })
+      })
 
       return sendRenderResult({
         req,

--- a/test/e2e/app-dir/cache-components-dynamic-routes/app/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-routes/app/[[...slug]]/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from 'next/navigation'
+
+import { existingSlugs, isKnownSlug, normalizeSlug } from '../../lib/slugs'
+
+export const instant = false
+
+export function generateStaticParams() {
+  return existingSlugs.map((slug) => ({
+    slug: slug.split('/').filter(Boolean),
+  }))
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>
+}) {
+  const { slug: segments } = await params
+  const slug = normalizeSlug(segments)
+
+  if (!isKnownSlug(slug)) {
+    notFound()
+  }
+
+  return <h1>Hello, World!</h1>
+}

--- a/test/e2e/app-dir/cache-components-dynamic-routes/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-routes/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-dynamic-routes/cache-components-dynamic-routes.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-routes/cache-components-dynamic-routes.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('cacheComponents dynamic routes', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('returns 404 for invalid dynamic routes on the first request', async () => {
+    const first = await next.fetch('/this-page-does-not-exist', {
+      redirect: 'manual',
+    })
+    expect(first.status).toBe(404)
+
+    const second = await next.fetch('/this-page-does-not-exist', {
+      redirect: 'manual',
+    })
+    expect(second.status).toBe(404)
+  })
+
+  it('returns 200 for dynamic routes that are valid but not prerendered', async () => {
+    const res = await next.fetch('/my-new-page')
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('Hello, World!')
+  })
+})

--- a/test/e2e/app-dir/cache-components-dynamic-routes/lib/slugs.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-routes/lib/slugs.ts
@@ -1,0 +1,11 @@
+export const existingSlugs = ['/', '/about', '/contact']
+
+export const newSlugs = ['/my-new-page']
+
+export function normalizeSlug(slug?: string[]) {
+  return '/' + (slug?.join('/') ?? '')
+}
+
+export function isKnownSlug(slug: string) {
+  return existingSlugs.includes(slug) || newSlugs.includes(slug)
+}

--- a/test/e2e/app-dir/cache-components-dynamic-routes/next.config.js
+++ b/test/e2e/app-dir/cache-components-dynamic-routes/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What?

Fixes `cacheComponents` dynamic routes returning a `200` status for invalid routes on the first production request.

### Why?

When a postponed HTML response is resumed, `notFound()` can be discovered only during the resume render. The handler previously sent the fallback shell before that resume result was available, so headers were committed as `200`.

### How?

Await the resumed render before sending the HTML response, apply the resumed status, then continue streaming the resumed body through the existing transformer.

Added an e2e regression for an optional catch-all dynamic route using `cacheComponents`, `generateStaticParams`, and `instant = false`.

Fixes #95380

<!-- NEXT_JS_LLM_PR -->