### PR TITLE
feat(draft-mode): allow overriding cookie attributes in draftMode().enable()

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/draft-mode.mdx
+++ b/docs/01-app/03-api-reference/04-functions/draft-mode.mdx
@@ -30,11 +30,20 @@ export default async function Page() {
 
 The following methods and properties are available:
 
-| Method      | Description                                                                       |
-| ----------- | --------------------------------------------------------------------------------- |
-| `isEnabled` | A boolean value that indicates if Draft Mode is enabled.                          |
-| `enable()`  | Enables Draft Mode in a Route Handler by setting a cookie (`__prerender_bypass`). |
-| `disable()` | Disables Draft Mode in a Route Handler by deleting a cookie.                      |
+| Method             | Description                                                                       |
+| ------------------ | --------------------------------------------------------------------------------- |
+| `isEnabled`        | A boolean value that indicates if Draft Mode is enabled.                          |
+| `enable(options?)` | Enables Draft Mode in a Route Handler by setting a cookie (`__prerender_bypass`). |
+| `disable()`        | Disables Draft Mode in a Route Handler by deleting a cookie.                      |
+
+`enable()` optionally accepts an object to override the attributes used for the `__prerender_bypass` cookie:
+
+| Option     | Type                                     | Description                                               |
+| ---------- | ---------------------------------------- | --------------------------------------------------------- |
+| `sameSite` | `boolean \| 'lax' \| 'strict' \| 'none'` | Sets the `SameSite` attribute of the cookie.              |
+| `secure`   | `boolean`                                | Sets the `Secure` attribute of the cookie.                |
+| `path`     | `string`                                 | Sets the `Path` attribute of the cookie. Defaults to `/`. |
+| `domain`   | `string`                                 | Sets the `Domain` attribute of the cookie.                |
 
 ## Good to know
 
@@ -71,6 +80,32 @@ export async function GET(request) {
   return new Response('Draft mode is enabled')
 }
 ```
+
+### Enabling Draft Mode in a cross-origin iframe
+
+By default, the `__prerender_bypass` cookie is set with `SameSite=Lax` on the development server (and `SameSite=None; Secure` in production). When your app is embedded in a cross-origin `<iframe>` (for example, a headless CMS preview), the browser will not send a `SameSite=Lax` cookie. Pass `sameSite` and `secure` to `enable()` to opt into cross-site cookies:
+
+```tsx filename="app/draft/route.ts" switcher
+import { draftMode } from 'next/headers'
+
+export async function GET(request: Request) {
+  const draft = await draftMode()
+  draft.enable({ sameSite: 'none', secure: true })
+  return new Response('Draft mode is enabled')
+}
+```
+
+```js filename="app/draft/route.js" switcher
+import { draftMode } from 'next/headers'
+
+export async function GET(request) {
+  const draft = await draftMode()
+  draft.enable({ sameSite: 'none', secure: true })
+  return new Response('Draft mode is enabled')
+}
+```
+
+> **Good to know**: `SameSite=None` requires the `Secure` attribute, so the cookie is only sent over HTTPS.
 
 ### Disabling Draft Mode
 
@@ -136,5 +171,6 @@ export default async function Page() {
 
 | Version      | Changes                                                                                                  |
 | ------------ | -------------------------------------------------------------------------------------------------------- |
+| `v16.3.0`    | `enable()` accepts an options object to override the `__prerender_bypass` cookie attributes.             |
 | `v15.0.0-RC` | `draftMode` is now an async function. A [codemod](/docs/app/guides/upgrading/codemods#150) is available. |
 | `v13.4.0`    | `draftMode` introduced.                                                                                  |

--- a/packages/next/src/server/async-storage/draft-mode-provider.ts
+++ b/packages/next/src/server/async-storage/draft-mode-provider.ts
@@ -1,12 +1,26 @@
 import type { IncomingHttpHeaders } from 'http'
 import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
-import type { ResponseCookies } from '../web/spec-extension/cookies'
+import type {
+  ResponseCookie,
+  ResponseCookies,
+} from '../web/spec-extension/cookies'
 
 import {
   COOKIE_NAME_PRERENDER_BYPASS,
   checkIsOnDemandRevalidate,
 } from '../api-utils'
 import type { __ApiPreviewProps } from '../api-utils'
+
+/**
+ * Cookie attributes that can be overridden when enabling Draft Mode. This is
+ * primarily useful for supporting Draft Mode inside a cross-origin `<iframe>`
+ * (e.g. a headless CMS preview), which requires `sameSite: 'none'` and
+ * `secure: true`.
+ */
+export type EnableDraftModeOptions = Pick<
+  ResponseCookie,
+  'sameSite' | 'secure' | 'path' | 'domain'
+>
 
 export class DraftModeProvider {
   /**
@@ -56,7 +70,7 @@ export class DraftModeProvider {
     return this._isEnabled
   }
 
-  enable() {
+  enable(options?: EnableDraftModeOptions) {
     if (!this._previewModeId) {
       throw new Error(
         'Invariant: previewProps missing previewModeId this should never happen'
@@ -70,6 +84,7 @@ export class DraftModeProvider {
       sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
       secure: process.env.NODE_ENV !== 'development',
       path: '/',
+      ...options,
     })
 
     this._isEnabled = true

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -3,7 +3,10 @@ import {
   throwForMissingRequestStore,
 } from '../app-render/work-unit-async-storage.external'
 
-import type { DraftModeProvider } from '../async-storage/draft-mode-provider'
+import type {
+  DraftModeProvider,
+  EnableDraftModeOptions,
+} from '../async-storage/draft-mode-provider'
 
 import {
   workAsyncStorage,
@@ -158,12 +161,12 @@ class DraftMode {
     }
     return false
   }
-  public enable() {
+  public enable(options?: EnableDraftModeOptions) {
     // We have a store we want to track dynamic data access to ensure we
     // don't statically generate routes that manipulate draft mode.
     trackDynamicDraftMode('draftMode().enable()', this.enable)
     if (this._provider !== null) {
-      this._provider.enable()
+      this._provider.enable(options)
     }
   }
   public disable() {

--- a/packages/next/src/server/web/spec-extension/cookies.ts
+++ b/packages/next/src/server/web/spec-extension/cookies.ts
@@ -2,4 +2,5 @@ export {
   RequestCookies,
   ResponseCookies,
   stringifyCookie,
+  type ResponseCookie,
 } from 'next/dist/compiled/@edge-runtime/cookies'

--- a/test/e2e/app-dir/draft-mode/app/enable-with-options/route.ts
+++ b/test/e2e/app-dir/draft-mode/app/enable-with-options/route.ts
@@ -1,0 +1,8 @@
+import { draftMode } from 'next/headers'
+
+export async function GET() {
+  ;(await draftMode()).enable({ sameSite: 'none', secure: true })
+  return new Response(
+    'Enabled in Route Handler using `(await draftMode()).enable({ sameSite: "none", secure: true })`, check cookies'
+  )
+}

--- a/test/e2e/app-dir/draft-mode/app/with-edge/enable-with-options/route.ts
+++ b/test/e2e/app-dir/draft-mode/app/with-edge/enable-with-options/route.ts
@@ -1,0 +1,8 @@
+import { draftMode } from 'next/headers'
+
+export async function GET() {
+  ;(await draftMode()).enable({ sameSite: 'none', secure: true })
+  return new Response(
+    'Enabled in Route Handler using `(await draftMode()).enable({ sameSite: "none", secure: true })`, check cookies'
+  )
+}

--- a/test/e2e/app-dir/draft-mode/draft-mode.test.ts
+++ b/test/e2e/app-dir/draft-mode/draft-mode.test.ts
@@ -55,6 +55,17 @@ describe('app dir - draft mode', () => {
       expect(Cookie).toBeDefined()
     })
 
+    it('should allow overriding cookie attributes on enable', async () => {
+      const res = await next.fetch(`${basePath}enable-with-options`)
+      const h = res.headers.get('set-cookie') || ''
+      const cookie =
+        h
+          .split(/,(?=[^ ]*=)/)
+          .find((c) => c.trim().startsWith('__prerender_bypass')) || ''
+      expect(cookie.toLowerCase()).toContain('samesite=none')
+      expect(cookie.toLowerCase()).toContain('secure')
+    })
+
     it('should have set-cookie header with redirect location', async () => {
       const res = await next.fetch(`${basePath}enable-and-redirect`, {
         redirect: 'manual',


### PR DESCRIPTION
## Summary

Fixes #49927. App Router Draft Mode sets the `__prerender_bypass` cookie with `SameSite=Lax` on the dev server (and `SameSite=None; Secure` in production). Users embedding their app in a cross-origin `<iframe>` (headless CMS preview, e.g. Storyblok/Contentful) need `SameSite=None; Secure` so the browser sends the cookie in the iframe. Until now the only workaround was to re-set the cookie by hand after `enable()`.

This adds an optional options argument to `draftMode().enable()` that overrides the cookie attributes:

```ts
const draft = await draftMode()
draft.enable({ sameSite: 'none', secure: true })
```

The options are spread over the existing defaults, so behavior is unchanged when no argument is passed:

```ts
// draft-mode-provider.ts
this._mutableCookies.set({
  name: COOKIE_NAME_PRERENDER_BYPASS,
  value: this._previewModeId,
  httpOnly: true,
  sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
  secure: process.env.NODE_ENV !== 'development',
  path: '/',
  ...options, // new
})
```

`EnableDraftModeOptions` exposes the cross-site-relevant cookie attributes: `sameSite`, `secure`, `path`, `domain`.

Also updates the `draftMode` API reference docs and the e2e suite (`test/e2e/app-dir/draft-mode`) with a route that enables draft mode with overridden attributes, asserting the `Set-Cookie` header contains `SameSite=None; Secure` in both node and edge runtimes.

## Verification

- `pnpm test-dev-webpack test/e2e/app-dir/draft-mode/draft-mode.test.ts` — 20/20 passing (node + edge).

<!-- NEXT_JS_LLM_PR -->
