### PR TITLE
Report router transition end via a user-placed marker component

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -337,8 +337,14 @@ export function dispatchNavigateAction(
   // queued, so the hook runs outside React's render phase. (A user hook that
   // throws during the reducer would otherwise break error isolation between
   // hooks.) The transition object is threaded on the action so the reducer can
-  // attach the destination tree to it once it exists.
-  const instrumentationTransition = startRouterTransition(href, navigateType)
+  // attach the destination tree to it once it exists. The current state is
+  // passed in because router-transition must not import this module back
+  // (see startRouterTransition).
+  const instrumentationTransition = startRouterTransition(
+    href,
+    navigateType,
+    getCurrentAppRouterState()
+  )
 
   dispatchAppRouterAction({
     type: ACTION_NAVIGATE,
@@ -355,7 +361,11 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
-  const instrumentationTransition = startRouterTransition(href, 'traverse')
+  const instrumentationTransition = startRouterTransition(
+    href,
+    'traverse',
+    getCurrentAppRouterState()
+  )
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
     url: new URL(href),

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -29,6 +29,7 @@ import { resetKnownRoutes } from './segment-cache/optimistic-routes'
 import { FreshnessPolicy } from './router-reducer/ppr-navigations'
 import { addBasePath } from '../add-base-path'
 import { isExternalURL } from './app-router-utils'
+import { createHrefFromUrl } from './router-reducer/create-href-from-url'
 import type {
   AppRouterInstance,
   NavigateOptions,
@@ -361,14 +362,20 @@ export function dispatchTraverseAction(
   href: string,
   historyState: AppHistoryState | undefined
 ) {
+  const url = new URL(href)
+  // A traversal has no caller-provided destination string (the popstate
+  // handler only has the absolute `location.href`), so report the canonical
+  // relative form — pathname + search + hash, the shape navigations
+  // conventionally receive — instead of leaking the absolute URL and making
+  // the hooks' `url` argument shape depend on the navigation type.
   const instrumentationTransition = startRouterTransition(
-    href,
+    createHrefFromUrl(url),
     'traverse',
     getCurrentAppRouterState()
   )
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
-    url: new URL(href),
+    url,
     historyState,
     instrumentationTransition,
   })

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -27,6 +27,7 @@ import {
 import { dispatchAppRouterAction, useActionQueue } from './use-action-queue'
 import { setLastCommittedTree } from './router-reducer/reducers/committed-state'
 import { commitRouterTransition } from './router-transition'
+import { RouterTransitionEndContext } from './router-transition-end-marker'
 import { AppRouterAnnouncer } from './app-router-announcer'
 import { RedirectBoundary } from './redirect-boundary'
 import { findHeadInCache } from './router-reducer/reducers/find-head-in-cache'
@@ -569,6 +570,22 @@ function Router({
     const { OfflineProvider } =
       require('./use-offline') as typeof import('./use-offline')
     content = <OfflineProvider>{content}</OfflineProvider>
+  }
+
+  // Positive flag check so the provider is removed by DCE when the
+  // experimental lifecycle is disabled (the marker then reads the context's
+  // default `null` and reports nothing). The provider binds each render to
+  // the transition of the state being rendered, which is what lets an
+  // `unstable_RouterTransitionEndMarker` attribute itself correctly even
+  // when it mounts in the same React commit that applies the navigation.
+  if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    content = (
+      <RouterTransitionEndContext.Provider
+        value={state.instrumentationTransition}
+      >
+        {content}
+      </RouterTransitionEndContext.Provider>
+    )
   }
 
   return (

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -41,6 +41,7 @@ import {
 import { useNavFailureHandler } from './nav-failure-handler'
 import {
   dispatchTraverseAction,
+  getCurrentAppRouterState,
   publicAppRouterInstance,
   type AppRouterActionQueue,
   type GlobalErrorState,
@@ -344,9 +345,16 @@ function Router({
           historyState: appHistoryState,
           // TODO: Consider tracking perf for shallow routing. For now a
           // shallow history update is not a tracked transition — no `start`
-          // is emitted for it, so there is no pending transition to thread
-          // through, and it never reports a commit.
-          instrumentationTransition: null,
+          // is emitted for it and it never reports its own commit. But the
+          // produced state derives from the current one, so the current
+          // state's transition must be carried forward, exactly like a
+          // refresh (see settleRouterTransition's destination-preserving
+          // class): stamping null would swap RouterTransitionEndContext away
+          // from a navigation whose content is still streaming — its marker
+          // would reveal reading null and the navigation's `end` would be
+          // silently dropped.
+          instrumentationTransition:
+            getCurrentAppRouterState()?.instrumentationTransition ?? null,
         })
       })
     }

--- a/packages/next/src/client/components/navigation.react-server.ts
+++ b/packages/next/src/client/components/navigation.react-server.ts
@@ -6,6 +6,11 @@ export function unstable_isUnrecognizedActionError(): boolean {
   )
 }
 
+// A client component (its module has 'use client'), so importing it from a
+// server component produces a client reference — server components can place
+// the marker even though the reporting only exists on the client.
+export { unstable_RouterTransitionEndMarker } from './router-transition-end-marker'
+
 export { redirect, permanentRedirect } from './redirect'
 export { notFound } from './not-found'
 export { forbidden } from './forbidden'

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -351,6 +351,7 @@ export function useSelectedLayoutSegment(
 }
 
 export { unstable_isUnrecognizedActionError } from './unrecognized-action-error'
+export { unstable_RouterTransitionEndMarker } from './router-transition-end-marker'
 
 // Shared components APIs
 export {

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -279,9 +279,12 @@ export type AppRouterState = {
    * since their derived state re-derives the same destination and may
    * commit in its place.
    *
-   * Consumed read-only by HistoryUpdater, which reports `commit` for the
-   * transition carried by the state it applies. Nothing in the router may
-   * otherwise depend on this field.
+   * Consumed in two places, both read-only for the router: HistoryUpdater
+   * reports `commit` for the transition carried by the state it applies,
+   * and `RouterTransitionEndContext` exposes it to
+   * `unstable_RouterTransitionEndMarker` so a marker showing on screen can
+   * report `end` for the navigation that rendered it. Nothing in the router
+   * may otherwise depend on this field.
    */
   instrumentationTransition: PendingRouterTransition | null
 }

--- a/packages/next/src/client/components/router-transition-end-marker.tsx
+++ b/packages/next/src/client/components/router-transition-end-marker.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { createContext, useContext, useInsertionEffect, useRef } from 'react'
+import {
+  createContext,
+  useContext,
+  useInsertionEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react'
 import {
   reportRouterTransitionEnd,
   type PendingRouterTransition,
@@ -11,13 +17,11 @@ import {
  * (`AppRouterState.instrumentationTransition`) to end markers. Provided by
  * AppRouter (only when the experimental lifecycle flag is on), so the value
  * is fixed during the render that produces each React commit. That
- * render-time binding is what makes attribution independent of effect
- * order: a marker mounting in the very commit that applies a navigation
- * read that navigation's transition when it rendered, whether its insertion
- * effect runs before or after HistoryUpdater's; and a marker revealed by
- * streamed content later attributes to whatever navigation's state was
- * current when React retried its Suspense boundary — the page the user is
- * actually on.
+ * render-time binding is what makes attribution exact: a marker mounting in
+ * the very commit that applies a navigation read that navigation's
+ * transition when it rendered, and a marker revealed by streamed content
+ * later attributes to whatever navigation's state was current when React
+ * retried its Suspense boundary — the page the user is actually on.
  */
 export const RouterTransitionEndContext =
   createContext<PendingRouterTransition | null>(null)
@@ -38,29 +42,49 @@ export const RouterTransitionEndContext =
  *
  *     import { unstable_RouterTransitionEndMarker as RouterTransitionEndMarker } from 'next/navigation'
  *
- * Reporting is once per navigation, on mount: whichever marker shows first
- * ends the transition, and additional markers (parallel routes, an
- * alternative marker inside `error.js`) are no-ops after it. A marker that
- * stays mounted across a navigation (e.g. in a shared layout) does not
+ * Reporting is once per navigation, when the marker shows: whichever marker
+ * shows first ends the transition, and additional markers (parallel routes,
+ * an alternative marker inside `error.js`) are no-ops after it. "Shows"
+ * means committed to the screen — a fresh mount, or an `<Activity>` reveal
+ * when the router re-shows a preserved page (cacheComponents keeps visited
+ * pages hidden in Activity boundaries, so a back/forward traversal reveals
+ * the same marker instance instead of mounting a new one). A marker that
+ * stays on screen across a navigation (e.g. in a shared layout) does not
  * re-report — nothing new was shown — which is why markers belong in
  * page-level content. Routes that render no marker simply produce no `end`
  * event.
  */
 function RouterTransitionEndMarker(): null {
   const transition = useContext(RouterTransitionEndContext)
-  // Reporting is keyed to this marker instance's mount: `transition` is in
-  // the effect's dependencies only because it is read inside, so the ref
-  // latch keeps the effect from re-reporting when a navigation swaps the
-  // context value under a still-mounted marker. (Cross-marker and
-  // StrictMode-replay dedupe live in the transition's own phase latch; this
-  // ref only pins "mount" semantics.)
-  const didReport = useRef(false)
+  // The reporting effect below deliberately has no dependencies, so it reads
+  // the transition through a ref kept current on every render — by the time
+  // any effect runs for a commit, the ref holds the transition of the router
+  // state that produced that commit.
+  const latestTransition = useRef(transition)
   useInsertionEffect(() => {
-    if (!didReport.current) {
-      didReport.current = true
-      reportRouterTransitionEnd(transition)
-    }
+    latestTransition.current = transition
   }, [transition])
+  // "Showing" is a layout effect on purpose, and with no dependencies on
+  // purpose:
+  //
+  // - Layout effects are disconnected when an <Activity> hides the marker's
+  //   page and reconnected when it is revealed, so the effect re-fires when a
+  //   traversal re-shows a preserved page — the reveal IS the page loading,
+  //   even though nothing remounted. (Insertion effects do not participate
+  //   in Activity's disconnect/reconnect cycle, so they would miss reveals.)
+  // - No dependencies means a navigation that merely swaps the context value
+  //   under a marker that stayed on screen does not re-fire the effect —
+  //   nothing new was shown. (Cross-marker, StrictMode-replay, and
+  //   reveal-of-an-already-ended-transition dedupe all live in the
+  //   transition's own phase latch.)
+  //
+  // Ordering: within a React commit, every insertion effect runs before any
+  // layout effect, so HistoryUpdater has already emitted `commit` for the
+  // state this marker rendered under — `end` is always reported after
+  // `commit`.
+  useLayoutEffect(() => {
+    reportRouterTransitionEnd(latestTransition.current)
+  }, [])
   return null
 }
 

--- a/packages/next/src/client/components/router-transition-end-marker.tsx
+++ b/packages/next/src/client/components/router-transition-end-marker.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { createContext, useContext, useInsertionEffect, useRef } from 'react'
+import {
+  reportRouterTransitionEnd,
+  type PendingRouterTransition,
+} from './router-transition'
+
+/**
+ * Exposes the transition carried by the current router state
+ * (`AppRouterState.instrumentationTransition`) to end markers. Provided by
+ * AppRouter (only when the experimental lifecycle flag is on), so the value
+ * is fixed during the render that produces each React commit. That
+ * render-time binding is what makes attribution independent of effect
+ * order: a marker mounting in the very commit that applies a navigation
+ * read that navigation's transition when it rendered, whether its insertion
+ * effect runs before or after HistoryUpdater's; and a marker revealed by
+ * streamed content later attributes to whatever navigation's state was
+ * current when React retried its Suspense boundary — the page the user is
+ * actually on.
+ */
+export const RouterTransitionEndContext =
+  createContext<PendingRouterTransition | null>(null)
+
+/**
+ * Declares "the page has loaded" for the instrumentation-client router
+ * transition lifecycle: when the first marker rendered for a navigation's
+ * destination is committed to the screen, the navigation's
+ * `unstable_onRouterTransitionEnd` hook fires. Place it next to the content
+ * whose visibility completes the page — typically inside the Suspense
+ * boundary that streams in last — so `end - commit` measures the
+ * post-navigation streaming/rendering cost the app actually cares about.
+ * The marker renders nothing.
+ *
+ * JSX treats lowercase-first tags as host elements, so (like React's own
+ * `unstable_`-prefixed components) the import must be aliased to a
+ * capitalized name:
+ *
+ *     import { unstable_RouterTransitionEndMarker as RouterTransitionEndMarker } from 'next/navigation'
+ *
+ * Reporting is once per navigation, on mount: whichever marker shows first
+ * ends the transition, and additional markers (parallel routes, an
+ * alternative marker inside `error.js`) are no-ops after it. A marker that
+ * stays mounted across a navigation (e.g. in a shared layout) does not
+ * re-report — nothing new was shown — which is why markers belong in
+ * page-level content. Routes that render no marker simply produce no `end`
+ * event.
+ */
+function RouterTransitionEndMarker(): null {
+  const transition = useContext(RouterTransitionEndContext)
+  // Reporting is keyed to this marker instance's mount: `transition` is in
+  // the effect's dependencies only because it is read inside, so the ref
+  // latch keeps the effect from re-reporting when a navigation swaps the
+  // context value under a still-mounted marker. (Cross-marker and
+  // StrictMode-replay dedupe live in the transition's own phase latch; this
+  // ref only pins "mount" semantics.)
+  const didReport = useRef(false)
+  useInsertionEffect(() => {
+    if (!didReport.current) {
+      didReport.current = true
+      reportRouterTransitionEnd(transition)
+    }
+  }, [transition])
+  return null
+}
+
+// Exported under the unstable_ prefix (the public name while the lifecycle
+// is experimental); the component is defined under its plain name because
+// hooks lint requires component names to start with an uppercase letter.
+export { RouterTransitionEndMarker as unstable_RouterTransitionEndMarker }

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -60,10 +60,14 @@ export type PendingRouterTransition = {
   phase: 'pending' | 'committed' | 'ended'
   /**
    * Set when an `unstable_RouterTransitionEndMarker` showed before `commit`
-   * was emitted — its insertion effect ran in the same React commit that
-   * applies the navigation, possibly before HistoryUpdater's. The commit
-   * emission consumes it to report `end` right after `commit`, with the same
-   * timestamp: the marker and the navigation committed in the same instant.
+   * was emitted; the commit emission consumes it to report `end` right after
+   * `commit`, with the same timestamp. Defensive: the marker reports from a
+   * layout effect and HistoryUpdater emits `commit` from an insertion
+   * effect, and within a React commit every insertion effect runs before any
+   * layout effect — so under the current ordering this can never be set. It
+   * exists so a marker showing ahead of its commit degrades to a correctly
+   * ordered event pair instead of an `end` before its `commit` (or a lost
+   * `end`) if that ordering assumption is ever broken.
    */
   markerDidShow: boolean
   /**
@@ -462,10 +466,10 @@ function sweepReplacedRouterTransitions(): void {
  * re-renders of an already-committed state, and for derived states
  * (refreshes) that carry a transition another state already committed.
  *
- * If an `unstable_RouterTransitionEndMarker` showed inside this same React
- * commit — its insertion effect can run before HistoryUpdater's — `end` is
- * emitted here too, right after `commit`, so consumers always observe the
- * events in lifecycle order.
+ * If an `unstable_RouterTransitionEndMarker` somehow showed before this ran
+ * (`markerDidShow`, a defensive path — see its doc), `end` is emitted here
+ * too, right after `commit`, so consumers always observe the events in
+ * lifecycle order.
  */
 export function commitRouterTransition(state: AppRouterState): void {
   if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
@@ -540,19 +544,19 @@ export function commitRouterTransition(state: AppRouterState): void {
 }
 
 /**
- * Called from `unstable_RouterTransitionEndMarker`'s insertion effect when
- * the marker is committed to the screen: the destination declared "the page
- * has loaded". The transition is the one carried by the router state the
- * marker rendered under (read from context at render time, so a marker
- * mounting in the very commit that applies the navigation still attributes
- * to the right transition regardless of effect order — see
- * `RouterTransitionEndContext`).
+ * Called from `unstable_RouterTransitionEndMarker`'s layout effect when the
+ * marker is committed to the screen — a fresh mount or an `<Activity>`
+ * reveal: the destination declared "the page has loaded". The transition is
+ * the one carried by the router state the marker rendered under (read from
+ * context at render time — see `RouterTransitionEndContext`), and layout
+ * effects run after the insertion effect where HistoryUpdater emits
+ * `commit`, so the transition has normally already committed here.
  *
  * The phase latch means only the first marker to show reports the `end` for
  * a transition: later markers, StrictMode's replayed effects, and markers
- * mounting under a state whose transition already ended are all no-ops. A
- * marker that shows before the transition's `commit` was emitted (same
- * React commit, marker effect first) only records that it showed; the
+ * showing under a state whose transition already ended are all no-ops. A
+ * marker that shows before the transition's `commit` was emitted (a
+ * defensive path — see `markerDidShow`) only records that it showed; the
  * commit emission reports `end` right after `commit`.
  */
 export function reportRouterTransitionEnd(

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -160,9 +160,15 @@ function timestamp(): number {
  * `pendingTransitions` immediately, so that it is reported as aborted if a
  * newer navigation commits before this one produces a destination tree.
  *
- * The `from` route describes the route being left; it is read from the
- * current AppRouterState here (rather than passed in) since this is the only
- * transition hook that needs it.
+ * The `from` route describes the route being left; the dispatch site passes
+ * the current AppRouterState in (rather than this module reading it from
+ * app-router-instance) so that this module never references
+ * app-router-instance: even a lazy `require` is traced statically by
+ * bundlers, and this module is reachable from `next/navigation` (via
+ * `unstable_RouterTransitionEndMarker`), which is bundled in contexts —
+ * instrumentation-client, the react-server layer — where the router reducer
+ * graph behind app-router-instance (react-server-dom-webpack etc.) must not
+ * be pulled in and may not even resolve.
  *
  * Returns the pending transition when the lifecycle is active — the caller
  * puts the object on the dispatched action so the queue can settle it
@@ -171,7 +177,8 @@ function timestamp(): number {
  */
 export function startRouterTransition(
   url: string,
-  type: RouterTransitionType
+  type: RouterTransitionType,
+  state: AppRouterState | null
 ): PendingRouterTransition | null {
   // Positive flag check so the instrumentation-only path is removed by DCE when disabled.
   if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
@@ -179,12 +186,6 @@ export function startRouterTransition(
       return null
     }
 
-    // Lazy require to avoid a static import cycle: app-router-instance
-    // imports this module to emit `start` when dispatching. (Same pattern as
-    // links.ts.)
-    const { getCurrentAppRouterState } =
-      require('./app-router-instance') as typeof import('./app-router-instance')
-    const state = getCurrentAppRouterState()
     if (state === null) {
       // Navigations can only be dispatched after hydration creates the action
       // queue, so this shouldn't happen; degrade to the legacy hook shape

--- a/packages/next/src/client/components/router-transition.ts
+++ b/packages/next/src/client/components/router-transition.ts
@@ -32,8 +32,8 @@ import type {
 // instrumentation-client router transition hooks. Created when `start` is
 // emitted and threaded through the navigate/restore action, so the navigation
 // code that produces the destination state stamps this same shared object
-// onto the state (`AppRouterState.instrumentationTransition`) rather than
-// look it up by id.
+// onto the state (`AppRouterState.instrumentationTransition`) and writes
+// cache-miss marks into it, rather than look it up by id.
 export type PendingRouterTransition = {
   /** Opaque id shared by every event emitted for this transition. */
   id: string
@@ -52,12 +52,20 @@ export type PendingRouterTransition = {
    * Where the transition is in its reportable lifecycle. `pending` from
    * start until HistoryUpdater applies a state carrying this transition
    * (`AppRouterState.instrumentationTransition`), `committed` once `commit`
-   * has been emitted. A one-way latch: it only advances, which is what makes
-   * the emission point idempotent against re-renders, StrictMode double
-   * effects, and derived states (refreshes) that carry an already-reported
-   * transition.
+   * has been emitted, `ended` once `end` has been emitted. A one-way latch:
+   * it only advances, which is what makes the emission points idempotent
+   * against re-renders, StrictMode double effects, and derived states
+   * (refreshes) that carry an already-reported transition.
    */
-  phase: 'pending' | 'committed'
+  phase: 'pending' | 'committed' | 'ended'
+  /**
+   * Set when an `unstable_RouterTransitionEndMarker` showed before `commit`
+   * was emitted — its insertion effect ran in the same React commit that
+   * applies the navigation, possibly before HistoryUpdater's. The commit
+   * emission consumes it to report `end` right after `commit`, with the same
+   * timestamp: the marker and the navigation committed in the same instant.
+   */
+  markerDidShow: boolean
   /**
    * Whether the action queue discarded this transition's action because a
    * newer navigation was dispatched. A replaced transition's state can never
@@ -95,6 +103,7 @@ const pendingTransitions: PendingRouterTransition[] = []
 // building event payloads no registered hook would receive.
 let hasStartHook = false
 let hasCommitHook = false
+let hasEndHook = false
 let hasAbortHook = false
 
 export function initializeRouterTransitionModules(
@@ -108,6 +117,9 @@ export function initializeRouterTransitionModules(
   )
   hasCommitHook = instrumentationModules.some(
     (hooks) => typeof hooks.unstable_onRouterTransitionCommit === 'function'
+  )
+  hasEndHook = instrumentationModules.some(
+    (hooks) => typeof hooks.unstable_onRouterTransitionEnd === 'function'
   )
   hasAbortHook = instrumentationModules.some(
     (hooks) => typeof hooks.unstable_onRouterTransitionAbort === 'function'
@@ -128,7 +140,7 @@ function callHooks(invoke: (hooks: ClientInstrumentationHooks) => void): void {
 }
 
 function hasLifecycleInstrumentation(): boolean {
-  return hasStartHook || hasCommitHook || hasAbortHook
+  return hasStartHook || hasCommitHook || hasEndHook || hasAbortHook
 }
 
 /**
@@ -187,6 +199,7 @@ export function startRouterTransition(
       type,
       url,
       phase: 'pending',
+      markerDidShow: false,
       replaced: false,
       cacheHit: true,
     }
@@ -321,11 +334,12 @@ export function settleRouterTransition(
 /**
  * Applies the `cacheHit` consequence when a destination-preserving action
  * derives a new state from a tracked-but-not-yet-committed one (see
- * `settleRouterTransition`). The destination identity needs no re-pointing —
- * the reducer copies `instrumentationTransition` onto the derived state, so
- * HistoryUpdater finds the transition on whichever state ends up committing.
- * No-op in the common case where the base state's transition was already
- * committed (a plain refresh of a settled page) or nothing is in flight.
+ * `settleRouterTransition`). The destination identity itself needs no
+ * re-pointing anymore — the reducer copies `instrumentationTransition` onto
+ * the derived state, so HistoryUpdater finds the transition on whichever
+ * state ends up committing. No-op in the common case where the base state's
+ * transition was already committed (a plain refresh of a settled page) or
+ * nothing is in flight.
  */
 function retargetRouterTransition(
   prevState: AppRouterState,
@@ -446,6 +460,11 @@ function sweepReplacedRouterTransitions(): void {
  * a no-op for states that carry no tracked transition (server actions), for
  * re-renders of an already-committed state, and for derived states
  * (refreshes) that carry a transition another state already committed.
+ *
+ * If an `unstable_RouterTransitionEndMarker` showed inside this same React
+ * commit — its insertion effect can run before HistoryUpdater's — `end` is
+ * emitted here too, right after `commit`, so consumers always observe the
+ * events in lifecycle order.
  */
 export function commitRouterTransition(state: AppRouterState): void {
   if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
@@ -506,9 +525,78 @@ export function commitRouterTransition(state: AppRouterState): void {
         })
       )
     }
+    if (committed.markerDidShow) {
+      // The destination's end marker mounted in this same React commit (the
+      // navigation committed with the marker's content already available, so
+      // there is nothing left to stream): the page ended the moment it
+      // committed. Reported after `commit` and with the same timestamp.
+      emitRouterTransitionEnd(committed, now)
+    }
     // Entries newer than the committed one stay pending, but if all of them
     // were already replaced, their race can no longer produce a commit.
     sweepReplacedRouterTransitions()
+  }
+}
+
+/**
+ * Called from `unstable_RouterTransitionEndMarker`'s insertion effect when
+ * the marker is committed to the screen: the destination declared "the page
+ * has loaded". The transition is the one carried by the router state the
+ * marker rendered under (read from context at render time, so a marker
+ * mounting in the very commit that applies the navigation still attributes
+ * to the right transition regardless of effect order — see
+ * `RouterTransitionEndContext`).
+ *
+ * The phase latch means only the first marker to show reports the `end` for
+ * a transition: later markers, StrictMode's replayed effects, and markers
+ * mounting under a state whose transition already ended are all no-ops. A
+ * marker that shows before the transition's `commit` was emitted (same
+ * React commit, marker effect first) only records that it showed; the
+ * commit emission reports `end` right after `commit`.
+ */
+export function reportRouterTransitionEnd(
+  transition: PendingRouterTransition | null
+): void {
+  if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    if (transition === null) {
+      return
+    }
+    switch (transition.phase) {
+      case 'pending':
+        transition.markerDidShow = true
+        return
+      case 'committed':
+        emitRouterTransitionEnd(transition, timestamp())
+        return
+      case 'ended':
+        return
+      default:
+        transition.phase satisfies never
+    }
+  }
+}
+
+function emitRouterTransitionEnd(
+  transition: PendingRouterTransition,
+  now: number
+): void {
+  // Both callers are already inside the flag; repeated here so the event
+  // payload is provably removed from flag-off bundles without relying on
+  // the minifier dropping this (then-unreferenced) function.
+  if (process.env.__NEXT_INSTRUMENTATION_CLIENT_ROUTER_TRANSITION_EVENTS) {
+    transition.phase = 'ended'
+    if (hasEndHook) {
+      callHooks((hooks) =>
+        hooks.unstable_onRouterTransitionEnd?.(
+          transition.url,
+          transition.type,
+          {
+            id: transition.id,
+            timestamp: now,
+          }
+        )
+      )
+    }
   }
 }
 

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -132,6 +132,27 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
   cacheHit: boolean
 }
 
+/**
+ * Emitted when the navigation's destination declares itself loaded: the first
+ * `unstable_RouterTransitionEndMarker` rendered for the destination is
+ * committed to the screen. The marker is user-placed — the app decides what
+ * "the page has loaded" means by rendering the marker next to that content
+ * (typically inside the Suspense boundary whose reveal completes the page).
+ *
+ * The timestamp is the React commit that showed the marker, so
+ * `end.timestamp - commit.timestamp` measures the streaming/client-rendering
+ * cost paid after the navigation was applied. When the marker is part of the
+ * content the navigation itself commits (fully prefetched pages, hash-only
+ * navigations, BFCache traversals), `end` is reported in the same commit and
+ * carries the same timestamp as `commit`.
+ *
+ * At most one `end` is reported per transition, always after its `commit`.
+ * It is not guaranteed: a route that renders no marker, a marker whose
+ * content never streams in, or a newer navigation replacing the page before
+ * the marker shows all leave the transition with a `commit` but no `end`.
+ */
+export type RouterTransitionEndEvent = RouterTransitionEvent
+
 export type RouterTransitionAbortEvent = RouterTransitionEvent & {
   /**
    * The id of the transition whose commit replaced (and thereby aborted)
@@ -151,6 +172,11 @@ export type ClientInstrumentationHooks = {
     url: string,
     navigationType: RouterTransitionType,
     event: RouterTransitionCommitEvent
+  ) => void
+  unstable_onRouterTransitionEnd?: (
+    url: string,
+    navigationType: RouterTransitionType,
+    event: RouterTransitionEndEvent
   ) => void
   unstable_onRouterTransitionAbort?: (
     url: string,

--- a/packages/next/src/client/router-transition-types.ts
+++ b/packages/next/src/client/router-transition-types.ts
@@ -1,7 +1,15 @@
 export type RouterTransitionType = 'push' | 'replace' | 'traverse'
 
 export type RouterTransitionEvent = {
+  /** Opaque id shared by every event emitted for one transition. */
   id: string
+  /**
+   * High-resolution Unix epoch milliseconds, derived from the monotonic
+   * clock (`performance.timeOrigin + performance.now()`) rather than
+   * `Date.now()`, so timestamps within a page never step backwards. Subtract
+   * `performance.timeOrigin` to place an event on the performance timeline
+   * next to `PerformanceObserver` entries.
+   */
   timestamp: number
 }
 
@@ -134,22 +142,25 @@ export type RouterTransitionCommitEvent = RouterTransitionEvent & {
 
 /**
  * Emitted when the navigation's destination declares itself loaded: the first
- * `unstable_RouterTransitionEndMarker` rendered for the destination is
- * committed to the screen. The marker is user-placed — the app decides what
- * "the page has loaded" means by rendering the marker next to that content
- * (typically inside the Suspense boundary whose reveal completes the page).
+ * `unstable_RouterTransitionEndMarker` newly shown for the destination is
+ * committed to the screen — a fresh mount, or a preserved page re-shown by a
+ * traversal. The marker is user-placed — the app decides what "the page has
+ * loaded" means by rendering the marker next to that content (typically
+ * inside the Suspense boundary whose reveal completes the page).
  *
  * The timestamp is the React commit that showed the marker, so
  * `end.timestamp - commit.timestamp` measures the streaming/client-rendering
  * cost paid after the navigation was applied. When the marker is part of the
- * content the navigation itself commits (fully prefetched pages, hash-only
- * navigations, BFCache traversals), `end` is reported in the same commit and
- * carries the same timestamp as `commit`.
+ * content the navigation itself commits (a fully prefetched page's fresh
+ * mount, a preserved page re-shown by a traversal), `end` is reported in the
+ * same React commit, immediately after `commit`.
  *
  * At most one `end` is reported per transition, always after its `commit`.
  * It is not guaranteed: a route that renders no marker, a marker whose
- * content never streams in, or a newer navigation replacing the page before
- * the marker shows all leave the transition with a `commit` but no `end`.
+ * content never streams in, a newer navigation replacing the page before the
+ * marker shows, and a navigation that shows nothing new (hash-only: the
+ * already-on-screen marker never left the screen, so no marker newly shows)
+ * all leave the transition with a `commit` but no `end`.
  */
 export type RouterTransitionEndEvent = RouterTransitionEvent
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,6 +50,7 @@ export type {
   RouterTransitionRoute,
   RouterTransitionStartEvent,
   RouterTransitionCommitEvent,
+  RouterTransitionEndEvent,
   RouterTransitionAbortEvent,
 } from './client/router-transition-types'
 

--- a/test/e2e/instrumentation-client-hook/app-router/app/end-marker/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/end-marker/page.tsx
@@ -1,0 +1,15 @@
+// JSX treats lowercase-first tags as host elements, so the unstable_
+// export must be aliased to a capitalized name to render as a component.
+import { unstable_RouterTransitionEndMarker as RouterTransitionEndMarker } from 'next/navigation'
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="end-marker-page">End marker</h1>
+      {/* The marker is part of the page's own (static) content: it is
+          committed by the navigation itself, so `end` is reported in the
+          same React commit as `commit`. */}
+      <RouterTransitionEndMarker />
+    </>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
@@ -36,6 +36,14 @@ export default function RootLayout({ children }) {
           <li>
             <Link href="/query?tab=stats">Query page with query</Link>
           </li>
+          <li>
+            <Link href="/end-marker" prefetch={true}>
+              End marker page
+            </Link>
+          </li>
+          <li>
+            <Link href="/streaming">Streaming page</Link>
+          </li>
         </ul>
         {/* Rendered in the layout so the buttons are available on every page
             (several lifecycle tests navigate first and then trigger a race

--- a/test/e2e/instrumentation-client-hook/app-router/app/streaming-slow/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/streaming-slow/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+// JSX treats lowercase-first tags as host elements, so the unstable_
+// export must be aliased to a capitalized name to render as a component.
+import { unstable_RouterTransitionEndMarker as RouterTransitionEndMarker } from 'next/navigation'
+
+async function StreamedContent() {
+  // Like /streaming, but slow enough (~3s) that a test can deterministically
+  // interleave a shallow history update between the navigation's commit and
+  // the marker's reveal.
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 3000))
+  return (
+    <>
+      <p id="streaming-slow-content">Slowly streamed content</p>
+      <RouterTransitionEndMarker />
+    </>
+  )
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="streaming-slow-page">Streaming slow</h1>
+      <Suspense fallback={<p id="streaming-slow-fallback">Loading…</p>}>
+        <StreamedContent />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/streaming/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/streaming/page.tsx
@@ -1,0 +1,33 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+// JSX treats lowercase-first tags as host elements, so the unstable_
+// export must be aliased to a capitalized name to render as a component.
+import { unstable_RouterTransitionEndMarker as RouterTransitionEndMarker } from 'next/navigation'
+
+async function StreamedContent() {
+  // Dynamic + delayed so the content always arrives after the navigation
+  // commits: the commit shows the fallback, and the marker reveals with the
+  // streamed content ~1s later.
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  return (
+    <>
+      <p id="streaming-content">Streamed content</p>
+      {/* The app declares the page loaded when this content shows: the
+          marker is inside the Suspense boundary, so it mounts in the React
+          commit that reveals the streamed content. */}
+      <RouterTransitionEndMarker />
+    </>
+  )
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="streaming-page">Streaming</h1>
+      <Suspense fallback={<p id="streaming-fallback">Loading…</p>}>
+        <StreamedContent />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/test-controls.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/test-controls.tsx
@@ -11,6 +11,12 @@ export function TestControls() {
         Push hash
       </button>
       <button
+        id="push-end-marker-hash"
+        onClick={() => router.push('/end-marker#section')}
+      >
+        Push end-marker hash
+      </button>
+      <button
         id="push-no-prefetch"
         onClick={() => {
           // A programmatic push with no <Link> in the viewport: nothing was

--- a/test/e2e/instrumentation-client-hook/app-router/app/test-controls.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/test-controls.tsx
@@ -17,6 +17,23 @@ export function TestControls() {
         Push end-marker hash
       </button>
       <button
+        id="push-streaming-slow"
+        onClick={() => router.push('/streaming-slow')}
+      >
+        Push streaming slow
+      </button>
+      <button
+        id="shallow-tweak-streaming-slow"
+        onClick={() => {
+          // Shallow routing exactly as the docs recommend (app-owned null
+          // state): fails the internal-state guard in the patched pushState,
+          // so it dispatches the ACTION_RESTORE sync path.
+          window.history.pushState(null, '', '/streaming-slow?tab=2')
+        }}
+      >
+        Shallow tweak streaming slow
+      </button>
+      <button
         id="push-no-prefetch"
         onClick={() => {
           // A programmatic push with no <Link> in the viewport: nothing was

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -15,6 +15,9 @@ function record(
   ;(window as any).__ROUTER_TRANSITION_EVENTS.push({
     phase,
     url: new URL(href, window.location.href).pathname,
+    // The href argument exactly as the hook received it, for asserting the
+    // url shape contract (canonical relative form on every navigation type).
+    rawUrl: href,
     navigateType,
     event,
   })

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -51,6 +51,16 @@ export function unstable_onRouterTransitionCommit(
   record('commit', href, navigateType, event)
 }
 
+export function unstable_onRouterTransitionEnd(
+  href: string,
+  navigateType: string,
+  event: unknown
+) {
+  const pathname = new URL(href, window.location.href).pathname
+  console.log(`[Router Transition End] [${navigateType}] ${pathname}`)
+  record('end', href, navigateType, event)
+}
+
 export function unstable_onRouterTransitionAbort(
   href: string,
   navigateType: string,

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -376,6 +376,86 @@ describe('Instrumentation Client Hook', () => {
       })
     })
 
+    it('reports end when the destination’s end marker reveals with streamed content, after commit', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/streaming"]').click()
+      // The navigation commits with the Suspense fallback; the marker is
+      // inside the boundary, so `end` must not exist yet when the streamed
+      // content is still pending. Wait for the reveal, then for the event.
+      await browser.elementById('streaming-content')
+      const events = await retry(async () => {
+        const snapshot = await getTransitionEvents(browser)
+        expect(snapshot.filter((e) => e.phase === 'end')).toHaveLength(1)
+        return snapshot
+      })
+
+      const start = events.find((e) => e.phase === 'start')
+      const commit = lastCommit(events)
+      const end = events.find((e) => e.phase === 'end')
+      expect(end.url).toBe('/streaming')
+      expect(end.navigateType).toBe('push')
+      // `end` correlates to the same transition as its start/commit, is
+      // reported after `commit`, and carries exactly the public fields.
+      expect(end.event.id).toBe(start.event.id)
+      expect(end.event.id).toBe(commit.event.id)
+      expect(events.indexOf(end)).toBeGreaterThan(events.indexOf(commit))
+      expect(Object.keys(end.event).sort()).toEqual(['id', 'timestamp'])
+      // The reveal waited on the server's 1s delay, so the end-commit gap
+      // measures streaming cost: clearly after the commit, not the same
+      // instant. (Asserted loosely to keep slow CI off the flake list.)
+      expect(end.event.timestamp - commit.event.timestamp).toBeGreaterThan(100)
+    })
+
+    it('reports end in the same commit when the marker is part of the committed content', async () => {
+      const browser = await next.browser('/')
+
+      // The marker is in the page's own content and the link is prefetched,
+      // so the navigation commits with the marker already on screen: `end`
+      // reports immediately after `commit`, not in a later reveal.
+      await browser.waitForIdleNetwork()
+      await browser.elementByCss('a[href="/end-marker"]').click()
+      await browser.elementById('end-marker-page')
+      const events = await retry(async () => {
+        const snapshot = await getTransitionEvents(browser)
+        expect(snapshot.filter((e) => e.phase === 'end')).toHaveLength(1)
+        return snapshot
+      })
+
+      const commit = lastCommit(events)
+      const end = events.find((e) => e.phase === 'end')
+      expect(end.event.id).toBe(commit.event.id)
+      expect(events.indexOf(end)).toBeGreaterThan(events.indexOf(commit))
+      expect(end.event.timestamp).toBeGreaterThanOrEqual(commit.event.timestamp)
+    })
+
+    it('reports no end for a route that renders no marker', async () => {
+      const browser = await next.browser('/')
+
+      // Navigate to an unmarked route, then to a marked one. The marked
+      // navigation’s `end` is the fence that bounds the wait: once it
+      // arrives, the unmarked navigation can no longer produce one.
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await waitForCommitCount(browser, 1)
+
+      await browser.elementByCss('a[href="/end-marker"]').click()
+      await browser.elementById('end-marker-page')
+      const events = await retry(async () => {
+        const snapshot = await getTransitionEvents(browser)
+        expect(snapshot.filter((e) => e.phase === 'end')).toHaveLength(1)
+        return snapshot
+      })
+
+      // The only `end` belongs to the marked navigation — the unmarked
+      // one ended its lifecycle at `commit`.
+      const commits = events.filter((e) => e.phase === 'commit')
+      expect(commits).toHaveLength(2)
+      const end = events.find((e) => e.phase === 'end')
+      expect(end.event.id).toBe(commits[1].event.id)
+      expect(end.event.id).not.toBe(commits[0].event.id)
+    })
+
     it('describes routes across group, dynamic, catch-all, rewritten, hash, query, and intercepted URLs', async () => {
       // One journey through every route-description shape the describe logic
       // handles; each leg waits for its commit and asserts on the newest

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -503,6 +503,51 @@ describe('Instrumentation Client Hook', () => {
       )
     })
 
+    it('reports no end for a hash-only navigation on a marked page: nothing newly shows', async () => {
+      const browser = await next.browser('/')
+      await browser.waitForIdleNetwork()
+
+      // Land on the marked page (end #1).
+      await browser.elementByCss('a[href="/end-marker"]').click()
+      await browser.elementById('end-marker-page')
+      await retry(async () => {
+        expect(
+          (await getTransitionEvents(browser)).filter((e) => e.phase === 'end')
+        ).toHaveLength(1)
+      })
+
+      // A hash-only push on the marked page: the committed tree is the tree
+      // already on screen, so its marker never leaves the screen and nothing
+      // newly shows — the navigation commits but no marker declares a load.
+      await browser.elementById('push-end-marker-hash').click()
+      await waitForCommitCount(browser, 2)
+
+      // Fence: leave and re-enter the marked page. Its `end` bounds the
+      // negative wait — once it arrives, the hash navigation (which committed
+      // two navigations earlier) can no longer produce one.
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await waitForCommitCount(browser, 3)
+      await browser.elementByCss('a[href="/end-marker"]').click()
+      const events = await retry(async () => {
+        const snapshot = await getTransitionEvents(browser)
+        expect(snapshot.filter((e) => e.phase === 'end')).toHaveLength(2)
+        return snapshot
+      })
+
+      const commits = events.filter((e) => e.phase === 'commit')
+      expect(commits).toHaveLength(4)
+      const hashCommit = commits[1]
+      expect(hashCommit.event.to.canonicalUrl).toBe('/end-marker#section')
+      // Both ends belong to the full navigations onto the marked page —
+      // neither to the hash-only one.
+      const ends = events.filter((e) => e.phase === 'end')
+      expect(ends.map((e) => e.event.id)).toEqual([
+        commits[0].event.id,
+        commits[3].event.id,
+      ])
+    })
+
     it('reports the canonical relative URL on every navigation type, including traversals', async () => {
       const browser = await next.browser('/')
 

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -456,6 +456,75 @@ describe('Instrumentation Client Hook', () => {
       expect(end.event.id).not.toBe(commits[0].event.id)
     })
 
+    it('reports end when a traversal re-shows a marked route, and none for an unmarked one', async () => {
+      const browser = await next.browser('/')
+      await browser.waitForIdleNetwork()
+
+      // Visit the marked page (end #1), then an unmarked page: two pushes.
+      await browser.elementByCss('a[href="/end-marker"]').click()
+      await browser.elementById('end-marker-page')
+      await retry(async () => {
+        const snapshot = await getTransitionEvents(browser)
+        expect(snapshot.filter((e) => e.phase === 'end')).toHaveLength(1)
+      })
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await waitForCommitCount(browser, 2)
+
+      // Traverse back to the marked page. Under cacheComponents the page was
+      // preserved in a hidden <Activity> boundary, so nothing remounts — the
+      // reveal itself must report the traversal's `end`. (Element waits can't
+      // fence this step: the hidden page's DOM is still attached, so the
+      // marker element is findable before the traversal commits.)
+      await browser.back()
+      const events = await retry(async () => {
+        const snapshot = await getTransitionEvents(browser)
+        expect(snapshot.filter((e) => e.phase === 'end')).toHaveLength(2)
+        return snapshot
+      })
+
+      const traverseCommit = lastCommit(events)
+      expect(traverseCommit.navigateType).toBe('traverse')
+      expect(traverseCommit.event.to.canonicalUrl).toBe('/end-marker')
+      const ends = events.filter((e) => e.phase === 'end')
+      // The traversal's own `end`, after its `commit` — not a late report
+      // against the push that first mounted the marker, and nothing for the
+      // unmarked page's push.
+      expect(ends[1].event.id).toBe(traverseCommit.event.id)
+      expect(events.indexOf(ends[1])).toBeGreaterThan(
+        events.indexOf(traverseCommit)
+      )
+      expect(ends[1].event.timestamp).toBeGreaterThanOrEqual(
+        traverseCommit.event.timestamp
+      )
+      const somePageCommit = events.filter((e) => e.phase === 'commit')[1]
+      expect(ends.some((e) => e.event.id === somePageCommit.event.id)).toBe(
+        false
+      )
+    })
+
+    it('reports the canonical relative URL on every navigation type, including traversals', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/some-page"]').click()
+      await browser.elementById('some-page')
+      await waitForCommitCount(browser, 1)
+      await browser.back()
+      const events = await waitForCommitCount(browser, 2)
+
+      // The hooks' `url` argument is the canonical relative href for pushes
+      // and traversals alike: a traversal must not leak the absolute
+      // `location.href` the popstate handler works with.
+      const push = events.find((e) => e.phase === 'start')
+      expect(push.navigateType).toBe('push')
+      expect(push.rawUrl).toBe('/some-page')
+      const traverseEvents = events.filter((e) => e.navigateType === 'traverse')
+      expect(traverseEvents.length).toBeGreaterThanOrEqual(2)
+      for (const event of traverseEvents) {
+        expect(event.rawUrl).toBe('/')
+      }
+    })
+
     it('describes routes across group, dynamic, catch-all, rewritten, hash, query, and intercepted URLs', async () => {
       // One journey through every route-description shape the describe logic
       // handles; each leg waits for its commit and asserts on the newest

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -407,6 +407,40 @@ describe('Instrumentation Client Hook', () => {
       expect(end.event.timestamp - commit.event.timestamp).toBeGreaterThan(100)
     })
 
+    it('reports end when shallow routing happens while the destination is still streaming', async () => {
+      const browser = await next.browser('/')
+
+      // Navigate to the slow-streaming marked page: the navigation commits
+      // with the fallback and the marker's content streams for ~3s.
+      await browser.elementById('push-streaming-slow').click()
+      const commit = lastCommit(await waitForCommitCount(browser, 1))
+
+      // Shallow-update the URL the way the docs recommend
+      // (history.pushState with app-owned state) while the content is still
+      // streaming. The restore this dispatches derives a state from the
+      // navigation's — it must carry the navigation's transition forward, or
+      // the marker reveals under a null context and the `end` is dropped.
+      await browser.elementById('shallow-tweak-streaming-slow').click()
+      await retry(async () => {
+        expect(await browser.eval('window.location.search')).toBe('?tab=2')
+      })
+
+      await browser.elementById('streaming-slow-content')
+      const events = await retry(async () => {
+        const snapshot = await getTransitionEvents(browser)
+        expect(snapshot.filter((e) => e.phase === 'end')).toHaveLength(1)
+        return snapshot
+      })
+      const end = events.find((e) => e.phase === 'end')
+      expect(end.event.id).toBe(commit.event.id)
+      expect(end.event.timestamp).toBeGreaterThan(commit.event.timestamp)
+      // The shallow update is not a navigation: it must not corrupt the rest
+      // of the lifecycle either — no extra start/commit, no bogus abort.
+      expect(events.filter((e) => e.phase === 'start')).toHaveLength(1)
+      expect(events.filter((e) => e.phase === 'commit')).toHaveLength(1)
+      expect(events.filter((e) => e.phase === 'abort')).toHaveLength(0)
+    })
+
     it('reports end in the same commit when the marker is part of the committed content', async () => {
       const browser = await next.browser('/')
 


### PR DESCRIPTION
## Summary

Stacked on #95531.

Adds the third lifecycle event to the instrumentation-client router transition hooks: `unstable_onRouterTransitionEnd`, reporting when the destination page **declares itself loaded**. The declaration is a user-placed marker component:

```tsx
import { unstable_RouterTransitionEndMarker as RouterTransitionEndMarker } from 'next/navigation'

<Suspense fallback={<Skeleton />}>
  <Feed />
  <RouterTransitionEndMarker />
</Suspense>
```

When the first marker rendered for a navigation's destination is committed to the screen, the transition's `end` fires with that commit's timestamp. Together with the existing events, the latency story is complete:

| span | measures |
|---|---|
| `commit - start` | how long the navigation blocked before it was applied |
| `end - commit` | streaming / client-rendering cost paid after it was applied |

read against `cacheHit` (#95531), which attributes the first span to prefetching.

### Why a user-placed marker

The framework can only observe segment-granularity reveals; the user's own `<Suspense>` boundaries — where the content that actually matters streams in — are invisible to it. Inverting the responsibility makes React's reveal semantics do the measurement: a boundary only commits once its content is ready, so *marker mounted* = *the content the app declared meaningful is on screen*. It also gives `end` app-defined meaning (element-timing style) that no heuristic could infer, and composes: a marker in `error.tsx` reports an end for failed loads too.

Semantics:

- **First marker wins.** At most one `end` per transition, always after its `commit`, reported by whichever marker shows first. Later markers, StrictMode replays, and re-renders are no-ops (the transition's phase latch gains an `ended` state).
- **Same-commit degenerate case.** When the marker is part of the content the navigation itself commits (fully prefetched page, hash-only navigation, BFCache traversal), `end` reports in the same React commit as `commit`.
- **Not guaranteed.** No marker on the route, content that never streams in, or a newer navigation replacing the page all leave a transition with a `commit` but no `end` — the same "no terminal event" contract failed navigations already have.
- A marker that stays mounted across a navigation (shared layout) does not re-report — nothing new was shown. Markers belong in page-level content.

### How the marker attributes itself

The transition's identity lives on the router state (`AppRouterState.instrumentationTransition`, introduced in #95328): this PR adds the render-time consumer. `RouterTransitionEndContext` — provided by AppRouter, DCE'd when the flag is off — exposes the current state's transition to markers. Because markers read it at **render time**, a marker mounting in the very commit that applies the navigation attributes correctly even if its insertion effect runs before HistoryUpdater's; that ordering only affects *when* the event is emitted, which the `markerDidShow` handoff resolves (the commit emission reports `end` right after `commit`, with the same timestamp). A marker revealed by streamed content later reports immediately, against the page the user is actually on.

Note on naming: like React's own `unstable_`-prefixed components, the export must be aliased to a capitalized name at the import site — JSX treats lowercase-first tags as host elements (this is called out in the component's JSDoc; an unaliased `<unstable_RouterTransitionEndMarker />` silently renders a custom element).

## Verification

- `pnpm test-dev-turbo test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts` — 29 passed.
- `pnpm test-start-turbo test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts` — 28 passed (pre-restack; re-verified in dev after restacking onto the state-borne base).
- Manual smoke against a minimal app (`next dev`): `/end-marker` (marker in prefetched static content) reported `end` 0.6ms after `commit` in the same React commit; `/streaming` (marker inside a Suspense boundary with a 1s server delay) reported `end` ~997ms after `commit`, correlated by id, payload exactly `{id, timestamp}`.

<!-- NEXT_JS_LLM_PR -->
