### PR TITLE
fix(eslint): support custom pageExtensions in no-html-link-for-pages

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -2,6 +2,10 @@ import { defineRule } from '../utils/define-rule'
 import * as path from 'path'
 import * as fs from 'fs'
 import { getRootDirs } from '../utils/get-root-dirs'
+import {
+  getPageExtensions,
+  buildPageExtensionRegex,
+} from '../utils/page-extensions'
 
 import {
   getUrlFromPagesDirectories,
@@ -24,7 +28,10 @@ const fsExistsSyncCache = {}
 const memoize = <T = any>(fn: (...args: any[]) => T) => {
   const cache = {}
   return (...args: any[]): T => {
-    const key = JSON.stringify(args)
+    // Stringify args, but handle RegExp specially by converting to string
+    const key = JSON.stringify(
+      args.map((arg) => (arg instanceof RegExp ? arg.toString() : arg))
+    )
     if (cache[key] === undefined) {
       cache[key] = fn(...args)
     }
@@ -74,6 +81,10 @@ export default defineRule({
 
     const rootDirs = getRootDirs(context)
 
+    // Get page extensions from config or use defaults
+    const pageExtensions = getPageExtensions(context)
+    const pageExtensionRegex = buildPageExtensionRegex(pageExtensions)
+
     const pagesDirs = (
       customPagesDirectory
         ? [customPagesDirectory]
@@ -107,8 +118,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensionRegex
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensionRegex
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/page-extensions.ts
+++ b/packages/eslint-plugin-next/src/utils/page-extensions.ts
@@ -1,0 +1,109 @@
+import * as path from 'path'
+import * as fs from 'fs'
+import type { Rule } from 'eslint'
+import { getRootDirs } from './get-root-dirs'
+
+/**
+ * Default Next.js page extensions
+ */
+const DEFAULT_PAGE_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js']
+
+/**
+ * Cache for page extensions to avoid repeated file reads
+ */
+const pageExtensionsCache: Map<string, string[]> = new Map()
+
+/**
+ * Gets page extensions from Next.js config or returns defaults
+ */
+export function getPageExtensions(context: Rule.RuleContext): string[] {
+  // Check if page extensions are provided in ESLint settings
+  const nextSettings: { pageExtensions?: string[] } =
+    context.settings.next || {}
+
+  if (
+    nextSettings.pageExtensions &&
+    Array.isArray(nextSettings.pageExtensions)
+  ) {
+    return nextSettings.pageExtensions
+  }
+
+  // Try to read from next.config files
+  const rootDirs = getRootDirs(context)
+
+  for (const rootDir of rootDirs) {
+    const cacheKey = rootDir
+    if (pageExtensionsCache.has(cacheKey)) {
+      return pageExtensionsCache.get(cacheKey)!
+    }
+
+    const extensions = tryReadNextConfig(rootDir)
+    if (extensions) {
+      pageExtensionsCache.set(cacheKey, extensions)
+      return extensions
+    }
+  }
+
+  return DEFAULT_PAGE_EXTENSIONS
+}
+
+/**
+ * Attempts to read pageExtensions from next.config.* files
+ */
+function tryReadNextConfig(rootDir: string): string[] | null {
+  const configFiles = [
+    'next.config.js',
+    'next.config.mjs',
+    'next.config.ts',
+    'next.config.mts',
+  ]
+
+  for (const configFile of configFiles) {
+    const configPath = path.join(rootDir, configFile)
+
+    if (!fs.existsSync(configPath)) {
+      continue
+    }
+
+    try {
+      const content = fs.readFileSync(configPath, 'utf8')
+
+      // Simple regex-based extraction — not perfect but works for most cases
+      // Looks for: pageExtensions: ['tsx', 'ts', ...] or pageExtensions:['tsx','ts',...]
+      const match = content.match(
+        /pageExtensions\s*:\s*\[\s*([^\]]+)\s*\]/
+      )
+
+      if (match) {
+        // Extract quoted strings from the array
+        const extensionsStr = match[1]
+        const extensions = extensionsStr
+          .match(/['"`]([^'"`]+)['"`]/g)
+          ?.map((ext) => ext.replace(/['"`]/g, ''))
+          .filter(Boolean)
+
+        if (extensions && extensions.length > 0) {
+          return extensions
+        }
+      }
+    } catch (error) {
+      // If we can't read or parse the config, just continue
+      continue
+    }
+  }
+
+  return null
+}
+
+/**
+ * Builds a regex pattern from page extensions
+ * Example: ['tsx', 'ts', 'jsx', 'js'] => /\.(tsx|ts|jsx|js)$/
+ */
+export function buildPageExtensionRegex(extensions: string[]): RegExp {
+  // Escape special regex characters in extensions
+  const escapedExtensions = extensions.map((ext) =>
+    ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  )
+  return new RegExp(`\\.(${escapedExtensions.join('|')})$`)
+}
+

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -8,25 +8,34 @@ const fsReadDirSyncCache = {}
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensionRegex: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (pageExtensionRegex.test(dirent.name)) {
+      // Check if it's an index file
+      const indexMatch = dirent.name.match(/^index\.(.+)$/)
+      if (indexMatch) {
+        res.push(`${urlprefix}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      // Remove extension from filename for URL
+      res.push(`${urlprefix}${dirent.name.replace(pageExtensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensionRegex
+          )
+        )
       }
     }
   })
@@ -36,24 +45,38 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensionRegex: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (pageExtensionRegex.test(dirent.name)) {
+      // Check if it's a page file
+      const pageMatch = dirent.name.match(/^page\.(.+)$/)
+      if (pageMatch) {
+        res.push(`${urlprefix}`)
+      } else {
+        // Check if it's not a layout file
+        const layoutMatch = dirent.name.match(/^layout\.(.+)$/)
+        if (!layoutMatch) {
+          res.push(`${urlprefix}${dirent.name.replace(pageExtensionRegex, '')}`)
+        }
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForAppDir(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensionRegex
+          )
+        )
       }
     }
   })
@@ -136,13 +159,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensionRegex: RegExp
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensionRegex)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +182,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensionRegex: RegExp
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensionRegex)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,10 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withCustomPageExtensions = path.join(
+  __dirname,
+  'with-custom-page-extensions'
+)
 
 const linters = {
   withoutPages: new Linter({
@@ -26,6 +30,10 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withCustomPageExtensions: new Linter({
+    cwd: withCustomPageExtensions,
     configType: 'eslintrc',
   }),
 }
@@ -494,5 +502,79 @@ describe('no-html-link-for-pages', function () {
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
+  })
+
+  // Tests for custom pageExtensions
+  describe('with custom pageExtensions', function () {
+    const invalidCodeForCustomExtensions = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/'>Homepage</a>
+        <a href='/about'>About</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
+    const invalidDynamicCodeForCustomExtensions = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/blog/my-post'>Blog Post</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
+    it('should detect pages with custom extensions from next.config.js', function () {
+      const reports = linters.withCustomPageExtensions.verify(
+        invalidCodeForCustomExtensions,
+        linterConfig,
+        { filename: 'foo.js' }
+      )
+      // Should detect both / and /about as invalid
+      assert.equal(reports.length, 2, 'Expected 2 lint errors')
+      assert.equal(
+        reports[0].message,
+        'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+      )
+      assert.equal(
+        reports[1].message,
+        'Do not use an `<a>` element to navigate to `/about/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+      )
+    })
+
+    it('should detect dynamic routes with custom extensions', function () {
+      const [report] = linters.withCustomPageExtensions.verify(
+        invalidDynamicCodeForCustomExtensions,
+        linterConfig,
+        { filename: 'foo.js' }
+      )
+      assert.notEqual(report, undefined, 'No lint errors found.')
+      assert.equal(
+        report.message,
+        'Do not use an `<a>` element to navigate to `/blog/my-post/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+      )
+    })
+
+    it('should work with valid external links', function () {
+      const report = linters.withCustomPageExtensions.verify(
+        validExternalLinkCode,
+        linterConfig,
+        { filename: 'foo.js' }
+      )
+      assert.deepEqual(report, [])
+    })
   })
 })

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/next.config.js
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+}

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/about.page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <div>About Page</div>
+}

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/blog/[slug].page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/blog/[slug].page.tsx
@@ -1,0 +1,3 @@
+export default function BlogPost() {
+  return <div>Blog Post</div>
+}

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/index.page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home Page</div>
+}


### PR DESCRIPTION
Fixes #53473

The ESLint rule was hardcoded to only recognize .js/.jsx/.ts/.tsx files. Now it dynamically reads pageExtensions from next.config.js or ESLint settings — allowing it to work with custom extensions like .page.tsx.

Changes:
- Created page-extensions.ts utility to read config and build regex
- Updated url.ts to accept dynamic extension patterns
- Modified no-html-link-for-pages rule to use dynamic extensions
- Added tests with custom pageExtensions config
- Maintains backward compatibility with default extensions

Testing:
- Added test directory: with-custom-page-extensions/
- Tests cover: static routes, dynamic routes, external links
- Config parsing handles .js, .mjs, .ts, .mts variants
- Falls back gracefully to defaults if config missing

This fix benefits anyone using custom page naming conventions — a common pattern in large monorepos and structured projects.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
