### PR TITLE
test: allow-runtime breaks Link's Server component child detection

### DIFF
--- a/test/e2e/legacy-link-behavior/app/passHref/default/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/passHref/default/page.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
-import { ClientComponent } from './_client'
+import CustomComponent from '../_client'
 
 export default function Page() {
   return (
     <>
       <Link href="/about" legacyBehavior passHref>
-        <ClientComponent>About</ClientComponent>
+        <CustomComponent>About</CustomComponent>
       </Link>
     </>
   )

--- a/test/e2e/legacy-link-behavior/app/passHref/dynamic/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/passHref/dynamic/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import CustomComponent from '../_client'
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <Link href="/about" legacyBehavior passHref>
+      <CustomComponent>About</CustomComponent>
+    </Link>
+  )
+}

--- a/test/e2e/legacy-link-behavior/app/passHref/runtime/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/passHref/runtime/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
-import CustomComponent from './_client'
+import CustomComponent from '../_client'
+
+export const prefetch = 'allow-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client-with-rsc-child/default/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client-with-rsc-child/default/page.tsx
@@ -1,5 +1,5 @@
-import { ClientLink } from '../client-link'
-import ClientA from './_client'
+import { ClientLink } from '../../client-link'
+import ClientA from '../_client'
 
 export default function Page() {
   return (

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client-with-rsc-child/dynamic/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client-with-rsc-child/dynamic/page.tsx
@@ -1,0 +1,27 @@
+import { connection } from 'next/server'
+import { ClientLink } from '../../client-link'
+import ClientA from '../_client'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <ClientLink href="/about">
+      <ClientA>
+        <RSC />
+      </ClientA>
+    </ClientLink>
+  )
+}
+
+async function RSC() {
+  return <span>About</span>
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client-with-rsc-child/runtime/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client-with-rsc-child/runtime/page.tsx
@@ -1,0 +1,20 @@
+import { ClientLink } from '../../client-link'
+import ClientA from '../_client'
+
+export const prefetch = 'allow-runtime'
+
+export default function Page() {
+  return (
+    <>
+      <ClientLink href="/about">
+        <ClientA>
+          <RSC />
+        </ClientA>
+      </ClientLink>
+    </>
+  )
+}
+
+async function RSC() {
+  return <span>About</span>
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client/default/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client/default/page.tsx
@@ -1,5 +1,5 @@
-import { ClientLink } from '../client-link'
-import ClientA from './_client'
+import { ClientLink } from '../../client-link'
+import ClientA from '../_client'
 
 export default function Page() {
   return (

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client/dynamic/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client/dynamic/page.tsx
@@ -1,0 +1,21 @@
+import { connection } from 'next/server'
+import { ClientLink } from '../../client-link'
+import ClientA from '../_client'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <ClientLink href="/about">
+      <ClientA>About</ClientA>
+    </ClientLink>
+  )
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client/runtime/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-client/client/runtime/page.tsx
@@ -1,0 +1,14 @@
+import { ClientLink } from '../../client-link'
+import ClientA from '../_client'
+
+export const prefetch = 'allow-runtime'
+
+export default function Page() {
+  return (
+    <>
+      <ClientLink href="/about">
+        <ClientA>About</ClientA>
+      </ClientLink>
+    </>
+  )
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client-with-rsc-child/default/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client-with-rsc-child/default/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { ClientComponent } from './_client'
+import { ClientComponent } from '../_client'
 
 export default function Page() {
   return (

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client-with-rsc-child/dynamic/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client-with-rsc-child/dynamic/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+import { ClientComponent } from '../_client'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <Link href="/about" legacyBehavior passHref>
+      <ClientComponent>
+        <RSC />
+      </ClientComponent>
+    </Link>
+  )
+}
+
+function RSC() {
+  return <span>About</span>
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client-with-rsc-child/runtime/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client-with-rsc-child/runtime/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+import { ClientComponent } from '../_client'
+
+export const prefetch = 'allow-runtime'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/about" legacyBehavior passHref>
+        <ClientComponent>
+          <RSC />
+        </ClientComponent>
+      </Link>
+    </>
+  )
+}
+
+function RSC() {
+  return <span>About</span>
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client/default/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client/default/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+import { ClientComponent } from '../_client'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/about" legacyBehavior passHref>
+        <ClientComponent>About</ClientComponent>
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client/dynamic/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client/dynamic/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { ClientComponent } from '../_client'
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return (
+    <Link href="/about" legacyBehavior passHref>
+      <ClientComponent>About</ClientComponent>
+    </Link>
+  )
+}

--- a/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client/runtime/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/validations/rsc-that-renders-link/client/runtime/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+import { ClientComponent } from '../_client'
+
+export const prefetch = 'allow-runtime'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/about" legacyBehavior passHref>
+        <ClientComponent>About</ClientComponent>
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/legacy-link-behavior/index.test.ts
+++ b/test/e2e/legacy-link-behavior/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { retry, waitForNoErrorToast } from 'next-test-utils'
 
 describe('Link with legacyBehavior', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -14,7 +14,7 @@ describe('Link with legacyBehavior', () => {
   describe('if the child is an <a> tag', () => {
     it('forwards the href attribute', async () => {
       const $ = await next.render$('/')
-      const $a = $('a')
+      const $a = $('a[href="/about"]')
 
       expect($a.text()).toBe('About')
       expect($a.attr('href')).toBe('/about')
@@ -22,7 +22,7 @@ describe('Link with legacyBehavior', () => {
 
     it('navigates correctly', async () => {
       const browser = await next.browser('/')
-      await browser.elementByCss('a').click()
+      await browser.elementByCss('a[href="/about"]').click()
       const title = await browser.elementByCss('#about-page').text()
 
       expect(title).toBe('About Page')
@@ -31,7 +31,7 @@ describe('Link with legacyBehavior', () => {
 
   it('works if the child is a number', async () => {
     const browser = await next.browser('/child-is-a-number')
-    await browser.elementByCss('a').click()
+    await browser.elementByCss('a[href="/about"]').click()
     const title = await browser.elementByCss('h1').text()
 
     expect(title).toBe('About Page')
@@ -39,7 +39,7 @@ describe('Link with legacyBehavior', () => {
 
   it('works if the child is a string', async () => {
     const browser = await next.browser('/child-is-a-string')
-    await browser.elementByCss('a').click()
+    await browser.elementByCss('a[href="/about"]').click()
     const title = await browser.elementByCss('h1').text()
 
     expect(title).toBe('About Page')
@@ -78,15 +78,16 @@ describe('Link with legacyBehavior', () => {
   describe('passHref', () => {
     it('forwards the href attribute', async () => {
       const $ = await next.render$('/passHref')
-      const $a = $('a')
-
+      const $a = $('a[href="/about"]')
       expect($a.text()).toBe('About')
       expect($a.attr('href')).toBe('/about')
     })
 
     it('navigates correctly', async () => {
       const browser = await next.browser('/passHref')
-      await browser.elementByCss('a').click()
+      await waitForNoErrorToast(browser)
+
+      await browser.elementByCss('a[href="/about"]').click()
       const title = await browser.elementByCss('h1').text()
 
       expect(title).toBe('About Page')

--- a/test/e2e/legacy-link-behavior/index.test.ts
+++ b/test/e2e/legacy-link-behavior/index.test.ts
@@ -1,5 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry, waitForNoErrorToast } from 'next-test-utils'
+import { openRedbox, retry } from 'next-test-utils'
+import {
+  createRedboxSnapshot,
+  type ErrorSnapshot,
+} from '../../lib/add-redbox-matchers'
 
 describe('Link with legacyBehavior', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -76,21 +80,85 @@ describe('Link with legacyBehavior', () => {
   })
 
   describe('passHref', () => {
-    it('forwards the href attribute', async () => {
-      const $ = await next.render$('/passHref')
+    const expectHrefToBeForwardedInSSR = async (path: string) => {
+      const $ = await next.render$(path)
       const $a = $('a[href="/about"]')
       expect($a.text()).toBe('About')
       expect($a.attr('href')).toBe('/about')
-    })
+    }
 
-    it('navigates correctly', async () => {
-      const browser = await next.browser('/passHref')
-      await waitForNoErrorToast(browser)
+    const expectLinkClickToNavigate = async (path: string) => {
+      const browser = await next.browser(path)
+
+      if (isNextDev) {
+        // We expect a deprecation warning (in a collapsed redbox), but no other errors (e.g. no errors thrown by Link)
+        await openRedbox(browser)
+        expect(await createRedboxSnapshot(browser, next)).toEqual(
+          expect.objectContaining<Partial<ErrorSnapshot>>({
+            label: 'Console Error',
+            description: expect.stringContaining(
+              `\`legacyBehavior\` is deprecated and will be removed in a future release.`
+            ),
+          })
+        )
+        await browser.locateRedbox().press('Escape') // Close redbox so we can click the link
+      }
 
       await browser.elementByCss('a[href="/about"]').click()
-      const title = await browser.elementByCss('h1').text()
 
+      const title = await browser.elementByCss('h1').text()
       expect(title).toBe('About Page')
+    }
+
+    describe('with no prefech config', () => {
+      it('forwards the href attribute', async () => {
+        await expectHrefToBeForwardedInSSR('/passHref/default')
+      })
+
+      it('navigates correctly', async () => {
+        await expectLinkClickToNavigate('/passHref/default')
+      })
+    })
+
+    describe('with runtime prefetch', () => {
+      it('forwards the href attribute', async () => {
+        await expectHrefToBeForwardedInSSR('/passHref/runtime')
+      })
+
+      it('navigates correctly (failing)', async () => {
+        if (isNextDev) {
+          // FIXME(NAR-876): false positive due to debug info blocking the child
+          // await expectLinkClickToNavigate('/passHref/runtime')
+
+          const browser = await next.browser('/passHref/runtime')
+          await expect(browser).toDisplayRedbox(`
+           {
+             "code": "E863",
+             "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "app/passHref/runtime/page.tsx (9:7) @ Page
+           >  9 |       <Link href="/about" legacyBehavior passHref>
+                |       ^",
+             "stack": [
+               "Page app/passHref/runtime/page.tsx (9:7)",
+             ],
+           }
+          `)
+        } else {
+          await expectLinkClickToNavigate('/passHref/runtime')
+        }
+      })
+    })
+
+    describe('in dynamic code', () => {
+      it('forwards the href attribute', async () => {
+        await expectHrefToBeForwardedInSSR('/passHref/dynamic')
+      })
+
+      it('navigates correctly', async () => {
+        await expectLinkClickToNavigate('/passHref/dynamic')
+      })
     })
   })
 })

--- a/test/e2e/legacy-link-behavior/validations.console.test.ts
+++ b/test/e2e/legacy-link-behavior/validations.console.test.ts
@@ -1,5 +1,6 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
+import { getDeterministicOutput } from '../app-dir/cache-components-errors/utils'
 
 const partialPrefetching = !!process.env.__NEXT_PARTIAL_PREFETCHING
 
@@ -9,7 +10,7 @@ describe('Validations for <Link legacyBehavior>', () => {
     skipDeployment: true,
   })
   if (skipped) return
-  let previousOutputIndex
+  let previousOutputIndex = 0
 
   beforeEach(() => {
     previousOutputIndex = next.cliOutput.length
@@ -63,16 +64,18 @@ describe('Validations for <Link legacyBehavior>', () => {
           if (partialPrefetching) {
             // In Partial Prefetching, we do a second render to produce the embedded
             // runtime prefetch stream, which results in a second log.
-            expect(newConsoleOutput()).toMatchInlineSnapshot(`
+            expect(
+              getDeterministicOutput(newConsoleOutput(), { isMinified: true })
+            ).toMatchInlineSnapshot(`
              "Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag.
-             Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag.
-             "
+             Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag."
             `)
           } else {
-            expect(newConsoleOutput()).toMatchInlineSnapshot(`
-             "Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag.
-             "
-            `)
+            expect(
+              getDeterministicOutput(newConsoleOutput(), { isMinified: true })
+            ).toMatchInlineSnapshot(
+              `"Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag."`
+            )
           }
         }
       })
@@ -124,16 +127,56 @@ describe('Validations for <Link legacyBehavior>', () => {
         }
       })
 
-      it('does not warn or throw if you pass a client component', async () => {
-        const browser = await next.browser(
-          '/validations/rsc-that-renders-link/client'
-        )
+      describe('does not warn or throw if you pass a client component', () => {
+        it('with no prefetch config', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-link/client/default'
+          )
+          if (isNextDev) {
+            await waitForNoRedbox(browser)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
 
-        if (isNextDev) {
-          await waitForNoRedbox(browser)
-        } else {
-          expect(newConsoleOutput()).toEqual('')
-        }
+        it('with runtime prefetch', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-link/client/runtime'
+          )
+
+          if (isNextDev) {
+            // FIXME(NAR-876): false positive due to debug info blocking the child
+            // await waitForNoRedbox(browser)
+
+            await expect(browser).toDisplayRedbox(`
+             {
+               "code": "E863",
+               "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
+               "environmentLabel": null,
+               "label": "Runtime Error",
+               "source": "app/validations/rsc-that-renders-link/client/runtime/page.tsx (9:7) @ Page
+             >  9 |       <Link href="/about" legacyBehavior passHref>
+                  |       ^",
+               "stack": [
+                 "Page app/validations/rsc-that-renders-link/client/runtime/page.tsx (9:7)",
+               ],
+             }
+            `)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
+
+        it('in dynamic code', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-link/client/dynamic'
+          )
+          if (isNextDev) {
+            await waitForNoRedbox(browser)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
       })
 
       it('does not warn or throw if you pass a server component into a client component', async () => {
@@ -241,28 +284,112 @@ describe('Validations for <Link legacyBehavior>', () => {
         }
       })
 
-      it('does not warn or throw if you pass a client component', async () => {
-        const browser = await next.browser(
-          '/validations/rsc-that-renders-client/client'
-        )
+      describe('does not warn or throw if you pass a client component', () => {
+        it('with no prefetch config', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-client/client/default'
+          )
+          if (isNextDev) {
+            await waitForNoRedbox(browser)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
 
-        if (isNextDev) {
-          await waitForNoRedbox(browser)
-        } else {
-          expect(newConsoleOutput()).toEqual('')
-        }
+        it('with runtime prefetch', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-client/client/runtime'
+          )
+
+          if (isNextDev) {
+            // FIXME(NAR-876): false positive due to debug info blocking the child
+            // await waitForNoRedbox(browser)
+
+            await expect(browser).toDisplayRedbox(`
+             {
+               "code": "E863",
+               "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
+               "environmentLabel": null,
+               "label": "Runtime Error",
+               "source": "app/validations/rsc-that-renders-client/client-link.tsx (7:10) @ ClientLink
+             > 7 |   return <Link legacyBehavior passHref {...props} />
+                 |          ^",
+               "stack": [
+                 "ClientLink app/validations/rsc-that-renders-client/client-link.tsx (7:10)",
+                 "Page app/validations/rsc-that-renders-client/client/runtime/page.tsx (9:7)",
+               ],
+             }
+            `)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
+
+        it('in dynamic code', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-client/client/dynamic'
+          )
+          if (isNextDev) {
+            await waitForNoRedbox(browser)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
       })
 
-      it('does not warn or throw if you pass a server component into a client component', async () => {
-        const browser = await next.browser(
-          '/validations/rsc-that-renders-client/client-with-rsc-child'
-        )
+      describe('does not warn or throw if you pass a server component into a client component', () => {
+        it('with no prefetch config', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-client/client-with-rsc-child/default'
+          )
 
-        if (isNextDev) {
-          await waitForNoRedbox(browser)
-        } else {
-          expect(newConsoleOutput()).toEqual('')
-        }
+          if (isNextDev) {
+            await waitForNoRedbox(browser)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
+
+        it('with runtime prefetch', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-client/client-with-rsc-child/runtime'
+          )
+
+          if (isNextDev) {
+            // FIXME(NAR-876): false positive due to debug info blocking the child
+            // await waitForNoRedbox(browser)
+
+            await expect(browser).toDisplayRedbox(`
+             {
+               "code": "E863",
+               "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
+               "environmentLabel": null,
+               "label": "Runtime Error",
+               "source": "app/validations/rsc-that-renders-client/client-link.tsx (7:10) @ ClientLink
+             > 7 |   return <Link legacyBehavior passHref {...props} />
+                 |          ^",
+               "stack": [
+                 "ClientLink app/validations/rsc-that-renders-client/client-link.tsx (7:10)",
+                 "Page app/validations/rsc-that-renders-client/client-with-rsc-child/runtime/page.tsx (9:7)",
+               ],
+             }
+            `)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
+
+        it('in dynamic code', async () => {
+          const browser = await next.browser(
+            '/validations/rsc-that-renders-client/client-with-rsc-child/dynamic'
+          )
+
+          if (isNextDev) {
+            await waitForNoRedbox(browser)
+          } else {
+            expect(newConsoleOutput()).toEqual('')
+          }
+        })
       })
     })
   })


### PR DESCRIPTION
See NAR-876. We discovered this problem in #95384, when removing the Early/Late stage split, but it turns out that this was a preexisting race that occurs for runtime-prefetchable segments the problem existed before for runtime (which currently render in EarlyStatic, a task earlier than non-runtime-prefetchable segments)

adds failing tests for `passHref` with allow-runtime (i.e. when the segment runs early), and passing tests for it in the dynamic stage (when the passHref is gated behind dynamic, which seems to delay it long enough for the debug channel to initialize)