### PR TITLE
[ci] Pin typescript version in tests

### DIFF
--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -13,7 +13,6 @@ describe('Error overlay - RSC build errors', () => {
       'react-tweet': '^3.2.0',
       '@mdx-js/react': '^2.3.0',
       tailwindcss: '^3.2.6',
-      typescript: 'latest',
       '@types/react': '^18.0.28',
       '@types/react-dom': '^18.0.10',
       'image-size': '^1.0.2',

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -7,9 +7,7 @@ describe('useDefineForClassFields SWC option', () => {
     files: join(__dirname, 'fixture'),
     dependencies: {
       mobx: '6.3.7',
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
       'mobx-react': '7.2.1',
     },
   })

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -8,9 +8,7 @@ describe('correct tsconfig.json defaults', () => {
     },
     skipStart: true,
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
     },
   })
 

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -32,9 +32,7 @@ describe('jsconfig-path-reloading', () => {
             }),
       },
       dependencies: {
-        typescript: 'latest',
         '@types/react': 'latest',
-        '@types/node': 'latest',
       },
     })
 

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -26,7 +26,7 @@ describe('tsconfig-path-reloading', () => {
     addAfterStart?: boolean
     testBaseUrl: boolean
   }) {
-    const typescriptVersion = testBaseUrl ? '5.9.3' : 'latest'
+    const typescriptVersion = testBaseUrl ? '5.9.3' : '6.0.3'
 
     const { next } = nextTestSetup({
       files: {

--- a/test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
+++ b/test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
@@ -62,9 +62,7 @@ describe('typescript-app-type-declarations', () => {
       'next-env.d.ts': nextEnvDts,
     },
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
     },
   })
 

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -4,9 +4,7 @@ describe('navigation between pages and app dir', () => {
   const { next } = nextTestSetup({
     files: new FileRef(__dirname),
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
     },
   })
 

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -4,9 +4,7 @@ describe('redirects and rewrites', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
     },
   })
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -260,7 +260,7 @@ export class NextInstance {
           '@types/react': '19.2.2',
           '@types/react-dom': '19.2.1',
           typescript: '6.0.3',
-          '@types/node': '26.1.1',
+          '@types/node': '26.1.0',
           ...this.dependencies,
           ...this.packageJson?.dependencies,
         }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -259,8 +259,8 @@ export class NextInstance {
           'react-dom': reactVersion,
           '@types/react': '19.2.2',
           '@types/react-dom': '19.2.1',
-          typescript: 'latest',
-          '@types/node': 'latest',
+          typescript: '6.0.3',
+          '@types/node': '26.1.1',
           ...this.dependencies,
           ...this.packageJson?.dependencies,
         }

--- a/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
+++ b/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
@@ -11,9 +11,7 @@ describe('Does not override tsconfig moduleResolution field during build', () =>
       pkg: new FileRef(join(__dirname, 'pkg')),
     },
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
       pkg: './pkg',
     },
   })

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -7,8 +7,6 @@ describe('TypeScript basic', () => {
     files: new FileRef(path.join(__dirname, 'app')),
     dependencies: {
       '@next/bundle-analyzer': 'canary',
-      typescript: 'latest',
-      '@types/node': 'latest',
       '@types/react': 'latest',
       '@types/react-dom': 'latest',
     },


### PR DESCRIPTION
Typescript 7 came out, which is breaking a lot of our e2e tests.