### PR TITLE
docs: add React performance profiling guide and react-performance-tracks skills

### DIFF
--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -211,25 +211,30 @@ The Suspense view shows the same single late reveal wherever the slow child live
 The problem is that **one boundary wraps several pieces that load at different speeds**, so React can only reveal them together. Give each independently-paced piece its own boundary so each reveals as soon as its own data is ready:
 
 ```tsx filename="app/dashboard/page.tsx"
-<Suspense fallback={<StatsSkeleton />}>
-  <Stats />
-</Suspense>
-<Suspense fallback={<ActivitySkeleton />}>
-  <ActivityFeed teamIds={user.teamIds} />
-</Suspense>
-<Suspense fallback={<WhoIsOnlineSkeleton />}>
-  <WhoIsOnline teamIds={user.teamIds} />
-</Suspense>
+return (
+  <>
+    <Header user={user} teams={teams} notifications={notifications} />
+
+    <Suspense fallback={<StatsSkeleton />}>
+      <Stats />
+    </Suspense>
+    <Suspense fallback={<ActivitySkeleton />}>
+      <ActivityFeed teamIds={user.teamIds} />
+    </Suspense>
+    <Suspense fallback={<WhoIsOnlineSkeleton />}>
+      <WhoIsOnline teamIds={user.teamIds} />
+    </Suspense>
+  </>
+)
 ```
 
 See [Parallel streaming with sibling boundaries](/docs/app/guides/streaming#parallel-streaming-with-sibling-boundaries).
 
 Reload again. The Suspense view now shows three reveal events at different times. The `Stats` and `ActivityFeed` sections paint as soon as their own data is ready, and only the `WhoIsOnline` region keeps its fallback until it resolves.
 
-Splitting has two things to get right,
+The split turned one fallback into three. The `Header` renders from the shell data, so it is on screen at once, and only `Stats`, `ActivityFeed`, and `WhoIsOnline` wait behind a boundary.
 
-- keep everything that does not need the slow data (headings, layout, chrome) outside the boundaries, so only the data-dependent parts ever show a fallback, and
-- size each fallback to match the content it replaces, so a reveal swaps in place instead of shifting the page as sections pop in.
+Push each boundary down to the part that actually awaits data, and leave the rest outside. Size each fallback to match its content, so a reveal swaps in place instead of shifting the page as sections arrive.
 
 <details>
   <summary>Nesting boundaries does not serialize them</summary>
@@ -259,8 +264,6 @@ Both `RandomRoll` reads start together. On the **Server Components** track they 
 </details>
 
 {/* TODO: screenshot, Suspense view: three staggered reveals (after) */}
-
-One reveal is now several. Content shows sooner, but a page that fills in piece by piece can read as busier, even slower, than the single reveal it replaced. That is what the two rules above prevent: chrome stays in the static frame and fallbacks hold their space, so the reveals do not reshuffle the layout.
 
 The more of the page that is already there on load, the less has to stream behind a fallback at all.
 

--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -254,7 +254,7 @@ async function ActivityList({ teamIds }: { teamIds: string[] }) {
 
 Now the heading is on screen with the rest of the shell, and only the list streams. The page stops wrapping `ActivityFeed` in a boundary, because the boundary lives inside it.
 
-Splitting is only worth it when you can show more up front, the chrome and frames, and scope the skeleton to just the data that is still loading. Start with one boundary, lower it as far as the page benefits, and size each fallback to minimize layout shift.
+Splitting is only worth it when you can show more up front, the chrome and frames, and scope the skeleton to just the data that is still loading. Start with one boundary and push it down only as far as what you reveal still makes sense on its own. The heading reads fine without the list, but do not surface UI that means nothing until its data lands. Size each fallback to minimize layout shift.
 
 <details>
   <summary>Nesting boundaries does not serialize them</summary>

--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -228,11 +228,62 @@ Reload again. The Suspense view now shows three reveal events at different times
 
 Splitting has two things to get right. Keep everything that does not need the slow data (headings, layout, chrome) outside the boundaries, so only the data-dependent parts ever show a fallback. And size each fallback to match the content it replaces, so a reveal swaps in place instead of shifting the page as sections pop in.
 
-Rendering more of the page as a static shell takes this further, leaving even less behind a fallback, see [Next steps](#next-steps).
+<details>
+  <summary>Nesting boundaries does not serialize them</summary>
+
+```tsx
+import { setTimeout } from 'node:timers/promises'
+
+async function RandomRoll({ delay }: { delay: number }) {
+  await setTimeout(delay) // stand-in for a slow read
+  return <pre>{Math.random().toString(36).slice(2)}</pre>
+}
+
+function Rolls() {
+  return (
+    <Suspense fallback={<p>Rolling...</p>}>
+      <RandomRoll delay={1000} />
+      <Suspense fallback={<p>Still rolling...</p>}>
+        <RandomRoll delay={2000} />
+      </Suspense>
+    </Suspense>
+  )
+}
+```
+
+Both `RandomRoll` reads start together. On the **Server Components** track they run in parallel and the pair finishes at 2s, not 3s, even though one boundary sits inside the other. A `<Suspense>` orders when its content is revealed, not when its data is fetched. Nest boundaries for a staggered reveal, not to sequence the work behind them.
+
+</details>
 
 {/* TODO: screenshot, Suspense view: three staggered reveals (after) */}
 
-{/* TODO: introduce Cache Components as a model that makes both problems above (the data waterfall and the single-boundary reveal) easier to reason about */}
+### Cache Components helps with both
+
+[Cache Components](/docs/app/getting-started/caching) lets one page mix static and dynamic content. In the demo the teams a user belongs to rarely change, so `getTeams` does not need to run on every request. Caching it for days is reasonable, as it almost never changes within that window, while a `cacheTag` allows an on-demand refresh when necessary:
+
+```tsx filename="lib/api.ts"
+import { cacheLife, cacheTag } from 'next/cache'
+
+async function getTeams(teamIds: string[]) {
+  'use cache'
+  cacheLife('days')
+  cacheTag('teams')
+  // served from cache until a team edit calls revalidateTag('teams')
+}
+```
+
+The same reasoning covers the other reads: cache what changes rarely, tag it so a mutation can refresh it, and keep genuinely live data dynamic. `WhoIsOnline` is real-time, so it stays behind `<Suspense>` and streams per request while the cached sections render instantly:
+
+```tsx filename="app/dashboard/page.tsx"
+{/* cached: in the static shell, no fallback */}
+<Stats />                                
+<Suspense fallback={<WhoIsOnlineSkeleton />}>
+  {/* live: streams per request */}
+  <WhoIsOnline teamIds={user.teamIds} />
+</Suspense>
+```
+
+Each read you cache is one less waterfall and one less fallback at request time. That is a production change, though: the development tracks this guide reads still run the work, so the win shows up in a deployed build, not here.
 
 ### Step 3: Catch a blocking keystroke
 
@@ -359,7 +410,7 @@ appeared on, and the fix.
 
 ## Next steps
 
-The fixes in this guide are runtime fixes: they reorder or defer the work the server does on every request. The larger win is often to stop doing that work per request at all. With [Cache Components](/docs/app/getting-started/caching), you cache the parts of a page that do not change per request so they render into the static shell, leaving only genuinely dynamic data to stream. Profiling still tells you what to cache first: the reads that show up as the longest spans on the Server Components track are the best candidates.
+Profiling and [Cache Components](/docs/app/getting-started/caching) pull in the same direction. The tracks tell you what to cache first: the reads that show up as the longest spans on the Server Components track are the best candidates, and caching them shrinks what the tracks have to show next time.
 
 - [Parallelize data fetching](/docs/app/getting-started/fetching-data#parallel-data-fetching)
 - [Stream content with sibling Suspense boundaries](/docs/app/guides/streaming#parallel-streaming-with-sibling-boundaries)

--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -12,25 +12,25 @@ related:
 
 Browsers ship dev tools that measure and show what your app actually did. This guide uses the [Chrome Performance panel](https://developer.chrome.com/docs/devtools/performance/reference) and the [React Developer Tools](https://react.dev/learn/react-developer-tools) extension to profile a Next.js app and find what makes it slow.
 
-The goal is to use these tools instead of guessing from the source or scattering `console.log` timings. This guide is a how-to for finding and fixing problems.
+The goal is to use these tools instead of guessing from the source or scattering `console.log` timings. This guide is a how-to for finding and fixing problems by hand, and the same loop can be [automated with a skill](#automate-the-loop-with-a-skill).
 
 ## The DevTools
 
-The Performance panel records a timeline of what the browser did during a session: every task, render, and network request, each with a start time and duration. You [record a session](https://developer.chrome.com/docs/devtools/performance/reference#record) by starting the recording, reloading the page or interacting with it, then stopping.
+The Performance panel records a timeline of what the browser did during a session: tasks, renders, and network requests, with their start times and durations. You [record a session](https://developer.chrome.com/docs/devtools/performance/reference#record) by starting the recording, reloading the page or interacting with it, then stopping.
 
 React annotates that timeline with its own tracks: **Scheduler**, **Components**, and **Server Components**.
 
-For a reference on what each track, subtrack, and marker shows, see [React Performance Tracks](https://react.dev/reference/dev-tools/react-performance-tracks).
+For a reference on what the tracks, subtracks, and markers show, see [React Performance Tracks](https://react.dev/reference/dev-tools/react-performance-tracks).
 
-React DevTools also adds a **Suspense** view that marks when each `<Suspense>` boundary swaps its fallback for content. Together they show the three problems this guide covers: **sequential awaits on the server**, **content held behind a single boundary**, and **work that runs on the frame of a keystroke**.
+React DevTools also adds a **Suspense** view that marks when a `<Suspense>` boundary swaps its fallback for content. Together they show the three problems this guide covers: **sequential awaits on the server**, **content held behind a single boundary**, and **work that runs on the frame of a keystroke**.
 
 > **Good to know:** You need Chrome with the Performance panel open and the React Developer Tools extension installed. The React tracks appear in development or a profiling build (the **Server Components** track is development-only) and need no extra configuration or instrumentation.
 
 ## Profiling
 
-The examples profile a small demo dashboard, one problem per step, each following the same loop: record the app, read one track, recognize the pattern, apply the fix, then record again to confirm the fix worked.
+The examples profile a small demo dashboard, one problem per step, following the same loop: record the app, read one track, recognize the pattern, apply the fix, then record again to confirm the fix worked.
 
-The demo is structured so each pattern is easy to see. Real apps bury the same patterns in more code, but the workflow is the same.
+The demo is structured so the patterns are easy to see. Real apps bury the same patterns in more code, but the workflow is the same.
 
 Follow along with the demo: [performance-profiling-playground](https://github.com/OWNER/REPO), clone the repository, install dependencies and start the dev server.
 {/* TODO: set the demo repository URL */}
@@ -49,18 +49,18 @@ export default async function DashboardPage() {
 }
 ```
 
-Record a page load in the Performance panel and open the **Server Components** track. Observe the three spans: `getTeams` starts only when `getUser` resolves, and `getNotifications` only when `getTeams` does. Each `await` has to resolve before the page can render any components. This is a **data waterfall**.
+Record a page load in the Performance panel and open the **Server Components** track. Observe the three spans: `getTeams` starts only when `getUser` resolves, and `getNotifications` only when `getTeams` does. The awaits run one after another, so the page cannot render until the last one resolves. This is a **data waterfall**.
 
 Reads that do not depend on one another could be started at the same time instead, which would cut the total down to just the slowest read.
 
 > **Good to know:** Running independent reads at the same time is concurrency, not parallelism. These reads are I/O-bound, so each `await` mostly waits on a network or database response, and a single thread can keep several requests in flight at once. They overlap their waiting instead of taking turns.
 
-The Performance panel can save the recording as JSON, where every span carries its own start and duration, so the tracks can be read programmatically, not only on screen.
+The Performance panel can save the recording as JSON, where the spans carry their own start and duration, so the tracks can be read programmatically, not only on screen.
 
 <details>
   <summary>Read the Server Components track as data</summary>
 
-In the Performance panel, **Save profile** writes the whole recording to JSON, and each bar you saw is an event in it. A single read looks like this:
+In the Performance panel, **Save profile** writes the whole recording to JSON, and the bars you saw are events in it. A single read looks like this:
 
 ```json
 {
@@ -389,15 +389,17 @@ export const Results = memo(function Results({
 
 On its own, `useDeferredValue` is not enough here. Typing updates `query`, which re-renders `Explorer` on every keystroke, and that re-renders `Results` with it, filter and all. Wrapping `Results` in [`memo`](https://react.dev/reference/react/memo) lets it skip the urgent keystroke render, because its props (`issues` and the lagging `deferredQuery`) have not changed yet. The filter then runs once `deferredQuery` catches up, as a deferred, interruptible task. You need both: `useDeferredValue` to defer the work, and `memo` to stop the keystroke render from doing it anyway.
 
+> **Good to know:** [React Compiler](https://react.dev/learn/react-compiler) adds this memoization for you. With it enabled you can drop the manual `memo` and `useMemo` and keep only `useDeferredValue`, which the compiler does not insert.
+
 Record again. The keystroke task is short (the input and its paint fit in one frame), and the filtering runs afterward as a separate, lower-priority task on the main thread.
 
 {/* TODO: screenshot, main thread: short keystroke, deferred filter (after) */}
 
-[Building interactive apps](/docs/app/guides/interactive-apps) goes deeper on keeping interactions responsive: transitions, optimistic updates, and memoizing the list so it does not re-render on every keystroke.
+[Building interactive apps](/docs/app/guides/interactive-apps) goes deeper on keeping interactions responsive with transitions and optimistic updates.
 
 ## Automate the loop with a skill
 
-Every step above is the same loop: one capture, one track, recognize the pattern. It does not need a human watching, so an agent can run it.
+The loop is mechanical: capture, read one track, spot the pattern. An agent can drive it, not just a person.
 
 [`agent-browser`](https://www.npmjs.com/package/agent-browser) drives a real Chrome with React DevTools from the command line. It runs the same captures you did by hand (start and stop a performance trace, read the Suspense boundary classifier, record a render profile) and returns them as JSON an agent can parse.
 

--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -28,11 +28,11 @@ React DevTools also adds a **Suspense** view that marks when each `<Suspense>` b
 
 ## Profiling
 
-The examples profile a small demo dashboard, one problem per step, each following the same loop: record the app, read one track, recognize the pattern, apply the fix, then record again to confirm the shape changed.
+The examples profile a small demo dashboard, one problem per step, each following the same loop: record the app, read one track, recognize the pattern, apply the fix, then record again to confirm the fix worked.
 
-The demo is tiny, so each pattern is easy to see. Real apps bury the same patterns in more code, but the workflow is the same.
+The demo is structured so each pattern is easy to see. Real apps bury the same patterns in more code, but the workflow is the same.
 
-Follow along with the demo: [performance-profiling-playground](https://github.com/OWNER/REPO)
+Follow along with the demo: [performance-profiling-playground](https://github.com/OWNER/REPO), clone the repository, install dependencies and start the dev server.
 {/* TODO: set the demo repository URL */}
 
 ### Step 1: Find a server-data waterfall
@@ -49,13 +49,13 @@ export default async function DashboardPage() {
 }
 ```
 
-Record a page load in the Performance panel and open the **Server Components** track. Observe the three spans: `getTeams` starts only when `getUser` resolves, and `getNotifications` only when `getTeams` does. Each `await` pauses the page render until it resolves. This is a **data waterfall**.
+Record a page load in the Performance panel and open the **Server Components** track. Observe the three spans: `getTeams` starts only when `getUser` resolves, and `getNotifications` only when `getTeams` does. Each `await` has to resolve before the page can render any components. This is a **data waterfall**.
 
 Reads that do not depend on one another could be started at the same time instead, which would cut the total down to just the slowest read.
 
 > **Good to know:** Running independent reads at the same time is concurrency, not parallelism. These reads are I/O-bound, so each `await` mostly waits on a network or database response, and a single thread can keep several requests in flight at once. They overlap their waiting instead of taking turns.
 
-The Performance panel can save the recording as JSON, where every span carries its own start and duration, the same data the [`next-performance-profiling`](#automate-the-loop-with-a-skill) skill parses to find the waterfall.
+The Performance panel can save the recording as JSON, where every span carries its own start and duration, so the tracks can be read programmatically, not only on screen.
 
 <details>
   <summary>Read the Server Components track as data</summary>
@@ -144,15 +144,15 @@ See [Parallel data fetching](/docs/app/getting-started/fetching-data#parallel-da
 
 > **Good to know:** `Promise.all` rejects as a unit: one failed read fails the whole page, the same all-or-nothing risk as the sequential version. Use [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) when each read should resolve or fail on its own. A rejected `Promise.all` also does not cancel the other reads, which keep running, so abort them with an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) if a failure leaves the page unusable.
 
-Record again. The waterfall is gone: the reads now start together instead of one after another, so the group finishes in the time of its slowest member.
+Record again. The waterfall is gone: the reads now start together instead of one after another, so the group finishes in the time of its slowest member. The shell now finishes at `getUser` plus the slower of the two overlapping reads, not the sum of all three.
 
 {/* TODO: screenshot, Server Components track after parallelizing (after) */}
 
-Notice that after the fix the track shows `getUser` then `getTeams`, with no `getNotifications` span even though it still ran. The track draws only the read on the critical path, and when reads run at once that is the slowest one. Here `getNotifications` (250ms) finishes while `getTeams` (300ms) is still going, so `getTeams` sets the timing and gets the span. Even so, `getNotifications` runs and its result is still used, though it was not what held the render up.
+Notice that after the fix the track shows `getUser` then `getTeams`, with no `getNotifications` span even though it still ran. In this app `getNotifications` finishes in 250ms while `getTeams` takes 300ms, so `getTeams` is the one holding up the render, and the span takes its name.
 
-So do not verify a parallel fix by counting spans. Check the timing instead: the shell now finishes at `getUser` plus the slower of the two overlapping reads, not the sum of all three.
+Often the better structure is to move each read into the component that uses it, so the read starts when that component renders instead of blocking the page up front. 
 
-Often the better structure is to move each read into the component that uses it, so the read starts when that component renders instead of blocking the page up front. The demo does this for its content sections: `ActivityFeed` awaits its own data, so it can sit behind its own boundary and stream independently.
+The demo does this for its content sections: `ActivityFeed` awaits its own data, so it can sit behind its own boundary and stream independently.
 
 ```tsx filename="app/dashboard/components/activity-feed.tsx"
 export async function ActivityFeed({ teamIds }: { teamIds: string[] }) {
@@ -224,9 +224,12 @@ The problem is that **one boundary wraps several pieces that load at different s
 
 See [Parallel streaming with sibling boundaries](/docs/app/guides/streaming#parallel-streaming-with-sibling-boundaries).
 
-Reload again. The Suspense view now shows three reveal events at different times. The `Stats` and `ActivityFeed` sections paint as soon as their own data is ready, and only `WhoIsOnline`'s region keeps its fallback until it resolves.
+Reload again. The Suspense view now shows three reveal events at different times. The `Stats` and `ActivityFeed` sections paint as soon as their own data is ready, and only the `WhoIsOnline` region keeps its fallback until it resolves.
 
-Splitting has two things to get right. Keep everything that does not need the slow data (headings, layout, chrome) outside the boundaries, so only the data-dependent parts ever show a fallback. And size each fallback to match the content it replaces, so a reveal swaps in place instead of shifting the page as sections pop in.
+Splitting has two things to get right,
+
+- keep everything that does not need the slow data (headings, layout, chrome) outside the boundaries, so only the data-dependent parts ever show a fallback, and
+- size each fallback to match the content it replaces, so a reveal swaps in place instead of shifting the page as sections pop in.
 
 <details>
   <summary>Nesting boundaries does not serialize them</summary>
@@ -257,6 +260,10 @@ Both `RandomRoll` reads start together. On the **Server Components** track they 
 
 {/* TODO: screenshot, Suspense view: three staggered reveals (after) */}
 
+One reveal is now several. Content shows sooner, but a page that fills in piece by piece can read as busier, even slower, than the single reveal it replaced. That is what the two rules above prevent: chrome stays in the static frame and fallbacks hold their space, so the reveals do not reshuffle the layout.
+
+The more of the page that is already there on load, the less has to stream behind a fallback at all.
+
 ### Cache Components helps with both
 
 [Cache Components](/docs/app/getting-started/caching) lets one page mix static and dynamic content. In the demo the teams a user belongs to rarely change, so `getTeams` does not need to run on every request. Caching it for days is reasonable, as it almost never changes within that window, while a `cacheTag` allows an on-demand refresh when necessary:
@@ -272,7 +279,7 @@ async function getTeams(teamIds: string[]) {
 }
 ```
 
-The same reasoning covers the other reads: cache what changes rarely, tag it so a mutation can refresh it, and keep genuinely live data dynamic. `WhoIsOnline` is real-time, so it stays behind `<Suspense>` and streams per request while the cached sections render instantly:
+The same reasoning covers the other reads: cache the ones that change rarely, and keep genuinely live data dynamic. `Stats` reads `getStats`, so caching that read the same way puts `Stats` in the static shell with no fallback. `WhoIsOnline` is real-time, so you do not cache it. It keeps its `<Suspense>` boundary from the last step and streams per request:
 
 ```tsx filename="app/dashboard/page.tsx"
 {/* cached: in the static shell, no fallback */}
@@ -283,7 +290,9 @@ The same reasoning covers the other reads: cache what changes rarely, tag it so 
 </Suspense>
 ```
 
-Each read you cache is one less waterfall and one less fallback at request time. That is a production change, though: the development tracks this guide reads still run the work, so the win shows up in a deployed build, not here.
+Each read you cache is one less waterfall and one less fallback at request time. That answers the tradeoff Step 2 ended on: the cached sections are part of the static shell, on the page from the first byte with no reveal, so only the live data streams. You are back to a couple of dynamic holes instead of a page full of staggered reveals, and revalidation keeps the cached parts current.
+
+> **Good to know:** In development the cache starts cold, so a `use cache` read still runs on the first render and the tracks show the waterfall.
 
 ### Step 3: Catch a blocking keystroke
 

--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -1,0 +1,367 @@
+---
+title: How to diagnose performance problems with React Performance Tracks
+nav_title: Profiling performance
+description: Profile a Next.js app in the Chrome Performance panel and React DevTools to find data waterfalls, slow Suspense boundaries, and blocking interactions (a React profiler workflow).
+related:
+  description: Guides for fixing the problems you find.
+  links:
+    - app/getting-started/fetching-data
+    - app/guides/streaming
+    - app/guides/interactive-apps
+---
+
+Browsers ship dev tools that measure and show what your app actually did. This guide uses the [Chrome Performance panel](https://developer.chrome.com/docs/devtools/performance/reference) and the [React Developer Tools](https://react.dev/learn/react-developer-tools) extension to profile a Next.js app and find what makes it slow.
+
+The goal is to use these tools instead of guessing from the source or scattering `console.log` timings. This guide is a how-to for finding and fixing problems.
+
+## The DevTools
+
+The Performance panel records a timeline of what the browser did during a session: every task, render, and network request, each with a start time and duration. You [record a session](https://developer.chrome.com/docs/devtools/performance/reference#record) by starting the recording, reloading the page or interacting with it, then stopping.
+
+React annotates that timeline with its own tracks: **Scheduler**, **Components**, and **Server Components**.
+
+For a reference on what each track, subtrack, and marker shows, see [React Performance Tracks](https://react.dev/reference/dev-tools/react-performance-tracks).
+
+React DevTools also adds a **Suspense** view that marks when each `<Suspense>` boundary swaps its fallback for content. Together they show the three problems this guide covers: **sequential awaits on the server**, **content held behind a single boundary**, and **work that runs on the frame of a keystroke**.
+
+> **Good to know:** You need Chrome with the Performance panel open and the React Developer Tools extension installed. The React tracks appear in development or a profiling build (the **Server Components** track is development-only) and need no extra configuration or instrumentation.
+
+## Profiling
+
+The examples profile a small demo dashboard, one problem per step, each following the same loop: record the app, read one track, recognize the pattern, apply the fix, then record again to confirm the shape changed.
+
+The demo is tiny, so each pattern is easy to see. Real apps bury the same patterns in more code, but the workflow is the same.
+
+Follow along with the demo: [performance-profiling-playground](https://github.com/OWNER/REPO)
+{/* TODO: set the demo repository URL */}
+
+### Step 1: Find a server-data waterfall
+
+In the demo, the dashboard page is a Server Component that reads three things before it renders the header:
+
+```tsx filename="app/dashboard/page.tsx"
+export default async function DashboardPage() {
+  const user = await getUser()
+  const teams = await getTeams(user.teamIds)
+  const notifications = await getNotifications(user.teamIds)
+
+  return <Header user={user} teams={teams} notifications={notifications} />
+}
+```
+
+Record a page load in the Performance panel and open the **Server Components** track. Observe the three spans: `getTeams` starts only when `getUser` resolves, and `getNotifications` only when `getTeams` does. Each `await` pauses the page render until it resolves. This is a **data waterfall**.
+
+Reads that do not depend on one another could be started at the same time instead, which would cut the total down to just the slowest read.
+
+> **Good to know:** Running independent reads at the same time is concurrency, not parallelism. These reads are I/O-bound, so each `await` mostly waits on a network or database response, and a single thread can keep several requests in flight at once. They overlap their waiting instead of taking turns.
+
+The Performance panel can save the recording as JSON, where every span carries its own start and duration, the same data the [`react-performance-tracks`](#automate-the-loop-with-a-skill) skill parses to find the waterfall.
+
+<details>
+  <summary>Read the Server Components track as data</summary>
+
+In the Performance panel, **Save profile** writes the whole recording to JSON, and each bar you saw is an event in it. A single read looks like this:
+
+```json
+{
+  "name": "await getTeams",
+  "cat": "blink.user_timing",
+  "ph": "b",
+  "id2": { "local": "0x7b" },
+  "ts": 486651743590,
+  "args": {
+    "detail": "{\"devtools\":{\"track\":\"Primary\",\"trackGroup\":\"Server Components ⚛\"}}"
+  }
+}
+```
+
+That is the begin (`ph: "b"`) of one span. A matching end (`ph: "e"`) with the same `id2.local` closes it, and the gap between their `ts` values (in microseconds) is its duration. The `args.detail` field, present only on the begin, names the track. These are the same three bars you saw stepping down on screen, now as values you can measure.
+
+To check the whole recording at once, pair the events and compute each duration:
+
+```js filename="parse-trace.js"
+const { traceEvents } = require('./trace.json')
+
+// Keep only the begin/end user-timing events, in time order.
+const timingEvents = traceEvents
+  .filter((event) => /user_timing/.test(event.cat || ''))
+  .filter((event) => event.ph === 'b' || event.ph === 'e')
+  .sort((a, b) => a.ts - b.ts)
+
+const openSpans = new Map()
+const spans = []
+
+for (const event of timingEvents) {
+  const key = `${event.id2?.local}|${event.name}`
+
+  // A "begin" opens a span; the matching "end" closes it.
+  if (event.ph === 'b') {
+    openSpans.set(key, event)
+    continue
+  }
+
+  const begin = openSpans.get(key)
+  if (!begin) continue
+  openSpans.delete(key)
+
+  const { trackGroup } = JSON.parse(begin.args.detail).devtools
+  spans.push({
+    name: begin.name,
+    trackGroup,
+    start: begin.ts,
+    dur: (event.ts - begin.ts) / 1000, // duration in ms
+  })
+}
+```
+
+With the spans as data, a script can flag the waterfall (two reads back to back on the same track) or hand the timings to an agent. Compare the start time of dependent work, not the raw span count: a read that resolves before a slower sibling in the same `Promise.all` never gets a span.
+
+</details>
+
+{/* TODO: screenshot, Server Components track showing the waterfall (before) */}
+
+In the demo all three reads sit in one function, so the waterfall is easy to spot in the source. In production it might look more like this: the layout awaits the user, the page awaits the teams, a nested panel awaits its own data.
+
+```txt
+app/layout.tsx              await getUser()
+  app/dashboard/page.tsx        await getTeams()
+    components/panel.tsx            await getNotifications()
+```
+
+Scattered like this, no single file shows the serialization, but the track still draws the three spans back to back.
+
+Because the other two need `user.teamIds`, `getUser` has to resolve first. But `getNotifications` and `getTeams` do not depend on each other, so run them together instead of in sequence:
+
+```tsx filename="app/dashboard/page.tsx"
+const user = await getUser()
+const [notifications, teams] = await Promise.all([
+  getNotifications(user.teamIds),
+  getTeams(user.teamIds),
+])
+```
+
+See [Parallel data fetching](/docs/app/getting-started/fetching-data#parallel-data-fetching) for the full pattern, including how to keep a real dependency in sequence.
+
+> **Good to know:** `Promise.all` rejects as a unit: one failed read fails the whole page, the same all-or-nothing risk as the sequential version. Use [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) when each read should resolve or fail on its own. A rejected `Promise.all` also does not cancel the other reads, which keep running, so abort them with an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) if a failure leaves the page unusable.
+
+Record again. The waterfall is gone: the reads now start together instead of one after another, so the group finishes in the time of its slowest member.
+
+{/* TODO: screenshot, Server Components track after parallelizing (after) */}
+
+Notice that after the fix the track shows `getUser` then `getTeams`, with no `getNotifications` span even though it still ran. The track draws only the read on the critical path, and when reads run at once that is the slowest one. Here `getNotifications` (250ms) finishes while `getTeams` (300ms) is still going, so `getTeams` sets the timing and gets the span. Even so, `getNotifications` runs and its result is still used, though it was not what held the render up.
+
+So do not verify a parallel fix by counting spans. Check the timing instead: the shell now finishes at `getUser` plus the slower of the two overlapping reads, not the sum of all three.
+
+Often the better structure is to move each read into the component that uses it, so the read starts when that component renders instead of blocking the page up front. The demo does this for its content sections: `ActivityFeed` awaits its own data, so it can sit behind its own boundary and stream independently.
+
+```tsx filename="app/dashboard/components/activity-feed.tsx"
+export async function ActivityFeed({ teamIds }: { teamIds: string[] }) {
+  const activities = await getActivity(teamIds)
+
+  return <ActivityList activities={activities} />
+}
+```
+
+Profile as you refactor, so moving reads between components does not quietly reintroduce the waterfall.
+
+You can also start a read in the page without awaiting it and pass the unawaited promise down. Such a promise can even cross the boundary into a Client Component, read there with [`use`](https://react.dev/reference/react/use). Either way, deferring the read is what lets the rest of the page render while the data loads, which is the subject of the next step.
+
+### Step 2: Find content gated by one boundary
+
+In the demo, a single `<Suspense>` boundary wraps the whole content area of the dashboard, with three sections that load at different speeds inside it:
+
+```tsx filename="app/dashboard/page.tsx"
+return (
+  <>
+    <Header user={user} teams={teams} notifications={notifications} />
+
+    <Suspense fallback={<ContentSkeleton />}>
+      <Stats />
+      <ActivityFeed teamIds={user.teamIds} />
+      <WhoIsOnline teamIds={user.teamIds} />
+    </Suspense>
+  </>
+)
+```
+
+Open the **Suspense** view in React Developer Tools and reload this page. The panel draws each `<Suspense>` boundary and marks the point where it swaps its fallback for content. Here one boundary covers the whole area, and its reveal is a single event late on the timeline: the fallback stays until the slowest child, `WhoIsOnline` (about 1.2s), resolves. The `Stats` and `ActivityFeed` sections finish earlier, but their content does not appear, because a boundary reveals only when every child inside it is ready.
+
+The same reveal also appears on the **Scheduler** track in the Performance panel. Record both at once to line the reveal up against the rest of the timeline (network requests, hydration, other renders) and see what the fallback was waiting on.
+
+{/* TODO: screenshot, Suspense view: one late reveal (before) */}
+
+In the demo the boundary and its children sit in one file. In a real app the boundary is often far from the child that gates it: a layout wraps everything in one `<Suspense>`, while the slow data lives in a deeply nested component.
+
+```txt
+app/dashboard/layout.tsx
+  // one boundary, high up
+  <Suspense fallback={<Skeleton />}>
+
+  app/dashboard/page.tsx
+    // ready fast, but held back
+    <Stats />
+
+    components/who-is-online.tsx
+      // slow; gates everything above
+      await getWhoIsOnline()
+```
+
+The Suspense view shows the same single late reveal wherever the slow child lives.
+
+The problem is that **one boundary wraps several pieces that load at different speeds**, so React can only reveal them together. Give each independently-paced piece its own boundary so each reveals as soon as its own data is ready:
+
+```tsx filename="app/dashboard/page.tsx"
+<Suspense fallback={<StatsSkeleton />}>
+  <Stats />
+</Suspense>
+<Suspense fallback={<ActivitySkeleton />}>
+  <ActivityFeed teamIds={user.teamIds} />
+</Suspense>
+<Suspense fallback={<WhoIsOnlineSkeleton />}>
+  <WhoIsOnline teamIds={user.teamIds} />
+</Suspense>
+```
+
+See [Parallel streaming with sibling boundaries](/docs/app/guides/streaming#parallel-streaming-with-sibling-boundaries).
+
+Reload again. The Suspense view now shows three reveal events at different times. The `Stats` and `ActivityFeed` sections paint as soon as their own data is ready, and only `WhoIsOnline`'s region keeps its fallback until it resolves.
+
+Splitting has two things to get right. Keep everything that does not need the slow data (headings, layout, chrome) outside the boundaries, so only the data-dependent parts ever show a fallback. And size each fallback to match the content it replaces, so a reveal swaps in place instead of shifting the page as sections pop in.
+
+Rendering more of the page as a static shell takes this further, leaving even less behind a fallback, see [Next steps](#next-steps).
+
+{/* TODO: screenshot, Suspense view: three staggered reveals (after) */}
+
+{/* TODO: introduce Cache Components as a model that makes both problems above (the data waterfall and the single-boundary reveal) easier to reason about */}
+
+### Step 3: Catch a blocking keystroke
+
+In the demo, the `/explorer` page has a search box that filters a large list synchronously as you type. The query lives in one client component and the filtering happens in a child:
+
+```tsx filename="app/explorer/explorer.tsx"
+'use client'
+
+export function Explorer() {
+  const issues = useMemo(() => generateIssues(5000), [])
+  const [query, setQuery] = useState('')
+
+  return (
+    <>
+      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <Results issues={issues} query={query} />
+    </>
+  )
+}
+```
+
+```tsx filename="app/explorer/results.tsx"
+'use client'
+
+// No memo: re-renders and re-filters all 5000 rows on every keystroke.
+export function Results({ issues, query }: { issues: Issue[]; query: string }) {
+  const q = query.trim().toLowerCase()
+  const matches =
+    q === '' ? issues : issues.filter((i) => i.title.toLowerCase().includes(q))
+
+  return (
+    <ul>
+      {matches.map((issue) => (
+        <Row key={issue.id} issue={issue} />
+      ))}
+    </ul>
+  )
+}
+```
+
+Record while typing and look at the **main thread** in the Performance panel. Each keystroke produces a long task: a wide block, flagged with the red long-task corner, that runs from the input event until the next paint. The character you typed appears only after the block finishes. This is what a poor [Interaction to Next Paint (INP)](https://web.dev/articles/inp) score measures.
+
+{/* TODO: screenshot, main thread: long task per keystroke (before) */}
+
+Unlike the server and boundary problems, this one is not as easily visible on the React tracks. A controlled input's `onChange` renders synchronously inside the event, so React finishes inside that one main-thread task instead of scheduling separate work you could watch on the Scheduler track. To confirm the paint is waiting on it, line the long task up with the keystroke on the **Interactions** track: the next paint lands only after the task ends.
+
+<details>
+  <summary>Why the blocking render is quiet on the React tracks</summary>
+
+Record the renders across a single keystroke and read the per-component table. Two things stand out:
+
+- `Explorer` renders **once**, its change reason the `query` state you typed into. That part is correct.
+- The `Row`s re-render in the **thousands**, with change reason `parent` (not their own props). They re-render only because `Results` above them did.
+
+Meanwhile the Scheduler track shows a single `Update` and **no** `Cascading Update`. So this is not a cascade. It is one correct render at the top dragging a synchronous re-render of unmemoized children below it, which is why the keystroke lands as one long `EventDispatch` on the main thread.
+
+</details>
+
+This is a **blocking interaction**. Keep the typed value urgent and let the expensive filter run at a lower priority with `useDeferredValue`, passing the deferred value to the list:
+
+```tsx filename="app/explorer/explorer.tsx"
+export function Explorer() {
+  const issues = useMemo(() => generateIssues(5000), [])
+  const [query, setQuery] = useState('')
+  const deferredQuery = useDeferredValue(query)
+
+  return (
+    <>
+      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <Results issues={issues} query={deferredQuery} />
+    </>
+  )
+}
+```
+
+```tsx filename="app/explorer/results.tsx"
+// memo lets Results skip the keystroke render while deferredQuery is unchanged.
+export const Results = memo(function Results({
+  issues,
+  query,
+}: {
+  issues: Issue[]
+  query: string
+}) {
+  const q = query.trim().toLowerCase()
+  const matches =
+    q === '' ? issues : issues.filter((i) => i.title.toLowerCase().includes(q))
+  // ...renders the list
+})
+```
+
+On its own, `useDeferredValue` is not enough here. Typing updates `query`, which re-renders `Explorer` on every keystroke, and that re-renders `Results` with it, filter and all. Wrapping `Results` in [`memo`](https://react.dev/reference/react/memo) lets it skip the urgent keystroke render, because its props (`issues` and the lagging `deferredQuery`) have not changed yet. The filter then runs once `deferredQuery` catches up, as a deferred, interruptible task. You need both: `useDeferredValue` to defer the work, and `memo` to stop the keystroke render from doing it anyway.
+
+Record again. The keystroke task is short (the input and its paint fit in one frame), and the filtering runs afterward as a separate, lower-priority task on the main thread.
+
+{/* TODO: screenshot, main thread: short keystroke, deferred filter (after) */}
+
+[Building interactive apps](/docs/app/guides/interactive-apps) goes deeper on keeping interactions responsive: transitions, optimistic updates, and memoizing the list so it does not re-render on every keystroke.
+
+## Automate the loop with a skill
+
+Every step above is the same loop: one capture, one track, recognize the pattern. It does not need a human watching, so an agent can run it.
+
+[`agent-browser`](https://www.npmjs.com/package/agent-browser) drives a real Chrome with React DevTools from the command line. It runs the same captures you did by hand (start and stop a performance trace, read the Suspense boundary classifier, record a render profile) and returns them as JSON an agent can parse.
+
+This repository ships a [`react-performance-tracks`](https://github.com/vercel/next.js/tree/canary/skills/react-performance-tracks) skill that runs this loop for an agent. It builds on [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop), which opens the browser and connects to `/_next/mcp`.
+
+Loaded against a running app, the skill:
+
+1. triages with `vitals` and picks the surface that matches the symptom,
+2. captures it (a performance trace, the Suspense classifier, or a render profile),
+3. reads the result, recognizes the pattern, and proposes the fix,
+4. re-captures to confirm the shape changed.
+
+It also carries the traps that mislead a first read, learned from running it against builds with planted problems: StrictMode doubling dev renders, or a synchronous input whose blocking render looks nothing like a cascade.
+
+Point an agent at a running app with the skill loaded and it runs the same diagnosis these steps describe. For example:
+
+```txt
+Profile the /dashboard and /explorer routes for performance problems using the
+react-performance-tracks skill. For each issue, report the symptom, the track it
+appeared on, and the fix.
+```
+
+## Next steps
+
+The fixes in this guide are runtime fixes: they reorder or defer the work the server does on every request. The larger win is often to stop doing that work per request at all. With [Cache Components](/docs/app/getting-started/caching), you cache the parts of a page that do not change per request so they render into the static shell, leaving only genuinely dynamic data to stream. Profiling still tells you what to cache first: the reads that show up as the longest spans on the Server Components track are the best candidates.
+
+- [Parallelize data fetching](/docs/app/getting-started/fetching-data#parallel-data-fetching)
+- [Stream content with sibling Suspense boundaries](/docs/app/guides/streaming#parallel-streaming-with-sibling-boundaries)
+- [Keep interactions responsive with transitions](/docs/app/guides/interactive-apps)
+- [Cache work out of the request path with Cache Components](/docs/app/getting-started/caching)

--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -55,7 +55,7 @@ Reads that do not depend on one another could be started at the same time instea
 
 > **Good to know:** Running independent reads at the same time is concurrency, not parallelism. These reads are I/O-bound, so each `await` mostly waits on a network or database response, and a single thread can keep several requests in flight at once. They overlap their waiting instead of taking turns.
 
-The Performance panel can save the recording as JSON, where every span carries its own start and duration, the same data the [`react-performance-tracks`](#automate-the-loop-with-a-skill) skill parses to find the waterfall.
+The Performance panel can save the recording as JSON, where every span carries its own start and duration, the same data the [`next-performance-profiling`](#automate-the-loop-with-a-skill) skill parses to find the waterfall.
 
 <details>
   <summary>Read the Server Components track as data</summary>
@@ -338,7 +338,7 @@ Every step above is the same loop: one capture, one track, recognize the pattern
 
 [`agent-browser`](https://www.npmjs.com/package/agent-browser) drives a real Chrome with React DevTools from the command line. It runs the same captures you did by hand (start and stop a performance trace, read the Suspense boundary classifier, record a render profile) and returns them as JSON an agent can parse.
 
-This repository ships a [`react-performance-tracks`](https://github.com/vercel/next.js/tree/canary/skills/react-performance-tracks) skill that runs this loop for an agent. It builds on [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop), which opens the browser and connects to `/_next/mcp`.
+This repository ships a [`next-performance-profiling`](https://github.com/vercel/next.js/tree/canary/skills/next-performance-profiling) skill that runs this loop for an agent. It builds on [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop), which opens the browser and connects to `/_next/mcp`.
 
 Loaded against a running app, the skill:
 
@@ -353,7 +353,7 @@ Point an agent at a running app with the skill loaded and it runs the same diagn
 
 ```txt
 Profile the /dashboard and /explorer routes for performance problems using the
-react-performance-tracks skill. For each issue, report the symptom, the track it
+next-performance-profiling skill. For each issue, report the symptom, the track it
 appeared on, and the fix.
 ```
 

--- a/docs/01-app/02-guides/profiling-performance.mdx
+++ b/docs/01-app/02-guides/profiling-performance.mdx
@@ -190,7 +190,7 @@ The same reveal also appears on the **Scheduler** track in the Performance panel
 
 {/* TODO: screenshot, Suspense view: one late reveal (before) */}
 
-In the demo the boundary and its children sit in one file. In a real app the boundary is often far from the child that gates it: a layout wraps everything in one `<Suspense>`, while the slow data lives in a deeply nested component.
+Here the boundary and its children sit in one file. In production it might look more like this: a layout wraps a region in one `<Suspense>`, and the slow read lives in a component nested deep inside it.
 
 ```txt
 app/dashboard/layout.tsx
@@ -208,7 +208,7 @@ app/dashboard/layout.tsx
 
 The Suspense view shows the same single late reveal wherever the slow child lives.
 
-The problem is that **one boundary wraps several pieces that load at different speeds**, so React can only reveal them together. Give each independently-paced piece its own boundary so each reveals as soon as its own data is ready:
+A boundary reveals its contents once all of its members are ready, and that is often fine. In some cases, though, more content can be revealed sooner: here `Stats` and `ActivityFeed` are ready long before `WhoIsOnline`, yet the single boundary makes them wait for it. Give each section its own boundary so it reveals as soon as its own data is ready:
 
 ```tsx filename="app/dashboard/page.tsx"
 return (
@@ -232,9 +232,29 @@ See [Parallel streaming with sibling boundaries](/docs/app/guides/streaming#para
 
 Reload again. The Suspense view now shows three reveal events at different times. The `Stats` and `ActivityFeed` sections paint as soon as their own data is ready, and only the `WhoIsOnline` region keeps its fallback until it resolves.
 
-The split turned one fallback into three. The `Header` renders from the shell data, so it is on screen at once, and only `Stats`, `ActivityFeed`, and `WhoIsOnline` wait behind a boundary.
+Each skeleton still stands in for a whole section, its frame and its data. Push the boundary lower to show the frame right away and suspend only the data. `ActivityFeed` can render its heading and wrap just the list:
 
-Push each boundary down to the part that actually awaits data, and leave the rest outside. Size each fallback to match its content, so a reveal swaps in place instead of shifting the page as sections arrive.
+```tsx filename="app/dashboard/components/activity-feed.tsx"
+export function ActivityFeed({ teamIds }: { teamIds: string[] }) {
+  return (
+    <section>
+      <h2>Recent activity</h2>
+      <Suspense fallback={<ActivityListSkeleton />}>
+        <ActivityList teamIds={teamIds} />
+      </Suspense>
+    </section>
+  )
+}
+
+async function ActivityList({ teamIds }: { teamIds: string[] }) {
+  const activities = await getActivity(teamIds)
+  // ...renders the rows
+}
+```
+
+Now the heading is on screen with the rest of the shell, and only the list streams. The page stops wrapping `ActivityFeed` in a boundary, because the boundary lives inside it.
+
+Splitting is only worth it when you can show more up front, the chrome and frames, and scope the skeleton to just the data that is still loading. Start with one boundary, lower it as far as the page benefits, and size each fallback to minimize layout shift.
 
 <details>
   <summary>Nesting boundaries does not serialize them</summary>

--- a/skills/next-performance-profiling/SKILL.md
+++ b/skills/next-performance-profiling/SKILL.md
@@ -42,7 +42,7 @@ Capture a baseline, read it, form one hypothesis, fix, then re-capture and compa
 
 ### content gated by one Suspense boundary → Suspense view
 
-`react suspense` classifies boundaries (`N boundaries: M dynamic holes`) and names the actionable one; a single dynamic hole over a whole section is the smell. Quantify the gating from the stream: fetch with `Accept-Encoding: identity` and log when each child's HTML arrives versus when the boundary's `$RC("B:n")` swap fires. One late `$RC` while children were ready earlier means the slowest child is holding the fast ones. (This stream probe uses `curl`/`fetch` deliberately: it measures the network, not the browser, so `next-dev-loop`'s "no curl" rule does not apply. If curl is unavailable, use the trace: a child's span duration equals the reveal delay it causes.) **Fix:** give each independently paced child its own `<Suspense>`. **Verify:** one `$RC` per child, staggered.
+`react suspense` classifies boundaries (`N boundaries: M dynamic holes`) and names the actionable one; a single dynamic gap over a whole section is the smell. Quantify the gating from the stream: fetch with `Accept-Encoding: identity` and log when each child's HTML arrives versus when the boundary's `$RC("B:n")` swap fires. One late `$RC` while children were ready earlier means the slowest child is holding the fast ones. (This stream probe uses `curl`/`fetch` deliberately: it measures the network, not the browser, so `next-dev-loop`'s "no curl" rule does not apply. If curl is unavailable, use the trace: a child's span duration equals the reveal delay it causes.) **Fix:** give each independently paced child its own `<Suspense>`. **Verify:** one `$RC` per child, staggered.
 
 ### slow interaction → Scheduler ⚛ + render profile
 
@@ -51,7 +51,7 @@ Capture a baseline, read it, form one hypothesis, fix, then re-capture and compa
 - **A. Cascading render.** A component re-renders more than once, and the extra render's reason is a state hook other than the one you touched. The Scheduler ⚛ track shows an `Update` followed by a `Cascading Update`. Cause: derived data mirrored into `useState` and synced with `useEffect`. **Fix:** compute during render; delete the state and effect.
 - **B. Blocking / large render.** The touched component renders once (reason: the hook you touched), there is **no** `Cascading Update`, but a child re-renders in large counts with reason `parent`, and the interaction is a long `EventDispatch` on the main thread. A controlled input renders synchronously inside the event, so the Scheduler track is sparse and the long task is the reliable signal. **Fix:** `React.memo` the expensive children, `useDeferredValue` or `useTransition` the input, virtualize a large list. `useDeferredValue` without `memo` does nothing.
 
-**The absence of a `Cascading Update` does not mean "no bug."** It tells mode A from mode B. Read the per-component counts and `parent` reasons, not just the Scheduler markers.
+**The absence of a `Cascading Update` does not mean "no bug."** It tells mode A from mode B. Read the per-component counts and `parent` reasons, not only the Scheduler markers.
 
 ## reading a trace
 

--- a/skills/next-performance-profiling/SKILL.md
+++ b/skills/next-performance-profiling/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: react-performance-tracks
+name: next-performance-profiling
 description: >
   Diagnose React performance problems in a running Next.js app by capturing and
   reading the React Performance Tracks and the React DevTools Suspense view. Use
@@ -9,14 +9,14 @@ description: >
   rather than guessing from the source.
 ---
 
-# react-performance-tracks
+# next-performance-profiling
 
 Find a React performance problem by measuring it. React 19.2 emits Performance Tracks (Scheduler ⚛, Components ⚛, Server Components ⚛) into the browser's performance timeline, and React DevTools adds a Suspense view showing fallback to content reveals. This skill is the loop for capturing those signals and naming the fix. The worked numbers live in the companion guide and demo (see [references](#references)); this file is the method.
 
 ## requires
 
 - React **19.2+** in development or a profiling build (the tracks are dev-only).
-- A live browser session with React DevTools enabled. Opening it, sessions, `--restore`, and `/_next/mcp` are the `next-dev-loop` skill's job. **Run its preflight first;** this skill picks up once the commands below work.
+- A live browser session with React DevTools enabled, which is the [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) skill's job: it opens the browser, restores the session, enables React DevTools, and connects `/_next/mcp`. **Load and run `next-dev-loop` first.** This skill picks up once its preflight passes. Install it if your agent does not have it: `npx skills add https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop`.
 - `agent-browser` **>= 0.31** for the `react` and `trace` subcommands. Read flags from the React and Performance sections of `agent-browser --help` (a per-subcommand `--help` only prints the global help). Every `react` command needs `--json`. Agents run headless; omit `--headed`.
 
 Commands this skill drives: `vitals <url> --json` (first triage), `react suspense --json`, `react renders start` / `stop --json`, and `trace start` / `trace stop <path>` (equivalent to `profiler`; both carry the `blink.user_timing` category the tracks live in).

--- a/skills/react-performance-tracks/SKILL.md
+++ b/skills/react-performance-tracks/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: react-performance-tracks
+description: >
+  Diagnose React performance problems in a running Next.js app by capturing and
+  reading the React Performance Tracks and the React DevTools Suspense view. Use
+  when an app feels slow and you need to find the cause (slow first paint, late
+  or janky reveals, a server data waterfall, content gated behind one Suspense
+  boundary, cascading renders, or an interaction that blocks the main thread)
+  rather than guessing from the source.
+---
+
+# react-performance-tracks
+
+Find a React performance problem by measuring it. React 19.2 emits Performance Tracks (Scheduler ⚛, Components ⚛, Server Components ⚛) into the browser's performance timeline, and React DevTools adds a Suspense view showing fallback to content reveals. This skill is the loop for capturing those signals and naming the fix. The worked numbers live in the companion guide and demo (see [references](#references)); this file is the method.
+
+## requires
+
+- React **19.2+** in development or a profiling build (the tracks are dev-only).
+- A live browser session with React DevTools enabled. Opening it, sessions, `--restore`, and `/_next/mcp` are the `next-dev-loop` skill's job. **Run its preflight first;** this skill picks up once the commands below work.
+- `agent-browser` **>= 0.31** for the `react` and `trace` subcommands. Read flags from the React and Performance sections of `agent-browser --help` (a per-subcommand `--help` only prints the global help). Every `react` command needs `--json`. Agents run headless; omit `--headed`.
+
+Commands this skill drives: `vitals <url> --json` (first triage), `react suspense --json`, `react renders start` / `stop --json`, and `trace start` / `trace stop <path>` (equivalent to `profiler`; both carry the `blink.user_timing` category the tracks live in).
+
+## reach for the right surface
+
+Triage with `agent-browser vitals <url> --json`: TTFB, LCP, and INP tell you which row below applies, and a route can hit more than one. Then capture only the matching surface, not everything.
+
+| symptom                                        | surface                                            | capture                                                  |
+| ---------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------- |
+| slow to show anything; high TTFB               | Server Components ⚛                               | `trace`, read the I/O waterfall                          |
+| content reveals late, all at once              | Suspense view + `$RC` stream                       | `react suspense`, stream timing                          |
+| interaction double-renders / brief stale flash | Scheduler ⚛ `Cascading Update` + render profile   | `react renders … --json`, `trace`                        |
+| interaction is laggy; poor INP                 | Scheduler ⚛ Blocking (long task) + render profile | `trace` (long `EventDispatch`), `react renders … --json` |
+
+## the loop
+
+Capture a baseline, read it, form one hypothesis, fix, then re-capture and compare the same number. A fix you cannot show in a before/after capture is not verified.
+
+### server data waterfall → Server Components ⚛
+
+`trace start` → `open <url>` (a fresh load, not `reload`) → `wait` past the slowest data → `trace stop <path>`. On the Server Components ⚛ track, server I/O awaits appear as spans on the Primary track. **The tell:** independent reads that staircase, each span starting where the previous ends. Compare against work that should depend on them: if downstream work starts later than `start_of_first + max(durations)`, something is serialized needlessly. **Fix:** `Promise.all` the independent reads; keep a read in sequence only if it needs the previous result.
+
+### content gated by one Suspense boundary → Suspense view
+
+`react suspense` classifies boundaries (`N boundaries: M dynamic holes`) and names the actionable one; a single dynamic hole over a whole section is the smell. Quantify the gating from the stream: fetch with `Accept-Encoding: identity` and log when each child's HTML arrives versus when the boundary's `$RC("B:n")` swap fires. One late `$RC` while children were ready earlier means the slowest child is holding the fast ones. (This stream probe uses `curl`/`fetch` deliberately: it measures the network, not the browser, so `next-dev-loop`'s "no curl" rule does not apply. If curl is unavailable, use the trace: a child's span duration equals the reveal delay it causes.) **Fix:** give each independently paced child its own `<Suspense>`. **Verify:** one `$RC` per child, staggered.
+
+### slow interaction → Scheduler ⚛ + render profile
+
+`react renders start` → do the interaction → `react renders stop --json`. Read the per-component table (`Insts | Re-renders | Self | Top change reason`). Two opposite-looking modes:
+
+- **A. Cascading render.** A component re-renders more than once, and the extra render's reason is a state hook other than the one you touched. The Scheduler ⚛ track shows an `Update` followed by a `Cascading Update`. Cause: derived data mirrored into `useState` and synced with `useEffect`. **Fix:** compute during render; delete the state and effect.
+- **B. Blocking / large render.** The touched component renders once (reason: the hook you touched), there is **no** `Cascading Update`, but a child re-renders in large counts with reason `parent`, and the interaction is a long `EventDispatch` on the main thread. A controlled input renders synchronously inside the event, so the Scheduler track is sparse and the long task is the reliable signal. **Fix:** `React.memo` the expensive children, `useDeferredValue` or `useTransition` the input, virtualize a large list. `useDeferredValue` without `memo` does nothing.
+
+**The absence of a `Cascading Update` does not mean "no bug."** It tells mode A from mode B. Read the per-component counts and `parent` reasons, not just the Scheduler markers.
+
+## reading a trace
+
+React tracks are `blink.user_timing` events: an async begin (`ph:"b"`) and end (`ph:"e"`) paired by `id2.local`, where only the begin carries `args.detail` (a JSON string with `devtools.trackGroup`, `devtools.track`, `devtools.tooltipText`). Save the profile as JSON and pair them:
+
+```js
+const { traceEvents } = require('./trace.json')
+
+// Keep only the begin/end user-timing events, in time order.
+const timingEvents = traceEvents
+  .filter((event) => /user_timing/.test(event.cat || ''))
+  .filter((event) => event.ph === 'b' || event.ph === 'e')
+  .sort((a, b) => a.ts - b.ts)
+
+const openSpans = new Map()
+const spans = []
+
+for (const event of timingEvents) {
+  const key = `${event.id2?.local}|${event.name}`
+
+  // A "begin" opens a span; the matching "end" closes it.
+  if (event.ph === 'b') {
+    openSpans.set(key, event)
+    continue
+  }
+
+  const begin = openSpans.get(key)
+  if (!begin) continue
+  openSpans.delete(key)
+
+  const { trackGroup } = JSON.parse(begin.args.detail).devtools
+  spans.push({
+    name: begin.name,
+    trackGroup,
+    start: begin.ts,
+    dur: (event.ts - begin.ts) / 1000, // duration in ms
+  })
+}
+```
+
+For a blocking interaction, also scan complete (`ph:"X"`) events named `EventDispatch` / `FunctionCall` by `dur`; that is the long task. Real traces are large, so parse the file once and query the arrays.
+
+## gotchas
+
+- `react <cmd>` without `--json` prints `✓ Done` and no data.
+- The page can drift to `about:blank`. Check `get url`, and trace a fresh `open <url>`, not `reload`.
+- Let HMR settle before a render capture (`wait` after `open`). A recompile injects phantom renders (reason `state: "compiling" -> "none"`, mount counts unrelated to your data). Absurd counts mean you captured a recompile.
+- StrictMode doubles dev renders, so a list of N rows shows about 2N instances. Read counts relatively (before vs after), or use a profiling build.
+- A `Promise.all` group is recorded on the track as only the read that gates it (the slowest to resolve); members that resolve earlier get no span at all, even on the Server Requests track. So after a parallel fix, expect fewer spans, not the same set overlapping. A missing span is not proof nothing ran. Never verify a parallel fix by counting spans; verify it by timing: the gating read now starts right after its prerequisite, and dependent work starts earlier.
+- The `react renders stop` "recording Xs" header is wall-clock since `start`, not your interaction. Confirm the capture from the change-reason column.
+- `[agent-browser] restore: missing` is expected on first run.
+
+## when you get lost
+
+An empty or malformed capture (no Server Components ⚛ track, an empty render profile, a trace of the wrong navigation) is almost always preflight: React DevTools not enabled at launch, a drifted page, or a keystroke that did not register. Re-run `next-dev-loop` preflight before touching app code. A capture that merely lacks a `Cascading Update` is not a failure; see mode B.
+
+## references
+
+- Companion guide (the human walkthrough of these steps): the Next.js [Profiling performance](/docs/app/guides/profiling-performance) guide.


### PR DESCRIPTION
Profiling an App with React Dev Tools

- Step 1, fixing a data waterfall
- Step 2, narrow down Suspense boundaries
- Explain how both can be fixed with cache components
- Step 3, blocking keystroke

TODO:

- [ ] write an eval for the Skill
- [ ] rename guide, it is not about performance necessarily
- [ ] all the screenshots
- [ ] sync with repository for the walkthrough app
- [ ] dxagent run


Closes: https://linear.app/vercel/issue/DOC-6459/using-performance-tracks-and-suspense-dev-tools-in-nextjs-apps