### PR TITLE
[16.x] [ci] Pin typescript version in tests (#95619)

### DIFF
--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -13,7 +13,6 @@ describe('Error overlay - RSC build errors', () => {
       'react-tweet': '^3.2.0',
       '@mdx-js/react': '^2.3.0',
       tailwindcss: '^3.2.6',
-      typescript: 'latest',
       '@types/react': '^18.0.28',
       '@types/react-dom': '^18.0.10',
       'image-size': '^1.0.2',

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -7,9 +7,7 @@ describe('useDefineForClassFields SWC option', () => {
     files: join(__dirname, 'fixture'),
     dependencies: {
       mobx: '6.3.7',
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
       'mobx-react': '7.2.1',
     },
   })

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -12,9 +12,7 @@ describe('correct tsconfig.json defaults', () => {
       },
       skipStart: true,
       dependencies: {
-        typescript: 'latest',
         '@types/react': 'latest',
-        '@types/node': 'latest',
       },
     })
   })

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -36,9 +36,7 @@ describe('jsconfig-path-reloading', () => {
               }),
         },
         dependencies: {
-          typescript: 'latest',
           '@types/react': 'latest',
-          '@types/node': 'latest',
         },
       })
 

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -36,7 +36,7 @@ describe('tsconfig-path-reloading', () => {
               }),
         },
         dependencies: {
-          typescript: 'latest',
+          typescript: '6.0.3',
           '@types/react': 'latest',
           '@types/node': 'latest',
         },

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -9,9 +9,7 @@ describe('navigation between pages and app dir', () => {
     next = await createNext({
       files: new FileRef(__dirname),
       dependencies: {
-        typescript: 'latest',
         '@types/react': 'latest',
-        '@types/node': 'latest',
       },
     })
   })

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -4,9 +4,7 @@ describe('redirects and rewrites', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
     },
   })
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -254,8 +254,8 @@ export class NextInstance {
           'react-dom': reactVersion,
           '@types/react': '19.2.2',
           '@types/react-dom': '19.2.1',
-          typescript: 'latest',
-          '@types/node': 'latest',
+          typescript: '6.0.3',
+          '@types/node': '26.1.0',
           ...this.dependencies,
           ...this.packageJson?.dependencies,
         }

--- a/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
+++ b/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
@@ -11,9 +11,7 @@ describe('Does not override tsconfig moduleResolution field during build', () =>
       pkg: new FileRef(join(__dirname, 'pkg')),
     },
     dependencies: {
-      typescript: 'latest',
       '@types/react': 'latest',
-      '@types/node': 'latest',
       pkg: './pkg',
     },
   })

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -11,8 +11,6 @@ describe('TypeScript basic', () => {
       files: new FileRef(path.join(__dirname, 'app')),
       dependencies: {
         '@next/bundle-analyzer': 'canary',
-        typescript: 'latest',
-        '@types/node': 'latest',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',
       },


### PR DESCRIPTION
Backports [[ci] Pin typescript version in tests (#95619)](https://github.com/vercel/next.js/pull/95619) to `next-16-2`.

**We don't need a backport for `next-15-5` because it was already pinned by https://github.com/vercel/next.js/pull/93107**

TypeScript 7 was released, which breaks e2e tests that install `typescript: 'latest'`. This pins `typescript` to `6.0.3` and `@types/node` to `26.1.0` in the test defaults instead.

Notes on conflict resolution:
- `next-16-2` still uses the older `createNext`/`beforeAll` test style in several of these files; the dependency changes were applied on top of that structure.
- `test/development/typescript-app-type-declarations` does not exist on `next-16-2`, so that part of the change was dropped.
- `test/development/tsconfig-path-reloading` has no `testBaseUrl` variant on this branch, so `typescript` is pinned directly to `6.0.3`.

<!-- NEXT_JS_LLM_PR -->