### PR TITLE
[turbopack] Rewrite CJS modules into tree-shakeable modules (when possible)

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -259,6 +259,9 @@ pub struct EcmascriptOptions {
     pub inline_helpers: bool,
     /// Whether to infer side effect free modules via local analysis. Defaults to true.
     pub infer_module_side_effects: bool,
+    /// Whether to tree-shake statically-analyzable CommonJS modules (drop unused
+    /// `exports.foo = …` exports). See `references/exports/cjs.rs`.
+    pub cjs_tree_shaking: bool,
 }
 
 #[turbo_tasks::value(task_input)]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -35,7 +35,9 @@ use super::{
 };
 use crate::{
     magic_identifier::{self, MAGIC_IDENTIFIER_DEFAULT_EXPORT_ATOM},
+    references::exports::cjs::CjsExportFormat,
     tree_shake::optimizations::GraphOptimizer,
+    utils::unparen,
 };
 
 /// The id of an item
@@ -868,13 +870,153 @@ impl DepGraph {
         comments: &dyn Comments,
         unresolved_ctxt: SyntaxContext,
         top_level_ctxt: SyntaxContext,
+        // For a statically-analyzable CommonJS module (structurally wrapped as
+        // a `Module`), the analyzer's per-statement export map: recognized
+        // top-level export writes and `__esModule` marker statements, keyed by
+        // statement index (see `analyze_cjs_exports`). Empty for ESM modules.
+        mut cjs_exports: FxHashMap<usize, CjsExportFormat>,
     ) -> (Vec<ItemId>, FxHashMap<ItemId, ItemData>) {
         let top_level_vars = collect_top_level_decls(module);
         let mut exports = vec![];
         let mut items = FxHashMap::default();
         let mut ids = vec![];
 
+        struct CjsExportWrites {
+            pairs: Vec<(Atom, Expr)>,
+            from_object_literal: bool,
+        }
+
+        let is_static_cjs = !cjs_exports.is_empty();
+
         for (index, item) in module.body.iter().enumerate() {
+            if is_static_cjs {
+                // If the CJS analyzer recognized this statement (by its index) as an
+                // export write or the `__esModule` marker, handle it here; otherwise
+                // fall through to the normal item handling below.
+                //
+                // The `__esModule` marker statement is dropped.
+                //
+                // Each recognized export write becomes, per name, a synthesized
+                // `const __TURBOPACK_cjs_export__NAME = EXPR` item (the value) plus
+                // an `export { __TURBOPACK_cjs_export__NAME as NAME }` item — the
+                // latter created from the `exports` list by the shared loop at the
+                // end of `init`, exactly as for an ESM `export const`:
+                //
+                //     exports.foo = 1               →  const __TURBOPACK_cjs_export__foo = 1
+                //                                      export { __TURBOPACK_cjs_export__foo as foo
+                // }
+                //
+                //     module.exports = { a, b: 2 }  →  const __TURBOPACK_cjs_export__a = a
+                //                                      export { __TURBOPACK_cjs_export__a as a }
+                //                                      const __TURBOPACK_cjs_export__b = 2
+                //                                      export { __TURBOPACK_cjs_export__b as b }
+                let exports_to_synthesize = match cjs_exports.remove(&index) {
+                    Some(CjsExportFormat::EsModuleMarker) => continue,
+                    Some(CjsExportFormat::Named(name)) => {
+                        // The export map is built from these same statements, so
+                        // the shape is guaranteed.
+                        let rhs = if let ModuleItem::Stmt(Stmt::Expr(ExprStmt { expr, .. })) = item
+                            && let Expr::Assign(assign) = unparen(expr)
+                        {
+                            (*assign.right).clone()
+                        } else {
+                            unreachable!("CJS exports map entry does not match its statement")
+                        };
+                        Some(CjsExportWrites {
+                            pairs: vec![(name, rhs)],
+                            from_object_literal: false,
+                        })
+                    }
+                    Some(CjsExportFormat::ObjectLiteral(pairs)) => Some(CjsExportWrites {
+                        pairs,
+                        from_object_literal: true,
+                    }),
+                    Some(CjsExportFormat::Unsafe) | None => None,
+                };
+                if let Some(CjsExportWrites {
+                    pairs,
+                    from_object_literal,
+                }) = exports_to_synthesize
+                {
+                    for (pos, (export_name, value)) in pairs.into_iter().enumerate() {
+                        // Find the variables the value uses: read/written now, and
+                        // captured by its closures.
+                        let mut vars = ids_used_by_ignoring_nested(
+                            &value,
+                            unresolved_ctxt,
+                            top_level_ctxt,
+                            &top_level_vars,
+                        );
+                        let captured_ids = ids_captured_by(
+                            &value,
+                            unresolved_ctxt,
+                            top_level_ctxt,
+                            &top_level_vars,
+                        );
+
+                        // Name the binding that holds this export's value.
+                        let local = Ident::new(
+                            format!("__TURBOPACK_cjs_export__{export_name}").into(),
+                            DUMMY_SP,
+                            top_level_ctxt,
+                        );
+                        vars.write.insert(local.to_id());
+
+                        // A pure value makes the write droppable when the name is
+                        // unused; an impure one keeps it as a module-evaluation
+                        // side effect so it always runs.
+                        let side_effects = vars.found_unresolved
+                            || value.may_have_side_effects(ExprCtx {
+                                unresolved_ctxt,
+                                is_unresolved_ref_safe: false,
+                                in_strict: false,
+                                remaining_depth: 4,
+                            });
+
+                        // Build the `const __TURBOPACK_cjs_export__NAME = value` item.
+                        let data = ItemData {
+                            var_decls: [local.to_id()].into_iter().collect(),
+                            read_vars: vars.read,
+                            eventual_read_vars: captured_ids.read,
+                            write_vars: vars.write,
+                            eventual_write_vars: captured_ids.write,
+                            content: ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+                                span: DUMMY_SP,
+                                kind: VarDeclKind::Const,
+                                decls: vec![VarDeclarator {
+                                    span: DUMMY_SP,
+                                    name: local.clone().into(),
+                                    init: Some(Box::new(value)),
+                                    definite: false,
+                                }],
+                                ..Default::default()
+                            })))),
+                            side_effects,
+                            ..Default::default()
+                        };
+
+                        // Add it to the graph under a unique id.
+                        let id = ItemId::Item {
+                            index,
+                            // Distinct `VarDeclarator(pos)` kinds keep item ids
+                            // unique for the multiple properties of one
+                            // `module.exports = { … }` statement.
+                            kind: if from_object_literal {
+                                ItemIdItemKind::VarDeclarator(pos as u32)
+                            } else {
+                                ItemIdItemKind::Normal
+                            },
+                        };
+                        ids.push(id.clone());
+                        items.insert(id, data);
+
+                        // Register the binding as export `export_name`.
+                        exports.push((local.to_id(), export_name));
+                    }
+                    continue;
+                }
+            }
+
             // Fill exports
             if let ModuleItem::ModuleDecl(item) = item {
                 match item {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -21,7 +21,10 @@ pub(crate) use self::graph::{
     PartId, create_turbopack_part_id_assert, find_turbopack_part_id_in_asserts,
 };
 use crate::{
-    EcmascriptModuleAsset, EcmascriptParsable, analyzer::graph::EvalContext, parse::ParseResult,
+    EcmascriptModuleAsset, EcmascriptParsable,
+    analyzer::graph::EvalContext,
+    parse::ParseResult,
+    references::exports::cjs::{CjsExportFormat, analyze_cjs_exports},
 };
 
 mod graph;
@@ -34,6 +37,19 @@ mod tests;
 mod util;
 
 pub(crate) const TURBOPACK_PART_IMPORT_SOURCE: &str = "__TURBOPACK_PART__";
+
+/// Wraps a CommonJS `Program::Script` in a `Module` — each statement becomes a
+/// `ModuleItem::Stmt` — so it can flow through the (ESM-shaped) tree shaker.
+pub(crate) fn cjs_script_to_module(program: &Program) -> Option<Module> {
+    let Program::Script(script) = program else {
+        return None;
+    };
+    Some(Module {
+        span: script.span,
+        body: script.body.iter().cloned().map(ModuleItem::Stmt).collect(),
+        shebang: script.shebang.clone(),
+    })
+}
 
 pub struct Analyzer<'a> {
     g: &'a mut DepGraph,
@@ -71,9 +87,16 @@ impl Analyzer<'_> {
         comments: &dyn Comments,
         unresolved_ctxt: SyntaxContext,
         top_level_ctxt: SyntaxContext,
+        cjs_exports: FxHashMap<usize, CjsExportFormat>,
     ) -> (DepGraph, FxHashMap<ItemId, ItemData>) {
         let mut g = DepGraph::default();
-        let (item_ids, mut items) = g.init(module, comments, unresolved_ctxt, top_level_ctxt);
+        let (item_ids, mut items) = g.init(
+            module,
+            comments,
+            unresolved_ctxt,
+            top_level_ctxt,
+            cjs_exports,
+        );
 
         let mut analyzer = Analyzer {
             g: &mut g,
@@ -454,6 +477,17 @@ pub(crate) enum SplitResult {
 
         #[turbo_tasks(debug_ignore, trace_ignore)]
         star_reexports: Vec<ExportAll>,
+
+        /// Whether this split module is a statically-analyzable CommonJS module
+        /// (see `cjs_script_to_module`). Whole-module consumers must then
+        /// reconstruct a real `module.exports` instead of an ESM facade — e.g.
+        /// for a module exporting `foo`:
+        ///
+        /// ```js
+        /// import { foo as __TURBOPACK_cjs_facade__foo } from "…" with { __turbopack_part__: "exports" };
+        /// exports.foo = __TURBOPACK_cjs_facade__foo;
+        /// ```
+        is_cjs: bool,
     },
     Failed {
         parse_result: ResolvedVc<ParseResult>,
@@ -491,6 +525,8 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
         .cell());
     }
 
+    let cjs_tree_shaking = asset.await?.options.await?.cjs_tree_shaking;
+
     let parse_result = parsed.await?;
 
     match &*parse_result {
@@ -503,17 +539,48 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
             program_source,
             ..
         } => {
-            // If the script file is a common js file, we cannot split the module
-            if util::should_skip_tree_shaking(program) {
+            // CommonJS: if CJS tree-shaking is on and this is a safe, statically-analyzable
+            // CommonJS script with at least one export, wrap it as a `Module` so
+            // it can flow through the (ESM-shaped) tree-shaker; `DepGraph::init`
+            // then uses the analysis's export map to rewrite each export write
+            // into ESM syntax so it tree-shakes like a normal ESM export, e.g.
+            // `exports.foo = 1` becomes
+            // `const __TURBOPACK_cjs_export__foo = 1; export { __TURBOPACK_cjs_export__foo as foo
+            // }`. ESM modules — and CommonJS we can't safely split — yield `None`.
+            let (cjs_module, cjs_analysis) = if cjs_tree_shaking {
+                let analysis = GLOBALS.set(globals, || {
+                    analyze_cjs_exports(program, eval_context.unresolved_mark)
+                });
+                if !analysis.is_unsafe && !analysis.names.is_empty() {
+                    cjs_script_to_module(program).map(|module| (module, analysis))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+            .unzip();
+            let is_cjs = cjs_module.is_some();
+
+            // Pick the `Module` to tree-shake
+            let module = if let Some(cjs_module) = &cjs_module {
+                // The wrapped CommonJS module from above.
+                cjs_module
+            } else if util::should_skip_tree_shaking(program) {
+                // Not splittable — a plain CommonJS script, or a module with no
+                // ESM exports. Emit it whole.
                 return Ok(SplitResult::Failed {
                     parse_result: parsed,
                 }
                 .cell());
-            }
-
-            let module = match program {
-                Program::Module(module) => module,
-                Program::Script(..) => unreachable!("CJS is already handled"),
+            } else {
+                // A real ESM module.
+                match program {
+                    Program::Module(module) => module,
+                    Program::Script(..) => {
+                        unreachable!("a splittable CommonJS script is handled above")
+                    }
+                }
             };
 
             // We copy directives like `use client` or `use server` to each module
@@ -538,6 +605,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                     comments,
                     SyntaxContext::empty().apply_mark(eval_context.unresolved_mark),
                     SyntaxContext::empty().apply_mark(eval_context.top_level_mark),
+                    cjs_analysis.map(|a| a.exports).unwrap_or_default(),
                 )
             });
 
@@ -593,6 +661,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                 deps: part_deps,
                 modules,
                 star_reexports,
+                is_cjs,
             }
             .cell())
         }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
@@ -4,11 +4,14 @@ use anyhow::Error;
 use serde::Deserialize;
 use swc_core::{
     atoms::{Wtf8Atom, atom},
-    common::{Mark, SourceMap, SyntaxContext, comments::SingleThreadedComments, util::take::Take},
+    common::{
+        FileName, Mark, SourceMap, SyntaxContext, comments::SingleThreadedComments,
+        util::take::Take,
+    },
     ecma::{
         ast::{EsVersion, Id, Module},
         codegen::text_writer::JsWriter,
-        parser::{EsSyntax, parse_file_as_module},
+        parser::{EsSyntax, Syntax, parse_file_as_module, parse_file_as_program},
         visit::VisitMutWith,
     },
     testing::{self, NormalizedOutput, fixture},
@@ -16,12 +19,14 @@ use swc_core::{
 use turbo_tasks::FxIndexSet;
 
 use super::{
-    Analyzer, Key,
+    Analyzer, Key, cjs_script_to_module,
     graph::{
-        DepGraph, Dependency, InternedGraph, ItemId, ItemIdGroupKind, Mode, SplitModuleResult,
+        DepGraph, Dependency, InternedGraph, ItemData, ItemId, ItemIdGroupKind, Mode,
+        SplitModuleResult,
     },
     merge::Merger,
 };
+use crate::references::exports::cjs::analyze_cjs_exports;
 
 #[fixture("tests/tree-shaker/analyzer/**/input.js")]
 fn test_fixture(input: PathBuf) {
@@ -71,7 +76,13 @@ fn run(input: PathBuf) {
         ));
 
         let mut g = DepGraph::default();
-        let (item_ids, mut items) = g.init(&module, &comments, unresolved_ctxt, top_level_ctxt);
+        let (item_ids, mut items) = g.init(
+            &module,
+            &comments,
+            unresolved_ctxt,
+            top_level_ctxt,
+            Default::default(),
+        );
 
         let mut s = String::new();
 
@@ -369,4 +380,257 @@ fn render_item_id(id: &ItemId) -> Option<String> {
         ItemId::Group(ItemIdGroupKind::Export(_, name)) => Some(format!("export {name}")),
         _ => None,
     }
+}
+
+/// A safe CommonJS module, wrapped as a `Module` and analyzed with its CJS
+/// exports map, should flow through the tree-shaker and yield one
+/// `Key::Export` entrypoint per named export — proving the export map links
+/// end-to-end.
+#[test]
+fn cjs_normalized_module_produces_export_parts() {
+    testing::run_test(false, |cm, _handler| {
+        let fm = cm.new_source_file(
+            FileName::Anon.into(),
+            "exports.foo = 1; exports.bar = 2;".to_string(),
+        );
+        let comments = SingleThreadedComments::default();
+        let mut program = parse_file_as_program(
+            &fm,
+            Syntax::Es(EsSyntax::default()),
+            EsVersion::latest(),
+            Some(&comments),
+            &mut vec![],
+        )
+        .unwrap();
+
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+        let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
+        let top_level_ctxt = SyntaxContext::empty().apply_mark(top_level_mark);
+        program.visit_mut_with(&mut swc_core::ecma::transforms::base::resolver(
+            unresolved_mark,
+            top_level_mark,
+            false,
+        ));
+
+        let analysis = analyze_cjs_exports(&program, unresolved_mark);
+        assert!(!analysis.is_unsafe, "expected an analyzable CJS module");
+        let module = cjs_script_to_module(&program).expect("a CJS script should wrap as a module");
+
+        let (mut g, items) = Analyzer::analyze(
+            &module,
+            &comments,
+            unresolved_ctxt,
+            top_level_ctxt,
+            analysis.exports,
+        );
+        g.handle_weak(Mode::Production);
+        let result = g.split_module(&[], &items);
+
+        assert!(
+            result.entrypoints.contains_key(&Key::Export("foo".into())),
+            "expected an Export(\"foo\") entrypoint, got {:?}",
+            result.entrypoints
+        );
+        assert!(
+            result.entrypoints.contains_key(&Key::Export("bar".into())),
+            "expected an Export(\"bar\") entrypoint, got {:?}",
+            result.entrypoints
+        );
+
+        // The two independent exports must land in *different* parts, and each
+        // part must contain only its own export's code — proving an unused
+        // export's code is not pulled into another export's part (i.e. it can be
+        // dropped when only the sibling is imported).
+        let foo_idx = *result.entrypoints.get(&Key::Export("foo".into())).unwrap() as usize;
+        let bar_idx = *result.entrypoints.get(&Key::Export("bar".into())).unwrap() as usize;
+        assert_ne!(foo_idx, bar_idx, "foo and bar should be in separate parts");
+
+        let foo_part = print(&cm, &[&result.modules[foo_idx]]);
+        let bar_part = print(&cm, &[&result.modules[bar_idx]]);
+
+        assert!(
+            foo_part.contains("foo") && !foo_part.contains("bar"),
+            "foo part is not disjoint from bar:\n{foo_part}"
+        );
+        assert!(
+            bar_part.contains("bar") && !bar_part.contains("foo"),
+            "bar part is not disjoint from foo:\n{bar_part}"
+        );
+
+        // The whole-module reconstruction (`EcmascriptModuleCjsFacadeModule`)
+        // imports from the `Key::Exports` part — it must exist for a CJS split.
+        assert!(
+            result.entrypoints.contains_key(&Key::Exports),
+            "expected an Exports entrypoint, got {:?}",
+            result.entrypoints
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Parse `code` as a CommonJS script, wrap it as a `Module`, and run the
+/// tree-shaker analysis with its CJS exports map. Returns the dependency
+/// graph and per-item data. Mirrors the harness in
+/// `cjs_normalized_module_produces_export_parts`.
+fn analyze_cjs_source(
+    cm: &Arc<SourceMap>,
+    code: &str,
+) -> (DepGraph, rustc_hash::FxHashMap<ItemId, ItemData>) {
+    let fm = cm.new_source_file(FileName::Anon.into(), code.to_string());
+    let comments = SingleThreadedComments::default();
+    let mut program = parse_file_as_program(
+        &fm,
+        Syntax::Es(EsSyntax::default()),
+        EsVersion::latest(),
+        Some(&comments),
+        &mut vec![],
+    )
+    .unwrap();
+
+    let unresolved_mark = Mark::new();
+    let top_level_mark = Mark::new();
+    let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
+    let top_level_ctxt = SyntaxContext::empty().apply_mark(top_level_mark);
+    program.visit_mut_with(&mut swc_core::ecma::transforms::base::resolver(
+        unresolved_mark,
+        top_level_mark,
+        false,
+    ));
+
+    let analysis = analyze_cjs_exports(&program, unresolved_mark);
+    assert!(!analysis.is_unsafe, "expected an analyzable CJS module");
+    let module = cjs_script_to_module(&program).expect("a CJS script should wrap as a module");
+    Analyzer::analyze(
+        &module,
+        &comments,
+        unresolved_ctxt,
+        top_level_ctxt,
+        analysis.exports,
+    )
+}
+
+/// Locate the synthesized `const __TURBOPACK_cjs_export__<name> = …` item for a
+/// CommonJS named export and report whether it's pinned as a module-evaluation
+/// side effect. Returns `None` if no such synthesized item exists.
+fn cjs_export_side_effects(
+    items: &rustc_hash::FxHashMap<ItemId, ItemData>,
+    export_name: &str,
+) -> Option<bool> {
+    let target = format!("__TURBOPACK_cjs_export__{export_name}");
+    items.values().find_map(|data| {
+        data.var_decls
+            .iter()
+            .any(|id| id.0.as_str() == target)
+            .then_some(data.side_effects)
+    })
+}
+
+/// An impure export RHS (`exports.x = sideEffect()`) must keep the synthesized
+/// export const pinned as a module-evaluation side effect, while pure RHS forms
+/// (a literal, a function expression) must not be side effects — so they stay
+/// droppable when the export is unused.
+#[test]
+fn cjs_impure_export_rhs_is_pinned_as_side_effect() {
+    testing::run_test(false, |cm, _handler| {
+        let (_g, items) = analyze_cjs_source(
+            &cm,
+            "exports.x = sideEffect(); exports.y = 1; exports.z = function () {};",
+        );
+
+        assert_eq!(
+            cjs_export_side_effects(&items, "x"),
+            Some(true),
+            "impure RHS (sideEffect()) must be pinned as a module-evaluation side effect",
+        );
+        assert_eq!(
+            cjs_export_side_effects(&items, "y"),
+            Some(false),
+            "pure literal RHS must not be a module-evaluation side effect",
+        );
+        assert_eq!(
+            cjs_export_side_effects(&items, "z"),
+            Some(false),
+            "pure function-expression RHS must not be a module-evaluation side effect",
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// A bare statement interleaved between exports (`exports.a = 1; sideEffect();
+/// exports.b = 2;`) must be retained as a module-evaluation side effect, and
+/// both surrounding pure exports must remain individually addressable
+/// entrypoints — preserving evaluation-order semantics.
+#[test]
+fn cjs_interleaved_side_effect_is_retained() {
+    testing::run_test(false, |cm, _handler| {
+        let (mut g, items) = analyze_cjs_source(&cm, "exports.a = 1; sideEffect(); exports.b = 2;");
+
+        // The recognized `exports.a`/`exports.b` writes are synthesized into
+        // `const` var declarations, so the only remaining bare expression
+        // statement item is `sideEffect()`. It must be marked side-effectful so
+        // it is retained during module evaluation.
+        let interleaved = items
+            .values()
+            .find(|data| {
+                matches!(
+                    &data.content,
+                    swc_core::ecma::ast::ModuleItem::Stmt(swc_core::ecma::ast::Stmt::Expr(_))
+                )
+            })
+            .expect("the interleaved sideEffect() statement item must exist");
+        assert!(
+            interleaved.side_effects,
+            "the interleaved sideEffect() statement must be retained as a side effect",
+        );
+
+        // Both pure exports remain individually addressable entrypoints.
+        g.handle_weak(Mode::Production);
+        let result = g.split_module(&[], &items);
+        assert!(
+            result.entrypoints.contains_key(&Key::Export("a".into())),
+            "expected an Export(\"a\") entrypoint, got {:?}",
+            result.entrypoints
+        );
+        assert!(
+            result.entrypoints.contains_key(&Key::Export("b".into())),
+            "expected an Export(\"b\") entrypoint, got {:?}",
+            result.entrypoints
+        );
+
+        // The surrounding pure exports are themselves not side effects.
+        assert_eq!(cjs_export_side_effects(&items, "a"), Some(false));
+        assert_eq!(cjs_export_side_effects(&items, "b"), Some(false));
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Pure, unused exports (`exports.foo = 1; exports.bar = 2;`) must not force
+/// module evaluation: neither synthesized export const is a module-evaluation
+/// side effect, so both can be dropped when unused.
+#[test]
+fn cjs_pure_unused_exports_are_not_module_evaluation_side_effects() {
+    testing::run_test(false, |cm, _handler| {
+        let (_g, items) = analyze_cjs_source(&cm, "exports.foo = 1; exports.bar = 2;");
+
+        assert_eq!(
+            cjs_export_side_effects(&items, "foo"),
+            Some(false),
+            "a pure export const must not be a module-evaluation side effect",
+        );
+        assert_eq!(
+            cjs_export_side_effects(&items, "bar"),
+            Some(false),
+            "a pure export const must not be a module-evaluation side effect",
+        );
+
+        Ok(())
+    })
+    .unwrap();
 }

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -246,6 +246,7 @@ impl ModuleOptions {
                     source_maps: ecmascript_source_maps,
                     inline_helpers,
                     infer_module_side_effects,
+                    cjs_tree_shaking,
                     ref preset_env_config,
                     ..
                 },
@@ -336,6 +337,7 @@ impl ModuleOptions {
             enable_exports_info_inlining,
             inline_helpers,
             infer_module_side_effects,
+            cjs_tree_shaking,
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.resolved_cell();

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -281,6 +281,9 @@ pub struct EcmascriptOptionsContext {
     /// Whether to infer side effect free modules via local analysis. Defaults to true.
     pub infer_module_side_effects: bool,
 
+    /// Whether to enable tree-shaking of CommonJS modules. Defaults to false.
+    pub cjs_tree_shaking: bool,
+
     /// Additional SWC preset-env options (mode, coreJs, include, exclude, etc.).
     pub preset_env_config: Option<ResolvedVc<PresetEnvConfig>>,
 


### PR DESCRIPTION
This PR calls `analyze_cjs_exports()` (introduced in https://github.com/vercel/next.js/pull/95656), and, if it is safe to, it takes the information from that analysis and uses it to transform the CJS module into something that the ESM-tree shaker can understand. 

For example, the following:

```javascript
exports.foo = 1
```

Becomes...

```javascript
const __TURBOPACK_cjs_export__foo = 1
export { __TURBOPACK_cjs_export__foo as foo }
```

And 

```javascript
module.exports = { a, b: 2 }
```

becomes:

```javascript
const __TURBOPACK_cjs_export__a = a
export { __TURBOPACK_cjs_export__a as a }
const __TURBOPACK_cjs_export__b = 2
export { __TURBOPACK_cjs_export__b as b }
```

After doing this, the module should be able to flow through the tree-shaker as expected.

We also drop `exports.__esModule` and add it back in https://github.com/vercel/next.js/pull/95658 which constructs an entire module that can be imported as a whole.

This PR stack is only to add module-fragments tree shaking, CJS doesn't do anything in re-exports tree shaking at the moment.