### PR TITLE
Keep the request body a plain Readable after middleware so Readable.toWeb() doesn't hang

### DIFF
--- a/packages/next/src/server/body-streams.ts
+++ b/packages/next/src/server/body-streams.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage } from 'http'
-import type { Readable } from 'stream'
-import { PassThrough } from 'stream'
+import { PassThrough, Readable } from 'stream'
 import bytes from 'next/dist/compiled/bytes'
 
 const DEFAULT_BODY_CLONE_SIZE_LIMIT = 10 * 1024 * 1024 // 10MB
@@ -79,7 +78,13 @@ export function getCloneableBody<T extends IncomingMessage>(
     cloneBodyStream() {
       const input = buffered ?? readable
       const p1 = new PassThrough()
-      const p2 = new PassThrough()
+      // `p2` becomes the buffered body that replaces the original request stream
+      // in `finalize()` via `replaceRequestBody`. Since it is only ever fed via
+      // `.push()`, it must be a plain Readable: a Duplex (PassThrough) would copy
+      // its writable-side internals (`_writableState`, `write`, `end`, ...) onto the
+      // IncomingMessage, making the request look like an unfinished writable stream
+      // and hanging Node stream APIs such as `Readable.toWeb()`.
+      const p2 = new Readable({ read() {} })
 
       let bytesRead = 0
       const bodySizeLimit = sizeLimit ?? DEFAULT_BODY_CLONE_SIZE_LIMIT

--- a/test/e2e/proxy-readable-toweb/pages/api/echo-events.js
+++ b/test/e2e/proxy-readable-toweb/pages/api/echo-events.js
@@ -1,0 +1,21 @@
+export const config = {
+  api: { bodyParser: false },
+}
+
+async function readBodyWithEvents(readable) {
+  const chunks = []
+  await new Promise((resolve, reject) => {
+    readable.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+    readable.on('end', resolve)
+    readable.on('error', reject)
+  })
+  return Buffer.concat(chunks)
+}
+
+export default async function handler(req, res) {
+  const body = await readBodyWithEvents(req)
+
+  res.status(200).json({
+    echo: JSON.parse(body.toString()),
+  })
+}

--- a/test/e2e/proxy-readable-toweb/pages/api/echo.js
+++ b/test/e2e/proxy-readable-toweb/pages/api/echo.js
@@ -1,0 +1,29 @@
+import { Readable } from 'stream'
+
+export const config = {
+  api: { bodyParser: false },
+}
+
+async function readBodyWithReadableToWeb(readable) {
+  const reader = Readable.toWeb(readable).getReader()
+  const chunks = []
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(Buffer.from(value))
+  }
+
+  return Buffer.concat(chunks)
+}
+
+export default async function handler(req, res) {
+  const body = await readBodyWithReadableToWeb(req)
+
+  res.status(200).json({
+    echo: JSON.parse(body.toString()),
+    writableState: Boolean(req._writableState),
+    write: typeof req.write,
+    end: typeof req.end,
+  })
+}

--- a/test/e2e/proxy-readable-toweb/proxy-readable-toweb.test.ts
+++ b/test/e2e/proxy-readable-toweb/proxy-readable-toweb.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('proxy request body with Readable.toWeb', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('allows a pages api route to read the proxied body with Readable.toWeb()', async () => {
+    const body = JSON.stringify({ hello: 'world' })
+
+    const res = await next.fetch('/api/echo', {
+      body,
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    })
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data).toEqual({
+      echo: { hello: 'world' },
+      writableState: false,
+      write: 'undefined',
+      end: 'undefined',
+    })
+  })
+
+  it('still allows a pages api route to read the proxied body with node events', async () => {
+    const body = JSON.stringify({ hello: 'world' })
+
+    const res = await next.fetch('/api/echo-events', {
+      body,
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    })
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data).toEqual({
+      echo: { hello: 'world' },
+    })
+  })
+})

--- a/test/e2e/proxy-readable-toweb/proxy.ts
+++ b/test/e2e/proxy-readable-toweb/proxy.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function proxy(_request: NextRequest) {
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+}

--- a/test/unit/body-streams.test.ts
+++ b/test/unit/body-streams.test.ts
@@ -1,0 +1,79 @@
+import type { IncomingMessage } from 'http'
+import { Readable } from 'stream'
+import { getCloneableBody } from 'next/dist/server/body-streams'
+
+function mockIncoming(body: string): IncomingMessage {
+  const readable = new Readable({ read() {} })
+  process.nextTick(() => {
+    readable.push(Buffer.from(body))
+    readable.push(null)
+  })
+  return readable as unknown as IncomingMessage
+}
+
+async function readAll(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+async function readAllWeb(stream: Readable, timeoutMs = 1000): Promise<Buffer> {
+  let timeout: ReturnType<typeof setTimeout>
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error('Timed out reading stream via Readable.toWeb()'))
+    }, timeoutMs)
+  })
+
+  try {
+    return await Promise.race([
+      (async () => {
+        const web = Readable.toWeb(stream)
+        const reader = web.getReader()
+        const out: Buffer[] = []
+
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) break
+          out.push(Buffer.from(value))
+        }
+
+        return Buffer.concat(out)
+      })(),
+      timeoutPromise,
+    ])
+  } finally {
+    clearTimeout(timeout!)
+  }
+}
+
+describe('getCloneableBody', () => {
+  // Regression test for https://github.com/vercel/next.js/issues/95335
+  //
+  // After middleware clones the request body and `finalize()` swaps the buffered
+  // stream back onto the request, the request must stay a plain Readable. The
+  // buffered stream used to be a Duplex (PassThrough) whose writable-side
+  // internals (`_writableState`, `write`, `end`, ...) were copied onto the
+  // IncomingMessage, so a downstream handler reading a POST body via
+  // `Readable.toWeb()` saw an unfinished writable side and hung forever.
+  it('leaves the finalized request body consumable via Readable.toWeb()', async () => {
+    const body = 'hello world'
+    const req = mockIncoming(body)
+
+    const cloneable = getCloneableBody(req)
+    const middlewareCopy = cloneable.cloneBodyStream()
+
+    // Middleware consumes its own copy of the body (e.g. via NextResponse.next()).
+    expect((await readAll(middlewareCopy)).toString()).toBe(body)
+
+    await cloneable.finalize()
+
+    // The request must not masquerade as a writable stream after finalize.
+    expect((req as any)._writableState).toBeUndefined()
+    expect((req as any).write).toBeUndefined()
+    expect((req as any).end).toBeUndefined()
+    expect((await readAllWeb(req as unknown as Readable)).toString()).toBe(body)
+  })
+})


### PR DESCRIPTION
Recreation of https://github.com/vercel/next.js/pull/95370

### What's the problem?

A `POST` (or `PUT`/`PATCH`) request that passes through middleware returning `NextResponse.next()` hangs indefinitely when the downstream handler reads the body via Node's `Readable.toWeb()`. The request never completes and eventually times out.

Reproduction: https://github.com/abir-taheer/next-js-readable-stream-bug

### Root cause

When middleware runs, `runMiddleware` clones the request body and later calls `finalize()`, which grafts the buffered stream back onto the original `IncomingMessage` via `replaceRequestBody()` (`packages/next/src/server/body-streams.ts`). `replaceRequestBody` copies the buffered stream's enumerable properties onto the request.

The buffered stream (`p2`) was a `PassThrough` — a `Duplex` — so its writable-side internals (`_writableState` plus the enumerable `Writable` methods like `write`/`end`) were copied onto the `IncomingMessage`. Because that `_writableState.finished` is `false`, Node stream utilities that inspect it — including `Readable.toWeb()`, which uses `finished()`/end-of-stream detection — treat the request as a still-open writable stream and wait forever.

`NextResponse.rewrite()` is unaffected (it builds a new internal request and skips this path), and `GET`/`HEAD` requests are fine because there is no body to clone.

### The fix

`p2` is only ever fed with `.push()`, so it never needs a writable side. Making it a plain `Readable` instead of a `PassThrough` keeps the finalized request a pure `Readable`, so `Readable.toWeb()` (and any other duck-typing based on `_writableState`) behaves correctly. No behavior change for the existing consumers, which only read the stream.

### Testing

Added `test/unit/body-streams.test.ts`, which drives the real clone → `finalize()` flow and asserts the finalized request:
- is no longer writable (`_writableState` is `undefined`), and
- is fully consumable via `Readable.toWeb()` (this hangs before the fix).

Fixes #95335

<!-- NEXT_JS_LLM_PR -->
