### PR TITLE
Static generation: batched concurrency → rolling concurrency

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/staticGeneration.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/staticGeneration.mdx
@@ -14,6 +14,7 @@ const nextConfig: NextConfig = {
     staticGenerationRetryCount: 1,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
+    staticGenerationRollingConcurrency: false,
   },
 }
 
@@ -26,6 +27,7 @@ const nextConfig = {
     staticGenerationRetryCount: 1,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
+    staticGenerationRollingConcurrency: false,
   },
 }
 
@@ -39,3 +41,4 @@ The following options are available:
 - `staticGenerationRetryCount`: The number of times to retry a failed page generation before failing the build.
 - `staticGenerationMaxConcurrency`: The maximum number of pages to be processed per worker.
 - `staticGenerationMinPagesPerWorker`: The minimum number of pages to be processed before starting a new worker.
+- `staticGenerationRollingConcurrency`: Start exporting the next page as soon as a concurrency slot frees up, instead of waiting for the whole batch of `staticGenerationMaxConcurrency` pages to finish.

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1418,5 +1418,6 @@
   "1417": "Could not parse output from TypeScript's --showConfig.",
   "1418": "TypeScript %s does not provide the compiler API required by Next.js. Enable %s in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1419": "TypeScript CLI interrupted by %s",
-  "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s"
+  "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s",
+  "1421": "maxConcurrency must be a positive integer"
 }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -54,7 +54,11 @@ import { isStaticGenBailoutError } from '../client/components/static-generation-
 import type { PagesRenderContext, PagesSharedContext } from '../server/render'
 import type { AppSharedContext } from '../server/app-render/app-render'
 import { MultiFileWriter } from '../lib/multi-file-writer'
-import { runWithConcurrency } from '../lib/run-with-concurrency'
+import {
+  runInBatches,
+  runWithConcurrency,
+  type RunWithConcurrencyFn,
+} from '../lib/run-with-concurrency'
 import { createRenderResumeDataCache } from '../server/resume-data-cache/resume-data-cache'
 import { installGlobalBehaviors } from '../server/node-environment-extensions/global-behaviors'
 ;(globalThis as any).__NEXT_DATA__ = {
@@ -523,7 +527,12 @@ export async function exportPages(
     return { result, path, page, pageKey }
   }
 
-  return runWithConcurrency(exportPaths, maxConcurrency, exportPageWithRetry)
+  const runTasks: RunWithConcurrencyFn = nextConfig.experimental
+    .staticGenerationRollingConcurrency
+    ? runWithConcurrency
+    : runInBatches
+
+  return runTasks(exportPaths, maxConcurrency, exportPageWithRetry)
 }
 
 async function exportPage(

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -54,6 +54,7 @@ import { isStaticGenBailoutError } from '../client/components/static-generation-
 import type { PagesRenderContext, PagesSharedContext } from '../server/render'
 import type { AppSharedContext } from '../server/app-render/app-render'
 import { MultiFileWriter } from '../lib/multi-file-writer'
+import { runWithConcurrency } from '../lib/run-with-concurrency'
 import { createRenderResumeDataCache } from '../server/resume-data-cache/resume-data-cache'
 import { installGlobalBehaviors } from '../server/node-environment-extensions/global-behaviors'
 ;(globalThis as any).__NEXT_DATA__ = {
@@ -398,16 +399,17 @@ export async function exportPages(
 
   const maxConcurrency =
     nextConfig.experimental.staticGenerationMaxConcurrency ?? 8
-  const results: ExportPagesResult = []
+  const configuredMaxAttempts =
+    nextConfig.experimental.staticGenerationRetryCount ?? 1
 
   const exportPageWithRetry = async (
-    exportPath: ExportPathEntry,
-    maxAttempts: number
-  ) => {
+    exportPath: ExportPathEntry
+  ): Promise<ExportPagesResult[number]> => {
     const { page, path } = exportPath
     const pageKey = page !== path ? `${page}: ${path}` : path
     let attempt = 0
     let result
+    let maxAttempts = configuredMaxAttempts
 
     const hasDebuggerAttached =
       // Also tests for `inspect-brk`
@@ -521,22 +523,7 @@ export async function exportPages(
     return { result, path, page, pageKey }
   }
 
-  for (let i = 0; i < exportPaths.length; i += maxConcurrency) {
-    const subset = exportPaths.slice(i, i + maxConcurrency)
-
-    const subsetResults = await Promise.all(
-      subset.map((exportPath) =>
-        exportPageWithRetry(
-          exportPath,
-          nextConfig.experimental.staticGenerationRetryCount ?? 1
-        )
-      )
-    )
-
-    results.push(...subsetResults)
-  }
-
-  return results
+  return runWithConcurrency(exportPaths, maxConcurrency, exportPageWithRetry)
 }
 
 async function exportPage(

--- a/packages/next/src/lib/run-with-concurrency.test.ts
+++ b/packages/next/src/lib/run-with-concurrency.test.ts
@@ -61,12 +61,15 @@ describe('runWithConcurrency', () => {
     expect(started).toEqual([0, 1])
   })
 
-  it('rejects invalid maxConcurrency values', async () => {
-    const worker = jest.fn(async (item: number) => item)
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects an invalid maxConcurrency value of %p',
+    async (maxConcurrency) => {
+      const worker = jest.fn(async (item: number) => item)
 
-    await expect(runWithConcurrency([0, 1], 0, worker)).rejects.toThrow(
-      'maxConcurrency must be a positive integer'
-    )
-    expect(worker).not.toHaveBeenCalled()
-  })
+      await expect(
+        runWithConcurrency([0, 1], maxConcurrency, worker)
+      ).rejects.toThrow('maxConcurrency must be a positive integer')
+      expect(worker).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/packages/next/src/lib/run-with-concurrency.test.ts
+++ b/packages/next/src/lib/run-with-concurrency.test.ts
@@ -72,6 +72,9 @@ describe('runWithConcurrency', () => {
 
     firstItemGate.resolve()
     await expect(result).rejects.toBe(error)
+    // No extra turn is needed before these assertions: the promise only
+    // settles after every worker has returned, and only workers call the
+    // callback, so `started` and `finished` cannot change anymore.
     expect(finished).toEqual([0])
     expect(started).toEqual([0, 1])
   })
@@ -159,6 +162,9 @@ describe('runInBatches', () => {
 
     firstItemGate.resolve()
     await expect(result).rejects.toBe(error)
+    // No extra turn is needed before these assertions: the promise only
+    // settles after every worker has returned, and only workers call the
+    // callback, so `started` and `finished` cannot change anymore.
     expect(finished).toEqual([0])
     expect(started).toEqual([0, 1])
   })

--- a/packages/next/src/lib/run-with-concurrency.test.ts
+++ b/packages/next/src/lib/run-with-concurrency.test.ts
@@ -72,9 +72,6 @@ describe('runWithConcurrency', () => {
 
     firstItemGate.resolve()
     await expect(result).rejects.toBe(error)
-    // No extra turn is needed before these assertions: the promise only
-    // settles after every worker has returned, and only workers call the
-    // callback, so `started` and `finished` cannot change anymore.
     expect(finished).toEqual([0])
     expect(started).toEqual([0, 1])
   })
@@ -162,9 +159,6 @@ describe('runInBatches', () => {
 
     firstItemGate.resolve()
     await expect(result).rejects.toBe(error)
-    // No extra turn is needed before these assertions: the promise only
-    // settles after every worker has returned, and only workers call the
-    // callback, so `started` and `finished` cannot change anymore.
     expect(finished).toEqual([0])
     expect(started).toEqual([0, 1])
   })

--- a/packages/next/src/lib/run-with-concurrency.test.ts
+++ b/packages/next/src/lib/run-with-concurrency.test.ts
@@ -36,9 +36,10 @@ describe('runWithConcurrency', () => {
     ])
   })
 
-  it('stops starting new items after a worker rejects', async () => {
+  it('stops starting new items after a worker rejects and waits for in-flight items', async () => {
     const firstItemGate = new DetachedPromise<void>()
     const started: number[] = []
+    const finished: number[] = []
     const error = new Error('unexpected failure')
 
     const result = runWithConcurrency([0, 1, 2], 2, async (item) => {
@@ -50,14 +51,28 @@ describe('runWithConcurrency', () => {
         throw error
       }
 
+      finished.push(item)
       return item
     })
 
-    await expect(result).rejects.toBe(error)
+    let settled = false
+    result.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+
+    await waitForNextTurn()
     expect(started).toEqual([0, 1])
+    // Item 0 is still running, so the returned promise must not settle yet.
+    expect(settled).toBe(false)
 
     firstItemGate.resolve()
-    await waitForNextTurn()
+    await expect(result).rejects.toBe(error)
+    expect(finished).toEqual([0])
     expect(started).toEqual([0, 1])
   })
 

--- a/packages/next/src/lib/run-with-concurrency.test.ts
+++ b/packages/next/src/lib/run-with-concurrency.test.ts
@@ -1,5 +1,5 @@
 import { DetachedPromise } from './detached-promise'
-import { runWithConcurrency } from './run-with-concurrency'
+import { runInBatches, runWithConcurrency } from './run-with-concurrency'
 
 const waitForNextTurn = () =>
   new Promise<void>((resolve) => setImmediate(resolve))
@@ -75,15 +75,95 @@ describe('runWithConcurrency', () => {
     expect(finished).toEqual([0])
     expect(started).toEqual([0, 1])
   })
+})
 
+describe('runInBatches', () => {
+  it('waits for the whole batch before starting the next one', async () => {
+    const gates = Array.from({ length: 4 }, () => new DetachedPromise<void>())
+    const started: number[] = []
+
+    const result = runInBatches([0, 1, 2, 3], 2, async (item) => {
+      started.push(item)
+      await gates[item].promise
+      return `result ${item}`
+    })
+
+    expect(started).toEqual([0, 1])
+
+    // Unlike rolling concurrency, one finished item does not start the next
+    // item while the rest of the batch is still running.
+    gates[1].resolve()
+    await waitForNextTurn()
+    expect(started).toEqual([0, 1])
+
+    gates[0].resolve()
+    await waitForNextTurn()
+    expect(started).toEqual([0, 1, 2, 3])
+
+    gates[2].resolve()
+    gates[3].resolve()
+
+    await expect(result).resolves.toEqual([
+      'result 0',
+      'result 1',
+      'result 2',
+      'result 3',
+    ])
+  })
+
+  it('stops starting new batches after a rejection and waits for in-flight items', async () => {
+    const firstItemGate = new DetachedPromise<void>()
+    const started: number[] = []
+    const finished: number[] = []
+    const error = new Error('unexpected failure')
+
+    const result = runInBatches([0, 1, 2], 2, async (item) => {
+      started.push(item)
+
+      if (item === 0) {
+        await firstItemGate.promise
+      } else if (item === 1) {
+        throw error
+      }
+
+      finished.push(item)
+      return item
+    })
+
+    let settled = false
+    result.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+
+    await waitForNextTurn()
+    expect(started).toEqual([0, 1])
+    // Item 0 is still running, so the returned promise must not settle yet.
+    expect(settled).toBe(false)
+
+    firstItemGate.resolve()
+    await expect(result).rejects.toBe(error)
+    expect(finished).toEqual([0])
+    expect(started).toEqual([0, 1])
+  })
+})
+
+describe.each([
+  ['runWithConcurrency', runWithConcurrency],
+  ['runInBatches', runInBatches],
+] as const)('%s', (_name, run) => {
   it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
     'rejects an invalid maxConcurrency value of %p',
     async (maxConcurrency) => {
       const worker = jest.fn(async (item: number) => item)
 
-      await expect(
-        runWithConcurrency([0, 1], maxConcurrency, worker)
-      ).rejects.toThrow('maxConcurrency must be a positive integer')
+      await expect(run([0, 1], maxConcurrency, worker)).rejects.toThrow(
+        'maxConcurrency must be a positive integer'
+      )
       expect(worker).not.toHaveBeenCalled()
     }
   )

--- a/packages/next/src/lib/run-with-concurrency.test.ts
+++ b/packages/next/src/lib/run-with-concurrency.test.ts
@@ -111,6 +111,18 @@ describe('runInBatches', () => {
     ])
   })
 
+  it('handles a final partial batch', async () => {
+    const started: number[] = []
+
+    const result = runInBatches([0, 1, 2, 3, 4], 2, async (item) => {
+      started.push(item)
+      return item * 10
+    })
+
+    await expect(result).resolves.toEqual([0, 10, 20, 30, 40])
+    expect(started).toEqual([0, 1, 2, 3, 4])
+  })
+
   it('stops starting new batches after a rejection and waits for in-flight items', async () => {
     const firstItemGate = new DetachedPromise<void>()
     const started: number[] = []

--- a/packages/next/src/lib/run-with-concurrency.test.ts
+++ b/packages/next/src/lib/run-with-concurrency.test.ts
@@ -1,0 +1,72 @@
+import { DetachedPromise } from './detached-promise'
+import { runWithConcurrency } from './run-with-concurrency'
+
+const waitForNextTurn = () =>
+  new Promise<void>((resolve) => setImmediate(resolve))
+
+describe('runWithConcurrency', () => {
+  it('starts the next item as soon as a worker is available', async () => {
+    const gates = Array.from({ length: 4 }, () => new DetachedPromise<void>())
+    const started: number[] = []
+
+    const result = runWithConcurrency([0, 1, 2, 3], 2, async (item) => {
+      started.push(item)
+      await gates[item].promise
+      return `result ${item}`
+    })
+
+    expect(started).toEqual([0, 1])
+
+    gates[1].resolve()
+    await waitForNextTurn()
+    expect(started).toEqual([0, 1, 2])
+
+    gates[2].resolve()
+    await waitForNextTurn()
+    expect(started).toEqual([0, 1, 2, 3])
+
+    gates[3].resolve()
+    gates[0].resolve()
+
+    await expect(result).resolves.toEqual([
+      'result 0',
+      'result 1',
+      'result 2',
+      'result 3',
+    ])
+  })
+
+  it('stops starting new items after a worker rejects', async () => {
+    const firstItemGate = new DetachedPromise<void>()
+    const started: number[] = []
+    const error = new Error('unexpected failure')
+
+    const result = runWithConcurrency([0, 1, 2], 2, async (item) => {
+      started.push(item)
+
+      if (item === 0) {
+        await firstItemGate.promise
+      } else if (item === 1) {
+        throw error
+      }
+
+      return item
+    })
+
+    await expect(result).rejects.toBe(error)
+    expect(started).toEqual([0, 1])
+
+    firstItemGate.resolve()
+    await waitForNextTurn()
+    expect(started).toEqual([0, 1])
+  })
+
+  it('rejects invalid maxConcurrency values', async () => {
+    const worker = jest.fn(async (item: number) => item)
+
+    await expect(runWithConcurrency([0, 1], 0, worker)).rejects.toThrow(
+      'maxConcurrency must be a positive integer'
+    )
+    expect(worker).not.toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/lib/run-with-concurrency.ts
+++ b/packages/next/src/lib/run-with-concurrency.ts
@@ -1,0 +1,55 @@
+/**
+ * Maps over `items` while limiting the number of concurrently running tasks.
+ * Results are returned in the same order as the input items.
+ */
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  maxConcurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+    throw new RangeError('maxConcurrency must be a positive integer')
+  }
+
+  if (items.length === 0) {
+    return []
+  }
+
+  // Fill the array up front so that out-of-order completions do not make it
+  // sparse. Every entry is replaced before this function returns.
+  const results: Array<R | undefined> = []
+  for (let i = 0; i < items.length; i++) {
+    results.push(undefined)
+  }
+
+  let nextIndex = 0
+  let stopped = false
+
+  async function runWorker(): Promise<void> {
+    while (!stopped) {
+      const index = nextIndex
+      if (index >= items.length) {
+        return
+      }
+      nextIndex = index + 1
+
+      try {
+        results[index] = await fn(items[index])
+      } catch (error) {
+        // Other workers can finish their current task, but must not start new
+        // work after an unexpected failure.
+        stopped = true
+        throw error
+      }
+    }
+  }
+
+  const workerCount = Math.min(maxConcurrency, items.length)
+  const workers: Promise<void>[] = []
+  for (let i = 0; i < workerCount; i++) {
+    workers.push(runWorker())
+  }
+
+  await Promise.all(workers)
+  return results as R[]
+}

--- a/packages/next/src/lib/run-with-concurrency.ts
+++ b/packages/next/src/lib/run-with-concurrency.ts
@@ -34,12 +34,11 @@ export async function runWithConcurrency<T, R>(
     return []
   }
 
-  // Fill the array up front so that out-of-order completions do not make it
-  // sparse. Every entry is replaced before this function returns.
-  const results: Array<R | undefined> = []
-  for (let i = 0; i < items.length; i++) {
-    results.push(undefined)
-  }
+  // Workers finish out of order and write to `results[index]` directly, so
+  // create the array at its final length instead of pushing. On the success
+  // path every slot is overwritten with a real result, which is what makes
+  // the `as R[]` cast at the end safe.
+  const results: Array<R | undefined> = new Array(items.length).fill(undefined)
 
   let nextIndex = 0
   let stopped = false

--- a/packages/next/src/lib/run-with-concurrency.ts
+++ b/packages/next/src/lib/run-with-concurrency.ts
@@ -1,6 +1,10 @@
 /**
  * Maps over `items` while limiting the number of concurrently running tasks.
  * Results are returned in the same order as the input items.
+ *
+ * After the first rejection is observed, no new tasks are started. Tasks that
+ * are already running are not cancelled, and the returned promise rejects
+ * without waiting for them to finish.
  */
 export async function runWithConcurrency<T, R>(
   items: readonly T[],

--- a/packages/next/src/lib/run-with-concurrency.ts
+++ b/packages/next/src/lib/run-with-concurrency.ts
@@ -1,19 +1,34 @@
 /**
- * Maps over `items` while limiting the number of concurrently running tasks.
- * Results are returned in the same order as the input items.
+ * Signature shared by the concurrency-limited task runners in this module.
+ * Callers can switch between implementations without changing the call site.
  *
+ * Shared contract: results are returned in the same order as the input items.
  * After the first rejection is observed, no new tasks are started. Tasks that
  * are already running are not cancelled; the returned promise waits for them
  * to settle and then rejects with the first error.
+ */
+export type RunWithConcurrencyFn = <T, R>(
+  items: readonly T[],
+  maxConcurrency: number,
+  fn: (item: T) => Promise<R>
+) => Promise<R[]>
+
+function assertValidMaxConcurrency(maxConcurrency: number): void {
+  if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+    throw new RangeError('maxConcurrency must be a positive integer')
+  }
+}
+
+/**
+ * Maps over `items` with rolling concurrency: the next item starts as soon as
+ * one of the `maxConcurrency` workers becomes available.
  */
 export async function runWithConcurrency<T, R>(
   items: readonly T[],
   maxConcurrency: number,
   fn: (item: T) => Promise<R>
 ): Promise<R[]> {
-  if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
-    throw new RangeError('maxConcurrency must be a positive integer')
-  }
+  assertValidMaxConcurrency(maxConcurrency)
 
   if (items.length === 0) {
     return []
@@ -67,4 +82,32 @@ export async function runWithConcurrency<T, R>(
   }
 
   return results as R[]
+}
+
+/**
+ * Maps over `items` in fixed batches of `maxConcurrency` tasks: the next
+ * batch does not start until every task in the current batch has settled.
+ */
+export async function runInBatches<T, R>(
+  items: readonly T[],
+  maxConcurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  assertValidMaxConcurrency(maxConcurrency)
+
+  const results: R[] = []
+
+  for (let i = 0; i < items.length; i += maxConcurrency) {
+    const batch = items.slice(i, i + maxConcurrency)
+    const settled = await Promise.allSettled(batch.map((item) => fn(item)))
+
+    for (const outcome of settled) {
+      if (outcome.status === 'rejected') {
+        throw outcome.reason
+      }
+      results.push(outcome.value)
+    }
+  }
+
+  return results
 }

--- a/packages/next/src/lib/run-with-concurrency.ts
+++ b/packages/next/src/lib/run-with-concurrency.ts
@@ -3,8 +3,8 @@
  * Results are returned in the same order as the input items.
  *
  * After the first rejection is observed, no new tasks are started. Tasks that
- * are already running are not cancelled, and the returned promise rejects
- * without waiting for them to finish.
+ * are already running are not cancelled; the returned promise waits for them
+ * to settle and then rejects with the first error.
  */
 export async function runWithConcurrency<T, R>(
   items: readonly T[],
@@ -28,6 +28,7 @@ export async function runWithConcurrency<T, R>(
 
   let nextIndex = 0
   let stopped = false
+  let firstError: unknown
 
   async function runWorker(): Promise<void> {
     while (!stopped) {
@@ -42,8 +43,11 @@ export async function runWithConcurrency<T, R>(
       } catch (error) {
         // Other workers can finish their current task, but must not start new
         // work after an unexpected failure.
-        stopped = true
-        throw error
+        if (!stopped) {
+          stopped = true
+          firstError = error
+        }
+        return
       }
     }
   }
@@ -54,6 +58,13 @@ export async function runWithConcurrency<T, R>(
     workers.push(runWorker())
   }
 
+  // Workers never reject; they record the first error and stop instead, so
+  // this waits for all in-flight tasks to settle.
   await Promise.all(workers)
+
+  if (stopped) {
+    throw firstError
+  }
+
   return results as R[]
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -437,7 +437,7 @@ export const experimentalSchema = {
     })
     .optional(),
   staticGenerationRetryCount: z.number().int().optional(),
-  staticGenerationMaxConcurrency: z.number().int().optional(),
+  staticGenerationMaxConcurrency: z.number().int().positive().optional(),
   staticGenerationMinPagesPerWorker: z.number().int().optional(),
   typedEnv: z.boolean().optional(),
   serverComponentsHmrCache: z.boolean().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -439,6 +439,7 @@ export const experimentalSchema = {
   staticGenerationRetryCount: z.number().int().optional(),
   staticGenerationMaxConcurrency: z.number().int().positive().optional(),
   staticGenerationMinPagesPerWorker: z.number().int().optional(),
+  staticGenerationRollingConcurrency: z.boolean().optional(),
   typedEnv: z.boolean().optional(),
   serverComponentsHmrCache: z.boolean().optional(),
   serverComponentsHmrCancellation: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1199,6 +1199,13 @@ export interface ExperimentalConfig {
   staticGenerationMinPagesPerWorker?: number
 
   /**
+   * Uses rolling concurrency during static generation: the next page starts
+   * exporting as soon as a concurrency slot frees up, instead of waiting for
+   * the whole batch of `staticGenerationMaxConcurrency` pages to finish.
+   */
+  staticGenerationRollingConcurrency?: boolean
+
+  /**
    * Allows previously fetched data to be re-used when editing server components.
    */
   serverComponentsHmrCache?: boolean
@@ -2176,6 +2183,7 @@ export const defaultConfig = Object.freeze({
     serverComponentsHmrCancellation: false,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
+    staticGenerationRollingConcurrency: false,
     transitionIndicator: false,
     gestureTransition: false,
     inlineCss: false,

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -338,6 +338,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/lib/resolve-build-paths.js",
            "/node_modules/next/dist/lib/resolve-from.js",
            "/node_modules/next/dist/lib/route-pattern-normalizer.js",
+           "/node_modules/next/dist/lib/run-with-concurrency.js",
            "/node_modules/next/dist/lib/scheduler.js",
            "/node_modules/next/dist/lib/semver-noop.js",
            "/node_modules/next/dist/lib/server-external-packages.jsonc",


### PR DESCRIPTION
Adds rolling concurrency for static generation page export, gated behind a new experimental flag. Default behavior is unchanged (batched).