### PR TITLE
[test] Pin isolated fixtures to repo TypeScript

### DIFF
--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -13,7 +13,6 @@ describe('Error overlay - RSC build errors', () => {
       'react-tweet': '^3.2.0',
       '@mdx-js/react': '^2.3.0',
       tailwindcss: '^3.2.6',
-      typescript: 'latest',
       '@types/react': '^18.0.28',
       '@types/react-dom': '^18.0.10',
       'image-size': '^1.0.2',

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -7,7 +7,6 @@ describe('useDefineForClassFields SWC option', () => {
     files: join(__dirname, 'fixture'),
     dependencies: {
       mobx: '6.3.7',
-      typescript: 'latest',
       '@types/react': 'latest',
       '@types/node': 'latest',
       'mobx-react': '7.2.1',

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -8,7 +8,6 @@ describe('correct tsconfig.json defaults', () => {
     },
     skipStart: true,
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
       '@types/node': 'latest',
     },

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -32,7 +32,6 @@ describe('jsconfig-path-reloading', () => {
             }),
       },
       dependencies: {
-        typescript: 'latest',
         '@types/react': 'latest',
         '@types/node': 'latest',
       },

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -26,8 +26,6 @@ describe('tsconfig-path-reloading', () => {
     addAfterStart?: boolean
     testBaseUrl: boolean
   }) {
-    const typescriptVersion = testBaseUrl ? '5.9.3' : 'latest'
-
     const { next } = nextTestSetup({
       files: {
         components: new FileRef(join(__dirname, 'app/components')),
@@ -40,7 +38,7 @@ describe('tsconfig-path-reloading', () => {
             }),
       },
       dependencies: {
-        typescript: typescriptVersion,
+        ...(testBaseUrl ? { typescript: '5.9.3' } : {}),
         '@types/react': 'latest',
         '@types/node': 'latest',
       },

--- a/test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
+++ b/test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
@@ -62,7 +62,6 @@ describe('typescript-app-type-declarations', () => {
       'next-env.d.ts': nextEnvDts,
     },
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
       '@types/node': 'latest',
     },

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -4,7 +4,6 @@ describe('navigation between pages and app dir', () => {
   const { next } = nextTestSetup({
     files: new FileRef(__dirname),
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
       '@types/node': 'latest',
     },

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -4,7 +4,6 @@ describe('redirects and rewrites', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
       '@types/node': 'latest',
     },

--- a/test/e2e/app-dir/types/types.test.ts
+++ b/test/e2e/app-dir/types/types.test.ts
@@ -1,6 +1,9 @@
 import { execSync } from 'child_process'
 import { nextTestSetup } from 'e2e-utils'
 
+const repoTypeScriptVersion: string = require('../../../../package.json')
+  .devDependencies.typescript
+
 describe('app-dir types', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
@@ -11,6 +14,18 @@ describe('app-dir types', () => {
   if (skipped) {
     return
   }
+
+  it('uses the repo TypeScript version', async () => {
+    const packageJson = JSON.parse(await next.readFile('package.json'))
+    expect(packageJson.dependencies.typescript).toBe(repoTypeScriptVersion)
+
+    if (!process.env.NEXT_SKIP_ISOLATE) {
+      const installedPackageJson = JSON.parse(
+        await next.readFile('node_modules/typescript/package.json')
+      )
+      expect(installedPackageJson.version).toBe(repoTypeScriptVersion)
+    }
+  })
 
   it('should check types', async () => {
     execSync('pnpm next typegen', { cwd: next.testDir, stdio: 'inherit' })

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -73,8 +73,12 @@ type OmitFirstArgument<F> = F extends (
 // prettier-ignore
 const nextjsReactPeerVersion = "19.2.7";
 
-const ROOT_PACKAGE_MANAGER: string =
-  require('../../../package.json').packageManager
+const ROOT_PACKAGE_JSON: {
+  packageManager: string
+  devDependencies: { typescript: string }
+} = require('../../../package.json')
+const ROOT_PACKAGE_MANAGER = ROOT_PACKAGE_JSON.packageManager
+const ROOT_TYPESCRIPT_VERSION = ROOT_PACKAGE_JSON.devDependencies.typescript
 
 export class NextInstance {
   protected files: ResolvedFileConfig
@@ -259,7 +263,7 @@ export class NextInstance {
           'react-dom': reactVersion,
           '@types/react': '19.2.2',
           '@types/react-dom': '19.2.1',
-          typescript: 'latest',
+          typescript: ROOT_TYPESCRIPT_VERSION,
           '@types/node': 'latest',
           ...this.dependencies,
           ...this.packageJson?.dependencies,

--- a/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
+++ b/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
@@ -11,7 +11,6 @@ describe('Does not override tsconfig moduleResolution field during build', () =>
       pkg: new FileRef(join(__dirname, 'pkg')),
     },
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
       '@types/node': 'latest',
       pkg: './pkg',

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -7,7 +7,6 @@ describe('TypeScript basic', () => {
     files: new FileRef(path.join(__dirname, 'app')),
     dependencies: {
       '@next/bundle-analyzer': 'canary',
-      typescript: 'latest',
       '@types/node': 'latest',
       '@types/react': 'latest',
       '@types/react-dom': 'latest',


### PR DESCRIPTION
Isolated test apps were installing typescript: latest, so the TypeScript 7 release moved the test matrix to a compiler that no longer exposes the compiler API Next.js uses. This makes generic fixtures use the exact TypeScript version already validated by the repo while leaving explicit version-specific tests alone. Verified across app-dir types, tsconfig defaults and reloading, production TypeScript, native TS config, skip-isolate, and pnpm types. Related to #95490 and #95572; this restores deterministic coverage but does not add TypeScript 7 support.

<!-- NEXT_JS_LLM_PR -->