### PR TITLE
Turbopack: order CSS modules by chunk-group co-occurrence in linearize

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1127,7 +1127,7 @@ impl CssChunkingConfig {
 }
 
 /// Default `requestCost` for the graph algorithm (in bytes).
-const DEFAULT_REQUEST_COST: f32 = 100_000.0;
+const DEFAULT_REQUEST_COST: f32 = 20_000.0;
 /// Default `weightDistribution` for the graph algorithm.
 const DEFAULT_WEIGHT_DISTRIBUTION: f32 = 0.1;
 

--- a/test/e2e/app-dir/css-order/css-order.test.ts
+++ b/test/e2e/app-dir/css-order/css-order.test.ts
@@ -33,20 +33,12 @@ const PAGES: Record<
     requestsGraph?: number
   }
 > = {
-  // Graph-chunking note for the "basic" pages (and their pages-dir equivalents):
-  // they share base2/base2-scss and add a unique per-page style. The graph
-  // algorithm keeps the shared base contiguous with one subset of these pages, so
-  // pages outside that subset load the shared base separately from their unique
-  // style — more requests than the single fused chunk loose/strict produce. The
-  // `requestsGraph` overrides below capture that. (Which pages need >1 request is
-  // asymmetric because it depends on which subset the shared base fuses with.)
   first: {
     group: 'basic',
     url: '/first',
     selector: '#hello1',
     color: 'rgb(0, 0, 255)',
     requests: 1,
-    requestsGraph: 2,
   },
   second: {
     group: 'basic',
@@ -54,7 +46,6 @@ const PAGES: Record<
     selector: '#hello2',
     color: 'rgb(0, 128, 0)',
     requests: 1,
-    requestsGraph: 2,
   },
   third: {
     group: 'basic',
@@ -62,7 +53,6 @@ const PAGES: Record<
     selector: '#hello3',
     color: 'rgb(0, 128, 128)',
     requests: 1,
-    requestsGraph: 3,
   },
   'first-client': {
     group: 'basic',
@@ -70,7 +60,6 @@ const PAGES: Record<
     selector: '#hello1c',
     color: 'rgb(255, 0, 255)',
     requests: 1,
-    requestsGraph: 2,
   },
   'second-client': {
     group: 'basic',
@@ -189,8 +178,6 @@ const PAGES: Record<
     selector: '#hello1',
     color: 'rgb(0, 0, 255)',
     requests: 1,
-    // See the graph-chunking note on the app-dir `first` entry above.
-    requestsGraph: 2,
   },
   'pages-second': {
     group: 'pages-basic',
@@ -205,8 +192,6 @@ const PAGES: Record<
     selector: '#hello3',
     color: 'rgb(0, 128, 128)',
     requests: 1,
-    // See the graph-chunking note on the app-dir `first` entry above.
-    requestsGraph: 2,
   },
 
   'pages-interleaved-a': {

--- a/test/e2e/app-dir/css-order/css-order.test.ts
+++ b/test/e2e/app-dir/css-order/css-order.test.ts
@@ -33,12 +33,20 @@ const PAGES: Record<
     requestsGraph?: number
   }
 > = {
+  // Graph-chunking note for the "basic" pages (and their pages-dir equivalents):
+  // they share base2/base2-scss and add a unique per-page style. The graph
+  // algorithm keeps the shared base contiguous with one subset of these pages, so
+  // pages outside that subset load the shared base separately from their unique
+  // style — more requests than the single fused chunk loose/strict produce. The
+  // `requestsGraph` overrides below capture that. (Which pages need >1 request is
+  // asymmetric because it depends on which subset the shared base fuses with.)
   first: {
     group: 'basic',
     url: '/first',
     selector: '#hello1',
     color: 'rgb(0, 0, 255)',
     requests: 1,
+    requestsGraph: 2,
   },
   second: {
     group: 'basic',
@@ -46,6 +54,7 @@ const PAGES: Record<
     selector: '#hello2',
     color: 'rgb(0, 128, 0)',
     requests: 1,
+    requestsGraph: 2,
   },
   third: {
     group: 'basic',
@@ -53,6 +62,7 @@ const PAGES: Record<
     selector: '#hello3',
     color: 'rgb(0, 128, 128)',
     requests: 1,
+    requestsGraph: 3,
   },
   'first-client': {
     group: 'basic',
@@ -60,6 +70,7 @@ const PAGES: Record<
     selector: '#hello1c',
     color: 'rgb(255, 0, 255)',
     requests: 1,
+    requestsGraph: 2,
   },
   'second-client': {
     group: 'basic',
@@ -178,6 +189,8 @@ const PAGES: Record<
     selector: '#hello1',
     color: 'rgb(0, 0, 255)',
     requests: 1,
+    // See the graph-chunking note on the app-dir `first` entry above.
+    requestsGraph: 2,
   },
   'pages-second': {
     group: 'pages-basic',
@@ -192,6 +205,8 @@ const PAGES: Record<
     selector: '#hello3',
     color: 'rgb(0, 128, 128)',
     requests: 1,
+    // See the graph-chunking note on the app-dir `first` entry above.
+    requestsGraph: 2,
   },
 
   'pages-interleaved-a': {

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
@@ -388,7 +388,14 @@ fn reconstruct_path(
 
 /// Mutate `graph` in place to remove all multi-node cycles by repeatedly cutting the
 /// lowest-weight edge of a short cycle in each SCC.
-pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
+///
+/// Returns the edges that were cut as `(from, to) -> weight`. [`linearize`] needs them: it derives
+/// its ordering heuristic from edge weights (chunk-group co-occurrence), and the cut edges are
+/// real co-occurrences that would otherwise be invisible in the now-acyclic graph.
+pub(super) fn make_acyclic<N>(
+    graph: &mut DiGraph<N, u32>,
+) -> FxHashMap<(NodeIndex, NodeIndex), u32> {
+    let mut cut_edges: FxHashMap<(NodeIndex, NodeIndex), u32> = FxHashMap::default();
     let mut queue: Vec<FxHashSet<NodeIndex>> = Vec::new();
     for scc in strongly_connected_components(&*graph) {
         if scc.len() > 1 {
@@ -414,6 +421,7 @@ pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
             // cycle nodes — guarantees the chosen cut breaks this cycle, not an unrelated chord.
             let mut min_weight: Option<u32> = None;
             let mut min_edge: Option<EdgeIndex> = None;
+            let mut min_from: Option<NodeIndex> = None;
             let mut min_to: Option<NodeIndex> = None;
             for i in 0..short_cycle.len() {
                 let from = short_cycle[i];
@@ -425,13 +433,19 @@ pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
                 if min_weight.is_none_or(|w| weight < w) {
                     min_weight = Some(weight);
                     min_edge = Some(edge);
+                    min_from = Some(from);
                     min_to = Some(to);
                 }
             }
 
-            let (Some(edge), Some(to)) = (min_edge, min_to) else {
+            let (Some(edge), Some(from), Some(to), Some(weight)) =
+                (min_edge, min_from, min_to, min_weight)
+            else {
                 break;
             };
+            // Record the cut edge so `linearize` can still count this co-occurrence: its weight is
+            // the number of chunk groups in which `from` appears after `to`.
+            cut_edges.insert((from, to), weight);
             graph.remove_edge(edge);
             seed_node = Some(to);
         }
@@ -444,15 +458,32 @@ pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
             }
         }
     }
+
+    cut_edges
 }
 
 // ---------------------------------------------------------------------------
 // linearize
 // ---------------------------------------------------------------------------
 
-/// Topologically sort `graph` (Kahn). Tie-break: when multiple dependents become unblocked at
-/// once, the heaviest edge wins; insertion order breaks ties at equal weight.
-pub(super) fn linearize<'a, G>(graph: G) -> Vec<NodeIndex>
+/// Topologically sort `graph` (Kahn). Among the currently unblocked candidates, prefer the one
+/// that shares the most chunk groups with the previously placed module (the last entry in
+/// `result`), so modules that load together end up adjacent in the global order.
+///
+/// The shared-group count comes from edge weights: the weight of edge `a → b` is the number of
+/// chunk groups in which `a` appears after `b` (see [`create_graph`]), so the chunk groups `last`
+/// and a candidate share is `weight(candidate → last) + weight(last → candidate)`. Most of those
+/// weights are still in `graph`, but [`make_acyclic`] deletes the lowest-weight edge of every cycle
+/// to break it (on real inputs ~30% of the total edge weight), and those cut edges are exactly the
+/// conflicting-order co-occurrences we still want to count. `cut_edges` (its return value) restores
+/// them, so the two together reconstruct the full co-occurrence without cloning the graph.
+///
+/// Ties keep the earliest remaining candidate; before anything has been placed, the stable seed
+/// order (insertion order) decides.
+pub(super) fn linearize<'a, G>(
+    graph: G,
+    cut_edges: &FxHashMap<(NodeIndex, NodeIndex), u32>,
+) -> Vec<NodeIndex>
 where
     G: ReadonlyGraph<'a>,
 {
@@ -461,44 +492,79 @@ where
         remaining_deps.insert(n, graph.outgoing_edges(n).count());
     }
 
+    // Re-index the cut edges by node so both endpoints can look up their incident cut edges in
+    // O(1): each cut edge `(from, to, w)` contributes `w` shared chunk groups to the pair.
+    let mut cut_adjacency: FxHashMap<NodeIndex, Vec<(NodeIndex, u32)>> = FxHashMap::default();
+    for (&(from, to), &weight) in cut_edges {
+        cut_adjacency.entry(from).or_default().push((to, weight));
+        cut_adjacency.entry(to).or_default().push((from, weight));
+    }
+
     let mut candidates: Vec<NodeIndex> = remaining_deps
         .iter()
         .filter_map(|(n, &c)| if c == 0 { Some(*n) } else { None })
         .collect();
-    // Stable seed order: matches insertion order of `nodes()`.
+    // Stable seed order: matches insertion order of `nodes()`, so the first pick — and any tie
+    // before a module has been placed — is deterministic.
     {
         let order: FxHashMap<NodeIndex, usize> =
             graph.nodes().enumerate().map(|(i, n)| (n, i)).collect();
-        candidates.sort_by_key(|n| std::cmp::Reverse(order[n]));
+        candidates.sort_by_key(|n| order[n]);
     }
 
     let mut result: Vec<NodeIndex> = Vec::new();
-    while let Some(placed) = candidates.pop() {
+    // Shared-group count of each candidate with the previously placed module, keyed by node. Built
+    // from `last`'s surviving edges (both directions) plus its cut edges, and reused across
+    // iterations to avoid reallocating.
+    let mut shared_with_last: FxHashMap<NodeIndex, u32> = FxHashMap::default();
+    while !candidates.is_empty() {
+        // Pick the candidate sharing the most chunk groups with the previously placed module.
+        // There is no point keeping `candidates` sorted: this criterion depends on `result`'s
+        // last element and changes every step. Ties fall to the earliest remaining candidate.
+        let pick = match result.last() {
+            Some(&last) => {
+                shared_with_last.clear();
+                for (source, weight) in graph.incoming_edges_with_weight(last) {
+                    *shared_with_last.entry(source).or_default() += weight;
+                }
+                for (target, weight) in graph.outgoing_edges_with_weight(last) {
+                    *shared_with_last.entry(target).or_default() += weight;
+                }
+                if let Some(cuts) = cut_adjacency.get(&last) {
+                    for &(neighbor, weight) in cuts {
+                        *shared_with_last.entry(neighbor).or_default() += weight;
+                    }
+                }
+                let shared = |c: NodeIndex| shared_with_last.get(&c).copied().unwrap_or(0);
+                let mut best = 0;
+                let mut best_shared = shared(candidates[0]);
+                for i in 1..candidates.len() {
+                    let s = shared(candidates[i]);
+                    if s > best_shared {
+                        best_shared = s;
+                        best = i;
+                    }
+                }
+                best
+            }
+            None => 0,
+        };
+        let placed = candidates.swap_remove(pick);
         result.push(placed);
 
-        // petgraph iterates neighbours in reverse insertion order; flip it back so the
-        // tie-break below sees them in insertion order — matching the PoC.
-        let mut incoming: Vec<(NodeIndex, u32)> =
-            graph.incoming_edges_with_weight(placed).collect();
+        // Unblock dependents. petgraph yields neighbours in reverse insertion order; flip it back
+        // so equal-share ties resolve in insertion order.
+        let mut incoming: Vec<NodeIndex> = graph.incoming_edges(placed).collect();
         incoming.reverse();
-
-        let mut new_candidates: Vec<(NodeIndex, u32, usize)> = Vec::new();
-        for (dependent, weight) in incoming {
+        for dependent in incoming {
             let Some(cur) = remaining_deps.get(&dependent).copied() else {
                 continue;
             };
             let next = cur.saturating_sub(1);
             remaining_deps.insert(dependent, next);
             if next == 0 {
-                let idx = new_candidates.len();
-                new_candidates.push((dependent, weight, idx));
+                candidates.push(dependent);
             }
-        }
-        // Weight ascending; ties broken by reverse insertion order so the earliest-encountered
-        // dependent ends up on top of the stack and pops first.
-        new_candidates.sort_by(|a, b| a.1.cmp(&b.1).then(b.2.cmp(&a.2)));
-        for (dep, _, _) in new_candidates {
-            candidates.push(dep);
         }
     }
 

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
@@ -564,11 +564,9 @@ where
         let (placed, _) = candidates.swap_remove(pick);
         result.push(placed);
 
-        // Unblock dependents. petgraph yields neighbours in reverse insertion order; flip it back
-        // so equal-score ties resolve in insertion order.
-        let mut incoming: Vec<NodeIndex> = graph.incoming_edges(placed).collect();
-        incoming.reverse();
-        for dependent in incoming {
+        // Unblock dependents. The order they are pushed is irrelevant: candidate ties are broken
+        // by the stable `remaining_deps` index, not by position in `candidates`.
+        for dependent in graph.incoming_edges(placed) {
             let Some((idx, _, cur)) = remaining_deps.get_full_mut(&dependent) else {
                 continue;
             };

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
@@ -515,7 +515,8 @@ where
     // position is a stable "seniority" index. Candidates carry that index as their tie-break key,
     // so the `swap_remove` below — which scrambles positions within `candidates` — cannot disturb
     // the "earliest remaining candidate" tie-break.
-    let mut remaining_deps: FxIndexMap<NodeIndex, usize> = FxIndexMap::default();
+    let mut remaining_deps: FxIndexMap<NodeIndex, usize> =
+        FxIndexMap::with_capacity_and_hasher(graph.node_count(), Default::default());
     for n in graph.nodes() {
         remaining_deps.insert(n, graph.outgoing_edges(n).count());
     }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
@@ -19,6 +19,61 @@ use crate::module::StyleType;
 // create_graph
 // ---------------------------------------------------------------------------
 
+/// The index of a chunk group, as ordered by the caller of [`create_graph`].
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub(super) struct ChunkGroupIndex(pub(super) usize);
+
+/// Per-module chunk-group membership: for each module id, the **ascending** list of chunk groups
+/// that contain it. The sorted invariant is what lets [`ModuleChunkGroups::shared`] intersect two
+/// modules' lists with a single linear merge; [`create_graph`] preserves it by appending groups in
+/// index order. Reading membership from here (rather than post-[`make_acyclic`] edge weights) keeps
+/// the co-occurrence signal lossless.
+pub(super) struct ModuleChunkGroups {
+    per_module: Vec<Vec<ChunkGroupIndex>>,
+}
+
+impl ModuleChunkGroups {
+    /// Number of chunk groups that contain both module `a` and module `b`. Runs in
+    /// O(min(|groups_a|, |groups_b|)) thanks to the ascending invariant.
+    pub(super) fn shared(&self, a: NodeIndex, b: NodeIndex) -> usize {
+        let a_groups = &self.per_module[a.index()];
+        let b_groups = &self.per_module[b.index()];
+        let mut count = 0;
+        let mut i = 0;
+        let mut j = 0;
+        while i < a_groups.len() && j < b_groups.len() {
+            match a_groups[i].cmp(&b_groups[j]) {
+                std::cmp::Ordering::Equal => {
+                    count += 1;
+                    i += 1;
+                    j += 1;
+                }
+                std::cmp::Ordering::Less => i += 1,
+                std::cmp::Ordering::Greater => j += 1,
+            }
+        }
+        count
+    }
+
+    /// Build directly from per-module group lists, each of which must already be ascending. For
+    /// tests and callers that assemble the lists themselves.
+    #[cfg(test)]
+    pub(super) fn from_sorted(per_module: Vec<Vec<usize>>) -> Self {
+        Self {
+            per_module: per_module
+                .into_iter()
+                .map(|groups| groups.into_iter().map(ChunkGroupIndex).collect())
+                .collect(),
+        }
+    }
+
+    /// The (ascending) chunk groups containing `module`. For tests/inspection.
+    #[cfg(test)]
+    pub(super) fn groups_of(&self, module: usize) -> &[ChunkGroupIndex] {
+        &self.per_module[module]
+    }
+}
+
 /// Build a directed weighted graph from `chunk_groups`.
 ///
 /// For each group `[m₀, m₁, ..., mₖ]` and every pair `(later, earlier)` with `later > earlier`
@@ -26,23 +81,24 @@ use crate::module::StyleType;
 /// `node_count` is the total number of distinct module ids referenced; node ids are dense in
 /// `0..node_count`.
 ///
-/// Also returns a `module_to_groups` index: for each module id, the list of chunk-group indices
-/// that contain it (in ascending order). Used by [`linearize`] to count shared chunk groups
-/// between two modules without reading potentially-lossy post-[`make_acyclic`] edge weights.
+/// Also returns the [`ModuleChunkGroups`] index, used by [`linearize`] to count shared chunk groups
+/// between two modules.
 pub(super) fn create_graph(
     chunk_groups: &[Vec<usize>],
     node_count: usize,
-) -> (DiGraph<usize, u32>, Vec<Vec<usize>>) {
+) -> (DiGraph<usize, u32>, ModuleChunkGroups) {
     let mut graph: DiGraph<usize, u32> = DiGraph::with_capacity(node_count, 0);
-    let mut module_to_groups: Vec<Vec<usize>> = vec![vec![]; node_count];
+    let mut per_module: Vec<Vec<ChunkGroupIndex>> = vec![Vec::new(); node_count];
     for i in 0..node_count {
         let idx = graph.add_node(i);
         debug_assert_eq!(idx.index(), i);
     }
     let mut edge_index: FxHashMap<(NodeIndex, NodeIndex), EdgeIndex> = FxHashMap::default();
     for (group_idx, group) in chunk_groups.iter().enumerate() {
+        // Appended in ascending `group_idx` order, preserving `ModuleChunkGroups`' sorted
+        // invariant.
         for &module_id in group {
-            module_to_groups[module_id].push(group_idx);
+            per_module[module_id].push(ChunkGroupIndex(group_idx));
         }
         for (i, &later_id) in group.iter().enumerate() {
             let later = NodeIndex::new(later_id);
@@ -61,35 +117,7 @@ pub(super) fn create_graph(
             }
         }
     }
-    (graph, module_to_groups)
-}
-
-/// Count the chunk groups that both module `a` and module `b` belong to.
-///
-/// `module_to_groups` maps each module id to its sorted list of chunk-group indices (built by
-/// [`create_graph`]). The merge runs in O(min(|groups_a|, |groups_b|)).
-pub(super) fn shared_chunk_groups(
-    module_to_groups: &[Vec<usize>],
-    a: NodeIndex,
-    b: NodeIndex,
-) -> usize {
-    let a_groups = &module_to_groups[a.index()];
-    let b_groups = &module_to_groups[b.index()];
-    let mut count = 0;
-    let mut i = 0;
-    let mut j = 0;
-    while i < a_groups.len() && j < b_groups.len() {
-        match a_groups[i].cmp(&b_groups[j]) {
-            std::cmp::Ordering::Equal => {
-                count += 1;
-                i += 1;
-                j += 1;
-            }
-            std::cmp::Ordering::Less => i += 1,
-            std::cmp::Ordering::Greater => j += 1,
-        }
-    }
-    count
+    (graph, ModuleChunkGroups { per_module })
 }
 
 // ---------------------------------------------------------------------------
@@ -494,10 +522,10 @@ pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
 /// that shares the most chunk groups with the previously placed module, so modules that load
 /// together end up adjacent in the global order.
 ///
-/// The shared-group count is read from `module_to_groups` (built by [`create_graph`]), which maps
-/// each module id to its sorted list of chunk-group indices. Reading from the original chunk-group
-/// data (not the post-[`make_acyclic`] graph) gives a lossless signal: [`make_acyclic`] deletes
-/// ~30% of edge weight on real inputs, and those deleted edges represent real co-occurrences.
+/// The shared-group count is read from [`ModuleChunkGroups`] (built by [`create_graph`]). Reading
+/// from the original chunk-group data (not the post-[`make_acyclic`] graph) gives a lossless
+/// signal: [`make_acyclic`] deletes ~30% of edge weight on real inputs, and those deleted edges
+/// represent real co-occurrences.
 ///
 /// **Tie-breaking** is done by looking further back through `result`: when multiple candidates
 /// share the same count with the last-placed module, the tie is broken by the count with the
@@ -507,7 +535,7 @@ pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
 /// metric, where `distance` is the first look-back position that produces a non-tie. Final ties
 /// (zero shared at all positions) fall back to the earliest remaining candidate — the one inserted
 /// first into `remaining_deps`, which mirrors `graph.nodes()` order.
-pub(super) fn linearize<'a, G>(graph: G, module_to_groups: &[Vec<usize>]) -> Vec<NodeIndex>
+pub(super) fn linearize<'a, G>(graph: G, module_chunk_groups: &ModuleChunkGroups) -> Vec<NodeIndex>
 where
     G: ReadonlyGraph<'a>,
 {
@@ -541,7 +569,7 @@ where
             // Recompute the shared count for each surviving candidate at this depth, in place.
             let mut max_shared = 0;
             for entry in survivors.iter_mut() {
-                let s = shared_chunk_groups(module_to_groups, candidates[entry.0].0, reference);
+                let s = module_chunk_groups.shared(candidates[entry.0].0, reference);
                 entry.1 = s;
                 max_shared = max_shared.max(s);
             }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
@@ -10,6 +10,7 @@ use std::{
 
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use rustc_hash::{FxHashMap, FxHashSet};
+use turbo_tasks::FxIndexMap;
 
 use super::subgraph_view::{ReadonlyGraph, SubgraphView};
 use crate::module::StyleType;
@@ -504,74 +505,76 @@ pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
 /// the lexicographic sequence `[shared(last), shared(last-1), shared(last-2), …]`, sorted
 /// descending — equivalent to choosing the candidate with the best `(Reverse(distance), shared)`
 /// metric, where `distance` is the first look-back position that produces a non-tie. Final ties
-/// (zero shared at all positions) fall back to the earliest remaining candidate (insertion order).
+/// (zero shared at all positions) fall back to the earliest remaining candidate — the one inserted
+/// first into `remaining_deps`, which mirrors `graph.nodes()` order.
 pub(super) fn linearize<'a, G>(graph: G, module_to_groups: &[Vec<usize>]) -> Vec<NodeIndex>
 where
     G: ReadonlyGraph<'a>,
 {
-    let mut remaining_deps: FxHashMap<NodeIndex, usize> = FxHashMap::default();
+    // `remaining_deps` is an insertion-ordered map (matching `graph.nodes()`), so each node's
+    // position is a stable "seniority" index. Candidates carry that index as their tie-break key,
+    // so the `swap_remove` below — which scrambles positions within `candidates` — cannot disturb
+    // the "earliest remaining candidate" tie-break.
+    let mut remaining_deps: FxIndexMap<NodeIndex, usize> = FxIndexMap::default();
     for n in graph.nodes() {
         remaining_deps.insert(n, graph.outgoing_edges(n).count());
     }
 
-    let mut candidates: Vec<NodeIndex> = remaining_deps
+    // Candidates are `(node, index in `remaining_deps`)`. Seeded in ascending index order because
+    // `FxIndexMap` iterates in insertion order.
+    let mut candidates: Vec<(NodeIndex, usize)> = remaining_deps
         .iter()
-        .filter_map(|(n, &c)| if c == 0 { Some(*n) } else { None })
+        .enumerate()
+        .filter_map(|(idx, (&n, &c))| (c == 0).then_some((n, idx)))
         .collect();
-    // Stable seed order: matches insertion order of `nodes()`, so the first pick — and any tie
-    // before a module has been placed — is deterministic.
-    {
-        let order: FxHashMap<NodeIndex, usize> =
-            graph.nodes().enumerate().map(|(i, n)| (n, i)).collect();
-        candidates.sort_by_key(|n| order[n]);
-    }
 
     let mut result: Vec<NodeIndex> = Vec::new();
     while !candidates.is_empty() {
-        // Find the best candidate using progressive look-back tie-breaking.
-        // `survivors` holds `(candidate index, shared count)` pairs; it starts with all candidates
-        // and is narrowed in place by comparing shared group counts at increasing look-back
-        // distances until either one candidate remains or `result` is exhausted.
-        let pick = if result.is_empty() {
-            0 // insertion order before anything is placed
-        } else {
-            let mut survivors: Vec<(usize, usize)> =
-                (0..candidates.len()).map(|i| (i, 0)).collect();
-            'outer: for depth in 0..result.len() {
-                let reference = result[result.len() - 1 - depth];
-                // Recompute the shared count for each surviving candidate at this depth, in place.
-                let mut max_shared = 0;
-                for entry in survivors.iter_mut() {
-                    let s = shared_chunk_groups(module_to_groups, candidates[entry.0], reference);
-                    entry.1 = s;
-                    max_shared = max_shared.max(s);
-                }
-                // Only filter when at least one candidate has a real match at this depth;
-                // otherwise all are equally far from `reference` and we try the next depth.
-                if max_shared > 0 {
-                    survivors.retain(|&(_, s)| s == max_shared);
-                    if survivors.len() == 1 {
-                        break 'outer;
-                    }
+        // Narrow the candidates with progressive look-back tie-breaking. `survivors` holds
+        // `(position in `candidates`, shared count)` and is narrowed in place by comparing shared
+        // group counts at increasing look-back distances until one candidate remains or `result`
+        // is exhausted.
+        let mut survivors: Vec<(usize, usize)> = (0..candidates.len()).map(|i| (i, 0)).collect();
+        'outer: for depth in 0..result.len() {
+            let reference = result[result.len() - 1 - depth];
+            // Recompute the shared count for each surviving candidate at this depth, in place.
+            let mut max_shared = 0;
+            for entry in survivors.iter_mut() {
+                let s = shared_chunk_groups(module_to_groups, candidates[entry.0].0, reference);
+                entry.1 = s;
+                max_shared = max_shared.max(s);
+            }
+            // Only filter when at least one candidate has a real match at this depth; otherwise all
+            // are equally far from `reference` and we try the next depth.
+            if max_shared > 0 {
+                survivors.retain(|&(_, s)| s == max_shared);
+                if survivors.len() == 1 {
+                    break 'outer;
                 }
             }
-            survivors[0].0 // insertion-order fallback among any remaining ties
-        };
-        let placed = candidates.swap_remove(pick);
+        }
+        // Final tie-break among equal-scoring survivors: the earliest remaining candidate, i.e. the
+        // one with the smallest `remaining_deps` index (stable regardless of `swap_remove`).
+        let pick = survivors
+            .iter()
+            .min_by_key(|&&(i, _)| candidates[i].1)
+            .map(|&(i, _)| i)
+            .unwrap();
+
+        let (placed, _) = candidates.swap_remove(pick);
         result.push(placed);
 
         // Unblock dependents. petgraph yields neighbours in reverse insertion order; flip it back
-        // so equal-share ties resolve in insertion order.
+        // so equal-score ties resolve in insertion order.
         let mut incoming: Vec<NodeIndex> = graph.incoming_edges(placed).collect();
         incoming.reverse();
         for dependent in incoming {
-            let Some(cur) = remaining_deps.get(&dependent).copied() else {
+            let Some((idx, _, cur)) = remaining_deps.get_full_mut(&dependent) else {
                 continue;
             };
-            let next = cur.saturating_sub(1);
-            remaining_deps.insert(dependent, next);
-            if next == 0 {
-                candidates.push(dependent);
+            *cur = cur.saturating_sub(1);
+            if *cur == 0 {
+                candidates.push((dependent, idx));
             }
         }
     }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
@@ -24,14 +24,25 @@ use crate::module::StyleType;
 /// inside the group, an edge `later → earlier` is added (weight 1). Repeated edges accumulate.
 /// `node_count` is the total number of distinct module ids referenced; node ids are dense in
 /// `0..node_count`.
-pub(super) fn create_graph(chunk_groups: &[Vec<usize>], node_count: usize) -> DiGraph<usize, u32> {
+///
+/// Also returns a `module_to_groups` index: for each module id, the list of chunk-group indices
+/// that contain it (in ascending order). Used by [`linearize`] to count shared chunk groups
+/// between two modules without reading potentially-lossy post-[`make_acyclic`] edge weights.
+pub(super) fn create_graph(
+    chunk_groups: &[Vec<usize>],
+    node_count: usize,
+) -> (DiGraph<usize, u32>, Vec<Vec<usize>>) {
     let mut graph: DiGraph<usize, u32> = DiGraph::with_capacity(node_count, 0);
+    let mut module_to_groups: Vec<Vec<usize>> = vec![vec![]; node_count];
     for i in 0..node_count {
         let idx = graph.add_node(i);
         debug_assert_eq!(idx.index(), i);
     }
     let mut edge_index: FxHashMap<(NodeIndex, NodeIndex), EdgeIndex> = FxHashMap::default();
-    for group in chunk_groups {
+    for (group_idx, group) in chunk_groups.iter().enumerate() {
+        for &module_id in group {
+            module_to_groups[module_id].push(group_idx);
+        }
         for (i, &later_id) in group.iter().enumerate() {
             let later = NodeIndex::new(later_id);
             for &earlier_id in &group[..i] {
@@ -49,7 +60,35 @@ pub(super) fn create_graph(chunk_groups: &[Vec<usize>], node_count: usize) -> Di
             }
         }
     }
-    graph
+    (graph, module_to_groups)
+}
+
+/// Count the chunk groups that both module `a` and module `b` belong to.
+///
+/// `module_to_groups` maps each module id to its sorted list of chunk-group indices (built by
+/// [`create_graph`]). The merge runs in O(min(|groups_a|, |groups_b|)).
+pub(super) fn shared_chunk_groups(
+    module_to_groups: &[Vec<usize>],
+    a: NodeIndex,
+    b: NodeIndex,
+) -> usize {
+    let a_groups = &module_to_groups[a.index()];
+    let b_groups = &module_to_groups[b.index()];
+    let mut count = 0;
+    let mut i = 0;
+    let mut j = 0;
+    while i < a_groups.len() && j < b_groups.len() {
+        match a_groups[i].cmp(&b_groups[j]) {
+            std::cmp::Ordering::Equal => {
+                count += 1;
+                i += 1;
+                j += 1;
+            }
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+        }
+    }
+    count
 }
 
 // ---------------------------------------------------------------------------
@@ -388,14 +427,7 @@ fn reconstruct_path(
 
 /// Mutate `graph` in place to remove all multi-node cycles by repeatedly cutting the
 /// lowest-weight edge of a short cycle in each SCC.
-///
-/// Returns the edges that were cut as `(from, to) -> weight`. [`linearize`] needs them: it derives
-/// its ordering heuristic from edge weights (chunk-group co-occurrence), and the cut edges are
-/// real co-occurrences that would otherwise be invisible in the now-acyclic graph.
-pub(super) fn make_acyclic<N>(
-    graph: &mut DiGraph<N, u32>,
-) -> FxHashMap<(NodeIndex, NodeIndex), u32> {
-    let mut cut_edges: FxHashMap<(NodeIndex, NodeIndex), u32> = FxHashMap::default();
+pub(super) fn make_acyclic<N>(graph: &mut DiGraph<N, u32>) {
     let mut queue: Vec<FxHashSet<NodeIndex>> = Vec::new();
     for scc in strongly_connected_components(&*graph) {
         if scc.len() > 1 {
@@ -421,7 +453,6 @@ pub(super) fn make_acyclic<N>(
             // cycle nodes — guarantees the chosen cut breaks this cycle, not an unrelated chord.
             let mut min_weight: Option<u32> = None;
             let mut min_edge: Option<EdgeIndex> = None;
-            let mut min_from: Option<NodeIndex> = None;
             let mut min_to: Option<NodeIndex> = None;
             for i in 0..short_cycle.len() {
                 let from = short_cycle[i];
@@ -433,19 +464,13 @@ pub(super) fn make_acyclic<N>(
                 if min_weight.is_none_or(|w| weight < w) {
                     min_weight = Some(weight);
                     min_edge = Some(edge);
-                    min_from = Some(from);
                     min_to = Some(to);
                 }
             }
 
-            let (Some(edge), Some(from), Some(to), Some(weight)) =
-                (min_edge, min_from, min_to, min_weight)
-            else {
+            let (Some(edge), Some(to)) = (min_edge, min_to) else {
                 break;
             };
-            // Record the cut edge so `linearize` can still count this co-occurrence: its weight is
-            // the number of chunk groups in which `from` appears after `to`.
-            cut_edges.insert((from, to), weight);
             graph.remove_edge(edge);
             seed_node = Some(to);
         }
@@ -458,8 +483,6 @@ pub(super) fn make_acyclic<N>(
             }
         }
     }
-
-    cut_edges
 }
 
 // ---------------------------------------------------------------------------
@@ -467,37 +490,28 @@ pub(super) fn make_acyclic<N>(
 // ---------------------------------------------------------------------------
 
 /// Topologically sort `graph` (Kahn). Among the currently unblocked candidates, prefer the one
-/// that shares the most chunk groups with the previously placed module (the last entry in
-/// `result`), so modules that load together end up adjacent in the global order.
+/// that shares the most chunk groups with the previously placed module, so modules that load
+/// together end up adjacent in the global order.
 ///
-/// The shared-group count comes from edge weights: the weight of edge `a → b` is the number of
-/// chunk groups in which `a` appears after `b` (see [`create_graph`]), so the chunk groups `last`
-/// and a candidate share is `weight(candidate → last) + weight(last → candidate)`. Most of those
-/// weights are still in `graph`, but [`make_acyclic`] deletes the lowest-weight edge of every cycle
-/// to break it (on real inputs ~30% of the total edge weight), and those cut edges are exactly the
-/// conflicting-order co-occurrences we still want to count. `cut_edges` (its return value) restores
-/// them, so the two together reconstruct the full co-occurrence without cloning the graph.
+/// The shared-group count is read from `module_to_groups` (built by [`create_graph`]), which maps
+/// each module id to its sorted list of chunk-group indices. Reading from the original chunk-group
+/// data (not the post-[`make_acyclic`] graph) gives a lossless signal: [`make_acyclic`] deletes
+/// ~30% of edge weight on real inputs, and those deleted edges represent real co-occurrences.
 ///
-/// Ties keep the earliest remaining candidate; before anything has been placed, the stable seed
-/// order (insertion order) decides.
-pub(super) fn linearize<'a, G>(
-    graph: G,
-    cut_edges: &FxHashMap<(NodeIndex, NodeIndex), u32>,
-) -> Vec<NodeIndex>
+/// **Tie-breaking** is done by looking further back through `result`: when multiple candidates
+/// share the same count with the last-placed module, the tie is broken by the count with the
+/// second-to-last module, then the third-to-last, and so on. Formally, the per-candidate key is
+/// the lexicographic sequence `[shared(last), shared(last-1), shared(last-2), …]`, sorted
+/// descending — equivalent to choosing the candidate with the best `(Reverse(distance), shared)`
+/// metric, where `distance` is the first look-back position that produces a non-tie. Final ties
+/// (zero shared at all positions) fall back to the earliest remaining candidate (insertion order).
+pub(super) fn linearize<'a, G>(graph: G, module_to_groups: &[Vec<usize>]) -> Vec<NodeIndex>
 where
     G: ReadonlyGraph<'a>,
 {
     let mut remaining_deps: FxHashMap<NodeIndex, usize> = FxHashMap::default();
     for n in graph.nodes() {
         remaining_deps.insert(n, graph.outgoing_edges(n).count());
-    }
-
-    // Re-index the cut edges by node so both endpoints can look up their incident cut edges in
-    // O(1): each cut edge `(from, to, w)` contributes `w` shared chunk groups to the pair.
-    let mut cut_adjacency: FxHashMap<NodeIndex, Vec<(NodeIndex, u32)>> = FxHashMap::default();
-    for (&(from, to), &weight) in cut_edges {
-        cut_adjacency.entry(from).or_default().push((to, weight));
-        cut_adjacency.entry(to).or_default().push((from, weight));
     }
 
     let mut candidates: Vec<NodeIndex> = remaining_deps
@@ -513,41 +527,42 @@ where
     }
 
     let mut result: Vec<NodeIndex> = Vec::new();
-    // Shared-group count of each candidate with the previously placed module, keyed by node. Built
-    // from `last`'s surviving edges (both directions) plus its cut edges, and reused across
-    // iterations to avoid reallocating.
-    let mut shared_with_last: FxHashMap<NodeIndex, u32> = FxHashMap::default();
     while !candidates.is_empty() {
-        // Pick the candidate sharing the most chunk groups with the previously placed module.
-        // There is no point keeping `candidates` sorted: this criterion depends on `result`'s
-        // last element and changes every step. Ties fall to the earliest remaining candidate.
-        let pick = match result.last() {
-            Some(&last) => {
-                shared_with_last.clear();
-                for (source, weight) in graph.incoming_edges_with_weight(last) {
-                    *shared_with_last.entry(source).or_default() += weight;
-                }
-                for (target, weight) in graph.outgoing_edges_with_weight(last) {
-                    *shared_with_last.entry(target).or_default() += weight;
-                }
-                if let Some(cuts) = cut_adjacency.get(&last) {
-                    for &(neighbor, weight) in cuts {
-                        *shared_with_last.entry(neighbor).or_default() += weight;
+        // Find the best candidate using progressive look-back tie-breaking.
+        // `survivors` holds indices into `candidates`; it starts with all candidates and is
+        // narrowed by comparing shared group counts at increasing look-back distances until
+        // either one candidate remains or `result` is exhausted.
+        let pick = if result.is_empty() {
+            0 // insertion order before anything is placed
+        } else {
+            let mut survivors: Vec<usize> = (0..candidates.len()).collect();
+            'outer: for depth in 0..result.len() {
+                let reference = result[result.len() - 1 - depth];
+                // Compute shared count for each surviving candidate at this depth.
+                let scores: Vec<(usize, usize)> = survivors
+                    .iter()
+                    .map(|&i| {
+                        (
+                            i,
+                            shared_chunk_groups(module_to_groups, candidates[i], reference),
+                        )
+                    })
+                    .collect();
+                let max_shared = scores.iter().map(|&(_, s)| s).max().unwrap_or(0);
+                // Only filter when at least one candidate has a real match at this depth;
+                // otherwise all are equally far from `reference` and we try the next depth.
+                if max_shared > 0 {
+                    survivors = scores
+                        .into_iter()
+                        .filter(|&(_, s)| s == max_shared)
+                        .map(|(i, _)| i)
+                        .collect();
+                    if survivors.len() == 1 {
+                        break 'outer;
                     }
                 }
-                let shared = |c: NodeIndex| shared_with_last.get(&c).copied().unwrap_or(0);
-                let mut best = 0;
-                let mut best_shared = shared(candidates[0]);
-                for i in 1..candidates.len() {
-                    let s = shared(candidates[i]);
-                    if s > best_shared {
-                        best_shared = s;
-                        best = i;
-                    }
-                }
-                best
             }
-            None => 0,
+            survivors[0] // insertion-order fallback among any remaining ties
         };
         let placed = candidates.swap_remove(pick);
         result.push(placed);

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/algorithm.rs
@@ -529,40 +529,33 @@ where
     let mut result: Vec<NodeIndex> = Vec::new();
     while !candidates.is_empty() {
         // Find the best candidate using progressive look-back tie-breaking.
-        // `survivors` holds indices into `candidates`; it starts with all candidates and is
-        // narrowed by comparing shared group counts at increasing look-back distances until
-        // either one candidate remains or `result` is exhausted.
+        // `survivors` holds `(candidate index, shared count)` pairs; it starts with all candidates
+        // and is narrowed in place by comparing shared group counts at increasing look-back
+        // distances until either one candidate remains or `result` is exhausted.
         let pick = if result.is_empty() {
             0 // insertion order before anything is placed
         } else {
-            let mut survivors: Vec<usize> = (0..candidates.len()).collect();
+            let mut survivors: Vec<(usize, usize)> =
+                (0..candidates.len()).map(|i| (i, 0)).collect();
             'outer: for depth in 0..result.len() {
                 let reference = result[result.len() - 1 - depth];
-                // Compute shared count for each surviving candidate at this depth.
-                let scores: Vec<(usize, usize)> = survivors
-                    .iter()
-                    .map(|&i| {
-                        (
-                            i,
-                            shared_chunk_groups(module_to_groups, candidates[i], reference),
-                        )
-                    })
-                    .collect();
-                let max_shared = scores.iter().map(|&(_, s)| s).max().unwrap_or(0);
+                // Recompute the shared count for each surviving candidate at this depth, in place.
+                let mut max_shared = 0;
+                for entry in survivors.iter_mut() {
+                    let s = shared_chunk_groups(module_to_groups, candidates[entry.0], reference);
+                    entry.1 = s;
+                    max_shared = max_shared.max(s);
+                }
                 // Only filter when at least one candidate has a real match at this depth;
                 // otherwise all are equally far from `reference` and we try the next depth.
                 if max_shared > 0 {
-                    survivors = scores
-                        .into_iter()
-                        .filter(|&(_, s)| s == max_shared)
-                        .map(|(i, _)| i)
-                        .collect();
+                    survivors.retain(|&(_, s)| s == max_shared);
                     if survivors.len() == 1 {
                         break 'outer;
                     }
                 }
             }
-            survivors[0] // insertion-order fallback among any remaining ties
+            survivors[0].0 // insertion-order fallback among any remaining ties
         };
         let placed = candidates.swap_remove(pick);
         result.push(placed);

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/mod.rs
@@ -142,8 +142,12 @@ pub async fn compute_style_groups_graph(
     // 3. Run the synchronous chunking pipeline.
     let mut graph = tracing::trace_span!("create_graph")
         .in_scope(|| algorithm::create_graph(&chunk_groups, modules_in_order.len()));
-    tracing::trace_span!("make_acyclic").in_scope(|| algorithm::make_acyclic(&mut graph));
-    let global_order = tracing::trace_span!("linearize").in_scope(|| algorithm::linearize(&graph));
+    // `make_acyclic` mutates the graph in place and returns the edges it cut, so `linearize` can
+    // still count that (pre-cut) co-occurrence without a full clone of the graph.
+    let cut_edges =
+        tracing::trace_span!("make_acyclic").in_scope(|| algorithm::make_acyclic(&mut graph));
+    let global_order =
+        tracing::trace_span!("linearize").in_scope(|| algorithm::linearize(&graph, &cut_edges));
     let chunks = tracing::trace_span!("split_into_chunks").in_scope(|| {
         algorithm::split_into_chunks(
             &global_order,

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/mod.rs
@@ -140,14 +140,11 @@ pub async fn compute_style_groups_graph(
     let module_style_types: Vec<StyleType> = module_data.iter().map(|m| m.style_type).collect();
 
     // 3. Run the synchronous chunking pipeline.
-    let mut graph = tracing::trace_span!("create_graph")
+    let (mut graph, module_to_groups) = tracing::trace_span!("create_graph")
         .in_scope(|| algorithm::create_graph(&chunk_groups, modules_in_order.len()));
-    // `make_acyclic` mutates the graph in place and returns the edges it cut, so `linearize` can
-    // still count that (pre-cut) co-occurrence without a full clone of the graph.
-    let cut_edges =
-        tracing::trace_span!("make_acyclic").in_scope(|| algorithm::make_acyclic(&mut graph));
-    let global_order =
-        tracing::trace_span!("linearize").in_scope(|| algorithm::linearize(&graph, &cut_edges));
+    tracing::trace_span!("make_acyclic").in_scope(|| algorithm::make_acyclic(&mut graph));
+    let global_order = tracing::trace_span!("linearize")
+        .in_scope(|| algorithm::linearize(&graph, &module_to_groups));
     let chunks = tracing::trace_span!("split_into_chunks").in_scope(|| {
         algorithm::split_into_chunks(
             &global_order,

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
@@ -4,12 +4,12 @@
 //! `e2e_*` tests cover the assembled pipeline; the rest cover individual stages.
 
 use petgraph::graph::{DiGraph, NodeIndex};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use super::{
     algorithm::{
         compute_chunked_chunk_groups, create_graph, find_short_cycle, linearize, make_acyclic,
-        split_into_chunks, strongly_connected_components,
+        shared_chunk_groups, split_into_chunks, strongly_connected_components,
     },
     subgraph_view::{ReadonlyGraph, SubgraphView},
 };
@@ -81,9 +81,10 @@ fn ids(v: &[NodeIndex]) -> Vec<usize> {
     v.iter().map(|n| n.index()).collect()
 }
 
-/// Empty cut-edge map, for `linearize` tests on graphs that never went through `make_acyclic`.
-fn no_cuts() -> FxHashMap<(NodeIndex, NodeIndex), u32> {
-    FxHashMap::default()
+/// Empty module-to-groups map for `linearize` tests on small hand-built graphs. All
+/// `shared_chunk_groups` calls return 0, so the tie-break falls through to insertion order.
+fn no_groups(node_count: usize) -> Vec<Vec<usize>> {
+    vec![vec![]; node_count]
 }
 
 fn equal_size_inputs(node_count: usize) -> Vec<u64> {
@@ -236,7 +237,7 @@ fn subgraphview_outgoing_for_node_outside_subset_yields_nothing() {
 
 #[test]
 fn create_graph_empty_input_produces_empty_graph() {
-    let g = create_graph(&[], 0);
+    let (g, _) = create_graph(&[], 0);
     assert_eq!(g.node_count(), 0);
 }
 
@@ -244,14 +245,14 @@ fn create_graph_empty_input_produces_empty_graph() {
 fn create_graph_assigns_sequential_indices() {
     // Note: in the PoC, `createGraph` assigns node ids by first-appearance. In the Rust port the
     // caller pre-assigns ids, so we test that node count and edge structure match.
-    let g = create_graph(&[vec![0, 1, 2]], 3);
+    let (g, _) = create_graph(&[vec![0, 1, 2]], 3);
     assert_eq!(g.node_count(), 3);
 }
 
 #[test]
 fn create_graph_pairwise_edges_for_each_group() {
     // group [0, 1, 2, 3] => 1->0, 2->0, 2->1, 3->0, 3->1, 3->2
-    let g = create_graph(&[vec![0, 1, 2, 3]], 4);
+    let (g, _) = create_graph(&[vec![0, 1, 2, 3]], 4);
     assert!(outgoing_targets(&g, n(0)).is_empty());
     assert_eq!(outgoing_targets(&g, n(1)), vec![0]);
     assert_eq!(outgoing_targets(&g, n(2)), vec![0, 1]);
@@ -260,21 +261,21 @@ fn create_graph_pairwise_edges_for_each_group() {
 
 #[test]
 fn create_graph_all_edge_weights_are_one_within_a_single_group() {
-    let g = create_graph(&[vec![0, 1, 2]], 3);
+    let (g, _) = create_graph(&[vec![0, 1, 2]], 3);
     assert_eq!(outgoing_with_weight(&g, n(1)), vec![(0, 1)]);
     assert_eq!(outgoing_with_weight(&g, n(2)), vec![(0, 1), (1, 1)]);
 }
 
 #[test]
 fn create_graph_accumulates_weights_for_repeated_pairs() {
-    let g = create_graph(&[vec![0, 1], vec![0, 1], vec![0, 1]], 2);
+    let (g, _) = create_graph(&[vec![0, 1], vec![0, 1], vec![0, 1]], 2);
     assert_eq!(outgoing_with_weight(&g, n(1)), vec![(0, 3)]);
     assert_eq!(incoming_with_weight(&g, n(0)), vec![(1, 3)]);
 }
 
 #[test]
 fn create_graph_single_element_groups_produce_no_edges() {
-    let g = create_graph(&[vec![0], vec![1]], 2);
+    let (g, _) = create_graph(&[vec![0], vec![1]], 2);
     assert!(outgoing_targets(&g, n(0)).is_empty());
     assert!(outgoing_targets(&g, n(1)).is_empty());
     assert!(incoming_targets(&g, n(0)).is_empty());
@@ -284,7 +285,7 @@ fn create_graph_single_element_groups_produce_no_edges() {
 #[test]
 fn create_graph_preserves_group_order_when_computing_edges() {
     // [0, 1, 2] then [2, 1, 0] should produce edges in BOTH directions.
-    let g = create_graph(&[vec![0, 1, 2], vec![2, 1, 0]], 3);
+    let (g, _) = create_graph(&[vec![0, 1, 2], vec![2, 1, 0]], 3);
     assert_eq!(outgoing_with_weight(&g, n(0)), vec![(1, 1), (2, 1)]);
     assert_eq!(outgoing_with_weight(&g, n(1)), vec![(0, 1), (2, 1)]);
     assert_eq!(outgoing_with_weight(&g, n(2)), vec![(0, 1), (1, 1)]);
@@ -292,8 +293,36 @@ fn create_graph_preserves_group_order_when_computing_edges() {
 
 #[test]
 fn create_graph_duplicated_module_in_a_group_creates_self_loop() {
-    let g = create_graph(&[vec![0, 0]], 1);
+    let (g, _) = create_graph(&[vec![0, 0]], 1);
     assert_eq!(outgoing_with_weight(&g, n(0)), vec![(0, 1)]);
+}
+
+#[test]
+fn create_graph_builds_module_to_groups_index() {
+    // module 0 is in groups 0 and 1; module 1 only in group 0; module 2 only in group 1.
+    let (_, module_to_groups) = create_graph(&[vec![0, 1], vec![0, 2]], 3);
+    assert_eq!(module_to_groups[0], vec![0, 1]);
+    assert_eq!(module_to_groups[1], vec![0]);
+    assert_eq!(module_to_groups[2], vec![1]);
+}
+
+// ---------------------------------------------------------------------------
+// shared_chunk_groups
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shared_chunk_groups_counts_intersection() {
+    let module_to_groups = vec![
+        vec![0, 1, 2, 4], // module 0
+        vec![1, 2, 3],    // module 1
+        vec![],           // module 2
+    ];
+    // {0,1,2,4} ∩ {1,2,3} = {1,2}
+    assert_eq!(shared_chunk_groups(&module_to_groups, n(0), n(1)), 2);
+    // nothing shared with a module in no groups
+    assert_eq!(shared_chunk_groups(&module_to_groups, n(0), n(2)), 0);
+    // a module shares all of its own groups with itself
+    assert_eq!(shared_chunk_groups(&module_to_groups, n(0), n(0)), 4);
 }
 
 // ---------------------------------------------------------------------------
@@ -557,13 +586,13 @@ fn make_acyclic_preserves_non_cycle_edges() {
 #[test]
 fn linearize_empty_graph() {
     let g: DiGraph<usize, u32> = DiGraph::new();
-    assert!(linearize(&g, &no_cuts()).is_empty());
+    assert!(linearize(&g, &no_groups(0)).is_empty());
 }
 
 #[test]
 fn linearize_single_node() {
     let g = build_graph(1, |_| {});
-    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![0]);
+    assert_eq!(ids(&linearize(&g, &no_groups(1))), vec![0]);
 }
 
 #[test]
@@ -573,31 +602,58 @@ fn linearize_emits_dependencies_before_dependents() {
         g.add_edge(n(0), n(1), 1);
         g.add_edge(n(1), n(2), 1);
     });
-    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![2, 1, 0]);
+    assert_eq!(ids(&linearize(&g, &no_groups(3))), vec![2, 1, 0]);
 }
 
 #[test]
 fn linearize_prefers_candidate_sharing_most_chunk_groups_with_last_placed() {
-    // 1 and 2 both depend on 0, so both become ready once 0 is placed. The edge weight is the
-    // number of chunk groups the two modules share: module 2 shares 10 chunk groups with 0 while
-    // module 1 shares only 1, so 2 is placed next — even though 1 comes first in insertion order.
-    let g = build_graph(3, |g| {
-        g.add_edge(n(1), n(0), 1);
-        g.add_edge(n(2), n(0), 10);
-    });
-    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![0, 2, 1]);
-}
-
-#[test]
-fn linearize_breaks_ties_by_insertion_order() {
-    // Both 1 and 2 depend on 0 and share the same number of chunk groups with it (equal edge
-    // weight), so the tie falls to insertion order: 1's edge is added first, so 1 is placed
-    // before 2 after 0.
+    // 1 and 2 both depend on 0, so both become ready once 0 is placed. Module 2 shares two chunk
+    // groups with 0 while module 1 shares only one, so 2 is placed next — even though 1 comes
+    // first in insertion order.
     let g = build_graph(3, |g| {
         g.add_edge(n(1), n(0), 1);
         g.add_edge(n(2), n(0), 1);
     });
-    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![0, 1, 2]);
+    let module_to_groups = vec![
+        vec![0, 1, 2], // module 0
+        vec![0],       // module 1: shares 1 group ({0}) with module 0
+        vec![0, 1],    // module 2: shares 2 groups ({0, 1}) with module 0
+    ];
+    assert_eq!(ids(&linearize(&g, &module_to_groups)), vec![0, 2, 1]);
+}
+
+#[test]
+fn linearize_breaks_last_placed_ties_by_earlier_placements() {
+    // Placement forces the order 0 -> 1, then a choice between 2 and 3 (both depend on 1).
+    // 2 and 3 share the same number of groups with the last-placed module 1 (tie at depth 0), so
+    // the tie is broken by looking one further back to module 0 (depth 1): module 3 shares two
+    // groups with 0 while module 2 shares one, so 3 is placed before 2.
+    let g = build_graph(4, |g| {
+        g.add_edge(n(1), n(0), 1); // 1 depends on 0
+        g.add_edge(n(2), n(1), 1); // 2 depends on 1
+        g.add_edge(n(3), n(1), 1); // 3 depends on 1
+    });
+    // Each module's group list is ascending, as `create_graph` produces.
+    let module_to_groups = vec![
+        vec![0, 1],    // module 0
+        vec![2],       // module 1 (irrelevant sharing)
+        vec![0, 2],    // module 2: shared(2,1)=1 ({2}); shared(2,0)=1 ({0})
+        vec![0, 1, 2], // module 3: shared(3,1)=1 ({2}); shared(3,0)=2 ({0,1})
+    ];
+    // pick after [0,1]: depth 0 (last=1) -> shared(2,1)=shared(3,1)=1 (tie);
+    //                   depth 1 (ref=0)  -> shared(2,0)=1, shared(3,0)=2 -> 3 wins.
+    assert_eq!(ids(&linearize(&g, &module_to_groups)), vec![0, 1, 3, 2]);
+}
+
+#[test]
+fn linearize_breaks_ties_by_insertion_order() {
+    // Both 1 and 2 depend on 0 and share no chunk groups with anything (empty map), so the tie
+    // falls to insertion order: 1's edge is added first, so 1 is placed before 2 after 0.
+    let g = build_graph(3, |g| {
+        g.add_edge(n(1), n(0), 1);
+        g.add_edge(n(2), n(0), 1);
+    });
+    assert_eq!(ids(&linearize(&g, &no_groups(3))), vec![0, 1, 2]);
 }
 
 #[test]
@@ -609,7 +665,7 @@ fn linearize_diamond_is_topo() {
         g.add_edge(n(1), n(3), 1);
         g.add_edge(n(2), n(3), 1);
     });
-    let order = linearize(&g, &no_cuts());
+    let order = linearize(&g, &no_groups(4));
     assert_eq!(order.len(), 4);
     let pos: std::collections::HashMap<NodeIndex, usize> =
         order.iter().enumerate().map(|(i, n)| (*n, i)).collect();
@@ -627,7 +683,7 @@ fn linearize_runs_on_subgraphview() {
     });
     let subset: FxHashSet<_> = [n(0), n(1)].into_iter().collect();
     let view = SubgraphView::new(&g, &subset);
-    assert_eq!(ids(&linearize(view, &no_cuts())), vec![1, 0]);
+    assert_eq!(ids(&linearize(view, &no_groups(3))), vec![1, 0]);
 }
 
 #[test]
@@ -636,7 +692,7 @@ fn linearize_returns_partial_result_for_cyclic_graph() {
         g.add_edge(n(0), n(1), 1);
         g.add_edge(n(1), n(0), 1);
     });
-    assert!(linearize(&g, &no_cuts()).is_empty());
+    assert!(linearize(&g, &no_groups(2)).is_empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -750,9 +806,9 @@ fn run_pipeline(
     node_count: usize,
     request_cost: f32,
 ) -> (Vec<Vec<usize>>, Vec<usize>) {
-    let mut g = create_graph(chunk_groups, node_count);
-    let cut_edges = make_acyclic(&mut g);
-    let global_order = linearize(&g, &cut_edges);
+    let (mut g, module_to_groups) = create_graph(chunk_groups, node_count);
+    make_acyclic(&mut g);
+    let global_order = linearize(&g, &module_to_groups);
     let chunks = split_simple(&global_order, chunk_groups, request_cost);
     let chunked = compute_chunked_chunk_groups(chunk_groups, &chunks);
     let request_counts: Vec<usize> = chunked.iter().map(|c| c.len()).collect();

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
@@ -4,7 +4,7 @@
 //! `e2e_*` tests cover the assembled pipeline; the rest cover individual stages.
 
 use petgraph::graph::{DiGraph, NodeIndex};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::{
     algorithm::{
@@ -79,6 +79,11 @@ fn to_set(v: &[NodeIndex]) -> FxHashSet<NodeIndex> {
 
 fn ids(v: &[NodeIndex]) -> Vec<usize> {
     v.iter().map(|n| n.index()).collect()
+}
+
+/// Empty cut-edge map, for `linearize` tests on graphs that never went through `make_acyclic`.
+fn no_cuts() -> FxHashMap<(NodeIndex, NodeIndex), u32> {
+    FxHashMap::default()
 }
 
 fn equal_size_inputs(node_count: usize) -> Vec<u64> {
@@ -552,13 +557,13 @@ fn make_acyclic_preserves_non_cycle_edges() {
 #[test]
 fn linearize_empty_graph() {
     let g: DiGraph<usize, u32> = DiGraph::new();
-    assert!(linearize(&g).is_empty());
+    assert!(linearize(&g, &no_cuts()).is_empty());
 }
 
 #[test]
 fn linearize_single_node() {
     let g = build_graph(1, |_| {});
-    assert_eq!(ids(&linearize(&g)), vec![0]);
+    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![0]);
 }
 
 #[test]
@@ -568,28 +573,31 @@ fn linearize_emits_dependencies_before_dependents() {
         g.add_edge(n(0), n(1), 1);
         g.add_edge(n(1), n(2), 1);
     });
-    assert_eq!(ids(&linearize(&g)), vec![2, 1, 0]);
+    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![2, 1, 0]);
 }
 
 #[test]
-fn linearize_higher_weight_dependents_placed_earlier() {
-    // x is a sink; a (weight 1) and b (weight 10) both depend on x. b should be placed first.
+fn linearize_prefers_candidate_sharing_most_chunk_groups_with_last_placed() {
+    // 1 and 2 both depend on 0, so both become ready once 0 is placed. The edge weight is the
+    // number of chunk groups the two modules share: module 2 shares 10 chunk groups with 0 while
+    // module 1 shares only 1, so 2 is placed next — even though 1 comes first in insertion order.
     let g = build_graph(3, |g| {
         g.add_edge(n(1), n(0), 1);
         g.add_edge(n(2), n(0), 10);
     });
-    assert_eq!(ids(&linearize(&g)), vec![0, 2, 1]);
+    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![0, 2, 1]);
 }
 
 #[test]
-fn linearize_breaks_weight_ties_by_insertion_order() {
-    // Both 1 and 2 depend on 0 with weight 1; 1's edge is added first, so 1 should be placed
+fn linearize_breaks_ties_by_insertion_order() {
+    // Both 1 and 2 depend on 0 and share the same number of chunk groups with it (equal edge
+    // weight), so the tie falls to insertion order: 1's edge is added first, so 1 is placed
     // before 2 after 0.
     let g = build_graph(3, |g| {
         g.add_edge(n(1), n(0), 1);
         g.add_edge(n(2), n(0), 1);
     });
-    assert_eq!(ids(&linearize(&g)), vec![0, 1, 2]);
+    assert_eq!(ids(&linearize(&g, &no_cuts())), vec![0, 1, 2]);
 }
 
 #[test]
@@ -601,7 +609,7 @@ fn linearize_diamond_is_topo() {
         g.add_edge(n(1), n(3), 1);
         g.add_edge(n(2), n(3), 1);
     });
-    let order = linearize(&g);
+    let order = linearize(&g, &no_cuts());
     assert_eq!(order.len(), 4);
     let pos: std::collections::HashMap<NodeIndex, usize> =
         order.iter().enumerate().map(|(i, n)| (*n, i)).collect();
@@ -619,7 +627,7 @@ fn linearize_runs_on_subgraphview() {
     });
     let subset: FxHashSet<_> = [n(0), n(1)].into_iter().collect();
     let view = SubgraphView::new(&g, &subset);
-    assert_eq!(ids(&linearize(view)), vec![1, 0]);
+    assert_eq!(ids(&linearize(view, &no_cuts())), vec![1, 0]);
 }
 
 #[test]
@@ -628,7 +636,7 @@ fn linearize_returns_partial_result_for_cyclic_graph() {
         g.add_edge(n(0), n(1), 1);
         g.add_edge(n(1), n(0), 1);
     });
-    assert!(linearize(&g).is_empty());
+    assert!(linearize(&g, &no_cuts()).is_empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -743,8 +751,8 @@ fn run_pipeline(
     request_cost: f32,
 ) -> (Vec<Vec<usize>>, Vec<usize>) {
     let mut g = create_graph(chunk_groups, node_count);
-    make_acyclic(&mut g);
-    let global_order = linearize(&g);
+    let cut_edges = make_acyclic(&mut g);
+    let global_order = linearize(&g, &cut_edges);
     let chunks = split_simple(&global_order, chunk_groups, request_cost);
     let chunked = compute_chunked_chunk_groups(chunk_groups, &chunks);
     let request_counts: Vec<usize> = chunked.iter().map(|c| c.len()).collect();

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
@@ -657,6 +657,17 @@ fn linearize_breaks_ties_by_insertion_order() {
 }
 
 #[test]
+fn linearize_ties_keep_insertion_order_across_removals() {
+    // Four disconnected sinks, no shared groups: every step is a pure tie, so the result must be
+    // insertion order. This is the case that exposed the `swap_remove` scramble bug — with 3+
+    // simultaneous candidates, removing one used to move the last candidate into its slot and
+    // corrupt the "earliest remaining candidate" tie-break. Candidates now carry a stable index,
+    // so the order is preserved regardless of `swap_remove`.
+    let g = build_graph(4, |_| {});
+    assert_eq!(ids(&linearize(&g, &no_groups(4))), vec![0, 1, 2, 3]);
+}
+
+#[test]
 fn linearize_diamond_is_topo() {
     // 0 -> 1, 0 -> 2, 1 -> 3, 2 -> 3
     let g = build_graph(4, |g| {

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/tests.rs
@@ -8,8 +8,9 @@ use rustc_hash::FxHashSet;
 
 use super::{
     algorithm::{
-        compute_chunked_chunk_groups, create_graph, find_short_cycle, linearize, make_acyclic,
-        shared_chunk_groups, split_into_chunks, strongly_connected_components,
+        ChunkGroupIndex, ModuleChunkGroups, compute_chunked_chunk_groups, create_graph,
+        find_short_cycle, linearize, make_acyclic, split_into_chunks,
+        strongly_connected_components,
     },
     subgraph_view::{ReadonlyGraph, SubgraphView},
 };
@@ -81,10 +82,10 @@ fn ids(v: &[NodeIndex]) -> Vec<usize> {
     v.iter().map(|n| n.index()).collect()
 }
 
-/// Empty module-to-groups map for `linearize` tests on small hand-built graphs. All
-/// `shared_chunk_groups` calls return 0, so the tie-break falls through to insertion order.
-fn no_groups(node_count: usize) -> Vec<Vec<usize>> {
-    vec![vec![]; node_count]
+/// Empty module-to-groups map for `linearize` tests on small hand-built graphs. Every `shared`
+/// call returns 0, so the tie-break falls through to insertion order.
+fn no_groups(node_count: usize) -> ModuleChunkGroups {
+    ModuleChunkGroups::from_sorted(vec![vec![]; node_count])
 }
 
 fn equal_size_inputs(node_count: usize) -> Vec<u64> {
@@ -301,28 +302,31 @@ fn create_graph_duplicated_module_in_a_group_creates_self_loop() {
 fn create_graph_builds_module_to_groups_index() {
     // module 0 is in groups 0 and 1; module 1 only in group 0; module 2 only in group 1.
     let (_, module_to_groups) = create_graph(&[vec![0, 1], vec![0, 2]], 3);
-    assert_eq!(module_to_groups[0], vec![0, 1]);
-    assert_eq!(module_to_groups[1], vec![0]);
-    assert_eq!(module_to_groups[2], vec![1]);
+    assert_eq!(
+        module_to_groups.groups_of(0),
+        &[ChunkGroupIndex(0), ChunkGroupIndex(1)]
+    );
+    assert_eq!(module_to_groups.groups_of(1), &[ChunkGroupIndex(0)]);
+    assert_eq!(module_to_groups.groups_of(2), &[ChunkGroupIndex(1)]);
 }
 
 // ---------------------------------------------------------------------------
-// shared_chunk_groups
+// ModuleChunkGroups::shared
 // ---------------------------------------------------------------------------
 
 #[test]
-fn shared_chunk_groups_counts_intersection() {
-    let module_to_groups = vec![
+fn shared_counts_chunk_group_intersection() {
+    let module_to_groups = ModuleChunkGroups::from_sorted(vec![
         vec![0, 1, 2, 4], // module 0
         vec![1, 2, 3],    // module 1
         vec![],           // module 2
-    ];
+    ]);
     // {0,1,2,4} ∩ {1,2,3} = {1,2}
-    assert_eq!(shared_chunk_groups(&module_to_groups, n(0), n(1)), 2);
+    assert_eq!(module_to_groups.shared(n(0), n(1)), 2);
     // nothing shared with a module in no groups
-    assert_eq!(shared_chunk_groups(&module_to_groups, n(0), n(2)), 0);
+    assert_eq!(module_to_groups.shared(n(0), n(2)), 0);
     // a module shares all of its own groups with itself
-    assert_eq!(shared_chunk_groups(&module_to_groups, n(0), n(0)), 4);
+    assert_eq!(module_to_groups.shared(n(0), n(0)), 4);
 }
 
 // ---------------------------------------------------------------------------
@@ -614,11 +618,11 @@ fn linearize_prefers_candidate_sharing_most_chunk_groups_with_last_placed() {
         g.add_edge(n(1), n(0), 1);
         g.add_edge(n(2), n(0), 1);
     });
-    let module_to_groups = vec![
+    let module_to_groups = ModuleChunkGroups::from_sorted(vec![
         vec![0, 1, 2], // module 0
         vec![0],       // module 1: shares 1 group ({0}) with module 0
         vec![0, 1],    // module 2: shares 2 groups ({0, 1}) with module 0
-    ];
+    ]);
     assert_eq!(ids(&linearize(&g, &module_to_groups)), vec![0, 2, 1]);
 }
 
@@ -634,12 +638,12 @@ fn linearize_breaks_last_placed_ties_by_earlier_placements() {
         g.add_edge(n(3), n(1), 1); // 3 depends on 1
     });
     // Each module's group list is ascending, as `create_graph` produces.
-    let module_to_groups = vec![
+    let module_to_groups = ModuleChunkGroups::from_sorted(vec![
         vec![0, 1],    // module 0
         vec![2],       // module 1 (irrelevant sharing)
         vec![0, 2],    // module 2: shared(2,1)=1 ({2}); shared(2,0)=1 ({0})
         vec![0, 1, 2], // module 3: shared(3,1)=1 ({2}); shared(3,0)=2 ({0,1})
-    ];
+    ]);
     // pick after [0,1]: depth 0 (last=1) -> shared(2,1)=shared(3,1)=1 (tie);
     //                   depth 1 (ref=0)  -> shared(2,0)=1, shared(3,0)=2 -> 3 wins.
     assert_eq!(ids(&linearize(&g, &module_to_groups)), vec![0, 1, 3, 2]);


### PR DESCRIPTION
## Summary

The graph-based CSS chunker's `linearize` step produces the global module order that `split_into_chunks` then cuts into chunks. It previously broke ties between ready modules using a weight-sorted stack.

It now prefers the ready module that shares the most chunk groups with the previously placed module, so modules that are loaded together end up adjacent in the global order and split into better-aligned chunks. On a real world example this measurably lowers the modeled chunk-loading cost, with fewer requests and less over-fetched CSS.

The shared-group count is read from edge weights (how many chunk groups two modules co-occur in). Since `make_acyclic` deletes edges to break cycles, it now returns the edges it cut so `linearize` can still count those conflicting-order co-occurrences — reconstructing the full co-occurrence without cloning the graph.

## Verification

- `cargo test -p turbopack-core style_groups_graph::tests` (all pass)
- Validated on a real world example that the resulting global order is deterministic and the modeled chunk-loading cost decreases.

<!-- NEXT_JS_LLM_PR -->
