### PR TITLE
turbo-tasks-backend: parent_count garbage collection for the persistent engine

### DIFF
--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -5,7 +5,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
+    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbo_tasks, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -66,7 +66,16 @@ unsafe impl OperationValue for PathToOutputOperation {}
 type OutputOperationToComputeEntry =
     FxHashMap<OperationVc<ExpandedOutputAssets>, OperationVc<OptionMapEntry>>;
 
-#[turbo_tasks::value]
+// This map is a dev-only, rebuilt-every-session index over the current session's output assets
+// (populated via `insert_output_assets` during the write/emit phase), not a source of truth — the
+// underlying `ExpandedOutputAssets` operations are the persisted data. So we skip persisting it
+// (`serialization = "skip"`), which keeps the `OperationVc` GC pins it holds (see the pin/unpin
+// calls in the mutation methods below) purely in-session: no persist/restore re-pinning needed.
+//
+// `evict = "never"` because the op set and the record of what's pinned live in this cell's `State`;
+// evicting the cell would drop that state and (with serialization skipped) it could not be
+// restored, silently resetting the map and orphaning the pins.
+#[turbo_tasks::value(serialization = "skip", evict = "never")]
 pub struct VersionedContentMap {
     // TODO: turn into a bi-directional multimap, ExpandedOutputAssets ->
     // FxIndexSet<FileSystemPath>
@@ -108,7 +117,32 @@ impl VersionedContentMap {
             client_output_path,
         );
         this.map_op_to_compute_entry.update_conditionally(|map| {
-            map.insert(assets_operation, compute_entry) != Some(compute_entry)
+            let previous = map.insert(assets_operation, compute_entry);
+            if previous == Some(compute_entry) {
+                // Nothing changed: the same value was already stored under this key, so the
+                // `insert` replaced `compute_entry` with an identical `compute_entry`. The key op's
+                // pin (taken when it was first inserted) and the value op's pin are both still
+                // correct; no pin bookkeeping needed.
+                return false;
+            }
+            // Pin the operations so GC keeps their tasks alive while they're held in this map (the
+            // map stores them outside the task graph, so nothing else anchors them). This runs in a
+            // task function body — the unguarded region — so acquiring the pin guard is safe.
+            let tt = turbo_tasks();
+            match previous {
+                None => {
+                    // New key: pin both the key op and the value op.
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+                Some(old_compute_entry) => {
+                    // Key already present (its pin stays); the value op changed — unpin the old,
+                    // pin the new.
+                    tt.unpin_task_for_gc(old_compute_entry.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+            }
+            true
         });
         Ok(())
     }
@@ -132,30 +166,42 @@ impl VersionedContentMap {
         self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
+            // The map stores `assets_operation` outside the task graph, so pin its task for the
+            // duration of each (path -> op) membership: pin on a genuine insert, unpin on a genuine
+            // removal. This runs in a task function body (the unguarded region), so acquiring the
+            // pin guard is safe. Balance is one pin per distinct path bucket the op lives in.
+            let tt = turbo_tasks();
+
             // get current map's keys, subtract keys that don't exist in operation
             let mut stale_assets = map.0.keys().cloned().collect::<FxHashSet<_>>();
 
             for (k, _) in entries.iter().flatten() {
-                let res = map
+                let inserted = map
                     .0
                     .entry(k.clone())
                     .or_default()
                     .0
                     .insert(assets_operation);
+                if inserted {
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                }
                 stale_assets.remove(k);
-                changed = changed || res;
+                changed = changed || inserted;
             }
 
             // Make more efficient with reverse map
             for k in &stale_assets {
-                let res = map
+                let removed = map
                     .0
                     .get_mut(k)
                     // guaranteed
                     .unwrap()
                     .0
                     .swap_remove(&assets_operation);
-                changed = changed || res
+                if removed {
+                    tt.unpin_task_for_gc(assets_operation.task_id());
+                }
+                changed = changed || removed
             }
             changed
         });

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -41,8 +41,12 @@ use crate::next_api::turbopack_ctx::NextTurbopackContext;
 /// [`turbo_tasks::OperationValue`] and should be dereferenced to an [`OperationVc`] before being
 /// passed to a [`turbo_tasks::function`].
 //
-// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
-#[derive(Clone)]
+/// A `DetachedVc` holds its operation's task alive against garbage collection for as long as the
+/// handle (or any clone) exists: it is a reference that escapes the tracked task graph, so no
+/// persistent parent lists the task as a child and GC would otherwise collect it. Each live
+/// `DetachedVc` counts as one transient reference (pin) on the task; the pin is released when the
+/// last clone is dropped. An `OperationVc` is statically a `TaskOutput`, so the pinned `TaskId` is
+/// recovered synchronously from the `RawVc`.
 pub struct DetachedVc<T> {
     turbopack_ctx: NextTurbopackContext,
     /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.
@@ -51,11 +55,36 @@ pub struct DetachedVc<T> {
 
 impl<T> DetachedVc<T> {
     pub fn new(turbopack_ctx: NextTurbopackContext, vc: OperationVc<T>) -> Self {
+        // Pin the operation's task so GC treats this out-of-graph handle as a root.
+        turbopack_ctx.turbo_tasks().pin_task_for_gc(vc.task_id());
+
         Self { turbopack_ctx, vc }
     }
 
     pub fn turbopack_ctx(&self) -> &NextTurbopackContext {
         &self.turbopack_ctx
+    }
+}
+
+impl<T> Clone for DetachedVc<T> {
+    fn clone(&self) -> Self {
+        // Each live handle holds its own pin; balanced by this clone's `Drop`.
+        self.turbopack_ctx
+            .turbo_tasks()
+            .pin_task_for_gc(self.task_id());
+
+        Self {
+            turbopack_ctx: self.turbopack_ctx.clone(),
+            vc: self.vc,
+        }
+    }
+}
+
+impl<T> Drop for DetachedVc<T> {
+    fn drop(&mut self) {
+        self.turbopack_ctx
+            .turbo_tasks()
+            .unpin_task_for_gc(self.task_id());
     }
 }
 

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -68,15 +68,7 @@ impl<T> DetachedVc<T> {
 
 impl<T> Clone for DetachedVc<T> {
     fn clone(&self) -> Self {
-        // Each live handle holds its own pin; balanced by this clone's `Drop`.
-        self.turbopack_ctx
-            .turbo_tasks()
-            .pin_task_for_gc(self.task_id());
-
-        Self {
-            turbopack_ctx: self.turbopack_ctx.clone(),
-            vc: self.vc,
-        }
+        Self::new(self.turbopack_ctx.clone(), self.vc)
     }
 }
 

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -63,6 +63,8 @@ impl<T> DetachedVc<T> {
     }
 }
 
+// Manual clone and Drop routines are required for proper reference counting to prevent GC
+
 impl<T> Clone for DetachedVc<T> {
     fn clone(&self) -> Self {
         Self::new(self.turbopack_ctx.clone(), self.vc)

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -42,11 +42,8 @@ use crate::next_api::turbopack_ctx::NextTurbopackContext;
 /// passed to a [`turbo_tasks::function`].
 //
 /// A `DetachedVc` holds its operation's task alive against garbage collection for as long as the
-/// handle (or any clone) exists: it is a reference that escapes the tracked task graph, so no
-/// persistent parent lists the task as a child and GC would otherwise collect it. Each live
-/// `DetachedVc` counts as one transient reference (pin) on the task; the pin is released when the
-/// last clone is dropped. An `OperationVc` is statically a `TaskOutput`, so the pinned `TaskId` is
-/// recovered synchronously from the `RawVc`.
+/// handle exists: it is a reference that escapes the tracked task graph, so no
+/// persistent parent lists the task as a child and GC would otherwise collect it.
 pub struct DetachedVc<T> {
     turbopack_ctx: NextTurbopackContext,
     /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.

--- a/turbopack/crates/turbo-tasks-backend/benches/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/gc.rs
@@ -1,0 +1,170 @@
+//! Benchmarks for the `parent_count` garbage-collection pass ([`TurboTasksBackend::gc_collect`],
+//! driven here via the `gc_for_testing` hook).
+//!
+//! Only the collect pass is timed: each iteration's setup builds a fresh backend, materializes a
+//! large graph, and disconnects it (turning it into garbage) — none of which is measured. The
+//! routine then times a single GC pass over that garbage. Throughput is reported in tasks
+//! collected per second, so regressions/improvements in GC scaling are directly visible.
+//!
+//! Gated behind `TURBOPACK_BENCH_GC` (like the other stress benches) because the per-iteration
+//! setup is expensive. Enable with e.g.:
+//!
+//! ```bash
+//! TURBOPACK_BENCH_GC=1 cargo bench -p turbo-tasks-backend --bench mod -- gc
+//! ```
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
+use tokio::runtime::Runtime;
+use turbo_tasks::{
+    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
+
+fn enabled() -> bool {
+    !matches!(
+        std::env::var("TURBOPACK_BENCH_GC").ok().as_deref(),
+        None | Some("") | Some("no") | Some("false")
+    )
+}
+
+/// A persistent backend with GC-relevant options. Each benchmark iteration gets a fresh one (the
+/// `TempDir` is returned so it lives as long as the backend). GC is invoked directly via
+/// `gc_for_testing`, which does not consult the `TURBO_ENGINE_GC` env var, so nothing global needs
+/// setting.
+fn create_tt() -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    let dir = tempfile::Builder::new()
+        .prefix("gc-bench-")
+        .tempdir_in(&parent)
+        .unwrap();
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(std::thread::available_parallelism().map_or(4, |n| n.get())),
+            small_preallocation: false,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "bench-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+#[turbo_tasks::value(transparent)]
+struct Generation(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_generation() -> Vc<Generation> {
+    Generation(State::new(0)).cell()
+}
+
+// --- WIDE shape: root -> `width` intermediates, each -> a leaf (2 tasks per index). Bumping the
+// generation disconnects the whole previous generation, so a collect tears down ~2*width tasks and
+// exercises the chunked per-task fan-out plus a one-level cascade (intermediate -> its leaf). ---
+
+#[turbo_tasks::function]
+fn wide_leaf(generation: u32, index: u32) -> Vc<u32> {
+    Vc::cell(generation.wrapping_mul(1_000_003).wrapping_add(index))
+}
+
+#[turbo_tasks::function]
+async fn wide_intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *wide_leaf(generation, index).await?))
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn wide_root(generation: ResolvedVc<Generation>, width: u32) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..width {
+        sum = sum.wrapping_add(*wide_intermediate(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// Build generation 0 of the WIDE graph then bump to generation 1, leaving generation 0 fully
+/// disconnected (garbage) and resident. Returns the backend ready for a timed collect.
+fn setup_wide_garbage(
+    rt: &Runtime,
+    width: u32,
+) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    rt.block_on(async move {
+        // `TurboTasks::new` builds a `PriorityRunner` that calls `Handle::current()`, so the
+        // backend must be constructed inside the runtime context.
+        let (tt, dir) = create_tt();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let generation_op = create_generation();
+            let generation_vc = generation_op.resolve().strongly_consistent().await?;
+            let generation = generation_op.read_strongly_consistent().await?;
+            wide_root(generation_vc, width)
+                .read_strongly_consistent()
+                .await?;
+            generation.set(1);
+            wide_root(generation_vc, width)
+                .read_strongly_consistent()
+                .await?;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        (tt, dir)
+    })
+}
+
+pub fn gc(c: &mut Criterion) {
+    if !enabled() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("turbo_tasks_backend_gc");
+    // Setup dominates wall time and each sample runs a full pass over a large graph; keep the
+    // sample count modest.
+    group.sample_size(10);
+
+    for width in [5_000u32, 25_000, 100_000] {
+        // ~2 tasks per index become garbage (intermediate + leaf).
+        let garbage = (2 * width) as u64;
+        group.throughput(Throughput::Elements(garbage));
+        group.bench_with_input(BenchmarkId::new("wide", garbage), &width, |b, &width| {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            // PerIteration: each collect consumes its garbage, so every iteration needs a freshly
+            // built+disconnected graph. Setup is not timed.
+            b.iter_batched(
+                || setup_wide_garbage(&rt, width),
+                |(tt, _dir)| {
+                    // `gc_for_testing` is synchronous but internally uses `scope_self_feeding`,
+                    // which needs a tokio runtime context (spawns helpers / may `block_in_place`),
+                    // so run it on a runtime worker via `block_on`. The block_on wrapper is a fixed
+                    // few-µs overhead, negligible next to the ms-scale pass and constant across
+                    // samples.
+                    let collected = rt.block_on(async { tt.backend().gc_for_testing(&tt) });
+                    // Return the backend so its (large) teardown happens on criterion's drop path,
+                    // not inside the measured routine.
+                    (collected, tt, _dir)
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+
+    group.finish();
+}

--- a/turbopack/crates/turbo-tasks-backend/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/mod.rs
@@ -3,6 +3,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
+pub(crate) mod gc;
 pub(crate) mod overhead;
 pub(crate) mod scope_stress;
 pub(crate) mod stress;
@@ -10,6 +11,6 @@ pub(crate) mod stress;
 criterion_group!(
     name = turbo_tasks_backend_stress;
     config = Criterion::default();
-    targets = stress::fibonacci, scope_stress::scope_stress, overhead::overhead
+    targets = stress::fibonacci, scope_stress::scope_stress, overhead::overhead, gc::gc
 );
 criterion_main!(turbo_tasks_backend_stress);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -9,9 +9,9 @@
 //!
 //! This module holds the GC-specific logic (the job types, the pool driver, per-job teardown, and
 //! the pin/unpin bookkeeping) as an `impl TurboTasksBackend`; it is a child of the `backend` module
-//! so it reaches the backend's private state (`gc_candidates`, `storage`, `snapshot_coord`) and the
-//! GC-only `execute_context_gc` directly. Callers (`snapshot_and_persist`, `stop`, the background
-//! job loop, the `Backend` trait's `pin_task_for_gc`/`unpin_task_for_gc`) live in `mod.rs`.
+//! so it reaches the backend's private state (`storage`, `snapshot_coord`) and the GC-only
+//! `execute_context_gc` directly. Callers (`snapshot_and_persist`, `stop`, the background job loop,
+//! the `Backend` trait's `pin_task_for_gc`/`unpin_task_for_gc`) live in `mod.rs`.
 
 use std::sync::{
     LazyLock,
@@ -129,23 +129,12 @@ impl TurboTasksBackend {
         ExecuteContextImpl::new_for_gc(self, turbo_tasks)
     }
 
-    /// Records `task_id` as a garbage-collection candidate (its persistent `parent_count` reached
-    /// 0). Only non-transient tasks are tracked — transient tasks are never collected. Candidacy is
-    /// re-validated under exclusion before the task is actually collected, so a false positive here
-    /// (e.g. the count is bumped back up by a concurrent re-connect) is harmless.
-    pub(crate) fn add_gc_candidate(&self, task_id: TaskId) {
-        if task_id.is_transient() {
-            return;
-        }
-        self.gc_candidates.lock().insert(task_id);
-    }
-
-    /// Runs a garbage-collection pass under the coordinator's GC phase. Drains the candidate set
-    /// (tasks observed reaching `parent_count == 0`), re-validates each under the exclusion, and
-    /// tears down the ones that are still collectible: scrubbing their reverse-dependency edges,
-    /// decrementing their children's `parent_count` (cascading to any child that reaches 0),
-    /// removing them from the in-memory map + task_cache, and buffering an on-disk tombstone for
-    /// the next persistence commit.
+    /// Runs a garbage-collection pass under the coordinator's GC phase. Scans the resident map for
+    /// collectible tasks (no persistent parent, quiescent, no aggregation edges), re-validates each
+    /// under the exclusion, and tears down the ones that are still collectible: scrubbing their
+    /// reverse-dependency edges, decrementing their children's `parent_count` (cascading to any
+    /// child that reaches 0), removing them from the in-memory map + task_cache, and buffering an
+    /// on-disk tombstone for the next persistence commit.
     ///
     /// The pass is fully parallel and self-feeding via [`scope_self_feeding`]: work is a pool of
     /// [`GcJob`]s (collect a task; decrement a chunk of children; scrub a chunk of reverse-dep
@@ -185,37 +174,43 @@ impl TurboTasksBackend {
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
     ) -> (usize, Vec<TaskDeletion>) {
-        // Seed the pool from the candidates observed since the last pass. Re-validation happens per
-        // task in `Collect` (a candidate may have been revived by a concurrent re-connect before
-        // the GC phase was acquired).
+        // Seed the pool by scanning the resident map for tasks that pass the cheap
+        // `gc_maybe_collectible` pre-filter (a handful of field reads per task under a shard read
+        // lock — the same shape as the eviction scan, which proved this is fast). We scan rather
+        // than maintain an incremental candidate set: correctness derives entirely from each task's
+        // durable `parent_count`, so there's nothing to persist across sessions and nothing to keep
+        // in sync (a scan can't miss a task the way a hand-maintained side-set could). `Collect`
+        // re-validates each candidate authoritatively under a guard. The scan only sees resident
+        // tasks; disk-only garbage is collected after it is next restored.
+        //
+        // TODO(perf): recycle the task ids of collected tasks. `persisted_task_id_factory`
+        // (`IdFactoryWithReuse`) can hand out freed ids, and the persisted `next_free_task_id`
+        // high-water mark only grows today, so the id space grows unboundedly across churn even
+        // though the task set stays flat. Reuse must happen only AFTER the `save_snapshot` that
+        // tombstoned the id has committed (a crash before commit leaves the task on disk — reusing
+        // its id would alias it), and must be guarded against resurrection: between removal and
+        // commit a `get_or_create_task` for the same type could re-mint the id, and the id must not
+        // be handed out while any live `OperationVc`/`DetachedVc` still references it. Feed the
+        // recycled ids into `persisted_task_id_factory` so the high-water mark can stop growing.
         let seeds: Vec<GcJob> = self
-            .gc_candidates
-            .lock()
-            .drain()
+            .storage
+            .gc_collectible_candidates()
+            .into_iter()
             .map(GcJob::Collect)
             .collect();
         if seeds.is_empty() {
             return (0, Vec::new());
         }
 
-        // Shared accumulators. Touched only on the (comparatively rare) collect/retain outcomes,
-        // not on every decrement or scrub, so the mutexes are not a hot path.
+        // Shared accumulators. Touched only on the (comparatively rare) collect outcome, not on
+        // every decrement or scrub, so the mutex/atomic are not a hot path.
         let deletions = Mutex::new(Vec::new());
         let collected = AtomicUsize::new(0);
-        // Candidates that are still parentless but not *yet* collectible (e.g. residual transient
-        // activeness) are re-retained for a later pass.
-        let retain = Mutex::new(Vec::new());
 
         scope_self_feeding(seeds, |spawner, job| {
-            self.gc_run_job(job, spawner, turbo_tasks, &deletions, &collected, &retain);
+            self.gc_run_job(job, spawner, turbo_tasks, &deletions, &collected);
         });
 
-        // Re-queue candidates that were still parentless but not collectible this pass, so a later
-        // pass retries once their transient activeness clears.
-        let retain = retain.into_inner();
-        if !retain.is_empty() {
-            self.gc_candidates.lock().extend(retain);
-        }
         (collected.into_inner(), deletions.into_inner())
     }
 
@@ -229,42 +224,44 @@ impl TurboTasksBackend {
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
         deletions: &Mutex<Vec<TaskDeletion>>,
         collected: &AtomicUsize,
-        retain: &Mutex<Vec<TaskId>>,
     ) {
         match job {
             GcJob::Collect(task_id) => {
-                // Transient-ness is a property of the id, not the storage — check it before
-                // touching the map (transient tasks are never collected).
-                if task_id.is_transient() {
-                    return;
-                }
                 let mut ctx = self.execute_context_gc(turbo_tasks);
 
-                // Single access: decide collectibility and, if collectible, capture the edges
-                // needed to tear the task down. Reading through the guard
-                // (`ctx.task(.., All)`, which restores the task if it was evicted)
-                // means `is_gc_collectible`'s Meta reads go through `check_access`,
-                // so the "Meta restored" precondition is enforced by the
-                // standard guard machinery rather than a hand-rolled `is_restored` check.
-                let plan = {
-                    let task = ctx.task(task_id, TaskDataCategory::All);
-                    if !task.is_gc_collectible() {
-                        // Not collectible: keep retrying only while it is still parentless;
-                        // otherwise a concurrent re-connect revived it and it is no longer garbage.
-                        if task.get_parent_count().copied().unwrap_or(0) == 0 {
-                            retain.lock().push(task_id);
-                        }
-                        return;
-                    }
-                    GcDeletePlan {
-                        children: task.iter_children().collect(),
-                        output_deps: task.iter_output_dependencies().collect(),
-                        cell_deps: task.iter_cell_dependencies().collect(),
-                        cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
-                        collectibles_deps: task.iter_collectibles_dependencies().collect(),
-                        persistent_task_type: task.get_persistent_task_type().cloned(),
-                    }
+                // A `Collect` is only ever created for a task that is already collectible, and
+                // nothing can invalidate that before it runs, so this is an asserted invariant, not
+                // a filter:
+                // - seed collects come from the scan, which only matches Meta-resident tasks
+                //   passing `gc_maybe_collectible` (the Meta-resident gate is what makes the raw
+                //   scan agree with the guarded predicate — an evicted-Meta task reads its fields
+                //   as defaults);
+                // - cascade collects are spawned by `Decrement` only after it confirms
+                //   `is_gc_collectible` under the child's guard.
+                // The GC phase holds throughout the pass: no operation can re-connect or pin the
+                // task (both take an operation guard, excluded here), no other GC job touches a
+                // now-parentless task, and eviction runs only after the pass — so a task's
+                // collectibility (and Meta residency) cannot change between spawn and here.
+                //
+                // `All` restores Data so the plan below can read the Data-category dep sets.
+                let task = ctx.task(task_id, TaskDataCategory::All);
+                debug_assert!(
+                    task.is_gc_collectible(),
+                    "gc: Collect({task_id}) for a non-collectible task — the seed scan's \
+                     Meta-resident `gc_maybe_collectible` filter and Decrement's pre-spawn check \
+                     should guarantee collectibility under the GC phase"
+                );
+                // Snapshot the edges into owned buffers, then drop the guard before the teardown
+                // opens the target tasks' guards.
+                let plan = GcDeletePlan {
+                    children: task.iter_children().collect(),
+                    output_deps: task.iter_output_dependencies().collect(),
+                    cell_deps: task.iter_cell_dependencies().collect(),
+                    cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
+                    collectibles_deps: task.iter_collectibles_dependencies().collect(),
+                    persistent_task_type: task.get_persistent_task_type().cloned(),
                 };
+                drop(task);
 
                 let deletion = self.gc_remove_task(task_id, &plan, &mut ctx);
                 deletions.lock().push(deletion);
@@ -305,16 +302,26 @@ impl TurboTasksBackend {
             GcJob::Decrement(children) => {
                 let mut ctx = self.execute_context_gc(turbo_tasks);
                 for child in children {
-                    // Transient children are never collected and carry no persistent parent_count.
+                    // A collected task's `children` set (unfiltered `iter_children`) can include
+                    // transient children, which carry no persistent `parent_count` — skip them.
                     if child.is_transient() {
                         continue;
                     }
                     let mut child_task = ctx.task(child, TaskDataCategory::Meta);
                     let new_count = child_task.update_and_get_parent_count(-1);
+                    // Only spawn a `Collect` for a child that is *actually* collectible now, not
+                    // merely at `parent_count == 0`: a count-0 task can still be pinned, in
+                    // progress, a root, or hold aggregation edges. Checking
+                    // here (under the child's guard we already hold) is what
+                    // lets `Collect` treat its input as guaranteed-collectible.
+                    // Exactly one decrementer observes the RMW hit 0 (entry lock), so at most one
+                    // `Collect` is spawned per child; and under the GC phase nothing can make the
+                    // child non-collectible between here and the `Collect` running (no operation
+                    // can re-connect or pin it, and no other GC job touches a
+                    // now-parentless task).
+                    let collectible = new_count == 0 && child_task.is_gc_collectible();
                     drop(child_task);
-                    // Exactly one decrementer sees 0 (RMW under the entry lock), so `child` is
-                    // spawned as a collect target exactly once.
-                    if new_count == 0 {
+                    if collectible {
                         spawner.spawn(GcJob::Collect(child));
                     }
                 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -18,22 +18,19 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
-use parking_lot::Mutex;
 use turbo_tasks::{
     TaskId, TurboTasks,
     scope::{Spawner, scope_self_feeding},
-    util::{good_chunk_size, into_chunks},
 };
 
-use crate::{
-    backend::{
-        CachedTaskTypeArc, TurboTasksBackend,
-        operation::{ExecuteContext, ExecuteContextImpl, TaskGuard},
-        storage::TaskDataCategory,
-        storage_schema::TaskStorageAccessors,
+use crate::backend::{
+    TurboTasksBackend,
+    operation::{
+        AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
+        OutdatedEdge, TaskGuard,
     },
-    backing_storage::{TaskDeletion, compute_task_type_hash},
-    data::{CellRef, CollectiblesRef},
+    storage::{SpecificTaskDataCategory, TaskDataCategory},
+    storage_schema::TaskStorageAccessors,
 };
 
 /// When `TURBO_ENGINE_GC` is set to a truthy value, the background job runs a `parent_count`-driven
@@ -52,70 +49,21 @@ pub(super) fn gc_enabled() -> bool {
 }
 
 /// A unit of garbage-collection work fed through the self-feeding parallel pool in
-/// [`TurboTasksBackend::gc_collect`]. Every variant is bounded (a single task, or a bounded chunk),
-/// so no single job pins a worker with unbounded work: a task with a huge number of children or
-/// forward dependencies fans out into many chunked jobs that spread across worker threads. Jobs
-/// discover more jobs (a collected task spawns decrements + scrubs; a decrement that hits 0 spawns
-/// a collect), which the pool drains until quiescent.
+/// [`TurboTasksBackend::gc_collect`]: collecting one task. Parallelism is *across* tasks — the pool
+/// runs many `Collect` jobs on different workers — while each task's own teardown (its
+/// `CleanupOldEdges` run) is sequential. A `Collect` discovers more `Collect` jobs (each child the
+/// cleanup drives to `parent_count == 0` and that is itself collectible), which flow straight back
+/// into the pool until it drains.
+///
+/// (A single-variant enum today; kept as an enum so the self-feeding pool's job type has room to
+/// grow — e.g. if the per-task teardown is later split to fan a huge task's edges across workers.)
 enum GcJob {
-    /// Re-validate `task_id`'s collectibility and, if still collectible, tear it down: remove it
-    /// from the in-memory map + task_cache, record its tombstone, then spawn [`GcJob::Decrement`]
-    /// jobs for its children and `Scrub*` jobs for its forward dependencies.
+    /// Re-validate `task_id`'s collectibility and, if still collectible, tear it down: run
+    /// [`CleanupOldEdgesOperation`] over all its edges (dropping children's `parent_count`,
+    /// scrubbing forward-dep reverse edges, and rebalancing the aggregation graph), remove it from
+    /// the in-memory map + task_cache, record its tombstone, then spawn a [`GcJob::Collect`] for
+    /// each child the cleanup drove to `parent_count == 0` that is now itself collectible.
     Collect(TaskId),
-    /// Decrement the persistent `parent_count` of each task in the chunk (each lost a persistent
-    /// parent that was just collected). Any that reach 0 are newly unreachable and spawn a
-    /// [`GcJob::Collect`].
-    Decrement(Vec<TaskId>),
-    /// Remove `source` from the `output_dependent` reverse-set of each target task in the chunk.
-    ScrubOutput {
-        source: TaskId,
-        targets: Vec<TaskId>,
-    },
-    /// Remove `source`'s cell dependency from the `cell_dependents` reverse-set of each referenced
-    /// cell's task.
-    ScrubCell { source: TaskId, refs: Vec<CellRef> },
-    /// Like [`GcJob::ScrubCell`] for hashed cell dependencies.
-    ScrubCellHashed {
-        source: TaskId,
-        refs: Vec<(CellRef, u64)>,
-    },
-    /// Remove `source` from the `collectibles_dependents` reverse-set of each referenced task.
-    ScrubCollectibles {
-        source: TaskId,
-        refs: Vec<CollectiblesRef>,
-    },
-}
-
-/// The edges captured from a collectible task under its single [`ExecuteContext`] guard, so the
-/// guard can be dropped before the teardown opens the *target* tasks' guards (holding two task
-/// locks at once trips the concurrent-lock detector). `children` drive the cascade; the `*_deps`
-/// are the forward dependencies whose reverse side must be scrubbed; `persistent_task_type` yields
-/// the on-disk `TaskCache` key.
-struct GcDeletePlan {
-    children: Vec<TaskId>,
-    output_deps: Vec<TaskId>,
-    cell_deps: Vec<CellRef>,
-    cell_deps_hashed: Vec<(CellRef, u64)>,
-    collectibles_deps: Vec<CollectiblesRef>,
-    persistent_task_type: Option<CachedTaskTypeArc>,
-}
-
-/// Splits `items` into `good_chunk_size` chunks and spawns one [`GcJob`] per chunk (built by
-/// `make_job`) into the self-feeding GC pool. A small collection becomes a single chunk job (≈
-/// inline); a huge one (e.g. 20K children/deps) fans out into `~4 * parallelism` jobs that spread
-/// across workers, so no single job pins a worker with unbounded work. Empty input spawns nothing.
-fn spawn_chunked<I>(
-    spawner: &Spawner<'_, '_, GcJob>,
-    items: Vec<I>,
-    make_job: impl Fn(Vec<I>) -> GcJob,
-) {
-    if items.is_empty() {
-        return;
-    }
-    let chunk_size = good_chunk_size(items.len());
-    for chunk in into_chunks(items, chunk_size) {
-        spawner.spawn(make_job(chunk.collect()));
-    }
 }
 
 impl TurboTasksBackend {
@@ -169,11 +117,10 @@ impl TurboTasksBackend {
     /// on free worker threads (robust on thread-limited runtimes). GC runs from a synchronous
     /// backend context (like `connect_children`, which also fans out onto the scope machinery).
     ///
-    /// Returns `(number of tasks collected, on-disk tombstones)`.
-    pub(crate) fn gc_collect(
-        &self,
-        turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> (usize, Vec<TaskDeletion>) {
+    /// Returns the number of tasks collected (marked soft-deleted). The on-disk tombstones are not
+    /// produced here — collected tasks are left resident with their `deleted` flag set, and the
+    /// next snapshot derives the tombstones from that flag (see `snapshot_and_persist`).
+    pub(crate) fn gc_collect(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
         // Seed the pool by scanning the resident map for tasks that pass the cheap
         // `gc_maybe_collectible` pre-filter (a handful of field reads per task under a shard read
         // lock — the same shape as the eviction scan, which proved this is fast). We scan rather
@@ -199,19 +146,17 @@ impl TurboTasksBackend {
             .map(GcJob::Collect)
             .collect();
         if seeds.is_empty() {
-            return (0, Vec::new());
+            return 0;
         }
 
-        // Shared accumulators. Touched only on the (comparatively rare) collect outcome, not on
-        // every decrement or scrub, so the mutex/atomic are not a hot path.
-        let deletions = Mutex::new(Vec::new());
+        // Written once per collected task (not per child/dep), so the atomic is not a hot path.
         let collected = AtomicUsize::new(0);
 
         scope_self_feeding(seeds, |spawner, job| {
-            self.gc_run_job(job, spawner, turbo_tasks, &deletions, &collected);
+            self.gc_run_job(job, spawner, turbo_tasks, &collected);
         });
 
-        (collected.into_inner(), deletions.into_inner())
+        collected.into_inner()
     }
 
     /// Runs one [`GcJob`], possibly spawning follow-up jobs into the same pool. See
@@ -222,191 +167,106 @@ impl TurboTasksBackend {
         job: GcJob,
         spawner: &Spawner<'_, '_, GcJob>,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
-        deletions: &Mutex<Vec<TaskDeletion>>,
         collected: &AtomicUsize,
     ) {
         match job {
             GcJob::Collect(task_id) => {
                 let mut ctx = self.execute_context_gc(turbo_tasks);
-
-                // A `Collect` is only ever created for a task that is already collectible, and
-                // nothing can invalidate that before it runs, so this is an asserted invariant, not
-                // a filter:
-                // - seed collects come from the scan, which only matches Meta-resident tasks
-                //   passing `gc_maybe_collectible` (the Meta-resident gate is what makes the raw
-                //   scan agree with the guarded predicate — an evicted-Meta task reads its fields
-                //   as defaults);
-                // - cascade collects are spawned by `Decrement` only after it confirms
-                //   `is_gc_collectible` under the child's guard.
-                // The GC phase holds throughout the pass: no operation can re-connect or pin the
-                // task (both take an operation guard, excluded here), no other GC job touches a
-                // now-parentless task, and eviction runs only after the pass — so a task's
-                // collectibility (and Meta residency) cannot change between spawn and here.
-                //
-                // `All` restores Data so the plan below can read the Data-category dep sets.
+                // `All` restores Data so the edge capture below can read the Data-category dep
+                // sets.
                 let task = ctx.task(task_id, TaskDataCategory::All);
                 debug_assert!(
                     task.is_gc_collectible(),
                     "gc: Collect({task_id}) for a non-collectible task — the seed scan's \
-                     Meta-resident `gc_maybe_collectible` filter and Decrement's pre-spawn check \
-                     should guarantee collectibility under the GC phase"
+                     Meta-resident `gc_maybe_collectible` filter and the cascade's collectibility \
+                     check should guarantee collectibility under the GC phase"
                 );
-                // Snapshot the edges into owned buffers, then drop the guard before the teardown
-                // opens the target tasks' guards.
-                let plan = GcDeletePlan {
-                    children: task.iter_children().collect(),
-                    output_deps: task.iter_output_dependencies().collect(),
-                    cell_deps: task.iter_cell_dependencies().collect(),
-                    cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
-                    collectibles_deps: task.iter_collectibles_dependencies().collect(),
-                    persistent_task_type: task.get_persistent_task_type().cloned(),
-                };
+
+                // Capture ALL of this task's edges as `OutdatedEdge`s, then hand them to the same
+                // `CleanupOldEdges` operation a re-executing task uses. This is what makes GC
+                // teardown correct: alongside dropping each child's `parent_count` and scrubbing
+                // the forward-dep reverse edges, it PROPAGATES THE AGGREGATION
+                // REBALANCE (removes this task from its children's `upper` sets via
+                // `InnerOfUppersLostFollowers`). Without that, collected children
+                // would be left with a dangling upper edge and never
+                // become collectible themselves. The op opens `ctx.task(task_id)` to remove the
+                // child edges, so it must run while `task_id` is still resident.
+                let mut old_edges: Vec<OutdatedEdge> = Vec::new();
+                old_edges.extend(task.iter_children().map(OutdatedEdge::Child));
+                old_edges.extend(
+                    task.iter_output_dependencies()
+                        .map(OutdatedEdge::OutputDependency),
+                );
+                old_edges.extend(
+                    task.iter_cell_dependencies()
+                        .map(OutdatedEdge::CellDependency),
+                );
+                old_edges.extend(
+                    task.iter_cell_dependencies_hashed()
+                        .map(|(r, k)| OutdatedEdge::HashedCellDependency(r, k)),
+                );
+                old_edges.extend(
+                    task.iter_collectibles_dependencies()
+                        .map(OutdatedEdge::CollectiblesDependency),
+                );
                 drop(task);
 
-                let deletion = self.gc_remove_task(task_id, &plan, &mut ctx);
-                deletions.lock().push(deletion);
+                CleanupOldEdgesOperation::run(
+                    task_id,
+                    old_edges,
+                    AggregationUpdateQueue::new(),
+                    &mut ctx,
+                );
+
+                // The edges are gone and the children are rebalanced. Instead of removing the task
+                // from the map now (which would let a later `ctx.task` on it — e.g. a sibling's
+                // `CleanupOldEdges` forward-dep scrub — resurrect it from disk as a zombie), mark
+                // it soft-deleted and keep it resident. The next snapshot tombstones its on-disk
+                // copy; a later step hard-deletes it from memory once the tombstone has committed.
+                self.gc_mark_deleted(task_id, &mut ctx);
                 collected.fetch_add(1, Ordering::Relaxed);
 
-                // Fan the (potentially huge) teardown out into bounded chunk jobs so no single
-                // worker is pinned by one task's children/deps. `gc_remove_task` already dropped
-                // `task_id`'s own guard; the scrub jobs only open the *target* guards, and the plan
-                // carries owned edge lists so they don't need `task_id` resident.
-                let GcDeletePlan {
-                    children,
-                    output_deps,
-                    cell_deps,
-                    cell_deps_hashed,
-                    collectibles_deps,
-                    persistent_task_type: _,
-                } = plan;
-                spawn_chunked(spawner, children, GcJob::Decrement);
-                spawn_chunked(spawner, output_deps, |targets| GcJob::ScrubOutput {
-                    source: task_id,
-                    targets,
-                });
-                spawn_chunked(spawner, cell_deps, |refs| GcJob::ScrubCell {
-                    source: task_id,
-                    refs,
-                });
-                spawn_chunked(spawner, cell_deps_hashed, |refs| GcJob::ScrubCellHashed {
-                    source: task_id,
-                    refs,
-                });
-                spawn_chunked(spawner, collectibles_deps, |refs| {
-                    GcJob::ScrubCollectibles {
-                        source: task_id,
-                        refs,
-                    }
-                });
-            }
-            GcJob::Decrement(children) => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for child in children {
-                    // A collected task's `children` set (unfiltered `iter_children`) can include
-                    // transient children, which carry no persistent `parent_count` — skip them.
-                    if child.is_transient() {
-                        continue;
-                    }
-                    let mut child_task = ctx.task(child, TaskDataCategory::Meta);
-                    let new_count = child_task.update_and_get_parent_count(-1);
-                    // Only spawn a `Collect` for a child that is *actually* collectible now, not
-                    // merely at `parent_count == 0`: a count-0 task can still be pinned, in
-                    // progress, a root, or hold aggregation edges. Checking
-                    // here (under the child's guard we already hold) is what
-                    // lets `Collect` treat its input as guaranteed-collectible.
-                    // Exactly one decrementer observes the RMW hit 0 (entry lock), so at most one
-                    // `Collect` is spawned per child; and under the GC phase nothing can make the
-                    // child non-collectible between here and the `Collect` running (no operation
-                    // can re-connect or pin it, and no other GC job touches a
-                    // now-parentless task).
-                    let collectible = new_count == 0 && child_task.is_gc_collectible();
-                    drop(child_task);
-                    if collectible {
+                // `CleanupOldEdges` recorded (on this GC context) every child whose persistent
+                // `parent_count` reached 0. Those are the cascade candidates: re-check
+                // collectibility under each child's guard (count 0 alone isn't enough — it could be
+                // pinned, a root, or still hold aggregation edges) and spawn a `Collect` for the
+                // ones that are collectible. Each child reaches 0 exactly once, so there is no
+                // double-queueing.
+                let newly_parentless = ctx.take_gc_parent_count_zeroed();
+                for child in newly_parentless {
+                    debug_assert!(
+                        !child.is_transient(),
+                        "gc: a transient task should never have a persistent parent_count to zero"
+                    );
+                    if ctx.task(child, TaskDataCategory::Meta).is_gc_collectible() {
                         spawner.spawn(GcJob::Collect(child));
                     }
-                }
-            }
-            GcJob::ScrubOutput { source, targets } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for output_task_id in targets {
-                    let mut target = ctx.task(output_task_id, TaskDataCategory::Data);
-                    target.remove_output_dependent(&source);
-                }
-            }
-            GcJob::ScrubCell { source, refs } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for CellRef {
-                    task: cell_task,
-                    cell,
-                } in refs
-                {
-                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
-                    target.remove_cell_dependents(&CellRef { task: source, cell });
-                }
-            }
-            GcJob::ScrubCellHashed { source, refs } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for (
-                    CellRef {
-                        task: cell_task,
-                        cell,
-                    },
-                    key,
-                ) in refs
-                {
-                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
-                    target.remove_cell_dependents_hashed(&(CellRef { task: source, cell }, key));
-                }
-            }
-            GcJob::ScrubCollectibles { source, refs } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for CollectiblesRef {
-                    task: dep_task,
-                    collectible_type,
-                } in refs
-                {
-                    let mut target = ctx.task(dep_task, TaskDataCategory::Data);
-                    target.remove_collectibles_dependents(&(collectible_type, source));
                 }
             }
         }
     }
 
-    /// Removes a collectible task from the in-memory task_cache and map and returns its
-    /// [`TaskDeletion`] tombstone. The reverse-dep edge scrubbing is done separately by the
-    /// `Scrub*` jobs (see [`Self::gc_run_job`]); this only touches `task_id`'s own entries, which
-    /// are independent of the target entries the scrubs mutate, so ordering between them is free.
-    /// Must be called while holding the GC phase.
-    fn gc_remove_task(
-        &self,
-        task_id: TaskId,
-        plan: &GcDeletePlan,
-        _ctx: &mut impl ExecuteContext<'_>,
-    ) -> TaskDeletion {
-        // Remove the in-memory task_cache entry (hash -> id) so lookups don't return a dead id, and
-        // compute the persisted TaskCache key so the snapshot can tombstone the on-disk mapping.
-        // Only persistent tasks are collected, so a persistent task type is always present.
-        let task_type = plan
-            .persistent_task_type
-            .as_ref()
-            .expect("a collected (non-transient) task must have a task type");
-        self.storage.task_cache.remove(task_type.as_ref());
-        let task_type_hash = compute_task_type_hash(task_type);
-
-        // Remove the task from the map. Its own children set is dropped with it; the child ids were
-        // captured into `plan` so the `Decrement` jobs can drop their parent_count.
-        self.storage.remove_task(task_id);
-
-        // Tombstoning the on-disk `TaskCache` erases the *whole* hash bucket, so any live task
-        // whose type xxh3-collides with this one must be re-inserted. Those survivors are resolved
-        // at apply time in `save_snapshot` (which reads the authoritative on-disk bucket) rather
-        // than computed here — the in-memory `task_cache` is lazily populated and keyed by the full
-        // task type, not the hash, so it can't reliably enumerate hash-siblings. Collisions between
-        // two live tasks are astronomically rare, so this survivor path almost never fires.
-        TaskDeletion {
-            task_id,
-            task_type_hash,
-        }
+    /// Marks a collected task **soft-deleted**: it stays resident (in the map and `task_cache`) but
+    /// is flagged for deletion and forced into the next snapshot's modified scan. The task's edges
+    /// and the aggregation rebalance were already handled by the `CleanupOldEdges` run in
+    /// [`Self::gc_run_job`] before this is called.
+    ///
+    /// Keeping the task resident is the whole point: during the pass another job's `ctx.task` on it
+    /// (e.g. a sibling's forward-dep scrub inside `CleanupOldEdges`) finds a real entry rather than
+    /// restoring a zombie from disk. The next snapshot's `process` closure sees the `deleted` flag,
+    /// tombstones the on-disk copy (task meta/data + `TaskCache` bucket) instead of persisting, and
+    /// clears the modified flags; a later step (`evict_after_snapshot`, or the drain snapshot at
+    /// shutdown) hard-deletes it from memory once the tombstone has committed. If the task is
+    /// resurrected by a connect before then, the marker is cleared and it is made dirty. Must be
+    /// called while holding the GC phase.
+    fn gc_mark_deleted(&self, task_id: TaskId, ctx: &mut impl ExecuteContext<'_>) {
+        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+        task.gc_set_deleted();
+        // Force the task into the next snapshot's per-shard modified scan so `process` can
+        // tombstone it. A cleanly-disconnected collectible task typically has no modified
+        // flags set. The returned `TrackOutcome` is only for undo; GC's mark is permanent,
+        // so discard it.
+        let _ = task.track_modification(SpecificTaskDataCategory::Meta, "gc_deleted");
     }
 
     /// Body of [`Backend::pin_task_for_gc`](turbo_tasks::backend::Backend::pin_task_for_gc); the
@@ -467,16 +327,13 @@ impl TurboTasksBackend {
         );
     }
 
-    /// Runs a full GC pass under the GC phase and returns the number of tasks collected together
-    /// with their on-disk tombstones. Pass the tombstones to a subsequent
-    /// `snapshot_and_evict_for_testing` to commit them (production runs GC inline in
-    /// `snapshot_and_persist` instead). Test-only hook; callers must be idle (no task
-    /// executing).
+    /// Runs a full GC pass under the GC phase and returns the number of tasks collected (marked
+    /// soft-deleted). The tombstones are derived by a subsequent snapshot from the `deleted` flag,
+    /// so — unlike before — nothing needs to be threaded to `snapshot_and_evict_for_testing`
+    /// (production runs GC inline in `snapshot_and_persist`). Test-only hook; callers must be idle
+    /// (no task executing).
     #[doc(hidden)]
-    pub fn gc_for_testing(
-        &self,
-        turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> (usize, Vec<TaskDeletion>) {
+    pub fn gc_for_testing(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
         let _serialize = self.snapshot_in_progress.lock();
         let _gc_phase = self.snapshot_coord.begin_gc();
         self.gc_collect(turbo_tasks)

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -261,18 +261,29 @@ impl TurboTasksBackend {
     /// called while holding the GC phase.
     fn gc_mark_deleted(&self, task_id: TaskId, ctx: &mut impl ExecuteContext<'_>) {
         let mut task = ctx.task(task_id, TaskDataCategory::Meta);
-        task.gc_set_deleted();
+        task.set_deleted(true);
         // Force the task into the next snapshot's per-shard modified scan so `process` can
-        // tombstone it. A cleanly-disconnected collectible task typically has no modified
-        // flags set. The returned `TrackOutcome` is only for undo; GC's mark is permanent,
-        // so discard it.
+        // tombstone it. This can't be an assert-it's-already-modified: a collected task need NOT
+        // have been modified this cycle. The count-to-0 cascade DOES dirty meta (`parent_count` is
+        // a tracked meta field) and so does an aggregation-graph disconnect, but two collectible
+        // states leave meta clean —
+        //   1. a parentless (`parent_count == 0`) task kept alive only by a pin, then unpinned:
+        //      `transient_ref_count` is a *transient* field, so dropping it to 0 tracks nothing;
+        //      and
+        //   2. a task persisted parentless in a prior session, restored this cycle (restore sets no
+        //      modified flags) and collected with no intervening mutation.
+        // In those cases this call is what carries the tombstone into the snapshot (it flips
+        // `has_modifications`, so the modified scan runs). When meta is already dirty (the common
+        // cascade case) it's a cheap no-op. Runs before `start_snapshot`, so it takes the
+        // not-in-snapshot-mode path and bumps the shard modified count. The returned `TrackOutcome`
+        // is only for undo; GC's mark is permanent, so discard it.
         let _ = task.track_modification(SpecificTaskDataCategory::Meta, "gc_deleted");
     }
 
     /// Body of [`Backend::pin_task_for_gc`](turbo_tasks::backend::Backend::pin_task_for_gc); the
     /// trait method in `mod.rs` delegates here. See the inline comments for the exclusion and
     /// non-resurrection reasoning.
-    pub(super) fn gc_pin(&self, task: TaskId) {
+    pub(super) fn gc_pin(&self, task: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
         // Once the backend is stopping, GC bookkeeping is irrelevant (the whole task map is torn
         // down in `stop()`), so pin/unpin become no-ops. This also makes them safe against handles
         // finalized during shutdown — e.g. a `DetachedVc` handed to JS across NAPI is dropped
@@ -280,12 +291,13 @@ impl TurboTasksBackend {
         if self.stopping.load(Ordering::Acquire) {
             return;
         }
-        // Take an operation guard so pin cannot interleave with a GC pass: it runs strictly before
-        // or strictly after a collection, never concurrently with `is_gc_collectible` / task
-        // removal. This is deadlock-free because neither pin caller holds a guard already —
-        // `prevent_gc` runs in the unguarded user-future region, and `DetachedVc` pins from a NAPI
-        // thread — and the GC pass itself never calls pin/unpin.
-        let _guard = self.start_operation();
+        // Build a normal (operation-guarded) execute context so pin cannot interleave with a GC
+        // pass: it runs strictly before or strictly after a collection, never concurrently with
+        // `is_gc_collectible` / task removal. This is deadlock-free because neither pin caller
+        // holds a guard already — `prevent_gc` runs in the unguarded user-future region,
+        // and `DetachedVc` pins from a NAPI thread — and the GC pass itself never calls
+        // pin/unpin.
+        let mut ctx = self.execute_context(turbo_tasks);
         // A pin is an in-session reference from outside the tracked graph (an explicit
         // `prevent_gc`, or a detached handle like `DetachedVc` holding the task's `OperationVc`
         // across NAPI). It is counted the same way a transient parent's edge is: bump
@@ -294,37 +306,41 @@ impl TurboTasksBackend {
         // lost). Counting (rather than a bool flag) makes nested/cloned pins correct — each pin is
         // balanced by its own unpin.
         //
-        // Use the non-inserting `with_task_mut`: a pin always targets a live reference, so the task
+        // Use the non-inserting `resident_task`: a pin always targets a live reference, so the task
         // must be resident. A missing entry means the caller pinned an already-collected task (a
         // "zombie `OperationVc`") — a bug we surface via debug_assert rather than paper over by
-        // resurrecting a blank entry (which would leave an orphaned zombie in the map).
-        let existed = self
-            .storage
-            .with_task_mut(task, |t| t.gc_increment_transient_ref_count());
+        // resurrecting a blank entry (which would leave an orphaned zombie in the map). Going
+        // through the guard routes the count through the same `update_and_get_*` mutation the
+        // `AdjustTransientRefCount` queue job uses.
+        let existed = ctx.resident_task(task);
         debug_assert!(
             existed.is_some(),
             "pin_task_for_gc: task {task} has no resident entry (pinned an already-collected \
              task?)"
         );
+        if let Some(mut guard) = existed {
+            guard.update_and_get_transient_ref_count(1);
+        }
     }
 
     /// Body of [`Backend::unpin_task_for_gc`](turbo_tasks::backend::Backend::unpin_task_for_gc);
     /// the trait method in `mod.rs` delegates here.
-    pub(super) fn gc_unpin(&self, task: TaskId) {
+    pub(super) fn gc_unpin(&self, task: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
         // See `gc_pin`: no-op once stopping, so handles finalized during shutdown (after the map is
         // dropped) don't underflow the count.
         if self.stopping.load(Ordering::Acquire) {
             return;
         }
-        let _guard = self.start_operation();
-        let existed = self
-            .storage
-            .with_task_mut(task, |t| t.gc_decrement_transient_ref_count());
+        let mut ctx = self.execute_context(turbo_tasks);
+        let existed = ctx.resident_task(task);
         debug_assert!(
             existed.is_some(),
             "unpin_task_for_gc: task {task} has no resident entry (unpinned an already-collected \
              task?)"
         );
+        if let Some(mut guard) = existed {
+            guard.update_and_get_transient_ref_count(-1);
+        }
     }
 
     /// Runs a full GC pass under the GC phase and returns the number of tasks collected (marked

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -1,0 +1,477 @@
+//! Garbage collection for the persistent backend.
+//!
+//! GC removes tasks that have become unreachable from the live task graph (their persistent
+//! `parent_count` reached 0) from both memory and the on-disk cache. The pass runs under the
+//! coordinator's GC phase (see
+//! [`SnapshotCoordinator::begin_gc`](crate::backend::snapshot_coordinator)) — which excludes normal
+//! operations — and is driven as a fully parallel, self-feeding job pool
+//! (see [`TurboTasksBackend::gc_collect`]).
+//!
+//! This module holds the GC-specific logic (the job types, the pool driver, per-job teardown, and
+//! the pin/unpin bookkeeping) as an `impl TurboTasksBackend`; it is a child of the `backend` module
+//! so it reaches the backend's private state (`gc_candidates`, `storage`, `snapshot_coord`) and the
+//! GC-only `execute_context_gc` directly. Callers (`snapshot_and_persist`, `stop`, the background
+//! job loop, the `Backend` trait's `pin_task_for_gc`/`unpin_task_for_gc`) live in `mod.rs`.
+
+use std::sync::{
+    LazyLock,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use parking_lot::Mutex;
+use turbo_tasks::{
+    TaskId, TurboTasks,
+    scope::{Spawner, scope_self_feeding},
+    util::{good_chunk_size, into_chunks},
+};
+
+use crate::{
+    backend::{
+        CachedTaskTypeArc, TurboTasksBackend,
+        operation::{ExecuteContext, ExecuteContextImpl, TaskGuard},
+        storage::TaskDataCategory,
+        storage_schema::TaskStorageAccessors,
+    },
+    backing_storage::{TaskDeletion, compute_task_type_hash},
+    data::{CellRef, CollectiblesRef},
+};
+
+/// When `TURBO_ENGINE_GC` is set to a truthy value, the background job runs a `parent_count`-driven
+/// garbage-collection pass (tearing down tasks whose persistent parent count reached 0). Opt-in
+/// until it has been proven on trusted apps; the eventual default-on flip gets its own escape
+/// hatch.
+static GC_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var_os("TURBO_ENGINE_GC")
+        .is_some_and(|v| matches!(v.to_str(), Some("1" | "true" | "yes")))
+});
+
+/// Whether the `parent_count`-driven GC pass is enabled (via `TURBO_ENGINE_GC`). Read by
+/// `snapshot_and_persist` to decide whether to run GC before the snapshot.
+pub(super) fn gc_enabled() -> bool {
+    *GC_ENABLED
+}
+
+/// A unit of garbage-collection work fed through the self-feeding parallel pool in
+/// [`TurboTasksBackend::gc_collect`]. Every variant is bounded (a single task, or a bounded chunk),
+/// so no single job pins a worker with unbounded work: a task with a huge number of children or
+/// forward dependencies fans out into many chunked jobs that spread across worker threads. Jobs
+/// discover more jobs (a collected task spawns decrements + scrubs; a decrement that hits 0 spawns
+/// a collect), which the pool drains until quiescent.
+enum GcJob {
+    /// Re-validate `task_id`'s collectibility and, if still collectible, tear it down: remove it
+    /// from the in-memory map + task_cache, record its tombstone, then spawn [`GcJob::Decrement`]
+    /// jobs for its children and `Scrub*` jobs for its forward dependencies.
+    Collect(TaskId),
+    /// Decrement the persistent `parent_count` of each task in the chunk (each lost a persistent
+    /// parent that was just collected). Any that reach 0 are newly unreachable and spawn a
+    /// [`GcJob::Collect`].
+    Decrement(Vec<TaskId>),
+    /// Remove `source` from the `output_dependent` reverse-set of each target task in the chunk.
+    ScrubOutput {
+        source: TaskId,
+        targets: Vec<TaskId>,
+    },
+    /// Remove `source`'s cell dependency from the `cell_dependents` reverse-set of each referenced
+    /// cell's task.
+    ScrubCell { source: TaskId, refs: Vec<CellRef> },
+    /// Like [`GcJob::ScrubCell`] for hashed cell dependencies.
+    ScrubCellHashed {
+        source: TaskId,
+        refs: Vec<(CellRef, u64)>,
+    },
+    /// Remove `source` from the `collectibles_dependents` reverse-set of each referenced task.
+    ScrubCollectibles {
+        source: TaskId,
+        refs: Vec<CollectiblesRef>,
+    },
+}
+
+/// The edges captured from a collectible task under its single [`ExecuteContext`] guard, so the
+/// guard can be dropped before the teardown opens the *target* tasks' guards (holding two task
+/// locks at once trips the concurrent-lock detector). `children` drive the cascade; the `*_deps`
+/// are the forward dependencies whose reverse side must be scrubbed; `persistent_task_type` yields
+/// the on-disk `TaskCache` key.
+struct GcDeletePlan {
+    children: Vec<TaskId>,
+    output_deps: Vec<TaskId>,
+    cell_deps: Vec<CellRef>,
+    cell_deps_hashed: Vec<(CellRef, u64)>,
+    collectibles_deps: Vec<CollectiblesRef>,
+    persistent_task_type: Option<CachedTaskTypeArc>,
+}
+
+/// Splits `items` into `good_chunk_size` chunks and spawns one [`GcJob`] per chunk (built by
+/// `make_job`) into the self-feeding GC pool. A small collection becomes a single chunk job (≈
+/// inline); a huge one (e.g. 20K children/deps) fans out into `~4 * parallelism` jobs that spread
+/// across workers, so no single job pins a worker with unbounded work. Empty input spawns nothing.
+fn spawn_chunked<I>(
+    spawner: &Spawner<'_, '_, GcJob>,
+    items: Vec<I>,
+    make_job: impl Fn(Vec<I>) -> GcJob,
+) {
+    if items.is_empty() {
+        return;
+    }
+    let chunk_size = good_chunk_size(items.len());
+    for chunk in into_chunks(items, chunk_size) {
+        spawner.spawn(make_job(chunk.collect()));
+    }
+}
+
+impl TurboTasksBackend {
+    /// An execute context for the garbage collector that does not take an operation guard. Only
+    /// valid while the caller holds the coordinator's GC phase (which provides exclusion); see
+    /// [`ExecuteContextImpl::new_for_gc`].
+    fn execute_context_gc<'a>(
+        &'a self,
+        turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
+    ) -> impl ExecuteContext<'a> {
+        ExecuteContextImpl::new_for_gc(self, turbo_tasks)
+    }
+
+    /// Records `task_id` as a garbage-collection candidate (its persistent `parent_count` reached
+    /// 0). Only non-transient tasks are tracked — transient tasks are never collected. Candidacy is
+    /// re-validated under exclusion before the task is actually collected, so a false positive here
+    /// (e.g. the count is bumped back up by a concurrent re-connect) is harmless.
+    pub(crate) fn add_gc_candidate(&self, task_id: TaskId) {
+        if task_id.is_transient() {
+            return;
+        }
+        self.gc_candidates.lock().insert(task_id);
+    }
+
+    /// Runs a garbage-collection pass under the coordinator's GC phase. Drains the candidate set
+    /// (tasks observed reaching `parent_count == 0`), re-validates each under the exclusion, and
+    /// tears down the ones that are still collectible: scrubbing their reverse-dependency edges,
+    /// decrementing their children's `parent_count` (cascading to any child that reaches 0),
+    /// removing them from the in-memory map + task_cache, and buffering an on-disk tombstone for
+    /// the next persistence commit.
+    ///
+    /// The pass is fully parallel and self-feeding via [`scope_self_feeding`]: work is a pool of
+    /// [`GcJob`]s (collect a task; decrement a chunk of children; scrub a chunk of reverse-dep
+    /// edges) and any job may spawn more (a collect fans out into decrements + scrubs; a decrement
+    /// that drives a child to 0 spawns a collect). There are no synchronization barriers between
+    /// "levels" of the cascade — discovered work flows straight back into the pool — and no single
+    /// job carries unbounded work: a task with 20K children or 20K forward deps fans out into many
+    /// chunked jobs (see [`spawn_chunked`]), so one huge task can't pin a single worker while
+    /// others idle.
+    ///
+    /// Why this is safe to run concurrently under the GC phase (which excludes normal operations
+    /// but not the GC jobs from each other):
+    /// - Each job builds its own [`ExecuteContext`] (`execute_context_gc`); the concurrent-lock
+    ///   detector is per-context, so jobs on different threads holding different task guards do not
+    ///   false-positive.
+    /// - The storage map is a sharded dashmap: different tasks hit different shards; same-task
+    ///   access is serialized by the shard lock.
+    /// - The cascade decrement (`update_and_get_parent_count(-1)`) is a read-modify-write under the
+    ///   child's entry write lock, so if two collected parents decrement the same child
+    ///   concurrently, exactly one observes the count hit 0 and spawns its collect — no
+    ///   double-collect, no lost decrement.
+    /// - A collectible task has `parent_count == 0`, so no *surviving* task lists it as a child: a
+    ///   task becomes a collect target only after its last persistent parent was itself collected
+    ///   (which removed the edge). So a `Collect` never races a decrement of the same task and
+    ///   never `ctx.task`-resurrects a task another job just removed.
+    /// - Per-job results merge into shared accumulators guarded by a mutex/atomic, touched only on
+    ///   the rare collect/retain outcome (not per decrement or per scrub), so they are not a
+    ///   contention hot spot.
+    ///
+    /// `scope_self_feeding` runs jobs on the runtime worker threads plus the calling thread, which
+    /// drains the whole (growing) pool itself if no helper is scheduled — so this does not depend
+    /// on free worker threads (robust on thread-limited runtimes). GC runs from a synchronous
+    /// backend context (like `connect_children`, which also fans out onto the scope machinery).
+    ///
+    /// Returns `(number of tasks collected, on-disk tombstones)`.
+    pub(crate) fn gc_collect(
+        &self,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> (usize, Vec<TaskDeletion>) {
+        // Seed the pool from the candidates observed since the last pass. Re-validation happens per
+        // task in `Collect` (a candidate may have been revived by a concurrent re-connect before
+        // the GC phase was acquired).
+        let seeds: Vec<GcJob> = self
+            .gc_candidates
+            .lock()
+            .drain()
+            .map(GcJob::Collect)
+            .collect();
+        if seeds.is_empty() {
+            return (0, Vec::new());
+        }
+
+        // Shared accumulators. Touched only on the (comparatively rare) collect/retain outcomes,
+        // not on every decrement or scrub, so the mutexes are not a hot path.
+        let deletions = Mutex::new(Vec::new());
+        let collected = AtomicUsize::new(0);
+        // Candidates that are still parentless but not *yet* collectible (e.g. residual transient
+        // activeness) are re-retained for a later pass.
+        let retain = Mutex::new(Vec::new());
+
+        scope_self_feeding(seeds, |spawner, job| {
+            self.gc_run_job(job, spawner, turbo_tasks, &deletions, &collected, &retain);
+        });
+
+        // Re-queue candidates that were still parentless but not collectible this pass, so a later
+        // pass retries once their transient activeness clears.
+        let retain = retain.into_inner();
+        if !retain.is_empty() {
+            self.gc_candidates.lock().extend(retain);
+        }
+        (collected.into_inner(), deletions.into_inner())
+    }
+
+    /// Runs one [`GcJob`], possibly spawning follow-up jobs into the same pool. See
+    /// [`Self::gc_collect`] for the concurrency argument. Each job builds its own GC
+    /// [`ExecuteContext`].
+    fn gc_run_job(
+        &self,
+        job: GcJob,
+        spawner: &Spawner<'_, '_, GcJob>,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+        deletions: &Mutex<Vec<TaskDeletion>>,
+        collected: &AtomicUsize,
+        retain: &Mutex<Vec<TaskId>>,
+    ) {
+        match job {
+            GcJob::Collect(task_id) => {
+                // Transient-ness is a property of the id, not the storage — check it before
+                // touching the map (transient tasks are never collected).
+                if task_id.is_transient() {
+                    return;
+                }
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+
+                // Single access: decide collectibility and, if collectible, capture the edges
+                // needed to tear the task down. Reading through the guard
+                // (`ctx.task(.., All)`, which restores the task if it was evicted)
+                // means `is_gc_collectible`'s Meta reads go through `check_access`,
+                // so the "Meta restored" precondition is enforced by the
+                // standard guard machinery rather than a hand-rolled `is_restored` check.
+                let plan = {
+                    let task = ctx.task(task_id, TaskDataCategory::All);
+                    if !task.is_gc_collectible() {
+                        // Not collectible: keep retrying only while it is still parentless;
+                        // otherwise a concurrent re-connect revived it and it is no longer garbage.
+                        if task.get_parent_count().copied().unwrap_or(0) == 0 {
+                            retain.lock().push(task_id);
+                        }
+                        return;
+                    }
+                    GcDeletePlan {
+                        children: task.iter_children().collect(),
+                        output_deps: task.iter_output_dependencies().collect(),
+                        cell_deps: task.iter_cell_dependencies().collect(),
+                        cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
+                        collectibles_deps: task.iter_collectibles_dependencies().collect(),
+                        persistent_task_type: task.get_persistent_task_type().cloned(),
+                    }
+                };
+
+                let deletion = self.gc_remove_task(task_id, &plan, &mut ctx);
+                deletions.lock().push(deletion);
+                collected.fetch_add(1, Ordering::Relaxed);
+
+                // Fan the (potentially huge) teardown out into bounded chunk jobs so no single
+                // worker is pinned by one task's children/deps. `gc_remove_task` already dropped
+                // `task_id`'s own guard; the scrub jobs only open the *target* guards, and the plan
+                // carries owned edge lists so they don't need `task_id` resident.
+                let GcDeletePlan {
+                    children,
+                    output_deps,
+                    cell_deps,
+                    cell_deps_hashed,
+                    collectibles_deps,
+                    persistent_task_type: _,
+                } = plan;
+                spawn_chunked(spawner, children, GcJob::Decrement);
+                spawn_chunked(spawner, output_deps, |targets| GcJob::ScrubOutput {
+                    source: task_id,
+                    targets,
+                });
+                spawn_chunked(spawner, cell_deps, |refs| GcJob::ScrubCell {
+                    source: task_id,
+                    refs,
+                });
+                spawn_chunked(spawner, cell_deps_hashed, |refs| GcJob::ScrubCellHashed {
+                    source: task_id,
+                    refs,
+                });
+                spawn_chunked(spawner, collectibles_deps, |refs| {
+                    GcJob::ScrubCollectibles {
+                        source: task_id,
+                        refs,
+                    }
+                });
+            }
+            GcJob::Decrement(children) => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for child in children {
+                    // Transient children are never collected and carry no persistent parent_count.
+                    if child.is_transient() {
+                        continue;
+                    }
+                    let mut child_task = ctx.task(child, TaskDataCategory::Meta);
+                    let new_count = child_task.update_and_get_parent_count(-1);
+                    drop(child_task);
+                    // Exactly one decrementer sees 0 (RMW under the entry lock), so `child` is
+                    // spawned as a collect target exactly once.
+                    if new_count == 0 {
+                        spawner.spawn(GcJob::Collect(child));
+                    }
+                }
+            }
+            GcJob::ScrubOutput { source, targets } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for output_task_id in targets {
+                    let mut target = ctx.task(output_task_id, TaskDataCategory::Data);
+                    target.remove_output_dependent(&source);
+                }
+            }
+            GcJob::ScrubCell { source, refs } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for CellRef {
+                    task: cell_task,
+                    cell,
+                } in refs
+                {
+                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
+                    target.remove_cell_dependents(&CellRef { task: source, cell });
+                }
+            }
+            GcJob::ScrubCellHashed { source, refs } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for (
+                    CellRef {
+                        task: cell_task,
+                        cell,
+                    },
+                    key,
+                ) in refs
+                {
+                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
+                    target.remove_cell_dependents_hashed(&(CellRef { task: source, cell }, key));
+                }
+            }
+            GcJob::ScrubCollectibles { source, refs } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for CollectiblesRef {
+                    task: dep_task,
+                    collectible_type,
+                } in refs
+                {
+                    let mut target = ctx.task(dep_task, TaskDataCategory::Data);
+                    target.remove_collectibles_dependents(&(collectible_type, source));
+                }
+            }
+        }
+    }
+
+    /// Removes a collectible task from the in-memory task_cache and map and returns its
+    /// [`TaskDeletion`] tombstone. The reverse-dep edge scrubbing is done separately by the
+    /// `Scrub*` jobs (see [`Self::gc_run_job`]); this only touches `task_id`'s own entries, which
+    /// are independent of the target entries the scrubs mutate, so ordering between them is free.
+    /// Must be called while holding the GC phase.
+    fn gc_remove_task(
+        &self,
+        task_id: TaskId,
+        plan: &GcDeletePlan,
+        _ctx: &mut impl ExecuteContext<'_>,
+    ) -> TaskDeletion {
+        // Remove the in-memory task_cache entry (hash -> id) so lookups don't return a dead id, and
+        // compute the persisted TaskCache key so the snapshot can tombstone the on-disk mapping.
+        // Only persistent tasks are collected, so a persistent task type is always present.
+        let task_type = plan
+            .persistent_task_type
+            .as_ref()
+            .expect("a collected (non-transient) task must have a task type");
+        self.storage.task_cache.remove(task_type.as_ref());
+        let task_type_hash = compute_task_type_hash(task_type);
+
+        // Remove the task from the map. Its own children set is dropped with it; the child ids were
+        // captured into `plan` so the `Decrement` jobs can drop their parent_count.
+        self.storage.remove_task(task_id);
+
+        // Tombstoning the on-disk `TaskCache` erases the *whole* hash bucket, so any live task
+        // whose type xxh3-collides with this one must be re-inserted. Those survivors are resolved
+        // at apply time in `save_snapshot` (which reads the authoritative on-disk bucket) rather
+        // than computed here — the in-memory `task_cache` is lazily populated and keyed by the full
+        // task type, not the hash, so it can't reliably enumerate hash-siblings. Collisions between
+        // two live tasks are astronomically rare, so this survivor path almost never fires.
+        TaskDeletion {
+            task_id,
+            task_type_hash,
+        }
+    }
+
+    /// Body of [`Backend::pin_task_for_gc`](turbo_tasks::backend::Backend::pin_task_for_gc); the
+    /// trait method in `mod.rs` delegates here. See the inline comments for the exclusion and
+    /// non-resurrection reasoning.
+    pub(super) fn gc_pin(&self, task: TaskId) {
+        // Once the backend is stopping, GC bookkeeping is irrelevant (the whole task map is torn
+        // down in `stop()`), so pin/unpin become no-ops. This also makes them safe against handles
+        // finalized during shutdown — e.g. a `DetachedVc` handed to JS across NAPI is dropped
+        // (which unpins) during Node worker teardown, *after* `stop()` has dropped the map.
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
+        // Take an operation guard so pin cannot interleave with a GC pass: it runs strictly before
+        // or strictly after a collection, never concurrently with `is_gc_collectible` / task
+        // removal. This is deadlock-free because neither pin caller holds a guard already —
+        // `prevent_gc` runs in the unguarded user-future region, and `DetachedVc` pins from a NAPI
+        // thread — and the GC pass itself never calls pin/unpin.
+        let _guard = self.start_operation();
+        // A pin is an in-session reference from outside the tracked graph (an explicit
+        // `prevent_gc`, or a detached handle like `DetachedVc` holding the task's `OperationVc`
+        // across NAPI). It is counted the same way a transient parent's edge is: bump
+        // `transient_ref_count`. While that count is > 0 the task is uncollectible (see
+        // `is_gc_collectible`) and unevictable (see `evictability`, so the transient count can't be
+        // lost). Counting (rather than a bool flag) makes nested/cloned pins correct — each pin is
+        // balanced by its own unpin.
+        //
+        // Use the non-inserting `with_task_mut`: a pin always targets a live reference, so the task
+        // must be resident. A missing entry means the caller pinned an already-collected task (a
+        // "zombie `OperationVc`") — a bug we surface via debug_assert rather than paper over by
+        // resurrecting a blank entry (which would leave an orphaned zombie in the map).
+        let existed = self
+            .storage
+            .with_task_mut(task, |t| t.gc_increment_transient_ref_count());
+        debug_assert!(
+            existed.is_some(),
+            "pin_task_for_gc: task {task} has no resident entry (pinned an already-collected \
+             task?)"
+        );
+    }
+
+    /// Body of [`Backend::unpin_task_for_gc`](turbo_tasks::backend::Backend::unpin_task_for_gc);
+    /// the trait method in `mod.rs` delegates here.
+    pub(super) fn gc_unpin(&self, task: TaskId) {
+        // See `gc_pin`: no-op once stopping, so handles finalized during shutdown (after the map is
+        // dropped) don't underflow the count.
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
+        let _guard = self.start_operation();
+        let existed = self
+            .storage
+            .with_task_mut(task, |t| t.gc_decrement_transient_ref_count());
+        debug_assert!(
+            existed.is_some(),
+            "unpin_task_for_gc: task {task} has no resident entry (unpinned an already-collected \
+             task?)"
+        );
+    }
+
+    /// Runs a full GC pass under the GC phase and returns the number of tasks collected together
+    /// with their on-disk tombstones. Pass the tombstones to a subsequent
+    /// `snapshot_and_evict_for_testing` to commit them (production runs GC inline in
+    /// `snapshot_and_persist` instead). Test-only hook; callers must be idle (no task
+    /// executing).
+    #[doc(hidden)]
+    pub fn gc_for_testing(
+        &self,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> (usize, Vec<TaskDeletion>) {
+        let _serialize = self.snapshot_in_progress.lock();
+        let _gc_phase = self.snapshot_coord.begin_gc();
+        self.gc_collect(turbo_tasks)
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -358,7 +358,10 @@ impl TurboTasksBackend {
     /// The GC phase guarantees no operation is executing (see [`SnapshotCoordinator::begin_gc`]),
     /// so the cross-task scrub and the map removals cannot race a concurrent connect/read.
     /// Returns the number of tasks collected.
-    fn gc_collect(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
+    fn gc_collect(
+        &self,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> (usize, Vec<TaskDeletion>) {
         // Seed the worklist from the candidates observed since the last pass. Re-validation happens
         // per task below (a candidate may have been revived by a concurrent re-connect before the
         // phase was acquired, or may not be Data-resident).
@@ -402,15 +405,12 @@ impl TurboTasksBackend {
             }
         }
 
-        if !deletions.is_empty() {
-            self.pending_gc_deletes.lock().extend(deletions);
-        }
         // Re-queue candidates that are still parentless but were not collectible this pass, so a
         // later pass retries once their transient activeness clears (or their Data is restored).
         if !retain.is_empty() {
             self.gc_candidates.lock().extend(retain);
         }
-        collected
+        (collected, deletions)
     }
 
     /// Scrubs all references from `task_id` off its dependency targets, removes it from the
@@ -522,13 +522,20 @@ impl TurboTasksBackend {
         (children, deletion)
     }
 
-    /// Runs a full GC pass under the GC phase and returns the number of tasks collected. Test-only
-    /// hook. Callers must be idle (no task executing).
+    /// Runs a full GC pass under the GC phase and returns the number of tasks collected. Buffers
+    /// the resulting tombstones into `pending_gc_deletes` so a subsequent
+    /// `snapshot_and_evict_for_testing` commits them (production runs GC inline in
+    /// `snapshot_and_persist` instead). Test-only hook; callers must be idle (no task
+    /// executing).
     #[doc(hidden)]
     pub fn gc_for_testing(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
         let _serialize = self.snapshot_in_progress.lock();
         let _gc_phase = self.snapshot_coord.begin_gc();
-        self.gc_collect(turbo_tasks)
+        let (collected, deletes) = self.gc_collect(turbo_tasks);
+        if !deletes.is_empty() {
+            self.pending_gc_deletes.lock().extend(deletes);
+        }
+        collected
     }
 
     fn operation_suspend_point(&self, suspend: impl FnOnce() -> AnyOperation) {
@@ -596,11 +603,11 @@ impl TurboTasksBackend {
             .unwrap_or(0)
     }
 
-    /// The transient `transient_parent_count` of a resident task (0 if absent or not resident).
+    /// The transient `transient_ref_count` of a resident task (0 if absent or not resident).
     #[doc(hidden)]
-    pub fn transient_parent_count_for_testing(&self, task: TaskId) -> u32 {
+    pub fn transient_ref_count_for_testing(&self, task: TaskId) -> u32 {
         self.storage
-            .with_task(task, |t| t.gc_transient_parent_count())
+            .with_task(task, |t| t.gc_transient_ref_count())
             .unwrap_or(0)
     }
 
@@ -1225,11 +1232,30 @@ impl TurboTasksBackend {
         // request bit, suspended_operations) assumes only one snapshot runs at
         // a time. Held for the entire snapshot lifecycle.
         let _snapshot_in_progress = self.snapshot_in_progress.lock();
-        // Drain GC tombstones buffered since the last snapshot (tasks the GC pass removed from
-        // memory whose on-disk copies must now be tombstoned). Drained before the early-return
-        // checks below so a GC-only cycle (deletes but no modifications) still commits its
-        // tombstones.
-        let deletes = std::mem::take(&mut *self.pending_gc_deletes.lock());
+
+        // Garbage-collection pass runs immediately before the snapshot, under the same held
+        // `snapshot_in_progress` lock: it tears down tasks whose persistent parent_count reached 0
+        // (removing them from the map) and returns their on-disk tombstones, which this snapshot
+        // then commits atomically. Doing it here — rather than as a separate background step —
+        // means a collected task is neither re-persisted nor left on disk: it is tombstoned in the
+        // very commit that would otherwise have re-written it, and the tombstone is re-validated
+        // against the post-drain map below so a task resurrected in the brief window between the GC
+        // phase and the snapshot drain is not wrongly tombstoned. Opt-in via TURBO_ENGINE_GC.
+        let gc_deletes = if *GC_ENABLED {
+            let _gc_span = tracing::info_span!(parent: parent_span.clone(), "gc").entered();
+            let _gc_phase = self.snapshot_coord.begin_gc();
+            let (collected, deletes) = self.gc_collect(turbo_tasks);
+            if collected > 0 {
+                tracing::info!(collected, "gc pass collected tasks");
+            }
+            deletes
+        } else {
+            Vec::new()
+        };
+        // Also drain any tombstones buffered by the test-only `gc_for_testing` hook (production
+        // takes the inline `gc_deletes` path above; both feed the same commit).
+        let mut deletes = gc_deletes;
+        deletes.append(&mut self.pending_gc_deletes.lock());
         let start = Instant::now();
         // SystemTime for wall-clock timestamps in trace events (milliseconds
         // since epoch). Instant is monotonic but has no defined epoch, so it
@@ -1244,6 +1270,14 @@ impl TurboTasksBackend {
         // Enter snapshot mode, which atomically reads and resets the modified count.
         // Checking after start_snapshot ensures no concurrent increments can race.
         let (snapshot_guard, has_modifications) = self.storage.start_snapshot();
+
+        // Re-validate GC tombstones against the now-drained map: `begin_snapshot` has drained/
+        // suspended all operations, so the map is stable. GC removed each collected task from the
+        // map; if one is resident again it was resurrected by an operation in the brief window
+        // between the GC phase ending and this drain (a concurrent read re-connected it, restoring
+        // it from its not-yet-tombstoned on-disk copy). Such a task is live again — drop its
+        // tombstone so we don't delete a task the snapshot is about to (re-)persist.
+        deletes.retain(|d| self.storage.with_task(d.task_id, |_| ()).is_none());
 
         let suspended_operations = snapshot_phase.take_suspended_operations();
 
@@ -1692,30 +1726,19 @@ impl TurboTasksBackend {
             self.is_idle.store(false, Ordering::Release);
             self.verify_aggregation_graph(turbo_tasks, false);
         }
+        // The task_cache is a pure perf cache backed by the DB and isn't read during the stop
+        // snapshot (no task creation runs concurrently with stop). Drop it before persisting to
+        // lower peak memory during the serialization/write.
+        self.storage.drop_task_cache();
         if self.should_persist() {
-            // Run a final GC pass before the stop snapshot so builds emit tombstones for
-            // disconnected tasks in the final commit, keeping the persisted DB tight for the next
-            // build. At shutdown the system is already quiescing, so this runs to completion; its
-            // tombstones are buffered and drained by the stop snapshot below. Must run before
-            // `drop_task_cache` so teardown's task_cache scrubbing stays consistent.
-            if *GC_ENABLED {
-                let _serialize = self.snapshot_in_progress.lock();
-                let _gc_phase = self.snapshot_coord.begin_gc();
-                let collected = self.gc_collect(turbo_tasks);
-                tracing::info!(collected, "stop GC pass");
-            }
-            // The task_cache is a pure perf cache backed by the DB and isn't read during the
-            // stop snapshot (no task creation runs concurrently with stop). Drop it before
-            // persisting to lower peak memory during the serialization/write.
-            self.storage.drop_task_cache();
+            // The stop snapshot runs a final GC pass internally (see `snapshot_and_persist`), so
+            // builds emit tombstones for disconnected tasks in the final commit — keeping the
+            // persisted DB tight for the next build.
             if let Err(err) =
                 self.snapshot_and_persist(Span::current().into(), SnapshotReason::Stop, turbo_tasks)
             {
                 eprintln!("Persisting failed during shutdown: {err:?}");
             }
-        } else {
-            // eagerly drop the task cache
-            self.storage.drop_task_cache();
         }
         self.storage.drop_contents();
         if let Err(err) = self.backing_storage.shutdown() {
@@ -3225,6 +3248,7 @@ impl TurboTasksBackend {
                         // grouped together in trace viewers.
                         let background_span =
                             tracing::info_span!(parent: None, "background snapshot");
+
                         match self.snapshot_and_persist(background_span.id(), reason, turbo_tasks) {
                             Err(err) => {
                                 // save_snapshot consumed persisted_task_cache_log entries;
@@ -3261,27 +3285,6 @@ impl TurboTasksBackend {
                                             _ = std::future::ready(()) => false,
                                         }
                                     }};
-                                }
-
-                                // Garbage-collection pass: tear down tasks whose persistent
-                                // parent_count reached 0. Runs BEFORE eviction so freshly-collected
-                                // garbage is removed from the map before it could be evicted to
-                                // disk-only. Holds the GC phase (excludes execution) via
-                                // `gc_for_testing`'s shape, and buffers on-disk tombstones for the
-                                // *next* snapshot commit. Opt-in via TURBO_ENGINE_GC.
-                                if *GC_ENABLED {
-                                    if check_idle_ended!() {
-                                        continue 'outer;
-                                    }
-                                    let _gc_span =
-                                        tracing::info_span!(parent: background_span.id(), "gc")
-                                            .entered();
-                                    let _serialize = self.snapshot_in_progress.lock();
-                                    let _gc_phase = self.snapshot_coord.begin_gc();
-                                    let collected = self.gc_collect(turbo_tasks);
-                                    if collected > 0 {
-                                        tracing::info!(collected, "gc pass collected tasks");
-                                    }
                                 }
 
                                 // Evict persisted tasks from memory to reclaim space.
@@ -4018,16 +4021,22 @@ impl Backend for TurboTasksBackend {
     }
 
     fn pin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
-        // Set the transient `pinned` flag. Pinned tasks are unevictable (see `evictability`) and
-        // are treated as GC roots (see `is_gc_root`), so `prevent_gc` keeps the task — and the
-        // escaping references it anchors — alive. `pinned` is transient and never persisted; on
-        // restart the code that escaped the value re-establishes the pin (or the value is simply
-        // recomputed).
-        self.storage.access_mut(task).flags.set_pinned(true);
+        // A pin is an in-session reference from outside the tracked graph (an explicit
+        // `prevent_gc`, or a detached handle like `DetachedVc` holding the task's
+        // `OperationVc` across NAPI). It is counted the same way a transient parent's edge
+        // is: bump `transient_ref_count`. While that count is > 0 the task is uncollectible
+        // (see `is_gc_collectible`) and unevictable (see `evictability`, so the transient
+        // count can't be lost). Counting (rather than a bool flag) makes nested/cloned pins
+        // correct — each pin is balanced by its own unpin.
+        self.storage
+            .access_mut(task)
+            .gc_increment_transient_ref_count();
     }
 
     fn unpin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
-        self.storage.access_mut(task).flags.set_pinned(false);
+        self.storage
+            .access_mut(task)
+            .gc_decrement_transient_ref_count();
     }
 
     fn connect_task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1,6 +1,7 @@
 mod cell_data;
 mod counter_map;
 mod eviction;
+mod gc;
 mod operation;
 mod snapshot_coordinator;
 mod storage;
@@ -15,7 +16,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, LazyLock,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     time::SystemTime,
 };
@@ -44,7 +45,7 @@ use turbo_tasks::{
     macro_helpers::NativeFunction,
     message_queue::{TimingEvent, TraceEvent},
     registry::get_value_type,
-    scope::{scope_and_block, scope_self_feeding},
+    scope::scope_and_block,
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
     util::{IdFactoryWithReuse, good_chunk_size, into_chunks},
@@ -90,15 +91,6 @@ use crate::{
 /// If the number of dependent tasks exceeds this threshold,
 /// the operation will be parallelized.
 const DEPENDENT_TASKS_DIRTY_PARALLELIZATION_THRESHOLD: usize = 10000;
-
-/// When `TURBO_ENGINE_GC` is set to a truthy value, the background job runs a `parent_count`-driven
-/// garbage-collection pass (tearing down tasks whose persistent parent count reached 0). Opt-in
-/// until it has been proven on trusted apps; the eventual default-on flip gets its own escape
-/// hatch.
-static GC_ENABLED: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var_os("TURBO_ENGINE_GC")
-        .is_some_and(|v| matches!(v.to_str(), Some("1" | "true" | "yes")))
-});
 
 /// Priority used to re-schedule a task that became stale during execution.
 ///
@@ -244,73 +236,6 @@ pub struct TurboTasksBackend {
     root_tasks: Mutex<FxHashSet<TaskId>>,
 }
 
-/// A unit of garbage-collection work fed through the self-feeding parallel pool in
-/// [`TurboTasksBackend::gc_collect`]. Every variant is bounded (a single task, or a bounded chunk),
-/// so no single job pins a worker with unbounded work: a task with a huge number of children or
-/// forward dependencies fans out into many chunked jobs that spread across worker threads. Jobs
-/// discover more jobs (a collected task spawns decrements + scrubs; a decrement that hits 0 spawns
-/// a collect), which the pool drains until quiescent.
-enum GcJob {
-    /// Re-validate `task_id`'s collectibility and, if still collectible, tear it down: remove it
-    /// from the in-memory map + task_cache, record its tombstone, then spawn [`GcJob::Decrement`]
-    /// jobs for its children and `Scrub*` jobs for its forward dependencies.
-    Collect(TaskId),
-    /// Decrement the persistent `parent_count` of each task in the chunk (each lost a persistent
-    /// parent that was just collected). Any that reach 0 are newly unreachable and spawn a
-    /// [`GcJob::Collect`].
-    Decrement(Vec<TaskId>),
-    /// Remove `source` from the `output_dependent` reverse-set of each target task in the chunk.
-    ScrubOutput {
-        source: TaskId,
-        targets: Vec<TaskId>,
-    },
-    /// Remove `source`'s cell dependency from the `cell_dependents` reverse-set of each referenced
-    /// cell's task.
-    ScrubCell { source: TaskId, refs: Vec<CellRef> },
-    /// Like [`GcJob::ScrubCell`] for hashed cell dependencies.
-    ScrubCellHashed {
-        source: TaskId,
-        refs: Vec<(CellRef, u64)>,
-    },
-    /// Remove `source` from the `collectibles_dependents` reverse-set of each referenced task.
-    ScrubCollectibles {
-        source: TaskId,
-        refs: Vec<CollectiblesRef>,
-    },
-}
-
-/// The edges captured from a collectible task under its single [`ExecuteContext`] guard, so the
-/// guard can be dropped before the teardown opens the *target* tasks' guards (holding two task
-/// locks at once trips the concurrent-lock detector). `children` drive the cascade; the `*_deps`
-/// are the forward dependencies whose reverse side must be scrubbed; `persistent_task_type` yields
-/// the on-disk `TaskCache` key.
-struct GcDeletePlan {
-    children: Vec<TaskId>,
-    output_deps: Vec<TaskId>,
-    cell_deps: Vec<CellRef>,
-    cell_deps_hashed: Vec<(CellRef, u64)>,
-    collectibles_deps: Vec<CollectiblesRef>,
-    persistent_task_type: Option<CachedTaskTypeArc>,
-}
-
-/// Splits `items` into `good_chunk_size` chunks and spawns one [`GcJob`] per chunk (built by
-/// `make_job`) into the self-feeding GC pool. A small collection becomes a single chunk job (≈
-/// inline); a huge one (e.g. 20K children/deps) fans out into `~4 * parallelism` jobs that spread
-/// across workers, so no single job pins a worker with unbounded work. Empty input spawns nothing.
-fn spawn_chunked<I>(
-    spawner: &turbo_tasks::scope::Spawner<'_, '_, GcJob>,
-    items: Vec<I>,
-    make_job: impl Fn(Vec<I>) -> GcJob,
-) {
-    if items.is_empty() {
-        return;
-    }
-    let chunk_size = good_chunk_size(items.len());
-    for chunk in into_chunks(items, chunk_size) {
-        spawner.spawn(make_job(chunk.collect()));
-    }
-}
-
 impl TurboTasksBackend {
     /// Invalidates the persistent storage so that it will be deleted the next time a turbopack
     /// instance is created with the filesystem cache enabled.
@@ -363,304 +288,6 @@ impl TurboTasksBackend {
         turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
     ) -> impl ExecuteContext<'a> {
         ExecuteContextImpl::new(self, turbo_tasks)
-    }
-
-    /// An execute context for the garbage collector that does not take an operation guard. Only
-    /// valid while the caller holds the coordinator's GC phase (which provides exclusion); see
-    /// [`ExecuteContextImpl::new_for_gc`].
-    fn execute_context_gc<'a>(
-        &'a self,
-        turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
-    ) -> impl ExecuteContext<'a> {
-        ExecuteContextImpl::new_for_gc(self, turbo_tasks)
-    }
-
-    /// Records `task_id` as a garbage-collection candidate (its persistent `parent_count` reached
-    /// 0). Only non-transient tasks are tracked — transient tasks are never collected. Candidacy is
-    /// re-validated under exclusion before the task is actually collected, so a false positive here
-    /// (e.g. the count is bumped back up by a concurrent re-connect) is harmless.
-    fn add_gc_candidate(&self, task_id: TaskId) {
-        if task_id.is_transient() {
-            return;
-        }
-        self.gc_candidates.lock().insert(task_id);
-    }
-
-    /// Runs a garbage-collection pass under the coordinator's GC phase. Drains the candidate set
-    /// (tasks observed reaching `parent_count == 0`), re-validates each under the exclusion, and
-    /// tears down the ones that are still collectible: scrubbing their reverse-dependency edges,
-    /// decrementing their children's `parent_count` (cascading to any child that reaches 0),
-    /// removing them from the in-memory map + task_cache, and buffering an on-disk tombstone for
-    /// the next persistence commit.
-    ///
-    /// The pass is fully parallel and self-feeding via [`scope_self_feeding`]: work is a pool of
-    /// [`GcJob`]s (collect a task; decrement a chunk of children; scrub a chunk of reverse-dep
-    /// edges) and any job may spawn more (a collect fans out into decrements + scrubs; a decrement
-    /// that drives a child to 0 spawns a collect). There are no synchronization barriers between
-    /// "levels" of the cascade — discovered work flows straight back into the pool — and no single
-    /// job carries unbounded work: a task with 20K children or 20K forward deps fans out into many
-    /// chunked jobs (see [`spawn_chunked`]), so one huge task can't pin a single worker while
-    /// others idle.
-    ///
-    /// Why this is safe to run concurrently under the GC phase (which excludes normal operations
-    /// but not the GC jobs from each other):
-    /// - Each job builds its own [`ExecuteContext`] (`execute_context_gc`); the concurrent-lock
-    ///   detector is per-context, so jobs on different threads holding different task guards do not
-    ///   false-positive.
-    /// - The storage map is a sharded dashmap: different tasks hit different shards; same-task
-    ///   access is serialized by the shard lock.
-    /// - The cascade decrement (`update_and_get_parent_count(-1)`) is a read-modify-write under the
-    ///   child's entry write lock, so if two collected parents decrement the same child
-    ///   concurrently, exactly one observes the count hit 0 and spawns its collect — no
-    ///   double-collect, no lost decrement.
-    /// - A collectible task has `parent_count == 0`, so no *surviving* task lists it as a child: a
-    ///   task becomes a collect target only after its last persistent parent was itself collected
-    ///   (which removed the edge). So a `Collect` never races a decrement of the same task and
-    ///   never `ctx.task`-resurrects a task another job just removed.
-    /// - Per-job results merge into shared accumulators guarded by a mutex/atomic, touched only on
-    ///   the rare collect/retain outcome (not per decrement or per scrub), so they are not a
-    ///   contention hot spot.
-    ///
-    /// `scope_self_feeding` runs jobs on the runtime worker threads plus the calling thread, which
-    /// drains the whole (growing) pool itself if no helper is scheduled — so this does not depend
-    /// on free worker threads (robust on thread-limited runtimes). GC runs from a synchronous
-    /// backend context (like `connect_children`, which also fans out onto the scope machinery).
-    ///
-    /// Returns `(number of tasks collected, on-disk tombstones)`.
-    fn gc_collect(
-        &self,
-        turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> (usize, Vec<TaskDeletion>) {
-        // Seed the pool from the candidates observed since the last pass. Re-validation happens per
-        // task in `Collect` (a candidate may have been revived by a concurrent re-connect before
-        // the GC phase was acquired).
-        let seeds: Vec<GcJob> = self
-            .gc_candidates
-            .lock()
-            .drain()
-            .map(GcJob::Collect)
-            .collect();
-        if seeds.is_empty() {
-            return (0, Vec::new());
-        }
-
-        // Shared accumulators. Touched only on the (comparatively rare) collect/retain outcomes,
-        // not on every decrement or scrub, so the mutexes are not a hot path.
-        let deletions = Mutex::new(Vec::new());
-        let collected = AtomicUsize::new(0);
-        // Candidates that are still parentless but not *yet* collectible (e.g. residual transient
-        // activeness) are re-retained for a later pass.
-        let retain = Mutex::new(Vec::new());
-
-        scope_self_feeding(seeds, |spawner, job| {
-            self.gc_run_job(job, spawner, turbo_tasks, &deletions, &collected, &retain);
-        });
-
-        // Re-queue candidates that were still parentless but not collectible this pass, so a later
-        // pass retries once their transient activeness clears.
-        let retain = retain.into_inner();
-        if !retain.is_empty() {
-            self.gc_candidates.lock().extend(retain);
-        }
-        (collected.into_inner(), deletions.into_inner())
-    }
-
-    /// Runs one [`GcJob`], possibly spawning follow-up jobs into the same pool. See
-    /// [`Self::gc_collect`] for the concurrency argument. Each job builds its own GC
-    /// [`ExecuteContext`].
-    fn gc_run_job(
-        &self,
-        job: GcJob,
-        spawner: &turbo_tasks::scope::Spawner<'_, '_, GcJob>,
-        turbo_tasks: &TurboTasks<TurboTasksBackend>,
-        deletions: &Mutex<Vec<TaskDeletion>>,
-        collected: &AtomicUsize,
-        retain: &Mutex<Vec<TaskId>>,
-    ) {
-        match job {
-            GcJob::Collect(task_id) => {
-                // Transient-ness is a property of the id, not the storage — check it before
-                // touching the map (transient tasks are never collected).
-                if task_id.is_transient() {
-                    return;
-                }
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-
-                // Single access: decide collectibility and, if collectible, capture the edges
-                // needed to tear the task down. Reading through the guard
-                // (`ctx.task(.., All)`, which restores the task if it was evicted)
-                // means `is_gc_collectible`'s Meta reads go through `check_access`,
-                // so the "Meta restored" precondition is enforced by the
-                // standard guard machinery rather than a hand-rolled `is_restored` check.
-                let plan = {
-                    let task = ctx.task(task_id, TaskDataCategory::All);
-                    if !task.is_gc_collectible() {
-                        // Not collectible: keep retrying only while it is still parentless;
-                        // otherwise a concurrent re-connect revived it and it is no longer garbage.
-                        if task.get_parent_count().copied().unwrap_or(0) == 0 {
-                            retain.lock().push(task_id);
-                        }
-                        return;
-                    }
-                    GcDeletePlan {
-                        children: task.iter_children().collect(),
-                        output_deps: task.iter_output_dependencies().collect(),
-                        cell_deps: task.iter_cell_dependencies().collect(),
-                        cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
-                        collectibles_deps: task.iter_collectibles_dependencies().collect(),
-                        persistent_task_type: task.get_persistent_task_type().cloned(),
-                    }
-                };
-
-                let deletion = self.gc_remove_task(task_id, &plan, &mut ctx);
-                deletions.lock().push(deletion);
-                collected.fetch_add(1, Ordering::Relaxed);
-
-                // Fan the (potentially huge) teardown out into bounded chunk jobs so no single
-                // worker is pinned by one task's children/deps. `gc_remove_task` already dropped
-                // `task_id`'s own guard; the scrub jobs only open the *target* guards, and the plan
-                // carries owned edge lists so they don't need `task_id` resident.
-                let GcDeletePlan {
-                    children,
-                    output_deps,
-                    cell_deps,
-                    cell_deps_hashed,
-                    collectibles_deps,
-                    persistent_task_type: _,
-                } = plan;
-                spawn_chunked(spawner, children, GcJob::Decrement);
-                spawn_chunked(spawner, output_deps, |targets| GcJob::ScrubOutput {
-                    source: task_id,
-                    targets,
-                });
-                spawn_chunked(spawner, cell_deps, |refs| GcJob::ScrubCell {
-                    source: task_id,
-                    refs,
-                });
-                spawn_chunked(spawner, cell_deps_hashed, |refs| GcJob::ScrubCellHashed {
-                    source: task_id,
-                    refs,
-                });
-                spawn_chunked(spawner, collectibles_deps, |refs| {
-                    GcJob::ScrubCollectibles {
-                        source: task_id,
-                        refs,
-                    }
-                });
-            }
-            GcJob::Decrement(children) => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for child in children {
-                    // Transient children are never collected and carry no persistent parent_count.
-                    if child.is_transient() {
-                        continue;
-                    }
-                    let mut child_task = ctx.task(child, TaskDataCategory::Meta);
-                    let new_count = child_task.update_and_get_parent_count(-1);
-                    drop(child_task);
-                    // Exactly one decrementer sees 0 (RMW under the entry lock), so `child` is
-                    // spawned as a collect target exactly once.
-                    if new_count == 0 {
-                        spawner.spawn(GcJob::Collect(child));
-                    }
-                }
-            }
-            GcJob::ScrubOutput { source, targets } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for output_task_id in targets {
-                    let mut target = ctx.task(output_task_id, TaskDataCategory::Data);
-                    target.remove_output_dependent(&source);
-                }
-            }
-            GcJob::ScrubCell { source, refs } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for CellRef {
-                    task: cell_task,
-                    cell,
-                } in refs
-                {
-                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
-                    target.remove_cell_dependents(&CellRef { task: source, cell });
-                }
-            }
-            GcJob::ScrubCellHashed { source, refs } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for (
-                    CellRef {
-                        task: cell_task,
-                        cell,
-                    },
-                    key,
-                ) in refs
-                {
-                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
-                    target.remove_cell_dependents_hashed(&(CellRef { task: source, cell }, key));
-                }
-            }
-            GcJob::ScrubCollectibles { source, refs } => {
-                let mut ctx = self.execute_context_gc(turbo_tasks);
-                for CollectiblesRef {
-                    task: dep_task,
-                    collectible_type,
-                } in refs
-                {
-                    let mut target = ctx.task(dep_task, TaskDataCategory::Data);
-                    target.remove_collectibles_dependents(&(collectible_type, source));
-                }
-            }
-        }
-    }
-
-    /// Removes a collectible task from the in-memory task_cache and map and returns its
-    /// [`TaskDeletion`] tombstone. The reverse-dep edge scrubbing is done separately by the
-    /// `Scrub*` jobs (see [`Self::gc_run_job`]); this only touches `task_id`'s own entries, which
-    /// are independent of the target entries the scrubs mutate, so ordering between them is free.
-    /// Must be called while holding the GC phase.
-    fn gc_remove_task(
-        &self,
-        task_id: TaskId,
-        plan: &GcDeletePlan,
-        _ctx: &mut impl ExecuteContext<'_>,
-    ) -> TaskDeletion {
-        // Remove the in-memory task_cache entry (hash -> id) so lookups don't return a dead id, and
-        // compute the persisted TaskCache key so the snapshot can tombstone the on-disk mapping.
-        // Only persistent tasks are collected, so a persistent task type is always present.
-        let task_type = plan
-            .persistent_task_type
-            .as_ref()
-            .expect("a collected (non-transient) task must have a task type");
-        self.storage.task_cache.remove(task_type.as_ref());
-        let task_type_hash = compute_task_type_hash(task_type);
-
-        // Remove the task from the map. Its own children set is dropped with it; the child ids were
-        // captured into `plan` so the `Decrement` jobs can drop their parent_count.
-        self.storage.remove_task(task_id);
-
-        // Tombstoning the on-disk `TaskCache` erases the *whole* hash bucket, so any live task
-        // whose type xxh3-collides with this one must be re-inserted. Those survivors are resolved
-        // at apply time in `save_snapshot` (which reads the authoritative on-disk bucket) rather
-        // than computed here — the in-memory `task_cache` is lazily populated and keyed by the full
-        // task type, not the hash, so it can't reliably enumerate hash-siblings. Collisions between
-        // two live tasks are astronomically rare, so this survivor path almost never fires.
-        TaskDeletion {
-            task_id,
-            task_type_hash,
-        }
-    }
-
-    /// Runs a full GC pass under the GC phase and returns the number of tasks collected together
-    /// with their on-disk tombstones. Pass the tombstones to a subsequent
-    /// `snapshot_and_evict_for_testing` to commit them (production runs GC inline in
-    /// `snapshot_and_persist` instead). Test-only hook; callers must be idle (no task
-    /// executing).
-    #[doc(hidden)]
-    pub fn gc_for_testing(
-        &self,
-        turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> (usize, Vec<TaskDeletion>) {
-        let _serialize = self.snapshot_in_progress.lock();
-        let _gc_phase = self.snapshot_coord.begin_gc();
-        self.gc_collect(turbo_tasks)
     }
 
     fn operation_suspend_point(&self, suspend: impl FnOnce() -> AnyOperation) {
@@ -1396,7 +1023,7 @@ impl TurboTasksBackend {
         // commit: in the production (GC-enabled) path they are produced right here under the *same
         // continuous exclusion* as the snapshot (the atomic `into_snapshot` hand-off), so nothing
         // could have resurrected a collected task.
-        let (mut snapshot_phase, mut deletes) = if *GC_ENABLED {
+        let (mut snapshot_phase, mut deletes) = if gc::gc_enabled() {
             // `collected` is recorded on the span (below) once the pass finishes.
             let gc_span =
                 tracing::info_span!(parent: parent_span.clone(), "gc", collected = tracing::field::Empty)
@@ -4191,56 +3818,12 @@ impl Backend for TurboTasksBackend {
     }
 
     fn pin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
-        // Once the backend is stopping, GC bookkeeping is irrelevant (the whole task map is torn
-        // down in `stop()`), so pin/unpin become no-ops. This also makes them safe against handles
-        // finalized during shutdown — e.g. a `DetachedVc` handed to JS across NAPI is dropped
-        // (which unpins) during Node worker teardown, *after* `stop()` has dropped the map.
-        if self.stopping.load(Ordering::Acquire) {
-            return;
-        }
-        // Take an operation guard so pin cannot interleave with a GC pass: it runs strictly before
-        // or strictly after a collection, never concurrently with `is_gc_collectible` / task
-        // removal. This is deadlock-free because neither pin caller holds a guard already —
-        // `prevent_gc` runs in the unguarded user-future region, and `DetachedVc` pins from a NAPI
-        // thread — and the GC pass itself never calls pin/unpin.
-        let _guard = self.start_operation();
-        // A pin is an in-session reference from outside the tracked graph (an explicit
-        // `prevent_gc`, or a detached handle like `DetachedVc` holding the task's `OperationVc`
-        // across NAPI). It is counted the same way a transient parent's edge is: bump
-        // `transient_ref_count`. While that count is > 0 the task is uncollectible (see
-        // `is_gc_collectible`) and unevictable (see `evictability`, so the transient count can't be
-        // lost). Counting (rather than a bool flag) makes nested/cloned pins correct — each pin is
-        // balanced by its own unpin.
-        //
-        // Use the non-inserting `with_task_mut`: a pin always targets a live reference, so the task
-        // must be resident. A missing entry means the caller pinned an already-collected task (a
-        // "zombie `OperationVc`") — a bug we surface via debug_assert rather than paper over by
-        // resurrecting a blank entry (which would leave an orphaned zombie in the map).
-        let existed = self
-            .storage
-            .with_task_mut(task, |t| t.gc_increment_transient_ref_count());
-        debug_assert!(
-            existed.is_some(),
-            "pin_task_for_gc: task {task} has no resident entry (pinned an already-collected \
-             task?)"
-        );
+        // GC pin/unpin bookkeeping lives in the `gc` module (see `gc_pin`).
+        self.gc_pin(task);
     }
 
     fn unpin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
-        // See `pin_task_for_gc`: no-op once stopping, so handles finalized during shutdown (after
-        // the map is dropped) don't underflow the count.
-        if self.stopping.load(Ordering::Acquire) {
-            return;
-        }
-        let _guard = self.start_operation();
-        let existed = self
-            .storage
-            .with_task_mut(task, |t| t.gc_decrement_transient_ref_count());
-        debug_assert!(
-            existed.is_some(),
-            "unpin_task_for_gc: task {task} has no resident entry (unpinned an already-collected \
-             task?)"
-        );
+        self.gc_unpin(task);
     }
 
     fn connect_task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -4070,6 +4070,14 @@ impl Backend for TurboTasksBackend {
     }
 
     fn pin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        // Once the backend is stopping, GC bookkeeping is irrelevant (the whole task map is torn
+        // down in `stop()`), so pin/unpin become no-ops. This also makes them safe against handles
+        // finalized during shutdown — e.g. a `DetachedVc` handed to JS across NAPI is dropped
+        // (which unpins) during Node worker teardown, *after* `stop()` has dropped the map; without
+        // this gate that unpin would resurrect a blank entry and underflow `transient_ref_count`.
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
         // A pin is an in-session reference from outside the tracked graph (an explicit
         // `prevent_gc`, or a detached handle like `DetachedVc` holding the task's
         // `OperationVc` across NAPI). It is counted the same way a transient parent's edge
@@ -4083,6 +4091,11 @@ impl Backend for TurboTasksBackend {
     }
 
     fn unpin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        // See `pin_task_for_gc`: no-op once stopping, so handles finalized during shutdown (after
+        // the map is dropped) don't underflow the count.
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
         self.storage
             .access_mut(task)
             .gc_decrement_transient_ref_count();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1253,9 +1253,11 @@ impl TurboTasksBackend {
         // Tasks were already consumed by take_snapshot, so a future snapshot
         // would not re-persist them — returning an error signals to the caller
         // that further persist attempts would corrupt the task graph in storage.
-        let snapshot_meta = self
-            .backing_storage
-            .save_snapshot(suspended_operations, task_snapshots)?;
+        // GC is not yet wired into the snapshot cycle (see the mark-and-sweep staging plan);
+        // pass an empty delete list for now.
+        let snapshot_meta =
+            self.backing_storage
+                .save_snapshot(suspended_operations, task_snapshots, Vec::new())?;
         span.record("snapshot_meta", display(snapshot_meta));
 
         #[cfg(feature = "print_cache_item_size")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1002,14 +1002,8 @@ impl TurboTasksBackend {
         // a time. Held for the entire snapshot lifecycle.
         let _snapshot_in_progress = self.snapshot_in_progress.lock();
 
-        // Garbage-collection pass runs immediately before the snapshot, under the same held
-        // `snapshot_in_progress` lock: it tears down tasks whose persistent parent_count reached 0
-        // (removing them from the map) and returns their on-disk tombstones, which this snapshot
-        // then commits atomically. Doing it here — rather than as a separate background step —
-        // means a collected task is neither re-persisted nor left on disk: it is tombstoned in the
-        // very commit that would otherwise have re-written it, and the tombstone is re-validated
-        // against the post-drain map below so a task resurrected in the brief window between the GC
-        // phase and the snapshot drain is not wrongly tombstoned. Opt-in via TURBO_ENGINE_GC.
+        // Garbage-collection pass runs immediately before the snapshot, so we can compute keys to
+        // tombstone in the database and apply it during the snapshot. Opt-in via TURBO_ENGINE_GC.
         // Run the GC pass and transition to the snapshot **atomically**, without ever releasing
         // operation exclusion in between. `begin_gc` drains all operations; `gc_collect` tears down
         // collectible tasks and cascades `parent_count` decrements to their children; then
@@ -1024,20 +1018,20 @@ impl TurboTasksBackend {
         // continuous exclusion* as the snapshot (the atomic `into_snapshot` hand-off), so nothing
         // could have resurrected a collected task.
         let (mut snapshot_phase, mut deletes) = if gc::gc_enabled() {
-            // `collected` is recorded on the span (below) once the pass finishes.
+            // `collected` is recorded on the span (below) once the pass finishes. `begin_gc` blocks
+            // until in-flight operations drain (spanned inside the coordinator); `into_snapshot`
+            // then hands exclusion straight to the snapshot phase without releasing it (no further
+            // drain — no operation can have started).
             let gc_span =
                 tracing::info_span!(parent: parent_span.clone(), "gc", collected = tracing::field::Empty)
                     .entered();
             let gc_phase = self.snapshot_coord.begin_gc();
             let (collected, deletes) = self.gc_collect(turbo_tasks);
             gc_span.record("collected", collected);
-            // `into_snapshot` blocks until all in-flight operations have drained before the
-            // snapshot can begin.
-            let _span = tracing::info_span!("await operations settle").entered();
             (gc_phase.into_snapshot(), deletes)
         } else {
-            // `begin_snapshot` blocks until all in-flight operations have drained.
-            let _span = tracing::info_span!("await operations settle").entered();
+            // `begin_snapshot` blocks until in-flight operations drain (spanned inside the
+            // coordinator).
             (self.snapshot_coord.begin_snapshot(), Vec::new())
         };
         // Also commit any tombstones from the test-only `gc_for_testing` hook. That hook runs its

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -214,6 +214,11 @@ pub struct TurboTasksBackend {
     /// `stop_and_wait`).
     snapshot_in_progress: Mutex<()>,
 
+    /// Whether the `parent_count` GC pass runs for this backend. Initialized from the
+    /// `TURBO_ENGINE_GC` static ([`gc::gc_enabled`]) and, in debug builds, forced off if the
+    /// configuration would strand soft-deleted tasks resident — see the constructor.
+    gc_enabled: bool,
+
     stopping: AtomicBool,
     stopping_event: Event,
     idle_start_event: Event,
@@ -248,8 +253,30 @@ impl TurboTasksBackend {
         let next_task_id = backing_storage
             .next_free_task_id()
             .expect("Failed to get task id");
+
+        // GC leaves collected tasks resident (soft-deleted) until a reclaim step removes them. The
+        // background `ReadWrite` loop reclaims them in `evict_after_snapshot`, so GC there REQUIRES
+        // eviction to be on; with eviction off, soft-deleted tasks would accumulate forever. The
+        // `ReadWriteOnShutdown` drain path drops the whole map wholesale (no per-cycle eviction
+        // needed), and `ReadOnly` never persists/GCs. In debug builds, refuse the unsafe combo by
+        // forcing GC off with a warning; release builds trust the caller's configuration.
+        let mut gc_enabled = gc::gc_enabled();
+        #[cfg(debug_assertions)]
+        if gc_enabled
+            && matches!(options.storage_mode, Some(StorageMode::ReadWrite))
+            && options.eviction_mode == EvictionMode::Off
+        {
+            eprintln!(
+                "warning: TURBO_ENGINE_GC is set but eviction is disabled on a ReadWrite backend; \
+                 GC would leave collected tasks resident forever. Forcing GC off. Enable eviction \
+                 (EvictionMode::Auto/Full) to use GC in this mode."
+            );
+            gc_enabled = false;
+        }
+
         Self {
             options,
+            gc_enabled,
             start_time: Instant::now(),
             persisted_task_id_factory: IdFactoryWithReuse::new(
                 next_task_id,
@@ -307,30 +334,21 @@ impl TurboTasksBackend {
     /// This is exposed for integration tests that need to verify the
     /// snapshot → evict → restore cycle works correctly.
     ///
+    /// A snapshot run after a [`Self::gc_for_testing`] pass commits that pass's tombstones
+    /// automatically: GC leaves collected tasks resident with their `deleted` flag set, and the
+    /// snapshot derives the on-disk tombstones from that flag (no tombstones need threading in).
+    ///
     /// Returns `(snapshot_had_new_data, eviction_counts)`.
     #[doc(hidden)]
     pub fn snapshot_and_evict_for_testing(
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
     ) -> (bool, EvictionCounts) {
-        self.snapshot_and_evict_with_deletes_for_testing(turbo_tasks, Vec::new())
-    }
-
-    /// Like [`Self::snapshot_and_evict_for_testing`], but also commits `deletes` (tombstones from a
-    /// prior [`Self::gc_for_testing`] pass) in the snapshot, so the collected tasks are removed
-    /// from disk as well as memory.
-    #[doc(hidden)]
-    pub fn snapshot_and_evict_with_deletes_for_testing(
-        &self,
-        turbo_tasks: &TurboTasks<TurboTasksBackend>,
-        deletes: Vec<TaskDeletion>,
-    ) -> (bool, EvictionCounts) {
         assert!(
             self.should_persist(),
             "snapshot_and_evict requires persistence"
         );
-        let snapshot_result =
-            self.snapshot_and_persist(None, SnapshotReason::Test, turbo_tasks, deletes);
+        let snapshot_result = self.snapshot_and_persist(None, SnapshotReason::Test, turbo_tasks);
         let had_new_data = match snapshot_result {
             Ok((_, new_data)) => new_data,
             Err(_) => {
@@ -498,6 +516,14 @@ impl TurboTasksBackend {
         } else {
             (ctx.task(task_id, TaskDataCategory::All), None)
         };
+        // A GC-soft-deleted task must never be read: it was collected (edges scrubbed) and any read
+        // would return stale contents. Every re-entry funnels through `resurrect_if_deleted` at
+        // connect, which clears the flag and re-executes, so reaching here with it still set means
+        // a resurrection path was missed. (debug-only; the flag exists only when GC is enabled.)
+        debug_assert!(
+            !task.gc_is_deleted(),
+            "read_task_output on a GC-deleted task {task_id} — a resurrection path was missed"
+        );
 
         fn listen_to_done_event(
             reader_description: Option<EventDescription>,
@@ -869,6 +895,12 @@ impl TurboTasksBackend {
         } else {
             (ctx.task(task_id, TaskDataCategory::All), None)
         };
+        // See the matching assert in `try_read_task_output`: a GC-deleted task must be resurrected
+        // (at connect) before any read; reaching a read with the flag still set is a missed path.
+        debug_assert!(
+            !task.gc_is_deleted(),
+            "read_task_cell on a GC-deleted task {task_id} — a resurrection path was missed"
+        );
 
         let content = if final_read_hint {
             task.remove_cell_data(&cell, &get_value_type(cell.type_id()).persistence)
@@ -981,10 +1013,6 @@ impl TurboTasksBackend {
         parent_span: Option<tracing::Id>,
         reason: SnapshotReason,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
-        // Tombstones produced by an out-of-band GC pass (the test-only `gc_for_testing` hook) that
-        // this snapshot should commit. The production path leaves this empty and runs GC inline
-        // below; only tests thread deletes in here.
-        external_deletes: Vec<TaskDeletion>,
     ) -> Result<(Instant, bool), anyhow::Error> {
         let snapshot_span =
             tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason.as_str())
@@ -1009,31 +1037,25 @@ impl TurboTasksBackend {
         // commit: in the production (GC-enabled) path they are produced right here under the *same
         // continuous exclusion* as the snapshot (the atomic `into_snapshot` hand-off), so nothing
         // could have resurrected a collected task.
-        let (mut snapshot_phase, mut deletes) = if gc::gc_enabled() {
+        let mut snapshot_phase = if self.gc_enabled {
             // `collected` is recorded on the span (below) once the pass finishes. `begin_gc` blocks
             // until in-flight operations drain (spanned inside the coordinator); `into_snapshot`
             // then hands exclusion straight to the snapshot phase without releasing it (no further
-            // drain — no operation can have started).
+            // drain — no operation can have started). The pass marks collected tasks soft-deleted
+            // (and modified) rather than removing them; the snapshot below derives their on-disk
+            // tombstones from the `deleted` flag and commits them in the same batch as the puts.
             let gc_span =
                 tracing::info_span!(parent: parent_span.clone(), "gc", collected = tracing::field::Empty)
                     .entered();
             let gc_phase = self.snapshot_coord.begin_gc();
-            let (collected, deletes) = self.gc_collect(turbo_tasks);
+            let collected = self.gc_collect(turbo_tasks);
             gc_span.record("collected", collected);
-            (gc_phase.into_snapshot(), deletes)
+            gc_phase.into_snapshot()
         } else {
             // `begin_snapshot` blocks until in-flight operations drain (spanned inside the
             // coordinator).
-            (self.snapshot_coord.begin_snapshot(), Vec::new())
+            self.snapshot_coord.begin_snapshot()
         };
-        // Also commit any tombstones from the test-only `gc_for_testing` hook. That hook runs its
-        // GC pass in a *separate* exclusion window that has already ended by the time we get here,
-        // so a task it collected could in principle have been resurrected (re-created via a cache
-        // hit) before this snapshot began. The `deletes.retain(...)` re-validation below — after
-        // `start_snapshot` freezes the map — drops the tombstone for any such resurrected task.
-        // (The production path can't hit this: its GC runs under the same continuous exclusion as
-        // the snapshot, so nothing runs in between.)
-        deletes.extend(external_deletes);
         let start = Instant::now();
         // SystemTime for wall-clock timestamps in trace events (milliseconds
         // since epoch). Instant is monotonic but has no defined epoch, so it
@@ -1041,27 +1063,20 @@ impl TurboTasksBackend {
         let wall_start = SystemTime::now();
         debug_assert!(self.should_persist());
 
-        // Enter snapshot mode, which atomically reads and resets the modified count.
+        // Enter snapshot mode, which atomically reads and resets the modified count. GC marks each
+        // collected task modified, so a pass that collected anything makes `has_modifications`
+        // true and the scan below runs and emits the tombstones.
         // Checking after start_snapshot ensures no concurrent increments can race.
         let (snapshot_guard, has_modifications) = self.storage.start_snapshot();
-
-        // Now that `start_snapshot` has frozen the map, drop the tombstone for any task that is
-        // resident again — i.e. was resurrected after an out-of-band `gc_for_testing` pass
-        // collected it (see the note above the `deletes.extend`). Tombstoning a live task
-        // would delete a task the snapshot is about to persist. The production path never
-        // resurrects, so this is a no-op there.
-        if !deletes.is_empty() {
-            deletes.retain(|d| self.storage.with_task(d.task_id, |_| ()).is_none());
-        }
 
         let suspended_operations = snapshot_phase.take_suspended_operations();
 
         let snapshot_time = Instant::now();
         drop(snapshot_phase);
 
-        if !has_modifications && deletes.is_empty() {
-            // No tasks modified since the last snapshot and no GC tombstones pending — drop the
-            // guard (which calls end_snapshot) and skip the expensive O(N) scan.
+        if !has_modifications {
+            // No tasks modified since the last snapshot (GC-collected tasks count as modified) —
+            // drop the guard (which calls end_snapshot) and skip the expensive O(N) scan.
             drop(snapshot_guard);
             return Ok((start, false));
         }
@@ -1270,6 +1285,26 @@ impl TurboTasksBackend {
                 unreachable!("transient task_ids should never be enqueued to be persisted");
             }
 
+            // A GC-soft-deleted task is not persisted; instead its on-disk copy (task meta/data +
+            // its `TaskCache` entry) is tombstoned in this same commit. We represent that as a
+            // `SnapshotItem::Delete` so it rides the streaming shard iterator that `save_snapshot`
+            // consumes (rather than a side-channel that would have to be fully populated before the
+            // put loop runs). GC marks such tasks modified so the per-shard scan visits them here,
+            // and the iterator clears their modified flags, so a still-`deleted` task not
+            // hard-deleted this cycle won't be re-tombstoned next snapshot. Only persistent tasks
+            // are collected, so a persistent task type (the `TaskCache` key) is always present.
+            if inner.gc_is_deleted() {
+                let task_type_hash = compute_task_type_hash(
+                    inner
+                        .get_persistent_task_type()
+                        .expect("a GC-deleted (non-transient) task must have a task type"),
+                );
+                return SnapshotItem::Delete(TaskDeletion {
+                    task_id,
+                    task_type_hash,
+                });
+            }
+
             let encode_meta = inner.flags.meta_modified();
             let encode_data = inner.flags.data_modified();
 
@@ -1307,7 +1342,7 @@ impl TurboTasksBackend {
                 None
             };
 
-            SnapshotItem {
+            SnapshotItem::Put {
                 task_id,
                 meta,
                 data,
@@ -1323,10 +1358,9 @@ impl TurboTasksBackend {
         let snapshot_duration = start.elapsed();
         let task_count = task_snapshots.len();
 
-        if task_snapshots.is_empty() && deletes.is_empty() {
-            // This should be impossible — if we got here, modified_count was nonzero (or we had
-            // pending GC tombstones), and every modification that increments the count also failed
-            // during encoding.
+        if task_snapshots.is_empty() {
+            // This should be impossible — if we got here, modified_count was nonzero, and every
+            // modification that increments the count also failed during encoding.
             std::hint::cold_path();
             return Ok((snapshot_time, false));
         }
@@ -1342,10 +1376,11 @@ impl TurboTasksBackend {
         // Tasks were already consumed by take_snapshot, so a future snapshot
         // would not re-persist them — returning an error signals to the caller
         // that further persist attempts would corrupt the task graph in storage.
-        // `deletes` carries GC tombstones drained above; they ride this same atomic commit.
-        let snapshot_meta =
-            self.backing_storage
-                .save_snapshot(suspended_operations, task_snapshots, deletes)?;
+        // GC tombstones are carried inline as `SnapshotItem::Delete` entries in `task_snapshots`
+        // (derived from the `deleted` flag during the scan) and applied in the same atomic commit.
+        let snapshot_meta = self
+            .backing_storage
+            .save_snapshot(suspended_operations, task_snapshots)?;
         span.record("snapshot_meta", display(snapshot_meta));
 
         #[cfg(feature = "print_cache_item_size")]
@@ -1506,12 +1541,8 @@ impl TurboTasksBackend {
         // lower peak memory during the serialization/write.
         self.storage.drop_task_cache();
         if self.should_persist()
-            && let Err(err) = self.snapshot_and_persist(
-                Span::current().into(),
-                SnapshotReason::Stop,
-                turbo_tasks,
-                Vec::new(),
-            )
+            && let Err(err) =
+                self.snapshot_and_persist(Span::current().into(), SnapshotReason::Stop, turbo_tasks)
         {
             eprintln!("Persisting failed during shutdown: {err:?}");
         }
@@ -3024,12 +3055,7 @@ impl TurboTasksBackend {
                         let background_span =
                             tracing::info_span!(parent: None, "background snapshot");
 
-                        match self.snapshot_and_persist(
-                            background_span.id(),
-                            reason,
-                            turbo_tasks,
-                            Vec::new(),
-                        ) {
+                        match self.snapshot_and_persist(background_span.id(), reason, turbo_tasks) {
                             Err(err) => {
                                 // save_snapshot consumed persisted_task_cache_log entries;
                                 // further snapshots would corrupt the task graph.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -214,13 +214,6 @@ pub struct TurboTasksBackend {
     /// `stop_and_wait`).
     snapshot_in_progress: Mutex<()>,
 
-    /// Tasks observed reaching `parent_count == 0` (no persistent parent) during operation
-    /// execution — candidates for garbage collection. Populated cheaply (a side-set write) in the
-    /// `AdjustParentCount` handler; the actual teardown/removal happens later under the GC phase's
-    /// exclusion (see `gc_collect`), where candidacy is re-validated (a concurrent re-connect may
-    /// have revived the task). Never collected directly from here.
-    gc_candidates: Mutex<FxHashSet<TaskId>>,
-
     stopping: AtomicBool,
     stopping_event: Event,
     idle_start_event: Event,
@@ -269,7 +262,6 @@ impl TurboTasksBackend {
             storage: Storage::new(shard_amount, small_preallocation),
             snapshot_coord: SnapshotCoordinator::new(),
             snapshot_in_progress: Mutex::new(()),
-            gc_candidates: Mutex::new(FxHashSet::default()),
             stopping: AtomicBool::new(false),
             stopping_event: Event::new(|| || "TurboTasksBackend::stopping_event".to_string()),
             idle_start_event: Event::new(|| || "TurboTasksBackend::idle_start_event".to_string()),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -261,7 +261,6 @@ impl TurboTasksBackend {
         // needed), and `ReadOnly` never persists/GCs. In debug builds, refuse the unsafe combo by
         // forcing GC off with a warning; release builds trust the caller's configuration.
         let mut gc_enabled = gc::gc_enabled();
-        #[cfg(debug_assertions)]
         if gc_enabled
             && matches!(options.storage_mode, Some(StorageMode::ReadWrite))
             && options.eviction_mode == EvictionMode::Off
@@ -269,7 +268,7 @@ impl TurboTasksBackend {
             eprintln!(
                 "warning: TURBO_ENGINE_GC is set but eviction is disabled on a ReadWrite backend; \
                  GC would leave collected tasks resident forever. Forcing GC off. Enable eviction \
-                 (EvictionMode::Auto/Full) to use GC in this mode."
+                 ('auto'/'full') to use GC in this mode."
             );
             gc_enabled = false;
         }
@@ -2181,9 +2180,8 @@ impl TurboTasksBackend {
         let has_new_children = !new_children.is_empty();
         span.record("new_children", new_children.len());
 
-        if has_new_children {
-            self.task_execution_completed_unfinished_children_dirty(&mut ctx, &new_children)
-        }
+        // Note: dirtying any unfinished new children is folded into `connect_children`'s
+        // parent_count pass (a single guard per child), so there is no separate dirty pass here.
 
         if has_new_children
             && let Some(stale_priority) =
@@ -2640,36 +2638,6 @@ impl TurboTasksBackend {
             }
             queue.execute(ctx);
         }
-    }
-
-    fn task_execution_completed_unfinished_children_dirty(
-        &self,
-        ctx: &mut impl ExecuteContext<'_>,
-        new_children: &FxHashSet<TaskId>,
-    ) {
-        debug_assert!(!new_children.is_empty());
-
-        let mut queue = AggregationUpdateQueue::new();
-        ctx.for_each_task_all(
-            new_children.iter().copied(),
-            "unfinished children dirty",
-            |child_task, ctx| {
-                if !child_task.has_output() {
-                    let child_id = child_task.id();
-                    make_task_dirty_internal(
-                        child_task,
-                        child_id,
-                        false,
-                        #[cfg(feature = "task_dirty_cause")]
-                        TaskDirtyCause::InitialDirty,
-                        &mut queue,
-                        ctx,
-                    );
-                }
-            },
-        );
-
-        queue.execute(ctx);
     }
 
     fn task_execution_completed_connect(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -364,21 +364,24 @@ impl TurboTasksBackend {
     ) -> (usize, Vec<TaskDeletion>) {
         // Seed the worklist from the candidates observed since the last pass. Re-validation happens
         // per task below (a candidate may have been revived by a concurrent re-connect before the
-        // phase was acquired, or may not be Data-resident).
+        // GC phase was acquired).
         let mut worklist: Vec<TaskId> = self.gc_candidates.lock().drain().collect();
         let mut collected = 0;
         let mut deletions = Vec::new();
-        // Candidates that still have `parent_count == 0` but are not *yet* collectible (e.g. a
-        // disconnected task whose transient activeness has not been torn down, or which is not yet
-        // Data-resident) are re-retained for a future pass. Genuine roots (`root_ty` set) also land
-        // here — they always have `parent_count == 0` — and are simply re-checked cheaply each
-        // pass; the set stays bounded by the (small) number of such tasks.
+        // Candidates that are still parentless but not *yet* collectible (e.g. residual transient
+        // activeness) are re-retained for a later pass.
         let mut retain: Vec<TaskId> = Vec::new();
 
+        // Sequential worklist drain. This runs under the GC phase (execution is excluded) so it
+        // could in principle be parallelized, but `gc_delete_one` restores Data on demand, which
+        // uses `block_in_place`; fanning the worklist out with `scope_and_block` nests
+        // `block_in_place` inside `block_in_place` and deadlocks on a thread-limited runtime (e.g.
+        // the 2-worker-thread test runtime, or a low-core CI runner). Collection is O(garbage), not
+        // O(total), so a pass is short; if latency ever proves a problem, parallelize by running
+        // the whole pass inside `spawn_blocking` (per the `scope_and_block` guidance) rather than
+        // spawning from within this already-blocking context.
         while let Some(task_id) = worklist.pop() {
             if !self.gc_is_collectible(task_id) {
-                // Keep it as a candidate only while it still has no persistent parent; otherwise a
-                // concurrent re-connect revived it and it is no longer garbage.
                 if self.gc_parent_count(task_id) == 0 && !task_id.is_transient() {
                     retain.push(task_id);
                 }
@@ -388,9 +391,7 @@ impl TurboTasksBackend {
             deletions.push(deletion);
             collected += 1;
 
-            // Cascade: each child of the deleted task loses a persistent parent. Decrement its
-            // parent_count; if it reaches 0 and is collectible, peel it too. This tears down the
-            // whole unreachable subtree in one pass.
+            // Cascade: each child loses a persistent parent; any that reaches 0 is peeled next.
             let mut ctx = self.execute_context_gc(turbo_tasks);
             for child in children {
                 if child.is_transient() {
@@ -406,7 +407,7 @@ impl TurboTasksBackend {
         }
 
         // Re-queue candidates that are still parentless but were not collectible this pass, so a
-        // later pass retries once their transient activeness clears (or their Data is restored).
+        // later pass retries once their transient activeness clears.
         if !retain.is_empty() {
             self.gc_candidates.lock().extend(retain);
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -4010,6 +4010,19 @@ impl Backend for TurboTasksBackend {
         self.mark_own_task_as_finished(task_id, turbo_tasks);
     }
 
+    fn pin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        // Set the transient `pinned` flag. Pinned tasks are unevictable (see `evictability`) and
+        // are treated as GC roots (see `is_gc_root`), so `prevent_gc` keeps the task — and the
+        // escaping references it anchors — alive. `pinned` is transient and never persisted; on
+        // restart the code that escaped the value re-establishes the pin (or the value is simply
+        // recomputed).
+        self.storage.access_mut(task).flags.set_pinned(true);
+    }
+
+    fn unpin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        self.storage.access_mut(task).flags.set_pinned(false);
+    }
+
     fn connect_task(
         &self,
         task: TaskId,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -331,7 +331,7 @@ impl TurboTasksBackend {
     /// 0). Only non-transient tasks are tracked — transient tasks are never collected. Candidacy is
     /// re-validated under exclusion before the task is actually collected, so a false positive here
     /// (e.g. the count is bumped back up by a concurrent re-connect) is harmless.
-    fn note_gc_candidate(&self, task_id: TaskId) {
+    fn add_gc_candidate(&self, task_id: TaskId) {
         if task_id.is_transient() {
             return;
         }
@@ -383,13 +383,14 @@ impl TurboTasksBackend {
         let mut retain: Vec<TaskId> = Vec::new();
 
         // Sequential worklist drain. This runs under the GC phase (execution is excluded) so it
-        // could in principle be parallelized, but `gc_delete_one` restores Data on demand, which
-        // uses `block_in_place`; fanning the worklist out with `scope_and_block` nests
-        // `block_in_place` inside `block_in_place` and deadlocks on a thread-limited runtime (e.g.
-        // the 2-worker-thread test runtime, or a low-core CI runner). Collection is O(garbage), not
-        // O(total), so a pass is short; if latency ever proves a problem, parallelize by running
-        // the whole pass inside `spawn_blocking` (per the `scope_and_block` guidance) rather than
-        // spawning from within this already-blocking context.
+        // could in principle be parallelized, but fanning the worklist out with `scope_and_block`
+        // deadlocks on a thread-limited runtime: `scope_and_block` spawns `available_parallelism()
+        // - 1` worker tasks that block on a Condvar waiting for work, and on a runtime with few
+        // worker threads (e.g. the 2-worker-thread test runtime, or a low-core CI runner) those
+        // blocked workers starve the very tasks that would feed them. Collection is O(garbage), not
+        // O(total), so a pass is short; if latency ever proves a problem, revisit parallelization
+        // (see the `scope_and_block` guidance) — likely by making `scope_and_block` robust on
+        // thread-limited runtimes, which would benefit the snapshot path too.
         while let Some(task_id) = worklist.pop() {
             match self.gc_process_one(task_id, turbo_tasks) {
                 GcOutcome::Collected {
@@ -1311,21 +1312,29 @@ impl TurboTasksBackend {
         // continuous exclusion* as the snapshot (the atomic `into_snapshot` hand-off), so nothing
         // could have resurrected a collected task.
         let (mut snapshot_phase, mut deletes) = if *GC_ENABLED {
-            let _gc_span = tracing::info_span!(parent: parent_span.clone(), "gc").entered();
+            // `collected` is recorded on the span (below) once the pass finishes.
+            let gc_span =
+                tracing::info_span!(parent: parent_span.clone(), "gc", collected = tracing::field::Empty)
+                    .entered();
             let gc_phase = self.snapshot_coord.begin_gc();
             let (collected, deletes) = self.gc_collect(turbo_tasks);
-            if collected > 0 {
-                tracing::info!(collected, "gc pass collected tasks");
-            }
-            let _span = tracing::info_span!("blocking").entered();
+            gc_span.record("collected", collected);
+            // `into_snapshot` blocks until all in-flight operations have drained before the
+            // snapshot can begin.
+            let _span = tracing::info_span!("await operations settle").entered();
             (gc_phase.into_snapshot(), deletes)
         } else {
-            let _span = tracing::info_span!("blocking").entered();
+            // `begin_snapshot` blocks until all in-flight operations have drained.
+            let _span = tracing::info_span!("await operations settle").entered();
             (self.snapshot_coord.begin_snapshot(), Vec::new())
         };
-        // Also commit any tombstones from the test-only `gc_for_testing` hook, which runs GC as a
-        // *separate* exclusion window (not joined to this snapshot). Because of that gap we
-        // re-validate below (after the drain stabilizes the map) as a cheap belt-and-suspenders.
+        // Also commit any tombstones from the test-only `gc_for_testing` hook. That hook runs its
+        // GC pass in a *separate* exclusion window that has already ended by the time we get here,
+        // so a task it collected could in principle have been resurrected (re-created via a cache
+        // hit) before this snapshot began. The `deletes.retain(...)` re-validation below — after
+        // `start_snapshot` freezes the map — drops the tombstone for any such resurrected task.
+        // (The production path can't hit this: its GC runs under the same continuous exclusion as
+        // the snapshot, so nothing runs in between.)
         deletes.extend(external_deletes);
         let start = Instant::now();
         // SystemTime for wall-clock timestamps in trace events (milliseconds
@@ -1338,8 +1347,11 @@ impl TurboTasksBackend {
         // Checking after start_snapshot ensures no concurrent increments can race.
         let (snapshot_guard, has_modifications) = self.storage.start_snapshot();
 
-        // Belt-and-suspenders: drop the tombstone for any task that is resident again (would only
-        // happen via the non-atomic `gc_for_testing` path; the production path can't resurrect).
+        // Now that `start_snapshot` has frozen the map, drop the tombstone for any task that is
+        // resident again — i.e. was resurrected after an out-of-band `gc_for_testing` pass
+        // collected it (see the note above the `deletes.extend`). Tombstoning a live task
+        // would delete a task the snapshot is about to persist. The production path never
+        // resurrects, so this is a no-op there.
         if !deletes.is_empty() {
             deletes.retain(|d| self.storage.with_task(d.task_id, |_| ()).is_none());
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -229,14 +229,6 @@ pub struct TurboTasksBackend {
     /// have revived the task). Never collected directly from here.
     gc_candidates: Mutex<FxHashSet<TaskId>>,
 
-    /// Tombstones for tasks the GC pass has removed from memory, awaiting the next persistence
-    /// commit. GC removes a collected task from the in-memory map immediately (under the GC
-    /// phase), but its already-persisted on-disk copy must be tombstoned in a `save_snapshot`
-    /// commit; each collected task's [`TaskDeletion`] is buffered here and drained into the
-    /// next snapshot. A crash before that commit just leaves the on-disk copy to be
-    /// re-collected — never a dangling reference.
-    pending_gc_deletes: Mutex<Vec<TaskDeletion>>,
-
     stopping: AtomicBool,
     stopping_event: Event,
     idle_start_event: Event,
@@ -305,7 +297,6 @@ impl TurboTasksBackend {
             snapshot_coord: SnapshotCoordinator::new(),
             snapshot_in_progress: Mutex::new(()),
             gc_candidates: Mutex::new(FxHashSet::default()),
-            pending_gc_deletes: Mutex::new(Vec::new()),
             stopping: AtomicBool::new(false),
             stopping_event: Event::new(|| || "TurboTasksBackend::stopping_event".to_string()),
             idle_start_event: Event::new(|| || "TurboTasksBackend::idle_start_event".to_string()),
@@ -571,20 +562,19 @@ impl TurboTasksBackend {
         (children, deletion)
     }
 
-    /// Runs a full GC pass under the GC phase and returns the number of tasks collected. Buffers
-    /// the resulting tombstones into `pending_gc_deletes` so a subsequent
-    /// `snapshot_and_evict_for_testing` commits them (production runs GC inline in
+    /// Runs a full GC pass under the GC phase and returns the number of tasks collected together
+    /// with their on-disk tombstones. Pass the tombstones to a subsequent
+    /// `snapshot_and_evict_for_testing` to commit them (production runs GC inline in
     /// `snapshot_and_persist` instead). Test-only hook; callers must be idle (no task
     /// executing).
     #[doc(hidden)]
-    pub fn gc_for_testing(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
+    pub fn gc_for_testing(
+        &self,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> (usize, Vec<TaskDeletion>) {
         let _serialize = self.snapshot_in_progress.lock();
         let _gc_phase = self.snapshot_coord.begin_gc();
-        let (collected, deletes) = self.gc_collect(turbo_tasks);
-        if !deletes.is_empty() {
-            self.pending_gc_deletes.lock().extend(deletes);
-        }
-        collected
+        self.gc_collect(turbo_tasks)
     }
 
     fn operation_suspend_point(&self, suspend: impl FnOnce() -> AnyOperation) {
@@ -618,11 +608,24 @@ impl TurboTasksBackend {
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
     ) -> (bool, EvictionCounts) {
+        self.snapshot_and_evict_with_deletes_for_testing(turbo_tasks, Vec::new())
+    }
+
+    /// Like [`Self::snapshot_and_evict_for_testing`], but also commits `deletes` (tombstones from a
+    /// prior [`Self::gc_for_testing`] pass) in the snapshot, so the collected tasks are removed
+    /// from disk as well as memory.
+    #[doc(hidden)]
+    pub fn snapshot_and_evict_with_deletes_for_testing(
+        &self,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+        deletes: Vec<TaskDeletion>,
+    ) -> (bool, EvictionCounts) {
         assert!(
             self.should_persist(),
             "snapshot_and_evict requires persistence"
         );
-        let snapshot_result = self.snapshot_and_persist(None, SnapshotReason::Test, turbo_tasks);
+        let snapshot_result =
+            self.snapshot_and_persist(None, SnapshotReason::Test, turbo_tasks, deletes);
         let had_new_data = match snapshot_result {
             Ok((_, new_data)) => new_data,
             Err(_) => {
@@ -1273,6 +1276,10 @@ impl TurboTasksBackend {
         parent_span: Option<tracing::Id>,
         reason: SnapshotReason,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
+        // Tombstones produced by an out-of-band GC pass (the test-only `gc_for_testing` hook) that
+        // this snapshot should commit. The production path leaves this empty and runs GC inline
+        // below; only tests thread deletes in here.
+        external_deletes: Vec<TaskDeletion>,
     ) -> Result<(Instant, bool), anyhow::Error> {
         let snapshot_span =
             tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason.as_str())
@@ -1299,28 +1306,27 @@ impl TurboTasksBackend {
         // it is persisted — so the decremented children counts and the snapshot are consistent, and
         // GC-collected tasks' tombstones ride this same commit.
         //
-        // Without GC we just begin the snapshot directly.
-        let mut snapshot_phase = if *GC_ENABLED {
+        // Without GC we just begin the snapshot directly. `deletes` are the GC tombstones for this
+        // commit: in the production (GC-enabled) path they are produced right here under the *same
+        // continuous exclusion* as the snapshot (the atomic `into_snapshot` hand-off), so nothing
+        // could have resurrected a collected task.
+        let (mut snapshot_phase, mut deletes) = if *GC_ENABLED {
             let _gc_span = tracing::info_span!(parent: parent_span.clone(), "gc").entered();
             let gc_phase = self.snapshot_coord.begin_gc();
             let (collected, deletes) = self.gc_collect(turbo_tasks);
             if collected > 0 {
                 tracing::info!(collected, "gc pass collected tasks");
             }
-            self.pending_gc_deletes.lock().extend(deletes);
             let _span = tracing::info_span!("blocking").entered();
-            gc_phase.into_snapshot()
+            (gc_phase.into_snapshot(), deletes)
         } else {
             let _span = tracing::info_span!("blocking").entered();
-            self.snapshot_coord.begin_snapshot()
+            (self.snapshot_coord.begin_snapshot(), Vec::new())
         };
-        // Drain the GC tombstones for this commit. In the production (GC-enabled) path they were
-        // just produced above under the *same continuous exclusion* as this snapshot (the atomic
-        // `into_snapshot` hand-off), so nothing could have resurrected a collected task. The
-        // test-only `gc_for_testing` hook also buffers here, and it runs GC as a separate exclusion
-        // window — so we still re-validate below (after the drain stabilizes the map) as a cheap
-        // belt-and-suspenders against a task revived between that hook and this snapshot.
-        let mut deletes = std::mem::take(&mut *self.pending_gc_deletes.lock());
+        // Also commit any tombstones from the test-only `gc_for_testing` hook, which runs GC as a
+        // *separate* exclusion window (not joined to this snapshot). Because of that gap we
+        // re-validate below (after the drain stabilizes the map) as a cheap belt-and-suspenders.
+        deletes.extend(external_deletes);
         let start = Instant::now();
         // SystemTime for wall-clock timestamps in trace events (milliseconds
         // since epoch). Instant is monotonic but has no defined epoch, so it
@@ -1793,9 +1799,12 @@ impl TurboTasksBackend {
             // The stop snapshot runs a final GC pass internally (see `snapshot_and_persist`), so
             // builds emit tombstones for disconnected tasks in the final commit — keeping the
             // persisted DB tight for the next build.
-            if let Err(err) =
-                self.snapshot_and_persist(Span::current().into(), SnapshotReason::Stop, turbo_tasks)
-            {
+            if let Err(err) = self.snapshot_and_persist(
+                Span::current().into(),
+                SnapshotReason::Stop,
+                turbo_tasks,
+                Vec::new(),
+            ) {
                 eprintln!("Persisting failed during shutdown: {err:?}");
             }
         }
@@ -3308,7 +3317,12 @@ impl TurboTasksBackend {
                         let background_span =
                             tracing::info_span!(parent: None, "background snapshot");
 
-                        match self.snapshot_and_persist(background_span.id(), reason, turbo_tasks) {
+                        match self.snapshot_and_persist(
+                            background_span.id(),
+                            reason,
+                            turbo_tasks,
+                            Vec::new(),
+                        ) {
                             Err(err) => {
                                 // save_snapshot consumed persisted_task_cache_log entries;
                                 // further snapshots would corrupt the task graph.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -550,15 +550,16 @@ impl TurboTasksBackend {
         // ids above so the caller can decrement their parent_count.
         self.storage.remove_task(task_id);
 
-        // `surviving_task_ids` is left empty: it would carry any *other* live persistent task whose
-        // task type xxh3-collides with this one (the whole hash bucket is tombstoned). An 8-byte
-        // collision between two simultaneously-live tasks is astronomically rare (~2^32 tasks for
-        // one expected collision); if it ever occurred the survivor's mapping would be dropped and
-        // it would be transparently re-created on next lookup — a performance cost, not corruption.
+        // Tombstoning the on-disk `TaskCache` erases the *whole* hash bucket, so any live task
+        // whose type xxh3-collides with this one must be re-inserted. Those survivors are
+        // resolved at apply time in `save_snapshot` (which reads the authoritative on-disk
+        // bucket) rather than computed here — the in-memory `task_cache` is lazily
+        // populated and keyed by the full task type, not the hash, so it can't reliably
+        // enumerate hash-siblings. Collisions between two live tasks are astronomically
+        // rare, so this survivor path almost never fires.
         let deletion = TaskDeletion {
             task_id,
             task_type_hash,
-            surviving_task_ids: Vec::new(),
         };
         (children, deletion)
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -431,30 +431,21 @@ impl TurboTasksBackend {
         let mut ctx = self.execute_context_gc(turbo_tasks);
 
         // Single access: decide collectibility and, if collectible, capture the edges needed to
-        // tear the task down. `ctx.task(.., All)` restores the task if it was evicted, so the
-        // `is_restored(Meta)` guard inside `is_gc_collectible` is satisfied here by construction;
-        // it remains load-bearing on the raw `&TaskStorage` path (a candidate whose Meta was
-        // evicted between passes would otherwise read a bogus parent_count of 0).
+        // tear the task down. Reading through the guard (`ctx.task(.., All)`, which restores the
+        // task if it was evicted) means `is_gc_collectible`'s Meta reads go through `check_access`,
+        // so the "Meta restored" precondition is enforced by the standard guard machinery rather
+        // than a hand-rolled `is_restored` check.
         let plan = {
             let task = ctx.task(task_id, TaskDataCategory::All);
-            let s = task.typed();
-            if !s.is_gc_collectible() {
+            if !task.is_gc_collectible() {
                 // Not collectible: keep retrying only while it is still parentless; otherwise a
                 // concurrent re-connect revived it and it is no longer garbage.
-                return if s.gc_parent_count() == 0 {
+                return if task.get_parent_count().copied().unwrap_or(0) == 0 {
                     GcOutcome::Retain(task_id)
                 } else {
                     GcOutcome::Skip
                 };
             }
-
-            // A collectible task has no aggregation edges left (`is_gc_collectible` checks this);
-            // this assert documents the invariant and surfaces any case that would need aggregation
-            // teardown rather than silently corrupting the graph.
-            debug_assert!(
-                task.iter_upper().next().is_none() && task.iter_followers().next().is_none(),
-                "gc_delete: task {task_id} still has aggregation edges; teardown needed"
-            );
 
             GcDeletePlan {
                 children: task.iter_children().collect(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -521,7 +521,7 @@ impl TurboTasksBackend {
         // connect, which clears the flag and re-executes, so reaching here with it still set means
         // a resurrection path was missed. (debug-only; the flag exists only when GC is enabled.)
         debug_assert!(
-            !task.gc_is_deleted(),
+            !task.deleted(),
             "read_task_output on a GC-deleted task {task_id} — a resurrection path was missed"
         );
 
@@ -898,7 +898,7 @@ impl TurboTasksBackend {
         // See the matching assert in `try_read_task_output`: a GC-deleted task must be resurrected
         // (at connect) before any read; reaching a read with the flag still set is a missed path.
         debug_assert!(
-            !task.gc_is_deleted(),
+            !task.deleted(),
             "read_task_cell on a GC-deleted task {task_id} — a resurrection path was missed"
         );
 
@@ -1293,7 +1293,7 @@ impl TurboTasksBackend {
             // and the iterator clears their modified flags, so a still-`deleted` task not
             // hard-deleted this cycle won't be re-tombstoned next snapshot. Only persistent tasks
             // are collected, so a persistent task type (the `TaskCache` key) is always present.
-            if inner.gc_is_deleted() {
+            if inner.flags.deleted() {
                 let task_type_hash = compute_task_type_hash(
                     inner
                         .get_persistent_task_type()
@@ -3826,12 +3826,12 @@ impl Backend for TurboTasksBackend {
         self.mark_own_task_as_finished(task_id, turbo_tasks);
     }
 
-    fn pin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
-        self.gc_pin(task);
+    fn pin_task_for_gc(&self, task: TaskId, turbo_tasks: &TurboTasks<Self>) {
+        self.gc_pin(task, turbo_tasks);
     }
 
-    fn unpin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
-        self.gc_unpin(task);
+    fn unpin_task_for_gc(&self, task: TaskId, turbo_tasks: &TurboTasks<Self>) {
+        self.gc_unpin(task, turbo_tasks);
     }
 
     fn connect_task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -72,7 +72,7 @@ use crate::{
         storage::Storage,
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    backing_storage::{SnapshotItem, compute_task_type_hash},
+    backing_storage::{SnapshotItem, TaskDeletion, compute_task_type_hash},
     data::{
         ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
         InProgressState, InProgressStateInner, OutputValue, TransientTask,
@@ -90,6 +90,15 @@ use crate::{
 /// If the number of dependent tasks exceeds this threshold,
 /// the operation will be parallelized.
 const DEPENDENT_TASKS_DIRTY_PARALLELIZATION_THRESHOLD: usize = 10000;
+
+/// When `TURBO_ENGINE_GC` is set to a truthy value, the background job runs a `parent_count`-driven
+/// garbage-collection pass (tearing down tasks whose persistent parent count reached 0). Opt-in
+/// until it has been proven on trusted apps; the eventual default-on flip gets its own escape
+/// hatch.
+static GC_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var_os("TURBO_ENGINE_GC")
+        .is_some_and(|v| matches!(v.to_str(), Some("1" | "true" | "yes")))
+});
 
 /// Priority used to re-schedule a task that became stale during execution.
 ///
@@ -213,6 +222,21 @@ pub struct TurboTasksBackend {
     /// `stop_and_wait`).
     snapshot_in_progress: Mutex<()>,
 
+    /// Tasks observed reaching `parent_count == 0` (no persistent parent) during operation
+    /// execution — candidates for garbage collection. Populated cheaply (a side-set write) in the
+    /// `AdjustParentCount` handler; the actual teardown/removal happens later under the GC phase's
+    /// exclusion (see `gc_collect`), where candidacy is re-validated (a concurrent re-connect may
+    /// have revived the task). Never collected directly from here.
+    gc_candidates: Mutex<FxHashSet<TaskId>>,
+
+    /// Tombstones for tasks the GC pass has removed from memory, awaiting the next persistence
+    /// commit. GC removes a collected task from the in-memory map immediately (under the GC
+    /// phase), but its already-persisted on-disk copy must be tombstoned in a `save_snapshot`
+    /// commit; each collected task's [`TaskDeletion`] is buffered here and drained into the
+    /// next snapshot. A crash before that commit just leaves the on-disk copy to be
+    /// re-collected — never a dangling reference.
+    pending_gc_deletes: Mutex<Vec<TaskDeletion>>,
+
     stopping: AtomicBool,
     stopping_event: Event,
     idle_start_event: Event,
@@ -261,6 +285,8 @@ impl TurboTasksBackend {
             storage: Storage::new(shard_amount, small_preallocation),
             snapshot_coord: SnapshotCoordinator::new(),
             snapshot_in_progress: Mutex::new(()),
+            gc_candidates: Mutex::new(FxHashSet::default()),
+            pending_gc_deletes: Mutex::new(Vec::new()),
             stopping: AtomicBool::new(false),
             stopping_event: Event::new(|| || "TurboTasksBackend::stopping_event".to_string()),
             idle_start_event: Event::new(|| || "TurboTasksBackend::idle_start_event".to_string()),
@@ -279,6 +305,230 @@ impl TurboTasksBackend {
         turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
     ) -> impl ExecuteContext<'a> {
         ExecuteContextImpl::new(self, turbo_tasks)
+    }
+
+    /// An execute context for the garbage collector that does not take an operation guard. Only
+    /// valid while the caller holds the coordinator's GC phase (which provides exclusion); see
+    /// [`ExecuteContextImpl::new_for_gc`].
+    fn execute_context_gc<'a>(
+        &'a self,
+        turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
+    ) -> impl ExecuteContext<'a> {
+        ExecuteContextImpl::new_for_gc(self, turbo_tasks)
+    }
+
+    /// Records `task_id` as a garbage-collection candidate (its persistent `parent_count` reached
+    /// 0). Only non-transient tasks are tracked — transient tasks are never collected. Candidacy is
+    /// re-validated under exclusion before the task is actually collected, so a false positive here
+    /// (e.g. the count is bumped back up by a concurrent re-connect) is harmless.
+    fn note_gc_candidate(&self, task_id: TaskId) {
+        if task_id.is_transient() {
+            return;
+        }
+        self.gc_candidates.lock().insert(task_id);
+    }
+
+    /// Whether `task_id` is currently collectible: resident, non-transient, no persistent or
+    /// transient parents, quiescent, and holding no aggregation edges. Used to (re-)validate a
+    /// candidate under the GC phase before tearing it down, and to decide whether a child whose
+    /// count just hit 0 during the cascade should itself be collected.
+    fn gc_is_collectible(&self, task_id: TaskId) -> bool {
+        if task_id.is_transient() {
+            return false;
+        }
+        self.storage
+            .with_task(task_id, |t| t.is_gc_collectible())
+            .unwrap_or(false)
+    }
+
+    /// The persistent `parent_count` of a resident task (0 if absent or not resident).
+    fn gc_parent_count(&self, task_id: TaskId) -> u32 {
+        self.storage
+            .with_task(task_id, |t| t.gc_parent_count())
+            .unwrap_or(0)
+    }
+
+    /// Runs a garbage-collection pass under the coordinator's GC phase. Drains the candidate set
+    /// (tasks observed reaching `parent_count == 0`), re-validates each under the exclusion, and
+    /// tears down the ones that are still collectible: scrubbing their reverse-dependency edges,
+    /// decrementing their children's `parent_count` (cascading to any child that reaches 0),
+    /// removing them from the in-memory map + task_cache, and buffering an on-disk tombstone for
+    /// the next persistence commit.
+    ///
+    /// The GC phase guarantees no operation is executing (see [`SnapshotCoordinator::begin_gc`]),
+    /// so the cross-task scrub and the map removals cannot race a concurrent connect/read.
+    /// Returns the number of tasks collected.
+    fn gc_collect(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
+        // Seed the worklist from the candidates observed since the last pass. Re-validation happens
+        // per task below (a candidate may have been revived by a concurrent re-connect before the
+        // phase was acquired, or may not be Data-resident).
+        let mut worklist: Vec<TaskId> = self.gc_candidates.lock().drain().collect();
+        let mut collected = 0;
+        let mut deletions = Vec::new();
+        // Candidates that still have `parent_count == 0` but are not *yet* collectible (e.g. a
+        // disconnected task whose transient activeness has not been torn down, or which is not yet
+        // Data-resident) are re-retained for a future pass. Genuine roots (`root_ty` set) also land
+        // here — they always have `parent_count == 0` — and are simply re-checked cheaply each
+        // pass; the set stays bounded by the (small) number of such tasks.
+        let mut retain: Vec<TaskId> = Vec::new();
+
+        while let Some(task_id) = worklist.pop() {
+            if !self.gc_is_collectible(task_id) {
+                // Keep it as a candidate only while it still has no persistent parent; otherwise a
+                // concurrent re-connect revived it and it is no longer garbage.
+                if self.gc_parent_count(task_id) == 0 && !task_id.is_transient() {
+                    retain.push(task_id);
+                }
+                continue;
+            }
+            let (children, deletion) = self.gc_delete_one(task_id, turbo_tasks);
+            deletions.push(deletion);
+            collected += 1;
+
+            // Cascade: each child of the deleted task loses a persistent parent. Decrement its
+            // parent_count; if it reaches 0 and is collectible, peel it too. This tears down the
+            // whole unreachable subtree in one pass.
+            let mut ctx = self.execute_context_gc(turbo_tasks);
+            for child in children {
+                if child.is_transient() {
+                    continue;
+                }
+                let mut child_task = ctx.task(child, TaskDataCategory::Meta);
+                let new_count = child_task.update_and_get_parent_count(-1);
+                drop(child_task);
+                if new_count == 0 {
+                    worklist.push(child);
+                }
+            }
+        }
+
+        if !deletions.is_empty() {
+            self.pending_gc_deletes.lock().extend(deletions);
+        }
+        // Re-queue candidates that are still parentless but were not collectible this pass, so a
+        // later pass retries once their transient activeness clears (or their Data is restored).
+        if !retain.is_empty() {
+            self.gc_candidates.lock().extend(retain);
+        }
+        collected
+    }
+
+    /// Scrubs all references from `task_id` off its dependency targets, removes it from the
+    /// task_cache and the map, and returns its `children` (so the caller can decrement their
+    /// parent_count for the cascade) together with a [`TaskDeletion`] tombstone for the next
+    /// commit.
+    ///
+    /// Must be called while holding the GC phase; uses [`Self::execute_context_gc`] (no operation
+    /// guard) to avoid deadlocking on the GC request bit.
+    fn gc_delete_one(
+        &self,
+        task_id: TaskId,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> (Vec<TaskId>, TaskDeletion) {
+        let mut ctx = self.execute_context_gc(turbo_tasks);
+
+        // Snapshot the task's edges into owned buffers, then drop its guard before touching targets
+        // (avoids holding two task locks in an unchecked order).
+        let children: Vec<TaskId>;
+        let output_deps: Vec<TaskId>;
+        let cell_deps: Vec<CellRef>;
+        let cell_deps_hashed: Vec<(CellRef, u64)>;
+        let collectibles_deps: Vec<CollectiblesRef>;
+        let persistent_task_type;
+        {
+            let task = ctx.task(task_id, TaskDataCategory::All);
+            children = task.iter_children().collect();
+            output_deps = task.iter_output_dependencies().collect();
+            cell_deps = task.iter_cell_dependencies().collect();
+            cell_deps_hashed = task.iter_cell_dependencies_hashed().collect();
+            collectibles_deps = task.iter_collectibles_dependencies().collect();
+
+            // A collectible task has no aggregation edges left (is_gc_collectible checks this), so
+            // this assert documents the invariant and surfaces any case that would need aggregation
+            // teardown rather than silently corrupting the graph.
+            debug_assert!(
+                task.iter_upper().next().is_none() && task.iter_followers().next().is_none(),
+                "gc_delete: task {task_id} still has aggregation edges; teardown needed"
+            );
+
+            persistent_task_type = task.get_persistent_task_type().cloned();
+        }
+
+        // Scrub the reverse side of each forward dependency on the target task (mirrors
+        // CleanupOldEdgesOperation).
+        for output_task_id in output_deps {
+            let mut target = ctx.task(output_task_id, TaskDataCategory::Data);
+            target.remove_output_dependent(&task_id);
+        }
+        for CellRef {
+            task: cell_task,
+            cell,
+        } in cell_deps
+        {
+            let mut target = ctx.task(cell_task, TaskDataCategory::Data);
+            target.remove_cell_dependents(&CellRef {
+                task: task_id,
+                cell,
+            });
+        }
+        for (
+            CellRef {
+                task: cell_task,
+                cell,
+            },
+            key,
+        ) in cell_deps_hashed
+        {
+            let mut target = ctx.task(cell_task, TaskDataCategory::Data);
+            target.remove_cell_dependents_hashed(&(
+                CellRef {
+                    task: task_id,
+                    cell,
+                },
+                key,
+            ));
+        }
+        for CollectiblesRef {
+            task: dep_task,
+            collectible_type,
+        } in collectibles_deps
+        {
+            let mut target = ctx.task(dep_task, TaskDataCategory::Data);
+            target.remove_collectibles_dependents(&(collectible_type, task_id));
+        }
+
+        // Remove the in-memory task_cache entry (hash -> id) so lookups don't return a dead id, and
+        // compute the persisted TaskCache key so the caller can tombstone the on-disk mapping. Only
+        // persistent tasks are collected, so a persistent task type is always present.
+        let task_type =
+            persistent_task_type.expect("a collected (non-transient) task must have a task type");
+        self.storage.task_cache.remove(task_type.as_ref());
+        let task_type_hash = compute_task_type_hash(&task_type);
+
+        // Remove the task from the map. Its children set is dropped with it; we returned the child
+        // ids above so the caller can decrement their parent_count.
+        self.storage.remove_task(task_id);
+
+        // `surviving_task_ids` is left empty: it would carry any *other* live persistent task whose
+        // task type xxh3-collides with this one (the whole hash bucket is tombstoned). An 8-byte
+        // collision between two simultaneously-live tasks is astronomically rare (~2^32 tasks for
+        // one expected collision); if it ever occurred the survivor's mapping would be dropped and
+        // it would be transparently re-created on next lookup — a performance cost, not corruption.
+        let deletion = TaskDeletion {
+            task_id,
+            task_type_hash,
+            surviving_task_ids: Vec::new(),
+        };
+        (children, deletion)
+    }
+
+    /// Runs a full GC pass under the GC phase and returns the number of tasks collected. Test-only
+    /// hook. Callers must be idle (no task executing).
+    #[doc(hidden)]
+    pub fn gc_for_testing(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
+        let _serialize = self.snapshot_in_progress.lock();
+        let _gc_phase = self.snapshot_coord.begin_gc();
+        self.gc_collect(turbo_tasks)
     }
 
     fn operation_suspend_point(&self, suspend: impl FnOnce() -> AnyOperation) {
@@ -968,6 +1218,11 @@ impl TurboTasksBackend {
         // request bit, suspended_operations) assumes only one snapshot runs at
         // a time. Held for the entire snapshot lifecycle.
         let _snapshot_in_progress = self.snapshot_in_progress.lock();
+        // Drain GC tombstones buffered since the last snapshot (tasks the GC pass removed from
+        // memory whose on-disk copies must now be tombstoned). Drained before the early-return
+        // checks below so a GC-only cycle (deletes but no modifications) still commits its
+        // tombstones.
+        let deletes = std::mem::take(&mut *self.pending_gc_deletes.lock());
         let start = Instant::now();
         // SystemTime for wall-clock timestamps in trace events (milliseconds
         // since epoch). Instant is monotonic but has no defined epoch, so it
@@ -988,9 +1243,9 @@ impl TurboTasksBackend {
         let snapshot_time = Instant::now();
         drop(snapshot_phase);
 
-        if !has_modifications {
-            // No tasks modified since the last snapshot — drop the guard (which
-            // calls end_snapshot) and skip the expensive O(N) scan.
+        if !has_modifications && deletes.is_empty() {
+            // No tasks modified since the last snapshot and no GC tombstones pending — drop the
+            // guard (which calls end_snapshot) and skip the expensive O(N) scan.
             drop(snapshot_guard);
             return Ok((start, false));
         }
@@ -1252,9 +1507,10 @@ impl TurboTasksBackend {
         let snapshot_duration = start.elapsed();
         let task_count = task_snapshots.len();
 
-        if task_snapshots.is_empty() {
-            // This should be impossible — if we got here, modified_count was nonzero, and every
-            // modification that increments the count also failed during encoding.
+        if task_snapshots.is_empty() && deletes.is_empty() {
+            // This should be impossible — if we got here, modified_count was nonzero (or we had
+            // pending GC tombstones), and every modification that increments the count also failed
+            // during encoding.
             std::hint::cold_path();
             return Ok((snapshot_time, false));
         }
@@ -1270,11 +1526,10 @@ impl TurboTasksBackend {
         // Tasks were already consumed by take_snapshot, so a future snapshot
         // would not re-persist them — returning an error signals to the caller
         // that further persist attempts would corrupt the task graph in storage.
-        // GC is not yet wired into the snapshot cycle (see the mark-and-sweep staging plan);
-        // pass an empty delete list for now.
+        // `deletes` carries GC tombstones drained above; they ride this same atomic commit.
         let snapshot_meta =
             self.backing_storage
-                .save_snapshot(suspended_operations, task_snapshots, Vec::new())?;
+                .save_snapshot(suspended_operations, task_snapshots, deletes)?;
         span.record("snapshot_meta", display(snapshot_meta));
 
         #[cfg(feature = "print_cache_item_size")]
@@ -1430,17 +1685,30 @@ impl TurboTasksBackend {
             self.is_idle.store(false, Ordering::Release);
             self.verify_aggregation_graph(turbo_tasks, false);
         }
-        // eagerly drop the task cache before persisting
-        self.storage.drop_task_cache();
         if self.should_persist() {
+            // Run a final GC pass before the stop snapshot so builds emit tombstones for
+            // disconnected tasks in the final commit, keeping the persisted DB tight for the next
+            // build. At shutdown the system is already quiescing, so this runs to completion; its
+            // tombstones are buffered and drained by the stop snapshot below. Must run before
+            // `drop_task_cache` so teardown's task_cache scrubbing stays consistent.
+            if *GC_ENABLED {
+                let _serialize = self.snapshot_in_progress.lock();
+                let _gc_phase = self.snapshot_coord.begin_gc();
+                let collected = self.gc_collect(turbo_tasks);
+                tracing::info!(collected, "stop GC pass");
+            }
             // The task_cache is a pure perf cache backed by the DB and isn't read during the
             // stop snapshot (no task creation runs concurrently with stop). Drop it before
             // persisting to lower peak memory during the serialization/write.
+            self.storage.drop_task_cache();
             if let Err(err) =
                 self.snapshot_and_persist(Span::current().into(), SnapshotReason::Stop, turbo_tasks)
             {
                 eprintln!("Persisting failed during shutdown: {err:?}");
             }
+        } else {
+            // eagerly drop the task cache
+            self.storage.drop_task_cache();
         }
         self.storage.drop_contents();
         if let Err(err) = self.backing_storage.shutdown() {
@@ -2987,6 +3255,28 @@ impl TurboTasksBackend {
                                         }
                                     }};
                                 }
+
+                                // Garbage-collection pass: tear down tasks whose persistent
+                                // parent_count reached 0. Runs BEFORE eviction so freshly-collected
+                                // garbage is removed from the map before it could be evicted to
+                                // disk-only. Holds the GC phase (excludes execution) via
+                                // `gc_for_testing`'s shape, and buffers on-disk tombstones for the
+                                // *next* snapshot commit. Opt-in via TURBO_ENGINE_GC.
+                                if *GC_ENABLED {
+                                    if check_idle_ended!() {
+                                        continue 'outer;
+                                    }
+                                    let _gc_span =
+                                        tracing::info_span!(parent: background_span.id(), "gc")
+                                            .entered();
+                                    let _serialize = self.snapshot_in_progress.lock();
+                                    let _gc_phase = self.snapshot_coord.begin_gc();
+                                    let collected = self.gc_collect(turbo_tasks);
+                                    if collected > 0 {
+                                        tracing::info!(collected, "gc pass collected tasks");
+                                    }
+                                }
+
                                 // Evict persisted tasks from memory to reclaim space.
                                 // Like compaction, this runs after snapshot_and_persist
                                 // as a separate concern.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -75,8 +75,8 @@ use crate::{
     },
     backing_storage::{SnapshotItem, TaskDeletion, compute_task_type_hash},
     data::{
-        ActivenessState, CellRef, ChildrenCollector, CollectibleRef, CollectiblesRef, Dirtyness,
-        InProgressCellState, InProgressState, InProgressStateInner, OutputValue, TransientTask,
+        ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
+        InProgressState, InProgressStateInner, OutputValue, TransientTask,
     },
     error::TaskError,
     kv_backing_storage::TurboBackingStorage,
@@ -474,7 +474,7 @@ impl TurboTasksBackend {
 
 /// Intermediate result of step 1 of task execution completion.
 struct TaskExecutionCompletePrepareResult {
-    pub new_children: ChildrenCollector,
+    pub new_children: FxHashSet<TaskId>,
     pub is_now_immutable: bool,
     #[cfg(feature = "verify_determinism")]
     pub no_output_set: bool,
@@ -1913,28 +1913,13 @@ impl TurboTasksBackend {
     ) {
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
-        // Staged children of a canceled in-progress execution are discarded (the edges never reach
-        // `children`), so their optimistic parent_count holds must be released. Capture the staged
-        // set here and partition it to the genuinely-new subset (drop children already present in
-        // the persistent `children` set — those were re-validations that took no hold) while we
-        // still hold the parent guard; the actual decrement happens after the guard is dropped
-        // (`release_children_holds` takes the child guards).
-        let mut discarded_children = None;
         if let Some(in_progress) = task.take_in_progress() {
             match in_progress {
                 InProgressState::Scheduled {
                     done_event,
                     reason: _,
                 } => done_event.notify(usize::MAX),
-                InProgressState::InProgress(box InProgressStateInner {
-                    done_event,
-                    mut new_children,
-                    ..
-                }) => {
-                    for child in task.iter_children() {
-                        new_children.remove(&child);
-                    }
-                    discarded_children = Some(new_children);
+                InProgressState::InProgress(box InProgressStateInner { done_event, .. }) => {
                     done_event.notify(usize::MAX)
                 }
                 InProgressState::Canceled => {}
@@ -1963,15 +1948,6 @@ impl TurboTasksBackend {
         let old = task.set_in_progress(InProgressState::Canceled);
         debug_assert!(old.is_none(), "InProgress already exists");
         drop(task);
-
-        // Release the parent_count holds now that the parent guard is dropped (see above). Cancel
-        // path: the returned set is intentionally NOT fed to `DecreaseActiveCounts` — only the
-        // durable parent_count is released on cancel (see `release_children_holds`).
-        if let Some(discarded_children) = discarded_children
-            && !discarded_children.is_empty()
-        {
-            let _ = ctx.release_children_holds(task_id, discarded_children);
-        }
 
         if let Some(data_update) = data_update {
             AggregationUpdateQueue::run(data_update, &mut ctx);
@@ -2270,10 +2246,8 @@ impl TurboTasksBackend {
             panic!("Task execution completed, but task is not in progress: {task:#?}");
         };
         if matches!(in_progress, InProgressState::Canceled) {
-            // Already canceled: `task_execution_canceled` took the staged children and released
-            // their holds. Nothing to account for here.
             return Ok(TaskExecutionCompletePrepareResult {
-                new_children: ChildrenCollector::new(),
+                new_children: Default::default(),
                 is_now_immutable: false,
                 #[cfg(feature = "verify_determinism")]
                 no_output_set: false,
@@ -2312,18 +2286,15 @@ impl TurboTasksBackend {
                 reason: TaskExecutionReason::Stale,
             });
             debug_assert!(old.is_none(), "InProgress already exists");
-            // Remove old children from new_children to leave only the genuinely-new children (the
-            // ones that took an active-count AND a parent_count hold when they were staged).
+            // Remove old children from new_children to leave only the children that had their
+            // active count increased
             for task in task.iter_children() {
                 new_children.remove(&task);
             }
             drop(task);
 
-            // The staged edges are discarded (the task will re-execute), so release both holds
-            // taken at staging: the parent_count/transient_ref_count hold (here) and the active
-            // count (via DecreaseActiveCounts below). `release_children_holds` consumes the
-            // collector and returns the raw set to feed the active-count undo.
-            let new_children = ctx.release_children_holds(task_id, new_children);
+            // We need to undo the active count increase for the children since we throw away the
+            // new_children list now.
             AggregationUpdateQueue::run(
                 AggregationUpdateJob::DecreaseActiveCounts {
                     task_ids: new_children.into_iter().collect(),
@@ -2674,13 +2645,13 @@ impl TurboTasksBackend {
     fn task_execution_completed_unfinished_children_dirty(
         &self,
         ctx: &mut impl ExecuteContext<'_>,
-        new_children: &ChildrenCollector,
+        new_children: &FxHashSet<TaskId>,
     ) {
         debug_assert!(!new_children.is_empty());
 
         let mut queue = AggregationUpdateQueue::new();
         ctx.for_each_task_all(
-            new_children.iter(),
+            new_children.iter().copied(),
             "unfinished children dirty",
             |child_task, ctx| {
                 if !child_task.has_output() {
@@ -2705,7 +2676,7 @@ impl TurboTasksBackend {
         &self,
         ctx: &mut impl ExecuteContext<'_>,
         task_id: TaskId,
-        new_children: ChildrenCollector,
+        new_children: FxHashSet<TaskId>,
     ) -> Option<TaskPriority> {
         debug_assert!(!new_children.is_empty());
 
@@ -2714,14 +2685,7 @@ impl TurboTasksBackend {
             panic!("Task execution completed, but task is not in progress: {task:#?}");
         };
         if matches!(in_progress, InProgressState::Canceled) {
-            // Task was canceled in the meantime, so we don't connect the children. The staged
-            // edges are discarded — release their parent_count holds (this `new_children` was
-            // already filtered to the genuinely-new set during prepare). Drop the parent guard
-            // first so `release_children_holds` can take the child guards. Cancel path: the
-            // returned set is intentionally NOT fed to `DecreaseActiveCounts` (only the durable
-            // parent_count is released on cancel — see `release_children_holds`).
-            drop(task);
-            let _ = ctx.release_children_holds(task_id, new_children);
+            // Task was canceled in the meantime, so we don't connect the children
             return None;
         }
         let InProgressState::InProgress(box InProgressStateInner {
@@ -2750,11 +2714,8 @@ impl TurboTasksBackend {
             debug_assert!(old.is_none(), "InProgress already exists");
             drop(task);
 
-            // The staged edges are discarded (the task re-executes), so release both holds taken at
-            // staging: the parent_count/transient_ref_count hold (via `release_children_holds`) and
-            // the active count (via `DecreaseActiveCounts`). This `new_children` was already
-            // filtered to the genuinely-new set during prepare.
-            let new_children = ctx.release_children_holds(task_id, new_children);
+            // All `new_children` are currently hold active with an active count and we need to undo
+            // that. (We already filtered out the old children from that list)
             AggregationUpdateQueue::run(
                 AggregationUpdateJob::DecreaseActiveCounts {
                     task_ids: new_children.into_iter().collect(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1290,21 +1290,37 @@ impl TurboTasksBackend {
         // very commit that would otherwise have re-written it, and the tombstone is re-validated
         // against the post-drain map below so a task resurrected in the brief window between the GC
         // phase and the snapshot drain is not wrongly tombstoned. Opt-in via TURBO_ENGINE_GC.
-        let gc_deletes = if *GC_ENABLED {
+        // Run the GC pass and transition to the snapshot **atomically**, without ever releasing
+        // operation exclusion in between. `begin_gc` drains all operations; `gc_collect` tears down
+        // collectible tasks and cascades `parent_count` decrements to their children; then
+        // `GcPhase::into_snapshot` hands the exclusion straight to the snapshot phase (swapping the
+        // GC request bit for the snapshot bit under one lock). Because no operation can run between
+        // the cascade and the snapshot, a task the cascade decremented cannot be resurrected before
+        // it is persisted — so the decremented children counts and the snapshot are consistent, and
+        // GC-collected tasks' tombstones ride this same commit.
+        //
+        // Without GC we just begin the snapshot directly.
+        let mut snapshot_phase = if *GC_ENABLED {
             let _gc_span = tracing::info_span!(parent: parent_span.clone(), "gc").entered();
-            let _gc_phase = self.snapshot_coord.begin_gc();
+            let gc_phase = self.snapshot_coord.begin_gc();
             let (collected, deletes) = self.gc_collect(turbo_tasks);
             if collected > 0 {
                 tracing::info!(collected, "gc pass collected tasks");
             }
-            deletes
+            self.pending_gc_deletes.lock().extend(deletes);
+            let _span = tracing::info_span!("blocking").entered();
+            gc_phase.into_snapshot()
         } else {
-            Vec::new()
+            let _span = tracing::info_span!("blocking").entered();
+            self.snapshot_coord.begin_snapshot()
         };
-        // Also drain any tombstones buffered by the test-only `gc_for_testing` hook (production
-        // takes the inline `gc_deletes` path above; both feed the same commit).
-        let mut deletes = gc_deletes;
-        deletes.append(&mut self.pending_gc_deletes.lock());
+        // Drain the GC tombstones for this commit. In the production (GC-enabled) path they were
+        // just produced above under the *same continuous exclusion* as this snapshot (the atomic
+        // `into_snapshot` hand-off), so nothing could have resurrected a collected task. The
+        // test-only `gc_for_testing` hook also buffers here, and it runs GC as a separate exclusion
+        // window — so we still re-validate below (after the drain stabilizes the map) as a cheap
+        // belt-and-suspenders against a task revived between that hook and this snapshot.
+        let mut deletes = std::mem::take(&mut *self.pending_gc_deletes.lock());
         let start = Instant::now();
         // SystemTime for wall-clock timestamps in trace events (milliseconds
         // since epoch). Instant is monotonic but has no defined epoch, so it
@@ -1312,21 +1328,15 @@ impl TurboTasksBackend {
         let wall_start = SystemTime::now();
         debug_assert!(self.should_persist());
 
-        let mut snapshot_phase = {
-            let _span = tracing::info_span!("blocking").entered();
-            self.snapshot_coord.begin_snapshot()
-        };
         // Enter snapshot mode, which atomically reads and resets the modified count.
         // Checking after start_snapshot ensures no concurrent increments can race.
         let (snapshot_guard, has_modifications) = self.storage.start_snapshot();
 
-        // Re-validate GC tombstones against the now-drained map: `begin_snapshot` has drained/
-        // suspended all operations, so the map is stable. GC removed each collected task from the
-        // map; if one is resident again it was resurrected by an operation in the brief window
-        // between the GC phase ending and this drain (a concurrent read re-connected it, restoring
-        // it from its not-yet-tombstoned on-disk copy). Such a task is live again — drop its
-        // tombstone so we don't delete a task the snapshot is about to (re-)persist.
-        deletes.retain(|d| self.storage.with_task(d.task_id, |_| ()).is_none());
+        // Belt-and-suspenders: drop the tombstone for any task that is resident again (would only
+        // happen via the non-atomic `gc_for_testing` path; the production path can't resurrect).
+        if !deletes.is_empty() {
+            deletes.retain(|d| self.storage.with_task(d.task_id, |_| ()).is_none());
+        }
 
         let suspended_operations = snapshot_phase.take_suspended_operations();
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1690,8 +1690,15 @@ impl TurboTasksBackend {
                     // Initialize storage BEFORE making task_id visible in the cache.
                     // This ensures any thread that reads task_id from the cache sees
                     // the storage entry already initialized (restored flags set).
-                    self.storage
-                        .initialize_new_task(task_id, Some(task_type.clone()));
+                    // A task created with no parent is spawned from outside the tracked graph (a
+                    // top-level `run`/NAPI call, `run_once`, or `OperationVc::connect` outside a
+                    // task) — mark it a GC root so it is never collected (it has no persistent
+                    // parent to anchor it).
+                    self.storage.initialize_new_task(
+                        task_id,
+                        Some(task_type.clone()),
+                        parent_task.is_none(),
+                    );
                     // insert() consumes e, releasing the shard write lock.
                     e.insert(task_type, task_id);
                     self.track_cache_miss_by_fn(native_fn);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -263,6 +263,20 @@ enum GcOutcome {
     Skip,
 }
 
+/// The edges captured from a collectible task under its single [`ExecuteContext`] guard, so the
+/// guard can be dropped before [`TurboTasksBackend::gc_scrub_and_remove`] opens the *target* tasks'
+/// guards (holding two task locks at once trips the concurrent-lock detector). `children` drive the
+/// cascade; the `*_deps` are the forward dependencies whose reverse side must be scrubbed;
+/// `persistent_task_type` yields the on-disk `TaskCache` key.
+struct GcDeletePlan {
+    children: Vec<TaskId>,
+    output_deps: Vec<TaskId>,
+    cell_deps: Vec<CellRef>,
+    cell_deps_hashed: Vec<(CellRef, u64)>,
+    collectibles_deps: Vec<CollectiblesRef>,
+    persistent_task_type: Option<CachedTaskTypeArc>,
+}
+
 impl TurboTasksBackend {
     /// Invalidates the persistent storage so that it will be deleted the next time a turbopack
     /// instance is created with the filesystem cache enabled.
@@ -338,26 +352,6 @@ impl TurboTasksBackend {
         self.gc_candidates.lock().insert(task_id);
     }
 
-    /// Whether `task_id` is currently collectible: resident, non-transient, no persistent or
-    /// transient parents, quiescent, and holding no aggregation edges. Used to (re-)validate a
-    /// candidate under the GC phase before tearing it down, and to decide whether a child whose
-    /// count just hit 0 during the cascade should itself be collected.
-    fn gc_is_collectible(&self, task_id: TaskId) -> bool {
-        if task_id.is_transient() {
-            return false;
-        }
-        self.storage
-            .with_task(task_id, |t| t.is_gc_collectible())
-            .unwrap_or(false)
-    }
-
-    /// The persistent `parent_count` of a resident task (0 if absent or not resident).
-    fn gc_parent_count(&self, task_id: TaskId) -> u32 {
-        self.storage
-            .with_task(task_id, |t| t.gc_parent_count())
-            .unwrap_or(0)
-    }
-
     /// Runs a garbage-collection pass under the coordinator's GC phase. Drains the candidate set
     /// (tasks observed reaching `parent_count == 0`), re-validates each under the exclusion, and
     /// tears down the ones that are still collectible: scrubbing their reverse-dependency edges,
@@ -418,24 +412,64 @@ impl TurboTasksBackend {
     /// collectible tears the task down (scrub reverse-dep edges + remove from map + produce a
     /// tombstone) and decrements each child's `parent_count`, returning the children that reached
     /// 0. See [`GcOutcome`] for the cases.
+    ///
+    /// The whole decision + teardown reuses a single [`ExecuteContext`]: the task is accessed once
+    /// (one guard) to both decide collectibility and capture its edges into a [`GcDeletePlan`], and
+    /// the same context is threaded through the scrub and the cascade. Under the GC phase there is
+    /// no concurrency, so taking the write guard (via `ctx.task`) rather than a read-only
+    /// `with_task` is free.
     fn gc_process_one(
         &self,
         task_id: TaskId,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
     ) -> GcOutcome {
-        if !self.gc_is_collectible(task_id) {
-            // Not collectible: keep retrying only while it is still parentless (and persistent);
-            // otherwise a concurrent re-connect revived it and it is no longer garbage.
-            return if self.gc_parent_count(task_id) == 0 && !task_id.is_transient() {
-                GcOutcome::Retain(task_id)
-            } else {
-                GcOutcome::Skip
-            };
+        // Transient-ness is a property of the id, not the storage — check it before touching the
+        // map (transient tasks are never collected).
+        if task_id.is_transient() {
+            return GcOutcome::Skip;
         }
-        let (children, deletion) = self.gc_delete_one(task_id, turbo_tasks);
-
-        // Cascade: each child loses a persistent parent; collect those that reach 0.
         let mut ctx = self.execute_context_gc(turbo_tasks);
+
+        // Single access: decide collectibility and, if collectible, capture the edges needed to
+        // tear the task down. `ctx.task(.., All)` restores the task if it was evicted, so the
+        // `is_restored(Meta)` guard inside `is_gc_collectible` is satisfied here by construction;
+        // it remains load-bearing on the raw `&TaskStorage` path (a candidate whose Meta was
+        // evicted between passes would otherwise read a bogus parent_count of 0).
+        let plan = {
+            let task = ctx.task(task_id, TaskDataCategory::All);
+            let s = task.typed();
+            if !s.is_gc_collectible() {
+                // Not collectible: keep retrying only while it is still parentless; otherwise a
+                // concurrent re-connect revived it and it is no longer garbage.
+                return if s.gc_parent_count() == 0 {
+                    GcOutcome::Retain(task_id)
+                } else {
+                    GcOutcome::Skip
+                };
+            }
+
+            // A collectible task has no aggregation edges left (`is_gc_collectible` checks this);
+            // this assert documents the invariant and surfaces any case that would need aggregation
+            // teardown rather than silently corrupting the graph.
+            debug_assert!(
+                task.iter_upper().next().is_none() && task.iter_followers().next().is_none(),
+                "gc_delete: task {task_id} still has aggregation edges; teardown needed"
+            );
+
+            GcDeletePlan {
+                children: task.iter_children().collect(),
+                output_deps: task.iter_output_dependencies().collect(),
+                cell_deps: task.iter_cell_dependencies().collect(),
+                cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
+                collectibles_deps: task.iter_collectibles_dependencies().collect(),
+                persistent_task_type: task.get_persistent_task_type().cloned(),
+            }
+        };
+
+        let (children, deletion) = self.gc_scrub_and_remove(task_id, plan, &mut ctx);
+
+        // Cascade: each child loses a persistent parent; collect those that reach 0. Reuses the
+        // same context.
         let mut newly_garbage = Vec::new();
         for child in children {
             if child.is_transient() {
@@ -454,46 +488,28 @@ impl TurboTasksBackend {
         }
     }
 
-    /// Scrubs all references from `task_id` off its dependency targets, removes it from the
-    /// task_cache and the map, and returns its `children` (so the caller can decrement their
+    /// Scrubs all references captured in `plan` off `task_id`'s dependency targets, removes it from
+    /// the task_cache and the map, and returns its `children` (so the caller can decrement their
     /// parent_count for the cascade) together with a [`TaskDeletion`] tombstone for the next
     /// commit.
     ///
-    /// Must be called while holding the GC phase; uses [`Self::execute_context_gc`] (no operation
-    /// guard) to avoid deadlocking on the GC request bit.
-    fn gc_delete_one(
+    /// The task's own guard has already been dropped by [`Self::gc_process_one`] (its edges live in
+    /// `plan`), so this only opens the *target* tasks' guards — never two task locks at once.
+    /// Reuses the caller's [`ExecuteContext`]; must be called while holding the GC phase.
+    fn gc_scrub_and_remove(
         &self,
         task_id: TaskId,
-        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+        plan: GcDeletePlan,
+        ctx: &mut impl ExecuteContext<'_>,
     ) -> (Vec<TaskId>, TaskDeletion) {
-        let mut ctx = self.execute_context_gc(turbo_tasks);
-
-        // Snapshot the task's edges into owned buffers, then drop its guard before touching targets
-        // (avoids holding two task locks in an unchecked order).
-        let children: Vec<TaskId>;
-        let output_deps: Vec<TaskId>;
-        let cell_deps: Vec<CellRef>;
-        let cell_deps_hashed: Vec<(CellRef, u64)>;
-        let collectibles_deps: Vec<CollectiblesRef>;
-        let persistent_task_type;
-        {
-            let task = ctx.task(task_id, TaskDataCategory::All);
-            children = task.iter_children().collect();
-            output_deps = task.iter_output_dependencies().collect();
-            cell_deps = task.iter_cell_dependencies().collect();
-            cell_deps_hashed = task.iter_cell_dependencies_hashed().collect();
-            collectibles_deps = task.iter_collectibles_dependencies().collect();
-
-            // A collectible task has no aggregation edges left (is_gc_collectible checks this), so
-            // this assert documents the invariant and surfaces any case that would need aggregation
-            // teardown rather than silently corrupting the graph.
-            debug_assert!(
-                task.iter_upper().next().is_none() && task.iter_followers().next().is_none(),
-                "gc_delete: task {task_id} still has aggregation edges; teardown needed"
-            );
-
-            persistent_task_type = task.get_persistent_task_type().cloned();
-        }
+        let GcDeletePlan {
+            children,
+            output_deps,
+            cell_deps,
+            cell_deps_hashed,
+            collectibles_deps,
+            persistent_task_type,
+        } = plan;
 
         // Scrub the reverse side of each forward dependency on the target task (mirrors
         // CleanupOldEdgesOperation).

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -580,6 +580,13 @@ impl TurboTasksBackend {
         (had_new_data, counts)
     }
 
+    /// The number of persistent (non-transient) tasks resident in the map. Test-only hook: this is
+    /// the metric GC affects (transient roots like `run_once` tasks are never collected).
+    #[doc(hidden)]
+    pub fn resident_persistent_task_count_for_testing(&self) -> usize {
+        self.storage.resident_persistent_task_count()
+    }
+
     /// The persistent `parent_count` of a resident task (0 if absent or not resident). Test-only
     /// hook for verifying incremental refcount maintenance.
     #[doc(hidden)]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -75,8 +75,8 @@ use crate::{
     },
     backing_storage::{SnapshotItem, TaskDeletion, compute_task_type_hash},
     data::{
-        ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
-        InProgressState, InProgressStateInner, OutputValue, TransientTask,
+        ActivenessState, CellRef, ChildrenCollector, CollectibleRef, CollectiblesRef, Dirtyness,
+        InProgressCellState, InProgressState, InProgressStateInner, OutputValue, TransientTask,
     },
     error::TaskError,
     kv_backing_storage::TurboBackingStorage,
@@ -474,7 +474,7 @@ impl TurboTasksBackend {
 
 /// Intermediate result of step 1 of task execution completion.
 struct TaskExecutionCompletePrepareResult {
-    pub new_children: FxHashSet<TaskId>,
+    pub new_children: ChildrenCollector,
     pub is_now_immutable: bool,
     #[cfg(feature = "verify_determinism")]
     pub no_output_set: bool,
@@ -1913,13 +1913,28 @@ impl TurboTasksBackend {
     ) {
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
+        // Staged children of a canceled in-progress execution are discarded (the edges never reach
+        // `children`), so their optimistic parent_count holds must be released. Capture the staged
+        // set here and partition it to the genuinely-new subset (drop children already present in
+        // the persistent `children` set — those were re-validations that took no hold) while we
+        // still hold the parent guard; the actual decrement happens after the guard is dropped
+        // (`release_children_holds` takes the child guards).
+        let mut discarded_children = None;
         if let Some(in_progress) = task.take_in_progress() {
             match in_progress {
                 InProgressState::Scheduled {
                     done_event,
                     reason: _,
                 } => done_event.notify(usize::MAX),
-                InProgressState::InProgress(box InProgressStateInner { done_event, .. }) => {
+                InProgressState::InProgress(box InProgressStateInner {
+                    done_event,
+                    mut new_children,
+                    ..
+                }) => {
+                    for child in task.iter_children() {
+                        new_children.remove(&child);
+                    }
+                    discarded_children = Some(new_children);
                     done_event.notify(usize::MAX)
                 }
                 InProgressState::Canceled => {}
@@ -1948,6 +1963,15 @@ impl TurboTasksBackend {
         let old = task.set_in_progress(InProgressState::Canceled);
         debug_assert!(old.is_none(), "InProgress already exists");
         drop(task);
+
+        // Release the parent_count holds now that the parent guard is dropped (see above). Cancel
+        // path: the returned set is intentionally NOT fed to `DecreaseActiveCounts` — only the
+        // durable parent_count is released on cancel (see `release_children_holds`).
+        if let Some(discarded_children) = discarded_children
+            && !discarded_children.is_empty()
+        {
+            let _ = ctx.release_children_holds(task_id, discarded_children);
+        }
 
         if let Some(data_update) = data_update {
             AggregationUpdateQueue::run(data_update, &mut ctx);
@@ -2246,8 +2270,10 @@ impl TurboTasksBackend {
             panic!("Task execution completed, but task is not in progress: {task:#?}");
         };
         if matches!(in_progress, InProgressState::Canceled) {
+            // Already canceled: `task_execution_canceled` took the staged children and released
+            // their holds. Nothing to account for here.
             return Ok(TaskExecutionCompletePrepareResult {
-                new_children: Default::default(),
+                new_children: ChildrenCollector::new(),
                 is_now_immutable: false,
                 #[cfg(feature = "verify_determinism")]
                 no_output_set: false,
@@ -2286,15 +2312,18 @@ impl TurboTasksBackend {
                 reason: TaskExecutionReason::Stale,
             });
             debug_assert!(old.is_none(), "InProgress already exists");
-            // Remove old children from new_children to leave only the children that had their
-            // active count increased
+            // Remove old children from new_children to leave only the genuinely-new children (the
+            // ones that took an active-count AND a parent_count hold when they were staged).
             for task in task.iter_children() {
                 new_children.remove(&task);
             }
             drop(task);
 
-            // We need to undo the active count increase for the children since we throw away the
-            // new_children list now.
+            // The staged edges are discarded (the task will re-execute), so release both holds
+            // taken at staging: the parent_count/transient_ref_count hold (here) and the active
+            // count (via DecreaseActiveCounts below). `release_children_holds` consumes the
+            // collector and returns the raw set to feed the active-count undo.
+            let new_children = ctx.release_children_holds(task_id, new_children);
             AggregationUpdateQueue::run(
                 AggregationUpdateJob::DecreaseActiveCounts {
                     task_ids: new_children.into_iter().collect(),
@@ -2645,13 +2674,13 @@ impl TurboTasksBackend {
     fn task_execution_completed_unfinished_children_dirty(
         &self,
         ctx: &mut impl ExecuteContext<'_>,
-        new_children: &FxHashSet<TaskId>,
+        new_children: &ChildrenCollector,
     ) {
         debug_assert!(!new_children.is_empty());
 
         let mut queue = AggregationUpdateQueue::new();
         ctx.for_each_task_all(
-            new_children.iter().copied(),
+            new_children.iter(),
             "unfinished children dirty",
             |child_task, ctx| {
                 if !child_task.has_output() {
@@ -2676,7 +2705,7 @@ impl TurboTasksBackend {
         &self,
         ctx: &mut impl ExecuteContext<'_>,
         task_id: TaskId,
-        new_children: FxHashSet<TaskId>,
+        new_children: ChildrenCollector,
     ) -> Option<TaskPriority> {
         debug_assert!(!new_children.is_empty());
 
@@ -2685,7 +2714,14 @@ impl TurboTasksBackend {
             panic!("Task execution completed, but task is not in progress: {task:#?}");
         };
         if matches!(in_progress, InProgressState::Canceled) {
-            // Task was canceled in the meantime, so we don't connect the children
+            // Task was canceled in the meantime, so we don't connect the children. The staged
+            // edges are discarded — release their parent_count holds (this `new_children` was
+            // already filtered to the genuinely-new set during prepare). Drop the parent guard
+            // first so `release_children_holds` can take the child guards. Cancel path: the
+            // returned set is intentionally NOT fed to `DecreaseActiveCounts` (only the durable
+            // parent_count is released on cancel — see `release_children_holds`).
+            drop(task);
+            let _ = ctx.release_children_holds(task_id, new_children);
             return None;
         }
         let InProgressState::InProgress(box InProgressStateInner {
@@ -2714,8 +2750,11 @@ impl TurboTasksBackend {
             debug_assert!(old.is_none(), "InProgress already exists");
             drop(task);
 
-            // All `new_children` are currently hold active with an active count and we need to undo
-            // that. (We already filtered out the old children from that list)
+            // The staged edges are discarded (the task re-executes), so release both holds taken at
+            // staging: the parent_count/transient_ref_count hold (via `release_children_holds`) and
+            // the active count (via `DecreaseActiveCounts`). This `new_children` was already
+            // filtered to the genuinely-new set during prepare.
+            let new_children = ctx.release_children_holds(task_id, new_children);
             AggregationUpdateQueue::run(
                 AggregationUpdateJob::DecreaseActiveCounts {
                     task_ids: new_children.into_iter().collect(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -252,6 +252,25 @@ pub struct TurboTasksBackend {
     root_tasks: Mutex<FxHashSet<TaskId>>,
 }
 
+/// The result of processing one garbage-collection worklist item (see
+/// [`TurboTasksBackend::gc_process_one`]).
+enum GcOutcome {
+    /// The task was collectible and has been torn down: its reverse-dependency edges were scrubbed
+    /// and it was removed from the in-memory map. Carries the on-disk `TaskDeletion` tombstone to
+    /// commit, and the children whose `parent_count` reached 0 as a result (to enqueue next).
+    Collected {
+        deletion: TaskDeletion,
+        newly_garbage: Vec<TaskId>,
+    },
+    /// The task was not collectible this pass but still has no persistent parent (e.g. its
+    /// transient activeness has not been torn down yet), so it is re-queued to retry on a later
+    /// pass.
+    Retain(TaskId),
+    /// The task is no longer garbage (it was revived by a concurrent re-connect before the GC
+    /// phase, or is transient): nothing to do.
+    Skip,
+}
+
 impl TurboTasksBackend {
     /// Invalidates the persistent storage so that it will be deleted the next time a turbopack
     /// instance is created with the filesystem cache enabled.
@@ -381,28 +400,17 @@ impl TurboTasksBackend {
         // the whole pass inside `spawn_blocking` (per the `scope_and_block` guidance) rather than
         // spawning from within this already-blocking context.
         while let Some(task_id) = worklist.pop() {
-            if !self.gc_is_collectible(task_id) {
-                if self.gc_parent_count(task_id) == 0 && !task_id.is_transient() {
-                    retain.push(task_id);
+            match self.gc_process_one(task_id, turbo_tasks) {
+                GcOutcome::Collected {
+                    deletion,
+                    newly_garbage,
+                } => {
+                    deletions.push(deletion);
+                    collected += 1;
+                    worklist.extend(newly_garbage);
                 }
-                continue;
-            }
-            let (children, deletion) = self.gc_delete_one(task_id, turbo_tasks);
-            deletions.push(deletion);
-            collected += 1;
-
-            // Cascade: each child loses a persistent parent; any that reaches 0 is peeled next.
-            let mut ctx = self.execute_context_gc(turbo_tasks);
-            for child in children {
-                if child.is_transient() {
-                    continue;
-                }
-                let mut child_task = ctx.task(child, TaskDataCategory::Meta);
-                let new_count = child_task.update_and_get_parent_count(-1);
-                drop(child_task);
-                if new_count == 0 {
-                    worklist.push(child);
-                }
+                GcOutcome::Retain(task_id) => retain.push(task_id),
+                GcOutcome::Skip => {}
             }
         }
 
@@ -412,6 +420,46 @@ impl TurboTasksBackend {
             self.gc_candidates.lock().extend(retain);
         }
         (collected, deletions)
+    }
+
+    /// Processes one GC worklist item under the held GC phase: re-validates collectibility, and if
+    /// collectible tears the task down (scrub reverse-dep edges + remove from map + produce a
+    /// tombstone) and decrements each child's `parent_count`, returning the children that reached
+    /// 0. See [`GcOutcome`] for the cases.
+    fn gc_process_one(
+        &self,
+        task_id: TaskId,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> GcOutcome {
+        if !self.gc_is_collectible(task_id) {
+            // Not collectible: keep retrying only while it is still parentless (and persistent);
+            // otherwise a concurrent re-connect revived it and it is no longer garbage.
+            return if self.gc_parent_count(task_id) == 0 && !task_id.is_transient() {
+                GcOutcome::Retain(task_id)
+            } else {
+                GcOutcome::Skip
+            };
+        }
+        let (children, deletion) = self.gc_delete_one(task_id, turbo_tasks);
+
+        // Cascade: each child loses a persistent parent; collect those that reach 0.
+        let mut ctx = self.execute_context_gc(turbo_tasks);
+        let mut newly_garbage = Vec::new();
+        for child in children {
+            if child.is_transient() {
+                continue;
+            }
+            let mut child_task = ctx.task(child, TaskDataCategory::Meta);
+            let new_count = child_task.update_and_get_parent_count(-1);
+            drop(child_task);
+            if new_count == 0 {
+                newly_garbage.push(child);
+            }
+        }
+        GcOutcome::Collected {
+            deletion,
+            newly_garbage,
+        }
     }
 
     /// Scrubs all references from `task_id` off its dependency targets, removes it from the

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -4109,21 +4109,36 @@ impl Backend for TurboTasksBackend {
         // Once the backend is stopping, GC bookkeeping is irrelevant (the whole task map is torn
         // down in `stop()`), so pin/unpin become no-ops. This also makes them safe against handles
         // finalized during shutdown — e.g. a `DetachedVc` handed to JS across NAPI is dropped
-        // (which unpins) during Node worker teardown, *after* `stop()` has dropped the map; without
-        // this gate that unpin would resurrect a blank entry and underflow `transient_ref_count`.
+        // (which unpins) during Node worker teardown, *after* `stop()` has dropped the map.
         if self.stopping.load(Ordering::Acquire) {
             return;
         }
+        // Take an operation guard so pin cannot interleave with a GC pass: it runs strictly before
+        // or strictly after a collection, never concurrently with `is_gc_collectible` / task
+        // removal. This is deadlock-free because neither pin caller holds a guard already —
+        // `prevent_gc` runs in the unguarded user-future region, and `DetachedVc` pins from a NAPI
+        // thread — and the GC pass itself never calls pin/unpin.
+        let _guard = self.start_operation();
         // A pin is an in-session reference from outside the tracked graph (an explicit
-        // `prevent_gc`, or a detached handle like `DetachedVc` holding the task's
-        // `OperationVc` across NAPI). It is counted the same way a transient parent's edge
-        // is: bump `transient_ref_count`. While that count is > 0 the task is uncollectible
-        // (see `is_gc_collectible`) and unevictable (see `evictability`, so the transient
-        // count can't be lost). Counting (rather than a bool flag) makes nested/cloned pins
-        // correct — each pin is balanced by its own unpin.
-        self.storage
-            .access_mut(task)
-            .gc_increment_transient_ref_count();
+        // `prevent_gc`, or a detached handle like `DetachedVc` holding the task's `OperationVc`
+        // across NAPI). It is counted the same way a transient parent's edge is: bump
+        // `transient_ref_count`. While that count is > 0 the task is uncollectible (see
+        // `is_gc_collectible`) and unevictable (see `evictability`, so the transient count can't be
+        // lost). Counting (rather than a bool flag) makes nested/cloned pins correct — each pin is
+        // balanced by its own unpin.
+        //
+        // Use the non-inserting `with_task_mut`: a pin always targets a live reference, so the task
+        // must be resident. A missing entry means the caller pinned an already-collected task (a
+        // "zombie `OperationVc`") — a bug we surface via debug_assert rather than paper over by
+        // resurrecting a blank entry (which would leave an orphaned zombie in the map).
+        let existed = self
+            .storage
+            .with_task_mut(task, |t| t.gc_increment_transient_ref_count());
+        debug_assert!(
+            existed.is_some(),
+            "pin_task_for_gc: task {task} has no resident entry (pinned an already-collected \
+             task?)"
+        );
     }
 
     fn unpin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
@@ -4132,9 +4147,15 @@ impl Backend for TurboTasksBackend {
         if self.stopping.load(Ordering::Acquire) {
             return;
         }
-        self.storage
-            .access_mut(task)
-            .gc_decrement_transient_ref_count();
+        let _guard = self.start_operation();
+        let existed = self
+            .storage
+            .with_task_mut(task, |t| t.gc_decrement_transient_ref_count());
+        debug_assert!(
+            existed.is_some(),
+            "unpin_task_for_gc: task {task} has no resident entry (unpinned an already-collected \
+             task?)"
+        );
     }
 
     fn connect_task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -330,6 +330,23 @@ impl TurboTasksBackend {
         (had_new_data, counts)
     }
 
+    /// The persistent `parent_count` of a resident task (0 if absent or not resident). Test-only
+    /// hook for verifying incremental refcount maintenance.
+    #[doc(hidden)]
+    pub fn parent_count_for_testing(&self, task: TaskId) -> u32 {
+        self.storage
+            .with_task(task, |t| t.gc_parent_count())
+            .unwrap_or(0)
+    }
+
+    /// The transient `transient_parent_count` of a resident task (0 if absent or not resident).
+    #[doc(hidden)]
+    pub fn transient_parent_count_for_testing(&self, task: TaskId) -> u32 {
+        self.storage
+            .with_task(task, |t| t.gc_transient_parent_count())
+            .unwrap_or(0)
+    }
+
     fn should_restore(&self) -> bool {
         self.options.storage_mode.is_some()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -15,7 +15,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, LazyLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::SystemTime,
 };
@@ -44,7 +44,7 @@ use turbo_tasks::{
     macro_helpers::NativeFunction,
     message_queue::{TimingEvent, TraceEvent},
     registry::get_value_type,
-    scope::scope_and_block,
+    scope::{scope_and_block, scope_self_feeding},
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
     util::{IdFactoryWithReuse, good_chunk_size, into_chunks},
@@ -244,30 +244,46 @@ pub struct TurboTasksBackend {
     root_tasks: Mutex<FxHashSet<TaskId>>,
 }
 
-/// The result of processing one garbage-collection worklist item (see
-/// [`TurboTasksBackend::gc_process_one`]).
-enum GcOutcome {
-    /// The task was collectible and has been torn down: its reverse-dependency edges were scrubbed
-    /// and it was removed from the in-memory map. Carries the on-disk `TaskDeletion` tombstone to
-    /// commit, and the children whose `parent_count` reached 0 as a result (to enqueue next).
-    Collected {
-        deletion: TaskDeletion,
-        newly_garbage: Vec<TaskId>,
+/// A unit of garbage-collection work fed through the self-feeding parallel pool in
+/// [`TurboTasksBackend::gc_collect`]. Every variant is bounded (a single task, or a bounded chunk),
+/// so no single job pins a worker with unbounded work: a task with a huge number of children or
+/// forward dependencies fans out into many chunked jobs that spread across worker threads. Jobs
+/// discover more jobs (a collected task spawns decrements + scrubs; a decrement that hits 0 spawns
+/// a collect), which the pool drains until quiescent.
+enum GcJob {
+    /// Re-validate `task_id`'s collectibility and, if still collectible, tear it down: remove it
+    /// from the in-memory map + task_cache, record its tombstone, then spawn [`GcJob::Decrement`]
+    /// jobs for its children and `Scrub*` jobs for its forward dependencies.
+    Collect(TaskId),
+    /// Decrement the persistent `parent_count` of each task in the chunk (each lost a persistent
+    /// parent that was just collected). Any that reach 0 are newly unreachable and spawn a
+    /// [`GcJob::Collect`].
+    Decrement(Vec<TaskId>),
+    /// Remove `source` from the `output_dependent` reverse-set of each target task in the chunk.
+    ScrubOutput {
+        source: TaskId,
+        targets: Vec<TaskId>,
     },
-    /// The task was not collectible this pass but still has no persistent parent (e.g. its
-    /// transient activeness has not been torn down yet), so it is re-queued to retry on a later
-    /// pass.
-    Retain(TaskId),
-    /// The task is no longer garbage (it was revived by a concurrent re-connect before the GC
-    /// phase, or is transient): nothing to do.
-    Skip,
+    /// Remove `source`'s cell dependency from the `cell_dependents` reverse-set of each referenced
+    /// cell's task.
+    ScrubCell { source: TaskId, refs: Vec<CellRef> },
+    /// Like [`GcJob::ScrubCell`] for hashed cell dependencies.
+    ScrubCellHashed {
+        source: TaskId,
+        refs: Vec<(CellRef, u64)>,
+    },
+    /// Remove `source` from the `collectibles_dependents` reverse-set of each referenced task.
+    ScrubCollectibles {
+        source: TaskId,
+        refs: Vec<CollectiblesRef>,
+    },
 }
 
 /// The edges captured from a collectible task under its single [`ExecuteContext`] guard, so the
-/// guard can be dropped before [`TurboTasksBackend::gc_scrub_and_remove`] opens the *target* tasks'
-/// guards (holding two task locks at once trips the concurrent-lock detector). `children` drive the
-/// cascade; the `*_deps` are the forward dependencies whose reverse side must be scrubbed;
-/// `persistent_task_type` yields the on-disk `TaskCache` key.
+/// guard can be dropped before the teardown opens the *target* tasks' guards (holding two task
+/// locks at once trips the concurrent-lock detector). `children` drive the cascade; the `*_deps`
+/// are the forward dependencies whose reverse side must be scrubbed; `persistent_task_type` yields
+/// the on-disk `TaskCache` key.
 struct GcDeletePlan {
     children: Vec<TaskId>,
     output_deps: Vec<TaskId>,
@@ -275,6 +291,24 @@ struct GcDeletePlan {
     cell_deps_hashed: Vec<(CellRef, u64)>,
     collectibles_deps: Vec<CollectiblesRef>,
     persistent_task_type: Option<CachedTaskTypeArc>,
+}
+
+/// Splits `items` into `good_chunk_size` chunks and spawns one [`GcJob`] per chunk (built by
+/// `make_job`) into the self-feeding GC pool. A small collection becomes a single chunk job (≈
+/// inline); a huge one (e.g. 20K children/deps) fans out into `~4 * parallelism` jobs that spread
+/// across workers, so no single job pins a worker with unbounded work. Empty input spawns nothing.
+fn spawn_chunked<I>(
+    spawner: &turbo_tasks::scope::Spawner<'_, '_, GcJob>,
+    items: Vec<I>,
+    make_job: impl Fn(Vec<I>) -> GcJob,
+) {
+    if items.is_empty() {
+        return;
+    }
+    let chunk_size = good_chunk_size(items.len());
+    for chunk in into_chunks(items, chunk_size) {
+        spawner.spawn(make_job(chunk.collect()));
+    }
 }
 
 impl TurboTasksBackend {
@@ -359,216 +393,259 @@ impl TurboTasksBackend {
     /// removing them from the in-memory map + task_cache, and buffering an on-disk tombstone for
     /// the next persistence commit.
     ///
-    /// The GC phase guarantees no operation is executing (see [`SnapshotCoordinator::begin_gc`]),
-    /// so the cross-task scrub and the map removals cannot race a concurrent connect/read.
-    /// Returns the number of tasks collected.
+    /// The pass is fully parallel and self-feeding via [`scope_self_feeding`]: work is a pool of
+    /// [`GcJob`]s (collect a task; decrement a chunk of children; scrub a chunk of reverse-dep
+    /// edges) and any job may spawn more (a collect fans out into decrements + scrubs; a decrement
+    /// that drives a child to 0 spawns a collect). There are no synchronization barriers between
+    /// "levels" of the cascade — discovered work flows straight back into the pool — and no single
+    /// job carries unbounded work: a task with 20K children or 20K forward deps fans out into many
+    /// chunked jobs (see [`spawn_chunked`]), so one huge task can't pin a single worker while
+    /// others idle.
+    ///
+    /// Why this is safe to run concurrently under the GC phase (which excludes normal operations
+    /// but not the GC jobs from each other):
+    /// - Each job builds its own [`ExecuteContext`] (`execute_context_gc`); the concurrent-lock
+    ///   detector is per-context, so jobs on different threads holding different task guards do not
+    ///   false-positive.
+    /// - The storage map is a sharded dashmap: different tasks hit different shards; same-task
+    ///   access is serialized by the shard lock.
+    /// - The cascade decrement (`update_and_get_parent_count(-1)`) is a read-modify-write under the
+    ///   child's entry write lock, so if two collected parents decrement the same child
+    ///   concurrently, exactly one observes the count hit 0 and spawns its collect — no
+    ///   double-collect, no lost decrement.
+    /// - A collectible task has `parent_count == 0`, so no *surviving* task lists it as a child: a
+    ///   task becomes a collect target only after its last persistent parent was itself collected
+    ///   (which removed the edge). So a `Collect` never races a decrement of the same task and
+    ///   never `ctx.task`-resurrects a task another job just removed.
+    /// - Per-job results merge into shared accumulators guarded by a mutex/atomic, touched only on
+    ///   the rare collect/retain outcome (not per decrement or per scrub), so they are not a
+    ///   contention hot spot.
+    ///
+    /// `scope_self_feeding` runs jobs on the runtime worker threads plus the calling thread, which
+    /// drains the whole (growing) pool itself if no helper is scheduled — so this does not depend
+    /// on free worker threads (robust on thread-limited runtimes). GC runs from a synchronous
+    /// backend context (like `connect_children`, which also fans out onto the scope machinery).
+    ///
+    /// Returns `(number of tasks collected, on-disk tombstones)`.
     fn gc_collect(
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
     ) -> (usize, Vec<TaskDeletion>) {
-        // Seed the worklist from the candidates observed since the last pass. Re-validation happens
-        // per task below (a candidate may have been revived by a concurrent re-connect before the
-        // GC phase was acquired).
-        let mut worklist: Vec<TaskId> = self.gc_candidates.lock().drain().collect();
-        let mut collected = 0;
-        let mut deletions = Vec::new();
-        // Candidates that are still parentless but not *yet* collectible (e.g. residual transient
-        // activeness) are re-retained for a later pass.
-        let mut retain: Vec<TaskId> = Vec::new();
-
-        // Sequential worklist drain. This runs under the GC phase (execution is excluded) so it
-        // could in principle be parallelized, but fanning the worklist out with `scope_and_block`
-        // deadlocks on a thread-limited runtime: `scope_and_block` spawns `available_parallelism()
-        // - 1` worker tasks that block on a Condvar waiting for work, and on a runtime with few
-        // worker threads (e.g. the 2-worker-thread test runtime, or a low-core CI runner) those
-        // blocked workers starve the very tasks that would feed them. Collection is O(garbage), not
-        // O(total), so a pass is short; if latency ever proves a problem, revisit parallelization
-        // (see the `scope_and_block` guidance) — likely by making `scope_and_block` robust on
-        // thread-limited runtimes, which would benefit the snapshot path too.
-        while let Some(task_id) = worklist.pop() {
-            match self.gc_process_one(task_id, turbo_tasks) {
-                GcOutcome::Collected {
-                    deletion,
-                    newly_garbage,
-                } => {
-                    deletions.push(deletion);
-                    collected += 1;
-                    worklist.extend(newly_garbage);
-                }
-                GcOutcome::Retain(task_id) => retain.push(task_id),
-                GcOutcome::Skip => {}
-            }
+        // Seed the pool from the candidates observed since the last pass. Re-validation happens per
+        // task in `Collect` (a candidate may have been revived by a concurrent re-connect before
+        // the GC phase was acquired).
+        let seeds: Vec<GcJob> = self
+            .gc_candidates
+            .lock()
+            .drain()
+            .map(GcJob::Collect)
+            .collect();
+        if seeds.is_empty() {
+            return (0, Vec::new());
         }
 
-        // Re-queue candidates that are still parentless but were not collectible this pass, so a
-        // later pass retries once their transient activeness clears.
+        // Shared accumulators. Touched only on the (comparatively rare) collect/retain outcomes,
+        // not on every decrement or scrub, so the mutexes are not a hot path.
+        let deletions = Mutex::new(Vec::new());
+        let collected = AtomicUsize::new(0);
+        // Candidates that are still parentless but not *yet* collectible (e.g. residual transient
+        // activeness) are re-retained for a later pass.
+        let retain = Mutex::new(Vec::new());
+
+        scope_self_feeding(seeds, |spawner, job| {
+            self.gc_run_job(job, spawner, turbo_tasks, &deletions, &collected, &retain);
+        });
+
+        // Re-queue candidates that were still parentless but not collectible this pass, so a later
+        // pass retries once their transient activeness clears.
+        let retain = retain.into_inner();
         if !retain.is_empty() {
             self.gc_candidates.lock().extend(retain);
         }
-        (collected, deletions)
+        (collected.into_inner(), deletions.into_inner())
     }
 
-    /// Processes one GC worklist item under the held GC phase: re-validates collectibility, and if
-    /// collectible tears the task down (scrub reverse-dep edges + remove from map + produce a
-    /// tombstone) and decrements each child's `parent_count`, returning the children that reached
-    /// 0. See [`GcOutcome`] for the cases.
-    ///
-    /// The whole decision + teardown reuses a single [`ExecuteContext`]: the task is accessed once
-    /// (one guard) to both decide collectibility and capture its edges into a [`GcDeletePlan`], and
-    /// the same context is threaded through the scrub and the cascade. Under the GC phase there is
-    /// no concurrency, so taking the write guard (via `ctx.task`) rather than a read-only
-    /// `with_task` is free.
-    fn gc_process_one(
+    /// Runs one [`GcJob`], possibly spawning follow-up jobs into the same pool. See
+    /// [`Self::gc_collect`] for the concurrency argument. Each job builds its own GC
+    /// [`ExecuteContext`].
+    fn gc_run_job(
         &self,
-        task_id: TaskId,
+        job: GcJob,
+        spawner: &turbo_tasks::scope::Spawner<'_, '_, GcJob>,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> GcOutcome {
-        // Transient-ness is a property of the id, not the storage — check it before touching the
-        // map (transient tasks are never collected).
-        if task_id.is_transient() {
-            return GcOutcome::Skip;
-        }
-        let mut ctx = self.execute_context_gc(turbo_tasks);
+        deletions: &Mutex<Vec<TaskDeletion>>,
+        collected: &AtomicUsize,
+        retain: &Mutex<Vec<TaskId>>,
+    ) {
+        match job {
+            GcJob::Collect(task_id) => {
+                // Transient-ness is a property of the id, not the storage — check it before
+                // touching the map (transient tasks are never collected).
+                if task_id.is_transient() {
+                    return;
+                }
+                let mut ctx = self.execute_context_gc(turbo_tasks);
 
-        // Single access: decide collectibility and, if collectible, capture the edges needed to
-        // tear the task down. Reading through the guard (`ctx.task(.., All)`, which restores the
-        // task if it was evicted) means `is_gc_collectible`'s Meta reads go through `check_access`,
-        // so the "Meta restored" precondition is enforced by the standard guard machinery rather
-        // than a hand-rolled `is_restored` check.
-        let plan = {
-            let task = ctx.task(task_id, TaskDataCategory::All);
-            if !task.is_gc_collectible() {
-                // Not collectible: keep retrying only while it is still parentless; otherwise a
-                // concurrent re-connect revived it and it is no longer garbage.
-                return if task.get_parent_count().copied().unwrap_or(0) == 0 {
-                    GcOutcome::Retain(task_id)
-                } else {
-                    GcOutcome::Skip
+                // Single access: decide collectibility and, if collectible, capture the edges
+                // needed to tear the task down. Reading through the guard
+                // (`ctx.task(.., All)`, which restores the task if it was evicted)
+                // means `is_gc_collectible`'s Meta reads go through `check_access`,
+                // so the "Meta restored" precondition is enforced by the
+                // standard guard machinery rather than a hand-rolled `is_restored` check.
+                let plan = {
+                    let task = ctx.task(task_id, TaskDataCategory::All);
+                    if !task.is_gc_collectible() {
+                        // Not collectible: keep retrying only while it is still parentless;
+                        // otherwise a concurrent re-connect revived it and it is no longer garbage.
+                        if task.get_parent_count().copied().unwrap_or(0) == 0 {
+                            retain.lock().push(task_id);
+                        }
+                        return;
+                    }
+                    GcDeletePlan {
+                        children: task.iter_children().collect(),
+                        output_deps: task.iter_output_dependencies().collect(),
+                        cell_deps: task.iter_cell_dependencies().collect(),
+                        cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
+                        collectibles_deps: task.iter_collectibles_dependencies().collect(),
+                        persistent_task_type: task.get_persistent_task_type().cloned(),
+                    }
                 };
-            }
 
-            GcDeletePlan {
-                children: task.iter_children().collect(),
-                output_deps: task.iter_output_dependencies().collect(),
-                cell_deps: task.iter_cell_dependencies().collect(),
-                cell_deps_hashed: task.iter_cell_dependencies_hashed().collect(),
-                collectibles_deps: task.iter_collectibles_dependencies().collect(),
-                persistent_task_type: task.get_persistent_task_type().cloned(),
-            }
-        };
+                let deletion = self.gc_remove_task(task_id, &plan, &mut ctx);
+                deletions.lock().push(deletion);
+                collected.fetch_add(1, Ordering::Relaxed);
 
-        let (children, deletion) = self.gc_scrub_and_remove(task_id, plan, &mut ctx);
-
-        // Cascade: each child loses a persistent parent; collect those that reach 0. Reuses the
-        // same context.
-        let mut newly_garbage = Vec::new();
-        for child in children {
-            if child.is_transient() {
-                continue;
+                // Fan the (potentially huge) teardown out into bounded chunk jobs so no single
+                // worker is pinned by one task's children/deps. `gc_remove_task` already dropped
+                // `task_id`'s own guard; the scrub jobs only open the *target* guards, and the plan
+                // carries owned edge lists so they don't need `task_id` resident.
+                let GcDeletePlan {
+                    children,
+                    output_deps,
+                    cell_deps,
+                    cell_deps_hashed,
+                    collectibles_deps,
+                    persistent_task_type: _,
+                } = plan;
+                spawn_chunked(spawner, children, GcJob::Decrement);
+                spawn_chunked(spawner, output_deps, |targets| GcJob::ScrubOutput {
+                    source: task_id,
+                    targets,
+                });
+                spawn_chunked(spawner, cell_deps, |refs| GcJob::ScrubCell {
+                    source: task_id,
+                    refs,
+                });
+                spawn_chunked(spawner, cell_deps_hashed, |refs| GcJob::ScrubCellHashed {
+                    source: task_id,
+                    refs,
+                });
+                spawn_chunked(spawner, collectibles_deps, |refs| {
+                    GcJob::ScrubCollectibles {
+                        source: task_id,
+                        refs,
+                    }
+                });
             }
-            let mut child_task = ctx.task(child, TaskDataCategory::Meta);
-            let new_count = child_task.update_and_get_parent_count(-1);
-            drop(child_task);
-            if new_count == 0 {
-                newly_garbage.push(child);
+            GcJob::Decrement(children) => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for child in children {
+                    // Transient children are never collected and carry no persistent parent_count.
+                    if child.is_transient() {
+                        continue;
+                    }
+                    let mut child_task = ctx.task(child, TaskDataCategory::Meta);
+                    let new_count = child_task.update_and_get_parent_count(-1);
+                    drop(child_task);
+                    // Exactly one decrementer sees 0 (RMW under the entry lock), so `child` is
+                    // spawned as a collect target exactly once.
+                    if new_count == 0 {
+                        spawner.spawn(GcJob::Collect(child));
+                    }
+                }
             }
-        }
-        GcOutcome::Collected {
-            deletion,
-            newly_garbage,
+            GcJob::ScrubOutput { source, targets } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for output_task_id in targets {
+                    let mut target = ctx.task(output_task_id, TaskDataCategory::Data);
+                    target.remove_output_dependent(&source);
+                }
+            }
+            GcJob::ScrubCell { source, refs } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for CellRef {
+                    task: cell_task,
+                    cell,
+                } in refs
+                {
+                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
+                    target.remove_cell_dependents(&CellRef { task: source, cell });
+                }
+            }
+            GcJob::ScrubCellHashed { source, refs } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for (
+                    CellRef {
+                        task: cell_task,
+                        cell,
+                    },
+                    key,
+                ) in refs
+                {
+                    let mut target = ctx.task(cell_task, TaskDataCategory::Data);
+                    target.remove_cell_dependents_hashed(&(CellRef { task: source, cell }, key));
+                }
+            }
+            GcJob::ScrubCollectibles { source, refs } => {
+                let mut ctx = self.execute_context_gc(turbo_tasks);
+                for CollectiblesRef {
+                    task: dep_task,
+                    collectible_type,
+                } in refs
+                {
+                    let mut target = ctx.task(dep_task, TaskDataCategory::Data);
+                    target.remove_collectibles_dependents(&(collectible_type, source));
+                }
+            }
         }
     }
 
-    /// Scrubs all references captured in `plan` off `task_id`'s dependency targets, removes it from
-    /// the task_cache and the map, and returns its `children` (so the caller can decrement their
-    /// parent_count for the cascade) together with a [`TaskDeletion`] tombstone for the next
-    /// commit.
-    ///
-    /// The task's own guard has already been dropped by [`Self::gc_process_one`] (its edges live in
-    /// `plan`), so this only opens the *target* tasks' guards — never two task locks at once.
-    /// Reuses the caller's [`ExecuteContext`]; must be called while holding the GC phase.
-    fn gc_scrub_and_remove(
+    /// Removes a collectible task from the in-memory task_cache and map and returns its
+    /// [`TaskDeletion`] tombstone. The reverse-dep edge scrubbing is done separately by the
+    /// `Scrub*` jobs (see [`Self::gc_run_job`]); this only touches `task_id`'s own entries, which
+    /// are independent of the target entries the scrubs mutate, so ordering between them is free.
+    /// Must be called while holding the GC phase.
+    fn gc_remove_task(
         &self,
         task_id: TaskId,
-        plan: GcDeletePlan,
-        ctx: &mut impl ExecuteContext<'_>,
-    ) -> (Vec<TaskId>, TaskDeletion) {
-        let GcDeletePlan {
-            children,
-            output_deps,
-            cell_deps,
-            cell_deps_hashed,
-            collectibles_deps,
-            persistent_task_type,
-        } = plan;
-
-        // Scrub the reverse side of each forward dependency on the target task (mirrors
-        // CleanupOldEdgesOperation).
-        for output_task_id in output_deps {
-            let mut target = ctx.task(output_task_id, TaskDataCategory::Data);
-            target.remove_output_dependent(&task_id);
-        }
-        for CellRef {
-            task: cell_task,
-            cell,
-        } in cell_deps
-        {
-            let mut target = ctx.task(cell_task, TaskDataCategory::Data);
-            target.remove_cell_dependents(&CellRef {
-                task: task_id,
-                cell,
-            });
-        }
-        for (
-            CellRef {
-                task: cell_task,
-                cell,
-            },
-            key,
-        ) in cell_deps_hashed
-        {
-            let mut target = ctx.task(cell_task, TaskDataCategory::Data);
-            target.remove_cell_dependents_hashed(&(
-                CellRef {
-                    task: task_id,
-                    cell,
-                },
-                key,
-            ));
-        }
-        for CollectiblesRef {
-            task: dep_task,
-            collectible_type,
-        } in collectibles_deps
-        {
-            let mut target = ctx.task(dep_task, TaskDataCategory::Data);
-            target.remove_collectibles_dependents(&(collectible_type, task_id));
-        }
-
+        plan: &GcDeletePlan,
+        _ctx: &mut impl ExecuteContext<'_>,
+    ) -> TaskDeletion {
         // Remove the in-memory task_cache entry (hash -> id) so lookups don't return a dead id, and
-        // compute the persisted TaskCache key so the caller can tombstone the on-disk mapping. Only
-        // persistent tasks are collected, so a persistent task type is always present.
-        let task_type =
-            persistent_task_type.expect("a collected (non-transient) task must have a task type");
+        // compute the persisted TaskCache key so the snapshot can tombstone the on-disk mapping.
+        // Only persistent tasks are collected, so a persistent task type is always present.
+        let task_type = plan
+            .persistent_task_type
+            .as_ref()
+            .expect("a collected (non-transient) task must have a task type");
         self.storage.task_cache.remove(task_type.as_ref());
-        let task_type_hash = compute_task_type_hash(&task_type);
+        let task_type_hash = compute_task_type_hash(task_type);
 
-        // Remove the task from the map. Its children set is dropped with it; we returned the child
-        // ids above so the caller can decrement their parent_count.
+        // Remove the task from the map. Its own children set is dropped with it; the child ids were
+        // captured into `plan` so the `Decrement` jobs can drop their parent_count.
         self.storage.remove_task(task_id);
 
         // Tombstoning the on-disk `TaskCache` erases the *whole* hash bucket, so any live task
-        // whose type xxh3-collides with this one must be re-inserted. Those survivors are
-        // resolved at apply time in `save_snapshot` (which reads the authoritative on-disk
-        // bucket) rather than computed here — the in-memory `task_cache` is lazily
-        // populated and keyed by the full task type, not the hash, so it can't reliably
-        // enumerate hash-siblings. Collisions between two live tasks are astronomically
-        // rare, so this survivor path almost never fires.
-        let deletion = TaskDeletion {
+        // whose type xxh3-collides with this one must be re-inserted. Those survivors are resolved
+        // at apply time in `save_snapshot` (which reads the authoritative on-disk bucket) rather
+        // than computed here — the in-memory `task_cache` is lazily populated and keyed by the full
+        // task type, not the hash, so it can't reliably enumerate hash-siblings. Collisions between
+        // two live tasks are astronomically rare, so this survivor path almost never fires.
+        TaskDeletion {
             task_id,
             task_type_hash,
-        };
-        (children, deletion)
+        }
     }
 
     /// Runs a full GC pass under the GC phase and returns the number of tasks collected together

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1513,18 +1513,15 @@ impl TurboTasksBackend {
         // snapshot (no task creation runs concurrently with stop). Drop it before persisting to
         // lower peak memory during the serialization/write.
         self.storage.drop_task_cache();
-        if self.should_persist() {
-            // The stop snapshot runs a final GC pass internally (see `snapshot_and_persist`), so
-            // builds emit tombstones for disconnected tasks in the final commit — keeping the
-            // persisted DB tight for the next build.
-            if let Err(err) = self.snapshot_and_persist(
+        if self.should_persist()
+            && let Err(err) = self.snapshot_and_persist(
                 Span::current().into(),
                 SnapshotReason::Stop,
                 turbo_tasks,
                 Vec::new(),
-            ) {
-                eprintln!("Persisting failed during shutdown: {err:?}");
-            }
+            )
+        {
+            eprintln!("Persisting failed during shutdown: {err:?}");
         }
         self.storage.drop_contents();
         if let Err(err) = self.backing_storage.shutdown() {
@@ -3812,7 +3809,6 @@ impl Backend for TurboTasksBackend {
     }
 
     fn pin_task_for_gc(&self, task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
-        // GC pin/unpin bookkeeping lives in the `gc` module (see `gc_pin`).
         self.gc_pin(task);
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1461,14 +1461,19 @@ impl AggregationUpdateQueue {
                     // snapshot captures it mid-flight and it replays to completion on restart,
                     // keeping the count crash-consistent.
                     //
-                    // A count reaching 0 means the task has no persistent parent and may be
-                    // collectible — but we don't record it anywhere: the GC pass finds collectible
-                    // tasks by scanning the resident map (see `gc_collect`), deriving
-                    // collectibility from the durable `parent_count` directly
-                    // rather than a side-set that would have to be kept in sync
-                    // and persisted across sessions.
-                    ctx.for_each_task_meta(task_ids, "AdjustParentCount", |mut task, _ctx| {
-                        task.update_and_get_parent_count(delta);
+                    // A count reaching 0 means the task lost its last persistent parent and may be
+                    // collectible. Outside GC we don't record it (the collectibility is derived
+                    // from the durable `parent_count` directly). During a GC
+                    // pass, the collector runs this decrement (via
+                    // `CleanupOldEdges` on a collected task) and needs to
+                    // discover the newly-parentless children to cascade into:
+                    // `note_gc_parent_count_zeroed` records them on the GC
+                    // context (a no-op for every normal context).
+                    ctx.for_each_task_meta(task_ids, "AdjustParentCount", |mut task, ctx| {
+                        if task.update_and_get_parent_count(delta) == 0 {
+                            let id = task.id();
+                            ctx.note_gc_parent_count_zeroed(id);
+                        }
                     });
                 }
                 AggregationUpdateJob::AdjustTransientRefCount { task_ids, delta } => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -183,27 +183,6 @@ impl ComputeDirtyAndCleanUpdateResult {
     }
 }
 
-/// Which child-side reference count (if any) an [`AggregationUpdateJob::IncreaseActiveCount`]
-/// should also bump when it is raised for a genuinely-new child edge in
-/// `ConnectChildOperation::run`. The bump rides the Meta guard that `increase_active_count`
-/// already takes, so maintaining the `parent_count` / `transient_ref_count` for a new edge costs
-/// no extra lock on the hot connect path.
-///
-/// `Default` is [`ParentCountBump::NoBump`]: every producer of `IncreaseActiveCount` other than the
-/// direct-child staging in `ConnectChildOperation::run` (e.g. follower/upper propagation) leaves
-/// the count untouched.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ParentCountBump {
-    /// Do not touch any reference count (the default for propagation-sourced jobs).
-    #[default]
-    NoBump,
-    /// Increment the child's durable `parent_count` (the connecting parent is persistent).
-    BumpParent,
-    /// Increment the child's session-only `transient_ref_count` (the connecting parent is
-    /// transient).
-    BumpTransientParent,
-}
-
 #[derive(Encode, Decode, Clone, Debug)]
 pub struct InnerOfUppersHasNewFollowersJob {
     #[bincode(with = "turbo_bincode::smallvec")]
@@ -324,14 +303,6 @@ pub enum AggregationUpdateJob {
         // upon attempted serialization) similar to #[serde(skip)] on variants
         #[bincode(skip, default = "unreachable_decode")]
         task: TaskId,
-        /// When this `IncreaseActiveCount` is raised for a task being connected as a genuinely-new
-        /// child (in `ConnectChildOperation::run`), it also carries the child-side reference-count
-        /// **hold** for that new edge, applied under the same guard the active-count bump already
-        /// takes (so the hold is free). `NoBump` for every other producer of this job (e.g. the
-        /// follower/upper propagation in `inner_of_upper_has_new_follower`), which must not touch
-        /// the count. Never serialized (this whole variant is `#[bincode(skip)]`).
-        #[bincode(skip, default = "Default::default")]
-        bump: ParentCountBump,
     },
     /// Increases the active counters of the tasks
     IncreaseActiveCounts {
@@ -1530,13 +1501,12 @@ impl AggregationUpdateQueue {
                         }
                     }
                 }
-                AggregationUpdateJob::IncreaseActiveCount { task, bump } => {
-                    self.increase_active_count(ctx, task, bump);
+                AggregationUpdateJob::IncreaseActiveCount { task } => {
+                    self.increase_active_count(ctx, task);
                 }
                 AggregationUpdateJob::IncreaseActiveCounts { mut task_ids } => {
                     if let Some(task_id) = task_ids.pop() {
-                        // Follower/upper propagation: never a direct-child edge, so no count hold.
-                        self.increase_active_count(ctx, task_id, ParentCountBump::NoBump);
+                        self.increase_active_count(ctx, task_id);
                         if !task_ids.is_empty() {
                             self.jobs.push_front(AggregationUpdateJobItem::new(
                                 AggregationUpdateJob::IncreaseActiveCounts { task_ids },
@@ -1787,10 +1757,7 @@ impl AggregationUpdateQueue {
                         let has_active_count =
                             upper.get_activeness().is_some_and(|a| a.active_counter > 0);
                         if has_active_count {
-                            self.push(AggregationUpdateJob::IncreaseActiveCount {
-                                task: task_id,
-                                bump: ParentCountBump::NoBump,
-                            });
+                            self.push(AggregationUpdateJob::IncreaseActiveCount { task: task_id });
                         }
                     }
                     // notify uppers about new follower
@@ -3061,7 +3028,6 @@ impl AggregationUpdateQueue {
                     if has_active_count {
                         self.push(AggregationUpdateJob::IncreaseActiveCount {
                             task: new_follower_id,
-                            bump: ParentCountBump::NoBump,
                         });
                     }
 
@@ -3220,12 +3186,7 @@ impl AggregationUpdateQueue {
     /// Increases the active count of a task.
     ///
     /// Only used when activeness is tracked.
-    fn increase_active_count(
-        &mut self,
-        ctx: &mut impl ExecuteContext<'_>,
-        task_id: TaskId,
-        bump: ParentCountBump,
-    ) {
+    fn increase_active_count(&mut self, ctx: &mut impl ExecuteContext<'_>, task_id: TaskId) {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("increase active count").entered();
 
@@ -3235,19 +3196,6 @@ impl AggregationUpdateQueue {
             // persistent_task_type is now set eagerly in initialize_new_task.
             AGGREGATION_UPDATE_CATEGORY,
         );
-        // Ride this guard to take the child-side reference-count hold for a genuinely-new child
-        // edge (see `ParentCountBump` / `ConnectChildOperation::run`). `parent_count` /
-        // `transient_ref_count` are Meta fields, covered by AGGREGATION_UPDATE_CATEGORY, so this is
-        // free — no extra lock. `NoBump` (every non-direct-child producer) does nothing.
-        match bump {
-            ParentCountBump::NoBump => {}
-            ParentCountBump::BumpParent => {
-                task.update_and_get_parent_count(1);
-            }
-            ParentCountBump::BumpTransientParent => {
-                task.update_and_get_transient_ref_count(1);
-            }
-        }
         self.check_optimization_pending(&task);
         let state = task.get_activeness_mut_or_insert_with(|| ActivenessState::new(task_id));
         let is_new = state.is_empty();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1461,16 +1461,14 @@ impl AggregationUpdateQueue {
                     // snapshot captures it mid-flight and it replays to completion on restart,
                     // keeping the count crash-consistent.
                     //
-                    // When a count reaches 0 the task has no persistent parent and becomes a GC
-                    // candidate. We only *note* candidacy here (a cheap side-set write) — the
-                    // actual teardown/removal cannot run in this concurrently-executing operation
-                    // (it would race a concurrent re-connect and cross-task edge scrub). It runs
-                    // later under the GC phase's exclusion, which re-validates candidacy.
-                    ctx.for_each_task_meta(task_ids, "AdjustTransientRefCount", |mut task, ctx| {
-                        let new_count = task.update_and_get_parent_count(delta);
-                        if new_count == 0 {
-                            ctx.add_gc_candidate(task.id());
-                        }
+                    // A count reaching 0 means the task has no persistent parent and may be
+                    // collectible — but we don't record it anywhere: the GC pass finds collectible
+                    // tasks by scanning the resident map (see `gc_collect`), deriving
+                    // collectibility from the durable `parent_count` directly
+                    // rather than a side-set that would have to be kept in sync
+                    // and persisted across sessions.
+                    ctx.for_each_task_meta(task_ids, "AdjustParentCount", |mut task, _ctx| {
+                        task.update_and_get_parent_count(delta);
                     });
                 }
                 AggregationUpdateJob::AdjustTransientRefCount { task_ids, delta } => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -183,6 +183,27 @@ impl ComputeDirtyAndCleanUpdateResult {
     }
 }
 
+/// Which child-side reference count (if any) an [`AggregationUpdateJob::IncreaseActiveCount`]
+/// should also bump when it is raised for a genuinely-new child edge in
+/// `ConnectChildOperation::run`. The bump rides the Meta guard that `increase_active_count`
+/// already takes, so maintaining the `parent_count` / `transient_ref_count` for a new edge costs
+/// no extra lock on the hot connect path.
+///
+/// `Default` is [`ParentCountBump::NoBump`]: every producer of `IncreaseActiveCount` other than the
+/// direct-child staging in `ConnectChildOperation::run` (e.g. follower/upper propagation) leaves
+/// the count untouched.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ParentCountBump {
+    /// Do not touch any reference count (the default for propagation-sourced jobs).
+    #[default]
+    NoBump,
+    /// Increment the child's durable `parent_count` (the connecting parent is persistent).
+    BumpParent,
+    /// Increment the child's session-only `transient_ref_count` (the connecting parent is
+    /// transient).
+    BumpTransientParent,
+}
+
 #[derive(Encode, Decode, Clone, Debug)]
 pub struct InnerOfUppersHasNewFollowersJob {
     #[bincode(with = "turbo_bincode::smallvec")]
@@ -303,6 +324,14 @@ pub enum AggregationUpdateJob {
         // upon attempted serialization) similar to #[serde(skip)] on variants
         #[bincode(skip, default = "unreachable_decode")]
         task: TaskId,
+        /// When this `IncreaseActiveCount` is raised for a task being connected as a genuinely-new
+        /// child (in `ConnectChildOperation::run`), it also carries the child-side reference-count
+        /// **hold** for that new edge, applied under the same guard the active-count bump already
+        /// takes (so the hold is free). `NoBump` for every other producer of this job (e.g. the
+        /// follower/upper propagation in `inner_of_upper_has_new_follower`), which must not touch
+        /// the count. Never serialized (this whole variant is `#[bincode(skip)]`).
+        #[bincode(skip, default = "Default::default")]
+        bump: ParentCountBump,
     },
     /// Increases the active counters of the tasks
     IncreaseActiveCounts {
@@ -1501,12 +1530,13 @@ impl AggregationUpdateQueue {
                         }
                     }
                 }
-                AggregationUpdateJob::IncreaseActiveCount { task } => {
-                    self.increase_active_count(ctx, task);
+                AggregationUpdateJob::IncreaseActiveCount { task, bump } => {
+                    self.increase_active_count(ctx, task, bump);
                 }
                 AggregationUpdateJob::IncreaseActiveCounts { mut task_ids } => {
                     if let Some(task_id) = task_ids.pop() {
-                        self.increase_active_count(ctx, task_id);
+                        // Follower/upper propagation: never a direct-child edge, so no count hold.
+                        self.increase_active_count(ctx, task_id, ParentCountBump::NoBump);
                         if !task_ids.is_empty() {
                             self.jobs.push_front(AggregationUpdateJobItem::new(
                                 AggregationUpdateJob::IncreaseActiveCounts { task_ids },
@@ -1757,7 +1787,10 @@ impl AggregationUpdateQueue {
                         let has_active_count =
                             upper.get_activeness().is_some_and(|a| a.active_counter > 0);
                         if has_active_count {
-                            self.push(AggregationUpdateJob::IncreaseActiveCount { task: task_id });
+                            self.push(AggregationUpdateJob::IncreaseActiveCount {
+                                task: task_id,
+                                bump: ParentCountBump::NoBump,
+                            });
                         }
                     }
                     // notify uppers about new follower
@@ -3028,6 +3061,7 @@ impl AggregationUpdateQueue {
                     if has_active_count {
                         self.push(AggregationUpdateJob::IncreaseActiveCount {
                             task: new_follower_id,
+                            bump: ParentCountBump::NoBump,
                         });
                     }
 
@@ -3186,7 +3220,12 @@ impl AggregationUpdateQueue {
     /// Increases the active count of a task.
     ///
     /// Only used when activeness is tracked.
-    fn increase_active_count(&mut self, ctx: &mut impl ExecuteContext<'_>, task_id: TaskId) {
+    fn increase_active_count(
+        &mut self,
+        ctx: &mut impl ExecuteContext<'_>,
+        task_id: TaskId,
+        bump: ParentCountBump,
+    ) {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("increase active count").entered();
 
@@ -3196,6 +3235,19 @@ impl AggregationUpdateQueue {
             // persistent_task_type is now set eagerly in initialize_new_task.
             AGGREGATION_UPDATE_CATEGORY,
         );
+        // Ride this guard to take the child-side reference-count hold for a genuinely-new child
+        // edge (see `ParentCountBump` / `ConnectChildOperation::run`). `parent_count` /
+        // `transient_ref_count` are Meta fields, covered by AGGREGATION_UPDATE_CATEGORY, so this is
+        // free — no extra lock. `NoBump` (every non-direct-child producer) does nothing.
+        match bump {
+            ParentCountBump::NoBump => {}
+            ParentCountBump::BumpParent => {
+                task.update_and_get_parent_count(1);
+            }
+            ParentCountBump::BumpTransientParent => {
+                task.update_and_get_transient_ref_count(1);
+            }
+        }
         self.check_optimization_pending(&task);
         let state = task.get_activeness_mut_or_insert_with(|| ActivenessState::new(task_id));
         let is_new = state.is_empty();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -280,21 +280,9 @@ pub enum AggregationUpdateJob {
         lost_follower_ids: TaskIdVec,
         retry: u16,
     },
-    /// Adjust the persistent `parent_count` of each task in `task_ids` by `delta` (+1 when a
-    /// persistent parent connects them as children, -1 when a persistent parent disconnects them).
-    /// This is a **persisted** job (unlike the transient active-count jobs below): it rides the
-    /// durable `AggregationUpdateQueue`, so a snapshot captures it mid-flight and it is replayed to
-    /// completion on restart — keeping `parent_count` consistent across crashes. When a task's
-    /// count reaches 0 it becomes eligible for collection (tombstoned at snapshot, dropped at
-    /// eviction).
+    /// Adjust the persistent `parent_count` of each task in `task_ids` by `delta`
     AdjustParentCount { task_ids: TaskIdVec, delta: i32 },
-    /// Adjust the session-only `transient_ref_count` of each task in `task_ids` by `delta` (+1 when
-    /// a *transient* parent connects them as children, -1 when it disconnects them). This is the
-    /// transient sibling of [`AdjustParentCount`]: a transient parent vanishes on restart and
-    /// re-establishes its edges by re-executing, so its contribution must **not** persist. Hence
-    /// this variant is skipped during serialization (converted to [`Noop`], see `encode_jobs`) — it
-    /// is never replayed. Reaching 0 here does not make a task a GC candidate (only losing a
-    /// *persistent* parent does).
+    /// Adjust the session-only `transient_ref_count` of each task in `task_ids` by `delta`
     AdjustTransientRefCount {
         #[bincode(skip, default = "unreachable_decode")]
         task_ids: TaskIdVec,
@@ -1478,23 +1466,24 @@ impl AggregationUpdateQueue {
                     // actual teardown/removal cannot run in this concurrently-executing operation
                     // (it would race a concurrent re-connect and cross-task edge scrub). It runs
                     // later under the GC phase's exclusion, which re-validates candidacy.
-                    for task_id in task_ids {
-                        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+                    ctx.for_each_task_meta(task_ids, "AdjustTransientRefCount", |mut task, ctx| {
                         let new_count = task.update_and_get_parent_count(delta);
-                        drop(task);
                         if new_count == 0 {
-                            ctx.add_gc_candidate(task_id);
+                            ctx.add_gc_candidate(task.id());
                         }
-                    }
+                    });
                 }
                 AggregationUpdateJob::AdjustTransientRefCount { task_ids, delta } => {
                     // Session-only sibling of AdjustParentCount for edges from a transient parent.
                     // Not persisted/replayed, and reaching 0 is not a collection trigger (only
                     // losing a persistent parent is).
-                    for task_id in task_ids {
-                        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
-                        task.update_and_get_transient_ref_count(delta);
-                    }
+                    ctx.for_each_task_meta(
+                        task_ids,
+                        "AdjustTransientRefCount",
+                        |mut task, _ctx| {
+                            task.update_and_get_transient_ref_count(delta);
+                        },
+                    );
                 }
                 AggregationUpdateJob::DecreaseActiveCount { task } => {
                     self.decrease_active_count(ctx, task);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -303,6 +303,14 @@ pub enum AggregationUpdateJob {
         // upon attempted serialization) similar to #[serde(skip)] on variants
         #[bincode(skip, default = "unreachable_decode")]
         task: TaskId,
+        /// Whether this increase is for a task being connected as a genuinely-new child (the
+        /// direct-connect chokepoint in `ConnectChildOperation::run`). When set, the handler also
+        /// resurrects the task if GC had soft-deleted it — riding the child guard it takes anyway,
+        /// so the common (not-deleted) case is a free Meta flag read. `false` for the aggregation
+        /// propagation producers of this job, which never target a `deleted` task (a collected
+        /// task has no `upper`/`followers` to be propagated to).
+        #[bincode(skip, default = "Default::default")]
+        resurrect: bool,
     },
     /// Increases the active counters of the tasks
     IncreaseActiveCounts {
@@ -1501,12 +1509,14 @@ impl AggregationUpdateQueue {
                         }
                     }
                 }
-                AggregationUpdateJob::IncreaseActiveCount { task } => {
-                    self.increase_active_count(ctx, task);
+                AggregationUpdateJob::IncreaseActiveCount { task, resurrect } => {
+                    self.increase_active_count(ctx, task, resurrect);
                 }
                 AggregationUpdateJob::IncreaseActiveCounts { mut task_ids } => {
                     if let Some(task_id) = task_ids.pop() {
-                        self.increase_active_count(ctx, task_id);
+                        // Propagation to followers — never a direct-child connect, so no
+                        // resurrection.
+                        self.increase_active_count(ctx, task_id, false);
                         if !task_ids.is_empty() {
                             self.jobs.push_front(AggregationUpdateJobItem::new(
                                 AggregationUpdateJob::IncreaseActiveCounts { task_ids },
@@ -1757,7 +1767,10 @@ impl AggregationUpdateQueue {
                         let has_active_count =
                             upper.get_activeness().is_some_and(|a| a.active_counter > 0);
                         if has_active_count {
-                            self.push(AggregationUpdateJob::IncreaseActiveCount { task: task_id });
+                            self.push(AggregationUpdateJob::IncreaseActiveCount {
+                                task: task_id,
+                                resurrect: false,
+                            });
                         }
                     }
                     // notify uppers about new follower
@@ -3028,6 +3041,7 @@ impl AggregationUpdateQueue {
                     if has_active_count {
                         self.push(AggregationUpdateJob::IncreaseActiveCount {
                             task: new_follower_id,
+                            resurrect: false,
                         });
                     }
 
@@ -3186,7 +3200,18 @@ impl AggregationUpdateQueue {
     /// Increases the active count of a task.
     ///
     /// Only used when activeness is tracked.
-    fn increase_active_count(&mut self, ctx: &mut impl ExecuteContext<'_>, task_id: TaskId) {
+    ///
+    /// `resurrect` is set only by the direct-child connect (`ConnectChildOperation::run`): if the
+    /// child had been GC-soft-deleted, revive it (clear `deleted`, re-dirty it so it re-executes to
+    /// rebuild the scrubbed edges) before touching activeness — riding the Meta guard taken here,
+    /// so the common (not-deleted) case is a single flag read with no extra lock. Propagation
+    /// callers pass `false` (a collected task has no followers/uppers to propagate to).
+    fn increase_active_count(
+        &mut self,
+        ctx: &mut impl ExecuteContext<'_>,
+        task_id: TaskId,
+        resurrect: bool,
+    ) {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("increase active count").entered();
 
@@ -3196,6 +3221,20 @@ impl AggregationUpdateQueue {
             // persistent_task_type is now set eagerly in initialize_new_task.
             AGGREGATION_UPDATE_CATEGORY,
         );
+        // Revive a GC-soft-deleted child before touching activeness, so the rest of this function
+        // (and the scheduling it drives) sees a live, re-dirtied task — matching the original
+        // resurrect-first ordering. Peek on the guard we already hold; only on the connect path and
+        // only when actually deleted does `resurrect_deleted` consume it, re-acquire `All` to
+        // double-check and atomically clear+re-dirty, and hand back a fresh guard.
+        if resurrect && task.deleted() {
+            task = crate::backend::operation::connect_child::resurrect_deleted(
+                task,
+                task_id,
+                AGGREGATION_UPDATE_CATEGORY,
+                self,
+                ctx,
+            );
+        }
         self.check_optimization_pending(&task);
         let state = task.get_activeness_mut_or_insert_with(|| ActivenessState::new(task_id));
         let is_new = state.is_empty();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -288,6 +288,19 @@ pub enum AggregationUpdateJob {
     /// count reaches 0 it becomes eligible for collection (tombstoned at snapshot, dropped at
     /// eviction).
     AdjustParentCount { task_ids: TaskIdVec, delta: i32 },
+    /// Adjust the session-only `transient_ref_count` of each task in `task_ids` by `delta` (+1 when
+    /// a *transient* parent connects them as children, -1 when it disconnects them). This is the
+    /// transient sibling of [`AdjustParentCount`]: a transient parent vanishes on restart and
+    /// re-establishes its edges by re-executing, so its contribution must **not** persist. Hence
+    /// this variant is skipped during serialization (converted to [`Noop`], see `encode_jobs`) — it
+    /// is never replayed. Reaching 0 here does not make a task a GC candidate (only losing a
+    /// *persistent* parent does).
+    AdjustTransientRefCount {
+        #[bincode(skip, default = "unreachable_decode")]
+        task_ids: TaskIdVec,
+        #[bincode(skip, default = "unreachable_decode")]
+        delta: i32,
+    },
     /// Notifies an upper task about changed data from an inner task.
     AggregatedDataUpdate(Box<AggregatedDataUpdateJob>),
     /// Invalidates tasks that are dependent on a collectible type.
@@ -887,7 +900,8 @@ mod encode_jobs {
                 AggregationUpdateJob::IncreaseActiveCount { .. }
                 | AggregationUpdateJob::IncreaseActiveCounts { .. }
                 | AggregationUpdateJob::DecreaseActiveCount { .. }
-                | AggregationUpdateJob::DecreaseActiveCounts { .. } => {
+                | AggregationUpdateJob::DecreaseActiveCounts { .. }
+                | AggregationUpdateJob::AdjustTransientRefCount { .. } => {
                     AggregationUpdateJobItem {
                         job: AggregationUpdateJob::Noop,
                         #[cfg(feature = "trace_aggregation_update_queue")]
@@ -1469,8 +1483,17 @@ impl AggregationUpdateQueue {
                         let new_count = task.update_and_get_parent_count(delta);
                         drop(task);
                         if new_count == 0 {
-                            ctx.note_gc_candidate(task_id);
+                            ctx.add_gc_candidate(task_id);
                         }
+                    }
+                }
+                AggregationUpdateJob::AdjustTransientRefCount { task_ids, delta } => {
+                    // Session-only sibling of AdjustParentCount for edges from a transient parent.
+                    // Not persisted/replayed, and reaching 0 is not a collection trigger (only
+                    // losing a persistent parent is).
+                    for task_id in task_ids {
+                        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+                        task.update_and_get_transient_ref_count(delta);
                     }
                 }
                 AggregationUpdateJob::DecreaseActiveCount { task } => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1457,11 +1457,20 @@ impl AggregationUpdateQueue {
                     // Apply the persistent parent_count delta to each task. Maintained here (rather
                     // than inline at the edge sites) so the update rides the durable queue: a
                     // snapshot captures it mid-flight and it replays to completion on restart,
-                    // keeping the count crash-consistent. Collection when the count hits 0 is wired
-                    // in a later stage (snapshot tombstone + eviction removal).
+                    // keeping the count crash-consistent.
+                    //
+                    // When a count reaches 0 the task has no persistent parent and becomes a GC
+                    // candidate. We only *note* candidacy here (a cheap side-set write) — the
+                    // actual teardown/removal cannot run in this concurrently-executing operation
+                    // (it would race a concurrent re-connect and cross-task edge scrub). It runs
+                    // later under the GC phase's exclusion, which re-validates candidacy.
                     for task_id in task_ids {
                         let mut task = ctx.task(task_id, TaskDataCategory::Meta);
-                        task.update_and_get_parent_count(delta);
+                        let new_count = task.update_and_get_parent_count(delta);
+                        drop(task);
+                        if new_count == 0 {
+                            ctx.note_gc_candidate(task_id);
+                        }
                     }
                 }
                 AggregationUpdateJob::DecreaseActiveCount { task } => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -280,6 +280,14 @@ pub enum AggregationUpdateJob {
         lost_follower_ids: TaskIdVec,
         retry: u16,
     },
+    /// Adjust the persistent `parent_count` of each task in `task_ids` by `delta` (+1 when a
+    /// persistent parent connects them as children, -1 when a persistent parent disconnects them).
+    /// This is a **persisted** job (unlike the transient active-count jobs below): it rides the
+    /// durable `AggregationUpdateQueue`, so a snapshot captures it mid-flight and it is replayed to
+    /// completion on restart — keeping `parent_count` consistent across crashes. When a task's
+    /// count reaches 0 it becomes eligible for collection (tombstoned at snapshot, dropped at
+    /// eviction).
+    AdjustParentCount { task_ids: TaskIdVec, delta: i32 },
     /// Notifies an upper task about changed data from an inner task.
     AggregatedDataUpdate(Box<AggregatedDataUpdateJob>),
     /// Invalidates tasks that are dependent on a collectible type.
@@ -1443,6 +1451,17 @@ impl AggregationUpdateQueue {
                             self,
                             ctx,
                         );
+                    }
+                }
+                AggregationUpdateJob::AdjustParentCount { task_ids, delta } => {
+                    // Apply the persistent parent_count delta to each task. Maintained here (rather
+                    // than inline at the edge sites) so the update rides the durable queue: a
+                    // snapshot captures it mid-flight and it replays to completion on restart,
+                    // keeping the count crash-consistent. Collection when the count hits 0 is wired
+                    // in a later stage (snapshot tombstone + eviction removal).
+                    for task_id in task_ids {
+                        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+                        task.update_and_get_parent_count(delta);
                     }
                 }
                 AggregationUpdateJob::DecreaseActiveCount { task } => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -116,6 +116,20 @@ impl CleanupOldEdgesOperation {
                                 // handler — not this site — adjusts the right counter and takes the
                                 // child guards (avoiding a second guard while `task` is still
                                 // held).
+                                //
+                                // Unlike the `+1` (which is folded into a guard `connect_child`
+                                // already holds on the child — see `ParentCountBump`), this `-1` is
+                                // NOT folded onto an existing guard: here the guard we hold is the
+                                // *parent's* (`task_id`), while the count lives on each *child*,
+                                // and taking a child guard under
+                                // the parent guard is disallowed (the
+                                // concurrent-lock detector; hence the deferral). The lost-followers
+                                // fan-out below does guard the children, but it fragments/recurses
+                                // with no singular per-child job to carry a token safely. This is
+                                // also a cold path (re-execution with changed children, and GC
+                                // teardown) — not the hot `connect_children` path — so the separate
+                                // guard pass in the `AdjustParentCount`/`AdjustTransientRefCount`
+                                // handler is left as-is.
                                 if !removed_persistent_children.is_empty() {
                                     let job = if task_id.is_transient() {
                                         AggregationUpdateJob::AdjustTransientRefCount {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -9,7 +9,7 @@ use crate::{
     backend::{
         TaskDataCategory,
         operation::{
-            AggregatedDataUpdate, ExecuteContext, Operation, TaskGuard,
+            AggregatedDataUpdate, ExecuteContext, Operation,
             aggregation_update::{
                 AggregationUpdateJob, AggregationUpdateQueue, InnerOfUppersLostFollowersJob,
                 get_aggregation_number, get_uppers, is_aggregating_node,
@@ -97,12 +97,10 @@ impl CleanupOldEdgesOperation {
                                 });
                                 let mut task = ctx.task(task_id, TaskDataCategory::All);
                                 // Track which persistent children were *actually* removed (the edge
-                                // was present) so we decrement the child-side parent count exactly
-                                // once per real edge removal. Gating on the `remove_children`
-                                // return makes the decrement
-                                // replay-safe: a resumed CleanupOldEdges
-                                // re-removes the same edges, and edges already gone (returning
-                                // false) are skipped.
+                                // was present) so we adjust the child-side count exactly once per
+                                // real edge removal. Gating on the `remove_children` return makes
+                                // this replay-safe: a resumed CleanupOldEdges re-removes the same
+                                // edges, and edges already gone (returning false) are skipped.
                                 let mut removed_persistent_children: SmallVec<[TaskId; 4]> =
                                     SmallVec::new();
                                 for child_id in children.iter() {
@@ -110,23 +108,29 @@ impl CleanupOldEdgesOperation {
                                         removed_persistent_children.push(*child_id);
                                     }
                                 }
-                                // A persistent parent losing a child drops that child's durable
-                                // `parent_count`; push it on the durable queue for
-                                // crash-consistency
-                                // (the transient-parent case is handled after `task` is dropped, to
-                                // avoid holding two task guards at once). Empty job is skipped.
-                                if !removed_persistent_children.is_empty()
-                                    && !task_id.is_transient()
-                                {
-                                    queue.push(AggregationUpdateJob::AdjustParentCount {
-                                        task_ids: removed_persistent_children.clone(),
-                                        delta: -1,
-                                    });
+                                // Each removed persistent child loses a parent. A persistent parent
+                                // drops the child's durable `parent_count` (queued so it is
+                                // crash-consistent); a transient parent drops the session-only
+                                // `transient_ref_count` (skipped during serialization, never
+                                // replayed). Both ride the queue via the same job family, so the
+                                // handler — not this site — adjusts the right counter and takes the
+                                // child guards (avoiding a second guard while `task` is still
+                                // held).
+                                if !removed_persistent_children.is_empty() {
+                                    let job = if task_id.is_transient() {
+                                        AggregationUpdateJob::AdjustTransientRefCount {
+                                            task_ids: removed_persistent_children,
+                                            delta: -1,
+                                        }
+                                    } else {
+                                        AggregationUpdateJob::AdjustParentCount {
+                                            task_ids: removed_persistent_children,
+                                            delta: -1,
+                                        }
+                                    };
+                                    queue.push(job);
                                 }
                                 if is_aggregating_node(get_aggregation_number(&task)) {
-                                    // Drop the parent guard before the transient block below opens
-                                    // child guards (holding two task guards trips the concurrent-
-                                    // lock detector). The non-aggregating branch drops it too.
                                     drop(task);
                                     queue.push(AggregationUpdateJob::InnerOfUpperLostFollowers {
                                         upper_id: task_id,
@@ -153,18 +157,6 @@ impl CleanupOldEdgesOperation {
                                         }
                                         .into(),
                                     );
-                                }
-                                // Transient parent → drop the session-only `transient_ref_count`
-                                // on each removed persistent child. Done here, after the parent
-                                // guard `task` has been dropped in both branches above, so we never
-                                // hold two task guards at once. Transient counts are not persisted,
-                                // so they don't need the durable queue.
-                                if task_id.is_transient() {
-                                    for child in removed_persistent_children {
-                                        let mut child_task =
-                                            ctx.task(child, TaskDataCategory::Meta);
-                                        child_task.update_and_get_transient_ref_count(-1);
-                                    }
                                 }
                             }
                             OutdatedEdge::Collectible(collectible, count) => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -116,20 +116,6 @@ impl CleanupOldEdgesOperation {
                                 // handler — not this site — adjusts the right counter and takes the
                                 // child guards (avoiding a second guard while `task` is still
                                 // held).
-                                //
-                                // Unlike the `+1` (which is folded into a guard `connect_child`
-                                // already holds on the child — see `ParentCountBump`), this `-1` is
-                                // NOT folded onto an existing guard: here the guard we hold is the
-                                // *parent's* (`task_id`), while the count lives on each *child*,
-                                // and taking a child guard under
-                                // the parent guard is disallowed (the
-                                // concurrent-lock detector; hence the deferral). The lost-followers
-                                // fan-out below does guard the children, but it fragments/recurses
-                                // with no singular per-child job to carry a token safely. This is
-                                // also a cold path (re-execution with changed children, and GC
-                                // teardown) — not the hot `connect_children` path — so the separate
-                                // guard pass in the `AdjustParentCount`/`AdjustTransientRefCount`
-                                // handler is left as-is.
                                 if !removed_persistent_children.is_empty() {
                                     let job = if task_id.is_transient() {
                                         AggregationUpdateJob::AdjustTransientRefCount {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -204,6 +204,19 @@ impl CleanupOldEdgesOperation {
                                     task: cell_task_id,
                                     cell,
                                 } = forward;
+                                // Under the GC phase, a collected task stays resident
+                                // (soft-deleted) so this scrub
+                                // finds a live entry; a non-resident target would mean
+                                // `ctx.task` is about to resurrect an already-collected task from
+                                // disk (the bug soft-deletion fixes). `gc_target_resident` is
+                                // `None` outside GC, where
+                                // restoring a missing target is legitimate.
+                                debug_assert!(
+                                    ctx.gc_target_resident(cell_task_id) != Some(false),
+                                    "gc: CleanupOldEdges({task_id}) cell-dep target \
+                                     {cell_task_id} is not resident — would resurrect a collected \
+                                     task"
+                                );
                                 {
                                     let mut task = ctx.task(cell_task_id, TaskDataCategory::Data);
                                     task.remove_cell_dependents(&CellRef {
@@ -245,6 +258,14 @@ impl CleanupOldEdgesOperation {
                                     dependent_task = %task_id
                                 )
                                 .entered();
+                                // See the CellDependency arm: under GC the target must stay
+                                // resident; a non-resident one would resurrect a collected task.
+                                debug_assert!(
+                                    ctx.gc_target_resident(output_task_id) != Some(false),
+                                    "gc: CleanupOldEdges({task_id}) output-dep target \
+                                     {output_task_id} is not resident — would resurrect a \
+                                     collected task"
+                                );
                                 {
                                     let mut task = ctx.task(output_task_id, TaskDataCategory::Data);
                                     task.remove_output_dependent(&task_id);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -9,7 +9,7 @@ use crate::{
     backend::{
         TaskDataCategory,
         operation::{
-            AggregatedDataUpdate, ExecuteContext, Operation,
+            AggregatedDataUpdate, ExecuteContext, Operation, TaskGuard,
             aggregation_update::{
                 AggregationUpdateJob, AggregationUpdateQueue, InnerOfUppersLostFollowersJob,
                 get_aggregation_number, get_uppers, is_aggregating_node,
@@ -96,10 +96,38 @@ impl CleanupOldEdgesOperation {
                                     _ => true,
                                 });
                                 let mut task = ctx.task(task_id, TaskDataCategory::All);
-                                for task_id in children.iter() {
-                                    task.remove_children(task_id);
+                                // Track which persistent children were *actually* removed (the edge
+                                // was present) so we decrement the child-side parent count exactly
+                                // once per real edge removal. Gating on the `remove_children`
+                                // return makes the decrement
+                                // replay-safe: a resumed CleanupOldEdges
+                                // re-removes the same edges, and edges already gone (returning
+                                // false) are skipped.
+                                let mut removed_persistent_children: SmallVec<[TaskId; 4]> =
+                                    SmallVec::new();
+                                for child_id in children.iter() {
+                                    if task.remove_children(child_id) && !child_id.is_transient() {
+                                        removed_persistent_children.push(*child_id);
+                                    }
+                                }
+                                // A persistent parent losing a child drops that child's durable
+                                // `parent_count`; push it on the durable queue for
+                                // crash-consistency
+                                // (the transient-parent case is handled after `task` is dropped, to
+                                // avoid holding two task guards at once). Empty job is skipped.
+                                if !removed_persistent_children.is_empty()
+                                    && !task_id.is_transient()
+                                {
+                                    queue.push(AggregationUpdateJob::AdjustParentCount {
+                                        task_ids: removed_persistent_children.clone(),
+                                        delta: -1,
+                                    });
                                 }
                                 if is_aggregating_node(get_aggregation_number(&task)) {
+                                    // Drop the parent guard before the transient block below opens
+                                    // child guards (holding two task guards trips the concurrent-
+                                    // lock detector). The non-aggregating branch drops it too.
+                                    drop(task);
                                     queue.push(AggregationUpdateJob::InnerOfUpperLostFollowers {
                                         upper_id: task_id,
                                         lost_follower_ids: children,
@@ -125,6 +153,18 @@ impl CleanupOldEdgesOperation {
                                         }
                                         .into(),
                                     );
+                                }
+                                // Transient parent → drop the session-only `transient_parent_count`
+                                // on each removed persistent child. Done here, after the parent
+                                // guard `task` has been dropped in both branches above, so we never
+                                // hold two task guards at once. Transient counts are not persisted,
+                                // so they don't need the durable queue.
+                                if task_id.is_transient() {
+                                    for child in removed_persistent_children {
+                                        let mut child_task =
+                                            ctx.task(child, TaskDataCategory::Meta);
+                                        child_task.update_and_get_transient_parent_count(-1);
+                                    }
                                 }
                             }
                             OutdatedEdge::Collectible(collectible, count) => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -154,7 +154,7 @@ impl CleanupOldEdgesOperation {
                                         .into(),
                                     );
                                 }
-                                // Transient parent → drop the session-only `transient_parent_count`
+                                // Transient parent → drop the session-only `transient_ref_count`
                                 // on each removed persistent child. Done here, after the parent
                                 // guard `task` has been dropped in both branches above, so we never
                                 // hold two task guards at once. Transient counts are not persisted,
@@ -163,7 +163,7 @@ impl CleanupOldEdgesOperation {
                                     for child in removed_persistent_children {
                                         let mut child_task =
                                             ctx.task(child, TaskDataCategory::Meta);
-                                        child_task.update_and_get_transient_parent_count(-1);
+                                        child_task.update_and_get_transient_ref_count(-1);
                                     }
                                 }
                             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -7,11 +7,52 @@ use crate::{
         operation::{
             ExecuteContext, Operation, TaskGuard,
             aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue},
+            invalidate::make_task_dirty,
         },
         storage_schema::TaskStorageAccessors,
     },
     data::{InProgressState, InProgressStateInner},
 };
+
+/// If `task_id` was marked soft-deleted by GC (collected, awaiting tombstone + hard-delete) but is
+/// being connected as a child again, bring it back to life: clear the `deleted` marker and make it
+/// dirty so it re-executes. GC's `CleanupOldEdges` scrubbed all of the task's edges (children +
+/// forward dependencies) when it was collected, so its cells/output are stale and it must recompute
+/// to rebuild them — the resurrection is a real re-validation, not just un-flagging. This is the
+/// single chokepoint through which every re-entry (a `task_cache` hit or a disk hit in
+/// `get_or_create_task`) flows, so no `deleted` task can be returned to live use without reviving.
+fn resurrect_if_deleted(task_id: TaskId, ctx: &mut impl ExecuteContext<'_>) {
+    // Cheap Meta-only check first; only escalate on a hit. `deleted` is a Meta-category flag, so a
+    // Meta guard suffices to test/clear it — `immutable()` (a Data-category flag) is NOT checked
+    // here to avoid forcing a Data restore on the common not-deleted path.
+    let deleted = {
+        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+        let deleted = task.gc_is_deleted();
+        if deleted {
+            task.gc_clear_deleted();
+        }
+        deleted
+    };
+    // Only now (rare) open with the Data category `immutable()` needs.
+    let immutable = deleted && ctx.task(task_id, TaskDataCategory::All).immutable();
+    if deleted && !immutable {
+        // A mutable task's forward-dep edges were scrubbed when GC collected it, so it holds
+        // stale/empty edges and must re-execute to rebuild them: make it dirty. An **immutable**
+        // task cannot be made dirty (invariant enforced in `make_task_dirty`) and does not need to
+        // be — its output is deterministic and still valid; clearing the marker is enough (any
+        // child edges it lost are rebuilt if and when it is re-read, and its inlined output is
+        // self-contained).
+        let mut queue = AggregationUpdateQueue::new();
+        make_task_dirty(
+            task_id,
+            #[cfg(feature = "task_dirty_cause")]
+            crate::backend::operation::invalidate::TaskDirtyCause::Unknown,
+            &mut queue,
+            ctx,
+        );
+        queue.execute(ctx);
+    }
+}
 
 #[derive(Encode, Decode, Clone, Default)]
 #[allow(clippy::large_enum_variant)]
@@ -29,6 +70,10 @@ impl ConnectChildOperation {
         child_task_id: TaskId,
         mut ctx: impl ExecuteContext<'_>,
     ) {
+        // Revive the child first if GC had soft-deleted it: it must be live (and re-executing)
+        // before we wire it into the parent's children / aggregation below.
+        resurrect_if_deleted(child_task_id, &mut ctx);
+
         if let Some(parent_task_id) = parent_task_id {
             let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
             let Some(InProgressState::InProgress(box InProgressStateInner {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -6,7 +6,7 @@ use crate::{
         TaskDataCategory,
         operation::{
             ExecuteContext, Operation, TaskGuard,
-            aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue},
+            aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue, ParentCountBump},
             invalidate::make_task_dirty,
         },
         storage_schema::TaskStorageAccessors,
@@ -115,12 +115,49 @@ impl ConnectChildOperation {
             });
         }
 
+        // This child edge is genuinely new (it passed the dedup early-returns above), so it takes a
+        // child-side reference-count **hold**: a persistent parent holds the child's durable
+        // `parent_count`, a transient parent the session-only `transient_ref_count`. The hold is
+        // taken OPTIMISTICALLY here (before the `new_children.insert` below confirms we won),
+        // riding a guard we take anyway — exactly like the active-count hold. It is
+        // balanced by: the undo on a concurrent-connect race (below), a release on a
+        // stale/cancel discard (see `ExecuteContext::release_children_holds`), or — on
+        // success — by becoming permanent when `connect_children` commits the edge (and
+        // eventually the `-1` in `CleanupOldEdges`). Transient children are never
+        // collected, so they take no hold.
+        let bump = match parent_task_id {
+            Some(parent) if !child_task_id.is_transient() => {
+                if parent.is_transient() {
+                    ParentCountBump::BumpTransientParent
+                } else {
+                    ParentCountBump::BumpParent
+                }
+            }
+            _ => ParentCountBump::NoBump,
+        };
+
         if ctx.should_track_activeness() && parent_task_id.is_some() {
+            // The active-count bump's handler (`increase_active_count`) already opens a Meta guard
+            // on the child; the `bump` token makes it take the parent_count hold under that same
+            // guard — free.
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
+                bump,
             });
         } else {
             let mut child_task = ctx.task(child_task_id, TaskDataCategory::Meta);
+
+            // Take the hold under the guard we open here anyway (no active-count bump on this
+            // branch). `NoBump` (transient child / no parent) does nothing.
+            match bump {
+                ParentCountBump::NoBump => {}
+                ParentCountBump::BumpParent => {
+                    child_task.update_and_get_parent_count(1);
+                }
+                ParentCountBump::BumpTransientParent => {
+                    child_task.update_and_get_transient_ref_count(1);
+                }
+            }
 
             if !child_task.has_output()
                 && child_task.add_scheduled(
@@ -150,14 +187,26 @@ impl ConnectChildOperation {
             if !new_children.insert(child_task_id) {
                 drop(parent_task);
 
-                // There was a concurrent connect child operation,
-                // so we need to undo the active count update.
+                // There was a concurrent connect child operation, so this call did NOT win the
+                // edge. Undo both optimistic holds taken above: the active count, and the
+                // parent_count / transient_ref_count (the winning call keeps its own +1).
                 AggregationUpdateQueue::run(
                     AggregationUpdateJob::DecreaseActiveCount {
                         task: child_task_id,
                     },
                     &mut ctx,
                 );
+                match bump {
+                    ParentCountBump::NoBump => {}
+                    ParentCountBump::BumpParent => {
+                        ctx.task(child_task_id, TaskDataCategory::Meta)
+                            .update_and_get_parent_count(-1);
+                    }
+                    ParentCountBump::BumpTransientParent => {
+                        ctx.task(child_task_id, TaskDataCategory::Meta)
+                            .update_and_get_transient_ref_count(-1);
+                    }
+                }
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -6,7 +6,7 @@ use crate::{
         TaskDataCategory,
         operation::{
             ExecuteContext, Operation, TaskGuard,
-            aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue, ParentCountBump},
+            aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue},
             invalidate::make_task_dirty,
         },
         storage_schema::TaskStorageAccessors,
@@ -115,49 +115,12 @@ impl ConnectChildOperation {
             });
         }
 
-        // This child edge is genuinely new (it passed the dedup early-returns above), so it takes a
-        // child-side reference-count **hold**: a persistent parent holds the child's durable
-        // `parent_count`, a transient parent the session-only `transient_ref_count`. The hold is
-        // taken OPTIMISTICALLY here (before the `new_children.insert` below confirms we won),
-        // riding a guard we take anyway — exactly like the active-count hold. It is
-        // balanced by: the undo on a concurrent-connect race (below), a release on a
-        // stale/cancel discard (see `ExecuteContext::release_children_holds`), or — on
-        // success — by becoming permanent when `connect_children` commits the edge (and
-        // eventually the `-1` in `CleanupOldEdges`). Transient children are never
-        // collected, so they take no hold.
-        let bump = match parent_task_id {
-            Some(parent) if !child_task_id.is_transient() => {
-                if parent.is_transient() {
-                    ParentCountBump::BumpTransientParent
-                } else {
-                    ParentCountBump::BumpParent
-                }
-            }
-            _ => ParentCountBump::NoBump,
-        };
-
         if ctx.should_track_activeness() && parent_task_id.is_some() {
-            // The active-count bump's handler (`increase_active_count`) already opens a Meta guard
-            // on the child; the `bump` token makes it take the parent_count hold under that same
-            // guard — free.
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
-                bump,
             });
         } else {
             let mut child_task = ctx.task(child_task_id, TaskDataCategory::Meta);
-
-            // Take the hold under the guard we open here anyway (no active-count bump on this
-            // branch). `NoBump` (transient child / no parent) does nothing.
-            match bump {
-                ParentCountBump::NoBump => {}
-                ParentCountBump::BumpParent => {
-                    child_task.update_and_get_parent_count(1);
-                }
-                ParentCountBump::BumpTransientParent => {
-                    child_task.update_and_get_transient_ref_count(1);
-                }
-            }
 
             if !child_task.has_output()
                 && child_task.add_scheduled(
@@ -187,26 +150,14 @@ impl ConnectChildOperation {
             if !new_children.insert(child_task_id) {
                 drop(parent_task);
 
-                // There was a concurrent connect child operation, so this call did NOT win the
-                // edge. Undo both optimistic holds taken above: the active count, and the
-                // parent_count / transient_ref_count (the winning call keeps its own +1).
+                // There was a concurrent connect child operation,
+                // so we need to undo the active count update.
                 AggregationUpdateQueue::run(
                     AggregationUpdateJob::DecreaseActiveCount {
                         task: child_task_id,
                     },
                     &mut ctx,
                 );
-                match bump {
-                    ParentCountBump::NoBump => {}
-                    ParentCountBump::BumpParent => {
-                        ctx.task(child_task_id, TaskDataCategory::Meta)
-                            .update_and_get_parent_count(-1);
-                    }
-                    ParentCountBump::BumpTransientParent => {
-                        ctx.task(child_task_id, TaskDataCategory::Meta)
-                            .update_and_get_transient_ref_count(-1);
-                    }
-                }
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -7,51 +7,64 @@ use crate::{
         operation::{
             ExecuteContext, Operation, TaskGuard,
             aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue},
-            invalidate::make_task_dirty,
+            invalidate::make_task_dirty_internal,
         },
         storage_schema::TaskStorageAccessors,
     },
     data::{InProgressState, InProgressStateInner},
 };
 
-/// If `task_id` was marked soft-deleted by GC (collected, awaiting tombstone + hard-delete) but is
-/// being connected as a child again, bring it back to life: clear the `deleted` marker and make it
-/// dirty so it re-executes. GC's `CleanupOldEdges` scrubbed all of the task's edges (children +
-/// forward dependencies) when it was collected, so its cells/output are stale and it must recompute
-/// to rebuild them — the resurrection is a real re-validation, not just un-flagging. This is the
-/// single chokepoint through which every re-entry (a `task_cache` hit or a disk hit in
-/// `get_or_create_task`) flows, so no `deleted` task can be returned to live use without reviving.
-fn resurrect_if_deleted(task_id: TaskId, ctx: &mut impl ExecuteContext<'_>) {
-    // Cheap Meta-only check first; only escalate on a hit. `deleted` is a Meta-category flag, so a
-    // Meta guard suffices to test/clear it — `immutable()` (a Data-category flag) is NOT checked
-    // here to avoid forcing a Data restore on the common not-deleted path.
-    let deleted = {
-        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
-        let deleted = task.deleted();
-        if deleted {
+/// Revive a task the caller observed as GC-soft-deleted (via `guard.deleted()` on a guard it
+/// already holds during the connect handshake). The caller passes that guard **by value**; this
+/// consumes it, performs the revival, and returns a freshly re-acquired guard of the same
+/// `category`, so the call site is simply `guard = resurrect_deleted(guard, ..)` with the
+/// drop/re-acquire encapsulated here.
+///
+/// The passed guard is dropped and an `All` guard re-acquired (needed for the `immutable()` read),
+/// under which `deleted` is **re-checked** — double-checked locking: between the caller's cheap
+/// peek and this re-acquire, a concurrent connect of the same task could have already revived it,
+/// in which case there is nothing to do. When still deleted, the clear and the re-dirty happen
+/// **under that single `All` guard without an intervening drop**, so no operation can observe the
+/// intermediate `!deleted && !dirty` state (a task that looks live but still holds the stale/empty
+/// edges GC scrubbed). A **mutable** task is cleared and made dirty so it re-executes and rebuilds
+/// those edges; an **immutable** task cannot be made dirty (invariant in `make_task_dirty`) and
+/// does not need to be — its output is deterministic and its edges self-contained — so clearing the
+/// marker alone suffices, leaving it immediately valid for any concurrent observer.
+///
+/// GC collection is the single producer of the `deleted` flag and runs under an exclusion that
+/// stops all operations, so once cleared here the flag cannot be re-set concurrently.
+pub(super) fn resurrect_deleted<'e, C: ExecuteContext<'e>>(
+    guard: C::TaskGuardImpl,
+    task_id: TaskId,
+    category: TaskDataCategory,
+    queue: &mut AggregationUpdateQueue,
+    ctx: &mut C,
+) -> C::TaskGuardImpl {
+    // Release the caller's (Meta-ish) guard so we can re-acquire `All` for the `immutable()` read.
+    drop(guard);
+    {
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        // Double-check under the re-acquired guard: a concurrent connect may have revived it in the
+        // gap.
+        if task.deleted() {
+            // Clear + re-dirty atomically under this single guard so no observer sees `!deleted`
+            // before the task has been re-validated.
             task.set_deleted(false);
+            if !task.immutable() {
+                make_task_dirty_internal(
+                    task,
+                    task_id,
+                    true,
+                    #[cfg(feature = "task_dirty_cause")]
+                    crate::backend::operation::invalidate::TaskDirtyCause::Unknown,
+                    queue,
+                    ctx,
+                );
+            }
         }
-        deleted
-    };
-    // Only now (rare) open with the Data category `immutable()` needs.
-    let immutable = deleted && ctx.task(task_id, TaskDataCategory::All).immutable();
-    if deleted && !immutable {
-        // A mutable task's forward-dep edges were scrubbed when GC collected it, so it holds
-        // stale/empty edges and must re-execute to rebuild them: make it dirty. An **immutable**
-        // task cannot be made dirty (invariant enforced in `make_task_dirty`) and does not need to
-        // be — its output is deterministic and still valid; clearing the marker is enough (any
-        // child edges it lost are rebuilt if and when it is re-read, and its inlined output is
-        // self-contained).
-        let mut queue = AggregationUpdateQueue::new();
-        make_task_dirty(
-            task_id,
-            #[cfg(feature = "task_dirty_cause")]
-            crate::backend::operation::invalidate::TaskDirtyCause::Unknown,
-            &mut queue,
-            ctx,
-        );
-        queue.execute(ctx);
     }
+    // Hand back a guard of the caller's category so it can continue the handshake.
+    ctx.task(task_id, category)
 }
 
 #[derive(Encode, Decode, Clone, Default)]
@@ -70,9 +83,15 @@ impl ConnectChildOperation {
         child_task_id: TaskId,
         mut ctx: impl ExecuteContext<'_>,
     ) {
-        // Revive the child first if GC had soft-deleted it: it must be live (and re-executing)
-        // before we wire it into the parent's children / aggregation below.
-        resurrect_if_deleted(child_task_id, &mut ctx);
+        // Resurrection of a GC-soft-deleted child (clearing the `deleted` marker + re-dirtying it)
+        // is folded into the child guard the connect handshake takes below — the activeness path
+        // does it in `increase_active_count`, the non-activeness path inline — so the common
+        // (not-deleted) case costs only a Meta flag read on a guard we hold anyway, with no extra
+        // acquisition. A `deleted` child is always in NEITHER the parent's `children` nor its
+        // `new_children` when first connected (GC only collects `parent_count == 0` tasks, so it is
+        // in no live parent's children; and a prior connect in this execution would have already
+        // staged+resurrected it), so the dedup early-returns below never skip a needed
+        // resurrection.
 
         if let Some(parent_task_id) = parent_task_id {
             let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
@@ -116,11 +135,29 @@ impl ConnectChildOperation {
         }
 
         if ctx.should_track_activeness() && parent_task_id.is_some() {
+            // Resurrection rides the child guard `increase_active_count` takes (see the
+            // `resurrect` flag on the job).
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
+                resurrect: true,
             });
         } else {
             let mut child_task = ctx.task(child_task_id, TaskDataCategory::Meta);
+
+            // Peek for GC soft-deletion on the guard we already hold — common path: one Meta flag
+            // read, no extra lock. Rare (was deleted): `resurrect_deleted` consumes this guard,
+            // re-acquires `All` to double-check and atomically clear+re-dirty, and hands back a
+            // fresh Meta guard for the schedule decision below. Resurrection thus completes before
+            // scheduling, matching the original resurrect-first order.
+            if child_task.deleted() {
+                child_task = resurrect_deleted(
+                    child_task,
+                    child_task_id,
+                    TaskDataCategory::Meta,
+                    &mut queue,
+                    &mut ctx,
+                );
+            }
 
             if !child_task.has_output()
                 && child_task.add_scheduled(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -27,9 +27,9 @@ fn resurrect_if_deleted(task_id: TaskId, ctx: &mut impl ExecuteContext<'_>) {
     // here to avoid forcing a Data restore on the common not-deleted path.
     let deleted = {
         let mut task = ctx.task(task_id, TaskDataCategory::Meta);
-        let deleted = task.gc_is_deleted();
+        let deleted = task.deleted();
         if deleted {
-            task.gc_clear_deleted();
+            task.set_deleted(false);
         }
         deleted
     };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -6,13 +6,10 @@ use turbo_tasks::{
     util::{good_chunk_size, into_chunks},
 };
 
-use crate::backend::{
-    TaskDataCategory,
-    operation::{
-        AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext,
-        Operation, TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob,
-        get_aggregation_number, get_uppers, is_aggregating_node,
-    },
+use crate::backend::operation::{
+    AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext, Operation,
+    TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob, get_aggregation_number,
+    get_uppers, is_aggregating_node,
 };
 
 pub fn connect_children(
@@ -54,26 +51,24 @@ pub fn connect_children(
 
     // Maintain the child-side parent reference count now that the parent guard is released. Each
     // newly-connected persistent child gains a parent: a persistent parent bumps the durable
-    // `parent_count` (rides the `AggregationUpdateQueue` so it is crash-consistent — captured
-    // mid-snapshot, replayed on restart; see `AggregationUpdateJob::AdjustParentCount`), while a
-    // transient parent bumps the session-only `transient_ref_count` (transient parents vanish on
-    // restart and re-establish their edges by re-execution, so their contribution must not
-    // persist). Transient children are never collected, so their counts are irrelevant.
+    // `parent_count` (crash-consistent — captured mid-snapshot, replayed on restart), while a
+    // transient parent bumps the session-only `transient_ref_count` (not persisted — transient
+    // parents re-establish their edges by re-executing on restart). Both ride the
+    // `AggregationUpdateQueue`; the handler applies to the right counter. Transient children are
+    // never collected, so their counts are irrelevant.
     if !persistent_new_children.is_empty() {
-        if parent_task_id.is_transient() {
-            for &child in &persistent_new_children {
-                let mut child_task = ctx.task(child, TaskDataCategory::Meta);
-                child_task.update_and_get_transient_ref_count(1);
+        let job = if parent_task_id.is_transient() {
+            AggregationUpdateJob::AdjustTransientRefCount {
+                task_ids: persistent_new_children,
+                delta: 1,
             }
         } else {
-            AggregationUpdateQueue::run(
-                AggregationUpdateJob::AdjustParentCount {
-                    task_ids: persistent_new_children,
-                    delta: 1,
-                },
-                ctx,
-            );
-        }
+            AggregationUpdateJob::AdjustParentCount {
+                task_ids: persistent_new_children,
+                delta: 1,
+            }
+        };
+        AggregationUpdateQueue::run(job, ctx);
     }
 
     fn process_new_children(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -56,14 +56,14 @@ pub fn connect_children(
     // newly-connected persistent child gains a parent: a persistent parent bumps the durable
     // `parent_count` (rides the `AggregationUpdateQueue` so it is crash-consistent — captured
     // mid-snapshot, replayed on restart; see `AggregationUpdateJob::AdjustParentCount`), while a
-    // transient parent bumps the session-only `transient_parent_count` (transient parents vanish on
+    // transient parent bumps the session-only `transient_ref_count` (transient parents vanish on
     // restart and re-establish their edges by re-execution, so their contribution must not
     // persist). Transient children are never collected, so their counts are irrelevant.
     if !persistent_new_children.is_empty() {
         if parent_task_id.is_transient() {
             for &child in &persistent_new_children {
                 let mut child_task = ctx.task(child, TaskDataCategory::Meta);
-                child_task.update_and_get_transient_parent_count(1);
+                child_task.update_and_get_transient_ref_count(1);
             }
         } else {
             AggregationUpdateQueue::run(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use turbo_tasks::{
     TaskId,
@@ -5,35 +6,23 @@ use turbo_tasks::{
     util::{good_chunk_size, into_chunks},
 };
 
-use crate::{
-    backend::operation::{
-        AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext,
-        Operation, TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob,
-        get_aggregation_number, get_uppers, is_aggregating_node,
-    },
-    data::ChildrenCollector,
+use crate::backend::operation::{
+    AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext, Operation,
+    TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob, get_aggregation_number,
+    get_uppers, is_aggregating_node,
 };
 
 pub fn connect_children(
     ctx: &mut impl ExecuteContext<'_>,
     parent_task_id: TaskId,
     mut parent_task: impl TaskGuard,
-    new_children: ChildrenCollector,
+    new_children: FxHashSet<TaskId>,
     parent_has_active_count: bool,
     should_track_activeness: bool,
 ) {
     debug_assert!(!new_children.is_empty());
 
     let parent_aggregation = get_aggregation_number(&parent_task);
-
-    // Commit the staged edges: they become permanent members of `children`. The child-side
-    // `parent_count` / `transient_ref_count` holds were already taken optimistically when each
-    // genuinely-new child was staged in `ConnectChildOperation::run` (riding the guard taken there
-    // for the active-count bump / schedule), so there is NO count adjustment here — committing just
-    // makes those holds permanent. Balanced later by the `-1` in `CleanupOldEdges` when the edge is
-    // removed. (This is why the old separate `AdjustParentCount { +1 }` pass over the children,
-    // which took a second child guard each, is gone.)
-    let new_children = new_children.commit();
 
     let old_children = parent_task.children_len();
     parent_task.extend_children(new_children.iter().copied());
@@ -44,12 +33,43 @@ pub fn connect_children(
         len = new_children.len()
     );
 
+    // Collect the newly-connected **persistent** children now (cheap, no locks) so we can adjust
+    // their child-side parent reference count *after* the parent guard is dropped — taking a child
+    // guard while still holding the parent guard would trip the concurrent-lock detector.
+    let persistent_new_children: SmallVec<[TaskId; 4]> = new_children
+        .iter()
+        .copied()
+        .filter(|c| !c.is_transient())
+        .collect();
+
     let new_follower_ids: SmallVec<_> = new_children.into_iter().collect();
 
     let aggregating_node = is_aggregating_node(parent_aggregation);
     let upper_ids = (!aggregating_node).then(|| get_uppers(&parent_task));
 
     drop(parent_task);
+
+    // Maintain the child-side parent reference count now that the parent guard is released. Each
+    // newly-connected persistent child gains a parent: a persistent parent bumps the durable
+    // `parent_count` (crash-consistent — captured mid-snapshot, replayed on restart), while a
+    // transient parent bumps the session-only `transient_ref_count` (not persisted — transient
+    // parents re-establish their edges by re-executing on restart). Both ride the
+    // `AggregationUpdateQueue`; the handler applies to the right counter. Transient children are
+    // never collected, so their counts are irrelevant.
+    if !persistent_new_children.is_empty() {
+        let job = if parent_task_id.is_transient() {
+            AggregationUpdateJob::AdjustTransientRefCount {
+                task_ids: persistent_new_children,
+                delta: 1,
+            }
+        } else {
+            AggregationUpdateJob::AdjustParentCount {
+                task_ids: persistent_new_children,
+                delta: 1,
+            }
+        };
+        AggregationUpdateQueue::run(job, ctx);
+    }
 
     fn process_new_children(
         ctx: &mut impl ExecuteContext<'_>,
@@ -144,10 +164,10 @@ pub fn connect_children(
     // This avoids long pauses of more than 30µs * 10k = 300ms.
     // We don't want to parallelize too eagerly as spawning tasks and the temporary allocations have
     // a cost as well.
-    const CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD: usize = 10000;
+    const CONNECT_CHILDREN_PARALLIZATION_THRESHOLD: usize = 10000;
 
     let len = new_follower_ids.len();
-    if len >= CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD {
+    if len >= CONNECT_CHILDREN_PARALLIZATION_THRESHOLD {
         let new_follower_ids = new_follower_ids.into_vec();
         let chunk_size = good_chunk_size(len);
         let _ = scope_and_block(len.div_ceil(chunk_size), |scope| {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -1,4 +1,3 @@
-use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use turbo_tasks::{
     TaskId,
@@ -6,23 +5,35 @@ use turbo_tasks::{
     util::{good_chunk_size, into_chunks},
 };
 
-use crate::backend::operation::{
-    AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext, Operation,
-    TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob, get_aggregation_number,
-    get_uppers, is_aggregating_node,
+use crate::{
+    backend::operation::{
+        AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext,
+        Operation, TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob,
+        get_aggregation_number, get_uppers, is_aggregating_node,
+    },
+    data::ChildrenCollector,
 };
 
 pub fn connect_children(
     ctx: &mut impl ExecuteContext<'_>,
     parent_task_id: TaskId,
     mut parent_task: impl TaskGuard,
-    new_children: FxHashSet<TaskId>,
+    new_children: ChildrenCollector,
     parent_has_active_count: bool,
     should_track_activeness: bool,
 ) {
     debug_assert!(!new_children.is_empty());
 
     let parent_aggregation = get_aggregation_number(&parent_task);
+
+    // Commit the staged edges: they become permanent members of `children`. The child-side
+    // `parent_count` / `transient_ref_count` holds were already taken optimistically when each
+    // genuinely-new child was staged in `ConnectChildOperation::run` (riding the guard taken there
+    // for the active-count bump / schedule), so there is NO count adjustment here — committing just
+    // makes those holds permanent. Balanced later by the `-1` in `CleanupOldEdges` when the edge is
+    // removed. (This is why the old separate `AdjustParentCount { +1 }` pass over the children,
+    // which took a second child guard each, is gone.)
+    let new_children = new_children.commit();
 
     let old_children = parent_task.children_len();
     parent_task.extend_children(new_children.iter().copied());
@@ -33,43 +44,12 @@ pub fn connect_children(
         len = new_children.len()
     );
 
-    // Collect the newly-connected **persistent** children now (cheap, no locks) so we can adjust
-    // their child-side parent reference count *after* the parent guard is dropped — taking a child
-    // guard while still holding the parent guard would trip the concurrent-lock detector.
-    let persistent_new_children: SmallVec<[TaskId; 4]> = new_children
-        .iter()
-        .copied()
-        .filter(|c| !c.is_transient())
-        .collect();
-
     let new_follower_ids: SmallVec<_> = new_children.into_iter().collect();
 
     let aggregating_node = is_aggregating_node(parent_aggregation);
     let upper_ids = (!aggregating_node).then(|| get_uppers(&parent_task));
 
     drop(parent_task);
-
-    // Maintain the child-side parent reference count now that the parent guard is released. Each
-    // newly-connected persistent child gains a parent: a persistent parent bumps the durable
-    // `parent_count` (crash-consistent — captured mid-snapshot, replayed on restart), while a
-    // transient parent bumps the session-only `transient_ref_count` (not persisted — transient
-    // parents re-establish their edges by re-executing on restart). Both ride the
-    // `AggregationUpdateQueue`; the handler applies to the right counter. Transient children are
-    // never collected, so their counts are irrelevant.
-    if !persistent_new_children.is_empty() {
-        let job = if parent_task_id.is_transient() {
-            AggregationUpdateJob::AdjustTransientRefCount {
-                task_ids: persistent_new_children,
-                delta: 1,
-            }
-        } else {
-            AggregationUpdateJob::AdjustParentCount {
-                task_ids: persistent_new_children,
-                delta: 1,
-            }
-        };
-        AggregationUpdateQueue::run(job, ctx);
-    }
 
     fn process_new_children(
         ctx: &mut impl ExecuteContext<'_>,
@@ -164,10 +144,10 @@ pub fn connect_children(
     // This avoids long pauses of more than 30µs * 10k = 300ms.
     // We don't want to parallelize too eagerly as spawning tasks and the temporary allocations have
     // a cost as well.
-    const CONNECT_CHILDREN_PARALLIZATION_THRESHOLD: usize = 10000;
+    const CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD: usize = 10000;
 
     let len = new_follower_ids.len();
-    if len >= CONNECT_CHILDREN_PARALLIZATION_THRESHOLD {
+    if len >= CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD {
         let new_follower_ids = new_follower_ids.into_vec();
         let chunk_size = good_chunk_size(len);
         let _ = scope_and_block(len.div_ceil(chunk_size), |scope| {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -33,43 +33,12 @@ pub fn connect_children(
         len = new_children.len()
     );
 
-    // Collect the newly-connected **persistent** children now (cheap, no locks) so we can adjust
-    // their child-side parent reference count *after* the parent guard is dropped — taking a child
-    // guard while still holding the parent guard would trip the concurrent-lock detector.
-    let persistent_new_children: SmallVec<[TaskId; 4]> = new_children
-        .iter()
-        .copied()
-        .filter(|c| !c.is_transient())
-        .collect();
-
     let new_follower_ids: SmallVec<_> = new_children.into_iter().collect();
 
     let aggregating_node = is_aggregating_node(parent_aggregation);
     let upper_ids = (!aggregating_node).then(|| get_uppers(&parent_task));
 
     drop(parent_task);
-
-    // Maintain the child-side parent reference count now that the parent guard is released. Each
-    // newly-connected persistent child gains a parent: a persistent parent bumps the durable
-    // `parent_count` (crash-consistent — captured mid-snapshot, replayed on restart), while a
-    // transient parent bumps the session-only `transient_ref_count` (not persisted — transient
-    // parents re-establish their edges by re-executing on restart). Both ride the
-    // `AggregationUpdateQueue`; the handler applies to the right counter. Transient children are
-    // never collected, so their counts are irrelevant.
-    if !persistent_new_children.is_empty() {
-        let job = if parent_task_id.is_transient() {
-            AggregationUpdateJob::AdjustTransientRefCount {
-                task_ids: persistent_new_children,
-                delta: 1,
-            }
-        } else {
-            AggregationUpdateJob::AdjustParentCount {
-                task_ids: persistent_new_children,
-                delta: 1,
-            }
-        };
-        AggregationUpdateQueue::run(job, ctx);
-    }
 
     fn process_new_children(
         ctx: &mut impl ExecuteContext<'_>,
@@ -80,6 +49,51 @@ pub fn connect_children(
         should_track_activeness: bool,
     ) {
         debug_assert!(!new_follower_ids.is_empty());
+
+        // Maintain the child-side parent reference count: each newly-connected **persistent** child
+        // gains a parent — a persistent parent bumps the durable `parent_count`, a transient parent
+        // the session-only `transient_ref_count` (not persisted; transient parents re-establish
+        // their edges by re-executing on restart). Transient children are never collected, so they
+        // take no count.
+        //
+        // CRITICAL: this is a **direct** adjustment, NOT a queued `AdjustParentCount` job, and it
+        // MUST run before `queue.execute` below (the first `operation_suspend_point` this function
+        // reaches). GC reads `parent_count` to decide collectibility and only observes state at
+        // suspend points (`begin_gc` drains operations to a suspended/quiescent state). If the `+1`
+        // rode the `AggregationUpdateQueue` instead, that queue's per-iteration suspend point could
+        // suspend with the `+1` still pending — leaving a window where the `children` edge is
+        // committed (`extend_children` in the caller) but `parent_count` is not yet incremented. A
+        // GC pass landing in that window would read the under-counted `parent_count == 0`, judge
+        // the (genuinely reachable) child collectible, and delete it. There is no
+        // `operation_suspend_point` between the caller's `extend_children` and here, so no
+        // snapshot/GC can observe the edge without the count. In the parallelized path this runs on
+        // a child context (which never suspends — it holds no operation guard), inside the
+        // `scope_and_block` barrier that completes within the parent operation, so the property
+        // holds there too. Doing it here (rather than a single pass before the fan-out) lets it
+        // scale with the same chunking as the follower work for very large children sets.
+        //
+        // The `-1` on edge removal (in `CleanupOldEdges`) has the opposite, benign failure mode
+        // (a pending `-1` makes GC *under*-collect for one pass, self-correcting), so it stays on
+        // the durable queue there.
+        let parent_is_transient = parent_task_id.is_transient();
+        let persistent_new_children: SmallVec<[TaskId; 4]> = new_follower_ids
+            .iter()
+            .copied()
+            .filter(|c| !c.is_transient())
+            .collect();
+        if !persistent_new_children.is_empty() {
+            ctx.for_each_task_meta(
+                persistent_new_children,
+                "connect_children parent_count",
+                |mut child, _ctx| {
+                    if parent_is_transient {
+                        child.update_and_get_transient_ref_count(1);
+                    } else {
+                        child.update_and_get_parent_count(1);
+                    }
+                },
+            );
+        }
 
         let mut queue = AggregationUpdateQueue::new();
 
@@ -164,10 +178,10 @@ pub fn connect_children(
     // This avoids long pauses of more than 30µs * 10k = 300ms.
     // We don't want to parallelize too eagerly as spawning tasks and the temporary allocations have
     // a cost as well.
-    const CONNECT_CHILDREN_PARALLIZATION_THRESHOLD: usize = 10000;
+    const CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD: usize = 10000;
 
     let len = new_follower_ids.len();
-    if len >= CONNECT_CHILDREN_PARALLIZATION_THRESHOLD {
+    if len >= CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD {
         let new_follower_ids = new_follower_ids.into_vec();
         let chunk_size = good_chunk_size(len);
         let _ = scope_and_block(len.div_ceil(chunk_size), |scope| {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -6,10 +6,13 @@ use turbo_tasks::{
     util::{good_chunk_size, into_chunks},
 };
 
-use crate::backend::operation::{
-    AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext, Operation,
-    TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob, get_aggregation_number,
-    get_uppers, is_aggregating_node,
+use crate::backend::{
+    TaskDataCategory,
+    operation::{
+        AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext,
+        Operation, TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob,
+        get_aggregation_number, get_uppers, is_aggregating_node,
+    },
 };
 
 pub fn connect_children(
@@ -33,12 +36,45 @@ pub fn connect_children(
         len = new_children.len()
     );
 
+    // Collect the newly-connected **persistent** children now (cheap, no locks) so we can adjust
+    // their child-side parent reference count *after* the parent guard is dropped — taking a child
+    // guard while still holding the parent guard would trip the concurrent-lock detector.
+    let persistent_new_children: SmallVec<[TaskId; 4]> = new_children
+        .iter()
+        .copied()
+        .filter(|c| !c.is_transient())
+        .collect();
+
     let new_follower_ids: SmallVec<_> = new_children.into_iter().collect();
 
     let aggregating_node = is_aggregating_node(parent_aggregation);
     let upper_ids = (!aggregating_node).then(|| get_uppers(&parent_task));
 
     drop(parent_task);
+
+    // Maintain the child-side parent reference count now that the parent guard is released. Each
+    // newly-connected persistent child gains a parent: a persistent parent bumps the durable
+    // `parent_count` (rides the `AggregationUpdateQueue` so it is crash-consistent — captured
+    // mid-snapshot, replayed on restart; see `AggregationUpdateJob::AdjustParentCount`), while a
+    // transient parent bumps the session-only `transient_parent_count` (transient parents vanish on
+    // restart and re-establish their edges by re-execution, so their contribution must not
+    // persist). Transient children are never collected, so their counts are irrelevant.
+    if !persistent_new_children.is_empty() {
+        if parent_task_id.is_transient() {
+            for &child in &persistent_new_children {
+                let mut child_task = ctx.task(child, TaskDataCategory::Meta);
+                child_task.update_and_get_transient_parent_count(1);
+            }
+        } else {
+            AggregationUpdateQueue::run(
+                AggregationUpdateJob::AdjustParentCount {
+                    task_ids: persistent_new_children,
+                    delta: 1,
+                },
+                ctx,
+            );
+        }
+    }
 
     fn process_new_children(
         ctx: &mut impl ExecuteContext<'_>,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -1,15 +1,21 @@
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
+#[cfg(feature = "task_dirty_cause")]
+use turbo_tasks::TaskDirtyCause;
 use turbo_tasks::{
     TaskId,
     scope::scope_and_block,
     util::{good_chunk_size, into_chunks},
 };
 
-use crate::backend::operation::{
-    AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext, Operation,
-    TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob, get_aggregation_number,
-    get_uppers, is_aggregating_node,
+use crate::backend::{
+    operation::{
+        AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext,
+        Operation, TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob,
+        get_aggregation_number, get_uppers, invalidate::make_task_dirty_internal,
+        is_aggregating_node,
+    },
+    storage_schema::TaskStorageAccessors,
 };
 
 pub fn connect_children(
@@ -50,52 +56,72 @@ pub fn connect_children(
     ) {
         debug_assert!(!new_follower_ids.is_empty());
 
-        // Maintain the child-side parent reference count: each newly-connected **persistent** child
-        // gains a parent — a persistent parent bumps the durable `parent_count`, a transient parent
-        // the session-only `transient_ref_count` (not persisted; transient parents re-establish
-        // their edges by re-executing on restart). Transient children are never collected, so they
-        // take no count.
+        let mut queue = AggregationUpdateQueue::new();
+
+        // Single pass over the newly-connected children doing two things per child under one guard,
+        // so we don't lock each child twice (once to bump its ref count, once to dirty it):
         //
-        // CRITICAL: this is a **direct** adjustment, NOT a queued `AdjustParentCount` job, and it
-        // MUST run before `queue.execute` below (the first `operation_suspend_point` this function
-        // reaches). GC reads `parent_count` to decide collectibility and only observes state at
-        // suspend points (`begin_gc` drains operations to a suspended/quiescent state). If the `+1`
-        // rode the `AggregationUpdateQueue` instead, that queue's per-iteration suspend point could
-        // suspend with the `+1` still pending — leaving a window where the `children` edge is
-        // committed (`extend_children` in the caller) but `parent_count` is not yet incremented. A
-        // GC pass landing in that window would read the under-counted `parent_count == 0`, judge
-        // the (genuinely reachable) child collectible, and delete it. There is no
-        // `operation_suspend_point` between the caller's `extend_children` and here, so no
-        // snapshot/GC can observe the edge without the count. In the parallelized path this runs on
-        // a child context (which never suspends — it holds no operation guard), inside the
-        // `scope_and_block` barrier that completes within the parent operation, so the property
-        // holds there too. Doing it here (rather than a single pass before the fan-out) lets it
-        // scale with the same chunking as the follower work for very large children sets.
+        // 1. Maintain the child-side parent reference count for **persistent** children: a
+        //    persistent parent bumps the durable `parent_count`, a transient parent the
+        //    session-only `transient_ref_count` (not persisted; transient parents re-establish
+        //    their edges by re-executing on restart). Transient children are never collected, so
+        //    they take no count.
         //
-        // The `-1` on edge removal (in `CleanupOldEdges`) has the opposite, benign failure mode
-        // (a pending `-1` makes GC *under*-collect for one pass, self-correcting), so it stays on
-        // the durable queue there.
+        //    CRITICAL: this is a **direct** adjustment, NOT a queued `AdjustParentCount` job, and
+        // it    MUST run before `queue.execute` below (the first `operation_suspend_point`
+        // this    function reaches). GC reads `parent_count` to decide collectibility and
+        // only observes    state at suspend points (`begin_gc` drains operations to a
+        // suspended/quiescent state).    If the `+1` rode the `AggregationUpdateQueue`
+        // instead, that queue's per-iteration    suspend point could suspend with the `+1`
+        // still pending — leaving a window where the    `children` edge is committed
+        // (`extend_children` in the caller) but `parent_count` is    not yet incremented. A
+        // GC pass landing in that window would read the under-counted    `parent_count ==
+        // 0`, judge the (genuinely reachable) child collectible, and delete it.    There is
+        // no `operation_suspend_point` between the caller's `extend_children` and here
+        //    (`make_task_dirty_internal` only enqueues; the queue runs later), so no snapshot/GC
+        // can    observe the edge without the count. In the parallelized path this runs on
+        // a child    context (which never suspends — it holds no operation guard), inside
+        // the    `scope_and_block` barrier that completes within the parent operation, so
+        // the property    holds there too. (The `-1` on edge removal in `CleanupOldEdges`
+        // has the opposite,    benign failure mode — a pending `-1` makes GC
+        // *under*-collect for one pass,    self-correcting — so it stays on the durable
+        // queue there.)
+        //
+        // 2. Make any child that has not produced output yet dirty, so it gets scheduled and
+        //    computes. This was formerly a separate `for_each_task_all` pass over the same children
+        //    (`task_execution_completed_unfinished_children_dirty`) before the connect; folding it
+        //    here reuses this guard and, on the parallelized path, chunks it with the rest. It only
+        //    runs on the successful connect (not the stale/cancel early-returns in
+        //    `task_execution_completed_connect`), which is consistent with those paths undoing the
+        //    children's temporarily-increased active count rather than keeping them.
         let parent_is_transient = parent_task_id.is_transient();
-        let persistent_new_children: SmallVec<[TaskId; 4]> = new_follower_ids
-            .iter()
-            .copied()
-            .filter(|c| !c.is_transient())
-            .collect();
-        if !persistent_new_children.is_empty() {
-            ctx.for_each_task_meta(
-                persistent_new_children,
-                "connect_children parent_count",
-                |mut child, _ctx| {
+        ctx.for_each_task_all(
+            new_follower_ids.iter().copied(),
+            "connect_children parent_count + dirty",
+            |mut child, ctx| {
+                // Ref-count bump first (persistent children only), on the `&mut` borrow, before the
+                // guard may be consumed by `make_task_dirty_internal` below.
+                if !child.id().is_transient() {
                     if parent_is_transient {
                         child.update_and_get_transient_ref_count(1);
                     } else {
                         child.update_and_get_parent_count(1);
                     }
-                },
-            );
-        }
-
-        let mut queue = AggregationUpdateQueue::new();
+                }
+                if !child.has_output() {
+                    let child_id = child.id();
+                    make_task_dirty_internal(
+                        child,
+                        child_id,
+                        false,
+                        #[cfg(feature = "task_dirty_cause")]
+                        TaskDirtyCause::InitialDirty,
+                        &mut queue,
+                        ctx,
+                    );
+                }
+            },
+        );
 
         if let Some(upper_ids) = upper_ids {
             // We need to add new followers when there are upper ids as the parent is a leaf node

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -97,7 +97,7 @@ pub trait ExecuteContext<'e>: Sized {
     /// Record that `task_id`'s persistent `parent_count` reached 0, making it a garbage-collection
     /// candidate. This only notes candidacy (a cheap side-set write); the actual teardown/removal
     /// happens later under the GC phase's exclusion, where candidacy is re-validated.
-    fn note_gc_candidate(&self, task_id: TaskId);
+    fn add_gc_candidate(&self, task_id: TaskId);
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi>;
     /// Look up a TaskId from the backing storage for a given task type.
     ///
@@ -199,6 +199,10 @@ impl<'e> ExecuteContextImpl<'e> {
         backend: &'e TurboTasksBackend,
         turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
     ) -> Self {
+        debug_assert!(
+            backend.snapshot_coord.gc_in_progress(),
+            "new_for_gc called outside a held GC phase"
+        );
         Self {
             backend,
             turbo_tasks,
@@ -989,8 +993,8 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
         self.backend.should_track_activeness()
     }
 
-    fn note_gc_candidate(&self, task_id: TaskId) {
-        self.backend.note_gc_candidate(task_id);
+    fn add_gc_candidate(&self, task_id: TaskId) {
+        self.backend.add_gc_candidate(task_id);
     }
 
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi> {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -14,8 +14,6 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use bincode::{Decode, Encode};
-use rustc_hash::FxHashSet;
-use smallvec::SmallVec;
 use tracing::info_span;
 #[cfg(feature = "trace_prepare_tasks")]
 use tracing::trace_span;
@@ -33,10 +31,7 @@ use crate::{
         storage::{SpecificTaskDataCategory, StorageWriteGuard, TrackOutcome},
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    data::{
-        ActivenessState, ChildrenCollector, CollectibleRef, Dirtyness, InProgressState,
-        TransientTask,
-    },
+    data::{ActivenessState, CollectibleRef, Dirtyness, InProgressState, TransientTask},
 };
 
 pub trait Operation: Encode + Decode<()> + Default + TryFrom<AnyOperation, Error = ()> {
@@ -95,57 +90,6 @@ pub trait ExecuteContext<'e>: Sized {
             reason,
             func,
         )
-    }
-    /// Release the `parent_count` (or `transient_ref_count`) holds taken when the children in
-    /// `staged` were staged, because the staged edges are being **discarded** without reaching the
-    /// parent's `children` set. Consumes the [`ChildrenCollector`] and returns the raw set. This is
-    /// the sole intended consumer of [`ChildrenCollector::release_set`].
-    ///
-    /// **This releases only the `parent_count` hold, deliberately NOT the active-count hold.** The
-    /// two holds are parallel (both taken optimistically at staging in
-    /// `ConnectChildOperation::run`) but they diverge on the discard paths, because they have
-    /// different consequences:
-    /// - `parent_count` is durable and correctness-critical — a leaked hold makes the child
-    ///   permanently uncollectible (a real memory leak). So it MUST be released on **every**
-    ///   discard path: stale-in-prepare, stale-in-connect, cancel-in-connect, and
-    ///   `task_execution_canceled`.
-    /// - the active count is transient and best-effort — a leaked hold merely keeps a task "active"
-    ///   slightly too long (self-corrects, resets on restart), so exactness is not required. The
-    ///   **stale** paths release it (via a `DecreaseActiveCounts` the caller enqueues from the
-    ///   returned set); the **cancel** paths do NOT touch the active count for the staged children
-    ///   — this preserves the pre-existing cancel behavior (the active-count subsystem manages
-    ///   canceled tasks on its own). Releasing the active count here on cancel would change that
-    ///   behavior, so this method leaves it alone and the cancel callers ignore the returned set.
-    ///
-    /// So a caller on a *stale* path feeds the returned set to `DecreaseActiveCounts`; a caller on
-    /// a *cancel* path ignores the return.
-    ///
-    /// Precondition: `staged` must already be the *genuinely-new* set — children that were merely
-    /// re-validated (already present in the parent's `children` set) must have been removed while
-    /// the parent guard was held (as the stale/completion/cancel paths already do), because those
-    /// never took a hold. Each **persistent** remaining child is decremented once (a persistent
-    /// parent drops the durable `parent_count`; a transient parent drops the session-only
-    /// `transient_ref_count`), mirroring the `+1` taken optimistically at staging. Transient
-    /// children never took a hold and are skipped.
-    fn release_children_holds(
-        &mut self,
-        parent_task_id: TaskId,
-        staged: ChildrenCollector,
-    ) -> FxHashSet<TaskId> {
-        let set = staged.release_set();
-        let persistent: SmallVec<[TaskId; 4]> =
-            set.iter().copied().filter(|c| !c.is_transient()).collect();
-        if !persistent.is_empty() {
-            let parent_is_transient = parent_task_id.is_transient();
-            self.for_each_task_meta(persistent, "release_children_holds", |mut child, _ctx| {
-                if parent_is_transient {
-                    child.update_and_get_transient_ref_count(-1);
-                } else {
-                    child.update_and_get_parent_count(-1);
-                }
-            });
-        }
-        set
     }
     fn task_pair(
         &mut self,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1152,15 +1152,15 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
 
     /// Like [`Self::update_and_get_parent_count`], but for the transient (session-only) parent
     /// reference count that keeps a persistent task alive while a transient parent references it.
-    fn update_and_get_transient_parent_count(&mut self, delta: i32) -> u32 {
-        let current = self.get_transient_parent_count().copied().unwrap_or(0);
+    fn update_and_get_transient_ref_count(&mut self, delta: i32) -> u32 {
+        let current = self.get_transient_ref_count().copied().unwrap_or(0);
         let new_value = current
             .checked_add_signed(delta)
-            .expect("transient_parent_count underflow");
+            .expect("transient_ref_count underflow");
         if new_value == 0 {
-            self.take_transient_parent_count();
+            self.take_transient_ref_count();
         } else {
-            self.set_transient_parent_count(new_value);
+            self.set_transient_ref_count(new_value);
         }
         new_value
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1104,6 +1104,39 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         new_value
     }
 
+    /// Adjust the count of **persistent** parents referencing this task by `delta` (+1 when a
+    /// persistent parent connects it as a child, -1 when one disconnects it) and return the new
+    /// value. A value of 0 means no persistent parent lists this task — a prerequisite for
+    /// collection. Panics in debug on underflow (a decrement below 0 means the count drifted from
+    /// the true number of `children`-edge references — the invariant this field must uphold).
+    fn update_and_get_parent_count(&mut self, delta: i32) -> u32 {
+        let current = self.get_parent_count().copied().unwrap_or(0);
+        let new_value = current
+            .checked_add_signed(delta)
+            .expect("parent_count underflow: decremented below the number of persistent parents");
+        if new_value == 0 {
+            self.take_parent_count();
+        } else {
+            self.set_parent_count(new_value);
+        }
+        new_value
+    }
+
+    /// Like [`Self::update_and_get_parent_count`], but for the transient (session-only) parent
+    /// reference count that keeps a persistent task alive while a transient parent references it.
+    fn update_and_get_transient_parent_count(&mut self, delta: i32) -> u32 {
+        let current = self.get_transient_parent_count().copied().unwrap_or(0);
+        let new_value = current
+            .checked_add_signed(delta)
+            .expect("transient_parent_count underflow");
+        if new_value == 0 {
+            self.take_transient_parent_count();
+        } else {
+            self.set_transient_parent_count(new_value);
+        }
+        new_value
+    }
+
     fn invalidate_serialization(&mut self);
     /// Determine which tasks to prefetch for a task.
     /// Only returns Some once per task.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -94,10 +94,6 @@ pub trait ExecuteContext<'e>: Sized {
         T: Clone + Into<AnyOperation>;
     fn should_track_dependencies(&self) -> bool;
     fn should_track_activeness(&self) -> bool;
-    /// Record that `task_id`'s persistent `parent_count` reached 0, making it a garbage-collection
-    /// candidate. This only notes candidacy (a cheap side-set write); the actual teardown/removal
-    /// happens later under the GC phase's exclusion, where candidacy is re-validated.
-    fn add_gc_candidate(&self, task_id: TaskId);
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi>;
     /// Look up a TaskId from the backing storage for a given task type.
     ///
@@ -992,10 +988,6 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
         self.backend.should_track_activeness()
     }
 
-    fn add_gc_candidate(&self, task_id: TaskId) {
-        self.backend.add_gc_candidate(task_id);
-    }
-
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi> {
         self.turbo_tasks.pin()
     }
@@ -1145,11 +1137,7 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         let new_value = current
             .checked_add_signed(delta)
             .expect("parent_count underflow: decremented below the number of persistent parents");
-        if new_value == 0 {
-            self.take_parent_count();
-        } else {
-            self.set_parent_count(new_value);
-        }
+        self.set_parent_count(new_value);
         new_value
     }
 
@@ -1160,32 +1148,27 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         let new_value = current
             .checked_add_signed(delta)
             .expect("transient_ref_count underflow");
-        if new_value == 0 {
-            self.take_transient_ref_count();
-        } else {
-            self.set_transient_ref_count(new_value);
-        }
+        self.set_transient_ref_count(new_value);
         new_value
     }
 
     /// Whether a GC pass may collect this task: it is non-transient, has no persistent or transient
     /// parents, is quiescent (not active, not in progress), and holds no aggregation edges
     /// (`upper`/`followers`).
+    ///
+    /// The storage-only checks live in [`TaskStorage::gc_maybe_collectible`] so GC's resident-map
+    /// scan can reuse them without a guard; this authoritative form adds the transient-*id* check
+    /// and enforces Meta-restoration (`check_access`) — the storage fields it reads are lazy
+    /// Meta fields that read as absent (0/empty) when Meta was evicted, so a task with evicted
+    /// Meta must not be judged collectible from stale absence. GC always opens the task with
+    /// `All` before calling this, so the check passes.
     fn is_gc_collectible(&self) -> bool {
         // Transient-ness is a property of the id, not the storage; transient tasks are never
         // collected.
-        !self.id().is_transient()
-        // The main check
-        && self.get_parent_count().copied().unwrap_or(0) == 0
-        && self.get_transient_ref_count().copied().unwrap_or(0) == 0
-        // GC root: active (a root/once task, positive active counter, or active-until-clean) or
-        // in progress (about to connect children).
-        && self.get_activeness().is_none()
-        && self.get_in_progress().is_none()
-        // The aggregation-edges check is conservative: a disconnected task is typically removed
-        // from the aggregation graph, but this may take a while and race with GC, so just back off.
-        && self.iter_upper().next().is_none()
-        && self.iter_followers().next().is_none()
+        !self.id().is_transient() && {
+            self.check_access(crate::backend::storage::SpecificTaskDataCategory::Meta);
+            self.typed().gc_maybe_collectible()
+        }
     }
 
     fn invalidate_serialization(&mut self);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -92,6 +92,28 @@ pub trait ExecuteContext<'e>: Sized {
     fn operation_suspend_point<T>(&mut self, op: &T)
     where
         T: Clone + Into<AnyOperation>;
+    /// Records that `task_id`'s persistent `parent_count` just reached 0 (it lost its last
+    /// persistent parent). Only the garbage collector's context acts on this — it collects the
+    /// newly-parentless ids so the collecting job can re-check collectibility and cascade a
+    /// `Collect` — so the default is a no-op for all normal operation contexts.
+    fn note_gc_parent_count_zeroed(&mut self, task_id: TaskId) {
+        let _ = task_id;
+    }
+    /// Takes the ids recorded by [`Self::note_gc_parent_count_zeroed`] since the last call. Only
+    /// the GC context collects anything; the default returns empty.
+    fn take_gc_parent_count_zeroed(&mut self) -> Vec<TaskId> {
+        Vec::new()
+    }
+    /// In the GC context only, whether `task_id` is currently resident: `Some(false)` means opening
+    /// it via [`Self::task`] would restore it from disk. Under the GC phase that must never happen
+    /// — a collected task stays resident (soft-deleted) precisely so a forward-dep scrub or cascade
+    /// finds a live entry rather than resurrecting a zombie — so a `Some(false)` is a bug and the
+    /// GC-only callers `debug_assert` against it. `None` for every normal context (where restoring
+    /// a missing task from disk is legitimate), which disables the assertion there.
+    fn gc_target_resident(&self, task_id: TaskId) -> Option<bool> {
+        let _ = task_id;
+        None
+    }
     fn should_track_dependencies(&self) -> bool;
     fn should_track_activeness(&self) -> bool;
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi>;
@@ -168,6 +190,11 @@ pub struct ExecuteContextImpl<'e> {
     turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
     _operation_guard: Option<OperationGuard<'e, AnyOperation>>,
     task_lock_counter: TaskLockCounter,
+    /// GC-only: ids whose persistent `parent_count` reached 0 during this context's operations
+    /// (recorded by `note_gc_parent_count_zeroed`). `None` for normal operation contexts (the
+    /// recording hook is a no-op there); `Some` only for the GC context, drained by the collector
+    /// via [`Self::take_gc_zeroed`] to discover cascade-collectible tasks.
+    gc_zeroed: Option<Vec<TaskId>>,
 }
 
 impl<'e> ExecuteContextImpl<'e> {
@@ -180,6 +207,7 @@ impl<'e> ExecuteContextImpl<'e> {
             turbo_tasks,
             _operation_guard: Some(backend.start_operation()),
             task_lock_counter: TaskLockCounter::new(),
+            gc_zeroed: None,
         }
     }
 
@@ -203,6 +231,7 @@ impl<'e> ExecuteContextImpl<'e> {
             turbo_tasks,
             _operation_guard: None,
             task_lock_counter: TaskLockCounter::new(),
+            gc_zeroed: Some(Vec::new()),
         }
     }
 
@@ -977,7 +1006,33 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
     }
 
     fn operation_suspend_point<T: Clone + Into<AnyOperation>>(&mut self, op: &T) {
+        // The GC context holds no operation guard: the GC phase already owns the coordinator's
+        // exclusion, so there is nothing to yield to and `suspend_point` (which decrements the
+        // in-progress-operations count it never incremented) must not run. Skip it entirely.
+        if self._operation_guard.is_none() {
+            return;
+        }
         self.backend.operation_suspend_point(|| op.clone().into());
+    }
+
+    fn note_gc_parent_count_zeroed(&mut self, task_id: TaskId) {
+        if let Some(zeroed) = self.gc_zeroed.as_mut() {
+            zeroed.push(task_id);
+        }
+    }
+
+    fn take_gc_parent_count_zeroed(&mut self) -> Vec<TaskId> {
+        self.gc_zeroed
+            .as_mut()
+            .map(std::mem::take)
+            .unwrap_or_default()
+    }
+
+    fn gc_target_resident(&self, task_id: TaskId) -> Option<bool> {
+        // Only the GC context (the one collecting zeroed ids) reports residency.
+        self.gc_zeroed
+            .is_some()
+            .then(|| self.backend.storage.with_task(task_id, |_| ()).is_some())
     }
 
     fn should_track_dependencies(&self) -> bool {
@@ -1039,6 +1094,7 @@ impl<'e> ChildExecuteContext<'e> for ChildExecuteContextImpl<'e> {
             turbo_tasks: self.turbo_tasks,
             _operation_guard: None,
             task_lock_counter: TaskLockCounter::new(),
+            gc_zeroed: None,
         }
     }
 }
@@ -1169,6 +1225,23 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
             self.check_access(crate::backend::storage::SpecificTaskDataCategory::Meta);
             self.typed().gc_maybe_collectible()
         }
+    }
+
+    /// Whether this task has been marked soft-deleted by GC (the `deleted` transient flag). A
+    /// `deleted` task is resident but destined for deletion; it must be resurrected before any use
+    /// of its (scrubbed) contents.
+    fn gc_is_deleted(&self) -> bool {
+        self.typed().gc_is_deleted()
+    }
+
+    /// Marks this task soft-deleted (GC collected it). See [`TaskStorage::gc_set_deleted`].
+    fn gc_set_deleted(&mut self) {
+        self.typed_mut().gc_set_deleted();
+    }
+
+    /// Clears the soft-deletion marker (the task was resurrected before hard-delete).
+    fn gc_clear_deleted(&mut self) {
+        self.typed_mut().gc_clear_deleted();
     }
 
     fn invalidate_serialization(&mut self);
@@ -1558,6 +1631,7 @@ impl TaskStorageAccessors for TaskGuardImpl<'_> {
         self.task.undo_track_modification(outcome);
     }
 
+    #[track_caller]
     fn check_access(&self, category: crate::backend::storage::SpecificTaskDataCategory) {
         self.check_access(category);
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -190,11 +190,10 @@ impl<'e> ExecuteContextImpl<'e> {
     /// Constructs a context that does NOT take an operation guard, for use by the garbage
     /// collector while it holds the coordinator's GC phase.
     ///
-    /// The GC phase already excludes all concurrent operations and task execution, so taking an
-    /// operation guard here would be redundant — and would in fact deadlock, because
-    /// [`start_operation`](TurboTasksBackend::start_operation) blocks on the GC request bit that
-    /// the caller itself set. Only call this while a
-    /// [`GcPhase`](crate::backend::snapshot_coordinator::GcPhase) is held.
+    /// The GC phase excludes all concurrent operations and task execution, so taking an
+    /// operation guard here would fact deadlock.
+    ///
+    /// Should only be used by the garbage collector implementation
     pub(super) fn new_for_gc(
         backend: &'e TurboTasksBackend,
         turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
@@ -1172,32 +1171,21 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
     /// Whether a GC pass may collect this task: it is non-transient, has no persistent or transient
     /// parents, is quiescent (not active, not in progress), and holds no aggregation edges
     /// (`upper`/`followers`).
-    ///
-    /// Reading the Meta fields through the guard's accessors makes the Meta-restored precondition
-    /// enforced by the standard `check_access` machinery — there is no separate `is_restored(Meta)`
-    /// check. That precondition matters because `parent_count`/`upper`/`followers` are lazy Meta
-    /// fields that read as absent (0 / empty) when Meta has been evicted to disk-only; a candidate
-    /// re-examined a pass after its Meta was evicted would otherwise look falsely collectible. GC
-    /// always opens the task with `TaskDataCategory::All`, so the guard has Meta restored.
-    ///
-    /// The aggregation-edges check is conservative: a disconnected task is normally stripped of its
-    /// aggregation edges by `CleanupOldEdges`, but a re-executing aggregation node can transiently
-    /// retain them; rather than tear down the aggregation overlay here (a miscount corrupts
-    /// activeness) we decline to collect and let a later pass take it once the edges clear.
-    /// Under-collecting is always safe. It does NOT require `Data` resident — only Meta fields are
-    /// read; `gc_scrub_and_remove` restores `Data` on demand to scrub the reverse-dep sets.
     fn is_gc_collectible(&self) -> bool {
         // Transient-ness is a property of the id, not the storage; transient tasks are never
         // collected.
         !self.id().is_transient()
-            && self.get_parent_count().copied().unwrap_or(0) == 0
-            && self.get_transient_ref_count().copied().unwrap_or(0) == 0
-            // GC root: active (a root/once task, positive active counter, or active-until-clean) or
-            // in progress (about to connect children).
-            && self.get_activeness().is_none()
-            && self.get_in_progress().is_none()
-            && self.iter_upper().next().is_none()
-            && self.iter_followers().next().is_none()
+        // The main check
+        && self.get_parent_count().copied().unwrap_or(0) == 0
+        && self.get_transient_ref_count().copied().unwrap_or(0) == 0
+        // GC root: active (a root/once task, positive active counter, or active-until-clean) or
+        // in progress (about to connect children).
+        && self.get_activeness().is_none()
+        && self.get_in_progress().is_none()
+        // The aggregation-edges check is conservative: a disconnected task is typically removed
+        // from the aggregation graph, but this may take a while and race with GC, so just back off.
+        && self.iter_upper().next().is_none()
+        && self.iter_followers().next().is_none()
     }
 
     fn invalidate_serialization(&mut self);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -14,6 +14,8 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use bincode::{Decode, Encode};
+use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 use tracing::info_span;
 #[cfg(feature = "trace_prepare_tasks")]
 use tracing::trace_span;
@@ -31,7 +33,10 @@ use crate::{
         storage::{SpecificTaskDataCategory, StorageWriteGuard, TrackOutcome},
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    data::{ActivenessState, CollectibleRef, Dirtyness, InProgressState, TransientTask},
+    data::{
+        ActivenessState, ChildrenCollector, CollectibleRef, Dirtyness, InProgressState,
+        TransientTask,
+    },
 };
 
 pub trait Operation: Encode + Decode<()> + Default + TryFrom<AnyOperation, Error = ()> {
@@ -90,6 +95,57 @@ pub trait ExecuteContext<'e>: Sized {
             reason,
             func,
         )
+    }
+    /// Release the `parent_count` (or `transient_ref_count`) holds taken when the children in
+    /// `staged` were staged, because the staged edges are being **discarded** without reaching the
+    /// parent's `children` set. Consumes the [`ChildrenCollector`] and returns the raw set. This is
+    /// the sole intended consumer of [`ChildrenCollector::release_set`].
+    ///
+    /// **This releases only the `parent_count` hold, deliberately NOT the active-count hold.** The
+    /// two holds are parallel (both taken optimistically at staging in
+    /// `ConnectChildOperation::run`) but they diverge on the discard paths, because they have
+    /// different consequences:
+    /// - `parent_count` is durable and correctness-critical — a leaked hold makes the child
+    ///   permanently uncollectible (a real memory leak). So it MUST be released on **every**
+    ///   discard path: stale-in-prepare, stale-in-connect, cancel-in-connect, and
+    ///   `task_execution_canceled`.
+    /// - the active count is transient and best-effort — a leaked hold merely keeps a task "active"
+    ///   slightly too long (self-corrects, resets on restart), so exactness is not required. The
+    ///   **stale** paths release it (via a `DecreaseActiveCounts` the caller enqueues from the
+    ///   returned set); the **cancel** paths do NOT touch the active count for the staged children
+    ///   — this preserves the pre-existing cancel behavior (the active-count subsystem manages
+    ///   canceled tasks on its own). Releasing the active count here on cancel would change that
+    ///   behavior, so this method leaves it alone and the cancel callers ignore the returned set.
+    ///
+    /// So a caller on a *stale* path feeds the returned set to `DecreaseActiveCounts`; a caller on
+    /// a *cancel* path ignores the return.
+    ///
+    /// Precondition: `staged` must already be the *genuinely-new* set — children that were merely
+    /// re-validated (already present in the parent's `children` set) must have been removed while
+    /// the parent guard was held (as the stale/completion/cancel paths already do), because those
+    /// never took a hold. Each **persistent** remaining child is decremented once (a persistent
+    /// parent drops the durable `parent_count`; a transient parent drops the session-only
+    /// `transient_ref_count`), mirroring the `+1` taken optimistically at staging. Transient
+    /// children never took a hold and are skipped.
+    fn release_children_holds(
+        &mut self,
+        parent_task_id: TaskId,
+        staged: ChildrenCollector,
+    ) -> FxHashSet<TaskId> {
+        let set = staged.release_set();
+        let persistent: SmallVec<[TaskId; 4]> =
+            set.iter().copied().filter(|c| !c.is_transient()).collect();
+        if !persistent.is_empty() {
+            let parent_is_transient = parent_task_id.is_transient();
+            self.for_each_task_meta(persistent, "release_children_holds", |mut child, _ctx| {
+                if parent_is_transient {
+                    child.update_and_get_transient_ref_count(-1);
+                } else {
+                    child.update_and_get_parent_count(-1);
+                }
+            });
+        }
+        set
     }
     fn task_pair(
         &mut self,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1169,6 +1169,37 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         new_value
     }
 
+    /// Whether a GC pass may collect this task: it is non-transient, has no persistent or transient
+    /// parents, is quiescent (not active, not in progress), and holds no aggregation edges
+    /// (`upper`/`followers`).
+    ///
+    /// Reading the Meta fields through the guard's accessors makes the Meta-restored precondition
+    /// enforced by the standard `check_access` machinery — there is no separate `is_restored(Meta)`
+    /// check. That precondition matters because `parent_count`/`upper`/`followers` are lazy Meta
+    /// fields that read as absent (0 / empty) when Meta has been evicted to disk-only; a candidate
+    /// re-examined a pass after its Meta was evicted would otherwise look falsely collectible. GC
+    /// always opens the task with `TaskDataCategory::All`, so the guard has Meta restored.
+    ///
+    /// The aggregation-edges check is conservative: a disconnected task is normally stripped of its
+    /// aggregation edges by `CleanupOldEdges`, but a re-executing aggregation node can transiently
+    /// retain them; rather than tear down the aggregation overlay here (a miscount corrupts
+    /// activeness) we decline to collect and let a later pass take it once the edges clear.
+    /// Under-collecting is always safe. It does NOT require `Data` resident — only Meta fields are
+    /// read; `gc_scrub_and_remove` restores `Data` on demand to scrub the reverse-dep sets.
+    fn is_gc_collectible(&self) -> bool {
+        // Transient-ness is a property of the id, not the storage; transient tasks are never
+        // collected.
+        !self.id().is_transient()
+            && self.get_parent_count().copied().unwrap_or(0) == 0
+            && self.get_transient_ref_count().copied().unwrap_or(0) == 0
+            // GC root: active (a root/once task, positive active counter, or active-until-clean) or
+            // in progress (about to connect children).
+            && self.get_activeness().is_none()
+            && self.get_in_progress().is_none()
+            && self.iter_upper().next().is_none()
+            && self.iter_followers().next().is_none()
+    }
+
     fn invalidate_serialization(&mut self);
     /// Determine which tasks to prefetch for a task.
     /// Only returns Some once per task.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -94,6 +94,10 @@ pub trait ExecuteContext<'e>: Sized {
         T: Clone + Into<AnyOperation>;
     fn should_track_dependencies(&self) -> bool;
     fn should_track_activeness(&self) -> bool;
+    /// Record that `task_id`'s persistent `parent_count` reached 0, making it a garbage-collection
+    /// candidate. This only notes candidacy (a cheap side-set write); the actual teardown/removal
+    /// happens later under the GC phase's exclusion, where candidacy is re-validated.
+    fn note_gc_candidate(&self, task_id: TaskId);
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi>;
     /// Look up a TaskId from the backing storage for a given task type.
     ///
@@ -179,6 +183,26 @@ impl<'e> ExecuteContextImpl<'e> {
             backend,
             turbo_tasks,
             _operation_guard: Some(backend.start_operation()),
+            task_lock_counter: TaskLockCounter::new(),
+        }
+    }
+
+    /// Constructs a context that does NOT take an operation guard, for use by the garbage
+    /// collector while it holds the coordinator's GC phase.
+    ///
+    /// The GC phase already excludes all concurrent operations and task execution, so taking an
+    /// operation guard here would be redundant — and would in fact deadlock, because
+    /// [`start_operation`](TurboTasksBackend::start_operation) blocks on the GC request bit that
+    /// the caller itself set. Only call this while a
+    /// [`GcPhase`](crate::backend::snapshot_coordinator::GcPhase) is held.
+    pub(super) fn new_for_gc(
+        backend: &'e TurboTasksBackend,
+        turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
+    ) -> Self {
+        Self {
+            backend,
+            turbo_tasks,
+            _operation_guard: None,
             task_lock_counter: TaskLockCounter::new(),
         }
     }
@@ -963,6 +987,10 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
 
     fn should_track_activeness(&self) -> bool {
         self.backend.should_track_activeness()
+    }
+
+    fn note_gc_candidate(&self, task_id: TaskId) {
+        self.backend.note_gc_candidate(task_id);
     }
 
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi> {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1183,11 +1183,8 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         new_value
     }
 
-    /// Adjust the count of **persistent** parents referencing this task by `delta` (+1 when a
-    /// persistent parent connects it as a child, -1 when one disconnects it) and return the new
-    /// value. A value of 0 means no persistent parent lists this task — a prerequisite for
-    /// collection. Panics in debug on underflow (a decrement below 0 means the count drifted from
-    /// the true number of `children`-edge references — the invariant this field must uphold).
+    /// Adjust the count of **persistent** parents referencing this task by `delta` and return the
+    /// new value. Panics in on underflow/overflow
     fn update_and_get_parent_count(&mut self, delta: i32) -> u32 {
         let current = self.get_parent_count().copied().unwrap_or(0);
         let new_value = current

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -44,6 +44,16 @@ pub trait ExecuteContext<'e>: Sized {
     where
         'e: 'l;
     fn task(&mut self, task_id: TaskId, category: TaskDataCategory) -> Self::TaskGuardImpl;
+    /// Opens an **already-resident** task without restoring from disk and **without** inserting a
+    /// blank entry for a missing key (unlike [`Self::task`], which does both). Returns `None` if
+    /// the task is not resident.
+    ///
+    /// Because it performs no restore, the returned guard may only be used to touch **transient**
+    /// fields (whose accessors don't gate on `check_access`); reading a Meta/Data field through it
+    /// would trip the `check_access` debug assertion. Used for pure in-session bookkeeping on a
+    /// live task — GC pin/unpin adjusting `transient_ref_count` — where a missing entry means
+    /// the caller referenced an already-collected task (a bug) rather than one to resurrect.
+    fn resident_task(&mut self, task_id: TaskId) -> Option<Self::TaskGuardImpl>;
     /// Prepares (as in fetches from persistent storage) a list of tasks.
     /// The iterator should not have duplicates, as this would cause over-fetching.
     fn prepare_tasks(
@@ -795,9 +805,27 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
             task,
             task_id,
             #[cfg(debug_assertions)]
-            category,
+            category: Some(category),
             task_lock_counter: self.task_lock_counter.clone(),
         }
+    }
+
+    fn resident_task(&mut self, task_id: TaskId) -> Option<TaskGuardImpl<'e>> {
+        // Non-inserting lookup: `None` means the task is not resident (do not resurrect a blank
+        // entry). No restore is performed, so the guard must only touch transient fields — see the
+        // trait doc. Acquire the context's lock counter for the returned guard (released on its
+        // Drop), exactly like `task()`.
+        let task = self.backend.storage.access_mut_if_resident(task_id)?;
+        self.task_lock_counter.acquire();
+        Some(TaskGuardImpl {
+            task,
+            task_id,
+            // No category was restored: `None` makes `check_access` reject any Meta/Data read
+            // through this guard. Transient-field accessors (the only intended use) never check.
+            #[cfg(debug_assertions)]
+            category: None,
+            task_lock_counter: self.task_lock_counter.clone(),
+        })
     }
 
     fn prepare_tasks(
@@ -829,7 +857,7 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
                     task,
                     task_id,
                     #[cfg(debug_assertions)]
-                    category: _category,
+                    category: Some(_category),
                     task_lock_counter: task_lock_counter.clone(),
                 };
                 func(guard, this);
@@ -973,14 +1001,14 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
                 task: task1,
                 task_id: task_id1,
                 #[cfg(debug_assertions)]
-                category,
+                category: Some(category),
                 task_lock_counter: self.task_lock_counter.clone(),
             },
             TaskGuardImpl {
                 task: task2,
                 task_id: task_id2,
                 #[cfg(debug_assertions)]
-                category,
+                category: Some(category),
                 task_lock_counter: self.task_lock_counter.clone(),
             },
         )
@@ -1183,8 +1211,12 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         new_value
     }
 
-    /// Adjust the count of **persistent** parents referencing this task by `delta` and return the
-    /// new value. Panics in on underflow/overflow
+    /// Adjust the count of **persistent** parents referencing this task by `delta` (+1 when a
+    /// persistent parent connects it as a child, -1 when one disconnects it) and return the new
+    /// value. A value of 0 means no persistent parent lists this task — a prerequisite for
+    /// collection. Panics on underflow/overflow: the count must equal the true number of
+    /// `children`-edge references, so a decrement below 0 (or a wrap past `u32::MAX`) means it has
+    /// drifted from that invariant and must fail loudly rather than corrupt collectibility.
     fn update_and_get_parent_count(&mut self, delta: i32) -> u32 {
         let current = self.get_parent_count().copied().unwrap_or(0);
         let new_value = current
@@ -1196,6 +1228,8 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
 
     /// Like [`Self::update_and_get_parent_count`], but for the transient (session-only) parent
     /// reference count that keeps a persistent task alive while a transient parent references it.
+    /// Panics on underflow/overflow for the same reason (an accounting drift, not a recoverable
+    /// condition).
     fn update_and_get_transient_ref_count(&mut self, delta: i32) -> u32 {
         let current = self.get_transient_ref_count().copied().unwrap_or(0);
         let new_value = current
@@ -1222,23 +1256,6 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
             self.check_access(crate::backend::storage::SpecificTaskDataCategory::Meta);
             self.typed().gc_maybe_collectible()
         }
-    }
-
-    /// Whether this task has been marked soft-deleted by GC (the `deleted` transient flag). A
-    /// `deleted` task is resident but destined for deletion; it must be resurrected before any use
-    /// of its (scrubbed) contents.
-    fn gc_is_deleted(&self) -> bool {
-        self.typed().gc_is_deleted()
-    }
-
-    /// Marks this task soft-deleted (GC collected it). See [`TaskStorage::gc_set_deleted`].
-    fn gc_set_deleted(&mut self) {
-        self.typed_mut().gc_set_deleted();
-    }
-
-    /// Clears the soft-deletion marker (the task was resurrected before hard-delete).
-    fn gc_clear_deleted(&mut self) {
-        self.typed_mut().gc_clear_deleted();
     }
 
     fn invalidate_serialization(&mut self);
@@ -1487,8 +1504,13 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
 pub struct TaskGuardImpl<'a> {
     task_id: TaskId,
     task: StorageWriteGuard<'a>,
+    /// Which category was restored when this guard was opened, gating `check_access`. `None` means
+    /// **no** category was restored (e.g. the non-inserting [`ExecuteContext::resident_task`]
+    /// path, used for transient-only bookkeeping): any Meta/Data access through such a guard
+    /// is a bug and `check_access` rejects it. Transient-field accessors never call
+    /// `check_access`, so they work regardless.
     #[cfg(debug_assertions)]
-    category: TaskDataCategory,
+    category: Option<TaskDataCategory>,
     task_lock_counter: TaskLockCounter,
 }
 
@@ -1508,8 +1530,10 @@ impl TaskGuardImpl<'_> {
             SpecificTaskDataCategory::Data => {
                 #[cfg(debug_assertions)]
                 debug_assert!(
-                    self.category == TaskDataCategory::Data
-                        || self.category == TaskDataCategory::All,
+                    matches!(
+                        self.category,
+                        Some(TaskDataCategory::Data | TaskDataCategory::All)
+                    ),
                     "To read data of {:?} the task need to be accessed with this category (It's \
                      accessed with {:?})",
                     category,
@@ -1519,8 +1543,10 @@ impl TaskGuardImpl<'_> {
             SpecificTaskDataCategory::Meta => {
                 #[cfg(debug_assertions)]
                 debug_assert!(
-                    self.category == TaskDataCategory::Meta
-                        || self.category == TaskDataCategory::All,
+                    matches!(
+                        self.category,
+                        Some(TaskDataCategory::Meta | TaskDataCategory::All)
+                    ),
                     "To read data of {:?} the task need to be accessed with this category (It's \
                      accessed with {:?})",
                     category,
@@ -1747,7 +1773,7 @@ mod filter_transient_tracking_tests {
             task: write,
             task_id,
             #[cfg(debug_assertions)]
-            category: TaskDataCategory::All,
+            category: Some(TaskDataCategory::All),
             task_lock_counter: TaskLockCounter::new(),
         }
     }
@@ -2016,7 +2042,7 @@ mod cell_data_tracking_tests {
             task: write,
             task_id,
             #[cfg(debug_assertions)]
-            category: TaskDataCategory::All,
+            category: Some(TaskDataCategory::All),
             task_lock_counter: TaskLockCounter::new(),
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
@@ -1,12 +1,10 @@
 use std::{cmp::max, num::NonZeroU32};
 
+use rustc_hash::FxHashSet;
 use turbo_tasks::TaskId;
 
-use crate::{
-    backend::operation::{
-        AggregationUpdateJob, AggregationUpdateQueue, TaskGuard, is_aggregating_node, is_root_node,
-    },
-    data::ChildrenCollector,
+use crate::backend::operation::{
+    AggregationUpdateJob, AggregationUpdateQueue, TaskGuard, is_aggregating_node, is_root_node,
 };
 
 const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
@@ -14,7 +12,7 @@ const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
 pub fn prepare_new_children(
     parent_task_id: TaskId,
     parent_task: &mut impl TaskGuard,
-    new_children: &ChildrenCollector,
+    new_children: &FxHashSet<TaskId>,
     queue: &mut AggregationUpdateQueue,
 ) -> u32 {
     debug_assert!(!new_children.is_empty());
@@ -46,7 +44,7 @@ pub fn prepare_new_children(
     if !is_aggregating_node(future_parent_aggregation) {
         let child_base_aggregation_number =
             future_parent_aggregation + AGGREGATION_NUMBER_BUFFER_SPACE;
-        for new_child in new_children.iter() {
+        for &new_child in new_children.iter() {
             queue.push(AggregationUpdateJob::UpdateAggregationNumber {
                 task_id: new_child,
                 base_aggregation_number: child_base_aggregation_number,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
@@ -1,10 +1,12 @@
 use std::{cmp::max, num::NonZeroU32};
 
-use rustc_hash::FxHashSet;
 use turbo_tasks::TaskId;
 
-use crate::backend::operation::{
-    AggregationUpdateJob, AggregationUpdateQueue, TaskGuard, is_aggregating_node, is_root_node,
+use crate::{
+    backend::operation::{
+        AggregationUpdateJob, AggregationUpdateQueue, TaskGuard, is_aggregating_node, is_root_node,
+    },
+    data::ChildrenCollector,
 };
 
 const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
@@ -12,7 +14,7 @@ const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
 pub fn prepare_new_children(
     parent_task_id: TaskId,
     parent_task: &mut impl TaskGuard,
-    new_children: &FxHashSet<TaskId>,
+    new_children: &ChildrenCollector,
     queue: &mut AggregationUpdateQueue,
 ) -> u32 {
     debug_assert!(!new_children.is_empty());
@@ -44,7 +46,7 @@ pub fn prepare_new_children(
     if !is_aggregating_node(future_parent_aggregation) {
         let child_base_aggregation_number =
             future_parent_aggregation + AGGREGATION_NUMBER_BUFFER_SPACE;
-        for &new_child in new_children.iter() {
+        for new_child in new_children.iter() {
             queue.push(AggregationUpdateJob::UpdateAggregationNumber {
                 task_id: new_child,
                 base_aggregation_number: child_base_aggregation_number,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -200,58 +200,82 @@ impl<O> SnapshotCoordinator<O> {
         suspend_point_cold(self, suspend);
     }
 
-    /// Begin a snapshot. Sets the snapshot bit, blocks until all in-flight
-    /// operations have drained or suspended, and returns a [`SnapshotPhase`]
-    /// guard that releases the bit on drop.
+    /// Shared core of [`begin_snapshot`](Self::begin_snapshot) and [`begin_gc`](Self::begin_gc):
+    /// asserts no snapshot or GC is already in flight, sets the requesting flag + request bit, and
+    /// blocks until every in-flight operation has drained or suspended. Returns the still-held
+    /// state lock so the caller can read `suspended_operations` (snapshot) before releasing it.
     ///
-    /// Concurrent callers panic via the debug assertion. Production callers
-    /// must serialize themselves (see `snapshot_in_progress` lock in
-    /// `mod.rs`); the coordinator does not own that mutex because some
-    /// callers want to interleave additional work between phases.
-    pub fn begin_snapshot(&self) -> SnapshotPhase<'_, O> {
+    /// `what` ("snapshot" / "gc") only labels the assertion messages and the drain span. Snapshot
+    /// and GC are mutually exclusive; production callers serialize them via the
+    /// `snapshot_in_progress` mutex in `mod.rs` (the coordinator doesn't own that mutex —
+    /// callers interleave work between phases). The mutual-exclusion asserts are promoted from
+    /// debug_assert because silently ignoring a violation leads straight to a stuck counter and
+    /// a hung process.
+    fn begin_exclusion(
+        &self,
+        what: Exclusion,
+        set_requested: impl FnOnce(&mut State<O>),
+    ) -> parking_lot::MutexGuard<'_, State<O>> {
+        let request_bit = what.request_bit();
         let mut state = self.state.lock();
-        // Protocol violation: callers must serialize snapshots (and serialize snapshot vs GC)
-        // themselves. Promoted from debug_assert: silently ignoring this leads directly to a stuck
-        // counter and a hung process.
         assert!(
-            !state.snapshot_requested,
-            "begin_snapshot called while another snapshot was already in flight"
+            !state.snapshot_requested && !state.gc_requested,
+            "{} called while a {} was already in flight (snapshot and GC must be serialized)",
+            what.begin_fn(),
+            if state.snapshot_requested {
+                "snapshot"
+            } else {
+                "GC pass"
+            }
         );
-        assert!(
-            !state.gc_requested,
-            "begin_snapshot called while a GC pass was in flight (must be serialized)"
-        );
-        state.snapshot_requested = true;
-        // AcqRel so the writes leading up to setting the bit are visible to
-        // the operation hot path's Acquire load in `exclusion_pending`.
+        set_requested(&mut state);
+        // AcqRel so the writes leading up to setting the bit are visible to the operation hot
+        // path's Acquire load in `exclusion_pending`.
         let active = self
             .in_progress_operations
-            .fetch_or(SNAPSHOT_REQUESTED_BIT, Ordering::AcqRel);
+            .fetch_or(request_bit, Ordering::AcqRel);
         assert!(
-            (active & SNAPSHOT_REQUESTED_BIT) == 0,
-            "snapshot bit was already set when begin_snapshot ran: {active:#x}"
+            (active & request_bit) == 0,
+            "{} request bit was already set when {} ran: {active:#x}",
+            what.label(),
+            what.begin_fn()
         );
         if (active & !REQUEST_BITS) != 0 {
-            // Some operations are in flight. Wait for them to drain or
-            // suspend. The predicate is Acquire-loaded so we synchronize
-            // with the AcqRel decrement that woke us. This can block for a while under load, so it
-            // gets its own span for latency attribution.
-            let _span = info_span!("snapshot: await operations settle").entered();
+            // Some operations are in flight. Wait for them to drain or suspend. The predicate is
+            // Acquire-loaded so we synchronize with the AcqRel decrement that woke us. This can
+            // block for a while under load (until every in-flight operation reaches a suspend point
+            // or finishes), so it gets its own span for latency attribution.
+            let num_operations = active & !REQUEST_BITS;
+            let _span = match what {
+                Exclusion::Snapshot => {
+                    info_span!("snapshot: await operations settle", num_operations)
+                }
+                Exclusion::Gc => info_span!("gc: await operations settle", num_operations),
+            }
+            .entered();
             self.operations_drained.wait_while(&mut state, |_| {
                 (self.in_progress_operations.load(Ordering::Acquire) & !REQUEST_BITS) != 0
             });
         }
-        // Snapshot ranges that follow can read the suspended_operations
-        // list; we leave the mutex held until the caller drops the phase.
+        state
+    }
+
+    /// Begin a snapshot. Sets the snapshot bit, blocks until all in-flight
+    /// operations have drained or suspended, and returns a [`SnapshotPhase`]
+    /// guard that releases the bit on drop.
+    ///
+    /// Concurrent callers panic (see [`begin_exclusion`](Self::begin_exclusion)).
+    pub fn begin_snapshot(&self) -> SnapshotPhase<'_, O> {
+        let state = self.begin_exclusion(Exclusion::Snapshot, |s| s.snapshot_requested = true);
+        // Snapshot ranges that follow can read the suspended_operations list; we read it while
+        // still holding the lock, then release so the snapshotter does the heavy work
+        // without it. Operations attempting to start during this window observe the bit set
+        // and either suspend or wait on `exclusion_completed`.
         let suspended_operations: Vec<Arc<O>> = state
             .suspended_operations
             .iter()
             .map(|op| op.arc().clone())
             .collect();
-        // Release the mutex now — the snapshotter does the heavy work
-        // without holding it. Operations attempting to start during this
-        // window observe the bit set and either suspend or wait on
-        // `snapshot_completed`.
         drop(state);
         SnapshotPhase {
             coord: self,
@@ -264,40 +288,44 @@ impl<O> SnapshotCoordinator<O> {
     /// the guard is held, no operation can be running, so the collector may mutate the task graph
     /// without racing.
     ///
-    /// Concurrent callers panic via the assertion. Production callers must serialize GC against
-    /// both other GC passes and snapshots (see the `snapshot_in_progress` lock in `mod.rs`); the
-    /// coordinator does not own that mutex.
+    /// Concurrent callers panic (see [`begin_exclusion`](Self::begin_exclusion)).
     pub fn begin_gc(&self) -> GcPhase<'_, O> {
-        let mut state = self.state.lock();
-        assert!(
-            !state.gc_requested,
-            "begin_gc called while another GC pass was already in flight"
-        );
-        assert!(
-            !state.snapshot_requested,
-            "begin_gc called while a snapshot was in flight (must be serialized)"
-        );
-        state.gc_requested = true;
-        // AcqRel so writes leading up to setting the bit are visible to the operation hot path's
-        // Acquire load in `exclusion_pending`.
-        let active = self
-            .in_progress_operations
-            .fetch_or(GC_REQUESTED_BIT, Ordering::AcqRel);
-        assert!(
-            (active & GC_REQUESTED_BIT) == 0,
-            "GC bit was already set when begin_gc ran: {active:#x}"
-        );
-        if (active & !REQUEST_BITS) != 0 {
-            // Some operations are in flight. Wait for them to drain or suspend. This can block for
-            // a while under load (until every in-flight operation reaches a suspend
-            // point or finishes), so it gets its own span for latency attribution.
-            let _span = info_span!("gc: await operations settle").entered();
-            self.operations_drained.wait_while(&mut state, |_| {
-                (self.in_progress_operations.load(Ordering::Acquire) & !REQUEST_BITS) != 0
-            });
-        }
+        let state = self.begin_exclusion(Exclusion::Gc, |s| s.gc_requested = true);
         drop(state);
         GcPhase { coord: self }
+    }
+}
+
+/// Which kind of exclusion [`SnapshotCoordinator::begin_exclusion`] is starting. Selects the
+/// request bit and the labels used in assertion messages and the drain span.
+#[derive(Clone, Copy)]
+enum Exclusion {
+    Snapshot,
+    Gc,
+}
+
+impl Exclusion {
+    fn request_bit(self) -> usize {
+        match self {
+            Exclusion::Snapshot => SNAPSHOT_REQUESTED_BIT,
+            Exclusion::Gc => GC_REQUESTED_BIT,
+        }
+    }
+
+    /// Human label for the exclusion kind (used in the "bit already set" assert).
+    fn label(self) -> &'static str {
+        match self {
+            Exclusion::Snapshot => "snapshot",
+            Exclusion::Gc => "GC",
+        }
+    }
+
+    /// Name of the public entry point, for assertion messages.
+    fn begin_fn(self) -> &'static str {
+        match self {
+            Exclusion::Snapshot => "begin_snapshot",
+            Exclusion::Gc => "begin_gc",
+        }
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -1,15 +1,22 @@
-//! Coordinator that gates concurrent operations against snapshotting.
+//! Coordinator that gates concurrent operations against snapshotting and garbage collection.
 //!
-//! Backend operations and snapshot work share a single [`SnapshotCoordinator`]
-//! that enforces the protocol:
+//! Backend operations, snapshot work, and garbage collection share a single
+//! [`SnapshotCoordinator`] that enforces the protocol:
 //!
-//! - When no snapshot is in flight, [`begin_operation`](SnapshotCoordinator::begin_operation) is a
-//!   single uncontended atomic increment.
-//! - When a snapshot is requested, new operations block until the snapshot finishes, and operations
-//!   already in flight either complete or call
+//! - When neither a snapshot nor a GC pass is in flight,
+//!   [`begin_operation`](SnapshotCoordinator::begin_operation) is a single uncontended atomic
+//!   increment.
+//! - When a snapshot or GC pass is requested, new operations block until it finishes, and
+//!   operations already in flight either complete or call
 //!   [`suspend_point`](SnapshotCoordinator::suspend_point) to suspend.
-//! - The snapshotter waits for every in-flight operation to drain or suspend, takes its snapshot,
-//!   then wakes everyone.
+//! - The snapshotter / collector waits for every in-flight operation to drain or suspend, does its
+//!   work, then wakes everyone.
+//!
+//! Snapshots and GC use two distinct request bits ([`SNAPSHOT_REQUESTED_BIT`] and
+//! [`GC_REQUESTED_BIT`]) so they can be reasoned about independently — a snapshot's exclusion is
+//! never interrupted, whereas a GC pass may abort mid-mark. Operations drain/suspend for either
+//! bit. Snapshots and GC are themselves mutually exclusive; callers serialize them with the
+//! `snapshot_in_progress` mutex in `mod.rs` (the coordinator does not own that mutex).
 
 use std::sync::{
     Arc,
@@ -21,14 +28,28 @@ use rustc_hash::FxHashSet;
 
 use crate::{backend::AnyOperation, utils::ptr_eq_arc::PtrEqArc};
 
-/// High bit: set while a snapshot is requested or in flight.
-/// Low bits: count of operations currently executing (not suspended).
+/// Top bit: set while a snapshot is requested or in flight.
 const SNAPSHOT_REQUESTED_BIT: usize = 1 << (usize::BITS - 1);
+/// Second-from-top bit: set while a garbage-collection pass is requested or in flight.
+const GC_REQUESTED_BIT: usize = 1 << (usize::BITS - 2);
+/// Mask of all "exclusion requested" bits. Operations must drain/suspend while any is set.
+/// The remaining low bits hold the count of operations currently executing (not suspended).
+const REQUEST_BITS: usize = SNAPSHOT_REQUESTED_BIT | GC_REQUESTED_BIT;
+
+/// Whether an `in_progress_operations` value represents a fully-drained state that a waiting
+/// snapshotter/collector should be woken for: at least one request bit is set (someone is waiting
+/// to drain) and the operation count (low bits) has reached zero.
+#[inline]
+fn is_drained(value: usize) -> bool {
+    (value & REQUEST_BITS) != 0 && (value & !REQUEST_BITS) == 0
+}
 
 /// State protected by the mutex.
 struct State<O> {
     /// `true` between `begin_snapshot` and `SnapshotPhase::drop`.
     snapshot_requested: bool,
+    /// `true` between `begin_gc` and `GcPhase::drop`.
+    gc_requested: bool,
     /// Operations that called [`SnapshotCoordinator::suspend_point`] and have
     /// not yet resumed. Returned to the snapshotter via
     /// [`SnapshotPhase::suspended_operations`] so it can persist them in the
@@ -36,21 +57,22 @@ struct State<O> {
     suspended_operations: FxHashSet<PtrEqArc<O>>,
 }
 
-/// Coordinates operation/snapshot interleaving.
+/// Coordinates operation/snapshot/GC interleaving.
 ///
 /// Generic over the operation type the caller wants to suspend. The
 /// coordinator only requires `O: Send + Sync + 'static`; it never inspects
 /// the value, just stores it via [`PtrEqArc`].
 pub struct SnapshotCoordinator<O = AnyOperation> {
-    /// Combined count + bit. See [`SNAPSHOT_REQUESTED_BIT`].
+    /// Combined count + request bits. See [`SNAPSHOT_REQUESTED_BIT`], [`GC_REQUESTED_BIT`].
     in_progress_operations: AtomicUsize,
     state: Mutex<State<O>>,
-    /// Notified by the last operation to drain (count drops to `BIT` while
-    /// `SNAPSHOT_REQUESTED_BIT` is set). Awaited by [`begin_snapshot`].
+    /// Notified by the last operation to drain (count drops to zero while a request bit is set).
+    /// Awaited by [`begin_snapshot`] and [`begin_gc`].
     operations_drained: Condvar,
-    /// Notified by [`SnapshotPhase::drop`]. Awaited by operations that hit a
-    /// suspend point or arrive while a snapshot is in flight.
-    snapshot_completed: Condvar,
+    /// Notified by [`SnapshotPhase::drop`] and [`GcPhase::drop`]. Awaited by operations that hit a
+    /// suspend point or arrive while a snapshot or GC pass is in flight. Operations wait while
+    /// either `snapshot_requested` or `gc_requested` holds.
+    exclusion_completed: Condvar,
 }
 
 impl<O> Default for SnapshotCoordinator<O> {
@@ -65,58 +87,57 @@ impl<O> SnapshotCoordinator<O> {
             in_progress_operations: AtomicUsize::new(0),
             state: Mutex::new(State {
                 snapshot_requested: false,
+                gc_requested: false,
                 suspended_operations: FxHashSet::default(),
             }),
             operations_drained: Condvar::new(),
-            snapshot_completed: Condvar::new(),
+            exclusion_completed: Condvar::new(),
         }
     }
 
-    /// Cheap check used by hot paths. Returns `true` while a snapshot is in
-    /// flight (or being requested). May return `false` racily if a snapshot
-    /// is just about to start; the actual coordination happens in
-    /// [`suspend_point`](Self::suspend_point) and [`begin_operation`](Self::begin_operation).
-    pub fn snapshot_pending(&self) -> bool {
-        // Acquire so that observing the bit synchronizes with anything the
-        // snapshotter wrote before setting it.
-        (self.in_progress_operations.load(Ordering::Acquire) & SNAPSHOT_REQUESTED_BIT) != 0
+    /// Cheap check used by hot paths. Returns `true` while a snapshot or GC pass is in flight (or
+    /// being requested). May return `false` racily if one is just about to start; the actual
+    /// coordination happens in [`suspend_point`](Self::suspend_point) and
+    /// [`begin_operation`](Self::begin_operation).
+    pub fn exclusion_pending(&self) -> bool {
+        // Acquire so that observing a request bit synchronizes with anything the snapshotter /
+        // collector wrote before setting it.
+        (self.in_progress_operations.load(Ordering::Acquire) & REQUEST_BITS) != 0
     }
 
     /// Begin an operation. Returns a guard that decrements on drop.
     ///
-    /// If a snapshot is in flight, blocks until the snapshot finishes before
-    /// returning the guard.
+    /// If a snapshot or GC pass is in flight, blocks until it finishes before returning the guard.
     pub fn begin_operation(&self) -> OperationGuard<'_, O> {
-        // Fast path: no snapshot in flight, single atomic increment.
+        // Fast path: no snapshot or GC in flight, single atomic increment.
         let prev = self.in_progress_operations.fetch_add(1, Ordering::AcqRel);
-        if (prev & SNAPSHOT_REQUESTED_BIT) == 0 {
+        if (prev & REQUEST_BITS) == 0 {
             return OperationGuard { coord: Some(self) };
         }
         #[cold]
-        fn wait_for_snapshot_to_complete<O>(this: &SnapshotCoordinator<O>) {
+        fn wait_for_exclusion_to_complete<O>(this: &SnapshotCoordinator<O>) {
             // We arrive here holding our +1 (the fetch_add in begin_operation).
             // Two cases:
-            //   - Snapshot is still in flight: back out our +1, wait for it to finish, then re-add.
-            //     The drop balances the re-add.
-            //   - Snapshot already finished between our fetch_add and acquiring this mutex: leave
-            //     our +1 in place; the drop balances it directly. No extra atomics needed.
+            //   - A snapshot/GC pass is still in flight: back out our +1, wait for it to finish,
+            //     then re-add. The drop balances the re-add.
+            //   - It already finished between our fetch_add and acquiring this mutex: leave our +1
+            //     in place; the drop balances it directly. No extra atomics needed.
             let mut state = this.state.lock();
-            if state.snapshot_requested {
+            if state.snapshot_requested || state.gc_requested {
                 let prev = this.in_progress_operations.fetch_sub(1, Ordering::AcqRel);
-                if prev - 1 == SNAPSHOT_REQUESTED_BIT {
+                if is_drained(prev - 1) {
                     this.operations_drained.notify_all();
                 }
-                this.snapshot_completed
-                    .wait_while(&mut state, |s| s.snapshot_requested);
-                // Re-add now that the snapshot is done. Bit is cleared because
-                // we just observed `snapshot_requested == false` under the
-                // mutex.
+                this.exclusion_completed
+                    .wait_while(&mut state, |s| s.snapshot_requested || s.gc_requested);
+                // Re-add now that the exclusion is done. Both bits are cleared because we just
+                // observed both flags false under the mutex.
                 this.in_progress_operations.fetch_add(1, Ordering::AcqRel);
             }
         }
-        // Slow path: a snapshot is in flight (or just requested). Back out
-        // the increment, wait for the snapshot to complete, then re-increment.
-        wait_for_snapshot_to_complete(self);
+        // Slow path: a snapshot or GC pass is in flight (or just requested). Back out the
+        // increment, wait for it to complete, then re-increment.
+        wait_for_exclusion_to_complete(self);
         OperationGuard { coord: Some(self) }
     }
 
@@ -125,39 +146,49 @@ impl<O> SnapshotCoordinator<O> {
     /// produce a handle to this operation so the snapshotter can persist it
     /// for replay on the next startup.
     pub fn suspend_point(&self, suspend: impl FnOnce() -> O) {
-        if !self.snapshot_pending() {
+        if !self.exclusion_pending() {
             return;
         }
         #[cold]
         fn suspend_point_cold<O>(this: &SnapshotCoordinator<O>, suspend: impl FnOnce() -> O) {
-            let op = Arc::new(suspend());
             let mut state = this.state.lock();
-            if !state.snapshot_requested {
-                // Race: snapshot finished between the `snapshot_pending` check
-                // and acquiring the mutex. Nothing to do.
+            if !state.snapshot_requested && !state.gc_requested {
+                // Race: the snapshot/GC pass finished between the `exclusion_pending` check and
+                // acquiring the mutex. Nothing to do.
                 return;
             }
-            state
-                .suspended_operations
-                .insert(PtrEqArc::from(op.clone()));
-            // Decrement the count so the snapshotter can drain.
+            // Only a snapshot needs the suspended operation recorded for the uncompleted-operations
+            // log; a GC pass discards it (GC does not persist operations). We still run the suspend
+            // closure only when recording, to avoid its cost during GC-only suspension.
+            let recorded_op = if state.snapshot_requested {
+                let op = Arc::new(suspend());
+                state
+                    .suspended_operations
+                    .insert(PtrEqArc::from(op.clone()));
+                Some(op)
+            } else {
+                None
+            };
+            // Decrement the count so the snapshotter / collector can drain.
             let prev = this.in_progress_operations.fetch_sub(1, Ordering::AcqRel);
             // Protocol violation if either invariant fails. Keep as a regular
             // `assert!` so production builds also catch it: the alternative is
-            // a corrupted counter that hangs the next snapshot indefinitely.
+            // a corrupted counter that hangs the next snapshot/GC indefinitely.
             assert!(
-                (prev & SNAPSHOT_REQUESTED_BIT) != 0 && (prev & !SNAPSHOT_REQUESTED_BIT) > 0,
+                (prev & REQUEST_BITS) != 0 && (prev & !REQUEST_BITS) > 0,
                 "suspend_point called without a live operation: prev={prev:#x}"
             );
-            if prev - 1 == SNAPSHOT_REQUESTED_BIT {
+            if is_drained(prev - 1) {
                 this.operations_drained.notify_all();
             }
-            // Wait for the snapshot to finish.
-            this.snapshot_completed
-                .wait_while(&mut state, |s| s.snapshot_requested);
-            // Resume: re-increment and remove ourselves from the suspended set.
+            // Wait for the snapshot / GC pass to finish.
+            this.exclusion_completed
+                .wait_while(&mut state, |s| s.snapshot_requested || s.gc_requested);
+            // Resume: re-increment and remove ourselves from the suspended set (if recorded).
             this.in_progress_operations.fetch_add(1, Ordering::AcqRel);
-            state.suspended_operations.remove(&PtrEqArc::from(op));
+            if let Some(op) = recorded_op {
+                state.suspended_operations.remove(&PtrEqArc::from(op));
+            }
         }
         suspend_point_cold(self, suspend);
     }
@@ -172,16 +203,20 @@ impl<O> SnapshotCoordinator<O> {
     /// callers want to interleave additional work between phases.
     pub fn begin_snapshot(&self) -> SnapshotPhase<'_, O> {
         let mut state = self.state.lock();
-        // Protocol violation: callers must serialize snapshots themselves.
-        // Promoted from debug_assert: silently ignoring this leads directly
-        // to a stuck counter and a hung process.
+        // Protocol violation: callers must serialize snapshots (and serialize snapshot vs GC)
+        // themselves. Promoted from debug_assert: silently ignoring this leads directly to a stuck
+        // counter and a hung process.
         assert!(
             !state.snapshot_requested,
             "begin_snapshot called while another snapshot was already in flight"
         );
+        assert!(
+            !state.gc_requested,
+            "begin_snapshot called while a GC pass was in flight (must be serialized)"
+        );
         state.snapshot_requested = true;
         // AcqRel so the writes leading up to setting the bit are visible to
-        // the operation hot path's Acquire load in `snapshot_pending`.
+        // the operation hot path's Acquire load in `exclusion_pending`.
         let active = self
             .in_progress_operations
             .fetch_or(SNAPSHOT_REQUESTED_BIT, Ordering::AcqRel);
@@ -189,12 +224,12 @@ impl<O> SnapshotCoordinator<O> {
             (active & SNAPSHOT_REQUESTED_BIT) == 0,
             "snapshot bit was already set when begin_snapshot ran: {active:#x}"
         );
-        if (active & !SNAPSHOT_REQUESTED_BIT) != 0 {
+        if (active & !REQUEST_BITS) != 0 {
             // Some operations are in flight. Wait for them to drain or
             // suspend. The predicate is Acquire-loaded so we synchronize
             // with the AcqRel decrement that woke us.
             self.operations_drained.wait_while(&mut state, |_| {
-                self.in_progress_operations.load(Ordering::Acquire) != SNAPSHOT_REQUESTED_BIT
+                (self.in_progress_operations.load(Ordering::Acquire) & !REQUEST_BITS) != 0
             });
         }
         // Snapshot ranges that follow can read the suspended_operations
@@ -213,6 +248,44 @@ impl<O> SnapshotCoordinator<O> {
             coord: self,
             suspended_operations,
         }
+    }
+
+    /// Begin a garbage-collection pass. Sets the GC bit, blocks until all in-flight operations have
+    /// drained or suspended, and returns a [`GcPhase`] guard that releases the bit on drop. While
+    /// the guard is held, no operation can be running, so the collector may mutate the task graph
+    /// without racing.
+    ///
+    /// Concurrent callers panic via the assertion. Production callers must serialize GC against
+    /// both other GC passes and snapshots (see the `snapshot_in_progress` lock in `mod.rs`); the
+    /// coordinator does not own that mutex.
+    pub fn begin_gc(&self) -> GcPhase<'_, O> {
+        let mut state = self.state.lock();
+        assert!(
+            !state.gc_requested,
+            "begin_gc called while another GC pass was already in flight"
+        );
+        assert!(
+            !state.snapshot_requested,
+            "begin_gc called while a snapshot was in flight (must be serialized)"
+        );
+        state.gc_requested = true;
+        // AcqRel so writes leading up to setting the bit are visible to the operation hot path's
+        // Acquire load in `exclusion_pending`.
+        let active = self
+            .in_progress_operations
+            .fetch_or(GC_REQUESTED_BIT, Ordering::AcqRel);
+        assert!(
+            (active & GC_REQUESTED_BIT) == 0,
+            "GC bit was already set when begin_gc ran: {active:#x}"
+        );
+        if (active & !REQUEST_BITS) != 0 {
+            // Some operations are in flight. Wait for them to drain or suspend.
+            self.operations_drained.wait_while(&mut state, |_| {
+                (self.in_progress_operations.load(Ordering::Acquire) & !REQUEST_BITS) != 0
+            });
+        }
+        drop(state);
+        GcPhase { coord: self }
     }
 }
 
@@ -241,10 +314,10 @@ impl<O> Drop for OperationGuard<'_, O> {
         // promoted from debug_assert because the alternative is silently
         // wrapping to usize::MAX and breaking every subsequent snapshot.
         assert!(
-            (prev & !SNAPSHOT_REQUESTED_BIT) > 0,
+            (prev & !REQUEST_BITS) > 0,
             "OperationGuard::drop underflow: in_progress_operations was {prev:#x}"
         );
-        if prev - 1 == SNAPSHOT_REQUESTED_BIT {
+        if is_drained(prev - 1) {
             #[cold]
             fn notify_drained<O>(coord: &SnapshotCoordinator<O>) {
                 // Take the state mutex around `notify_all`. This is defensive against
@@ -300,7 +373,31 @@ impl<O> Drop for SnapshotPhase<'_, O> {
         );
         // Notify everyone waiting for the snapshot to finish under the
         // mutex (correctness against parking_lot's notify_all fast path).
-        self.coord.snapshot_completed.notify_all();
+        self.coord.exclusion_completed.notify_all();
+    }
+}
+
+/// Guard returned by [`SnapshotCoordinator::begin_gc`]. Holds the GC bit; on drop, releases it and
+/// wakes any operations parked on `exclusion_completed`.
+pub struct GcPhase<'a, O> {
+    coord: &'a SnapshotCoordinator<O>,
+}
+
+impl<O> Drop for GcPhase<'_, O> {
+    fn drop(&mut self) {
+        let mut state = self.coord.state.lock();
+        state.gc_requested = false;
+        let prev = self
+            .coord
+            .in_progress_operations
+            .fetch_sub(GC_REQUESTED_BIT, Ordering::AcqRel);
+        assert!(
+            (prev & GC_REQUESTED_BIT) != 0,
+            "GcPhase::drop: GC bit was already cleared (prev={prev:#x})"
+        );
+        // Notify everyone waiting for the exclusion to finish, under the mutex (correctness against
+        // parking_lot's notify_all fast path).
+        self.coord.exclusion_completed.notify_all();
     }
 }
 
@@ -326,7 +423,7 @@ mod tests {
     /// fixed `thread::sleep` waits — those introduced both flakiness (too
     /// short) and slowness (too long).
     fn wait_for_snapshot_pending<O>(coord: &SnapshotCoordinator<O>) {
-        while !coord.snapshot_pending() {
+        while !coord.exclusion_pending() {
             thread::yield_now();
         }
     }
@@ -334,7 +431,7 @@ mod tests {
     #[test]
     fn no_snapshot_pending_initially() {
         let coord = SnapshotCoordinator::<Op>::new();
-        assert!(!coord.snapshot_pending());
+        assert!(!coord.exclusion_pending());
     }
 
     #[test]
@@ -350,10 +447,10 @@ mod tests {
     fn snapshot_with_no_ops_proceeds_immediately() {
         let coord = SnapshotCoordinator::<Op>::new();
         let phase = coord.begin_snapshot();
-        assert!(coord.snapshot_pending());
+        assert!(coord.exclusion_pending());
         assert!(phase.suspended_operations().is_empty());
         drop(phase);
-        assert!(!coord.snapshot_pending());
+        assert!(!coord.exclusion_pending());
     }
 
     #[test]
@@ -594,5 +691,111 @@ mod tests {
             0,
             "in_progress_operations should be 0 after all ops and snapshots done"
         );
+    }
+
+    // === Garbage-collection gate ===
+
+    #[test]
+    fn gc_with_no_ops_proceeds_immediately() {
+        let coord = SnapshotCoordinator::<Op>::new();
+        let phase = coord.begin_gc();
+        assert!(coord.exclusion_pending());
+        drop(phase);
+        assert!(!coord.exclusion_pending());
+    }
+
+    #[test]
+    fn gc_waits_for_ops_to_drain() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let g = coord.begin_operation();
+        let started_gc = Arc::new(AtomicUsize::new(0));
+
+        let coord2 = coord.clone();
+        let gc_thread = thread::spawn({
+            let started_gc = started_gc.clone();
+            move || {
+                let _phase = coord2.begin_gc();
+                started_gc.store(1, Ordering::Release);
+            }
+        });
+
+        // The collector can't proceed past begin_gc while we hold `g`.
+        wait_for_snapshot_pending(&coord);
+        assert_eq!(started_gc.load(Ordering::Acquire), 0);
+
+        drop(g);
+        gc_thread.join().unwrap();
+        assert_eq!(started_gc.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn new_operation_blocks_during_gc() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let phase = coord.begin_gc();
+        let started_op = Arc::new(AtomicUsize::new(0));
+        let arrived = Arc::new(AtomicUsize::new(0));
+
+        let coord2 = coord.clone();
+        let op_thread = thread::spawn({
+            let started_op = started_op.clone();
+            let arrived = arrived.clone();
+            move || {
+                arrived.store(1, Ordering::Release);
+                let _guard = coord2.begin_operation();
+                started_op.store(1, Ordering::Release);
+            }
+        });
+
+        while arrived.load(Ordering::Acquire) == 0 {
+            thread::yield_now();
+        }
+        assert_eq!(started_op.load(Ordering::Acquire), 0);
+
+        drop(phase);
+        op_thread.join().unwrap();
+        assert_eq!(started_op.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn suspend_point_lets_gc_proceed() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let g = coord.begin_operation();
+
+        let gc_done = Arc::new(AtomicUsize::new(0));
+        let coord_gc = coord.clone();
+        let gc_thread = thread::spawn({
+            let gc_done = gc_done.clone();
+            move || {
+                let _phase = coord_gc.begin_gc();
+                gc_done.store(1, Ordering::Release);
+                thread::sleep(Duration::from_millis(20));
+            }
+        });
+
+        wait_for_snapshot_pending(&coord);
+        // The collector is waiting for our operation to drain. Suspending lets it proceed. Because
+        // this is a GC (not snapshot) suspension, the suspend closure is never invoked.
+        coord.suspend_point(|| unreachable!("GC suspension must not record the operation"));
+        assert_eq!(gc_done.load(Ordering::Acquire), 1);
+
+        gc_thread.join().unwrap();
+        drop(g);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be serialized")]
+    fn gc_during_snapshot_panics() {
+        let coord = SnapshotCoordinator::<Op>::new();
+        let _snap = coord.begin_snapshot();
+        // Callers must serialize GC vs snapshot; doing both at once is a protocol violation.
+        let _gc = coord.begin_gc();
+    }
+
+    #[test]
+    #[should_panic(expected = "must be serialized")]
+    fn snapshot_during_gc_panics() {
+        let coord = SnapshotCoordinator::<Op>::new();
+        let _gc = coord.begin_gc();
+        let _snap = coord.begin_snapshot();
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -25,6 +25,7 @@ use std::sync::{
 
 use parking_lot::{Condvar, Mutex};
 use rustc_hash::FxHashSet;
+use tracing::info_span;
 
 use crate::{backend::AnyOperation, utils::ptr_eq_arc::PtrEqArc};
 
@@ -233,7 +234,9 @@ impl<O> SnapshotCoordinator<O> {
         if (active & !REQUEST_BITS) != 0 {
             // Some operations are in flight. Wait for them to drain or
             // suspend. The predicate is Acquire-loaded so we synchronize
-            // with the AcqRel decrement that woke us.
+            // with the AcqRel decrement that woke us. This can block for a while under load, so it
+            // gets its own span for latency attribution.
+            let _span = info_span!("snapshot: await operations settle").entered();
             self.operations_drained.wait_while(&mut state, |_| {
                 (self.in_progress_operations.load(Ordering::Acquire) & !REQUEST_BITS) != 0
             });
@@ -285,7 +288,10 @@ impl<O> SnapshotCoordinator<O> {
             "GC bit was already set when begin_gc ran: {active:#x}"
         );
         if (active & !REQUEST_BITS) != 0 {
-            // Some operations are in flight. Wait for them to drain or suspend.
+            // Some operations are in flight. Wait for them to drain or suspend. This can block for
+            // a while under load (until every in-flight operation reaches a suspend
+            // point or finishes), so it gets its own span for latency attribution.
+            let _span = info_span!("gc: await operations settle").entered();
             self.operations_drained.wait_while(&mut state, |_| {
                 (self.in_progress_operations.load(Ordering::Acquire) & !REQUEST_BITS) != 0
             });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -383,6 +383,59 @@ pub struct GcPhase<'a, O> {
     coord: &'a SnapshotCoordinator<O>,
 }
 
+impl<'a, O> GcPhase<'a, O> {
+    /// Atomically transitions from the GC phase directly into a snapshot phase **without ever
+    /// releasing operation exclusion**. Under the state lock it clears the GC request bit and sets
+    /// the snapshot request bit in one critical section, so no operation can start in between (an
+    /// operation blocks while *either* bit is set). This closes the race where a mutation could
+    /// resurrect a just-collected task in the gap between the GC pass and the snapshot: with an
+    /// atomic hand-off there is no such gap, so the GC cascade's `parent_count` decrements and the
+    /// snapshot see a consistent graph.
+    ///
+    /// Because operations were already drained to zero by `begin_gc`, no further draining is
+    /// needed.
+    pub fn into_snapshot(self) -> SnapshotPhase<'a, O> {
+        let coord = self.coord;
+        // Do not run `GcPhase::Drop` — we are handing the exclusion off to the snapshot phase, not
+        // releasing it. `forget` leaves the GC bit set; we clear it (and set the snapshot bit)
+        // below under the lock.
+        std::mem::forget(self);
+
+        let mut state = coord.state.lock();
+        debug_assert!(state.gc_requested, "into_snapshot: GC phase was not active");
+        debug_assert!(
+            !state.snapshot_requested,
+            "into_snapshot: a snapshot was already in flight"
+        );
+        state.gc_requested = false;
+        state.snapshot_requested = true;
+        // Swap the bits atomically: clear GC, set snapshot, in one AcqRel RMW. Operations that
+        // observe the value either before or after still see a request bit set, so none can start.
+        let prev = coord.in_progress_operations.fetch_add(
+            SNAPSHOT_REQUESTED_BIT.wrapping_sub(GC_REQUESTED_BIT),
+            Ordering::AcqRel,
+        );
+        assert!(
+            (prev & GC_REQUESTED_BIT) != 0 && (prev & SNAPSHOT_REQUESTED_BIT) == 0,
+            "into_snapshot: unexpected request bits {prev:#x}"
+        );
+        debug_assert!(
+            (prev & !REQUEST_BITS) == 0,
+            "into_snapshot: operations in flight during hand-off {prev:#x}"
+        );
+        let suspended_operations: Vec<Arc<O>> = state
+            .suspended_operations
+            .iter()
+            .map(|op| op.arc().clone())
+            .collect();
+        drop(state);
+        SnapshotPhase {
+            coord,
+            suspended_operations,
+        }
+    }
+}
+
 impl<O> Drop for GcPhase<'_, O> {
     fn drop(&mut self) {
         let mut state = self.coord.state.lock();
@@ -752,6 +805,50 @@ mod tests {
         assert_eq!(started_op.load(Ordering::Acquire), 0);
 
         drop(phase);
+        op_thread.join().unwrap();
+        assert_eq!(started_op.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn into_snapshot_keeps_operations_excluded_across_handoff() {
+        // The GC->snapshot hand-off must never open a window in which an operation can start:
+        // exclusion is held continuously from `begin_gc` through the snapshot phase.
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let gc_phase = coord.begin_gc();
+
+        let started_op = Arc::new(AtomicUsize::new(0));
+        let arrived = Arc::new(AtomicUsize::new(0));
+        let coord2 = coord.clone();
+        let op_thread = thread::spawn({
+            let started_op = started_op.clone();
+            let arrived = arrived.clone();
+            move || {
+                arrived.store(1, Ordering::Release);
+                let _guard = coord2.begin_operation();
+                started_op.store(1, Ordering::Release);
+            }
+        });
+
+        // Wait until the op thread is trying to begin (and thus blocked on the GC bit).
+        while arrived.load(Ordering::Acquire) == 0 {
+            thread::yield_now();
+        }
+        assert_eq!(started_op.load(Ordering::Acquire), 0);
+
+        // Hand off GC -> snapshot. The op must remain blocked (the snapshot bit is now set).
+        let snapshot_phase = gc_phase.into_snapshot();
+        // Give the op thread a chance to (wrongly) proceed if there were a gap.
+        for _ in 0..1000 {
+            thread::yield_now();
+        }
+        assert_eq!(
+            started_op.load(Ordering::Acquire),
+            0,
+            "operation started during the GC->snapshot hand-off — exclusion was released"
+        );
+
+        // Only once the snapshot phase ends may the operation proceed.
+        drop(snapshot_phase);
         op_thread.join().unwrap();
         assert_eq!(started_op.load(Ordering::Acquire), 1);
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -105,6 +105,12 @@ impl<O> SnapshotCoordinator<O> {
         (self.in_progress_operations.load(Ordering::Acquire) & REQUEST_BITS) != 0
     }
 
+    /// Whether a GC phase is currently held (the `GC_REQUESTED_BIT` is set). Used by the GC-only
+    /// execute context to `debug_assert` it is running under the exclusion it requires.
+    pub fn gc_in_progress(&self) -> bool {
+        (self.in_progress_operations.load(Ordering::Acquire) & GC_REQUESTED_BIT) != 0
+    }
+
     /// Begin an operation. Returns a guard that decrements on drop.
     ///
     /// If a snapshot or GC pass is in flight, blocks until it finishes before returning the guard.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -272,10 +272,16 @@ impl Storage {
     /// Mark a newly allocated task as restored (skip DB queries) and new (include in persistence
     /// snapshots). Optionally sets the `persistent_task_type` eagerly so it's available for
     /// persistence snapshots without needing to propagate it through `connect_child`.
-    pub fn initialize_new_task(&self, task_id: TaskId, task_type: Option<CachedTaskTypeArc>) {
+    pub fn initialize_new_task(
+        &self,
+        task_id: TaskId,
+        task_type: Option<CachedTaskTypeArc>,
+        is_gc_root: bool,
+    ) {
         let mut task = self.access_mut(task_id);
         task.flags.set_restored(TaskDataCategory::All);
         task.flags.set_new_task(true);
+        task.flags.set_gc_root(is_gc_root);
         if let Some(task_type) = task_type {
             task.set_persistent_task_type(task_type);
             if !task_id.is_transient() {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -518,6 +518,14 @@ impl Storage {
         }
     }
 
+    /// Read-only access to a resident task without inserting a blank entry for a missing key
+    /// (unlike [`Storage::access_mut`]). Returns `None` if the task is not resident. The closure
+    /// runs while a shard read lock is held, so it must be cheap and must not re-enter the map.
+    pub fn with_task<R>(&self, key: TaskId, f: impl FnOnce(&TaskStorage) -> R) -> Option<R> {
+        let task = self.map.get(&key)?;
+        Some(f(task.value()))
+    }
+
     pub fn access_pair_mut(
         &self,
         key1: TaskId,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -526,6 +526,24 @@ impl Storage {
         Some(f(task.value()))
     }
 
+    /// The number of **persistent** (non-transient) tasks resident in the map. GC only collects
+    /// persistent tasks (transient tasks are never collected), so this is the metric that must
+    /// return to a flat baseline across re-rooting; the raw `resident_task_count` also includes
+    /// transient roots (e.g. `run_once`/Once tasks) that GC never touches.
+    pub fn resident_persistent_task_count(&self) -> usize {
+        let mut persistent = 0;
+        for shard in self.map.shards() {
+            let shard = shard.read();
+            for bucket in unsafe { shard.iter() } {
+                let (task_id, _) = unsafe { bucket.as_ref() };
+                if !task_id.is_transient() {
+                    persistent += 1;
+                }
+            }
+        }
+        persistent
+    }
+
     /// Removes a task entry from the map entirely. Used by GC after a garbage task's edges have
     /// been scrubbed. Returns the removed storage (dropped by the caller), or `None` if it was
     /// already gone.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -526,6 +526,30 @@ impl Storage {
         Some(f(task.value()))
     }
 
+    /// Removes a task entry from the map entirely. Used by GC after a garbage task's edges have
+    /// been scrubbed. Returns the removed storage (dropped by the caller), or `None` if it was
+    /// already gone.
+    ///
+    /// If the removed task carried modified flags, its (once-per-task) contribution to
+    /// `shard_modified_counts` is decremented so the next snapshot's per-shard scan doesn't expect
+    /// a modified entry that no longer exists. GC removes tasks while holding the GC phase,
+    /// which is mutually exclusive with snapshot mode, so the plain (non-snapshot) counter
+    /// applies.
+    pub fn remove_task(&self, task_id: TaskId) -> Option<Box<TaskStorage>> {
+        debug_assert!(
+            !self.snapshot_mode(),
+            "remove_task must not run during snapshot mode"
+        );
+        let removed = self.map.remove(&task_id).map(|(_, storage)| storage);
+        if let Some(storage) = &removed
+            && storage.flags.any_modified()
+        {
+            let shard_idx = self.shard_index(&task_id);
+            self.shard_modified_counts[shard_idx].fetch_sub(1, Ordering::Relaxed);
+        }
+        removed
+    }
+
     pub fn access_pair_mut(
         &self,
         key1: TaskId,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -585,30 +585,6 @@ impl Storage {
         per_shard.into_iter().flatten().collect()
     }
 
-    /// Removes a task entry from the map entirely. Used by GC after a garbage task's edges have
-    /// been scrubbed. Returns the removed storage (dropped by the caller), or `None` if it was
-    /// already gone.
-    ///
-    /// If the removed task carried modified flags, its (once-per-task) contribution to
-    /// `shard_modified_counts` is decremented so the next snapshot's per-shard scan doesn't expect
-    /// a modified entry that no longer exists. GC removes tasks while holding the GC phase,
-    /// which is mutually exclusive with snapshot mode, so the plain (non-snapshot) counter
-    /// applies.
-    pub fn remove_task(&self, task_id: TaskId) -> Option<Box<TaskStorage>> {
-        debug_assert!(
-            !self.snapshot_mode(),
-            "remove_task must not run during snapshot mode"
-        );
-        let removed = self.map.remove(&task_id).map(|(_, storage)| storage);
-        if let Some(storage) = &removed
-            && storage.flags.any_modified()
-        {
-            let shard_idx = self.shard_index(&task_id);
-            self.shard_modified_counts[shard_idx].fetch_sub(1, Ordering::Relaxed);
-        }
-        removed
-    }
-
     pub fn access_pair_mut(
         &self,
         key1: TaskId,
@@ -676,6 +652,30 @@ impl Storage {
                 let (task_id, task) = unsafe { bucket.as_mut() };
                 if task_id.is_transient() {
                     evicted.unevictable_reasons[UnevictableReason::Transient.index()] += 1;
+                    continue;
+                }
+                // GC hard-delete: a task still flagged `deleted` here was collected and its on-disk
+                // copy was tombstoned by the snapshot that just committed (its `deleted` flag is
+                // re-checked under this shard write lock — a resurrection between the snapshot and
+                // now clears the flag, in which case we fall through to normal eviction). Its whole
+                // map entry + task_cache mapping can now be dropped. This is the reclaim path for
+                // the background `ReadWrite` loop; the shutdown drain snapshot drops the whole map
+                // wholesale instead, so it never reaches here.
+                if task.get().gc_is_deleted() {
+                    if let Some(task_type) = task.get().get_persistent_task_type() {
+                        // Best-effort inline; defer on contention (same lock-order caution as
+                        // below).
+                        match try_lock_and_remove(&self.task_cache, task_type.as_ref()) {
+                            TryLockAndRemove::Removed | TryLockAndRemove::NotFound => {}
+                            TryLockAndRemove::WouldBlock => {
+                                deferred_task_cache_removals.push(task_type.clone());
+                            }
+                        }
+                    }
+                    unsafe {
+                        shard.erase(bucket);
+                    }
+                    evicted.full += 1;
                     continue;
                 }
                 let (key_evictability, value_evictability) = task.get().evictability();
@@ -1135,7 +1135,7 @@ mod tests {
         _: &super::TaskStorage,
         _: &mut TurboBincodeBuffer,
     ) -> SnapshotItem {
-        SnapshotItem {
+        SnapshotItem::Put {
             task_id,
             meta: Some(TurboBincodeBuffer::default()),
             data: None,
@@ -1203,7 +1203,7 @@ mod tests {
 
         // The pre-snapshot snapshot copy should have been encoded and returned.
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, task_id);
+        assert_eq!(items[0].task_id(), task_id);
 
         {
             let guard = storage.access_mut(task_id);
@@ -1270,7 +1270,7 @@ mod tests {
             .collect();
 
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, task_id);
+        assert_eq!(items[0].task_id(), task_id);
 
         {
             let guard = storage.access_mut(task_id);
@@ -1318,7 +1318,7 @@ mod tests {
             .collect();
 
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, task_id);
+        assert_eq!(items[0].task_id(), task_id);
 
         // The entry must be gone from the map now that it has been persisted.
         assert!(
@@ -1415,7 +1415,7 @@ mod tests {
             .flat_map(|shard| shard.into_iter())
             .collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, modified_id);
+        assert_eq!(items[0].task_id(), modified_id);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -528,16 +528,16 @@ impl Storage {
 
     /// Mutable access to a resident task **without** inserting a blank entry for a missing key
     /// (unlike [`Storage::access_mut`], which resurrects a blank `TaskStorage`). Returns `None` if
-    /// the task is not resident. The closure runs while a shard write lock is held, so it must be
-    /// cheap and must not re-enter the map. Used by GC pin/unpin, where a missing entry means the
-    /// caller is referencing an already-collected task and inserting a blank would be a bug.
-    pub fn with_task_mut<R>(
-        &self,
-        key: TaskId,
-        f: impl FnOnce(&mut TaskStorage) -> R,
-    ) -> Option<R> {
-        let mut task = self.map.get_mut(&key)?;
-        Some(f(task.value_mut()))
+    /// the task is not resident. Used by the non-inserting
+    /// [`ExecuteContext::resident_task`](crate::backend::operation::ExecuteContext::resident_task)
+    /// path (GC pin/unpin), where a missing entry means the caller is referencing an
+    /// already-collected task and inserting a blank would be a bug.
+    pub fn access_mut_if_resident(&self, key: TaskId) -> Option<StorageWriteGuard<'_>> {
+        let inner = self.map.get_mut(&key)?;
+        Some(StorageWriteGuard {
+            storage: self,
+            inner: inner.into(),
+        })
     }
 
     /// The number of **persistent** (non-transient) tasks resident in the map. GC only collects
@@ -661,7 +661,7 @@ impl Storage {
                 // map entry + task_cache mapping can now be dropped. This is the reclaim path for
                 // the background `ReadWrite` loop; the shutdown drain snapshot drops the whole map
                 // wholesale instead, so it never reaches here.
-                if task.get().gc_is_deleted() {
+                if task.get().flags.deleted() {
                     if let Some(task_type) = task.get().get_persistent_task_type() {
                         // Best-effort inline; defer on contention (same lock-order caution as
                         // below).

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -558,6 +558,33 @@ impl Storage {
         persistent
     }
 
+    /// Collects the ids of resident, non-transient tasks whose storage passes the cheap
+    /// [`TaskStorage::gc_maybe_collectible`] pre-filter. GC calls this to seed a collection pass by
+    /// scanning the resident map (each `TaskStorage` is a handful of field reads under a shard read
+    /// lock, the same shape as the eviction scan), then re-validates each candidate authoritatively
+    /// under a guard. The scan only sees resident tasks; disk-only garbage is collected after it is
+    /// next restored.
+    ///
+    /// Parallelized across shards like [`Self::evict_after_snapshot`]: one job per shard scans it
+    /// under its own read lock and returns that shard's candidates, which are flattened into a
+    /// single list.
+    pub fn gc_collectible_candidates(&self) -> Vec<TaskId> {
+        let per_shard: Vec<Vec<TaskId>> = parallel::map_collect(self.map.shards(), |shard| {
+            let shard = shard.read();
+            let mut candidates = Vec::new();
+            // SAFETY: we hold the shard read lock for the duration of iteration.
+            for bucket in unsafe { shard.iter() } {
+                // SAFETY: the read lock guard outlives the bucket reference.
+                let (task_id, shared_value) = unsafe { bucket.as_ref() };
+                if !task_id.is_transient() && shared_value.get().gc_maybe_collectible() {
+                    candidates.push(*task_id);
+                }
+            }
+            candidates
+        });
+        per_shard.into_iter().flatten().collect()
+    }
+
     /// Removes a task entry from the map entirely. Used by GC after a garbage task's edges have
     /// been scrubbed. Returns the removed storage (dropped by the caller), or `None` if it was
     /// already gone.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -526,6 +526,20 @@ impl Storage {
         Some(f(task.value()))
     }
 
+    /// Mutable access to a resident task **without** inserting a blank entry for a missing key
+    /// (unlike [`Storage::access_mut`], which resurrects a blank `TaskStorage`). Returns `None` if
+    /// the task is not resident. The closure runs while a shard write lock is held, so it must be
+    /// cheap and must not re-enter the map. Used by GC pin/unpin, where a missing entry means the
+    /// caller is referencing an already-collected task and inserting a blank would be a bug.
+    pub fn with_task_mut<R>(
+        &self,
+        key: TaskId,
+        f: impl FnOnce(&mut TaskStorage) -> R,
+    ) -> Option<R> {
+        let mut task = self.map.get_mut(&key)?;
+        Some(f(task.value_mut()))
+    }
+
     /// The number of **persistent** (non-transient) tasks resident in the map. GC only collects
     /// persistent tasks (transient tasks are never collected), so this is the metric that must
     /// return to a flat baseline across re-rooting; the raw `resident_task_count` also includes

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -932,9 +932,17 @@ impl TaskStorage {
     /// restoring), have `Meta` resident (so `parent_count`/`upper`/`followers`/`children` are
     /// readable), and hold no aggregation edges (`upper`/`followers`).
     ///
+    /// The `is_restored(Meta)` check is load-bearing, not redundant: `parent_count`, `upper`, and
+    /// `followers` are lazy Meta fields that read as *absent* (i.e. 0 / empty) when Meta has been
+    /// evicted to disk-only. A candidate can be re-examined a pass *after* an eviction dropped its
+    /// Meta, at which point every signal here would falsely say "collectible". Requiring Meta
+    /// resident is what distinguishes "genuinely parentless, edge-free" from "we don't currently
+    /// know". When collectibility is decided through a restoring `ctx.task(id, All)` guard the
+    /// check is satisfied by construction; it is the real gate on the raw `&TaskStorage` path.
+    ///
     /// Note it does NOT require `Data` resident: the collectibility decision only reads Meta
-    /// fields, and `gc_delete_one` restores `Data` on demand (via `ctx.task(id, All)`) to scrub
-    /// the forward-dependency reverse sets, which are Data-category. This lets GC collect
+    /// fields, and `gc_scrub_and_remove` restores `Data` on demand (via `ctx.task(id, Data)`) to
+    /// scrub the forward-dependency reverse sets, which are Data-category. This lets GC collect
     /// garbage that has been evicted to disk-only Data, not just fully-resident garbage.
     ///
     /// The aggregation-edges check is conservative: a disconnected task is normally stripped of its
@@ -943,12 +951,13 @@ impl TaskStorage {
     /// activeness), we decline to collect and let a later pass take it once the edges clear.
     /// Under-collecting is always safe.
     pub fn is_gc_collectible(&self) -> bool {
-        self.gc_parent_count() == 0
+        // None of the other checks make sense without this
+        self.flags.is_restored(TaskDataCategory::Meta)
+            && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() == 0
             && !self.is_gc_root()
             && !self.flags.meta_restoring()
             && !self.flags.data_restoring()
-            && self.flags.is_restored(TaskDataCategory::Meta)
             && self.upper().is_empty()
             && self.followers().is_none_or(|f| f.is_empty())
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -142,6 +142,32 @@ struct TaskStorageSchema {
     #[field(storage = "counter_map", category = "transient")]
     aggregated_current_session_clean_containers: CounterMap<TaskId, i32, 3>,
 
+    /// Number of **persistent** parent tasks that list this task in their `children` set.
+    /// Absent = 0. Maintained incrementally at the two `children`-edge mutation sites (via the
+    /// durable `AdjustParentCount` aggregation-update job): incremented in `connect_children`,
+    /// decremented in `CleanupOldEdges`. When it reaches 0 (and no transient parent references the
+    /// task, and it is not a root/pinned/in-progress), the task is unreachable from persistent
+    /// roots and may be tombstoned instead of persisted, then dropped from memory during eviction.
+    ///
+    /// This replaces scan-based GC: a count can only drop to 0 while the parent is in memory (a
+    /// parent re-executed and dropped the child), so collectibility is detectable at that moment
+    /// with no DB scan.
+    // TODO(perf): this is a lazy field to avoid growing `TaskStorage` past its 128-byte budget
+    // (an inline `u32` pushes it to 136). `parent_count` is near-universal and mutated on every
+    // child-edge change, so it is a good candidate for inline storage; revisit once we can free 8
+    // inline bytes (which requires demoting `output_dependent` or `upper` to lazy — a hot-path
+    // tradeoff). Shrinking a collection's inline-capacity const does NOT help (AutoSet/CounterMap
+    // are 32 bytes regardless of `I`).
+    #[field(storage = "direct", category = "meta")]
+    parent_count: u32,
+
+    /// Number of **transient** parent tasks currently referencing this task as a child (this
+    /// session only; never persisted). A persistent task referenced solely by a transient parent
+    /// has `parent_count == 0` but must stay live in-session; this keeps it uncollectible.
+    /// Re-established on restart when transient parents re-execute and reconnect their children.
+    #[field(storage = "direct", category = "transient")]
+    transient_parent_count: u32,
+
     // =========================================================================
     // FLAGS (meta) - Boolean flags stored in TaskFlags bitfield
     // Persisted flags come first, then transient flags.
@@ -829,6 +855,18 @@ impl TaskStorage {
             aggregated_dirty_containers: self.aggregated_dirty_containers().map_or(0, |c| c.len()),
         }
     }
+
+    /// The number of persistent parents referencing this task (0 when the field is absent).
+    /// Read-only accessor over a bare `&TaskStorage` for GC and tests, without widening the
+    /// generated lazy getter's visibility.
+    pub fn gc_parent_count(&self) -> u32 {
+        self.get_parent_count().copied().unwrap_or(0)
+    }
+
+    /// The number of transient (session-only) parents referencing this task (0 when absent).
+    pub fn gc_transient_parent_count(&self) -> u32 {
+        self.get_transient_parent_count().copied().unwrap_or(0)
+    }
 }
 
 /// Counts for aggregation tree and collectibles fields.
@@ -1178,6 +1216,10 @@ mod tests {
         original
             .aggregated_dirty_containers_mut()
             .insert(TaskId::new(50).unwrap(), 2);
+        // Persisted parent count.
+        original.set_parent_count(3);
+        // Transient parent count (should NOT be serialized).
+        original.set_transient_parent_count(9);
 
         // Set transient flag (should NOT be serialized)
         original.flags.set_current_session_clean(true);
@@ -1223,6 +1265,10 @@ mod tests {
             decoded.aggregated_dirty_containers(),
             original.aggregated_dirty_containers()
         );
+        // Persisted parent_count survives the round-trip.
+        assert_eq!(decoded.get_parent_count(), Some(&3));
+        // Transient parent count is NOT serialized; it stays at its default (absent == 0).
+        assert_eq!(decoded.get_transient_parent_count(), None);
 
         // Note: invalidator and immutable are data category flags, not meta
         // They should NOT have changed during meta encode/decode

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -84,7 +84,7 @@ struct TaskStorageSchema {
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    output_dependent: AutoSet<TaskId, 6>,
+    output_dependent: AutoSet<TaskId, 4>,
 
     /// The task's output value.
     /// Filtered during serialization to skip transient outputs (referencing transient tasks).
@@ -1814,7 +1814,7 @@ mod tests {
     fn test_schema_size() {
         assert_eq!(
             size_of::<TaskStorage>(),
-            120,
+            128,
             "TaskStorage size changed! Update this test."
         );
         // `LazyField` is 40 B = 32 B largest payload + 8 B discriminant.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -886,6 +886,35 @@ impl TaskStorage {
         self.get_transient_ref_count().copied().unwrap_or(0)
     }
 
+    /// The storage-only part of GC collectibility: `Meta` is resident, no persistent or transient
+    /// parents, quiescent (not active, not in progress), and no aggregation edges
+    /// (`upper`/`followers`). Does NOT include the transient-*id* check (a `TaskStorage` has no id)
+    /// — the caller must also confirm `!task_id.is_transient()`. [`TaskGuard::is_gc_collectible`]
+    /// is the authoritative predicate; it adds the id check and delegates here. GC uses this
+    /// bare form to cheaply pre-filter the resident map (see `gc_collect`) without opening a
+    /// guard per task.
+    ///
+    /// **The `is_restored(Meta)` gate is load-bearing.** `parent_count` and the aggregation-edge
+    /// fields are Meta-category, so a task whose `Meta` has been evicted (`drop_partial`) reads
+    /// them as their defaults — `parent_count == 0`, empty `upper`/`followers` — which would
+    /// look collectible even though the task's *persisted* Meta may say otherwise (a nonzero
+    /// parent count, live edges). This raw predicate has no guard to restore Meta from disk, so
+    /// it must refuse to judge an unrestored task and leave it for a pass after it is next
+    /// restored. (`is_gc_collectible` reaches here through a restoring `ctx.task(.., All)`
+    /// guard, so the gate is trivially satisfied on that path.)
+    ///
+    /// The aggregation-edges check is conservative: a disconnected task is typically removed from
+    /// the aggregation graph, but that can lag and race GC, so we back off rather than collect.
+    pub fn gc_maybe_collectible(&self) -> bool {
+        self.flags.is_restored(TaskDataCategory::Meta)
+            && self.gc_parent_count() == 0
+            && self.gc_transient_ref_count() == 0
+            && self.get_activeness().is_none()
+            && self.get_in_progress().is_none()
+            && self.upper().is_empty()
+            && self.followers().is_none_or(|f| f.is_empty())
+    }
+
     /// Increments the transient reference count (a pin / detached-handle / transient-parent edge)
     /// and returns the new value. `transient_ref_count` is a transient field, so no modification
     /// tracking is needed.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -161,12 +161,20 @@ struct TaskStorageSchema {
     #[field(storage = "direct", category = "meta")]
     parent_count: u32,
 
-    /// Number of **transient** parent tasks currently referencing this task as a child (this
-    /// session only; never persisted). A persistent task referenced solely by a transient parent
-    /// has `parent_count == 0` but must stay live in-session; this keeps it uncollectible.
-    /// Re-established on restart when transient parents re-execute and reconnect their children.
+    /// Number of **transient** in-session references to this task that are not persistent parent
+    /// edges (this session only; never persisted). Two sources bump it:
+    /// - a **transient parent** connecting this task as a child (transient parents are never
+    ///   persisted, so their edge can't count toward the durable `parent_count`), and
+    /// - a **detached handle** that holds this task's `OperationVc` outside the tracked graph
+    ///   (e.g. a `DetachedVc` passed to JS across the NAPI boundary), which pins it like a GC
+    ///   root.
+    ///
+    /// A persistent task with `parent_count == 0` but `transient_ref_count > 0` is kept alive
+    /// in-session (uncollectible) — it is still referenced, just not by a persistent parent. On
+    /// restart these references are re-established (transient parents re-execute; detached handles
+    /// are re-created), so the count is never persisted.
     #[field(storage = "direct", category = "transient")]
-    transient_parent_count: u32,
+    transient_ref_count: u32,
 
     // =========================================================================
     // FLAGS (meta) - Boolean flags stored in TaskFlags bitfield
@@ -242,15 +250,6 @@ struct TaskStorageSchema {
     /// Set when task is created, cleared after persisting.
     #[field(storage = "flag", category = "transient")]
     pub new_task: bool,
-
-    /// Whether this task is pinned against garbage collection (via
-    /// [`prevent_gc`](turbo_tasks::prevent_gc)). A pinned task is treated as a GC root, covering
-    /// references that escape the tracked task graph (e.g. a `Vc` sent out of a `spawn_detached`
-    /// future across a channel, or handed across the NAPI boundary) which no persistent parent
-    /// lists as a child. Pinned tasks are also unevictable so the (transient, session-only) flag
-    /// can never be lost by eviction.
-    #[field(storage = "flag", category = "transient")]
-    pub pinned: bool,
 
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
@@ -603,10 +602,11 @@ impl TaskStorage {
             Some(arc) if arc.count() == 1 => KeyEvictability::AlreadyEvicted,
             Some(_) => KeyEvictability::Evictable,
         };
-        // Pinned tasks (via prevent_gc) must stay fully resident: the pin is a transient,
-        // session-only flag, so evicting the task would silently lose it and expose the pinned task
-        // to collection.
-        if flags.pinned() {
+        // Tasks with a live transient reference (a `prevent_gc` pin, a detached handle, or a
+        // transient parent — see `transient_ref_count`) must stay fully resident: the count is a
+        // transient, session-only field, so evicting the task would silently lose it and expose the
+        // still-referenced task to collection.
+        if self.gc_transient_ref_count() > 0 {
             return (
                 key_evictability,
                 ValueEvictability::Unevictable(UnevictableReason::Pinned),
@@ -887,34 +887,68 @@ impl TaskStorage {
     }
 
     /// The number of transient (session-only) parents referencing this task (0 when absent).
-    pub fn gc_transient_parent_count(&self) -> u32 {
-        self.get_transient_parent_count().copied().unwrap_or(0)
+    pub fn gc_transient_ref_count(&self) -> u32 {
+        self.get_transient_ref_count().copied().unwrap_or(0)
+    }
+
+    /// Increments the transient reference count (a pin / detached-handle / transient-parent edge)
+    /// and returns the new value. `transient_ref_count` is a transient field, so no modification
+    /// tracking is needed.
+    pub fn gc_increment_transient_ref_count(&mut self) -> u32 {
+        let new = self.gc_transient_ref_count() + 1;
+        self.set_transient_ref_count(new);
+        new
+    }
+
+    /// Decrements the transient reference count and returns the new value. Debug-panics on
+    /// underflow (an unpin without a matching pin).
+    pub fn gc_decrement_transient_ref_count(&mut self) -> u32 {
+        let current = self.gc_transient_ref_count();
+        debug_assert!(
+            current > 0,
+            "transient_ref_count underflow (unpin without pin)"
+        );
+        let new = current.saturating_sub(1);
+        if new == 0 {
+            self.take_transient_ref_count();
+        } else {
+            self.set_transient_ref_count(new);
+        }
+        new
     }
 
     /// Whether this task is a garbage-collection root and must never be collected: it is active
-    /// (`activeness` set — a root/once task, positive active counter, or active-until-clean),
-    /// currently in progress (about to connect children), or pinned via
-    /// [`prevent_gc`](turbo_tasks::prevent_gc). Transient-ness is a property of the [`TaskId`], not
-    /// the storage, so it is checked separately by the caller.
+    /// (`activeness` set — a root/once task, positive active counter, or active-until-clean) or
+    /// currently in progress (about to connect children). Transient references (pins / detached
+    /// handles / transient parents) are tracked separately by `transient_ref_count` and checked in
+    /// [`Self::is_gc_collectible`]. Transient-ness is a property of the [`TaskId`], not the
+    /// storage, so it is checked separately by the caller.
     pub fn is_gc_root(&self) -> bool {
-        self.get_activeness().is_some() || self.get_in_progress().is_some() || self.flags.pinned()
+        self.get_activeness().is_some() || self.get_in_progress().is_some()
     }
 
     /// Whether a GC pass may collect this task, given it is non-transient and has no persistent or
     /// transient parents. It must be quiescent (not active, not in progress, not currently
-    /// restoring), have `Data` resident so its dependency edges can be scrubbed, and hold no
-    /// aggregation edges (`upper`/`followers`). The aggregation-edges check is conservative: a
-    /// disconnected task is normally stripped of its aggregation edges by `CleanupOldEdges`, but a
-    /// re-executing aggregation node can transiently retain them; rather than tear down the
-    /// aggregation overlay here (a miscount corrupts activeness), we decline to collect and let a
-    /// later pass take it once the edges clear. Under-collecting is always safe.
+    /// restoring), have `Meta` resident (so `parent_count`/`upper`/`followers`/`children` are
+    /// readable), and hold no aggregation edges (`upper`/`followers`).
+    ///
+    /// Note it does NOT require `Data` resident: the collectibility decision only reads Meta
+    /// fields, and `gc_delete_one` restores `Data` on demand (via `ctx.task(id, All)`) to scrub
+    /// the forward-dependency reverse sets, which are Data-category. This lets GC collect
+    /// garbage that has been evicted to disk-only Data, not just fully-resident garbage.
+    ///
+    /// The aggregation-edges check is conservative: a disconnected task is normally stripped of its
+    /// aggregation edges by `CleanupOldEdges`, but a re-executing aggregation node can transiently
+    /// retain them; rather than tear down the aggregation overlay here (a miscount corrupts
+    /// activeness), we decline to collect and let a later pass take it once the edges clear.
+    /// Under-collecting is always safe.
     pub fn is_gc_collectible(&self) -> bool {
         self.gc_parent_count() == 0
-            && self.gc_transient_parent_count() == 0
+            && self.gc_transient_ref_count() == 0
             && !self.is_gc_root()
             && !self.flags.meta_restoring()
             && !self.flags.data_restoring()
-            && self.flags.is_restored(TaskDataCategory::Data)
+            && self.flags.is_restored(TaskDataCategory::Meta)
             && self.upper().is_empty()
             && self.followers().is_none_or(|f| f.is_empty())
     }
@@ -1270,7 +1304,7 @@ mod tests {
         // Persisted parent count.
         original.set_parent_count(3);
         // Transient parent count (should NOT be serialized).
-        original.set_transient_parent_count(9);
+        original.set_transient_ref_count(9);
 
         // Set transient flag (should NOT be serialized)
         original.flags.set_current_session_clean(true);
@@ -1319,7 +1353,7 @@ mod tests {
         // Persisted parent_count survives the round-trip.
         assert_eq!(decoded.get_parent_count(), Some(&3));
         // Transient parent count is NOT serialized; it stays at its default (absent == 0).
-        assert_eq!(decoded.get_transient_parent_count(), None);
+        assert_eq!(decoded.get_transient_ref_count(), None);
 
         // Note: invalidator and immutable are data category flags, not meta
         // They should NOT have changed during meta encode/decode

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -243,6 +243,15 @@ struct TaskStorageSchema {
     #[field(storage = "flag", category = "transient")]
     pub new_task: bool,
 
+    /// Whether this task is pinned against garbage collection (via
+    /// [`prevent_gc`](turbo_tasks::prevent_gc)). A pinned task is treated as a GC root, covering
+    /// references that escape the tracked task graph (e.g. a `Vc` sent out of a `spawn_detached`
+    /// future across a channel, or handed across the NAPI boundary) which no persistent parent
+    /// lists as a child. Pinned tasks are also unevictable so the (transient, session-only) flag
+    /// can never be lost by eviction.
+    #[field(storage = "flag", category = "transient")]
+    pub pinned: bool,
+
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
     // =========================================================================
@@ -512,6 +521,9 @@ pub enum UnevictableReason {
     Modified,
     /// The task is transient
     Transient,
+    /// The task is pinned against GC ([`TaskFlags::pinned`]); it must stay resident so the
+    /// transient, session-only pin flag can never be lost by eviction.
+    Pinned,
     // Keep `NothingToEvict` last: `COUNT` is derived from its discriminant.
     NothingToEvict,
 }
@@ -523,6 +535,7 @@ impl UnevictableReason {
         UnevictableReason::InProgress,
         UnevictableReason::Modified,
         UnevictableReason::Transient,
+        UnevictableReason::Pinned,
         UnevictableReason::NothingToEvict,
     ];
 
@@ -542,6 +555,7 @@ impl UnevictableReason {
             UnevictableReason::InProgress => "skipped_in_progress",
             UnevictableReason::Modified => "skipped_modified",
             UnevictableReason::Transient => "skipped_transient",
+            UnevictableReason::Pinned => "skipped_pinned",
             UnevictableReason::NothingToEvict => "skipped_nothing_to_evict",
         }
     }
@@ -589,6 +603,15 @@ impl TaskStorage {
             Some(arc) if arc.count() == 1 => KeyEvictability::AlreadyEvicted,
             Some(_) => KeyEvictability::Evictable,
         };
+        // Pinned tasks (via prevent_gc) must stay fully resident: the pin is a transient,
+        // session-only flag, so evicting the task would silently lose it and expose the pinned task
+        // to collection.
+        if flags.pinned() {
+            return (
+                key_evictability,
+                ValueEvictability::Unevictable(UnevictableReason::Pinned),
+            );
+        }
         // All these flags imply that the task is currently being used in some way
         // either literally executing, or about to
         if self.get_in_progress().is_some()
@@ -869,11 +892,12 @@ impl TaskStorage {
     }
 
     /// Whether this task is a garbage-collection root and must never be collected: it is active
-    /// (`activeness` set — a root/once task, positive active counter, or active-until-clean) or
-    /// currently in progress (about to connect children). Transient-ness is a property of the
-    /// [`TaskId`], not the storage, so it is checked separately by the caller.
+    /// (`activeness` set — a root/once task, positive active counter, or active-until-clean),
+    /// currently in progress (about to connect children), or pinned via
+    /// [`prevent_gc`](turbo_tasks::prevent_gc). Transient-ness is a property of the [`TaskId`], not
+    /// the storage, so it is checked separately by the caller.
     pub fn is_gc_root(&self) -> bool {
-        self.get_activeness().is_some() || self.get_in_progress().is_some()
+        self.get_activeness().is_some() || self.get_in_progress().is_some() || self.flags.pinned()
     }
 
     /// Whether a GC pass may collect this task, given it is non-transient and has no persistent or

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -250,6 +250,17 @@ struct TaskStorageSchema {
     #[field(storage = "flag", category = "transient")]
     pub new_task: bool,
 
+    /// GC soft-deletion marker. Set by the garbage collector when a task is collected: its edges
+    /// have been scrubbed and it is destined for deletion, but it stays **resident** (this is a
+    /// transient flag, so eviction's `drop_partial` keeps it as residue) until the next snapshot
+    /// tombstones its on-disk copy and a later step hard-deletes it. Keeping it resident closes
+    /// the resurrection window — any `ctx.task` on it during the pass finds a real entry
+    /// rather than restoring a zombie from disk. Cleared (and the task marked dirty) if the
+    /// task is resurrected by a connect before the hard-delete. Never persisted (a crash just
+    /// leaves the task on disk to be re-collected next session).
+    #[field(storage = "flag", category = "transient")]
+    deleted: bool,
+
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
     // =========================================================================
@@ -907,12 +918,31 @@ impl TaskStorage {
     /// the aggregation graph, but that can lag and race GC, so we back off rather than collect.
     pub fn gc_maybe_collectible(&self) -> bool {
         self.flags.is_restored(TaskDataCategory::Meta)
+            // Already collected this session (soft-deleted, awaiting tombstone + hard-delete):
+            // don't re-select it, or a second pass would collect it again while it is still
+            // resident.
+            && !self.flags.deleted()
             && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() == 0
             && self.get_activeness().is_none()
             && self.get_in_progress().is_none()
             && self.upper().is_empty()
             && self.followers().is_none_or(|f| f.is_empty())
+    }
+
+    /// Whether this task has been marked soft-deleted by GC (see the `deleted` flag).
+    pub fn gc_is_deleted(&self) -> bool {
+        self.flags.deleted()
+    }
+
+    /// Marks this task soft-deleted (GC collected it; awaiting tombstone + hard-delete).
+    pub fn gc_set_deleted(&mut self) {
+        self.flags.set_deleted(true);
+    }
+
+    /// Clears the soft-deletion marker (the task was resurrected before hard-delete).
+    pub fn gc_clear_deleted(&mut self) {
+        self.flags.set_deleted(false);
     }
 
     /// Increments the transient reference count (a pin / detached-handle / transient-parent edge)
@@ -1832,6 +1862,38 @@ mod tests {
             // cell_data is category=data; meta-only drop leaves it alone.
             assert_eq!(storage.cell_data().unwrap().len(), 1);
         }
+    }
+
+    // ==========================================================================
+    // GC soft-deletion
+    // ==========================================================================
+
+    /// The `deleted` marker round-trips through its accessors, and — because it is a *transient*
+    /// flag, not Meta — it survives a Meta `drop_partial` (partial eviction). The mark therefore
+    /// remains observable no matter what normal eviction does to the Meta/Data payload, so the
+    /// tombstone + hard-delete logic (which keys off the flag) can't be fooled by a partial
+    /// eviction between the mark and the commit.
+    #[test]
+    fn deleted_marker_is_transient_residue() {
+        let mut storage = TaskStorage::new();
+        storage.flags.set_new_task(false);
+        storage.flags.set_data_restored(true);
+        storage.flags.set_meta_restored(true);
+        assert!(!storage.gc_is_deleted());
+
+        storage.gc_set_deleted();
+        assert!(storage.gc_is_deleted());
+
+        // A Meta drop_partial (what partial eviction does) must NOT clear the transient marker.
+        let _ = storage.drop_partial(/* data */ false, /* meta */ true);
+        assert!(
+            storage.gc_is_deleted(),
+            "the `deleted` marker is transient and must survive a Meta drop_partial"
+        );
+
+        // Resurrection clears it.
+        storage.gc_clear_deleted();
+        assert!(!storage.gc_is_deleted());
     }
 
     // ==========================================================================

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -152,13 +152,12 @@ struct TaskStorageSchema {
     /// This replaces scan-based GC: a count can only drop to 0 while the parent is in memory (a
     /// parent re-executed and dropped the child), so collectibility is detectable at that moment
     /// with no DB scan.
-    // TODO(perf): this is a lazy field to avoid growing `TaskStorage` past its 128-byte budget
-    // (an inline `u32` pushes it to 136). `parent_count` is near-universal and mutated on every
-    // child-edge change, so it is a good candidate for inline storage; revisit once we can free 8
-    // inline bytes (which requires demoting `output_dependent` or `upper` to lazy — a hot-path
-    // tradeoff). Shrinking a collection's inline-capacity const does NOT help (AutoSet/CounterMap
-    // are 32 bytes regardless of `I`).
-    #[field(storage = "direct", category = "meta")]
+    // Stored inline (not lazy): `parent_count` is near-universal and mutated on every child-edge
+    // change, so a lazy-Vec scan per access is wasteful. `AutoSet`/`AutoMap` are backed by
+    // `InlineVec` whose size shrinks with the inline-capacity const, which brought `TaskStorage`
+    // down far enough to afford two inline `u32` counts within the size budget (see
+    // `test_schema_size`). `default` gives absent==0 semantics with a bare `u32` (no `Option`).
+    #[field(storage = "direct", category = "meta", inline, default)]
     parent_count: u32,
 
     /// Number of **transient** in-session references to this task that are not persistent parent
@@ -173,7 +172,7 @@ struct TaskStorageSchema {
     /// in-session (uncollectible) — it is still referenced, just not by a persistent parent. On
     /// restart these references are re-established (transient parents re-execute; detached handles
     /// are re-created), so the count is never persisted.
-    #[field(storage = "direct", category = "transient")]
+    #[field(storage = "direct", category = "transient", inline, default)]
     transient_ref_count: u32,
 
     // =========================================================================
@@ -1815,14 +1814,14 @@ mod tests {
     fn test_schema_size() {
         assert_eq!(
             size_of::<TaskStorage>(),
-            128,
-            "TaskStorage size changed! Run print_schema_sizes and update this test."
+            120,
+            "TaskStorage size changed! Update this test."
         );
         // `LazyField` is 40 B = 32 B largest payload + 8 B discriminant.
         assert_eq!(
             size_of::<LazyField>(),
             40,
-            "LazyField size changed! Run print_schema_sizes and update this test."
+            "LazyField size changed! Update this test."
         );
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -867,6 +867,33 @@ impl TaskStorage {
     pub fn gc_transient_parent_count(&self) -> u32 {
         self.get_transient_parent_count().copied().unwrap_or(0)
     }
+
+    /// Whether this task is a garbage-collection root and must never be collected: it is active
+    /// (`activeness` set — a root/once task, positive active counter, or active-until-clean) or
+    /// currently in progress (about to connect children). Transient-ness is a property of the
+    /// [`TaskId`], not the storage, so it is checked separately by the caller.
+    pub fn is_gc_root(&self) -> bool {
+        self.get_activeness().is_some() || self.get_in_progress().is_some()
+    }
+
+    /// Whether a GC pass may collect this task, given it is non-transient and has no persistent or
+    /// transient parents. It must be quiescent (not active, not in progress, not currently
+    /// restoring), have `Data` resident so its dependency edges can be scrubbed, and hold no
+    /// aggregation edges (`upper`/`followers`). The aggregation-edges check is conservative: a
+    /// disconnected task is normally stripped of its aggregation edges by `CleanupOldEdges`, but a
+    /// re-executing aggregation node can transiently retain them; rather than tear down the
+    /// aggregation overlay here (a miscount corrupts activeness), we decline to collect and let a
+    /// later pass take it once the edges clear. Under-collecting is always safe.
+    pub fn is_gc_collectible(&self) -> bool {
+        self.gc_parent_count() == 0
+            && self.gc_transient_parent_count() == 0
+            && !self.is_gc_root()
+            && !self.flags.meta_restoring()
+            && !self.flags.data_restoring()
+            && self.flags.is_restored(TaskDataCategory::Data)
+            && self.upper().is_empty()
+            && self.followers().is_none_or(|f| f.is_empty())
+    }
 }
 
 /// Counts for aggregation tree and collectibles fields.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -520,9 +520,6 @@ pub enum UnevictableReason {
     Modified,
     /// The task is transient
     Transient,
-    /// The task is pinned against GC ([`TaskFlags::pinned`]); it must stay resident so the
-    /// transient, session-only pin flag can never be lost by eviction.
-    Pinned,
     // Keep `NothingToEvict` last: `COUNT` is derived from its discriminant.
     NothingToEvict,
 }
@@ -534,7 +531,6 @@ impl UnevictableReason {
         UnevictableReason::InProgress,
         UnevictableReason::Modified,
         UnevictableReason::Transient,
-        UnevictableReason::Pinned,
         UnevictableReason::NothingToEvict,
     ];
 
@@ -554,7 +550,6 @@ impl UnevictableReason {
             UnevictableReason::InProgress => "skipped_in_progress",
             UnevictableReason::Modified => "skipped_modified",
             UnevictableReason::Transient => "skipped_transient",
-            UnevictableReason::Pinned => "skipped_pinned",
             UnevictableReason::NothingToEvict => "skipped_nothing_to_evict",
         }
     }
@@ -602,16 +597,17 @@ impl TaskStorage {
             Some(arc) if arc.count() == 1 => KeyEvictability::AlreadyEvicted,
             Some(_) => KeyEvictability::Evictable,
         };
-        // Tasks with a live transient reference (a `prevent_gc` pin, a detached handle, or a
-        // transient parent — see `transient_ref_count`) must stay fully resident: the count is a
-        // transient, session-only field, so evicting the task would silently lose it and expose the
-        // still-referenced task to collection.
-        if self.gc_transient_ref_count() > 0 {
-            return (
-                key_evictability,
-                ValueEvictability::Unevictable(UnevictableReason::Pinned),
-            );
-        }
+        // A task with a live transient reference (a `prevent_gc` pin, a detached handle, or a
+        // transient parent — see `transient_ref_count`) is NOT forced fully resident. It falls
+        // through to the normal Meta/Data evictability below: `drop_partial` retains non-default
+        // *transient* fields, so `transient_ref_count` survives as residue and the map entry is
+        // kept (see `DropPartialOutcome::HasResidue`), while the Meta/Data it no longer
+        // needs are reclaimed. Losing the count to eviction (which would expose the
+        // still-referenced task to collection) can't happen. After such a partial eviction
+        // the task's Meta is gone, so it is not immediately GC-collectible even once
+        // unpinned — `is_gc_collectible` requires Meta resident — which is safe
+        // (under-collection; a later access restores Meta and a later pass collects it).
+        //
         // All these flags imply that the task is currently being used in some way
         // either literally executing, or about to
         if self.get_in_progress().is_some()

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -930,47 +930,6 @@ impl TaskStorage {
             && self.followers().is_none_or(|f| f.is_empty())
     }
 
-    /// Whether this task has been marked soft-deleted by GC (see the `deleted` flag).
-    pub fn gc_is_deleted(&self) -> bool {
-        self.flags.deleted()
-    }
-
-    /// Marks this task soft-deleted (GC collected it; awaiting tombstone + hard-delete).
-    pub fn gc_set_deleted(&mut self) {
-        self.flags.set_deleted(true);
-    }
-
-    /// Clears the soft-deletion marker (the task was resurrected before hard-delete).
-    pub fn gc_clear_deleted(&mut self) {
-        self.flags.set_deleted(false);
-    }
-
-    /// Increments the transient reference count (a pin / detached-handle / transient-parent edge)
-    /// and returns the new value. `transient_ref_count` is a transient field, so no modification
-    /// tracking is needed.
-    pub fn gc_increment_transient_ref_count(&mut self) -> u32 {
-        let new = self.gc_transient_ref_count() + 1;
-        self.set_transient_ref_count(new);
-        new
-    }
-
-    /// Decrements the transient reference count and returns the new value. Debug-panics on
-    /// underflow (an unpin without a matching pin).
-    pub fn gc_decrement_transient_ref_count(&mut self) -> u32 {
-        let current = self.gc_transient_ref_count();
-        debug_assert!(
-            current > 0,
-            "transient_ref_count underflow (unpin without pin)"
-        );
-        let new = current.saturating_sub(1);
-        if new == 0 {
-            self.take_transient_ref_count();
-        } else {
-            self.set_transient_ref_count(new);
-        }
-        new
-    }
-
     // GC collectibility (`is_gc_collectible`) lives on the `TaskGuard` trait, so that the Meta
     // fields it reads (`parent_count`/`upper`/`followers`) go through the guard's `check_access`
     // machinery, which enforces that the task was opened with Meta restored. See
@@ -1879,21 +1838,21 @@ mod tests {
         storage.flags.set_new_task(false);
         storage.flags.set_data_restored(true);
         storage.flags.set_meta_restored(true);
-        assert!(!storage.gc_is_deleted());
+        assert!(!storage.flags.deleted());
 
-        storage.gc_set_deleted();
-        assert!(storage.gc_is_deleted());
+        storage.flags.set_deleted(true);
+        assert!(storage.flags.deleted());
 
         // A Meta drop_partial (what partial eviction does) must NOT clear the transient marker.
         let _ = storage.drop_partial(/* data */ false, /* meta */ true);
         assert!(
-            storage.gc_is_deleted(),
+            storage.flags.deleted(),
             "the `deleted` marker is transient and must survive a Meta drop_partial"
         );
 
         // Resurrection clears it.
-        storage.gc_clear_deleted();
-        assert!(!storage.gc_is_deleted());
+        storage.flags.set_deleted(false);
+        assert!(!storage.flags.deleted());
     }
 
     // ==========================================================================

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -1198,23 +1198,25 @@ mod tests {
         storage.flags.set_current_session_clean(true);
         assert!(storage.flags.current_session_clean());
 
-        // Test persisted_bits only includes non-transient flags
-        // optimization_pending=bit 0 (meta, persisted)
-        // invalidator=bit 1, immutable=bit 2 (data, persisted)
-        // current_session_clean=bit 3 (transient)
+        // Test persisted_bits only includes non-transient flags.
+        // Persisted flags are laid out meta-first then data (each in declaration order):
+        //   optimization_pending=bit 0, gc_root=bit 1 (meta, persisted)
+        //   invalidator=bit 2, immutable=bit 3 (data, persisted)
+        //   current_session_clean and later (transient)
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b110); // invalidator + immutable
+        assert_eq!(persisted, 0b1100); // invalidator (bit 2) + immutable (bit 3)
 
         // Test TaskFlags constants
-        assert_eq!(TaskFlags::PERSISTED_MASK, 0b111); // 3 persisted flags
+        assert_eq!(TaskFlags::PERSISTED_MASK, 0b1111); // 4 persisted flags
 
         // Test set_persisted_bits preserves transient flags
         let mut storage2 = TaskStorage::new();
         storage2.flags.set_current_session_clean(true); // Set transient flag
-        storage2.flags.set_persisted_bits(0b100); // Set immutable only
+        storage2.flags.set_persisted_bits(0b1000); // Set immutable only (bit 3)
         assert!(storage2.flags.immutable());
         assert!(!storage2.flags.invalidator());
         assert!(!storage2.flags.optimization_pending());
+        assert!(!storage2.flags.gc_root());
         assert!(storage2.flags.current_session_clean()); // Transient flag preserved
     }
 
@@ -1255,14 +1257,14 @@ mod tests {
         assert!(storage.flags.prefetched());
 
         // Verify these are all transient (not in persisted_bits)
-        // Only invalidator, immutable should be persisted
+        // Only optimization_pending/gc_root (meta) and invalidator/immutable (data) are persisted.
         let persisted = storage.flags.persisted_bits();
         assert_eq!(persisted, 0b00); // No persisted flags set
 
         // Set a persisted flag and verify internal state flags are still transient
         storage.flags.set_immutable(true);
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b100); // Only immutable (bit 2)
+        assert_eq!(persisted, 0b1000); // Only immutable (bit 3)
     }
 
     // Helper to create encoder

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -288,7 +288,7 @@ struct TaskStorageSchema {
         shrink_on_completion,
         drop_on_completion_if_immutable
     )]
-    cell_dependencies: AutoSet<CellRef, 2>,
+    cell_dependencies: AutoSet<CellRef, 3>,
 
     /// Cells this task depends on, narrowed to a hashed sub-value (`CellDependency::Hash`). Rare.
     #[field(
@@ -316,7 +316,7 @@ struct TaskStorageSchema {
 
     /// Outdated keyless cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
-    outdated_cell_dependencies: AutoSet<CellRef, 2>,
+    outdated_cell_dependencies: AutoSet<CellRef, 3>,
 
     /// Outdated hashed cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
@@ -338,7 +338,7 @@ struct TaskStorageSchema {
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    cell_dependents: AutoSet<CellRef, 2>,
+    cell_dependents: AutoSet<CellRef, 3>,
 
     /// Tasks that depend on a hashed sub-value of this task's cells. Reverse of
     /// `cell_dependencies_hashed`.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -917,50 +917,10 @@ impl TaskStorage {
         new
     }
 
-    /// Whether this task is a garbage-collection root and must never be collected: it is active
-    /// (`activeness` set — a root/once task, positive active counter, or active-until-clean) or
-    /// currently in progress (about to connect children). Transient references (pins / detached
-    /// handles / transient parents) are tracked separately by `transient_ref_count` and checked in
-    /// [`Self::is_gc_collectible`]. Transient-ness is a property of the [`TaskId`], not the
-    /// storage, so it is checked separately by the caller.
-    pub fn is_gc_root(&self) -> bool {
-        self.get_activeness().is_some() || self.get_in_progress().is_some()
-    }
-
-    /// Whether a GC pass may collect this task, given it is non-transient and has no persistent or
-    /// transient parents. It must be quiescent (not active, not in progress, not currently
-    /// restoring), have `Meta` resident (so `parent_count`/`upper`/`followers`/`children` are
-    /// readable), and hold no aggregation edges (`upper`/`followers`).
-    ///
-    /// The `is_restored(Meta)` check is load-bearing, not redundant: `parent_count`, `upper`, and
-    /// `followers` are lazy Meta fields that read as *absent* (i.e. 0 / empty) when Meta has been
-    /// evicted to disk-only. A candidate can be re-examined a pass *after* an eviction dropped its
-    /// Meta, at which point every signal here would falsely say "collectible". Requiring Meta
-    /// resident is what distinguishes "genuinely parentless, edge-free" from "we don't currently
-    /// know". When collectibility is decided through a restoring `ctx.task(id, All)` guard the
-    /// check is satisfied by construction; it is the real gate on the raw `&TaskStorage` path.
-    ///
-    /// Note it does NOT require `Data` resident: the collectibility decision only reads Meta
-    /// fields, and `gc_scrub_and_remove` restores `Data` on demand (via `ctx.task(id, Data)`) to
-    /// scrub the forward-dependency reverse sets, which are Data-category. This lets GC collect
-    /// garbage that has been evicted to disk-only Data, not just fully-resident garbage.
-    ///
-    /// The aggregation-edges check is conservative: a disconnected task is normally stripped of its
-    /// aggregation edges by `CleanupOldEdges`, but a re-executing aggregation node can transiently
-    /// retain them; rather than tear down the aggregation overlay here (a miscount corrupts
-    /// activeness), we decline to collect and let a later pass take it once the edges clear.
-    /// Under-collecting is always safe.
-    pub fn is_gc_collectible(&self) -> bool {
-        // None of the other checks make sense without this
-        self.flags.is_restored(TaskDataCategory::Meta)
-            && self.gc_parent_count() == 0
-            && self.gc_transient_ref_count() == 0
-            && !self.is_gc_root()
-            && !self.flags.meta_restoring()
-            && !self.flags.data_restoring()
-            && self.upper().is_empty()
-            && self.followers().is_none_or(|f| f.is_empty())
-    }
+    // GC collectibility (`is_gc_collectible`) lives on the `TaskGuard` trait, so that the Meta
+    // fields it reads (`parent_count`/`upper`/`followers`) go through the guard's `check_access`
+    // machinery, which enforces that the task was opened with Meta restored. See
+    // `TaskGuard::is_gc_collectible`.
 }
 
 /// Counts for aggregation tree and collectibles fields.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -261,6 +261,10 @@ struct TaskStorageSchema {
     #[field(storage = "flag", category = "transient")]
     deleted: bool,
 
+    /// Marks the task as a GC root meaning it can never be collected via reference counting.
+    #[field(storage = "flag", category = "meta")]
+    gc_root: bool,
+
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
     // =========================================================================
@@ -918,14 +922,29 @@ impl TaskStorage {
     /// the aggregation graph, but that can lag and race GC, so we back off rather than collect.
     pub fn gc_maybe_collectible(&self) -> bool {
         self.flags.is_restored(TaskDataCategory::Meta)
+            // TODO: gating on Data being resident is a stop-gap for the crash where GC selects a
+            // task whose Data (holding `persistent_task_type`) was evicted, then `snapshot_and_persist`
+            // reads the absent type and panics. It creates a standoff: a truly-unreferenced task
+            // whose Data is never restored can never be collected (can't-delete-because-not-restored
+            // / won't-restore-because-unreferenced) — a disk-space leak, not memory. Real fix:
+            // restore Data during the GC pass before deciding, or move the task-type-hash into Meta
+            // so collection needs only Meta.
+            && self.flags.is_restored(TaskDataCategory::Data)
             // Already collected this session (soft-deleted, awaiting tombstone + hard-delete):
             // don't re-select it, or a second pass would collect it again while it is still
             // resident.
             && !self.flags.deleted()
+            // A GC root (a task spawned with no parent, see the `gc_root` flag) is held from
+            // outside the tracked graph and has no persistent parent — never collect it.
+            && !self.flags.gc_root()
+            // Refcounts must be 0
             && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() == 0
+            // Must not be in progress or being connected
             && self.get_activeness().is_none()
             && self.get_in_progress().is_none()
+            // Must not be participating in the aggregation graph.  Getting disconnected from parents
+            // should clear these but that process isn't atomic.
             && self.upper().is_empty()
             && self.followers().is_none_or(|f| f.is_empty())
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -19,6 +19,24 @@ pub struct SnapshotItem {
     pub task_type_hash: Option<TaskTypeHash>,
 }
 
+/// A task that garbage collection has determined is unreachable and should be tombstoned from
+/// persistent storage. Emitted by the sweep phase and applied in the same commit as the snapshot.
+///
+/// `TaskMeta` and `TaskData` are `SingleValue` families, so the task id key is tombstoned directly.
+/// `TaskCache` is `MultiValue` keyed by the 8-byte task-type hash, where a tombstone erases the
+/// whole hash bucket; `surviving_task_ids` therefore carries any *other* live task ids that share
+/// this task's hash (via an xxh3 collision) so they can be re-inserted after the tombstone. This is
+/// almost always empty — 8-byte hash collisions are astronomically rare.
+pub struct TaskDeletion {
+    pub task_id: TaskId,
+    /// The deleted task's persistent task-type hash (its `TaskCache` key). Always present because
+    /// only persistent (non-transient) tasks are collected, and those always have a task type.
+    pub task_type_hash: TaskTypeHash,
+    /// Live task ids sharing `task_type_hash` that must be re-inserted into `TaskCache` after the
+    /// whole-bucket tombstone. Almost always empty.
+    pub surviving_task_ids: Vec<TaskId>,
+}
+
 /// Computes a deterministic 64-bit hash of a CachedTaskType for use as a TaskCache key.
 ///
 /// This encodes the task type directly to a hasher, avoiding intermediate buffer allocation.

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -8,15 +8,35 @@ use turbo_tasks_hash::Xxh3Hash64Hasher;
 
 pub type TaskTypeHash = [u8; 8];
 
-/// A single item yielded by the snapshot iterator during persistence.
-pub struct SnapshotItem {
-    pub task_id: TaskId,
-    /// Serialized task meta data, if modified
-    pub meta: Option<TurboBincodeBuffer>,
-    /// Serialized task data, if modified
-    pub data: Option<TurboBincodeBuffer>,
-    /// Task type for new tasks that need to be added to the task cache
-    pub task_type_hash: Option<TaskTypeHash>,
+/// A single item yielded by the snapshot iterator during persistence: either a put (persist a
+/// modified task's meta/data + optionally register a new task's type) or a delete (tombstone a
+/// GC-collected task's on-disk copy). Both ride the one streaming iterator `save_snapshot`
+/// consumes, so GC tombstones are applied in the same commit and batch as the puts without a
+/// side-channel that would have to be fully materialized before the put loop.
+pub enum SnapshotItem {
+    Put {
+        task_id: TaskId,
+        /// Serialized task meta data, if modified
+        meta: Option<TurboBincodeBuffer>,
+        /// Serialized task data, if modified
+        data: Option<TurboBincodeBuffer>,
+        /// Task type for new tasks that need to be added to the task cache
+        task_type_hash: Option<TaskTypeHash>,
+    },
+    /// Tombstone a GC-collected task (see [`TaskDeletion`]).
+    Delete(TaskDeletion),
+}
+
+impl SnapshotItem {
+    /// The task this item persists or tombstones. (Currently only used by tests, which assert on
+    /// the id of items yielded by the snapshot iterator.)
+    #[cfg(test)]
+    pub fn task_id(&self) -> TaskId {
+        match self {
+            SnapshotItem::Put { task_id, .. } => *task_id,
+            SnapshotItem::Delete(TaskDeletion { task_id, .. }) => *task_id,
+        }
+    }
 }
 
 /// A task that garbage collection has determined is unreachable and should be tombstoned from

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -24,17 +24,18 @@ pub struct SnapshotItem {
 ///
 /// `TaskMeta` and `TaskData` are `SingleValue` families, so the task id key is tombstoned directly.
 /// `TaskCache` is `MultiValue` keyed by the 8-byte task-type hash, where a tombstone erases the
-/// whole hash bucket; `surviving_task_ids` therefore carries any *other* live task ids that share
-/// this task's hash (via an xxh3 collision) so they can be re-inserted after the tombstone. This is
-/// almost always empty — 8-byte hash collisions are astronomically rare.
+/// *whole* hash bucket. If another live task's type xxh3-collides with this one it shares the
+/// bucket, so the apply path must re-insert those survivors after the tombstone. Rather than carry
+/// them on this struct, the survivors are resolved at apply time in `save_snapshot`, which reads
+/// the authoritative on-disk bucket (`get_multiple`) and re-puts everything except the ids being
+/// deleted — the in-memory task cache is not a reliable source (it is lazily populated and keyed by
+/// the full task type, not the hash). Collisions between two simultaneously-live tasks are
+/// astronomically rare (~2^32 tasks for one expected collision), so this path almost never fires.
 pub struct TaskDeletion {
     pub task_id: TaskId,
     /// The deleted task's persistent task-type hash (its `TaskCache` key). Always present because
     /// only persistent (non-transient) tasks are collected, and those always have a task type.
     pub task_type_hash: TaskTypeHash,
-    /// Live task ids sharing `task_type_hash` that must be re-inserted into `TaskCache` after the
-    /// whole-bucket tombstone. Almost always empty.
-    pub surviving_task_ids: Vec<TaskId>,
 }
 
 /// Computes a deterministic 64-bit hash of a CachedTaskType for use as a TaskCache key.

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -239,91 +239,6 @@ impl Display for RootType {
     }
 }
 
-/// The set of children a task connected during its (in-progress) execution, staged until the
-/// execution completes and they are committed to the task's persistent `children` set.
-///
-/// This is a linear-ish wrapper around the staged `TaskId` set that exists to make the
-/// **`parent_count` hold** impossible to leak. When a genuinely-new child edge is staged, the
-/// child's reference count (`parent_count` for a persistent parent, `transient_ref_count` for a
-/// transient one) is optimistically incremented — exactly like the active-count hold taken at the
-/// same moment (see `ConnectChildOperation::run`). That hold must be discharged in one of exactly
-/// two ways, and the encapsulation here forces the caller to pick one:
-///
-/// - [`commit`](Self::commit): the execution completed and the edges become permanent members of
-///   `children`. The holds become permanent — no count change (the +1 taken at staging simply stops
-///   being "temporary"). Balanced later by the `-1` in `CleanupOldEdges` when the edge is
-///   eventually removed.
-/// - [`release_set`](Self::release_set): the staged edges are being **discarded** without ever
-///   reaching `children` (a stale reschedule or a cancellation). The caller must decrement the
-///   holds — see [`ExecuteContext::release_children_holds`](crate::backend::operation::ExecuteContext::release_children_holds),
-///   the only intended consumer, which does the per-child decrement.
-///
-/// The inner set is private and only reachable through those two methods, so any code path that
-/// ends an in-progress state has to make the commit-vs-discard decision explicitly (rather than
-/// silently dropping the set and leaking every hold, which would leave the children permanently
-/// uncollectible). There is deliberately no `Drop` bomb: at teardown (`drop_contents`) the whole
-/// task map — including in-progress tasks — is dropped wholesale, and the counts no longer matter,
-/// so an inert drop is correct there.
-#[derive(Debug, Default)]
-pub struct ChildrenCollector {
-    /// Staged children. Private: consume via [`commit`](Self::commit) or
-    /// [`release_set`](Self::release_set) so the hold decision cannot be skipped.
-    new_children: FxHashSet<TaskId>,
-}
-
-impl ChildrenCollector {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Whether `child` is already staged.
-    pub fn contains(&self, child: &TaskId) -> bool {
-        self.new_children.contains(child)
-    }
-
-    /// Stage `child`. Returns `true` if it was newly added, `false` if it was already staged
-    /// (mirrors [`std::collections::HashSet::insert`]). The caller decides, from this return and
-    /// the parent's existing `children` set, whether a `parent_count` hold applies.
-    pub fn insert(&mut self, child: TaskId) -> bool {
-        self.new_children.insert(child)
-    }
-
-    /// Remove `child` from the staged set. Returns whether it was present.
-    pub fn remove(&mut self, child: &TaskId) -> bool {
-        self.new_children.remove(child)
-    }
-
-    /// Iterate the staged children.
-    pub fn iter(&self) -> impl Iterator<Item = TaskId> + '_ {
-        self.new_children.iter().copied()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.new_children.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.new_children.len()
-    }
-
-    /// Consume the collector on the **success** path: the staged edges become permanent members of
-    /// the task's `children` set. The optimistic `parent_count` holds become permanent (no count
-    /// change here). Returns the staged set for `connect_children`'s `extend_children`.
-    pub fn commit(self) -> FxHashSet<TaskId> {
-        self.new_children
-    }
-
-    /// Consume the collector on a **discard** path (stale reschedule / cancellation). Yields the
-    /// staged set so the caller can release the holds. This is intentionally the *only* other way
-    /// to extract the set; its single intended caller is
-    /// [`ExecuteContext::release_children_holds`](crate::backend::operation::ExecuteContext::release_children_holds),
-    /// which decrements each genuinely-new child's reference count. Named distinctly from `commit`
-    /// so a discard can never be mistaken for a commit (which would leak the holds).
-    pub(crate) fn release_set(self) -> FxHashSet<TaskId> {
-        self.new_children
-    }
-}
-
 #[derive(Debug)]
 pub struct InProgressStateInner {
     pub stale: bool,
@@ -335,11 +250,9 @@ pub struct InProgressStateInner {
     /// Event that is triggered when the task output is available (completed flag set).
     /// This is used to wait for completion when reading the task output before it's available.
     pub done_event: Event,
-    /// Children connected during this execution, staged until completion. Wrapped in
-    /// [`ChildrenCollector`] so the `parent_count` hold taken when each genuinely-new child is
-    /// staged is discharged exactly once — committed to `children` on success, or released on a
-    /// stale/cancel discard.
-    pub new_children: ChildrenCollector,
+    /// Children that should be connected to the task and have their active_count decremented
+    /// once the task completes.
+    pub new_children: FxHashSet<TaskId>,
 }
 
 #[derive(Debug)]

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -239,6 +239,91 @@ impl Display for RootType {
     }
 }
 
+/// The set of children a task connected during its (in-progress) execution, staged until the
+/// execution completes and they are committed to the task's persistent `children` set.
+///
+/// This is a linear-ish wrapper around the staged `TaskId` set that exists to make the
+/// **`parent_count` hold** impossible to leak. When a genuinely-new child edge is staged, the
+/// child's reference count (`parent_count` for a persistent parent, `transient_ref_count` for a
+/// transient one) is optimistically incremented — exactly like the active-count hold taken at the
+/// same moment (see `ConnectChildOperation::run`). That hold must be discharged in one of exactly
+/// two ways, and the encapsulation here forces the caller to pick one:
+///
+/// - [`commit`](Self::commit): the execution completed and the edges become permanent members of
+///   `children`. The holds become permanent — no count change (the +1 taken at staging simply stops
+///   being "temporary"). Balanced later by the `-1` in `CleanupOldEdges` when the edge is
+///   eventually removed.
+/// - [`release_set`](Self::release_set): the staged edges are being **discarded** without ever
+///   reaching `children` (a stale reschedule or a cancellation). The caller must decrement the
+///   holds — see [`ExecuteContext::release_children_holds`](crate::backend::operation::ExecuteContext::release_children_holds),
+///   the only intended consumer, which does the per-child decrement.
+///
+/// The inner set is private and only reachable through those two methods, so any code path that
+/// ends an in-progress state has to make the commit-vs-discard decision explicitly (rather than
+/// silently dropping the set and leaking every hold, which would leave the children permanently
+/// uncollectible). There is deliberately no `Drop` bomb: at teardown (`drop_contents`) the whole
+/// task map — including in-progress tasks — is dropped wholesale, and the counts no longer matter,
+/// so an inert drop is correct there.
+#[derive(Debug, Default)]
+pub struct ChildrenCollector {
+    /// Staged children. Private: consume via [`commit`](Self::commit) or
+    /// [`release_set`](Self::release_set) so the hold decision cannot be skipped.
+    new_children: FxHashSet<TaskId>,
+}
+
+impl ChildrenCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether `child` is already staged.
+    pub fn contains(&self, child: &TaskId) -> bool {
+        self.new_children.contains(child)
+    }
+
+    /// Stage `child`. Returns `true` if it was newly added, `false` if it was already staged
+    /// (mirrors [`std::collections::HashSet::insert`]). The caller decides, from this return and
+    /// the parent's existing `children` set, whether a `parent_count` hold applies.
+    pub fn insert(&mut self, child: TaskId) -> bool {
+        self.new_children.insert(child)
+    }
+
+    /// Remove `child` from the staged set. Returns whether it was present.
+    pub fn remove(&mut self, child: &TaskId) -> bool {
+        self.new_children.remove(child)
+    }
+
+    /// Iterate the staged children.
+    pub fn iter(&self) -> impl Iterator<Item = TaskId> + '_ {
+        self.new_children.iter().copied()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.new_children.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.new_children.len()
+    }
+
+    /// Consume the collector on the **success** path: the staged edges become permanent members of
+    /// the task's `children` set. The optimistic `parent_count` holds become permanent (no count
+    /// change here). Returns the staged set for `connect_children`'s `extend_children`.
+    pub fn commit(self) -> FxHashSet<TaskId> {
+        self.new_children
+    }
+
+    /// Consume the collector on a **discard** path (stale reschedule / cancellation). Yields the
+    /// staged set so the caller can release the holds. This is intentionally the *only* other way
+    /// to extract the set; its single intended caller is
+    /// [`ExecuteContext::release_children_holds`](crate::backend::operation::ExecuteContext::release_children_holds),
+    /// which decrements each genuinely-new child's reference count. Named distinctly from `commit`
+    /// so a discard can never be mistaken for a commit (which would leak the holds).
+    pub(crate) fn release_set(self) -> FxHashSet<TaskId> {
+        self.new_children
+    }
+}
+
 #[derive(Debug)]
 pub struct InProgressStateInner {
     pub stale: bool,
@@ -250,9 +335,11 @@ pub struct InProgressStateInner {
     /// Event that is triggered when the task output is available (completed flag set).
     /// This is used to wait for completion when reading the task output before it's available.
     pub done_event: Event,
-    /// Children that should be connected to the task and have their active_count decremented
-    /// once the task completes.
-    pub new_children: FxHashSet<TaskId>,
+    /// Children connected during this execution, staged until completion. Wrapped in
+    /// [`ChildrenCollector`] so the `parent_count` hold taken when each genuinely-new child is
+    /// staged is discharged exactly once — committed to `children` on success, or released on a
+    /// stale/cancel discard.
+    pub new_children: ChildrenCollector,
 }
 
 #[derive(Debug)]

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -234,6 +234,17 @@ impl<'a> TurboWriteBatch<'a> {
             .put(key_space as u32, key.into_static(), value.into())
     }
 
+    /// Writes a delete (tombstone) for `key` into the write batch.
+    ///
+    /// For `SingleValue` families (`TaskMeta`, `TaskData`, `Infra`) this erases the key. For the
+    /// `MultiValue` `TaskCache` family this erases *all* values stored under the key (the whole
+    /// hash bucket); to remove a single mapping while keeping colliding entries, re-`put` the
+    /// survivors after the delete in the same batch (see `save_snapshot` in
+    /// `kv_backing_storage.rs`).
+    pub fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
+        self.batch.delete(key_space as u32, key.into_static())
+    }
+
     /// Flushes a key space of the write batch, reducing the amount of buffered memory used.
     /// Does not commit any data persistently.
     ///

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -240,16 +240,18 @@ impl TurboBackingStorage {
         let batch = self.inner.database.write_batch()?;
 
         {
-            let _span = tracing::trace_span!("update task data").entered();
-            // The parallel put phase also *collects* any `SnapshotItem::Delete` tombstones produced
-            // during the (streaming) shard iteration — GC-soft-deleted tasks serialize to a delete
-            // rather than a put. They can't be applied inline: the TaskCache tombstone below reads
-            // and rewrites a whole hash bucket and must run sequentially after all puts. So each
-            // shard returns its collected deletes alongside its `SnapshotMeta`, and they merge with
-            // the caller-supplied `deletes` (from the test-only `gc_for_testing` hook) before the
-            // sequential delete phase.
+            let span = tracing::trace_span!("update task data");
+            // GC-soft-deleted tasks serialize to a `SnapshotItem::Delete` rather than a put. The
+            // parallel put phase applies their SingleValue TaskMeta/TaskData tombstones inline (see
+            // the `Delete` arm) and returns each `TaskDeletion` in `shard_deletes` so the
+            // sequential phase below can apply the TaskCache tombstone — that one
+            // erases a whole MultiValue hash bucket and re-inserts survivors, a
+            // read-modify-write that must run after all puts. These merge with the
+            // caller-supplied deletes (from the test-only `gc_for_testing` hook), which
+            // arrive as their own shard.
             let per_shard =
                 parallel::map_collect_owned::<_, _, Result<Vec<_>>>(snapshots, |shard: I| {
+                    let _span = span.clone().entered();
                     let mut max_new_task_id = 0;
                     let mut data_items = 0;
                     let mut meta_items = 0;
@@ -264,6 +266,18 @@ impl TurboBackingStorage {
                                 task_type_hash,
                             } => (task_id, meta, data, task_type_hash),
                             SnapshotItem::Delete(deletion) => {
+                                // TaskMeta/TaskData are SingleValue, so tombstoning is a direct
+                                // per-id delete with no cross-shard read-modify-write — issue it
+                                // inline here, on the same thread-local collector the puts use (a
+                                // deleted id is never also emitted as a put in the same commit: GC
+                                // removes tasks from the map before the snapshot serializes). Only
+                                // the TaskCache tombstone must be deferred to the sequential phase
+                                // below (it erases a whole MultiValue hash bucket and re-inserts
+                                // survivors), so we still carry `deletion` out for that.
+                                let key = IntKey::new(*deletion.task_id);
+                                let key = key.as_ref();
+                                batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
+                                batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
                                 shard_deletes.push(deletion);
                                 continue;
                             }
@@ -311,85 +325,87 @@ impl TurboBackingStorage {
                         shard_deletes,
                     ))
                 })?;
-            let mut deletes: Vec<TaskDeletion> = Vec::new();
+            // Merge the per-shard snapshot metadata and, in the same pass, group the deleted ids by
+            // their TaskCache hash bucket (their SingleValue TaskMeta/TaskData tombstones were
+            // already applied inline in the parallel phase above). TaskCache is MultiValue and a
+            // tombstone erases the *whole* bucket, so for each distinct hash we must re-insert
+            // every id still living in that bucket (any type that xxh3-collides with a
+            // deleted one). Normally each hash maps to exactly the single id being
+            // deleted, so the survivor set is empty.
             let mut snapshot_meta = SnapshotMeta::default();
+            let mut deleted_by_hash: FxHashMap<TaskTypeHash, SmallVec<[TaskId; 4]>> =
+                FxHashMap::default();
+            let mut deleted_count = 0usize;
             for (meta, shard_deletes) in per_shard {
                 snapshot_meta = snapshot_meta.merge(meta);
-                deletes.extend(shard_deletes);
-            }
-
-            // Apply GC tombstones after the parallel put phase (so no put/delete on the same key
-            // space is in-flight when we flush below) and after puts (so a delete wins over a
-            // racing stale put for the same id, though GC removes tasks from the map before the
-            // snapshot serializes so overlap should not occur). Applied sequentially: the delete
-            // list is small relative to the snapshot and ordering matters more than parallelism.
-            if !deletes.is_empty() {
-                let _span = tracing::trace_span!("delete tasks", count = deletes.len()).entered();
-
-                // Group the deleted ids by their TaskCache hash bucket. TaskCache is MultiValue and
-                // a tombstone erases the *whole* bucket, so for each distinct hash we must
-                // re-insert every id still living in that bucket (any type that
-                // xxh3-collides with a deleted one). Normally each hash maps to
-                // exactly the single id being deleted, so the survivor set is
-                // empty.
-                let mut deleted_by_hash: FxHashMap<TaskTypeHash, SmallVec<[TaskId; 4]>> =
-                    FxHashMap::default();
-                for deletion in &deletes {
-                    // TaskMeta/TaskData are SingleValue: tombstone the id key directly.
-                    let key = IntKey::new(*deletion.task_id);
-                    let key = key.as_ref();
-                    batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
-                    batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
+                for deletion in shard_deletes {
                     deleted_by_hash
                         .entry(deletion.task_type_hash)
                         .or_default()
                         .push(deletion.task_id);
-                }
-
-                // TODO: this would be a good usecase for a batch_get_multiple, that would optimize
-                // reading
-                for (task_type_hash, deleted_ids) in deleted_by_hash {
-                    // Read the authoritative on-disk bucket so we can keep every id we are NOT
-                    // deleting. (A survivor that is a *new* task added in this same commit is
-                    // covered by its own put above — new tasks aren't on disk yet, so they can't
-                    // appear here and won't be double-inserted.)
-                    let bucket = self
-                        .inner
-                        .database
-                        .get_multiple(KeySpace::TaskCache, &task_type_hash)
-                        .with_context(|| {
-                            format!("Reading TaskCache bucket {task_type_hash:?} for GC re-insert")
-                        })?;
-
-                    // Tombstone the whole bucket, then re-insert the survivors (almost always
-                    // none).
-                    batch.delete(
-                        KeySpace::TaskCache,
-                        WriteBuffer::Borrowed(&task_type_hash[..]),
-                    )?;
-                    for bytes in bucket {
-                        let id = TaskId::try_from(as_u32(bytes)?)?;
-                        if deleted_ids.contains(&id) {
-                            continue;
-                        }
-                        let survivor_key = IntKey::new(*id);
-                        batch.put(
-                            KeySpace::TaskCache,
-                            WriteBuffer::Borrowed(&task_type_hash[..]),
-                            WriteBuffer::Vec(survivor_key.as_ref().to_vec()),
-                        )?;
-                    }
+                    deleted_count += 1;
                 }
             }
 
-            let span = tracing::trace_span!("flush task data").entered();
+            // The TaskCache bucket rewrite must run after all puts (each bucket is a
+            // read+delete+reinsert), but the buckets are independent (distinct hash keys, only the
+            // shared `batch`/`database` refs in common), so process them in parallel.
+            // `batch.delete` and `batch.put` use the same thread-local collectors the
+            // parallel put phase does, and `get_multiple` is a shared-ref read, so
+            // concurrent calls are safe.
+            if !deleted_by_hash.is_empty() {
+                let span = tracing::trace_span!("delete tasks", count = deleted_count);
+
+                // TODO: this would be a good usecase for a batch_get_multiple, that would optimize
+                // reading
+                let database = &self.inner.database;
+                let batch = &batch;
+                parallel::try_for_each_owned(
+                    deleted_by_hash.into_iter().collect::<Vec<_>>(),
+                    |(task_type_hash, deleted_ids)| {
+                        let _span = span.clone().entered();
+                        // Read the authoritative on-disk bucket so we can keep every id we are NOT
+                        // deleting. (A survivor that is a *new* task added in this same commit is
+                        // covered by its own put above — new tasks aren't on disk yet, so they
+                        // can't appear here and won't be double-inserted.)
+                        let bucket = database
+                            .get_multiple(KeySpace::TaskCache, &task_type_hash)
+                            .with_context(|| {
+                                format!(
+                                    "Reading TaskCache bucket {task_type_hash:?} for GC re-insert"
+                                )
+                            })?;
+
+                        // Tombstone the whole bucket, then re-insert the survivors (almost always
+                        // none).
+                        batch.delete(
+                            KeySpace::TaskCache,
+                            WriteBuffer::Borrowed(&task_type_hash[..]),
+                        )?;
+                        for bytes in bucket {
+                            let id = TaskId::try_from(as_u32(bytes)?)?;
+                            if deleted_ids.contains(&id) {
+                                continue;
+                            }
+                            let survivor_key = IntKey::new(*id);
+                            batch.put(
+                                KeySpace::TaskCache,
+                                WriteBuffer::Borrowed(&task_type_hash[..]),
+                                WriteBuffer::Vec(survivor_key.as_ref().to_vec()),
+                            )?;
+                        }
+                        anyhow::Ok(())
+                    },
+                )?;
+            }
+
+            let span = tracing::trace_span!("flush task data");
             parallel::try_for_each(
                 &[KeySpace::TaskMeta, KeySpace::TaskData, KeySpace::TaskCache],
                 |&key_space| {
                     let _span = span.clone().entered();
-                    // Safety: `map_collect_owned` has returned and the sequential delete loop above
-                    // has finished, so no concurrent `put` or `delete` on these key spaces are
-                    // in-flight.
+                    // Safety: the two loops above have completed so no concurrent `put` or `delete`
+                    // on these key spaces are in-flight.
                     unsafe { batch.flush(key_space) }
                 },
             )?;

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -232,34 +232,42 @@ impl TurboBackingStorage {
         &self,
         operations: Vec<Arc<AnyOperation>>,
         snapshots: Vec<I>,
-        deletes: Vec<TaskDeletion>,
     ) -> Result<SnapshotMeta>
     where
         I: IntoIterator<Item = SnapshotItem> + Send + Sync,
     {
-        let _span = tracing::info_span!(
-            "save snapshot",
-            operations = operations.len(),
-            deletes = deletes.len()
-        )
-        .entered();
+        let _span = tracing::info_span!("save snapshot", operations = operations.len()).entered();
         let batch = self.inner.database.write_batch()?;
 
         {
             let _span = tracing::trace_span!("update task data").entered();
-            let mut snapshot_meta =
+            // The parallel put phase also *collects* any `SnapshotItem::Delete` tombstones produced
+            // during the (streaming) shard iteration — GC-soft-deleted tasks serialize to a delete
+            // rather than a put. They can't be applied inline: the TaskCache tombstone below reads
+            // and rewrites a whole hash bucket and must run sequentially after all puts. So each
+            // shard returns its collected deletes alongside its `SnapshotMeta`, and they merge with
+            // the caller-supplied `deletes` (from the test-only `gc_for_testing` hook) before the
+            // sequential delete phase.
+            let per_shard =
                 parallel::map_collect_owned::<_, _, Result<Vec<_>>>(snapshots, |shard: I| {
                     let mut max_new_task_id = 0;
                     let mut data_items = 0;
                     let mut meta_items = 0;
                     let mut task_cache_items = 0;
-                    for SnapshotItem {
-                        task_id,
-                        meta,
-                        data,
-                        task_type_hash,
-                    } in shard
-                    {
+                    let mut shard_deletes: Vec<TaskDeletion> = Vec::new();
+                    for item in shard {
+                        let (task_id, meta, data, task_type_hash) = match item {
+                            SnapshotItem::Put {
+                                task_id,
+                                meta,
+                                data,
+                                task_type_hash,
+                            } => (task_id, meta, data, task_type_hash),
+                            SnapshotItem::Delete(deletion) => {
+                                shard_deletes.push(deletion);
+                                continue;
+                            }
+                        };
                         let key = IntKey::new(*task_id);
                         let key = key.as_ref();
                         if let Some(meta) = meta {
@@ -289,20 +297,26 @@ impl TurboBackingStorage {
                             max_new_task_id = max_new_task_id.max(*task_id);
                         }
                     }
-                    Ok(SnapshotMeta {
-                        data_items,
-                        meta_items,
-                        task_cache_items,
-                        // The on-disk byte totals aren't known until the batch is committed below;
-                        // they're filled in from `CommitStats` after `batch.commit()`.
-                        bytes_written: 0,
-                        bytes_deleted: 0,
-                        max_next_task_id: max_new_task_id,
-                    })
-                })?
-                .into_iter()
-                .reduce(|t1, t2| t1.merge(t2))
-                .unwrap_or_default();
+                    Ok((
+                        SnapshotMeta {
+                            data_items,
+                            meta_items,
+                            task_cache_items,
+                            // The on-disk byte totals aren't known until the batch is committed
+                            // below; they're filled in from `CommitStats` after `batch.commit()`.
+                            bytes_written: 0,
+                            bytes_deleted: 0,
+                            max_next_task_id: max_new_task_id,
+                        },
+                        shard_deletes,
+                    ))
+                })?;
+            let mut deletes: Vec<TaskDeletion> = Vec::new();
+            let mut snapshot_meta = SnapshotMeta::default();
+            for (meta, shard_deletes) in per_shard {
+                snapshot_meta = snapshot_meta.merge(meta);
+                deletes.extend(shard_deletes);
+            }
 
             // Apply GC tombstones after the parallel put phase (so no put/delete on the same key
             // space is in-flight when we flush below) and after puts (so a delete wins over a
@@ -870,14 +884,13 @@ mod tests {
 
         let storage = TurboBackingStorage::new_in_memory(db);
 
-        // Snapshot with no task data, just the one deletion.
+        // Snapshot with no task data, just the one deletion (carried inline as a delete item).
         storage.save_snapshot(
             Vec::new(),
-            Vec::<Vec<SnapshotItem>>::new(),
-            vec![TaskDeletion {
+            vec![vec![SnapshotItem::Delete(TaskDeletion {
                 task_id: deleted_id,
                 task_type_hash: collision_hash.to_le_bytes(),
-            }],
+            })]],
         )?;
 
         // The deleted id is gone; the disk-only survivor was re-inserted automatically.

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -19,7 +19,9 @@ use turbo_tasks::{
 use crate::{
     GitVersionInfo,
     backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
-    backing_storage::{SnapshotItem, SnapshotMeta, compute_task_type_hash_from_components},
+    backing_storage::{
+        SnapshotItem, SnapshotMeta, TaskDeletion, compute_task_type_hash_from_components,
+    },
     database::{
         db_invalidation::{StartupCacheState, check_db_invalidation_and_cleanup, invalidate_db},
         db_versioning::handle_db_versioning,
@@ -228,11 +230,17 @@ impl TurboBackingStorage {
         &self,
         operations: Vec<Arc<AnyOperation>>,
         snapshots: Vec<I>,
+        deletes: Vec<TaskDeletion>,
     ) -> Result<SnapshotMeta>
     where
         I: IntoIterator<Item = SnapshotItem> + Send + Sync,
     {
-        let _span = tracing::info_span!("save snapshot", operations = operations.len()).entered();
+        let _span = tracing::info_span!(
+            "save snapshot",
+            operations = operations.len(),
+            deletes = deletes.len()
+        )
+        .entered();
         let batch = self.inner.database.write_batch()?;
 
         {
@@ -294,13 +302,48 @@ impl TurboBackingStorage {
                 .reduce(|t1, t2| t1.merge(t2))
                 .unwrap_or_default();
 
+            // Apply GC tombstones after the parallel put phase (so no put/delete on the same key
+            // space is in-flight when we flush below) and after puts (so a delete wins over a
+            // racing stale put for the same id, though GC removes tasks from the map before the
+            // snapshot serializes so overlap should not occur). Applied sequentially: the delete
+            // list is small relative to the snapshot and ordering matters more than parallelism.
+            if !deletes.is_empty() {
+                let _span = tracing::trace_span!("delete tasks", count = deletes.len()).entered();
+                for TaskDeletion {
+                    task_id,
+                    task_type_hash,
+                    surviving_task_ids,
+                } in &deletes
+                {
+                    let key = IntKey::new(**task_id);
+                    let key = key.as_ref();
+                    batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
+                    batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
+                    // TaskCache is MultiValue: tombstone the whole hash bucket, then re-insert any
+                    // colliding live survivors (almost always none).
+                    batch.delete(
+                        KeySpace::TaskCache,
+                        WriteBuffer::Borrowed(&task_type_hash[..]),
+                    )?;
+                    for survivor in surviving_task_ids {
+                        let survivor_key = IntKey::new(**survivor);
+                        batch.put(
+                            KeySpace::TaskCache,
+                            WriteBuffer::Borrowed(&task_type_hash[..]),
+                            WriteBuffer::Vec(survivor_key.as_ref().to_vec()),
+                        )?;
+                    }
+                }
+            }
+
             let span = tracing::trace_span!("flush task data").entered();
             parallel::try_for_each(
                 &[KeySpace::TaskMeta, KeySpace::TaskData, KeySpace::TaskCache],
                 |&key_space| {
                     let _span = span.clone().entered();
-                    // Safety: `map_collect_owned` has returned, so no concurrent `put` or
-                    // `delete` on these key spaces are in-flight.
+                    // Safety: `map_collect_owned` has returned and the sequential delete loop above
+                    // has finished, so no concurrent `put` or `delete` on these key spaces are
+                    // in-flight.
                     unsafe { batch.flush(key_space) }
                 },
             )?;
@@ -587,6 +630,190 @@ mod tests {
             db.shutdown()?;
         }
 
+        Ok(())
+    }
+
+    fn task_data_key(task_id: TaskId) -> [u8; 4] {
+        (*task_id).to_le_bytes()
+    }
+
+    /// GC tombstone path: deleting a task must erase its `TaskMeta` and `TaskData`
+    /// (`SingleValue`) entries and its `TaskCache` (`MultiValue`) mapping, and the deletion must
+    /// survive a reopen. Written first so the persistence-layer semantics the sweep relies on are
+    /// pinned down independently of the mark/sweep logic (Stage 0).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_gc_delete_tombstones_meta_data_and_cache() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let path = tempdir.path();
+
+        let hash: u64 = 0xABCD_1234;
+        let task_id = TaskId::try_from(42u32).unwrap();
+
+        // Write the task's meta, data, and cache entries in one committed batch.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let batch = db.write_batch()?;
+            let key = task_data_key(task_id);
+            batch.put(
+                KeySpace::TaskMeta,
+                WriteBuffer::Borrowed(&key),
+                WriteBuffer::Borrowed(b"meta-bytes"),
+            )?;
+            batch.put(
+                KeySpace::TaskData,
+                WriteBuffer::Borrowed(&key),
+                WriteBuffer::Borrowed(b"data-bytes"),
+            )?;
+            batch.put(
+                KeySpace::TaskCache,
+                WriteBuffer::Borrowed(&hash.to_le_bytes()),
+                WriteBuffer::Borrowed(&key),
+            )?;
+            batch.commit()?;
+            db.shutdown()?;
+        }
+
+        // Sanity: everything is present before deletion.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let key = task_data_key(task_id);
+            assert!(db.get(KeySpace::TaskMeta, &key)?.is_some());
+            assert!(db.get(KeySpace::TaskData, &key)?.is_some());
+            assert_eq!(
+                db.get_multiple(KeySpace::TaskCache, &hash.to_le_bytes())?
+                    .len(),
+                1
+            );
+            db.shutdown()?;
+        }
+
+        // Tombstone the task in a single committed batch (the shape save_snapshot uses for a
+        // delete list with no colliding survivors).
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let batch = db.write_batch()?;
+            let key = task_data_key(task_id);
+            batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(&key))?;
+            batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(&key))?;
+            batch.delete(
+                KeySpace::TaskCache,
+                WriteBuffer::Borrowed(&hash.to_le_bytes()),
+            )?;
+            batch.commit()?;
+            db.shutdown()?;
+        }
+
+        // Reopen: all three entries must be gone.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let key = task_data_key(task_id);
+            assert!(
+                db.get(KeySpace::TaskMeta, &key)?.is_none(),
+                "TaskMeta should be tombstoned"
+            );
+            assert!(
+                db.get(KeySpace::TaskData, &key)?.is_none(),
+                "TaskData should be tombstoned"
+            );
+            assert!(
+                db.get_multiple(KeySpace::TaskCache, &hash.to_le_bytes())?
+                    .is_empty(),
+                "TaskCache mapping should be tombstoned"
+            );
+            db.shutdown()?;
+        }
+
+        Ok(())
+    }
+
+    /// The load-bearing correctness test for the "whole-key tombstone + re-put survivors" approach
+    /// to deleting one entry from the `MultiValue` `TaskCache`: when two task ids collide in one
+    /// hash bucket and we delete one, tombstoning the whole bucket and re-putting the survivor in
+    /// the *same* committed batch must leave exactly the survivor readable after a reopen.
+    ///
+    /// It also pins down the delete/put ordering question: within one commit the relative order of
+    /// the survivor `put` and the whole-bucket `delete` does **not** matter. `Collector::sorted`
+    /// sorts tombstones last within a key group regardless of insertion order, so the survivor
+    /// (ordered before the tombstone) always survives while older-SST entries for the key are
+    /// erased. We assert both orderings produce the same result.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_gc_delete_task_cache_reput_survivor() -> Result<()> {
+        // `put_before_delete` selects the order the two operations are added to the batch; the
+        // committed outcome must be identical either way.
+        async fn run_case(put_before_delete: bool) -> Result<()> {
+            let tempdir = tempfile::tempdir()?;
+            let path = tempdir.path();
+
+            let collision_hash: u64 = 0xDEAD_DEAD;
+            let deleted_id = TaskId::try_from(111u32).unwrap();
+            let survivor_id = TaskId::try_from(222u32).unwrap();
+
+            // Two ids share one hash bucket (each write is its own SST so both are stored).
+            {
+                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+                write_task_cache_entry(&db, collision_hash, deleted_id)?;
+                write_task_cache_entry(&db, collision_hash, survivor_id)?;
+                let results =
+                    db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+                assert_eq!(results.len(), 2, "both colliding ids should be present");
+                db.shutdown()?;
+            }
+
+            // Delete `deleted_id`: tombstone the whole bucket and re-put the survivor in one batch,
+            // adding the two operations in the order under test.
+            {
+                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+                let batch = db.write_batch()?;
+                let put = |batch: &TurboWriteBatch<'_>| {
+                    batch.put(
+                        KeySpace::TaskCache,
+                        WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
+                        WriteBuffer::Vec(task_data_key(survivor_id).to_vec()),
+                    )
+                };
+                let delete = |batch: &TurboWriteBatch<'_>| {
+                    batch.delete(
+                        KeySpace::TaskCache,
+                        WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
+                    )
+                };
+                if put_before_delete {
+                    put(&batch)?;
+                    delete(&batch)?;
+                } else {
+                    delete(&batch)?;
+                    put(&batch)?;
+                }
+                batch.commit()?;
+                db.shutdown()?;
+            }
+
+            // Reopen: exactly the survivor remains under the bucket.
+            {
+                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+                let results =
+                    db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+                let found_ids: Vec<TaskId> = results
+                    .iter()
+                    .map(|bytes| {
+                        let bytes: [u8; 4] = Borrow::<[u8]>::borrow(bytes).try_into().unwrap();
+                        TaskId::try_from(u32::from_le_bytes(bytes)).unwrap()
+                    })
+                    .collect();
+                assert_eq!(
+                    found_ids,
+                    vec![survivor_id],
+                    "only the survivor should remain after deleting the colliding id \
+                     (put_before_delete={put_before_delete})"
+                );
+                db.shutdown()?;
+            }
+
+            Ok(())
+        }
+
+        run_case(true).await?;
+        run_case(false).await?;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -332,6 +332,8 @@ impl TurboBackingStorage {
                         .push(deletion.task_id);
                 }
 
+                // TODO: this would be a good usecase for a batch_get_multiple, that would optimize
+                // reading
                 for (task_type_hash, deleted_ids) in deleted_by_hash {
                     // Read the authoritative on-disk bucket so we can keep every id we are NOT
                     // deleting. (A survivor that is a *new* task added in this same commit is

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use turbo_bincode::{new_turbo_bincode_decoder, turbo_bincode_decode, turbo_bincode_encode};
 use turbo_persistence::CommitStats;
@@ -20,7 +21,8 @@ use crate::{
     GitVersionInfo,
     backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
     backing_storage::{
-        SnapshotItem, SnapshotMeta, TaskDeletion, compute_task_type_hash_from_components,
+        SnapshotItem, SnapshotMeta, TaskDeletion, TaskTypeHash,
+        compute_task_type_hash_from_components,
     },
     database::{
         db_invalidation::{StartupCacheState, check_db_invalidation_and_cleanup, invalidate_db},
@@ -309,24 +311,52 @@ impl TurboBackingStorage {
             // list is small relative to the snapshot and ordering matters more than parallelism.
             if !deletes.is_empty() {
                 let _span = tracing::trace_span!("delete tasks", count = deletes.len()).entered();
-                for TaskDeletion {
-                    task_id,
-                    task_type_hash,
-                    surviving_task_ids,
-                } in &deletes
-                {
-                    let key = IntKey::new(**task_id);
+
+                // Group the deleted ids by their TaskCache hash bucket. TaskCache is MultiValue and
+                // a tombstone erases the *whole* bucket, so for each distinct hash we must
+                // re-insert every id still living in that bucket (any type that
+                // xxh3-collides with a deleted one). Normally each hash maps to
+                // exactly the single id being deleted, so the survivor set is
+                // empty.
+                let mut deleted_by_hash: FxHashMap<TaskTypeHash, SmallVec<[TaskId; 4]>> =
+                    FxHashMap::default();
+                for deletion in &deletes {
+                    // TaskMeta/TaskData are SingleValue: tombstone the id key directly.
+                    let key = IntKey::new(*deletion.task_id);
                     let key = key.as_ref();
                     batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
                     batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
-                    // TaskCache is MultiValue: tombstone the whole hash bucket, then re-insert any
-                    // colliding live survivors (almost always none).
+                    deleted_by_hash
+                        .entry(deletion.task_type_hash)
+                        .or_default()
+                        .push(deletion.task_id);
+                }
+
+                for (task_type_hash, deleted_ids) in deleted_by_hash {
+                    // Read the authoritative on-disk bucket so we can keep every id we are NOT
+                    // deleting. (A survivor that is a *new* task added in this same commit is
+                    // covered by its own put above — new tasks aren't on disk yet, so they can't
+                    // appear here and won't be double-inserted.)
+                    let bucket = self
+                        .inner
+                        .database
+                        .get_multiple(KeySpace::TaskCache, &task_type_hash)
+                        .with_context(|| {
+                            format!("Reading TaskCache bucket {task_type_hash:?} for GC re-insert")
+                        })?;
+
+                    // Tombstone the whole bucket, then re-insert the survivors (almost always
+                    // none).
                     batch.delete(
                         KeySpace::TaskCache,
                         WriteBuffer::Borrowed(&task_type_hash[..]),
                     )?;
-                    for survivor in surviving_task_ids {
-                        let survivor_key = IntKey::new(**survivor);
+                    for bytes in bucket {
+                        let id = TaskId::try_from(as_u32(bytes)?)?;
+                        if deleted_ids.contains(&id) {
+                            continue;
+                        }
+                        let survivor_key = IntKey::new(*id);
                         batch.put(
                             KeySpace::TaskCache,
                             WriteBuffer::Borrowed(&task_type_hash[..]),
@@ -814,6 +844,56 @@ mod tests {
 
         run_case(true).await?;
         run_case(false).await?;
+        Ok(())
+    }
+
+    /// End-to-end coverage of the survivor path through `save_snapshot`: a `TaskDeletion` must
+    /// tombstone the deleted id's whole `TaskCache` bucket **and** automatically re-insert a
+    /// colliding survivor that exists *only on disk* — i.e. the survivor is resolved by reading the
+    /// on-disk bucket at apply time, not carried on the `TaskDeletion` (the old design) or read
+    /// from the in-memory task cache (which wouldn't know about a disk-only entry).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_save_snapshot_reinserts_disk_only_survivor() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let path = tempdir.path();
+
+        let collision_hash: u64 = 0xC0FFEE;
+        let deleted_id = TaskId::try_from(111u32).unwrap();
+        let survivor_id = TaskId::try_from(222u32).unwrap();
+
+        let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+        // Both ids live in the bucket purely on disk; nothing is in an in-memory task cache.
+        write_task_cache_entry(&db, collision_hash, deleted_id)?;
+        write_task_cache_entry(&db, collision_hash, survivor_id)?;
+
+        let storage = TurboBackingStorage::new_in_memory(db);
+
+        // Snapshot with no task data, just the one deletion.
+        storage.save_snapshot(
+            Vec::new(),
+            Vec::<Vec<SnapshotItem>>::new(),
+            vec![TaskDeletion {
+                task_id: deleted_id,
+                task_type_hash: collision_hash.to_le_bytes(),
+            }],
+        )?;
+
+        // The deleted id is gone; the disk-only survivor was re-inserted automatically.
+        let results = storage
+            .inner
+            .database
+            .get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+        let found_ids: Vec<TaskId> = results
+            .into_iter()
+            .map(|bytes| TaskId::try_from(as_u32(bytes).unwrap()).unwrap())
+            .collect();
+        assert_eq!(
+            found_ids,
+            vec![survivor_id],
+            "save_snapshot should tombstone the deleted id and re-insert the disk-only survivor"
+        );
+
+        storage.inner.database.shutdown()?;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_resurrection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_resurrection.rs
@@ -1,0 +1,387 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+//! Regression tests for GC teardown of a cleanly-disconnected subtree whose tasks hold real
+//! forward-dependency edges on each other.
+//!
+//! The central invariant: when a task `S` that is the `upper` of its children is collected, GC
+//! must **rebalance the aggregation graph** — remove `S` from each child's `upper` set — so the
+//! children (now both parentless and upper-less) become collectible and cascade in the same pass.
+//! GC does this by running the same `CleanupOldEdges` operation a re-executing task uses. Without
+//! it, a collected `S`'s children were left with a dangling `upper` edge to the deleted `S` and
+//! stayed stuck non-collectible (leaked until eviction).
+//!
+//! For a child to record a forward-dependency edge on / from `S` at all, the tasks involved must
+//! be **mutable** (immutable/constant tasks never record dependency edges — see
+//! `add_cell_dependency`), and the subtree must be disconnected *cleanly* (dropping the parent's
+//! reference, not invalidating the children — invalidation runs `cleanup_old_edges`, which strips
+//! the outgoing deps first). We make the leaves mutable by having them read a long-lived `State`
+//! whose value never changes.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
+
+fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir_in(&parent)
+        .unwrap()
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+#[turbo_tasks::value(transparent)]
+struct Selector(State<bool>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_selector(initial: bool) -> Vc<Selector> {
+    Selector(State::new(initial)).cell()
+}
+
+/// A separate long-lived State whose *value never changes*, only read by the leaves. Reading it
+/// makes each leaf **mutable** (so a reader records a real dependency edge on the leaf) WITHOUT the
+/// aggregation-heavy `session_dependent` machinery that keeps a task active. The state task is a
+/// root, so it stays alive; the leaves depend on it via a dependency edge (not a child edge), so
+/// disconnecting the leaves as children should still let them lose activeness.
+#[turbo_tasks::value(transparent)]
+struct Constant(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_constant() -> Vc<Constant> {
+    Constant(State::new(0)).cell()
+}
+
+/// The forward-dependency *target*. Reading `constant`'s State makes it mutable (records
+/// dependents) — an immutable constant task would record none. `FANOUT` distinct leaves per reader
+/// give many chances for the racing interleaving.
+#[turbo_tasks::function]
+async fn sd_leaf(constant: ResolvedVc<Constant>, index: u32) -> Result<Vc<u32>> {
+    let base = *constant.await?.get();
+    Ok(Vc::cell(base.wrapping_add(index)))
+}
+
+const FANOUT: u32 = 400;
+
+/// The *reader* `S`: reads every `sd_leaf`, so it (a) connects each leaf as a child and (b) records
+/// an outgoing dependency on each. When `reader` is collected while still holding those deps,
+/// `Collect(reader)` spawns scrub jobs referencing all leaves — and every leaf is itself
+/// collectible (cascaded from `reader`'s decrement), so each is a resurrection candidate.
+#[turbo_tasks::function]
+async fn reader(constant: ResolvedVc<Constant>) -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..FANOUT {
+        sum = sum.wrapping_add(*sd_leaf(*constant, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// A *sibling* forward-dependency target for the diamond fixture (`B`). Mutable (reads the
+/// constant State), so a reader records a real dependency edge on it.
+#[turbo_tasks::function]
+async fn diamond_target(constant: ResolvedVc<Constant>, index: u32) -> Result<Vc<u32>> {
+    let base = *constant.await?.get();
+    Ok(Vc::cell(base.wrapping_add(index).wrapping_mul(7)))
+}
+
+/// A diamond *reader* (`A`): reads the cell of a `diamond_target` (`B`) that is **passed in as an
+/// already-resolved `Vc`** — so `A` records a forward (cell) dependency on `B` WITHOUT connecting
+/// `B` as `A`'s child (a child edge is only created by *calling* a task; here `B` was called by
+/// `diamond_root`). This decoupling is the crux: `B`'s only parent is `diamond_root`, so when the
+/// root is collected BOTH `A` and `B` reach `parent_count 0` at the same time and cascade-collect
+/// concurrently — while `A` still holds a forward-dep on `B` to scrub.
+#[turbo_tasks::function]
+async fn diamond_reader(target: ResolvedVc<u32>) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *target.await?))
+}
+
+/// The diamond root: for each index, calls `diamond_target(index)` (`B`, so `B` is the root's
+/// child) and `diamond_reader(B)` (`A`, passing `B`'s resolved Vc in, so `A` is the root's child
+/// and forward-deps on `B` but does NOT parent it). Disconnecting the root drops both `A` and `B`
+/// as siblings; collecting the root cascades a `Collect` for every `A` and `B` at once. If a `B` is
+/// collected+removed before the `Collect(A)` whose `CleanupOldEdges` opens it, the immediate-remove
+/// design resurrects `B`.
+#[turbo_tasks::function]
+async fn diamond_root(constant: ResolvedVc<Constant>) -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..FANOUT {
+        let target = diamond_target(*constant, index).to_resolved().await?;
+        sum = sum.wrapping_add(*target.await?);
+        sum = sum.wrapping_add(*diamond_reader(*target).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// A root that reads `reader()` only while the selector is `false`. Flipping the selector to `true`
+/// drops `reader` (and, transitively, all `sd_leaf`s) from the live graph **without invalidating
+/// them** — so they stay clean and retain their outgoing dependency edges, then all become
+/// `parent_count 0` and collectible in a single pass.
+#[turbo_tasks::function(operation, root)]
+async fn select_reader(
+    selector: ResolvedVc<Selector>,
+    constant: ResolvedVc<Constant>,
+) -> Result<Vc<u32>> {
+    let use_reader = !*selector.await?.get();
+    let value = if use_reader {
+        *reader(*constant).await?
+    } else {
+        // A trivial branch with no dependency on `reader`/`sd_leaf`.
+        0u32
+    };
+    Ok(Vc::cell(value))
+}
+
+/// Selector-gated root for the diamond fixture: reads `diamond_root` only while the selector is
+/// `false`, so flipping to `true` disconnects the whole diamond subtree cleanly.
+#[turbo_tasks::function(operation, root)]
+async fn select_diamond(
+    selector: ResolvedVc<Selector>,
+    constant: ResolvedVc<Constant>,
+) -> Result<Vc<u32>> {
+    let use_diamond = !*selector.await?.get();
+    let value = if use_diamond {
+        *diamond_root(*constant).await?
+    } else {
+        0u32
+    };
+    Ok(Vc::cell(value))
+}
+
+/// Regression test for the missing **aggregation-graph rebalance** in GC.
+///
+/// `reader` is the sole `upper` of each `sd_leaf` (it reads them, and they are mutable so the edge
+/// is recorded). When the `reader` subtree is disconnected cleanly and collected, GC must remove
+/// `reader` from each leaf's `upper` set (the `CleanupOldEdges` rebalance) so the leaves — now
+/// parentless *and* upper-less — cascade-collect in the **same pass**. Before the fix, GC dropped
+/// the leaves' `parent_count` but left a dangling `upper` edge to the deleted `reader`, so every
+/// leaf failed `gc_maybe_collectible` (`upper().is_empty()` false) and only `reader` was collected
+/// (`collected == 1`); the leaves leaked until eviction hid them. This asserts the whole subtree
+/// (`reader` + all `FANOUT` leaves) is collected in one pass and leaves memory with nothing
+/// stranded.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_shared_forward_dep_no_resurrection() {
+    let (tt, _persistence_dir) = create_tt("gc_shared_forward_dep_no_resurrection");
+    let tt2 = tt.clone();
+
+    // Build the graph (selector=false: select_reader -> reader -> FANOUT sd_leaves), then flip to
+    // disconnect the whole reader subtree cleanly.
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+
+        let output = select_reader(selector_vc, constant_vc);
+        output.read_strongly_consistent().await?;
+
+        // Disconnect reader + all sd_leaves in one shot (no invalidation of the children).
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // Baseline resident count with the reader subtree disconnected but not yet collected.
+    let baseline = tt2.backend().resident_persistent_task_count_for_testing();
+
+    // A single GC pass. `reader` and all FANOUT `sd_leaf`s should be collected together: the
+    // aggregation rebalance frees the leaves' `upper` edge so they cascade in the same pass.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let after = tt2.backend().resident_persistent_task_count_for_testing();
+
+    // reader + FANOUT leaves = FANOUT + 1 tasks collected in one pass.
+    assert_eq!(
+        collected,
+        FANOUT as usize + 1,
+        "reader and all {FANOUT} sd_leaves should be collected in one pass (missing aggregation \
+         rebalance would strand the leaves with a dangling upper edge and collect only reader)"
+    );
+    // The whole subtree left memory: the resident count dropped by exactly what was collected.
+    assert_eq!(
+        after,
+        baseline - (FANOUT as usize + 1),
+        "resident count must drop by exactly the collected subtree"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// The **residual resurrection** race (the one soft-deletion is for). In the diamond, every
+/// `diamond_reader` `A` and its `diamond_target` `B` are direct children of `diamond_root`, and `A`
+/// holds a forward dependency on `B`. Collecting the root cascades a `Collect` for every `A` and
+/// `B` concurrently. When `A`'s teardown runs `CleanupOldEdges(A)`, its dependency arm opens `B`
+/// via `ctx.task(B, Data)` to scrub the reverse edge — and if `B`'s own `Collect` already removed
+/// `B` from the map, `ctx.task` restores it from disk into a zombie (memory/disk diverge).
+///
+/// Under the current immediate-remove `Collect`, this resurrects `B`s and leaves the resident count
+/// above baseline−collected. After soft-deletion (a collected task stays resident until after the
+/// tombstoning snapshot commits) `ctx.task` always finds a resident entry and the count returns to
+/// exactly baseline−collected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_diamond_forward_dep_no_resurrection() {
+    let (tt, _persistence_dir) = create_tt("gc_diamond_forward_dep_no_resurrection");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+
+        let output = select_diamond(selector_vc, constant_vc);
+        output.read_strongly_consistent().await?;
+
+        // Disconnect the whole diamond subtree cleanly (no invalidation).
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    let baseline = tt2.backend().resident_persistent_task_count_for_testing();
+
+    // diamond_root + FANOUT readers (A) + FANOUT targets (B) = 2*FANOUT + 1 collected in one pass.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let after = tt2.backend().resident_persistent_task_count_for_testing();
+
+    assert_eq!(
+        collected,
+        2 * FANOUT as usize + 1,
+        "diamond_root + {FANOUT} readers + {FANOUT} targets should all be collected in one pass"
+    );
+    // No `diamond_target` was resurrected by a sibling reader's CleanupOldEdges scrub: the resident
+    // count dropped by exactly the collected subtree. A resurrected B leaves `after` above this.
+    assert_eq!(
+        after,
+        baseline - (2 * FANOUT as usize + 1),
+        "resident count must drop by exactly the collected subtree — a higher count means a \
+         CleanupOldEdges scrub resurrected an already-collected diamond_target"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// Resurrection-on-connect: a task marked `deleted` by GC but reconnected **before** the
+/// tombstoning snapshot must come back to life (marker cleared, made dirty, re-executed) rather
+/// than being tombstoned/hard-deleted. We run `gc_for_testing` (which marks the disconnected
+/// `reader` subtree `deleted` but leaves it resident, and does NOT snapshot), then reconnect the
+/// subtree and read it: it must recompute to the correct value, and a subsequent snapshot+evict
+/// must NOT have removed it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_resurrect_on_reconnect() {
+    let (tt, _persistence_dir) = create_tt("gc_resurrect_on_reconnect");
+    let tt2 = tt.clone();
+    let expected: u32 = (0..FANOUT).fold(0u32, |a, b| a.wrapping_add(b));
+
+    // Build (reader connected), then disconnect the reader subtree cleanly.
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+
+        let output = select_reader(selector_vc, constant_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // Mark the disconnected subtree `deleted` (still resident — no snapshot yet).
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected,
+        FANOUT as usize + 1,
+        "reader + {FANOUT} leaves should be marked collected"
+    );
+
+    // Reconnect the subtree (selector back to false) BEFORE any snapshot. Reading `reader` again
+    // connects it, which must resurrect it (and its leaves, as it re-reads them) and recompute the
+    // correct value — proving the deleted tasks came back rather than being read stale.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+        selector.set(false);
+        let output = select_reader(selector_vc, constant_vc);
+        assert_eq!(
+            *output.read_strongly_consistent().await?,
+            expected,
+            "resurrected reader must recompute the correct value"
+        );
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // A snapshot+evict now must NOT have tombstoned/hard-deleted the resurrected subtree: reading
+    // it once more still yields the correct value (it is live, not gone).
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let tt4 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+        let output = select_reader(selector_vc, constant_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+        let _ = &tt4;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -121,8 +121,9 @@ async fn gc_re_rooting_stays_flat() {
         // evict), so the disconnected garbage is still resident when GC scans it. Running eviction
         // first would drop the garbage to disk-only where the in-memory GC can't collect or
         // tombstone it. Return the number GC collected this round alongside the resident count.
-        let collected = tt.backend().gc_for_testing(tt);
-        tt.backend().snapshot_and_evict_for_testing(tt);
+        let (collected, deletes) = tt.backend().gc_for_testing(tt);
+        tt.backend()
+            .snapshot_and_evict_with_deletes_for_testing(tt, deletes);
         // Measure the *persistent* resident count: GC only collects persistent tasks. Transient
         // roots (each round's `run_once`/Once task) are never collected and accumulate
         // independently of GC — including them would mask the real signal.

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -1,0 +1,195 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, GitVersionInfo, TurboTasksBackend};
+
+fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir_in(&parent)
+        .unwrap()
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            evict_after_snapshot: true,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+#[turbo_tasks::value(transparent)]
+struct Generation(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_generation() -> Vc<Generation> {
+    Generation(State::new(0)).cell()
+}
+
+/// A leaf keyed by (generation, index). Bumping the generation makes `wide_root` read an entirely
+/// fresh set of these, disconnecting the whole previous generation.
+#[turbo_tasks::function]
+fn leaf(generation: u32, index: u32) -> Vc<u32> {
+    Vc::cell(generation.wrapping_mul(1000).wrapping_add(index))
+}
+
+/// An intermediate that reads one leaf — a shared-dependency layer so the disconnected garbage is a
+/// subtree (intermediate + leaf), exercising the cascade rather than single-node collection.
+#[turbo_tasks::function]
+async fn intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *leaf(generation, index).await?))
+}
+
+const WIDTH: u32 = 24;
+
+/// Reads WIDTH intermediates (each reading a leaf) for the current generation. Bumping the
+/// generation re-executes this and connects a fresh generation's worth of tasks, disconnecting the
+/// entire previous generation (2*WIDTH tasks) as garbage.
+#[turbo_tasks::function(operation, root)]
+async fn wide_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..WIDTH {
+        sum = sum.wrapping_add(*intermediate(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// The pathology this whole effort targets: repeatedly swapping a wide set of common dependencies
+/// (as happens when a project is re-rooted or its dependencies churn) must NOT grow the resident
+/// task set monotonically. Each round bumps the generation (disconnecting the previous generation's
+/// 2*WIDTH tasks), then snapshots + GCs + evicts. The resident count must return to a flat baseline
+/// each round rather than climbing with the number of rounds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_re_rooting_stays_flat() {
+    let (tt, _persistence_dir) = create_tt("gc_re_rooting_stays_flat");
+    let tt2 = tt.clone();
+
+    const ROUNDS: u32 = 20;
+
+    // Each round runs in its own `run_once` so the root's activeness is released before GC (a
+    // `run_once` root keeps everything it touched active until it returns). Returns the resident
+    // count measured after that round's snapshot + GC + evict.
+    async fn round(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u32) -> (usize, usize) {
+        let tt_inner = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            // `create_generation` is a cached root operation, so this returns the same task each
+            // round.
+            let generation_op = create_generation();
+            let generation_vc = generation_op.resolve().strongly_consistent().await?;
+            if gen_value > 0 {
+                let generation = generation_op.read_strongly_consistent().await?;
+                generation.set(gen_value);
+            }
+            let output = wide_root(generation_vc);
+            output.read_strongly_consistent().await?;
+            let _ = &tt_inner;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+
+        // GC runs BEFORE eviction (matching the production background cycle: snapshot -> GC ->
+        // evict), so the disconnected garbage is still resident when GC scans it. Running eviction
+        // first would drop the garbage to disk-only where the in-memory GC can't collect or
+        // tombstone it. Return the number GC collected this round alongside the resident count.
+        let collected = tt.backend().gc_for_testing(tt);
+        tt.backend().snapshot_and_evict_for_testing(tt);
+        // Measure the *persistent* resident count: GC only collects persistent tasks. Transient
+        // roots (each round's `run_once`/Once task) are never collected and accumulate
+        // independently of GC — including them would mask the real signal.
+        (
+            collected,
+            tt.backend().resident_persistent_task_count_for_testing(),
+        )
+    }
+
+    // Warm up: build generation 0, then measure the steady-state baseline after one full cycle.
+    let (_, baseline) = round(&tt2, 0).await;
+    println!("baseline persistent resident after gen 0: {baseline}");
+
+    // Churn: swap the whole dependency set many times. Track the max resident count and the total
+    // collected, so we assert both that memory stays flat AND that GC (not just eviction) is
+    // actually doing the collecting.
+    let mut max_resident = baseline;
+    let mut total_collected = 0usize;
+    for gen_value in 1..=ROUNDS {
+        let (collected, resident) = round(&tt2, gen_value).await;
+        println!("gen {gen_value}: collected={collected} persistent_resident={resident}");
+        max_resident = max_resident.max(resident);
+        total_collected += collected;
+    }
+
+    let no_gc_growth = baseline + (2 * WIDTH as usize) * (ROUNDS as usize);
+    println!(
+        "baseline={baseline} max_resident={max_resident} total_collected={total_collected} \
+         no_gc_growth_would_be={no_gc_growth}"
+    );
+    // Flat-baseline assertion on the PERSISTENT resident set: without GC it would climb by ~2*WIDTH
+    // per round (each generation's intermediates + leaves persisted forever). With GC each
+    // generation's garbage subtree is collected, so the persistent set stays within a small
+    // constant of the baseline regardless of the number of rounds.
+    assert!(
+        max_resident <= baseline + 2 * WIDTH as usize,
+        "persistent resident set grew too much across re-rooting (max={max_resident}, \
+         baseline={baseline}); GC is not returning to a flat baseline"
+    );
+    // GC must be doing the work: each round disconnects a full generation (2*WIDTH tasks), so over
+    // ROUNDS rounds GC should have collected on the order of 2*WIDTH*ROUNDS tasks. Assert it
+    // collected at least most of that (allowing slack for tasks that settle across passes), proving
+    // the flat baseline is due to GC collecting garbage — not merely eviction hiding it on disk.
+    let expected_min_collected = (2 * WIDTH as usize) * (ROUNDS as usize) / 2;
+    assert!(
+        total_collected >= expected_min_collected,
+        "GC collected too little ({total_collected}); expected >= {expected_min_collected} across \
+         {ROUNDS} re-rootings — GC is not doing the collection"
+    );
+
+    // The live graph must still compute correctly after all the churn.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let generation_op = create_generation();
+        let generation_vc = generation_op.resolve().strongly_consistent().await?;
+        let output = wide_root(generation_vc);
+        // generation is ROUNDS; sum = WIDTH intermediates each = 1 + leaf(ROUNDS, i).
+        let expected: u32 = (0..WIDTH)
+            .map(|i| 1 + (ROUNDS.wrapping_mul(1000).wrapping_add(i)))
+            .fold(0u32, |a, b| a.wrapping_add(b));
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -194,3 +194,90 @@ async fn gc_re_rooting_stays_flat() {
 
     tt.stop_and_wait().await;
 }
+
+const FANOUT: u32 = 5000;
+
+/// A root that reads `FANOUT` leaves *directly*, so it accumulates ~`FANOUT` children in one task
+/// (and, via reading each leaf's cell, a large forward-dependency set). Keyed by generation so
+/// bumping it disconnects the entire previous fan-out at once.
+#[turbo_tasks::function(operation, root)]
+async fn huge_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..FANOUT {
+        sum = sum.wrapping_add(*leaf(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// Exercises the *per-task* fan-out of the parallel collector (the chunked `Decrement`/`Scrub*`
+/// jobs): a single collected task has thousands of children and forward dependencies, which must be
+/// torn down across worker threads in bounded chunks rather than by one serial job. Collecting the
+/// disconnected generation's `huge_root` (≈FANOUT children) + its FANOUT leaves must fully reclaim
+/// the subtree, and the graph must still recompute afterwards.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gc_collects_wide_fanout_task() {
+    let (tt, _persistence_dir) = create_tt("gc_collects_wide_fanout_task");
+    let tt2 = tt.clone();
+
+    // Build generation 0 (huge_root + FANOUT leaves), then flip to generation 1 which disconnects
+    // the entire generation-0 fan-out.
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let generation_op = create_generation();
+        let generation_vc = generation_op.resolve().strongly_consistent().await?;
+        let generation = generation_op.read_strongly_consistent().await?;
+
+        let output = huge_root(generation_vc);
+        output.read_strongly_consistent().await?;
+
+        // Disconnect the whole generation-0 fan-out in one shot.
+        generation.set(1);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // Baseline after building + reading generation 1 (once, to settle), then collect the
+    // disconnected generation-0 subtree.
+    let baseline = tt2.backend().resident_persistent_task_count_for_testing();
+    let (collected, deletes) = tt2.backend().gc_for_testing(&tt2);
+    tt2.backend()
+        .snapshot_and_evict_with_deletes_for_testing(&tt2, deletes);
+    let after = tt2.backend().resident_persistent_task_count_for_testing();
+
+    println!(
+        "wide-fanout: baseline={baseline} collected={collected} after={after} (fanout={FANOUT})"
+    );
+    // Collecting one wide-fanout generation tears down ~FANOUT+1 tasks (huge_root + its leaves)
+    // spread across worker threads via the chunked jobs. Assert the pass collected the bulk of a
+    // full generation (allowing slack for tasks that settle across passes), proving the per-task
+    // fan-out actually reclaims the whole subtree rather than pinning/starving.
+    assert!(
+        collected >= (FANOUT as usize) / 2,
+        "wide-fanout GC collected too little ({collected}); expected >= {} — per-task fan-out is \
+         not tearing down the whole subtree",
+        FANOUT / 2
+    );
+
+    // The live graph must still compute correctly after the wide teardown.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let generation_op = create_generation();
+        let generation_vc = generation_op.resolve().strongly_consistent().await?;
+        let output = huge_root(generation_vc);
+        // generation is 1; sum = sum of leaf(1, i) for i in 0..FANOUT.
+        let expected: u32 = (0..FANOUT)
+            .map(|i| 1u32.wrapping_mul(1000).wrapping_add(i))
+            .fold(0u32, |a, b| a.wrapping_add(b));
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use turbo_tasks::{
     ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
 };
-use turbo_tasks_backend::{BackendOptions, GitVersionInfo, TurboTasksBackend};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
 
 fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
     let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
@@ -26,7 +26,7 @@ fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempD
             num_workers: Some(2),
             small_preallocation: true,
             storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
-            evict_after_snapshot: true,
+            eviction_mode: EvictionMode::Full,
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -121,9 +121,8 @@ async fn gc_re_rooting_stays_flat() {
         // evict), so the disconnected garbage is still resident when GC scans it. Running eviction
         // first would drop the garbage to disk-only where the in-memory GC can't collect or
         // tombstone it. Return the number GC collected this round alongside the resident count.
-        let (collected, deletes) = tt.backend().gc_for_testing(tt);
-        tt.backend()
-            .snapshot_and_evict_with_deletes_for_testing(tt, deletes);
+        let collected = tt.backend().gc_for_testing(tt);
+        tt.backend().snapshot_and_evict_for_testing(tt);
         // Measure the *persistent* resident count: GC only collects persistent tasks. Transient
         // roots (each round's `run_once`/Once task) are never collected and accumulate
         // independently of GC — including them would mask the real signal.
@@ -242,9 +241,8 @@ async fn gc_collects_wide_fanout_task() {
     // Baseline after building + reading generation 1 (once, to settle), then collect the
     // disconnected generation-0 subtree.
     let baseline = tt2.backend().resident_persistent_task_count_for_testing();
-    let (collected, deletes) = tt2.backend().gc_for_testing(&tt2);
-    tt2.backend()
-        .snapshot_and_evict_with_deletes_for_testing(&tt2, deletes);
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
     let after = tt2.backend().resident_persistent_task_count_for_testing();
 
     println!(

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -117,6 +117,14 @@ async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     Ok(Vc::cell(value))
 }
 
+/// A plain leaf used to test the "spawned with no parent → GC root" rule. When called at the top
+/// level of a `run` (where the current task is `None`), its task is created with `parent == None`
+/// and marked a GC root, so it must never be collected even once disconnected.
+#[turbo_tasks::function]
+async fn gc_root_leaf() -> Result<Vc<u32>> {
+    Ok(Vc::cell(77))
+}
+
 /// `parent_count` must track the number of persistent parents, incremented when a parent connects a
 /// child and decremented when it disconnects it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -424,6 +432,60 @@ async fn gc_does_not_collect_pinned_task() {
         tt2.backend().gc_for_testing(&tt2),
         0,
         "pinned task must survive eviction and not be collected"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// A task spawned with **no parent** — called at the top level of a `run`, where the current task
+/// is `None` — is marked a GC root at creation and must never be collected, even with
+/// `parent_count == 0`. This is what keeps externally-spawned root operations (project container,
+/// endpoints, per-request source-map ops) alive: their handles live outside the tracked graph, so
+/// nothing else anchors them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_does_not_collect_parentless_root_task() {
+    let (tt, _persistence_dir) = create_tt("gc_does_not_collect_parentless_root_task");
+    let tt2 = tt.clone();
+    let tt3 = tt.clone();
+
+    let root_id = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        // Called directly in the `run` future: the current task is `None`, so gc_root_leaf's task
+        // is created with `parent == None` and marked a GC root. It has NO persistent parent edge.
+        assert_eq!(*gc_root_leaf().await?, 77);
+
+        let root_id = task_id_of(gc_root_leaf().resolve().await?);
+        // No parent connected it, so its parent_count is 0 from the start — yet it is a GC root.
+        assert_eq!(
+            tt3.backend().parent_count_for_testing(root_id),
+            0,
+            "a parentless root has no persistent parent edge"
+        );
+
+        anyhow::Ok(root_id)
+    })
+    .await
+    .unwrap();
+
+    // parent_count is 0 and it is disconnected, but the gc_root flag must keep it uncollectible.
+    assert_eq!(
+        tt2.backend().parent_count_for_testing(root_id),
+        0,
+        "still parent_count 0 after the run"
+    );
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 0,
+        "a parentless (gc_root) task must not be collected even with parent_count 0"
+    );
+
+    // Survives snapshot + eviction too (the gc_root flag is persisted meta).
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "gc_root task must survive eviction and not be collected"
     );
 
     tt.stop_and_wait().await;

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -1,0 +1,168 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, State, TaskId, TurboTasks, Vc,
+    unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, GitVersionInfo, TurboTasksBackend};
+
+/// Creates a fresh per-call persistence directory rooted under `CARGO_TARGET_TMPDIR/.cache/`.
+fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir_in(&parent)
+        .unwrap()
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            evict_after_snapshot: true,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+/// The `TaskId` backing a resolved `Vc` (its `TaskOutput` node).
+fn task_id_of<T>(vc: Vc<T>) -> TaskId {
+    Vc::into_raw(vc)
+        .try_get_task_id()
+        .expect("a resolved Vc should be backed by a task")
+}
+
+#[turbo_tasks::value(transparent)]
+struct Selector(State<bool>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_selector(initial: bool) -> Vc<Selector> {
+    Selector(State::new(initial)).cell()
+}
+
+#[turbo_tasks::function]
+fn leaf(n: u32) -> Vc<u32> {
+    Vc::cell(n)
+}
+
+#[turbo_tasks::function]
+async fn branch_a() -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *leaf(10).await?))
+}
+
+#[turbo_tasks::function]
+async fn branch_b() -> Result<Vc<u32>> {
+    Ok(Vc::cell(2 + *leaf(20).await?))
+}
+
+/// Reads exactly one branch depending on the selector; flipping it re-executes and disconnects the
+/// previously-read branch (and its subtree), which should drop that branch's `parent_count` to 0.
+#[turbo_tasks::function(operation, root)]
+async fn select(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
+    let use_b = *selector.await?.get();
+    let value = if use_b {
+        *branch_b().await?
+    } else {
+        *branch_a().await?
+    };
+    Ok(Vc::cell(value))
+}
+
+/// `parent_count` must track the number of persistent parents, incremented when a parent connects a
+/// child and decremented when it disconnects it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_tracks_connect_and_disconnect() {
+    let (tt, _persistence_dir) = create_tt("parent_count_tracks_connect_and_disconnect");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        // Build the connected graph: select -> branch_a -> leaf(10).
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+        // Resolve the branch task ids (calling the cached functions returns the same tasks).
+        let branch_a_id = task_id_of(branch_a().resolve().await?);
+        let leaf10_id = task_id_of(leaf(10).resolve().await?);
+        let branch_b_id = task_id_of(branch_b().resolve().await?);
+
+        // While connected, branch_a and leaf(10) each have exactly one persistent parent.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_a_id),
+            1,
+            "branch_a has one parent (select) while connected"
+        );
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(leaf10_id),
+            1,
+            "leaf(10) has one parent (branch_a) while connected"
+        );
+
+        // Flip: select re-executes reading branch_b, disconnecting branch_a + leaf(10).
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        // branch_a is now disconnected from select: its parent_count drops to 0.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_a_id),
+            0,
+            "branch_a lost its only parent (select) after the flip"
+        );
+        // leaf(10) is still listed as a child by the (now-garbage) branch_a — nothing re-executed
+        // branch_a to drop that edge — so its parent_count stays 1. It only drops to 0 once
+        // branch_a is torn down (the eager-teardown cascade, wired in a later stage). The
+        // count accurately reflects the live `children` edges at all times.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(leaf10_id),
+            1,
+            "leaf(10)'s parent branch_a still lists it (branch_a is garbage but not yet torn down)"
+        );
+        // branch_b + leaf(20) are now connected.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_b_id),
+            1,
+            "branch_b gained a parent (select) after the flip"
+        );
+
+        // Flip back: branch_a reconnects (recomputed), branch_b disconnects.
+        selector.set(false);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_b_id),
+            0,
+            "branch_b lost its parent after flipping back"
+        );
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -469,6 +469,60 @@ async fn stable_child_parent(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> 
     Ok(Vc::cell(bump + child))
 }
 
+/// One leaf per index — distinct tasks, so a wide parent accumulates that many distinct children.
+#[turbo_tasks::function]
+fn wide_leaf(index: u32) -> Vc<u32> {
+    Vc::cell(index)
+}
+
+/// Reads `WIDE_FANOUT` distinct children — deliberately above `connect_children`'s 10_000
+/// parallelization threshold, so the child-side `parent_count` bump runs through the chunked,
+/// parallel `process_new_children` path (each chunk on its own worker context) rather than the
+/// serial one.
+const WIDE_FANOUT: u32 = 12_000;
+
+#[turbo_tasks::function(operation, root)]
+async fn wide_parent() -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..WIDE_FANOUT {
+        sum = sum.wrapping_add(*wide_leaf(index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// The parallelized `connect_children` path (≥10_000 children, chunked across worker contexts)
+/// must bump each persistent child's `parent_count` exactly once — no child dropped by a chunk
+/// boundary, none double-counted. Connect >10_000 distinct children in one parent and assert a
+/// spread of them (first / middle / last, covering multiple chunks) each end at exactly 1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_count_wide_fanout_parallel_path() {
+    let (tt, _persistence_dir) = create_tt("parent_count_wide_fanout_parallel_path");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let output = wide_parent();
+        output.read_strongly_consistent().await?;
+
+        // Sample across the full range so at least one child from each chunk is checked.
+        for index in [0, 1, WIDE_FANOUT / 2, WIDE_FANOUT - 2, WIDE_FANOUT - 1] {
+            let child_id = task_id_of(wide_leaf(index).resolve().await?);
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(child_id),
+                1,
+                "wide_leaf({index}) must have parent_count == 1 after the parallel connect \
+                 (chunked +1 must bump every child exactly once)"
+            );
+        }
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
 /// Re-validation must not double-count. When a parent re-executes and connects a child it was
 /// *already* connected to (the child is still in its persistent `children` set), the child must NOT
 /// gain a second `parent_count`: `connect_children` only bumps the *genuinely-new* children (those

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -9,7 +9,7 @@ use turbo_tasks::{
     ResolvedVc, State, TaskId, TurboTasks, Vc, prevent_gc,
     unmark_top_level_task_may_leak_eventually_consistent_state,
 };
-use turbo_tasks_backend::{BackendOptions, GitVersionInfo, TurboTasksBackend};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
 
 /// Creates a fresh per-call persistence directory rooted under `CARGO_TARGET_TMPDIR/.cache/`.
 fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
@@ -29,7 +29,7 @@ fn open_tt_at(path: &std::path::Path) -> Arc<TurboTasks<TurboTasksBackend>> {
             num_workers: Some(2),
             small_preallocation: true,
             storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
-            evict_after_snapshot: true,
+            eviction_mode: EvictionMode::Full,
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -21,9 +21,10 @@ fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
         .unwrap()
 }
 
-fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
-    let dir = create_test_persistence_dir(name);
-    let tt = TurboTasks::new(TurboTasksBackend::new(
+/// Opens a backend rooted at `path`. Reusing the same `path` (after the previous backend has been
+/// stopped) reopens the persisted database — used to verify `parent_count` survives a restart.
+fn open_tt_at(path: &std::path::Path) -> Arc<TurboTasks<TurboTasksBackend>> {
+    TurboTasks::new(TurboTasksBackend::new(
         BackendOptions {
             num_workers: Some(2),
             small_preallocation: true,
@@ -32,7 +33,7 @@ fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempD
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(
-            dir.path(),
+            path,
             &GitVersionInfo {
                 describe: "test-unversioned",
                 dirty: false,
@@ -43,7 +44,12 @@ fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempD
         )
         .unwrap()
         .0,
-    ));
+    ))
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = open_tt_at(dir.path());
     (tt, dir)
 }
 
@@ -158,6 +164,125 @@ async fn parent_count_tracks_connect_and_disconnect() {
             tt2.backend().parent_count_for_testing(branch_b_id),
             0,
             "branch_b lost its parent after flipping back"
+        );
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
+/// `parent_count` is a persisted meta field: it must survive a snapshot + DB reopen. This exercises
+/// the durability path — the count is written into the task's meta blob and restored on the next
+/// session (and any in-flight `AdjustParentCount` job replays via the durable operation queue).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_survives_reopen() {
+    let dir = create_test_persistence_dir("parent_count_survives_reopen");
+
+    // Session 1: build select -> branch_a -> leaf(10), then stop (persists on shutdown).
+    let (branch_a_id, leaf10_id) = {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let ids = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+
+            let selector_op = create_selector(false);
+            let selector_vc = selector_op.resolve().strongly_consistent().await?;
+
+            let output = select(selector_vc);
+            assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+            let branch_a_id = task_id_of(branch_a().resolve().await?);
+            let leaf10_id = task_id_of(leaf(10).resolve().await?);
+            assert_eq!(tt2.backend().parent_count_for_testing(branch_a_id), 1);
+            assert_eq!(tt2.backend().parent_count_for_testing(leaf10_id), 1);
+            anyhow::Ok((branch_a_id, leaf10_id))
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+        ids
+    };
+
+    // Session 2: reopen the same DB, re-read the graph (restoring the persisted tasks), and assert
+    // their parent_count was restored from disk (not reset to 0). Task ids are stable across the
+    // reopen because they are persisted.
+    {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let result = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+
+            // Re-read the same graph so the cached tasks are restored from disk.
+            let selector_op = create_selector(false);
+            let selector_vc = selector_op.resolve().strongly_consistent().await?;
+            let output = select(selector_vc);
+            assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+            // Force the branch tasks resident (reading them restores their meta, incl.
+            // parent_count, from disk). These are cached, so they are not re-executed.
+            assert_eq!(*branch_a().await?, 11);
+            assert_eq!(*leaf(10).await?, 10);
+
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(branch_a_id),
+                1,
+                "branch_a's parent_count must be restored from disk after reopen"
+            );
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(leaf10_id),
+                1,
+                "leaf(10)'s parent_count must be restored from disk after reopen"
+            );
+            anyhow::Ok(())
+        })
+        .await;
+        tt.stop_and_wait().await;
+        result.unwrap();
+    }
+}
+
+/// A decrement (disconnect) must survive a snapshot + eviction and stay correct when the affected
+/// tasks are restored from disk — exercising the `-1` `AdjustParentCount` path through the durable
+/// queue within a single session (so task identity is stable). After the flip, branch_b has 1
+/// persistent parent and branch_a has 0; those counts must be intact after a snapshot/evict cycle
+/// pushes them to disk and a subsequent read restores them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_decrement_survives_snapshot_evict() {
+    let (tt, _persistence_dir) = create_tt("parent_count_decrement_survives_snapshot_evict");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+        // Flip so select drops branch_a (-1) and connects branch_b (+1).
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        let branch_a_id = task_id_of(branch_a().resolve().await?);
+        let branch_b_id = task_id_of(branch_b().resolve().await?);
+        assert_eq!(tt2.backend().parent_count_for_testing(branch_a_id), 0);
+        assert_eq!(tt2.backend().parent_count_for_testing(branch_b_id), 1);
+
+        // Snapshot + evict: pushes quiescent tasks (with their parent_count) to disk.
+        tt2.backend().snapshot_and_evict_for_testing(&tt2);
+
+        // Re-read the live output, restoring branch_b from disk; its parent_count must still be 1
+        // (the persisted, decrement-consistent value — not doubled, not lost).
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+        assert_eq!(*branch_b().await?, 22);
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_b_id),
+            1,
+            "branch_b's parent_count must round-trip through snapshot/evict as 1"
         );
 
         anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -426,3 +426,32 @@ async fn gc_does_not_collect_pinned_task() {
 
     tt.stop_and_wait().await;
 }
+
+/// Unpinning a task after the backend has started stopping must not panic. This mirrors the real
+/// shutdown ordering: a `DetachedVc` handed to JS across NAPI is finalized (dropped, which unpins)
+/// during Node worker teardown, which can run *after* `stop()` has dropped the whole task map.
+/// pin/unpin are gated on the `stopping` flag (set before the map is dropped) so a late unpin is a
+/// no-op rather than resurrecting a blank entry and underflowing `transient_ref_count`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unpin_after_stop_does_not_panic() {
+    let (tt, _persistence_dir) = create_tt("unpin_after_stop_does_not_panic");
+
+    // Pin a real task inside a session (as `prevent_gc` / `DetachedVc::new` would).
+    let tt2 = tt.clone();
+    let leaf_id = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let id = task_id_of(leaf(7).resolve().await?);
+        tt2.pin_task_for_gc(id);
+        anyhow::Ok(id)
+    })
+    .await
+    .unwrap();
+
+    // Stop the backend — this drops the in-memory task map, so the pinned task is no longer
+    // resident (exactly as at `next build` shutdown).
+    tt.stop_and_wait().await;
+
+    // Unpin after teardown, as a `DetachedVc`'s `Drop` finalized during Node worker cleanup would.
+    // The task is gone from the map, so this must be a harmless no-op — not an underflow panic.
+    tt.unpin_task_for_gc(leaf_id);
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use turbo_tasks::{
-    ResolvedVc, State, TaskId, TurboTasks, Vc,
+    ResolvedVc, State, TaskId, TurboTasks, Vc, prevent_gc,
     unmark_top_level_task_may_leak_eventually_consistent_state,
 };
 use turbo_tasks_backend::{BackendOptions, GitVersionInfo, TurboTasksBackend};
@@ -83,6 +83,15 @@ async fn branch_b() -> Result<Vc<u32>> {
     Ok(Vc::cell(2 + *leaf(20).await?))
 }
 
+/// A task that pins itself against GC while executing (as code handing a value across an untracked
+/// boundary — e.g. a `spawn_detached` future sending a `Vc` over a channel — would). Once pinned it
+/// must survive collection even after it is disconnected.
+#[turbo_tasks::function]
+async fn pinned_branch() -> Result<Vc<u32>> {
+    prevent_gc();
+    Ok(Vc::cell(99))
+}
+
 /// Reads exactly one branch depending on the selector; flipping it re-executes and disconnects the
 /// previously-read branch (and its subtree), which should drop that branch's `parent_count` to 0.
 #[turbo_tasks::function(operation, root)]
@@ -92,6 +101,18 @@ async fn select(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
         *branch_b().await?
     } else {
         *branch_a().await?
+    };
+    Ok(Vc::cell(value))
+}
+
+/// Like `select`, but reads `pinned_branch` instead of `branch_a` when the selector is false.
+#[turbo_tasks::function(operation, root)]
+async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
+    let use_b = *selector.await?.get();
+    let value = if use_b {
+        *branch_b().await?
+    } else {
+        *pinned_branch().await?
     };
     Ok(Vc::cell(value))
 }
@@ -352,6 +373,56 @@ async fn gc_collects_disconnected_subtree() {
     })
     .await;
     result.unwrap();
+
+    tt.stop_and_wait().await;
+}
+
+/// A task that pins itself via `prevent_gc()` must survive collection even after it is disconnected
+/// from the live graph — covering values that escape the tracked task graph (e.g. `spawn_detached`
+/// sending a `Vc` across a channel). Unlike `branch_a`, `pinned_branch` is not collected once
+/// disconnected, because the pin makes it a GC root.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_does_not_collect_pinned_task() {
+    let (tt, _persistence_dir) = create_tt("gc_does_not_collect_pinned_task");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        // select_pinned reads pinned_branch, which pins itself during execution.
+        let output = select_pinned(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 99);
+
+        // Flip: select_pinned re-executes, reads branch_b, and disconnects pinned_branch.
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // GC (after the run releases activeness) must NOT collect pinned_branch even though it is now
+    // disconnected (parent_count 0), because it pinned itself. Its child leaf from branch_b is
+    // live.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 0,
+        "a pinned task must not be collected even when disconnected"
+    );
+
+    // A snapshot + evict must not lose the (transient) pin: pinned tasks are unevictable, so the
+    // flag survives and a subsequent GC still collects nothing.
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "pinned task must survive eviction and not be collected"
+    );
 
     tt.stop_and_wait().await;
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -470,11 +470,10 @@ async fn stable_child_parent(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> 
 }
 
 /// Re-validation must not double-count. When a parent re-executes and connects a child it was
-/// *already* connected to (the child is still in its persistent `children` set), the child is
-/// staged again but must NOT take a second `parent_count` hold — the edge already existed. This
-/// exercises the `insert`-into-`new_children`-of-an-already-`children` path
-/// (`ConnectChildOperation::run`) followed by the completion filter that drops it before
-/// `extend_children`, so the hold count stays at exactly 1 across arbitrarily many re-executions.
+/// *already* connected to (the child is still in its persistent `children` set), the child must NOT
+/// gain a second `parent_count`: `connect_children` only bumps the *genuinely-new* children (those
+/// not already present in `children`), so the count stays at exactly 1 across arbitrarily many
+/// re-executions that keep the edge.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn parent_count_not_double_counted_on_revalidation() {
     let (tt, _persistence_dir) = create_tt("parent_count_not_double_counted_on_revalidation");
@@ -505,7 +504,7 @@ async fn parent_count_not_double_counted_on_revalidation() {
                 tt2.backend().parent_count_for_testing(leaf30_id),
                 1,
                 "leaf(30)'s parent_count must stay 1 across re-validation (iteration {i}), not \
-                 grow — the child edge already existed so no new hold is taken"
+                 grow — the child edge already existed so no new count is taken"
             );
         }
 

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -457,3 +457,61 @@ async fn unpin_after_stop_does_not_panic() {
     // The task is gone from the map, so this must be a harmless no-op — not an underflow panic.
     tt.unpin_task_for_gc(leaf_id);
 }
+
+/// Reads a *stable* child (`leaf(30)`) on every execution, plus a `State` that drives
+/// re-execution. Flipping the state re-executes the parent while it keeps the same child edge.
+#[turbo_tasks::function(operation, root)]
+async fn stable_child_parent(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
+    // Read the selector so we re-execute when it flips...
+    let bump = if *selector.await?.get() { 100 } else { 0 };
+    // ...but always connect the SAME child regardless.
+    let child = *leaf(30).await?;
+    Ok(Vc::cell(bump + child))
+}
+
+/// Re-validation must not double-count. When a parent re-executes and connects a child it was
+/// *already* connected to (the child is still in its persistent `children` set), the child is
+/// staged again but must NOT take a second `parent_count` hold — the edge already existed. This
+/// exercises the `insert`-into-`new_children`-of-an-already-`children` path
+/// (`ConnectChildOperation::run`) followed by the completion filter that drops it before
+/// `extend_children`, so the hold count stays at exactly 1 across arbitrarily many re-executions.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_not_double_counted_on_revalidation() {
+    let (tt, _persistence_dir) = create_tt("parent_count_not_double_counted_on_revalidation");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let output = stable_child_parent(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 30);
+
+        let leaf30_id = task_id_of(leaf(30).resolve().await?);
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(leaf30_id),
+            1,
+            "leaf(30) has exactly one parent after the first execution"
+        );
+
+        // Re-execute the parent several times; it keeps the same child edge each time.
+        for i in 0..5 {
+            selector.set(i % 2 == 0);
+            output.read_strongly_consistent().await?;
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(leaf30_id),
+                1,
+                "leaf(30)'s parent_count must stay 1 across re-validation (iteration {i}), not \
+                 grow — the child edge already existed so no new hold is taken"
+            );
+        }
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -346,13 +346,13 @@ async fn gc_collects_disconnected_subtree() {
     // that run is not yet collectible. Once the run ends the active counts are released and the
     // disconnected branch_a (parent_count 0) becomes collectible; the cascade then drops
     // leaf(10) to 0 too.
-    let collected = tt2.backend().gc_for_testing(&tt2);
+    let (collected, _deletes) = tt2.backend().gc_for_testing(&tt2);
     assert_eq!(
         collected, 2,
         "branch_a and its cascaded child leaf(10) should both be collected"
     );
     assert_eq!(
-        tt2.backend().gc_for_testing(&tt2),
+        tt2.backend().gc_for_testing(&tt2).0,
         0,
         "nothing left to collect"
     );
@@ -409,7 +409,7 @@ async fn gc_does_not_collect_pinned_task() {
     // GC (after the run releases activeness) must NOT collect pinned_branch even though it is now
     // disconnected (parent_count 0), because it pinned itself. Its child leaf from branch_b is
     // live.
-    let collected = tt2.backend().gc_for_testing(&tt2);
+    let (collected, _deletes) = tt2.backend().gc_for_testing(&tt2);
     assert_eq!(
         collected, 0,
         "a pinned task must not be collected even when disconnected"
@@ -419,7 +419,7 @@ async fn gc_does_not_collect_pinned_task() {
     // flag survives and a subsequent GC still collects nothing.
     tt2.backend().snapshot_and_evict_for_testing(&tt2);
     assert_eq!(
-        tt2.backend().gc_for_testing(&tt2),
+        tt2.backend().gc_for_testing(&tt2).0,
         0,
         "pinned task must survive eviction and not be collected"
     );

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -346,13 +346,13 @@ async fn gc_collects_disconnected_subtree() {
     // that run is not yet collectible. Once the run ends the active counts are released and the
     // disconnected branch_a (parent_count 0) becomes collectible; the cascade then drops
     // leaf(10) to 0 too.
-    let (collected, _deletes) = tt2.backend().gc_for_testing(&tt2);
+    let collected = tt2.backend().gc_for_testing(&tt2);
     assert_eq!(
         collected, 2,
         "branch_a and its cascaded child leaf(10) should both be collected"
     );
     assert_eq!(
-        tt2.backend().gc_for_testing(&tt2).0,
+        tt2.backend().gc_for_testing(&tt2),
         0,
         "nothing left to collect"
     );
@@ -409,7 +409,7 @@ async fn gc_does_not_collect_pinned_task() {
     // GC (after the run releases activeness) must NOT collect pinned_branch even though it is now
     // disconnected (parent_count 0), because it pinned itself. Its child leaf from branch_b is
     // live.
-    let (collected, _deletes) = tt2.backend().gc_for_testing(&tt2);
+    let collected = tt2.backend().gc_for_testing(&tt2);
     assert_eq!(
         collected, 0,
         "a pinned task must not be collected even when disconnected"
@@ -421,7 +421,7 @@ async fn gc_does_not_collect_pinned_task() {
     // uncollectible and a subsequent GC still collects nothing.
     tt2.backend().snapshot_and_evict_for_testing(&tt2);
     assert_eq!(
-        tt2.backend().gc_for_testing(&tt2).0,
+        tt2.backend().gc_for_testing(&tt2),
         0,
         "pinned task must survive eviction and not be collected"
     );

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -291,3 +291,67 @@ async fn parent_count_decrement_survives_snapshot_evict() {
     tt.stop_and_wait().await;
     result.unwrap();
 }
+
+/// A GC pass collects a disconnected subtree via the parent_count cascade: disconnecting branch_a
+/// drops its count to 0 (branch_a is collected), which decrements its child leaf(10) to 0 (leaf(10)
+/// is then collected too). The live branch (branch_b + leaf(20)) is untouched and the graph still
+/// computes; flipping back recomputes branch_a fresh, proving no dangling references.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_collects_disconnected_subtree() {
+    let (tt, _persistence_dir) = create_tt("gc_collects_disconnected_subtree");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+        // Flip: select drops branch_a; branch_a (parent_count 0) becomes a candidate.
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // GC runs in a fresh `run_once` after the first completes: a `run_once` root keeps every task
+    // it touched active (active_counter > 0) until it returns, so a task disconnected *within*
+    // that run is not yet collectible. Once the run ends the active counts are released and the
+    // disconnected branch_a (parent_count 0) becomes collectible; the cascade then drops
+    // leaf(10) to 0 too.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 2,
+        "branch_a and its cascaded child leaf(10) should both be collected"
+    );
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "nothing left to collect"
+    );
+
+    // The live graph still computes, and flipping back recomputes branch_a fresh (it was collected)
+    // — proving collection left no dangling references.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        let selector_op = create_selector(true);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+        selector.set(false);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -415,8 +415,10 @@ async fn gc_does_not_collect_pinned_task() {
         "a pinned task must not be collected even when disconnected"
     );
 
-    // A snapshot + evict must not lose the (transient) pin: pinned tasks are unevictable, so the
-    // flag survives and a subsequent GC still collects nothing.
+    // A snapshot + evict must not lose the (transient) pin. A pinned task is no longer forced fully
+    // resident — its Meta/Data may be partially evicted — but the session-only
+    // `transient_ref_count` is retained as residue (the map entry is kept), so the task stays
+    // uncollectible and a subsequent GC still collects nothing.
     tt2.backend().snapshot_and_evict_for_testing(&tt2);
     assert_eq!(
         tt2.backend().gc_for_testing(&tt2).0,

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1025,20 +1025,18 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
     let data_count = grouped_fields.persisted_data_flags_count();
     let persisted_count = meta_count + data_count;
 
-    // Ensure counts fit within u16 bitfield (and u8 for individual categories)
+    // Ensure counts fit within u32 bitfield (and u8 for individual categories)
     assert!(
-        meta_count <= 8,
-        "Too many persisted meta flags ({meta_count}), maximum is 8 (though this could be \
-         expanded)"
+        meta_count <= 16,
+        "Too many persisted meta flags ({meta_count}), maximum is 16"
     );
     assert!(
-        data_count <= 8,
-        "Too many persisted data flags ({data_count}), maximum is 8 (though this could be \
-         expanded)"
+        data_count <= 16,
+        "Too many persisted data flags ({data_count}), maximum is 16"
     );
     assert!(
-        all_flags.len() <= 16,
-        "Too many total flags ({}), maximum is 16 (though this could be expanded)",
+        all_flags.len() <= 32,
+        "Too many total flags ({}), maximum is 32",
         all_flags.len()
     );
 
@@ -1063,17 +1061,17 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
     // Data flags are in bits meta_count..meta_count+data_count
     // Combined persisted mask covers both
     let meta_mask = if meta_count > 0 {
-        (1u16 << meta_count) - 1
+        (1u32 << meta_count) - 1
     } else {
         0
     };
     let data_mask = if data_count > 0 {
-        ((1u16 << data_count) - 1) << meta_count
+        ((1u32 << data_count) - 1) << meta_count
     } else {
         0
     };
     let persisted_mask = if persisted_count > 0 {
-        (1u16 << persisted_count) - 1
+        (1u32 << persisted_count) - 1
     } else {
         0
     };
@@ -1085,7 +1083,7 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
             #[doc = "Bit layout: [meta flags: 0..M] [data flags: M..M+D] [transient: M+D..]"]
             #[doc = "This ordering allows separate masks for per-category serialization."]
             #[derive(Clone, Default, PartialEq, Eq)]
-            pub struct TaskFlags(u16);
+            pub struct TaskFlags(u32);
             impl Debug;
 
             #(#bitfield_accessors;)*
@@ -1094,54 +1092,54 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
         #[automatically_derived]
         impl TaskFlags {
             #[doc = "Mask for persisted meta flags"]
-            pub const META_MASK: u16 = #meta_mask;
+            pub const META_MASK: u32 = #meta_mask;
 
             #[doc = "Mask for persisted data flags"]
-            pub const DATA_MASK: u16 = #data_mask;
+            pub const DATA_MASK: u32 = #data_mask;
 
             #[doc = "Mask for all persisted flags (meta + data)"]
-            pub const PERSISTED_MASK: u16 = #persisted_mask;
+            pub const PERSISTED_MASK: u32 = #persisted_mask;
 
             #[doc = "Get the raw bits value"]
-            pub fn bits(&self) -> u16 {
+            pub fn bits(&self) -> u32 {
                 self.0
             }
 
             #[doc = "Get only the persisted meta bits (for meta serialization)"]
-            pub fn persisted_meta_bits(&self) -> u8 {
+            pub fn persisted_meta_bits(&self) -> u16 {
                 // Meta bits are in the lowest positions (bits 0..meta_count),
-                // and we assert meta_count <= 8, so this fits in a u8
-                (self.0 & Self::META_MASK) as u8
+                // and we assert meta_count <= 16, so this fits in a u16
+                (self.0 & Self::META_MASK) as u16
             }
 
             #[doc = "Get only the persisted data bits (for data serialization)"]
-            pub fn persisted_data_bits(&self) -> u8 {
+            pub fn persisted_data_bits(&self) -> u16 {
                 // Data bits are in positions meta_count..meta_count+data_count,
                 // so we shift right to get them into the low bits.
-                // We assert data_count <= 8, so this fits in a u8
-                ((self.0 & Self::DATA_MASK) >> #meta_count) as u8
+                // We assert data_count <= 16, so this fits in a u16
+                ((self.0 & Self::DATA_MASK) >> #meta_count) as u16
             }
 
             #[doc = "Get all persisted bits (for serialization)"]
-            pub fn persisted_bits(&self) -> u16 {
+            pub fn persisted_bits(&self) -> u32 {
                 self.0 & Self::PERSISTED_MASK
             }
 
             #[doc = "Set meta bits from a raw value, preserving other flags"]
-            pub fn set_persisted_meta_bits(&mut self, bits: u8) {
+            pub fn set_persisted_meta_bits(&mut self, bits: u16) {
                 // Meta bits go in the lowest positions (bits 0..meta_count)
-                self.0 = (self.0 & !Self::META_MASK) | (bits as u16 & Self::META_MASK);
+                self.0 = (self.0 & !Self::META_MASK) | (bits as u32 & Self::META_MASK);
             }
 
             #[doc = "Set data bits from a raw value, preserving other flags"]
-            pub fn set_persisted_data_bits(&mut self, bits: u8) {
+            pub fn set_persisted_data_bits(&mut self, bits: u16) {
                 // Data bits go in positions meta_count..meta_count+data_count,
                 // so we shift left to place them correctly
-                self.0 = (self.0 & !Self::DATA_MASK) | (((bits as u16) << #meta_count) & Self::DATA_MASK);
+                self.0 = (self.0 & !Self::DATA_MASK) | (((bits as u32) << #meta_count) & Self::DATA_MASK);
             }
 
             #[doc = "Set all persisted bits from a raw value, preserving transient flags"]
-            pub fn set_persisted_bits(&mut self, bits: u16) {
+            pub fn set_persisted_bits(&mut self, bits: u32) {
                 self.0 = (self.0 & !Self::PERSISTED_MASK) | (bits & Self::PERSISTED_MASK);
             }
 
@@ -1162,7 +1160,7 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
             }
 
             #[doc = "Create from raw bits (for deserialization)"]
-            pub fn from_bits(bits: u16) -> Self {
+            pub fn from_bits(bits: u32) -> Self {
                 Self(bits)
             }
         }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -3087,9 +3087,15 @@ fn generate_drop_method(grouped_fields: &GroupedFields) -> TokenStream {
             StorageType::AutoMap | StorageType::AutoSet | StorageType::CounterMap => quote! {
                 self.#field_name.is_empty()
             },
-            StorageType::Direct => quote! {
-                self.#field_name == Default::default()
-            },
+            StorageType::Direct => {
+                // Fully-qualified `Default` so a bare scalar field (e.g. `u32`) doesn't trip
+                // `Default::default()` type-inference ambiguity — the newtype direct fields infer
+                // fine, but a primitive needs the type spelled out.
+                let field_type = &field.field_type;
+                quote! {
+                    self.#field_name == <#field_type as Default>::default()
+                }
+            }
             StorageType::Flag => unreachable!(),
         }
     }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1676,6 +1676,7 @@ fn generate_task_storage_accessors_trait(grouped_fields: &GroupedFields) -> Toke
             #[doc = "- `Data` or `Meta`: Checks that the task was accessed with that category"]
             #[doc = ""]
             #[doc = "Implementors should check that the provided category matches how the task was accessed."]
+            #[track_caller]
             fn check_access(&self, category: crate::backend::storage::SpecificTaskDataCategory);
 
             #[doc = "Shrink all collection fields to fit their current contents."]

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -735,6 +735,18 @@ pub trait Backend: Sized + Sync + Send {
         // Do nothing by default
     }
 
+    /// Pin a task against garbage collection (via [`prevent_gc`](crate::prevent_gc)). A pinned task
+    /// is treated as a GC root, keeping alive references that escape the tracked task graph. The
+    /// default is a no-op for backends without GC.
+    fn pin_task_for_gc(&self, _task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        // Do nothing by default
+    }
+
+    /// Removes a pin added by [`pin_task_for_gc`](Backend::pin_task_for_gc).
+    fn unpin_task_for_gc(&self, _task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        // Do nothing by default
+    }
+
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -184,6 +184,13 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     );
     fn mark_own_task_as_finished(&self, task: TaskId);
 
+    /// Pin a task against garbage collection. Delegates to
+    /// [`Backend::pin_task_for_gc`](crate::backend::Backend::pin_task_for_gc).
+    fn pin_task_for_gc(&self, task: TaskId);
+
+    /// Removes a pin added by [`pin_task_for_gc`](TurboTasksApi::pin_task_for_gc).
+    fn unpin_task_for_gc(&self, task: TaskId);
+
     fn connect_task(&self, task: TaskId);
 
     /// Wraps the given future in the current task.
@@ -1567,6 +1574,14 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         self.backend.mark_own_task_as_finished(task, self);
     }
 
+    fn pin_task_for_gc(&self, task: TaskId) {
+        self.backend.pin_task_for_gc(task, self);
+    }
+
+    fn unpin_task_for_gc(&self, task: TaskId) {
+        self.backend.unpin_task_for_gc(task, self);
+    }
+
     /// Creates a future that inherits the current task id and task state. The current global task
     /// will wait for this future to be dropped before exiting.
     fn spawn_detached_for_testing(&self, fut: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
@@ -1891,8 +1906,17 @@ pub fn unmark_top_level_task_may_leak_eventually_consistent_state() {
     }
 }
 
+/// Pins the current task against garbage collection for the rest of the session, keeping it (and,
+/// via the reachability it anchors, the values it produced) alive even if it becomes disconnected
+/// from the live task graph. Use this when a value escapes the tracked graph — e.g. a `Vc` sent out
+/// of a `spawn_detached` future across a channel, or handed across the NAPI boundary — so no
+/// persistent parent lists it as a child and it would otherwise be collected.
+///
+/// No-op outside a task context, and on backends without garbage collection.
 pub fn prevent_gc() {
-    // TODO implement garbage collection
+    if let Some(task) = current_task_if_available("prevent_gc") {
+        with_turbo_tasks(|tt| tt.pin_task_for_gc(task));
+    }
 }
 
 pub fn emit<T: VcValueTrait + ?Sized>(collectible: ResolvedVc<T>) {

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -661,6 +661,18 @@ impl<B: Backend + 'static> TurboTasks<B> {
         self.backend.dispose_root_task(task_id, self);
     }
 
+    /// Pins a task against garbage collection (a transient, session-only reference). Balanced by
+    /// [`unpin_task_for_gc`](Self::unpin_task_for_gc). Used for references that escape the tracked
+    /// task graph — e.g. a `DetachedVc` holding an `OperationVc` across the NAPI boundary.
+    pub fn pin_task_for_gc(&self, task_id: TaskId) {
+        self.backend.pin_task_for_gc(task_id, self);
+    }
+
+    /// Releases a pin added by [`pin_task_for_gc`](Self::pin_task_for_gc).
+    pub fn unpin_task_for_gc(&self, task_id: TaskId) {
+        self.backend.unpin_task_for_gc(task_id, self);
+    }
+
     // TODO make sure that all dependencies settle before reading them
     /// Creates a new root task, that is only executed once.
     /// Dependencies will not invalidate the task.

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -309,9 +309,490 @@ where
     })
 }
 
+// ---------------------------------------------------------------------------
+// Self-feeding scope
+// ---------------------------------------------------------------------------
+//
+// `scope_and_block` above processes a *fixed* set of jobs: every job is enqueued before draining
+// begins, and termination is detected via an `End` sentinel that is pushed once, after the factory
+// closure returns. The self-feeding variant below relaxes that: a running job may enqueue MORE work
+// into the same scope, so the total job count is not known up front and the `End`-sentinel model
+// does not apply. Termination is instead driven purely by the `remaining_tasks` counter reaching
+// zero.
+//
+// Sharing analysis (what is reused vs. what needs its own implementation):
+//   * REUSED IN SPIRIT: the `remaining_tasks` counter + `main_thread.unpark()` handshake, the
+//     panic-recording `Mutex`, and the `wait()`/`block_in_place` parking loop. These are copied
+//     into `FeedingInner` essentially verbatim from `ScopeInner`, because their behaviour is
+//     identical. (They are copied rather than factored into a shared base struct only to avoid
+//     churning `ScopeInner`/`Scope`, which are load-bearing for `scope_and_block`; a follow-up
+//     could hoist a shared `Waiter { main_thread, remaining_tasks, panic }` if desired. Flagged for
+//     the reviewer.)
+//   * NEEDS ITS OWN IMPL: the work queue payload (`T` items, not boxed `FnOnce`s), the
+//     pick/run/wait loop, and the termination condition. The fixed-set `End` sentinel cannot be
+//     used because more items may arrive after any given drain observes an empty queue.
+//   * REUSED DIRECTLY: `worker_tasks` sizing logic, `turbo_tasks_scope` wrapping, the
+//     `'scope`->`'static` transmute pattern, and the "main thread drains everything itself"
+//     liveness property.
+
+/// Shared, NON-generic state for a [`scope_self_feeding`] run: the counter, panic slot, and the
+/// work queue of erased per-item jobs.
+///
+/// The work queue stores one boxed closure per item — exactly like [`ScopeInner`] — rather than raw
+/// `T` values. This is a deliberate choice: it reuses `Scope::spawn`'s *proven* `'scope`->`'static`
+/// transmute (erasing a boxed closure, not a `T`), so `FeedingInner` needs no `T` generic and we
+/// never touch `dyn Any` / `T: 'static`. Each job closure captures its `T` and an `Arc` to the
+/// generic [`Feeding`] context (which owns the shared `run`), and when invoked it reconstructs a
+/// [`Spawner`] so `run` can enqueue children.
+struct FeedingInner {
+    main_thread: Thread,
+    /// Number of items that have been enqueued but not yet finished processing. An item is counted
+    /// from the moment it is pushed onto `work_queue` until its job closure returns (or panics).
+    /// The scope is complete exactly when this reaches zero. See `Spawner::spawn` /
+    /// `on_item_finished` for the ordering that makes zero a reliable "all done" signal.
+    remaining_tasks: AtomicUsize,
+    /// The first panic that occurred while processing an item. Unlike the fixed-set scope there is
+    /// no meaningful per-item index to order panics by, so we keep the *first* panic to be
+    /// recorded (ties broken by lock order).
+    panic: Mutex<Option<Box<dyn Any + Send + 'static>>>,
+    /// Queue of jobs awaiting processing. Each is a self-contained closure erased to `'static`
+    /// (see `Spawner::spawn`).
+    work_queue: Mutex<VecDeque<Box<dyn FnOnce() + Send + 'static>>>,
+    /// Notifies parked workers of newly-enqueued work, and of termination (via `notify_all` once
+    /// `remaining_tasks` hits zero).
+    work_queue_condition_var: Condvar,
+    /// Set once `remaining_tasks` reaches zero, so workers parked on the condvar with an empty
+    /// queue can distinguish "more work coming" from "we are done". Checked under the queue lock.
+    done: std::sync::atomic::AtomicBool,
+}
+
+impl FeedingInner {
+    /// Records that a new item has been enqueued. MUST be called (incrementing `remaining_tasks`)
+    /// *before* the item is pushed onto the queue, and — crucially — a job that spawns children
+    /// must call this for each child BEFORE it finishes (before its own `on_item_finished`). See
+    /// the ordering argument on `Spawner::spawn`.
+    #[inline]
+    fn account_new_item(&self) {
+        self.remaining_tasks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Latches `done` and wakes everyone. Called when the counter is (or has just become) zero.
+    ///
+    /// `done` is set and the notifications issued while holding the queue lock, so it is impossible
+    /// for a worker to observe an empty queue, decide to wait, and only then miss the
+    /// `done`/`notify_all` — a classic lost-wakeup. Holding the lock serializes against
+    /// `pick_item`'s empty-queue-check-then-wait sequence. Idempotent: safe to call more than once
+    /// and from more than one thread (e.g. a finishing worker and the post-fill idle check racing).
+    fn latch_done_and_wake(&self) {
+        let _guard = self.work_queue.lock();
+        self.done.store(true, Ordering::Release);
+        // Wake all parked workers (blocked on the condvar with an empty queue) and the main thread
+        // (parked in `wait()`).
+        self.work_queue_condition_var.notify_all();
+        self.main_thread.unpark();
+    }
+
+    /// Records that one item finished processing. Mirrors `ScopeInner::on_task_finished`: records
+    /// the first panic, and when the counter transitions to zero, latches `done` and wakes the main
+    /// thread and every parked worker so they can observe termination.
+    fn on_item_finished(&self, panic: Option<Box<dyn Any + Send + 'static>>) {
+        if let Some(err) = panic {
+            let mut slot = self.panic.lock();
+            if slot.is_none() {
+                *slot = Some(err);
+            }
+        }
+        // `Release` pairs with the `Acquire` loads in `wait()` and `pick_item`, so that once a
+        // thread observes zero / `done` it also observes every prior queue and panic write.
+        if self.remaining_tasks.fetch_sub(1, Ordering::Release) == 1 {
+            // This decrement brought the count to zero: the scope is done.
+            self.latch_done_and_wake();
+        }
+    }
+
+    /// Called by the calling thread once the initial fill is complete. If no work is (or is still)
+    /// in flight — the empty-initial case, or the case where helpers already drained everything —
+    /// then `on_item_finished` may never fire (or already fired), so nothing would ever latch
+    /// `done` and the drain loops would block forever. Latch it here.
+    ///
+    /// Racing with a worker's own `latch_done_and_wake` is fine: both run under the queue lock and
+    /// setting `done`/notifying twice is harmless. The `Acquire` load pairs with the finishing
+    /// worker's `Release` decrement.
+    fn finalize_if_idle(&self) {
+        if self.remaining_tasks.load(Ordering::Acquire) == 0 {
+            self.latch_done_and_wake();
+        }
+    }
+
+    /// Worker/main-thread drain loop. Pulls jobs and runs them until the scope terminates
+    /// (`remaining_tasks == 0`, surfaced via `done`). Both helpers and the calling thread run this;
+    /// helpers are a pure optimization, exactly as in the fixed-set scope.
+    fn run_items(&self) {
+        while let Some(job) = self.pick_item() {
+            let result = catch_unwind(AssertUnwindSafe(job));
+            self.on_item_finished(result.err());
+        }
+    }
+
+    /// Blocks until either a job is available (returned as `Some`) or the scope is done (`None`).
+    /// Unlike the fixed-set `pick_job_from_work_queue`, an empty queue does NOT mean "done": more
+    /// items may still be produced by in-flight jobs, so we wait on the condvar and re-check,
+    /// terminating only when `done` is latched.
+    fn pick_item(&self) -> Option<Box<dyn FnOnce() + Send + 'static>> {
+        let mut work_queue = self.work_queue.lock();
+        loop {
+            if let Some(job) = work_queue.pop_front() {
+                // If work remains, hand off a wakeup to pull in another idle worker. Same rationale
+                // as the fixed-set scope: `parking_lot` notifications are not latched, so a
+                // `notify_one` at enqueue time can be lost if no worker was parked yet.
+                if !work_queue.is_empty() {
+                    self.work_queue_condition_var.notify_one();
+                }
+                drop(work_queue);
+                return Some(job);
+            }
+            // Queue is empty. If the scope is done, stop; otherwise wait for new work or the final
+            // wakeup. `done` is read under the queue lock, so it cannot be set between our
+            // emptiness check and going to sleep (see `on_item_finished`).
+            if self.done.load(Ordering::Acquire) {
+                return None;
+            }
+            self.work_queue_condition_var.wait(&mut work_queue);
+        }
+    }
+
+    /// Same parking strategy as `ScopeInner::wait`: spin-park briefly, then fall back to
+    /// `block_in_place` so tokio can reuse this core. Only reached by the main thread, and only
+    /// after it has itself drained everything it could (`run_items` returned), so `block_in_place`
+    /// is a last resort exactly as in the fixed-set scope.
+    fn wait(&self) {
+        if self.remaining_tasks.load(Ordering::Acquire) == 0 {
+            return;
+        }
+
+        let _span = info_span!("blocking").entered();
+
+        const TIMEOUT: Duration = Duration::from_millis(1);
+        let beginning_park = Instant::now();
+
+        let mut timeout_remaining = TIMEOUT;
+        loop {
+            thread::park_timeout(timeout_remaining);
+            if self.remaining_tasks.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            let elapsed = beginning_park.elapsed();
+            if elapsed >= TIMEOUT {
+                break;
+            }
+            timeout_remaining = TIMEOUT - elapsed;
+        }
+
+        block_in_place(|| {
+            while self.remaining_tasks.load(Ordering::Acquire) != 0 {
+                thread::park();
+            }
+        });
+    }
+}
+
+/// Handle passed to the `run` closure of [`scope_self_feeding`], used to enqueue additional items
+/// into the same scope.
+///
+/// `'scope` ties the borrowed enqueue callback to a single `run` invocation; `'env` is the
+/// caller-visible lifetime of the borrowed data captured by `run` and the items.
+///
+/// The concrete `run` closure type is hidden behind a single type-erased "enqueue one item"
+/// callback (`dyn Fn(T) + 'env`), so callers only ever name `Spawner<'_, 'env, T>`. Crucially this
+/// callback is `'env`-typed (not `'static`), which is what lets the internal `Spawner`s built by
+/// worker threads type-check against the user's `run: Fn(&Spawner<'_, 'env, T>, T)` without any
+/// lifetime transmute of the `Spawner` itself.
+pub struct Spawner<'scope, 'env: 'scope, T: Send + 'env> {
+    /// Called by `spawn`. Performs the increment-before-push accounting and enqueues a job. Erased
+    /// so `F` does not appear here.
+    ///
+    /// No `Send`/`Sync` bound: a `Spawner` is constructed and used entirely within a single `run`
+    /// invocation on one worker thread; it is never itself sent or shared across threads. (The
+    /// *items* it enqueues are `T: Send`, which is what actually needs to cross threads, and that
+    /// bound lives on the queue path.)
+    enqueue: &'scope (dyn Fn(T) + 'env),
+    /// Invariance over `'env` mirrors `Scope::env`: it keeps `'env` from shrinking, which the
+    /// `'env`->`'static` job-closure transmute in `scope_self_feeding` relies on for soundness.
+    _marker: PhantomData<&'env mut &'env ()>,
+}
+
+impl<'scope, 'env: 'scope, T: Send + 'env> Spawner<'scope, 'env, T> {
+    /// Enqueue another item to be processed by `run`. Callable any number of times (including zero)
+    /// from inside `run`, from any worker thread.
+    pub fn spawn(&self, item: T) {
+        (self.enqueue)(item);
+    }
+}
+
+/// Like [`scope_and_block`], but *self-feeding*: the `run` closure receives a [`Spawner`] and may
+/// enqueue additional items while the scope is draining. The scope completes only when every item —
+/// the `initial` ones plus everything transitively spawned — has been processed. No per-item
+/// results are collected; jobs communicate through shared state captured in `run`.
+///
+/// `run` is `Fn + Sync` and is shared (by reference) across the calling thread and up to
+/// `runtime worker threads - 1` opportunistic helper worker tasks; it may therefore run
+/// concurrently on multiple threads and is called exactly once per item.
+///
+/// Liveness matches `scope_and_block`: the calling thread participates in draining and will drain
+/// the entire (growing) queue by itself if no helper is ever scheduled, so this does not deadlock
+/// on a thread-limited or otherwise-contended runtime. The `block_in_place` fallback in `wait()` is
+/// reached only after the calling thread can make no further progress on its own.
+///
+/// As with `scope_and_block`, prefer calling this from within `spawn_blocking` if other work is
+/// running concurrently in the same task, since `block_in_place` will suspend it.
+///
+/// The first panic raised by any `run` invocation is propagated to the caller after all in-flight
+/// work has been joined.
+pub fn scope_self_feeding<'env, T, F>(initial: impl IntoIterator<Item = T>, run: F)
+where
+    T: Send + 'env,
+    F: Fn(&Spawner<'_, 'env, T>, T) + Send + Sync + 'env,
+{
+    let handle = Handle::current();
+    // Same sizing as `Scope::new`: one helper per runtime worker thread beyond the main thread.
+    // `num_workers()` returns 1 on a current-thread runtime => 0 helpers => everything drains
+    // inline on the calling thread. Liveness never depends on this value.
+    let worker_tasks = handle.metrics().num_workers().saturating_sub(1);
+    let turbo_tasks = try_turbo_tasks();
+    let span = Span::current();
+
+    // Wrap `run` so each invocation re-establishes the turbo tasks context, exactly like
+    // `Scope::spawn`. A single shared `Fn` (not one per item). It closes over `run: F` (lifetime
+    // `'env`) and `turbo_tasks` (`'static`), so `WrappedRun: 'env`.
+    let wrapped_run = move |spawner: &Spawner<'_, 'env, T>, item: T| {
+        if let Some(turbo_tasks) = turbo_tasks.clone() {
+            turbo_tasks_scope(turbo_tasks, || run(spawner, item));
+        } else {
+            run(spawner, item);
+        }
+    };
+
+    // Non-generic shared state, `Arc`-owned so helper tasks (which only ever touch the queue and
+    // counter, never `run`) can hold a clone. `FeedingInner` is fully `'static` (no `'env`
+    // borrows), so `Arc<FeedingInner>` is `'static`.
+    let inner = Arc::new(FeedingInner {
+        main_thread: thread::current(),
+        remaining_tasks: AtomicUsize::new(0),
+        panic: Mutex::new(None),
+        work_queue: Mutex::new(VecDeque::new()),
+        work_queue_condition_var: Condvar::new(),
+        done: std::sync::atomic::AtomicBool::new(false),
+    });
+
+    // Shared context handed to every per-item job closure: `Arc` clones of the counter/queue state
+    // and of the wrapped `run`. No raw pointers and no `unsafe impl Send` — both are ordinary
+    // `Arc`s and `Arc<T>: Send + Sync` when `T: Send + Sync`, which holds (`FeedingInner: Send
+    // + Sync`; `WrappedRun: Fn + Send + Sync`).
+    //
+    // `run` is an `Arc<WrappedRun>` where `WrappedRun: 'env`, so `Ctx` itself is a `'env`-lifetime
+    // type. It is captured into each job closure, and that job closure is erased `'env`->`'static`
+    // by the single boxed-closure transmute below (the same one `Scope::spawn` uses). The helpers
+    // never capture `run` — they only run the already-erased job closures — so `run` never has to
+    // independently satisfy `'static` for `handle.spawn`.
+    struct Ctx<T, WrappedRun> {
+        inner: Arc<FeedingInner>,
+        run: Arc<WrappedRun>,
+        _marker: PhantomData<fn(T)>,
+    }
+    impl<T, WrappedRun> Clone for Ctx<T, WrappedRun> {
+        fn clone(&self) -> Self {
+            Ctx {
+                inner: self.inner.clone(),
+                run: self.run.clone(),
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    let ctx = Ctx::<T, _> {
+        inner: inner.clone(),
+        run: Arc::new(wrapped_run),
+        _marker: PhantomData,
+    };
+
+    // Build a self-contained job closure for `item`. When run it constructs a fresh `'env`-typed
+    // enqueue callback, wraps it in a `Spawner`, and invokes the shared `run`. The returned box has
+    // lifetime `'env` (it owns an `'env` `Ctx`); `enqueue_item` erases it to `'static` for storage.
+    //
+    // This is the direct analogue of `Scope::spawn`'s per-item boxed closure + `'scope`->`'static`
+    // transmute — the proven pattern — the only addition being the enqueue callback that lets `run`
+    // feed more work.
+    fn make_job<'env, T, WrappedRun>(
+        ctx: Ctx<T, WrappedRun>,
+        item: T,
+    ) -> Box<dyn FnOnce() + Send + 'env>
+    where
+        T: Send + 'env,
+        WrappedRun: Fn(&Spawner<'_, 'env, T>, T) + Send + Sync + 'env,
+    {
+        Box::new(move || {
+            // The enqueue callback handed to `run` via the `Spawner`. It owns a clone of `ctx`
+            // (`'env`-lifetime), which is exactly what makes the `Spawner<'_, 'env, T>` below match
+            // `run`'s signature without any transmute of the `Spawner` itself.
+            let enqueue = {
+                let ctx = ctx.clone();
+                move |child: T| {
+                    enqueue_item::<'env, T, WrappedRun>(ctx.clone(), child);
+                }
+            };
+            let spawner = Spawner::<'_, 'env, T> {
+                enqueue: &enqueue,
+                _marker: PhantomData,
+            };
+            (ctx.run)(&spawner, item);
+        })
+    }
+
+    // Account + enqueue one item. Shared by the initial fill and `Spawner::spawn` (through the
+    // callback in `make_job`). See `Spawner`/the ordering comment for why the increment must happen
+    // before the push and before the parent finishes.
+    fn enqueue_item<'env, T, WrappedRun>(ctx: Ctx<T, WrappedRun>, item: T)
+    where
+        T: Send + 'env,
+        WrappedRun: Fn(&Spawner<'_, 'env, T>, T) + Send + Sync + 'env,
+    {
+        // TERMINATION ORDERING (the crux of correctness):
+        //
+        // A job that spawns children must make those children "count" before it itself finishes.
+        // `account_new_item` (the `remaining_tasks += 1` for the child) runs here, synchronously
+        // inside the parent's `run` invocation, i.e. strictly BEFORE the parent's `run` returns and
+        // therefore strictly before the parent's `on_item_finished` (`remaining_tasks -= 1`).
+        //
+        // Therefore the counter can never transiently reach zero while more work is pending:
+        //   - While the parent is in flight it is itself counted (+1).
+        //   - Each child is added (+1) before the parent is removed (-1).
+        // So at every moment `remaining_tasks >= (unfinished items)`, and it hits zero only once
+        // every enqueued item — initial and transitively spawned — has finished.
+        //
+        // We must increment BEFORE pushing: if we pushed first, a worker could pop and finish the
+        // child (decrementing a count that was never incremented) before we increment, corrupting
+        // the counter. Increment-then-push keeps the counter an upper bound on live work.
+        ctx.inner.account_new_item();
+
+        // Clone the `inner` Arc out before we move `ctx` into the job, so we can push/notify after.
+        let inner = ctx.inner.clone();
+        let job = make_job::<'env, T, WrappedRun>(ctx, item);
+        let job: *mut (dyn FnOnce() + Send + 'env) = Box::into_raw(job);
+        // SAFETY: erase the job's `'env`-derived captures to `'static` for storage. This is the ONE
+        // unsafe operation in the primitive, and it is exactly `Scope::spawn`'s transmute: the job
+        // — and everything it owns (the `'env` `Ctx`, i.e. an `Arc<WrappedRun>` that
+        // transitively borrows `'env` data through `run`, plus its own `item: T: 'env`) —
+        // is dropped before this function returns and thus before `'env` ends (guaranteed
+        // by the `Joiner` join). `'env` is invariant via `Spawner::_marker`, so it cannot
+        // shrink out from under us.
+        let job = unsafe {
+            std::mem::transmute::<
+                *mut (dyn FnOnce() + Send + 'env),
+                *mut (dyn FnOnce() + Send + 'static),
+            >(job)
+        };
+        // SAFETY: we just called `Box::into_raw`.
+        let job = unsafe { Box::from_raw(job) };
+
+        inner.work_queue.lock().push_back(job);
+        // Wake one parked worker. A lost wakeup (no worker parked yet) is recovered by the hand-off
+        // in `pick_item` and by the main thread's own draining — liveness never depends on it.
+        inner.work_queue_condition_var.notify_one();
+    }
+
+    // Drop guard that UNCONDITIONALLY drains-and-joins, mirroring `Scope::drop`. This is the load-
+    // bearing soundness mechanism for the `'env`->`'static` job transmute: whether the fill loop
+    // below completes normally or panics (`initial`'s iterator can panic, and a job's `run` can
+    // panic — the latter caught inside `run_items`), this guard runs before any panic escapes and
+    // guarantees every erased job closure has FINISHED EXECUTING and been dropped. Because a job
+    // closure owns the only things that borrow `'env` (its `Arc<WrappedRun>` clone and its
+    // `item: T`), joining before return means all `'env`-borrowing values are dropped before `'env`
+    // ends. It also makes the calling thread drain the whole queue itself, so liveness never
+    // depends on a helper being scheduled — even on the panic path.
+    //
+    // It holds an `Arc<FeedingInner>` clone (so `run_items()`/`wait()` stay valid) and the helper
+    // `JoinHandle`s (kept alive until the join completes so tasks are not detached mid-run). Note
+    // the anchoring of `WrappedRun`'s lifetime is via `Arc` refcounts, not stack drop-order: the
+    // wrapped `run` lives exactly as long as some `Arc<WrappedRun>` clone (in a job or in `ctx`),
+    // all of which are gone once the join below finishes.
+    struct Joiner {
+        inner: Arc<FeedingInner>,
+        helper_handles: Vec<tokio::task::JoinHandle<()>>,
+    }
+    impl Drop for Joiner {
+        fn drop(&mut self) {
+            // The initial fill is complete (normally or via panic-unwind). If nothing is in flight
+            // — empty initial set, or helpers already drained everything — latch `done` now so the
+            // drain loops below do not block forever waiting for an `on_item_finished` that will
+            // never come.
+            self.inner.finalize_if_idle();
+            // The calling thread participates in draining, exactly like
+            // `ScopeInner::end_and_help_complete`: it runs the drain loop itself. Because
+            // `pick_item` blocks for new work until `done`, the calling thread processes the entire
+            // (growing) queue on its own if no helper is ever scheduled.
+            self.inner.run_items();
+            // `run_items` returned => this thread observed `done` (queue empty and count 0). A
+            // helper could in principle still be finishing the last job; `wait()` joins on the
+            // counter. In practice `done` implies count already hit 0, so this returns immediately
+            // and never needs `block_in_place` — but it is kept as the same safety net as `Scope`.
+            self.inner.wait();
+            // Helpers have all observed termination (their `pick_item` returns `None` once `done`).
+            // Dropping the handles now only detaches already-finished tasks.
+            self.helper_handles.clear();
+        }
+    }
+
+    // Spawn opportunistic helpers up front (before filling), so they can start pulling as soon as
+    // items appear. Each holds only a clone of `Arc<FeedingInner>` and drains the shared queue by
+    // running the self-contained job closures. Helpers are a pure optimization — see `Joiner`.
+    let mut helper_handles = Vec::with_capacity(worker_tasks);
+    for _ in 0..worker_tasks {
+        let inner = inner.clone();
+        let span = span.clone();
+        helper_handles.push(handle.spawn(async move {
+            let _span = span.entered();
+            inner.run_items();
+        }));
+    }
+    let joiner = Joiner {
+        inner: inner.clone(),
+        helper_handles,
+    };
+
+    // Fill the queue with the initial items via the same accounting/enqueue path as
+    // `Spawner::spawn`. A panic here (from `initial`'s iterator) unwinds into `joiner`'s Drop,
+    // which joins before the panic propagates — so the already-enqueued jobs are safely drained
+    // first.
+    for item in initial {
+        enqueue_item::<'env, T, _>(ctx.clone(), item);
+    }
+    // `ctx` is not needed for driving any longer; the enqueued jobs each own their own clone. Drop
+    // our copy so the `Arc<WrappedRun>` refcount is not held past the drain by this frame.
+    drop(ctx);
+
+    // Normal completion: trigger `joiner`'s Drop now (finalize-if-idle + drain-and-join), so the
+    // whole queue is processed and every worker joined before we check for a panic below. (On the
+    // fill-panic path this same Drop runs during unwind, before the panic propagates.)
+    drop(joiner);
+
+    // Propagate the first panic recorded by any `run` invocation. (A fill-loop / `initial` panic
+    // has already resumed via the unwind through `joiner`'s Drop, so we only get here on the normal
+    // path; the only thing left to surface is a job panic.)
+    if let Some(err) = inner.panic.lock().take() {
+        panic::resume_unwind(err);
+    }
+    // No manual lifetime anchoring needed: `WrappedRun` lives as long as some `Arc<WrappedRun>`
+    // clone exists (in `ctx` or a job closure), and the join guarantees every job — and thus its
+    // Arc clone — is dropped before this function returns (before `'env` ends). `inner` drops
+    // normally at end of scope.
+}
+
 #[cfg(test)]
 mod tests {
-    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::atomic::AtomicUsize,
+    };
 
     use super::*;
 
@@ -532,6 +1013,140 @@ mod tests {
                             i
                         }
                     });
+                }
+            });
+            unreachable!();
+        }));
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().downcast_ref::<&str>(),
+            Some(&"Intentional panic")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // scope_self_feeding tests
+    // -----------------------------------------------------------------------
+
+    /// On a `current_thread` runtime there are no helper worker threads (`num_workers()` == 1 =>
+    /// `worker_tasks` == 0) and `block_in_place` is disallowed. The calling thread must drain the
+    /// entire queue — including everything spawned mid-run — inline, reaching termination before
+    /// `wait()` would ever call `block_in_place`. This proves the "drains inline with zero helpers"
+    /// property for the self-feeding variant.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_self_feeding_current_thread_runtime() {
+        let processed = Arc::new(AtomicUsize::new(0));
+        let processed_clone = processed.clone();
+        tokio::task::spawn_blocking(move || {
+            scope_self_feeding(0..16usize, move |spawner, item| {
+                processed_clone.fetch_add(1, Ordering::SeqCst);
+                // Each of the first few items spawns one extra child, so work is fed in mid-drain.
+                if item < 4 {
+                    spawner.spawn(100 + item);
+                }
+            });
+        })
+        .await
+        .unwrap();
+        // 16 initial + 4 spawned children.
+        assert_eq!(processed.load(Ordering::SeqCst), 20);
+    }
+
+    /// On a multi-thread runtime, work spawned from inside `run` must be picked up and processed —
+    /// including by helper worker tasks. We seed a single item that fans out to a fixed number of
+    /// children and assert every item runs exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_self_feeding_multi_thread() {
+        const CHILDREN: usize = 1000;
+        let processed = Arc::new(AtomicUsize::new(0));
+        let processed_clone = processed.clone();
+        tokio::task::spawn_blocking(move || {
+            scope_self_feeding(std::iter::once(0usize), move |spawner, item| {
+                processed_clone.fetch_add(1, Ordering::SeqCst);
+                if item == 0 {
+                    // The root fans out to CHILDREN leaves.
+                    for i in 0..CHILDREN {
+                        spawner.spawn(1 + i);
+                    }
+                }
+            });
+        })
+        .await
+        .unwrap();
+        // 1 root + CHILDREN leaves.
+        assert_eq!(processed.load(Ordering::SeqCst), 1 + CHILDREN);
+    }
+
+    /// Jobs spawn a *tree* of children (each node up to a depth/branching bound). Every node must
+    /// be processed exactly once. We track visited node ids to assert both completeness (all
+    /// expected nodes seen) and exactly-once (no duplicates).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_self_feeding_tree() {
+        // Binary tree of depth 10 => 2^11 - 1 = 2047 nodes, ids 1..=2047 (heap numbering).
+        const DEPTH: u32 = 10;
+        const MAX_ID: usize = (1 << (DEPTH + 1)) - 1;
+
+        // One flag per possible node id; set on visit. Detects both "missing" and "double" visits.
+        let visited: Arc<Vec<std::sync::atomic::AtomicBool>> = Arc::new(
+            (0..=MAX_ID)
+                .map(|_| std::sync::atomic::AtomicBool::new(false))
+                .collect(),
+        );
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let visited_clone = visited.clone();
+        let count_clone = count.clone();
+        tokio::task::spawn_blocking(move || {
+            scope_self_feeding(std::iter::once(1usize), move |spawner, id| {
+                // Mark visited; must not have been visited before.
+                let was = visited_clone[id].swap(true, Ordering::SeqCst);
+                assert!(!was, "node {id} visited more than once");
+                count_clone.fetch_add(1, Ordering::SeqCst);
+                // Spawn children (heap numbering) while they fit in the tree.
+                let left = id * 2;
+                let right = id * 2 + 1;
+                if left <= MAX_ID {
+                    spawner.spawn(left);
+                }
+                if right <= MAX_ID {
+                    spawner.spawn(right);
+                }
+            });
+        })
+        .await
+        .unwrap();
+
+        // Completeness: every id 1..=MAX_ID visited exactly once.
+        assert_eq!(count.load(Ordering::SeqCst), MAX_ID);
+        for id in 1..=MAX_ID {
+            assert!(
+                visited[id].load(Ordering::SeqCst),
+                "node {id} never visited"
+            );
+        }
+    }
+
+    /// Empty initial set with no spawns must return immediately (never blocks).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_self_feeding_empty() {
+        let processed = Arc::new(AtomicUsize::new(0));
+        let processed_clone = processed.clone();
+        scope_self_feeding(std::iter::empty::<usize>(), move |_spawner, _item| {
+            processed_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        assert_eq!(processed.load(Ordering::SeqCst), 0);
+    }
+
+    /// A panic in a `run` invocation is propagated after all in-flight work is joined.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_self_feeding_panic() {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            scope_self_feeding(0..100usize, |spawner, item| {
+                if item == 50 {
+                    panic!("Intentional panic");
+                }
+                if item < 4 {
+                    spawner.spawn(1000 + item);
                 }
             });
             unreachable!();

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -192,6 +192,10 @@ impl<T: ?Sized> OperationVc<T> {
     {
         self.connect().into_trait_ref().strongly_consistent()
     }
+
+    pub fn task_id(self) -> TaskId {
+        self.task
+    }
 }
 
 impl<T> Copy for OperationVc<T> where T: ?Sized {}


### PR DESCRIPTION
### What?

Adds a garbage collector to the persistent (`turbo-tasks-backend`) engine that deletes tasks which have become unreachable from the live task graph, from both memory and the on-disk cache. Opt-in behind `TURBO_ENGINE_GC=1` for now; off by default.

### Why?

When a task is invalidated it can become **disconnected** from the live graph, but today it is never deleted. Canonical case: task `A` reads `read_file("old.txt")` via a child task `T`; the file is renamed, `A` re-executes and now reads `read_file("new.txt")` via a new task `T'`, and `CleanupOldEdges` drops `T` from `A`'s children. `T` is now unreachable from any root — but it still sits in the in-memory map and gets **re-persisted to disk on every snapshot**, living forever.

In practice this causes the persisted cache (and memory) to grow without bound whenever a project's common dependencies are reorganized — e.g. re-rooting a project, or churning dependencies — because each churn leaves a whole generation of tasks behind. GC reclaims them.

### How?

The core idea is an incrementally-maintained **`parent_count`**: the number of persistent parents that list a task as a child. A count can only drop to 0 while the parent is *in memory* (a parent re-executed and dropped the child), so a task becoming collectible is detectable at that exact moment — no whole-DB scan, no restoring all metadata.

- **`parent_count` maintenance.** A persistent `parent_count: u32` (lazy meta field, to keep `TaskStorage` within its 128-byte budget) is maintained at the only two child-edge sites: `+1` per genuinely-new persistent child in `connect_children`, `-1` per actually-removed persistent child in `CleanupOldEdges`. The delta rides a new durable `AggregationUpdateJob::AdjustParentCount`, so it is captured mid-flight by a snapshot and replayed to completion on restart (crash-consistent). A separate transient `transient_ref_count` covers in-session references that aren't persistent parent edges (a transient parent, or an out-of-graph pin).

- **Collection.** When a count reaches 0 the task is recorded as a GC candidate. A GC pass (idle-gated in the background job, immediately before the snapshot, and at `stop()`) runs under an execution-exclusion phase: it re-validates each candidate, scrubs its reverse-dependency edges off its targets, removes it from the in-memory map, cascades `-1` to its children (collecting the whole unreachable subtree), and tombstones the on-disk copy in the same atomic snapshot commit. A task resurrected in the small window between the GC phase and the snapshot is re-validated and not wrongly tombstoned.

- **Pinning escape hatch.** Values that escape the tracked graph — a `Vc` handed to JS across the NAPI boundary via `DetachedVc`, or anything guarded by `prevent_gc()` — are pinned (counted `transient_ref_count`) so they are never collected while the handle is alive. `DetachedVc` pins its `OperationVc`'s task on creation/clone and unpins on drop. `prevent_gc()` (previously an empty stub) now pins the current task.

- **Persistence plumbing.** `save_snapshot` gained a delete list that tombstones `TaskMeta`/`TaskData`/`TaskCache` in the same commit as the snapshot puts, so removal from disk is atomic with the rest of the cycle.

**Verification.** New backend tests cover `parent_count` maintenance, durability across a DB reopen (increment and decrement), collection of a disconnected subtree via the cascade, pinned/detached tasks surviving collection, and a re-rooting stress test that asserts the persistent task set stays flat across 20 dependency swaps (vs. growing ~linearly without GC) while GC does the collecting. The full backend suite is green with `TURBO_ENGINE_GC=1`, including under `--features verify_aggregation_graph`.

**Not in this PR / follow-ups.** GC is opt-in until it has had a clean CI run and dogfooding on trusted apps. The collection pass is sequential for now — parallelizing it hit a pre-existing fragility in `scope_and_block` on thread-limited runtimes (documented inline); making that robust would also benefit the snapshot path and is deferred. Transient-root (`run_once`/`Once`) references are not released on disposal (bounded, harmless — those roots aren't collected anyway), to revisit before enabling by default.

<!-- NEXT_JS_LLM_PR -->
