### PR TITLE
Fork navigation-testing-lock module

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -160,11 +160,19 @@ pub async fn get_client_resolve_options_context(
     let next_client_fallback_import_map = get_next_client_fallback_import_map(ty.clone())
         .to_resolved()
         .await?;
-    let next_client_resolved_map =
-        get_next_client_resolved_map(project_path.clone(), project_path.clone(), *mode.await?)
-            .await?
-            .to_resolved()
+    let expose_testing_api = mode.await?.is_development()
+        || *next_config
+            .enable_expose_testing_api_in_production_build()
             .await?;
+    let next_client_resolved_map = get_next_client_resolved_map(
+        project_path.clone(),
+        project_path.clone(),
+        *mode.await?,
+        expose_testing_api,
+    )
+    .await?
+    .to_resolved()
+    .await?;
     let mut custom_conditions: Vec<_> = mode.await?.custom_resolve_conditions().collect();
 
     if *next_config.enable_cache_components().await? {

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1292,6 +1292,7 @@ pub struct ExperimentalConfig {
     durable_use_cache_entries: Option<bool>,
     runtime_server_deployment_id: Option<bool>,
     supports_immutable_assets: Option<bool>,
+    expose_testing_api_in_production_build: Option<bool>,
 
     /// A salt to mix into chunk and asset content hashes. Empty string means
     /// no salt.
@@ -2330,6 +2331,15 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_blocking_ssr(&self) -> Vc<bool> {
         Vc::cell(self.experimental.blocking_ssr.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
+    pub fn enable_expose_testing_api_in_production_build(&self) -> Vc<bool> {
+        Vc::cell(
+            self.experimental
+                .expose_testing_api_in_production_build
+                .unwrap_or(false),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -568,6 +568,7 @@ pub async fn get_next_client_resolved_map(
     context_path: FileSystemPath,
     root: FileSystemPath,
     _mode: NextMode,
+    expose_testing_api: bool,
 ) -> Result<Vc<ResolvedMap>> {
     // In the browser bundle, swap every module that has a `.browser` sibling (see
     // BROWSER_VARIANT_MODULES, generated from the filesystem) for that sibling. The default
@@ -579,7 +580,7 @@ pub async fn get_next_client_resolved_map(
     // filesystem root so it matches wherever `next` resolves from (node_modules, pnpm store,
     // or monorepo `packages/next`).
     let fs_root = root.root().owned().await?;
-    let mut glob_mappings = Vec::with_capacity(BROWSER_VARIANT_MODULES.len());
+    let mut glob_mappings = Vec::with_capacity(BROWSER_VARIANT_MODULES.len() + 1);
     for module in BROWSER_VARIANT_MODULES {
         glob_mappings.push((
             fs_root.clone(),
@@ -595,6 +596,30 @@ pub async fn get_next_client_resolved_map(
             ),
         ));
     }
+
+    // When the Instant Navigation Testing API is disabled (production build
+    // without `experimental.exposeTestingApiInProductionBuild`), swap the
+    // navigation lock implementation for an inert shim so the testing
+    // machinery does not ship in the browser bundle. This mirrors the webpack
+    // alias in `create-compiler-aliases.ts`.
+    if !expose_testing_api {
+        glob_mappings.push((
+            fs_root,
+            Glob::new(
+                rcstr!("**/next/dist/client/components/segment-cache/navigation-testing-lock.js"),
+                GlobOptions::default(),
+            )
+            .to_resolved()
+            .await?,
+            request_to_import_mapping(
+                context_path.clone(),
+                rcstr!(
+                    "next/dist/client/components/segment-cache/navigation-testing-lock.disabled"
+                ),
+            ),
+        ));
+    }
+
     Ok(ResolvedMap {
         by_glob: glob_mappings,
     }

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -180,6 +180,22 @@ export function createWebpackAliases({
               `next/dist/${moduleId}.browser`,
             ])
           ),
+
+          // When the Instant Navigation Testing API is disabled (production
+          // build without `experimental.exposeTestingApiInProductionBuild`),
+          // swap the navigation lock implementation for an inert shim so the
+          // testing machinery does not ship in the browser bundle. Same
+          // resolved-path matching as the browser-variant swap above.
+          ...(!dev &&
+          config.experimental.exposeTestingApiInProductionBuild !== true
+            ? {
+                [path.join(
+                  NEXT_PROJECT_ROOT_DIST,
+                  'client/components/segment-cache/navigation-testing-lock.js'
+                ) + '$']:
+                  'next/dist/client/components/segment-cache/navigation-testing-lock.disabled',
+              }
+            : {}),
         }
       : {}),
 

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
@@ -1,0 +1,73 @@
+/**
+ * Inert stand-in for `./navigation-testing-lock`.
+ *
+ * When the Instant Navigation Testing API is disabled (a production build
+ * without `experimental.exposeTestingApiInProductionBuild`), the browser
+ * bundle resolves `./navigation-testing-lock` to this module instead of the
+ * real implementation, so none of the lock machinery ships. The alias is set
+ * up in `create-compiler-aliases.ts` (webpack) and
+ * `crates/next-core/src/next_import_map.rs` (Turbopack).
+ *
+ * Every export mirrors the real module's signature and returns the value the
+ * real implementation produces when no lock is held.
+ */
+
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
+import type { PendingSegmentCacheEntry, SegmentCacheEntry } from './cache'
+import type { FetchStrategy } from './types'
+import type {
+  NavigationLockPrefetch,
+  NavigationLockState,
+} from './navigation-testing-lock'
+
+export type {
+  NavigationLockPrefetch,
+  NavigationLockState,
+} from './navigation-testing-lock'
+
+export function getPreLockFetch(): typeof fetch | null {
+  return null
+}
+
+export function beginNavigationLockPrefetch(): NavigationLockPrefetch | null {
+  return null
+}
+
+export function recordNavigationLockOwnedEntry(
+  _entry: SegmentCacheEntry
+): void {}
+
+export function trackNavigationLockPrefetchEntry(
+  _prefetch: NavigationLockPrefetch,
+  _entry: PendingSegmentCacheEntry
+): void {}
+
+export function finishNavigationLockPrefetchSpawning(
+  _prefetch: NavigationLockPrefetch
+): void {}
+
+export function startListeningForInstantNavigationCookie(): void {}
+
+export function updateCapturedSPAToTree(
+  _fromTree: FlightRouterState,
+  _toTree: FlightRouterState
+): void {}
+
+export function isNavigationLocked(): boolean {
+  return false
+}
+
+export function getCurrentNavigationLock(): NavigationLockState | null {
+  return null
+}
+
+export function shouldRestrictNavigationToShell(
+  _rootPrefetchHints: number,
+  _linkFetchStrategy: FetchStrategy
+): boolean {
+  return false
+}
+
+export async function waitForNavigationLockIfActive(
+  _lock: NavigationLockState | null = null
+): Promise<void> {}

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -9,6 +9,13 @@
  * and delete the cookie to end one. Next.js writes captured values.
  * The CookieStore handler distinguishes them by value: pending = external,
  * captured = self-write (ignored).
+ *
+ * This module assumes the Instant Navigation Testing API is enabled. When it
+ * is disabled, the bundler resolves this module to
+ * `./navigation-testing-lock.disabled` instead (see
+ * `create-compiler-aliases.ts` for webpack and
+ * `crates/next-core/src/next_import_map.rs` for Turbopack), so none of this
+ * code ships in the browser bundle.
  */
 
 import {
@@ -138,10 +145,7 @@ export type NavigationLockState = {
 let lockState: NavigationLockState | null = null
 
 export function getPreLockFetch(): typeof fetch | null {
-  if (process.env.__NEXT_EXPOSE_TESTING_API && lockState !== null) {
-    return lockState.fetch
-  }
-  return null
+  return lockState !== null ? lockState.fetch : null
 }
 
 /**
@@ -156,7 +160,7 @@ export function getPreLockFetch(): typeof fetch | null {
  * count drains to 0 — i.e. spawning finished and every entry fulfilled.
  */
 export function beginNavigationLockPrefetch(): NavigationLockPrefetch | null {
-  if (process.env.__NEXT_EXPOSE_TESTING_API && lockState !== null) {
+  if (lockState !== null) {
     let resolve: () => void
     const promise = new Promise<void>((r) => {
       resolve = r
@@ -183,7 +187,7 @@ export function beginNavigationLockPrefetch(): NavigationLockPrefetch | null {
  * lock is held.
  */
 export function recordNavigationLockOwnedEntry(entry: SegmentCacheEntry): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API && lockState !== null) {
+  if (lockState !== null) {
     lockState.ownedEntries.add(entry)
   }
 }
@@ -198,20 +202,18 @@ export function trackNavigationLockPrefetchEntry(
   prefetch: NavigationLockPrefetch,
   entry: PendingSegmentCacheEntry
 ): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (prefetch.trackedEntries.has(entry)) {
-      return
-    }
-    prefetch.trackedEntries.add(entry)
-    prefetch.pendingCount++
-    const onSettled = () => {
-      prefetch.pendingCount--
-      settleNavigationLockPrefetchIfDrained(prefetch)
-    }
-    // Decrement whether the entry fulfills or its request rejects, so a failed
-    // segment can't leave the navigation waiting forever.
-    waitForSegmentCacheEntry(entry).then(onSettled, onSettled)
+  if (prefetch.trackedEntries.has(entry)) {
+    return
   }
+  prefetch.trackedEntries.add(entry)
+  prefetch.pendingCount++
+  const onSettled = () => {
+    prefetch.pendingCount--
+    settleNavigationLockPrefetchIfDrained(prefetch)
+  }
+  // Decrement whether the entry fulfills or its request rejects, so a failed
+  // segment can't leave the navigation waiting forever.
+  waitForSegmentCacheEntry(entry).then(onSettled, onSettled)
 }
 
 /**
@@ -222,25 +224,21 @@ export function trackNavigationLockPrefetchEntry(
 export function finishNavigationLockPrefetchSpawning(
   prefetch: NavigationLockPrefetch
 ): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    prefetch.pendingCount--
-    settleNavigationLockPrefetchIfDrained(prefetch)
-  }
+  prefetch.pendingCount--
+  settleNavigationLockPrefetchIfDrained(prefetch)
 }
 
 function settleNavigationLockPrefetchIfDrained(
   prefetch: NavigationLockPrefetch
 ): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (prefetch.pendingCount === 0) {
-      // Unregister from the lock (if still held) and resolve. Resolving is
-      // idempotent, so it's safe even if the lock already force-resolved this on
-      // release.
-      if (lockState !== null) {
-        lockState.activePrefetches.delete(prefetch)
-      }
-      prefetch.resolve()
+  if (prefetch.pendingCount === 0) {
+    // Unregister from the lock (if still held) and resolve. Resolving is
+    // idempotent, so it's safe even if the lock already force-resolved this on
+    // release.
+    if (lockState !== null) {
+      lockState.activePrefetches.delete(prefetch)
     }
+    prefetch.resolve()
   }
 }
 
@@ -263,9 +261,7 @@ function acquireLock(): void {
   // Install the fetch blocker. We only intercept `window.fetch` for the
   // duration of the lock so that — outside of a testing scope — user-
   // installed overrides of `window.fetch` are untouched.
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    window.fetch = globalFetchOverride
-  }
+  window.fetch = globalFetchOverride
 }
 
 function releaseLock(): void {
@@ -274,9 +270,7 @@ function releaseLock(): void {
   }
   // Restore the pre-lock `window.fetch` before resolving the lock promise
   // so any fetches queued on the promise see the restored fetch.
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    window.fetch = lockState.fetch
-  }
+  window.fetch = lockState.fetch
   const { resolveReleased, activePrefetches } = lockState
   lockState = null
   // Force-resolve every prefetch that hasn't finished, so a navigation still
@@ -328,81 +322,79 @@ function globalFetchOverride(
  * Called once during page initialization from app-globals.ts.
  */
 export function startListeningForInstantNavigationCookie(): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    // If the server served a shell, this is an MPA page load
-    // while the lock is held. Transition to captured-MPA and acquire.
-    if (self.__next_instant_test) {
-      if (typeof cookieStore !== 'undefined') {
-        // If the cookie was already cleared during the MPA page
-        // transition, reload to get the full dynamic page.
-        cookieStore.get(NEXT_INSTANT_TEST_COOKIE).then((cookie: any) => {
-          if (!cookie) {
-            window.location.reload()
-          }
-        })
-      }
-
-      // Acquire the lock before writing the cookie. writeCookieValue's
-      // guard requires lockState to be non-null at call time (so a stale
-      // write can't outlive its scope). On a fresh page load that scope
-      // is the one we're about to establish, so we have to establish it
-      // first.
-      acquireLock()
-      writeCookieValue([1, `c${Math.random()}`, null])
-    }
-
-    if (typeof cookieStore === 'undefined') {
-      return
-    }
-
-    cookieStore.addEventListener('change', (event: CookieChangeEvent) => {
-      for (const cookie of event.changed) {
-        if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
-          const state = parseCookieValue(cookie.value ?? '')
-
-          if (state === 'pending') {
-            // External actor starting a new lock scope.
-            if (lockState !== null) {
-              // This can be the delayed CookieStore event for the pending
-              // cookie that was already observed synchronously from
-              // document.cookie. Keep the existing lock identity so work that
-              // captured it keeps waiting on the same promise.
-              return
-            }
-            acquireLock()
-          }
-          // Captured value (our own transition) or empty. Ignore.
-          return
+  // If the server served a shell, this is an MPA page load
+  // while the lock is held. Transition to captured-MPA and acquire.
+  if (self.__next_instant_test) {
+    if (typeof cookieStore !== 'undefined') {
+      // If the cookie was already cleared during the MPA page
+      // transition, reload to get the full dynamic page.
+      cookieStore.get(NEXT_INSTANT_TEST_COOKIE).then((cookie: any) => {
+        if (!cookie) {
+          window.location.reload()
         }
-      }
+      })
+    }
 
-      for (const cookie of event.deleted) {
-        if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
-          if (lockState === null) {
-            // Either no lock is active, or this is the re-entrant change event
-            // from the defensive clear below (which runs after releaseLock).
-            // Nothing to release either way.
+    // Acquire the lock before writing the cookie. writeCookieValue's
+    // guard requires lockState to be non-null at call time (so a stale
+    // write can't outlive its scope). On a fresh page load that scope
+    // is the one we're about to establish, so we have to establish it
+    // first.
+    acquireLock()
+    writeCookieValue([1, `c${Math.random()}`, null])
+  }
+
+  if (typeof cookieStore === 'undefined') {
+    return
+  }
+
+  cookieStore.addEventListener('change', (event: CookieChangeEvent) => {
+    for (const cookie of event.changed) {
+      if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
+        const state = parseCookieValue(cookie.value ?? '')
+
+        if (state === 'pending') {
+          // External actor starting a new lock scope.
+          if (lockState !== null) {
+            // This can be the delayed CookieStore event for the pending
+            // cookie that was already observed synchronously from
+            // document.cookie. Keep the existing lock identity so work that
+            // captured it keeps waiting on the same promise.
             return
           }
-          releaseLock()
-          // A captured write from this page's bootstrap can resurrect the
-          // cookie in the narrow gap between the external delete and this
-          // handler: writeCookieValue's guard only rejects the write once the
-          // lock is torn down, which happens here. Now that the lock is
-          // released, no further captured write can re-add the cookie, so clear
-          // any entry that was resurrected in that gap. Otherwise an unlock
-          // that falls back to a hard reload (when the shell has not yet
-          // hydrated) would carry the stale cookie, be served the shell again,
-          // and re-enter instant mode with no scope left to release it.
-          if (typeof document !== 'undefined') {
-            document.cookie = `${NEXT_INSTANT_TEST_COOKIE}=; Path=/; Max-Age=0`
-          }
-          refreshOnInstantNavigationUnlock()
+          acquireLock()
+        }
+        // Captured value (our own transition) or empty. Ignore.
+        return
+      }
+    }
+
+    for (const cookie of event.deleted) {
+      if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
+        if (lockState === null) {
+          // Either no lock is active, or this is the re-entrant change event
+          // from the defensive clear below (which runs after releaseLock).
+          // Nothing to release either way.
           return
         }
+        releaseLock()
+        // A captured write from this page's bootstrap can resurrect the
+        // cookie in the narrow gap between the external delete and this
+        // handler: writeCookieValue's guard only rejects the write once the
+        // lock is torn down, which happens here. Now that the lock is
+        // released, no further captured write can re-add the cookie, so clear
+        // any entry that was resurrected in that gap. Otherwise an unlock
+        // that falls back to a hard reload (when the shell has not yet
+        // hydrated) would carry the stale cookie, be served the shell again,
+        // and re-enter instant mode with no scope left to release it.
+        if (typeof document !== 'undefined') {
+          document.cookie = `${NEXT_INSTANT_TEST_COOKIE}=; Path=/; Max-Age=0`
+        }
+        refreshOnInstantNavigationUnlock()
+        return
       }
-    })
-  }
+    }
+  })
 }
 
 /**
@@ -413,56 +405,49 @@ export function updateCapturedSPAToTree(
   fromTree: FlightRouterState,
   toTree: FlightRouterState
 ): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    writeCookieValue([1, `c${Math.random()}`, { from: fromTree, to: toTree }])
-  }
+  writeCookieValue([1, `c${Math.random()}`, { from: fromTree, to: toTree }])
 }
 
 /**
  * Returns true if the navigation lock is currently active.
  */
 export function isNavigationLocked(): boolean {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (lockState !== null) {
-      return true
-    }
+  if (lockState !== null) {
+    return true
+  }
 
-    // If `lockState` is null, fall back to reading the test cookie
-    // synchronously from `document.cookie`. This accounts for a small race
-    // between `cookieStore.set(...)` and its corresponding `change` event.
-    // During that gap `lockState` is still null even though the cookie
-    // indicates a new lock scope is starting.
-    if (typeof document === 'undefined') {
-      return false
-    }
-    const allCookies = document.cookie
-    if (!allCookies.includes(NEXT_INSTANT_TEST_COOKIE)) {
-      // Fast bail-out: in almost every navigation the test cookie is not
-      // set at all.
-      return false
-    }
-    const target = NEXT_INSTANT_TEST_COOKIE + '='
-    for (const segment of allCookies.split(';')) {
-      const trimmed = segment.trim()
-      if (
-        trimmed.startsWith(target) &&
-        parseCookieValue(trimmed.slice(target.length)) === 'pending'
-      ) {
-        // The cookie was set by an external actor but the change event was not
-        // yet dispatched. Acquire the lock synchronously.
-        acquireLock()
-        return true
-      }
+  // If `lockState` is null, fall back to reading the test cookie
+  // synchronously from `document.cookie`. This accounts for a small race
+  // between `cookieStore.set(...)` and its corresponding `change` event.
+  // During that gap `lockState` is still null even though the cookie
+  // indicates a new lock scope is starting.
+  if (typeof document === 'undefined') {
+    return false
+  }
+  const allCookies = document.cookie
+  if (!allCookies.includes(NEXT_INSTANT_TEST_COOKIE)) {
+    // Fast bail-out: in almost every navigation the test cookie is not
+    // set at all.
+    return false
+  }
+  const target = NEXT_INSTANT_TEST_COOKIE + '='
+  for (const segment of allCookies.split(';')) {
+    const trimmed = segment.trim()
+    if (
+      trimmed.startsWith(target) &&
+      parseCookieValue(trimmed.slice(target.length)) === 'pending'
+    ) {
+      // The cookie was set by an external actor but the change event was not
+      // yet dispatched. Acquire the lock synchronously.
+      acquireLock()
+      return true
     }
   }
   return false
 }
 
 export function getCurrentNavigationLock(): NavigationLockState | null {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    return lockState
-  }
-  return null
+  return lockState
 }
 
 /**
@@ -478,21 +463,18 @@ export function getCurrentNavigationLock(): NavigationLockState | null {
  * `<Link prefetch={true}>` or an eagerly-prefetched subtree, in which case the
  * concrete-param entry is genuinely warm and may be matched.
  *
- * Always returns false outside the testing API; the branch below is eliminated
- * from production bundles.
+ * Always returns false outside the testing API, via the aliased
+ * `navigation-testing-lock.disabled` module.
  */
 export function shouldRestrictNavigationToShell(
   rootPrefetchHints: number,
   linkFetchStrategy: FetchStrategy
 ): boolean {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    return (
-      isNavigationLocked() &&
-      (rootPrefetchHints & PrefetchHint.SubtreeHasPartialPrefetching) !== 0 &&
-      !subtreeHasSpeculativePrefetch(linkFetchStrategy, rootPrefetchHints)
-    )
-  }
-  return false
+  return (
+    isNavigationLocked() &&
+    (rootPrefetchHints & PrefetchHint.SubtreeHasPartialPrefetching) !== 0 &&
+    !subtreeHasSpeculativePrefetch(linkFetchStrategy, rootPrefetchHints)
+  )
 }
 
 /**
@@ -502,9 +484,7 @@ export function shouldRestrictNavigationToShell(
 export async function waitForNavigationLockIfActive(
   lock: NavigationLockState | null = getCurrentNavigationLock()
 ): Promise<void> {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (lock !== null) {
-      await lock.released
-    }
+  if (lock !== null) {
+    await lock.released
   }
 }


### PR DESCRIPTION
Ensures the module graph is not bundled. Right now this has no effect since all the modules imported by `navigation-test-lock` have legit uses in prod builds.

Also nice to not have to fork every single implementation inline.