### PR TITLE
Add `prefetch: 'app-shell'` option to the instant() navigation testing helper

### DIFF
--- a/packages/next-playwright/README.md
+++ b/packages/next-playwright/README.md
@@ -61,6 +61,36 @@ test('navigates to profile instantly', async ({ page }) => {
 })
 ```
 
+**Asserting on the App Shell only** (`prefetch: 'app-shell'`):
+
+By default, `instant()` assumes everything the link would have prefetched is
+cached — including per-link data and runtime-prefetched data on routes that
+allow runtime prefetching. To assert only on the route's shared
+[App Shell](https://nextjs.org/docs/app/guides/runtime-prefetching#app-shells)
+— the param- and searchParam-independent part that is reused across every
+navigation to the route — pass `prefetch: 'app-shell'`:
+
+```ts
+test('renders the app shell during navigation', async ({ page }) => {
+  await page.goto('/')
+
+  await instant(
+    page,
+    async () => {
+      await page.click('a[href="/products/123"]')
+
+      // Only the App Shell renders — content that depends on the concrete
+      // params (even runtime-prefetchable content) shows its fallback
+      await expect(page.locator('[data-testid="product-fallback"]')).toBeVisible()
+    },
+    { prefetch: 'app-shell' }
+  )
+
+  // After instant() returns, the rest of the page streams in
+  await expect(page.locator('[data-testid="product-name"]')).toBeVisible()
+})
+```
+
 ### Enabling in production builds
 
 In development (`next dev`), the testing API is available by default. In

--- a/packages/next-playwright/src/index.ts
+++ b/packages/next-playwright/src/index.ts
@@ -46,6 +46,30 @@ const INSTANT_COOKIE = 'next-instant-navigation-testing'
 // shares the browser context.
 const contextsWithActiveScope = new WeakSet<PlaywrightBrowserContext>()
 
+export interface InstantOptions {
+  /**
+   * The base URL of the application, used to scope the instant cookie to the
+   * correct domain before the first page load. If the page is already loaded,
+   * the URL is inferred automatically.
+   */
+  baseURL?: string
+  /**
+   * Which prefetched data the simulated warm cache contains.
+   *
+   * By default, navigations render everything the link would have prefetched —
+   * including per-link data and runtime-prefetched data (for routes that allow
+   * runtime prefetching).
+   *
+   * Pass `'app-shell'` to simulate a cache where only the route's shared App
+   * Shell is warm: navigations render just the App Shell (the param- and
+   * searchParam-independent part of the route, including its loading
+   * boundaries), regardless of the link's own prefetch configuration. Per-link
+   * and runtime-prefetched data is deferred until the callback returns, like
+   * any other dynamic data.
+   */
+  prefetch?: 'app-shell'
+}
+
 /**
  * Runs a function with instant navigation enabled. Within this scope,
  * navigations render the prefetched UI immediately and wait for the
@@ -64,13 +88,23 @@ const contextsWithActiveScope = new WeakSet<PlaywrightBrowserContext>()
  *     // ...
  *   }, { baseURL: 'http://localhost:3000' })
  *
+ * Pass `prefetch: 'app-shell'` to assert on just the App Shell — the
+ * shared, param-independent part of the route — instead of everything
+ * the link would have prefetched:
+ *
+ *   await instant(page, async () => {
+ *     await page.click('a[href="/products/123"]')
+ *     // Only the App Shell (e.g. loading boundaries) is rendered;
+ *     // per-link and runtime-prefetched data is deferred.
+ *   }, { prefetch: 'app-shell' })
+ *
  * When `@playwright/test` is installed, acquire/release actions appear
  * as labeled steps in the Playwright UI.
  */
 export async function instant<T>(
   page: PlaywrightPage,
   fn: () => Promise<T>,
-  options?: { baseURL?: string }
+  options?: InstantOptions
 ): Promise<T> {
   const context = page.context()
   if (contextsWithActiveScope.has(context)) {
@@ -99,11 +133,19 @@ export async function instant<T>(
     // ensures the cookie is present even on the very first navigation. The
     // cookie triggers the CookieStore change event in
     // navigation-testing-lock.ts, which acquires the in-memory navigation lock.
+    //
+    // The pending value optionally carries the scope's options in its third
+    // slot; Next.js preserves them on captured values so they survive MPA
+    // page loads within the scope.
+    const pendingValue =
+      options?.prefetch === 'app-shell'
+        ? [0, `p${Math.random()}`, { prefetch: 'app-shell' }]
+        : [0, `p${Math.random()}`]
     await step('Acquire Instant Lock', () =>
       context.addCookies([
         {
           name: INSTANT_COOKIE,
-          value: JSON.stringify([0, `p${Math.random()}`]),
+          value: JSON.stringify(pendingValue),
           domain: hostname,
           path: '/',
         },
@@ -170,10 +212,7 @@ async function releaseInstantCookie(
  * Throws a descriptive error if neither is available (e.g. fresh page
  * before any navigation).
  */
-function resolveURL(
-  page: PlaywrightPage,
-  options?: { baseURL?: string }
-): string {
+function resolveURL(page: PlaywrightPage, options?: InstantOptions): string {
   const url = options?.baseURL ?? page.url()
   if (url && url !== 'about:blank') {
     return url

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -15,6 +15,7 @@ import {
   PrefetchHint,
   type FlightRouterState,
   type InstantCookie,
+  type InstantCookieOptions,
 } from '../../../shared/lib/app-router-types'
 import { NEXT_INSTANT_TEST_COOKIE } from '../app-router-headers'
 import { refreshOnInstantNavigationUnlock } from '../use-action-queue'
@@ -28,20 +29,46 @@ import type { FetchStrategy } from './types'
 
 type InstantNavCookieState = 'empty' | 'pending' | 'mpa' | 'spa'
 
-function parseCookieValue(raw: string): InstantNavCookieState {
+type ParsedInstantCookie = {
+  state: InstantNavCookieState
+  options: InstantCookieOptions | null
+}
+
+/**
+ * Extracts the scope options from a cookie value's options slot. Only shapes
+ * we understand are accepted; anything else is treated as "no options" so a
+ * malformed value degrades to the default behavior.
+ */
+function parseCookieOptions(raw: unknown): InstantCookieOptions | null {
+  if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
+    if ((raw as InstantCookieOptions).prefetch === 'app-shell') {
+      return { prefetch: 'app-shell' }
+    }
+  }
+  return null
+}
+
+function parseCookieValue(raw: string): ParsedInstantCookie {
   if (raw === '') {
-    return 'empty'
+    return { state: 'empty', options: null }
   }
   try {
     const parsed = JSON.parse(raw)
     if (Array.isArray(parsed)) {
-      if (parsed.length >= 3) {
+      // Captured values have 1 as their first element; a pending value starts
+      // with 0 and may carry an options object in its third slot, so the array
+      // length alone can't distinguish the two.
+      if (parsed[0] === 1 && parsed.length >= 3) {
         const rawState = parsed[2]
-        return rawState === null ? 'mpa' : 'spa'
+        return {
+          state: rawState === null ? 'mpa' : 'spa',
+          options: parseCookieOptions(parsed[3]),
+        }
       }
+      return { state: 'pending', options: parseCookieOptions(parsed[2]) }
     }
   } catch {}
-  return 'pending'
+  return { state: 'pending', options: null }
 }
 
 function writeDocumentCookie(
@@ -84,6 +111,12 @@ function writeCookieValue(value: InstantCookie): void {
   // clears any such entry once the lock is released (see the `event.deleted`
   // loop below).
   const lockAtCall = lockState
+  // Preserve the scope's options on self-written (captured) values so they
+  // survive MPA page loads within the scope: the bootstrap on a fresh document
+  // re-reads them synchronously from the cookie.
+  if (lockAtCall !== null && lockAtCall.appShellOnly && value[0] === 1) {
+    value = [value[0], value[1], value[2], { prefetch: 'app-shell' }]
+  }
   cookieStore.get(NEXT_INSTANT_TEST_COOKIE).then((existing: any) => {
     if (existing && lockState === lockAtCall && lockAtCall !== null) {
       writeDocumentCookie(value, existing)
@@ -109,6 +142,11 @@ export type NavigationLockPrefetch = {
   resolve: () => void
   pendingCount: number
   trackedEntries: Set<PendingSegmentCacheEntry>
+  // Mirrors NavigationLockState.appShellOnly for the scope this prefetch was
+  // created in. When true, the scheduler stops the locked-navigation prefetch
+  // after the App Shell phases (skipping the Speculative phase), and the
+  // navigation forces the App Shell fetch strategy.
+  appShellOnly: boolean
 }
 
 export type NavigationLockState = {
@@ -133,6 +171,12 @@ export type NavigationLockState = {
   // entry left in the cache by an earlier navigation or prefetch. See
   // `readSegmentCacheEntryForNavigation`.
   ownedEntries: Set<SegmentCacheEntry>
+  // When true (instant() was configured with `prefetch: 'app-shell'`), locked
+  // navigations simulate a cache where only the route's shared App Shell is
+  // warm: the locked prefetch stops after the Shell phase — no per-link
+  // concrete-param or runtime-prefetch data is fetched — and navigation reads
+  // are restricted to shell entries regardless of the link's fetch strategy.
+  appShellOnly: boolean
 }
 
 let lockState: NavigationLockState | null = null
@@ -166,6 +210,7 @@ export function beginNavigationLockPrefetch(): NavigationLockPrefetch | null {
       resolve: resolve!,
       pendingCount: 1,
       trackedEntries: new Set(),
+      appShellOnly: lockState.appShellOnly,
     }
     lockState.activePrefetches.add(prefetch)
     return prefetch
@@ -244,7 +289,7 @@ function settleNavigationLockPrefetchIfDrained(
   }
 }
 
-function acquireLock(): void {
+function acquireLock(options: InstantCookieOptions | null): void {
   if (lockState !== null) {
     return
   }
@@ -258,6 +303,7 @@ function acquireLock(): void {
     fetch: window.fetch,
     activePrefetches: new Set(),
     ownedEntries: new Set(),
+    appShellOnly: options !== null && options.prefetch === 'app-shell',
   }
 
   // Install the fetch blocker. We only intercept `window.fetch` for the
@@ -332,9 +378,19 @@ export function startListeningForInstantNavigationCookie(): void {
     // If the server served a shell, this is an MPA page load
     // while the lock is held. Transition to captured-MPA and acquire.
     if (self.__next_instant_test) {
+      // The external actor can release the scope after the server renders the
+      // shell but before this bootstrap runs. Check synchronously before
+      // acquiring so that window does not create a lock with no deletion event
+      // left to release it.
+      const initialCookie = readCookieFromDocument()
+      if (initialCookie === null) {
+        window.location.reload()
+        return
+      }
+
       if (typeof cookieStore !== 'undefined') {
-        // If the cookie was already cleared during the MPA page
-        // transition, reload to get the full dynamic page.
+        // Catch a release that happens after the synchronous read above but
+        // before the Cookie Store listener below is ready.
         cookieStore.get(NEXT_INSTANT_TEST_COOKIE).then((cookie: any) => {
           if (!cookie) {
             window.location.reload()
@@ -346,8 +402,10 @@ export function startListeningForInstantNavigationCookie(): void {
       // guard requires lockState to be non-null at call time (so a stale
       // write can't outlive its scope). On a fresh page load that scope
       // is the one we're about to establish, so we have to establish it
-      // first.
-      acquireLock()
+      // first. The scope's options are recovered synchronously from the
+      // cookie (self-writes preserve them across captured transitions, so
+      // they survive multiple page loads within one scope).
+      acquireLock(initialCookie.options)
       writeCookieValue([1, `c${Math.random()}`, null])
     }
 
@@ -358,7 +416,7 @@ export function startListeningForInstantNavigationCookie(): void {
     cookieStore.addEventListener('change', (event: CookieChangeEvent) => {
       for (const cookie of event.changed) {
         if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
-          const state = parseCookieValue(cookie.value ?? '')
+          const { state, options } = parseCookieValue(cookie.value ?? '')
 
           if (state === 'pending') {
             // External actor starting a new lock scope.
@@ -367,17 +425,26 @@ export function startListeningForInstantNavigationCookie(): void {
               // cookie that was already observed synchronously from
               // document.cookie. Keep the existing lock identity so work that
               // captured it keeps waiting on the same promise.
-              return
+              break
             }
-            acquireLock()
+            acquireLock(options)
+            break
           }
-          // Captured value (our own transition) or empty. Ignore.
-          return
+          // Captured value (our own transition) or empty. Keep processing the
+          // event because Cookie Store may batch it with the deletion that
+          // releases the current lock.
+          break
         }
       }
 
       for (const cookie of event.deleted) {
         if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
+          const currentCookie = readCookieFromDocument()
+          if (currentCookie?.state === 'pending') {
+            // This deletion belongs to a stale entry from the previous scope;
+            // a new externally-created pending scope is already current.
+            return
+          }
           if (lockState === null) {
             // Either no lock is active, or this is the re-entrant change event
             // from the defensive clear below (which runs after releaseLock).
@@ -444,18 +511,41 @@ export function isNavigationLocked(): boolean {
     const target = NEXT_INSTANT_TEST_COOKIE + '='
     for (const segment of allCookies.split(';')) {
       const trimmed = segment.trim()
-      if (
-        trimmed.startsWith(target) &&
-        parseCookieValue(trimmed.slice(target.length)) === 'pending'
-      ) {
-        // The cookie was set by an external actor but the change event was not
-        // yet dispatched. Acquire the lock synchronously.
-        acquireLock()
-        return true
+      if (trimmed.startsWith(target)) {
+        const { state, options } = parseCookieValue(
+          trimmed.slice(target.length)
+        )
+        if (state === 'pending') {
+          // The cookie was set by an external actor but the change event was
+          // not yet dispatched. Acquire the lock synchronously.
+          acquireLock(options)
+          return true
+        }
       }
     }
   }
   return false
+}
+
+/**
+ * Synchronously reads the scope options from the instant cookie in
+ * `document.cookie`. Used during the MPA bootstrap, where the lock must be
+ * established before any async cookie read could resolve. The cookie may hold
+ * either the pending value written by the external actor or a captured value
+ * from an earlier navigation in the same scope; both carry the options.
+ */
+function readCookieFromDocument(): ParsedInstantCookie | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+  const target = NEXT_INSTANT_TEST_COOKIE + '='
+  for (const segment of document.cookie.split(';')) {
+    const trimmed = segment.trim()
+    if (trimmed.startsWith(target)) {
+      return parseCookieValue(trimmed.slice(target.length))
+    }
+  }
+  return null
 }
 
 export function getCurrentNavigationLock(): NavigationLockState | null {
@@ -463,6 +553,22 @@ export function getCurrentNavigationLock(): NavigationLockState | null {
     return lockState
   }
   return null
+}
+
+/**
+ * Returns true if the navigation lock is active and the scope simulates an
+ * App Shell-only cache (instant() was configured with `prefetch:
+ * 'app-shell'`). Unlike the locked navigation's own prefetch — which carries
+ * the flag on its NavigationLockPrefetch — this is consulted for every other
+ * prefetch task processed while the scope is active (e.g. a hover- or
+ * viewport-initiated link prefetch), so no per-link concrete-param or
+ * runtime-prefetch data is fetched anywhere during the scope.
+ */
+export function isNavigationLockedToAppShell(): boolean {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    return isNavigationLocked() && lockState !== null && lockState.appShellOnly
+  }
+  return false
 }
 
 /**
@@ -478,6 +584,10 @@ export function getCurrentNavigationLock(): NavigationLockState | null {
  * `<Link prefetch={true}>` or an eagerly-prefetched subtree, in which case the
  * concrete-param entry is genuinely warm and may be matched.
  *
+ * When the scope was configured with `prefetch: 'app-shell'`, it explicitly
+ * simulates a cache where only the App Shell is warm, so the restriction
+ * applies regardless of the route's hints or the link's fetch strategy.
+ *
  * Always returns false outside the testing API; the branch below is eliminated
  * from production bundles.
  */
@@ -486,8 +596,15 @@ export function shouldRestrictNavigationToShell(
   linkFetchStrategy: FetchStrategy
 ): boolean {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    if (!isNavigationLocked()) {
+      return false
+    }
+    // isNavigationLocked() acquires the lock synchronously if the pending
+    // cookie hasn't been observed yet, so lockState is non-null here.
+    if (lockState !== null && lockState.appShellOnly) {
+      return true
+    }
     return (
-      isNavigationLocked() &&
       (rootPrefetchHints & PrefetchHint.SubtreeHasPartialPrefetching) !== 0 &&
       !subtreeHasSpeculativePrefetch(linkFetchStrategy, rootPrefetchHints)
     )

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -1073,7 +1073,6 @@ async function ensurePrefetchThenNavigate(
   navigationLock: NavigationLock
 ): Promise<AppRouterState> {
   const link = getLinkForCurrentNavigation()
-  const fetchStrategy = link !== null ? link.fetchStrategy : FetchStrategy.PPR
 
   const cacheKey = createCacheKey(url.href, nextUrl)
 
@@ -1085,6 +1084,18 @@ async function ensurePrefetchThenNavigate(
   const { beginNavigationLockPrefetch } =
     require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
   const navigationLockPrefetch = beginNavigationLockPrefetch()
+
+  // When the scope simulates an App Shell-only cache, ignore the link's own
+  // fetch strategy (e.g. prefetch={true}) and use the default strategy — the
+  // scheduler stops the task after the App Shell phases anyway, and the
+  // simulation should not depend on how the link is configured.
+  const fetchStrategy =
+    navigationLockPrefetch !== null && navigationLockPrefetch.appShellOnly
+      ? FetchStrategy.PPR
+      : link !== null
+        ? link.fetchStrategy
+        : FetchStrategy.PPR
+
   schedulePrefetchTask(
     cacheKey,
     currentFlightRouterState,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -573,22 +573,42 @@ function processQueueInMicrotask() {
         // Continue to the next task
         task = heapPeek(taskHeap)
         continue
-      case PrefetchTaskExitStatus.Done:
-        if (task.phase === PrefetchPhase.RouteTree) {
+      case PrefetchTaskExitStatus.Done: {
+        // Instant Navigation Testing API: while a scope simulates an App
+        // Shell-only cache, every prefetch task stops before the Speculative
+        // phase, so no per-link concrete-param or runtime-prefetch data is
+        // fetched during the scope. This covers both the locked-navigation
+        // prefetch itself and incidental link prefetches (e.g. the hover-
+        // intent reschedule triggered by clicking the link). Background work
+        // is skipped too.
+        const stopBeforeSpeculativePhase =
+          process.env.__NEXT_EXPOSE_TESTING_API &&
+          (task._navigationLockPrefetch != null
+            ? task._navigationLockPrefetch.appShellOnly
+            : (
+                require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
+              ).isNavigationLockedToAppShell())
+        if (
+          task.phase === PrefetchPhase.RouteTree &&
+          !(stopBeforeSpeculativePhase && !process.env.__NEXT_APP_SHELLS)
+        ) {
           // Finished prefetching the route tree. If App Shells are enabled,
           // run the Shell phase next; otherwise go straight to Speculative.
           task.phase = process.env.__NEXT_APP_SHELLS
             ? PrefetchPhase.Shell
             : PrefetchPhase.Speculative
           heapResift(taskHeap, task)
-        } else if (task.phase === PrefetchPhase.Shell) {
+        } else if (
+          task.phase === PrefetchPhase.Shell &&
+          !stopBeforeSpeculativePhase
+        ) {
           // Shell phase complete. Always advance to Speculative regardless
           // of whether Shell-phase work fired — Speculative is responsible
           // for the per-link concrete work and runs even on routes whose
           // shell phase was a no-op.
           task.phase = PrefetchPhase.Speculative
           heapResift(taskHeap, task)
-        } else if (hasBackgroundWork) {
+        } else if (hasBackgroundWork && !stopBeforeSpeculativePhase) {
           // The task spawned additional background work. Reschedule the task
           // at background priority.
           task.priority = PrefetchPriority.Background
@@ -613,6 +633,7 @@ function processQueueInMicrotask() {
         }
         task = heapPeek(taskHeap)
         continue
+      }
       default:
         exitStatus satisfies never
     }

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -543,14 +543,30 @@ export type RSCPayload =
   | NavigationFlightResponse
   | ActionFlightResponse
 
+/**
+ * Options for an Instant Navigation Testing scope, set by the external actor
+ * (Playwright, devtools) on the pending cookie value and preserved by Next.js
+ * on captured values so they survive MPA page loads within the scope.
+ */
+export type InstantCookieOptions = {
+  /**
+   * When 'app-shell', locked navigations simulate a cache where only the
+   * route's shared App Shell is warm: the locked prefetch stops after the
+   * Shell phase (no per-link concrete-param or runtime-prefetch data is
+   * fetched) and navigation reads are restricted to shell entries.
+   */
+  prefetch?: 'app-shell'
+}
+
 export type InstantCookie =
   // pending (waiting to capture)
-  | [captured: 0, id: string]
+  | [captured: 0, id: string, options?: InstantCookieOptions]
   // captured MPA page load
-  | [captured: 1, id: string, state: null]
+  | [captured: 1, id: string, state: null, options?: InstantCookieOptions]
   // captured SPA navigation (from/to route trees)
   | [
       captured: 1,
       id: string,
       state: { from: FlightRouterState; to: FlightRouterState | null },
+      options?: InstantCookieOptions,
     ]

--- a/packages/next/src/shared/lib/instant-nav-cookie.ts
+++ b/packages/next/src/shared/lib/instant-nav-cookie.ts
@@ -12,7 +12,10 @@ export type InstantNavCookieData =
 export function parseInstantNavCookieValue(raw: string): InstantNavCookieData {
   try {
     const parsed = JSON.parse(raw)
-    if (Array.isArray(parsed) && parsed.length >= 3) {
+    // Captured values have 1 as their first element; a pending value starts
+    // with 0 and may carry an options object (see InstantCookieOptions), so
+    // the array length alone can't distinguish the two.
+    if (Array.isArray(parsed) && parsed[0] === 1 && parsed.length >= 3) {
       const rawState = parsed[2]
       if (rawState === null) {
         return { state: 'mpa' }

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/courses/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/courses/page.tsx
@@ -1,0 +1,95 @@
+/**
+ * The standard App Shell example (see the Runtime Prefetching guide): the
+ * destination mixes four kinds of content.
+ *
+ * - a static heading                        -> part of the App Shell
+ * - <FeaturedCourses>, 'use cache'          -> part of the App Shell
+ * - <EnrolledBadge>, reads a session cookie -> part of the App Shell: the
+ *                                              route reads cookies, so the
+ *                                              shell is the session-
+ *                                              personalized variant
+ * - <SortLabel>, reads searchParams         -> per-link data, omitted from
+ *                                              the App Shell
+ * - <LiveEnrollment>, uncached per request  -> only streams in after
+ *                                              navigation
+ *
+ * The App Shell is the route's rendered output minus per-link data. A runtime
+ * prefetch (`prefetch = 'allow-runtime'` + `<Link prefetch={true}>`)
+ * additionally resolves the link's searchParams.
+ */
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+
+export const prefetch = 'allow-runtime'
+
+type SearchParams = { [key: string]: string | string[] | undefined }
+
+export default function CoursesPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  return (
+    <>
+      <h1 data-testid="courses-heading">Courses</h1>
+      <Suspense
+        fallback={<p data-testid="badge-fallback">Checking enrollment...</p>}
+      >
+        <EnrolledBadge />
+      </Suspense>
+      <FeaturedCourses />
+      <Suspense fallback={<p data-testid="sort-fallback">Sorting...</p>}>
+        <SortLabel searchParams={searchParams} />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="live-fallback">Loading live count...</p>}
+      >
+        <LiveEnrollment />
+      </Suspense>
+    </>
+  )
+}
+
+// Reads the session cookie. The route therefore produces a session-
+// personalized App Shell variant, cached per session on the client rather
+// than shared across users — the badge is part of that shell.
+async function EnrolledBadge() {
+  const enrolled = (await cookies()).get('enrolled')?.value
+  return (
+    <p data-testid="enrolled-badge">
+      {enrolled ? `Enrolled: ${enrolled}` : 'Not enrolled'}
+    </p>
+  )
+}
+
+// Cached, request-independent: part of the App Shell.
+async function FeaturedCourses() {
+  'use cache'
+  const featured = ['Next.js from First Principles', 'React for Two']
+  return (
+    <ul data-testid="featured-courses">
+      {featured.map((title) => (
+        <li key={title}>{title}</li>
+      ))}
+    </ul>
+  )
+}
+
+// Reads the link's searchParams. Per-link request data: resolved by a runtime
+// prefetch, omitted from the App Shell by definition.
+async function SortLabel({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const { sort } = await searchParams
+  return <p data-testid="sort-label">Sorted by: {sort}</p>
+}
+
+// Uncached, must be fresh on every request: no prerender can include it, so
+// it only streams in after the navigation commits.
+async function LiveEnrollment() {
+  await connection()
+  return <p data-testid="live-enrollment">1,234 students enrolled right now</p>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/layout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react'
+import { LinkAccordion } from './link-accordion'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <nav>
+          {/* The destination opts into `prefetch = 'allow-runtime'` and the
+              link opts into `prefetch={true}`, the standard pairing for
+              prefetching request data beyond the App Shell. */}
+          <LinkAccordion
+            href="/courses?sort=featured"
+            prefetch={true}
+            id="courses-link"
+          >
+            Courses
+          </LinkAccordion>
+        </nav>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/link-accordion.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/link-accordion.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  id,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  id?: string
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch} id={id}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1 data-testid="home-title">Home</h1>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/app-shell/next.config.js
@@ -1,0 +1,26 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  // The standard App Shell setup (see the Runtime Prefetching guide): with
+  // Partial Prefetching, the App Shell is the prefetch baseline for every
+  // route, and a `<Link prefetch={true}>` to an `allow-runtime` route
+  // upgrades to a runtime prefetch instead of a legacy full prefetch.
+  partialPrefetching: true,
+  // The Instant Navigation devtools panel defaults to the dev tools position
+  // (bottom-left), where it can overlap the nav links and intercept clicks;
+  // move it aside.
+  devIndicators: { position: 'bottom-right' },
+  experimental: {
+    // App Shells is enabled implicitly by `cacheComponents`. `prefetchInlining`
+    // is kept `false` for parity with the sibling fixtures, so the non-inlined
+    // (speculative per-segment) static prefetch path is exercised alongside
+    // the app-shell prefetch.
+    // Enable the testing API in production builds for these tests.
+    exposeTestingApiInProductionBuild: true,
+    prefetchInlining: false,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -31,6 +31,7 @@ import {
 import { instant } from '@next/playwright'
 import { assertNoConsoleErrors } from 'next-test-utils'
 import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
 import { join } from 'node:path'
 
 /**
@@ -1263,6 +1264,155 @@ describe('instant-navigation-testing-api - partial prefetching (App Shells)', ()
       const fallback = page.locator('[data-testid="params-fallback"]')
       expect(await fallback.count()).toBe(0)
     })
+  })
+})
+
+describe('instant-navigation-testing-api - App Shell (prefetch: "app-shell")', () => {
+  const { next } = nextTestSetup({
+    files: join(__dirname, 'fixtures', 'app-shell'),
+  })
+
+  // Keep the eager link hidden until the instant lock is active. Otherwise a
+  // production viewport prefetch can enter the Speculative phase before the
+  // scope starts and issue a per-link request after the test begins recording.
+  async function revealAndNavigateToCourses(page: Playwright.Page) {
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+    await act(async () => {
+      await page
+        .locator('input[data-link-accordion="/courses?sort=featured"]')
+        .click()
+      await page.click('#courses-link')
+    })
+  }
+
+  // The fixture is the standard App Shell example (see the Runtime
+  // Prefetching guide): /courses mixes a static heading, a cached course
+  // list ('use cache'), a session-cookie badge, a searchParams-derived sort
+  // label, and an uncached live count. The link pairs the destination's
+  // `prefetch = 'allow-runtime'` with `prefetch={true}`.
+
+  // Control: by default, instant() simulates everything the link would have
+  // prefetched. The runtime prefetch resolves the request data available at
+  // prefetch time — including the link's searchParams — so only the uncached
+  // live count is deferred.
+  it('renders runtime-prefetched request data instantly by default', async () => {
+    const page = await openPage(next, '/', {
+      cookies: [{ name: 'enrolled', value: 'pro-plan' }],
+    })
+
+    await instant(page, async () => {
+      await revealAndNavigateToCourses(page)
+
+      // The App Shell content...
+      await page
+        .locator('[data-testid="courses-heading"]')
+        .waitFor({ state: 'visible' })
+      await page
+        .locator('[data-testid="featured-courses"]')
+        .waitFor({ state: 'visible' })
+
+      // ...plus the runtime-prefetched request data.
+      const badge = page.locator('[data-testid="enrolled-badge"]')
+      await badge.waitFor({ state: 'visible' })
+      expect(await badge.textContent()).toContain('Enrolled: pro-plan')
+
+      const sortLabel = page.locator('[data-testid="sort-label"]')
+      await sortLabel.waitFor({ state: 'visible' })
+      expect(await sortLabel.textContent()).toContain('Sorted by: featured')
+
+      // The uncached live count cannot be included in any prerender.
+      await page
+        .locator('[data-testid="live-fallback"]')
+        .waitFor({ state: 'visible' })
+      expect(
+        await page.locator('[data-testid="live-enrollment"]').count()
+      ).toBe(0)
+    })
+
+    // After the scope exits, the live count streams in.
+    await page
+      .locator('[data-testid="live-enrollment"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  // With `prefetch: 'app-shell'`, the same navigation simulates a cache where
+  // only the route's App Shell is warm — the per-route prerender minus
+  // per-link data — regardless of the link's own prefetch configuration.
+  it('renders only the App Shell with prefetch: "app-shell"', async () => {
+    const page = await openPage(next, '/', {
+      cookies: [{ name: 'enrolled', value: 'pro-plan' }],
+    })
+
+    // Record the prefetch protocol marker of every router request: '2' is a
+    // per-link runtime prefetch, '3' is the shared App Shell prefetch. This
+    // pins the scope to App Shell data at the network level too: prefetches
+    // triggered incidentally while the scope is active (clicking a link
+    // hovers it first, which normally reschedules the link's own prefetch)
+    // must not fetch per-link data either.
+    const prefetchHeaderValues: Array<string> = []
+    page.on('request', (req) => {
+      const headers = req.headers()
+      if (headers['rsc'] === '1') {
+        prefetchHeaderValues.push(headers['next-router-prefetch'] ?? 'none')
+      }
+    })
+
+    await instant(
+      page,
+      async () => {
+        await revealAndNavigateToCourses(page)
+
+        // The App Shell renders instantly: the static heading and the cached
+        // course list.
+        await page
+          .locator('[data-testid="courses-heading"]')
+          .waitFor({ state: 'visible' })
+        await page
+          .locator('[data-testid="featured-courses"]')
+          .waitFor({ state: 'visible' })
+
+        // The route reads cookies, so its App Shell is the session-
+        // personalized variant: the enrollment badge is part of the shell.
+        const badge = page.locator('[data-testid="enrolled-badge"]')
+        await badge.waitFor({ state: 'visible' })
+        expect(await badge.textContent()).toContain('Enrolled: pro-plan')
+
+        // Per-link data is NOT part of the App Shell, even though the link is
+        // configured to runtime-prefetch it: the searchParams-derived sort
+        // label shows its fallback.
+        await page
+          .locator('[data-testid="sort-fallback"]')
+          .waitFor({ state: 'visible' })
+        expect(await page.locator('[data-testid="sort-label"]').count()).toBe(0)
+
+        // The uncached live count is deferred as always.
+        await page
+          .locator('[data-testid="live-fallback"]')
+          .waitFor({ state: 'visible' })
+        expect(
+          await page.locator('[data-testid="live-enrollment"]').count()
+        ).toBe(0)
+
+        // The scope's cache was warmed via the App Shell prefetch ('3'), and
+        // no per-link runtime prefetch ('2') was made during the scope.
+        expect(prefetchHeaderValues).toContain('3')
+        expect(prefetchHeaderValues).not.toContain('2')
+      },
+      { prefetch: 'app-shell' }
+    )
+
+    // After the scope exits, the deferred request data streams in.
+    const badge = page.locator('[data-testid="enrolled-badge"]')
+    await badge.waitFor({ state: 'visible' })
+    expect(await badge.textContent()).toContain('Enrolled: pro-plan')
+
+    const sortLabel = page.locator('[data-testid="sort-label"]')
+    await sortLabel.waitFor({ state: 'visible' })
+    expect(await sortLabel.textContent()).toContain('Sorted by: featured')
+
+    await page
+      .locator('[data-testid="live-enrollment"]')
+      .waitFor({ state: 'visible' })
   })
 })
 


### PR DESCRIPTION
By default, instant() simulates a fully warm cache: navigations render
everything the link would have prefetched, including per-link and
runtime-prefetched data. This adds a way to assert on just the route's
shared App Shell:

  await instant(page, fn, { prefetch: 'app-shell' })

The option is carried on the instant cookie's pending value and preserved
on captured values, so it survives MPA page loads within a scope. While
active:

- the locked-navigation prefetch stops after the App Shell phases, so no
  per-link concrete-param or runtime-prefetch data is fetched, and
- navigation reads are restricted to shell entries regardless of the
  link's own fetch strategy (e.g. prefetch={true}).

Cookie parsers now discriminate pending vs. captured values by the first
element instead of array length, since pending values can carry options.