### PR TITLE
[ci] Bump PR stats job timeout to 35 minutes

### DIFF
--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -85,7 +85,9 @@ jobs:
   stats:
     name: Stats (${{ matrix.bundler }})
     needs: build
-    timeout-minutes: 25
+    # The webpack benchmark alone takes ~25 minutes, so anything at or below
+    # that cancels the job right as it finishes (seen on canary and PRs alike).
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

The webpack Stats job takes ~25 minutes — the last successful canary run finished 12 seconds under the limit — so `timeout-minutes: 25` routinely cancels the job right as the benchmark completes, leaving a red "cancelled" check on PRs and canary pushes. Bump the limit to 35 minutes.

Split out of #95531, where this rode along unrelated to the feature.

## Verification

- CI-only change; the Stats job on this PR exercises it directly.

<!-- NEXT_JS_LLM_PR -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q66pCEDJX1Jsgh9dAT5y33)_