### PR TITLE
Only compile edge instrumentation when an edge consumer exists (next dev)

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -143,6 +143,58 @@ type HandleRouteTypeHooks = {
   subscribeToChanges: StartChangeSubscription
 }
 
+/**
+ * Tracks whether an edge-runtime consumer (edge middleware or a route using
+ * `runtime = 'edge'`) has been seen for the given entrypoints.
+ *
+ * The edge variant of the instrumentation hook is only ever loaded by edge
+ * functions (its files are merged into edge function definitions in the
+ * middleware manifest), so it's only compiled once an edge consumer is
+ * discovered. Otherwise apps without any edge-runtime code would get
+ * irrelevant edge-compat issues reported for `instrumentation.ts` (e.g. when
+ * it uses Node.js APIs). See https://github.com/vercel/next.js/issues/86479
+ */
+const seenEdgeRuntimeConsumer = new WeakSet<Entrypoints>()
+
+export async function ensureEdgeInstrumentationBuilt({
+  entrypoints,
+  currentEntryIssues,
+  manifestLoader,
+  logErrors,
+  handleWrittenEndpoint,
+  startBuilding,
+}: {
+  entrypoints: Entrypoints
+  currentEntryIssues: EntryIssuesMap
+  manifestLoader: TurbopackManifestLoader
+  logErrors: boolean
+  handleWrittenEndpoint?: HandleWrittenEndpoint
+  startBuilding?: StartBuilding
+}): Promise<void> {
+  seenEdgeRuntimeConsumer.add(entrypoints)
+
+  const instrumentation = entrypoints.global.instrumentation
+  if (!instrumentation) {
+    return
+  }
+
+  const finishBuilding = startBuilding?.(
+    'instrumentation Edge',
+    undefined,
+    true
+  )
+  const key = getEntryKey('root', 'server', 'instrumentation.edge')
+
+  const writtenEndpoint = await instrumentation.edge.writeToDisk()
+  handleWrittenEndpoint?.(key, writtenEndpoint, false)
+  processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
+  await manifestLoader.loadMiddlewareManifest(
+    'instrumentation',
+    'instrumentation'
+  )
+  finishBuilding?.()
+}
+
 export async function handleRouteType({
   dev,
   page,
@@ -234,6 +286,13 @@ export async function handleRouteType({
         await manifestLoader.loadPagesManifest(page)
         if (type === 'edge') {
           warnAboutEdgeRuntime()
+          await ensureEdgeInstrumentationBuilt({
+            entrypoints,
+            currentEntryIssues,
+            manifestLoader,
+            logErrors,
+            handleWrittenEndpoint: hooks?.handleWrittenEndpoint,
+          })
           await manifestLoader.loadMiddlewareManifest(page, 'pages')
         } else {
           manifestLoader.deleteMiddlewareManifest(serverKey)
@@ -328,6 +387,13 @@ export async function handleRouteType({
       await manifestLoader.loadPagesManifest(page)
       if (type === 'edge') {
         warnAboutEdgeRuntime()
+        await ensureEdgeInstrumentationBuilt({
+          entrypoints,
+          currentEntryIssues,
+          manifestLoader,
+          logErrors,
+          handleWrittenEndpoint: hooks?.handleWrittenEndpoint,
+        })
         await manifestLoader.loadMiddlewareManifest(page, 'pages')
       } else {
         manifestLoader.deleteMiddlewareManifest(key)
@@ -382,6 +448,13 @@ export async function handleRouteType({
 
       if (type === 'edge') {
         warnAboutEdgeRuntime()
+        await ensureEdgeInstrumentationBuilt({
+          entrypoints,
+          currentEntryIssues,
+          manifestLoader,
+          logErrors,
+          handleWrittenEndpoint: hooks?.handleWrittenEndpoint,
+        })
         manifestLoader.loadMiddlewareManifest(page, 'app')
       } else {
         manifestLoader.deleteMiddlewareManifest(key)
@@ -414,6 +487,13 @@ export async function handleRouteType({
 
       if (type === 'edge') {
         warnAboutEdgeRuntime()
+        await ensureEdgeInstrumentationBuilt({
+          entrypoints,
+          currentEntryIssues,
+          manifestLoader,
+          logErrors,
+          handleWrittenEndpoint: hooks?.handleWrittenEndpoint,
+        })
         manifestLoader.loadMiddlewareManifest(page, 'app')
       } else {
         manifestLoader.deleteMiddlewareManifest(key)
@@ -659,32 +739,32 @@ export async function handleEntrypoints({
   currentEntrypoints.global.middleware = middleware
 
   if (instrumentation) {
-    const processInstrumentation = async (
-      name: string,
-      prop: 'nodeJs' | 'edge'
-    ) => {
-      const prettyName = {
-        nodeJs: 'Node.js',
-        edge: 'Edge',
-      }
-      const finishBuilding = dev.hooks.startBuilding(
-        `instrumentation ${prettyName[prop]}`,
-        undefined,
-        true
-      )
-      const key = getEntryKey('root', 'server', name)
-
-      const writtenEndpoint = await instrumentation[prop].writeToDisk()
-      dev.hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
-      processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
-      finishBuilding()
-    }
-    await processInstrumentation('instrumentation.nodeJs', 'nodeJs')
-    await processInstrumentation('instrumentation.edge', 'edge')
-    await manifestLoader.loadMiddlewareManifest(
-      'instrumentation',
-      'instrumentation'
+    const finishBuilding = dev.hooks.startBuilding(
+      'instrumentation Node.js',
+      undefined,
+      true
     )
+    const key = getEntryKey('root', 'server', 'instrumentation.nodeJs')
+
+    const writtenEndpoint = await instrumentation.nodeJs.writeToDisk()
+    dev.hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
+    processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
+    finishBuilding()
+
+    // The edge variant is only compiled when an edge-runtime consumer exists.
+    // If one was seen before (e.g. the instrumentation file changed), rebuild
+    // it here; otherwise it's built on demand when the first edge middleware
+    // or edge route is compiled.
+    if (seenEdgeRuntimeConsumer.has(currentEntrypoints)) {
+      await ensureEdgeInstrumentationBuilt({
+        entrypoints: currentEntrypoints,
+        currentEntryIssues,
+        manifestLoader,
+        logErrors,
+        handleWrittenEndpoint: dev.hooks.handleWrittenEndpoint,
+        startBuilding: dev.hooks.startBuilding,
+      })
+    }
     manifestLoader.writeManifests({
       devRewrites,
       productionRewrites: undefined,
@@ -721,6 +801,16 @@ export async function handleEntrypoints({
       const writtenEndpoint = await endpoint.writeToDisk()
       dev.hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
       processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
+      if (writtenEndpoint.type === 'edge') {
+        await ensureEdgeInstrumentationBuilt({
+          entrypoints: currentEntrypoints,
+          currentEntryIssues,
+          manifestLoader,
+          logErrors,
+          handleWrittenEndpoint: dev.hooks.handleWrittenEndpoint,
+          startBuilding: dev.hooks.startBuilding,
+        })
+      }
       await manifestLoader.loadMiddlewareManifest('middleware', 'middleware')
       const middlewareConfig =
         manifestLoader.getMiddlewareManifest(key)?.middleware['/']

--- a/test/development/instrumentation-hook-node-apis/app/layout.js
+++ b/test/development/instrumentation-hook-node-apis/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/instrumentation-hook-node-apis/app/page.js
+++ b/test/development/instrumentation-hook-node-apis/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/instrumentation-hook-node-apis/instrumentation-hook-node-apis.test.ts
+++ b/test/development/instrumentation-hook-node-apis/instrumentation-hook-node-apis.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+// The lazy edge-variant compilation of the instrumentation hook is
+// Turbopack-specific (https://github.com/vercel/next.js/issues/86479).
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'instrumentation-hook-node-apis',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+    })
+
+    it('should not report edge-runtime issues when there is no edge consumer', async () => {
+      const $ = await next.render$('/')
+      expect($('p').text()).toBe('hello world')
+
+      await retry(() => {
+        expect(next.cliOutput).toContain(
+          'instrumentation hook registered (nodejs)'
+        )
+      })
+
+      expect(next.cliOutput).not.toContain('Ecmascript file had an error')
+      expect(next.cliOutput).not.toContain('Edge Runtime')
+    })
+  }
+)

--- a/test/development/instrumentation-hook-node-apis/instrumentation.js
+++ b/test/development/instrumentation-hook-node-apis/instrumentation.js
@@ -1,0 +1,6 @@
+export function register() {
+  // Uses a Node.js-only API. This must not surface edge-runtime compat
+  // issues in dev when the app has no edge-runtime consumers.
+  process.on('warning', () => {})
+  console.log(`instrumentation hook registered (${process.env.NEXT_RUNTIME})`)
+}


### PR DESCRIPTION
Fixes #86479

### What?

In Turbopack dev mode, the edge variant of the instrumentation hook is no longer compiled unconditionally. It is compiled lazily, when the first edge-runtime consumer is discovered: edge middleware (checked when the middleware endpoint is written) or an edge route (checked in `handleRouteType`). Once an edge consumer has been seen, later `handleEntrypoints` passes (e.g. after the instrumentation file changes) rebuild it eagerly again.

### Why?

`handleEntrypoints` compiled both `instrumentation.nodeJs` and `instrumentation.edge` whenever an `instrumentation` file existed — even when the app had no edge-runtime consumer at all (Node.js `proxy.ts`, no `runtime = 'edge'` routes). The edge variant's output is only ever loaded by edge functions (its files are merged into edge function definitions in the middleware manifest), so the eager compilation only surfaced irrelevant edge-compat issues like:

```
A Node.js API is used (process.on at line: 4) which is not supported in the Edge Runtime.
Ecmascript file had an error
```

Since 16.2.x these surface as errors that block local dev (see https://github.com/vercel/next.js/issues/86479#issuecomment).

### How?

- Added `ensureEdgeInstrumentationBuilt()` which compiles the edge variant, reports its issues, and loads the instrumentation middleware manifest. It's invoked from the middleware path (when `writtenEndpoint.type === 'edge'`) and the four edge-route branches of `handleRouteType`, before manifests are written, so instrumentation files are always merged into edge function definitions before they execute.
- A `WeakSet<Entrypoints>` remembers that an edge consumer was seen so instrumentation changes keep rebuilding the edge variant.
- Added `test/development/instrumentation-hook-node-apis` verifying no edge-compat issues are reported for a Node-API-using `instrumentation.js` when no edge consumer exists. Existing `test/e2e/instrumentation-hook` edge cases (`with-middleware`, `with-edge-api`, `with-edge-page`, `with-async-edge-page`) verify the lazy path still delivers edge instrumentation, and pass.

Note: production builds (`next build`) compile the edge variant unconditionally on the Rust side (`endpoint_groups` in `crates/next-api/src/project.rs`) — that path is out of scope here and could be a follow-up.
