### PR TITLE
Add OpenTelemetry spans for API/middleware module loading and instrumentation register

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2627,7 +2627,6 @@ async function renderToHTMLOrFlightImpl(
               attributes: {
                 'next.clientComponentLoadCount':
                   metrics.clientComponentLoadCount,
-                'next.span_type': NextNodeServerSpan.clientComponentLoading,
               },
             })
             .end(
@@ -3329,17 +3328,12 @@ async function renderToStream(
   // Create the "render route (app)" span manually so we can keep it open during streaming.
   // This is necessary because errors inside Suspense boundaries are reported asynchronously
   // during stream consumption, after a typical wrapped function would have ended the span.
-  // Note: We pass the full span name as the first argument since startSpan uses it directly.
-  const renderSpan = getTracer().startSpan(
-    `render route (app) ${pagePath}` as any,
-    {
-      attributes: {
-        'next.span_name': `render route (app) ${pagePath}`,
-        'next.span_type': AppRenderSpan.getBodyResult,
-        'next.route': pagePath,
-      },
-    }
-  )
+  const renderSpan = getTracer().startSpan(AppRenderSpan.getBodyResult, {
+    spanName: `render route (app) ${pagePath}`,
+    attributes: {
+      'next.route': pagePath,
+    },
+  })
 
   // Helper to end the span with error status (used when throwing from catch blocks)
   const endSpanWithError = (err: unknown) => {

--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -8,7 +8,7 @@ import type {
 import { interopDefault } from '../../../lib/interop-default'
 import { afterRegistration as extendInstrumentationAfterRegistration } from './instrumentation-node-extensions'
 import { getTracer, SpanStatusCode } from '../trace/tracer'
-import { InstrumentationSpan } from '../trace/constants'
+import { InstrumentationSpan, type SpanTypes } from '../trace/constants'
 
 let cachedInstrumentationModule: InstrumentationModule
 
@@ -75,10 +75,13 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
     } finally {
       // Emitted after `register()` so a provider installed inside the hook is
       // in place. The span is backdated to cover the full hook duration.
-      const span = getTracer().startSpan(InstrumentationSpan.register, {
+      // Use the readable name as the OTel span name (matching `next.span_name`
+      // and the sibling module-loading spans), keeping the enum as the type.
+      const spanName = 'instrumentation register'
+      const span = getTracer().startSpan(spanName as SpanTypes, {
         startTime,
         attributes: {
-          'next.span_name': 'instrumentation register',
+          'next.span_name': spanName,
           'next.span_type': InstrumentationSpan.register,
         },
       })

--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -8,7 +8,7 @@ import type {
 import { interopDefault } from '../../../lib/interop-default'
 import { afterRegistration as extendInstrumentationAfterRegistration } from './instrumentation-node-extensions'
 import { getTracer, SpanStatusCode } from '../trace/tracer'
-import { InstrumentationSpan, type SpanTypes } from '../trace/constants'
+import { InstrumentationSpan } from '../trace/constants'
 
 let cachedInstrumentationModule: InstrumentationModule
 
@@ -68,13 +68,9 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
     } finally {
       // Emitted after `register()` so a provider installed inside the hook is
       // in place. The span is backdated to cover the full hook duration.
-      const spanName = 'instrumentation register'
-      const span = getTracer().startSpan(spanName as SpanTypes, {
+      const span = getTracer().startSpan(InstrumentationSpan.register, {
         startTime,
-        attributes: {
-          'next.span_name': spanName,
-          'next.span_type': InstrumentationSpan.register,
-        },
+        spanName: 'instrumentation register',
       })
       if (error) {
         span.recordException(error as Error)

--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -56,13 +56,6 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
   }
   const instrumentation = await instrumentationModulePromise
   if (instrumentation?.register) {
-    // `register()` runs once per server instance and must complete before the
-    // server can handle requests, so it is a major contributor to cold-start
-    // latency. It is also where the user typically installs their OpenTelemetry
-    // provider, which means no live span can wrap it — the tracer is a no-op
-    // until `register()` returns. To make this time visible anyway, we record
-    // the duration and emit a span with a backdated start time once the
-    // provider (if any) is available.
     const startTime = Date.now()
     let error: unknown
     try {
@@ -75,8 +68,6 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
     } finally {
       // Emitted after `register()` so a provider installed inside the hook is
       // in place. The span is backdated to cover the full hook duration.
-      // Use the readable name as the OTel span name (matching `next.span_name`
-      // and the sibling module-loading spans), keeping the enum as the type.
       const spanName = 'instrumentation register'
       const span = getTracer().startSpan(spanName as SpanTypes, {
         startTime,

--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -7,6 +7,8 @@ import type {
 } from '../../instrumentation/types'
 import { interopDefault } from '../../../lib/interop-default'
 import { afterRegistration as extendInstrumentationAfterRegistration } from './instrumentation-node-extensions'
+import { getTracer, SpanStatusCode } from '../trace/tracer'
+import { InstrumentationSpan } from '../trace/constants'
 
 let cachedInstrumentationModule: InstrumentationModule
 
@@ -54,12 +56,37 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
   }
   const instrumentation = await instrumentationModulePromise
   if (instrumentation?.register) {
+    // `register()` runs once per server instance and must complete before the
+    // server can handle requests, so it is a major contributor to cold-start
+    // latency. It is also where the user typically installs their OpenTelemetry
+    // provider, which means no live span can wrap it — the tracer is a no-op
+    // until `register()` returns. To make this time visible anyway, we record
+    // the duration and emit a span with a backdated start time once the
+    // provider (if any) is available.
+    const startTime = Date.now()
+    let error: unknown
     try {
       await instrumentation.register()
       extendInstrumentationAfterRegistration()
     } catch (err: any) {
+      error = err
       err.message = `An error occurred while loading instrumentation hook: ${err.message}`
       throw err
+    } finally {
+      // Emitted after `register()` so a provider installed inside the hook is
+      // in place. The span is backdated to cover the full hook duration.
+      const span = getTracer().startSpan(InstrumentationSpan.register, {
+        startTime,
+        attributes: {
+          'next.span_name': 'instrumentation register',
+          'next.span_type': InstrumentationSpan.register,
+        },
+      })
+      if (error) {
+        span.recordException(error as Error)
+        span.setStatus({ code: SpanStatusCode.ERROR })
+      }
+      span.end()
     }
   }
 }

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -27,6 +27,10 @@ enum LoadComponentsSpan {
   loadComponents = 'LoadComponents.loadComponents',
 }
 
+enum InstrumentationSpan {
+  register = 'Instrumentation.register',
+}
+
 enum NextServerSpan {
   getRequestHandler = 'NextServer.getRequestHandler',
   getRequestHandlerWithMetadata = 'NextServer.getRequestHandlerWithMetadata',
@@ -48,6 +52,7 @@ enum NextNodeServerSpan {
   sendRenderResult = 'NextNodeServer.sendRenderResult',
   proxyRequest = 'NextNodeServer.proxyRequest',
   runApi = 'NextNodeServer.runApi',
+  runMiddleware = 'NextNodeServer.runMiddleware',
   render = 'NextNodeServer.render',
   renderHTML = 'NextNodeServer.renderHTML',
   imageOptimizer = 'NextNodeServer.imageOptimizer',
@@ -115,6 +120,7 @@ enum MiddlewareSpan {
 type SpanTypes =
   | `${BaseServerSpan}`
   | `${LoadComponentsSpan}`
+  | `${InstrumentationSpan}`
   | `${NextServerSpan}`
   | `${StartServerSpan}`
   | `${NextNodeServerSpan}`
@@ -144,6 +150,9 @@ export const NextVanillaSpanAllowlist = new Set([
   NextNodeServerSpan.getLayoutOrPageModule,
   NextNodeServerSpan.startResponse,
   NextNodeServerSpan.clientComponentLoading,
+  NextNodeServerSpan.runApi,
+  NextNodeServerSpan.runMiddleware,
+  InstrumentationSpan.register,
 ])
 
 // These Spans are allowed to be always logged
@@ -157,6 +166,7 @@ export const LogSpanAllowList = new Set([
 export {
   BaseServerSpan,
   LoadComponentsSpan,
+  InstrumentationSpan,
   NextServerSpan,
   NextNodeServerSpan,
   StartServerSpan,

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -313,6 +313,27 @@ class NextTracerImpl implements NextTracer {
     return context.with(remoteContext, fn)
   }
 
+  // Resolves the span name and injects the standard `next.span_name` /
+  // `next.span_type` attributes. Shared by `trace` and `startSpan` so both
+  // paths label spans identically.
+  private resolveSpanOptions(
+    type: SpanTypes,
+    options: TracerSpanOptions
+  ): { spanName: string; options: TracerSpanOptions } {
+    const spanName = options.spanName ?? type
+    return {
+      spanName,
+      options: {
+        ...options,
+        attributes: {
+          'next.span_name': spanName,
+          'next.span_type': type,
+          ...options.attributes,
+        },
+      },
+    }
+  }
+
   // Trace, wrap implementation is inspired by datadog trace implementation
   // (https://datadoghq.dev/dd-trace-js/interfaces/tracer.html#trace).
   public trace<T>(
@@ -362,8 +383,6 @@ class NextTracerImpl implements NextTracer {
             options: { ...fnOrOptions },
           }
 
-    const spanName = options.spanName ?? type
-
     if (
       (!NextVanillaSpanAllowlist.has(type) &&
         process.env.NEXT_OTEL_VERBOSE !== '1') ||
@@ -371,6 +390,11 @@ class NextTracerImpl implements NextTracer {
     ) {
       return fn()
     }
+
+    const { spanName, options: resolvedOptions } = this.resolveSpanOptions(
+      type,
+      options
+    )
 
     // Trying to get active scoped span to assign parent. If option specifies parent span manually, will try to use it.
     let spanContext = this.getSpanContext(
@@ -391,16 +415,10 @@ class NextTracerImpl implements NextTracer {
 
     const spanId = getSpanId()
 
-    options.attributes = {
-      'next.span_name': spanName,
-      'next.span_type': type,
-      ...options.attributes,
-    }
-
     return context.with(spanContext.setValue(rootSpanIdKey, spanId), () =>
       this.runWithActiveSpan(
         spanName,
-        options,
+        resolvedOptions,
         spanContext,
         tracingEnabled,
         localSpanRecordingEnabled,
@@ -442,7 +460,7 @@ class NextTracerImpl implements NextTracer {
             rootSpanAttributesStore.set(
               spanId,
               new Map(
-                Object.entries(options.attributes ?? {}) as [
+                Object.entries(resolvedOptions.attributes ?? {}) as [
                   AttributeNames,
                   AttributeValue | undefined,
                 ][]
@@ -603,8 +621,13 @@ class NextTracerImpl implements NextTracer {
   public startSpan(type: SpanTypes): Span
   public startSpan(type: SpanTypes, options: TracerSpanOptions): Span
   public startSpan(...args: Array<any>): Span {
-    const [type, options]: [string, TracerSpanOptions | undefined] = args as any
+    const [type, options]: [SpanTypes, TracerSpanOptions | undefined] =
+      args as any
 
+    const { spanName, options: resolvedOptions } = this.resolveSpanOptions(
+      type,
+      options ?? {}
+    )
     const parentContext =
       this.getSpanContext(options?.parentSpan ?? this.getActiveScopeSpan()) ??
       context.active()
@@ -612,16 +635,24 @@ class NextTracerImpl implements NextTracer {
       getLocalSpanRecorder()?.isLocalSpanRecordingEnabled() ?? false
 
     if (!localSpanRecordingEnabled) {
-      return this.getTracerInstance().startSpan(type, options, parentContext)
+      return this.getTracerInstance().startSpan(
+        spanName,
+        resolvedOptions,
+        parentContext
+      )
     }
 
     const delegateSpan = this.isOpenTelemetryEnabled()
-      ? this.getTracerInstance().startSpan(type, options, parentContext)
+      ? this.getTracerInstance().startSpan(
+          spanName,
+          resolvedOptions,
+          parentContext
+        )
       : undefined
 
     return this.createLocalRecordingSpan(
-      type,
-      options ?? {},
+      spanName,
+      resolvedOptions,
       parentContext,
       delegateSpan
     )

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -214,6 +214,27 @@ const clientTraceDataSetter: TextMapSetter<ClientTraceDataEntry[]> = {
   },
 }
 
+// Resolves the span name and injects the standard `next.span_name` /
+// `next.span_type` attributes. Shared by `trace` and `startSpan` so both
+// paths label spans identically.
+function resolveSpanOptions(
+  type: SpanTypes,
+  options: TracerSpanOptions
+): { spanName: string; options: TracerSpanOptions } {
+  const spanName = options.spanName ?? type
+  return {
+    spanName,
+    options: {
+      ...options,
+      attributes: {
+        'next.span_name': spanName,
+        'next.span_type': type,
+        ...options.attributes,
+      },
+    },
+  }
+}
+
 class NextTracerImpl implements NextTracer {
   /**
    * Returns an instance to the trace with configured name.
@@ -313,27 +334,6 @@ class NextTracerImpl implements NextTracer {
     return context.with(remoteContext, fn)
   }
 
-  // Resolves the span name and injects the standard `next.span_name` /
-  // `next.span_type` attributes. Shared by `trace` and `startSpan` so both
-  // paths label spans identically.
-  private resolveSpanOptions(
-    type: SpanTypes,
-    options: TracerSpanOptions
-  ): { spanName: string; options: TracerSpanOptions } {
-    const spanName = options.spanName ?? type
-    return {
-      spanName,
-      options: {
-        ...options,
-        attributes: {
-          'next.span_name': spanName,
-          'next.span_type': type,
-          ...options.attributes,
-        },
-      },
-    }
-  }
-
   // Trace, wrap implementation is inspired by datadog trace implementation
   // (https://datadoghq.dev/dd-trace-js/interfaces/tracer.html#trace).
   public trace<T>(
@@ -391,14 +391,14 @@ class NextTracerImpl implements NextTracer {
       return fn()
     }
 
-    const { spanName, options: resolvedOptions } = this.resolveSpanOptions(
+    const { spanName, options: resolvedOptions } = resolveSpanOptions(
       type,
       options
     )
 
     // Trying to get active scoped span to assign parent. If option specifies parent span manually, will try to use it.
     let spanContext = this.getSpanContext(
-      options?.parentSpan ?? this.getActiveScopeSpan()
+      resolvedOptions?.parentSpan ?? this.getActiveScopeSpan()
     )
 
     if (!spanContext) {
@@ -624,7 +624,7 @@ class NextTracerImpl implements NextTracer {
     const [type, options]: [SpanTypes, TracerSpanOptions | undefined] =
       args as any
 
-    const { spanName, options: resolvedOptions } = this.resolveSpanOptions(
+    const { spanName, options: resolvedOptions } = resolveSpanOptions(
       type,
       options ?? {}
     )

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -585,7 +585,21 @@ export default class NextNodeServer extends BaseServer<
     req.url = `${parsedInitUrl.pathname}${parsedInitUrl.search || ''}`
 
     const loader = new NodeModuleLoader()
-    const module = (await loader.load(match.definition.filename)) as {
+    // Loading the route module reads and evaluates the bundled API route chunk
+    // from disk. On a cold module this can be a meaningful portion of the
+    // request's latency, so trace it separately from the handler execution
+    // (which is covered by the `Node.runHandler` span) to make that time
+    // visible in APM tools.
+    const module = (await getTracer().trace(
+      NextNodeServerSpan.runApi,
+      {
+        spanName: 'load api route module',
+        attributes: {
+          'next.route': match.definition.pathname,
+        },
+      },
+      () => loader.load(match.definition.filename)
+    )) as {
       handler: (
         req: IncomingMessage,
         res: ServerResponse,
@@ -1688,11 +1702,21 @@ export default class NextNodeServer extends BaseServer<
       return { finished: false }
     }
 
-    await this.ensureMiddleware(params.request.url)
-    const middlewareInfo = this.getEdgeFunctionInfo({
-      page: middleware.page,
-      middleware: true,
-    })
+    // Resolving and loading the middleware module (compiling the edge bundle
+    // and warming the sandbox on first use) happens before the middleware
+    // function itself runs, which is covered by the `Middleware.execute` span.
+    // Trace it separately so this setup cost is visible in APM tools.
+    const middlewareInfo = await getTracer().trace(
+      NextNodeServerSpan.runMiddleware,
+      { spanName: 'load middleware module' },
+      async () => {
+        await this.ensureMiddleware(params.request.url)
+        return this.getEdgeFunctionInfo({
+          page: middleware.page,
+          middleware: true,
+        })
+      }
+    )
 
     const method = (params.request.method || 'GET').toUpperCase()
     const requestData = {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -2167,5 +2167,10 @@ async function expectTrace(
     })
 
     expect(filteredTree).toMatchObject(match)
-  })
+    // Some spans (notably `NextNodeServer.clientComponentLoading`) end outside
+    // the request's synchronous span tree and are exported to the collector via
+    // an individual HTTP POST when they end. Under CI load that span can end and
+    // arrive slightly after the rest of the trace, so use a window a bit larger
+    // than the 3s default to let all spans arrive before matching.
+  }, 6_000)
 }

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -644,6 +644,32 @@ describe.each(
             )
           })
 
+          // Middleware runs as a separate internal request whose
+          // `handleRequest` span is not exported, so the `runMiddleware` span
+          // (`load middleware module`) is not a child of the page's
+          // `handleRequest` and can't be asserted via `expectTrace`. Assert it
+          // directly against the collected spans instead.
+          itEdge('should trace middleware module loading', async () => {
+            await next.fetch('/behind-middleware', env.fetchInit)
+
+            await retry(async () => {
+              const spans = getCollector().getSpans()
+              const middlewareLoadSpan = spans.find(
+                (span) =>
+                  span.attributes?.['next.span_type'] ===
+                  'NextNodeServer.runMiddleware'
+              )
+              expect(middlewareLoadSpan).toMatchObject({
+                runtime: 'nodejs',
+                name: 'load middleware module',
+                attributes: {
+                  'next.span_name': 'load middleware module',
+                  'next.span_type': 'NextNodeServer.runMiddleware',
+                },
+              })
+            })
+          })
+
           it('should handle error in RSC', async () => {
             await next.fetch(
               '/app/param/rsc-fetch/error?status=error',
@@ -1334,6 +1360,23 @@ describe.each(
                     kind: 0,
                     status: { code: 0 },
                   },
+                  // The `runApi` span is emitted by `next-server`'s routing
+                  // path. Direct entrypoint handlers load the route module
+                  // themselves, so this span is not present there.
+                  ...(useDirectEntrypointHandler
+                    ? []
+                    : [
+                        {
+                          name: 'load api route module',
+                          attributes: {
+                            'next.route': '/api/pages/[param]/basic',
+                            'next.span_name': 'load api route module',
+                            'next.span_type': 'NextNodeServer.runApi',
+                          },
+                          kind: 0,
+                          status: { code: 0 },
+                        },
+                      ]),
                 ],
               },
             ])
@@ -1394,6 +1437,23 @@ describe.each(
                     // TODO this difference is odd
                     status: { code: isNextDev ? 2 : 0 },
                   },
+                  // The `runApi` span is emitted by `next-server`'s routing
+                  // path. Direct entrypoint handlers load the route module
+                  // themselves, so this span is not present there.
+                  ...(useDirectEntrypointHandler
+                    ? []
+                    : [
+                        {
+                          name: 'load api route module',
+                          attributes: {
+                            'next.route': '/api/pages/[param]/error',
+                            'next.span_name': 'load api route module',
+                            'next.span_type': 'NextNodeServer.runApi',
+                          },
+                          kind: 0,
+                          status: { code: 0 },
+                        },
+                      ]),
                   ...(isNextDev
                     ? [
                         {
@@ -2026,7 +2086,15 @@ async function expectTrace(
   )
 
   await retry(async () => {
-    const traces = collector.getSpans()
+    const traces = collector.getSpans().filter(
+      (span) =>
+        // The instrumentation `register()` span is a lifecycle span emitted
+        // once at server startup with no request context (its own root trace).
+        // It would otherwise pollute the root set of whichever request trace's
+        // collector happens to be connected when the server first prepares, so
+        // exclude it from request-trace assertions.
+        span.attributes?.['next.span_type'] !== 'Instrumentation.register'
+    )
 
     const tree: HierSavedSpan[] = []
     const spansForTree: HierSavedSpan[] = traces.map((span) => ({

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -2088,11 +2088,8 @@ async function expectTrace(
   await retry(async () => {
     const traces = collector.getSpans().filter(
       (span) =>
-        // The instrumentation `register()` span is a lifecycle span emitted
-        // once at server startup with no request context (its own root trace).
-        // It would otherwise pollute the root set of whichever request trace's
-        // collector happens to be connected when the server first prepares, so
-        // exclude it from request-trace assertions.
+        // Drop the register span which only runs once and would otherwise pollute the first trace
+        // collected from the server
         span.attributes?.['next.span_type'] !== 'Instrumentation.register'
     )
 

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -5,6 +5,7 @@ import path from 'path'
 
 import { SavedSpan } from './constants'
 import { type Collector, connectCollector } from './collector'
+import { InstrumentationSpan } from 'next/src/server/lib/trace/constants'
 
 const EXTERNAL = {
   traceId: 'ee75cd9e534ff5e9ed78b4a0c706f0f2',
@@ -2090,7 +2091,7 @@ async function expectTrace(
       (span) =>
         // Drop the register span which only runs once and would otherwise pollute the first trace
         // collected from the server
-        span.attributes?.['next.span_type'] !== 'Instrumentation.register'
+        span.attributes?.['next.span_type'] !== InstrumentationSpan.register
     )
 
     const tree: HierSavedSpan[] = []


### PR DESCRIPTION
## Summary

Adds OpenTelemetry spans for work that happens on the critical path before a request's handler runs but was previously untraced, leaving a gap in traces (especially visible on cold starts).

- **`NextNodeServer.runApi`** — wraps the pages API route module load (`load api route module`). On a cold module this reads and evaluates the bundled route chunk, which can be a meaningful share of request latency. Previously only the handler execution (`Node.runHandler`) was traced.
- **`NextNodeServer.runMiddleware`** — wraps middleware module resolution/load (`load middleware module`), i.e. compiling the edge bundle and warming the sandbox on first use. Previously only `Middleware.execute` (the middleware function itself) was traced.
- **`Instrumentation.register`** — a span covering the instrumentation `register()` hook, which runs once per server instance and must complete before the server serves requests. Because `register()` is typically where the user installs their OTEL provider, no live span can wrap it (the tracer is a no-op until it returns), so the span is **backdated** to cover the hook duration and emitted once the provider is in place.

All three span types are added to `NextVanillaSpanAllowlist` so they reach user OTEL exporters.

The `register()` span maybe be root trace or run part of an initial request. `expectTrace` in the OTel e2e suite now excludes it so it does not pollute request-trace assertions.

## Verification

- `pnpm test-start-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts` (83 passed) — covers the new `runApi` / `runMiddleware` span assertions and the `register`-span filter across the default and direct-entrypoint variants
- `pnpm test-dev-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t "middleware"` (dev-mode middleware path)
- Manually confirmed via the collector that the backdated `Instrumentation.register` span is exported with a non-zero duration. Not asserted in the suite: it fires once per server lifetime while a per-test collector is connected, so a stable assertion is not feasible in this harness.

<!-- NEXT_JS_LLM_PR -->