### PR TITLE
[turbopack] Reconstruct a facade for full CJS modules

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -42,6 +42,7 @@ use crate::{
         unreachable::Unreachable,
         worker::{WorkerAssetReferenceCodeGen, WorkerGlobalsReplacementCodeGen},
     },
+    tree_shake::cjs_facade::CjsFacadeExportsCodeGen,
 };
 
 #[derive(Default)]
@@ -206,6 +207,7 @@ pub enum CodeGen {
     ServiceWorkerAssetReferenceCodeGen(ServiceWorkerAssetReferenceCodeGen),
     ModuleHotReferenceCodeGen(ModuleHotReferenceCodeGen),
     WorkerGlobalsReplacementCodeGen(WorkerGlobalsReplacementCodeGen),
+    CjsFacadeExports(CjsFacadeExportsCodeGen),
 }
 
 impl CodeGen {
@@ -244,6 +246,7 @@ impl CodeGen {
                 v.code_generation(ctx, scope_hoisting_context).await
             }
             Self::WorkerGlobalsReplacementCodeGen(v) => v.code_generation(ctx).await,
+            Self::CjsFacadeExports(v) => v.code_generation(ctx).await,
         }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/cjs_facade.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/cjs_facade.rs
@@ -1,0 +1,348 @@
+//! A dedicated module type for the whole-module reconstruction ("facade") of a
+//! split, statically-analyzable CommonJS module.
+//!
+//! Whole-module consumers (`require()`, `import * as ns`) need the reassembled,
+//! mutable `module.exports`.
+
+use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
+use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{
+        AssignExpr, AssignOp, AssignTarget, Expr, ExprStmt, Ident, IdentName, MemberExpr,
+        MemberProp, SimpleAssignTarget, Stmt,
+    },
+    quote,
+};
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
+use turbopack_core::{
+    chunk::{
+        AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset, ModuleChunkItemIdExt,
+    },
+    ident::AssetIdent,
+    module::{Module, ModuleSideEffects},
+    module_graph::ModuleGraph,
+    reference::{ModuleReference, ModuleReferences, SingleChunkableModuleReference},
+    resolve::{ExportUsage, ModulePart},
+};
+
+use crate::{
+    AnalyzeEcmascriptModuleResult, EcmascriptAnalyzable, EcmascriptAnalyzableExt,
+    EcmascriptModuleAsset, EcmascriptModuleContent, EcmascriptModuleContentOptions,
+    SpecifiedModuleType,
+    chunk::{
+        EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports,
+        ecmascript_chunk_item,
+    },
+    code_gen::{CodeGen, CodeGeneration, CodeGenerationHoistedStmt, CodeGens},
+    references::esm::base::EsmAssetReferences,
+    runtime_functions::TURBOPACK_IMPORT,
+    tree_shake::part::module::EcmascriptModulePartAsset,
+    utils::module_id_to_lit,
+};
+
+/// The whole-module reconstruction of a split CommonJS module. See the module
+/// docs.
+#[turbo_tasks::value]
+pub struct EcmascriptModuleCjsFacadeModule {
+    module: ResolvedVc<EcmascriptModuleAsset>,
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptModuleCjsFacadeModule {
+    #[turbo_tasks::function]
+    pub fn new(module: ResolvedVc<EcmascriptModuleAsset>) -> Vc<Self> {
+        EcmascriptModuleCjsFacadeModule { module }.cell()
+    }
+}
+
+impl EcmascriptModuleCjsFacadeModule {
+    /// The module's statically-known export names (source order) and whether it
+    /// carries the transpiled-ESM `__esModule` marker.
+    async fn static_exports(&self) -> Result<(Vec<RcStr>, bool)> {
+        let exports = self.module.get_exports().await?;
+        let EcmascriptExports::StaticCommonJs(cjs) = &*exports else {
+            bail!("EcmascriptModuleCjsFacadeModule must wrap a StaticCommonJs module");
+        };
+        let cjs = cjs.await?;
+        Ok((cjs.names.to_vec(), cjs.has_es_module))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Module for EcmascriptModuleCjsFacadeModule {
+    #[turbo_tasks::function]
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .module
+            .ident()
+            .owned()
+            .await?
+            .with_part(ModulePart::Facade)
+            .into_vc())
+    }
+
+    #[turbo_tasks::function]
+    fn source(&self) -> Vc<turbopack_core::source::OptionSource> {
+        Vc::cell(None)
+    }
+
+    #[turbo_tasks::function]
+    async fn references(&self) -> Result<Vc<ModuleReferences>> {
+        // Graph edges to the two parts the facade is built from: the module
+        // evaluation part (side effects) and the exports part (values). These
+        // create the chunking edges; the runtime imports are emitted by
+        // `CjsFacadeExportsCodeGen`.
+        //
+        // Mirrors the `ModulePart::Facade` arm of
+        // `EcmascriptModulePartAsset::references` in `tree_shake/part/module.rs`
+        // (the ESM facade's equivalent dependency declaration).
+        let part_dep =
+            |part: ModulePart, export: Vc<ExportUsage>| -> Vc<Box<dyn ModuleReference>> {
+                Vc::upcast(SingleChunkableModuleReference::new(
+                    Vc::upcast(EcmascriptModulePartAsset::new_with_resolved_part(
+                        *self.module,
+                        part,
+                    )),
+                    rcstr!("part reference"),
+                    export,
+                ))
+            };
+
+        Ok(Vc::cell(vec![
+            part_dep(ModulePart::evaluation(), ExportUsage::evaluation())
+                .to_resolved()
+                .await?,
+            part_dep(ModulePart::exports(), ExportUsage::all())
+                .to_resolved()
+                .await?,
+        ]))
+    }
+
+    #[turbo_tasks::function]
+    fn is_self_async(&self) -> Vc<bool> {
+        // CommonJS modules are never async.
+        Vc::cell(false)
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(&self) -> Vc<ModuleSideEffects> {
+        // The facade runs the module-evaluation part, so it has whatever side
+        // effects the original module does.
+        self.module.side_effects()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptAnalyzable for EcmascriptModuleCjsFacadeModule {
+    #[turbo_tasks::function]
+    fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+        bail!("EcmascriptModuleCjsFacadeModule::analyze shouldn't be called");
+    }
+
+    #[turbo_tasks::function]
+    fn module_content_without_analysis(
+        &self,
+        _generate_source_map: bool,
+    ) -> Result<Vc<EcmascriptModuleContent>> {
+        bail!(
+            "EcmascriptModuleCjsFacadeModule::module_content_without_analysis shouldn't be called"
+        );
+    }
+
+    #[turbo_tasks::function]
+    async fn module_content_options(
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+        async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
+    ) -> Result<Vc<EcmascriptModuleContentOptions>> {
+        let this = self.await?;
+        let (names, has_es_module) = this.static_exports().await?;
+
+        let code_generation =
+            Vc::<CodeGens>::cell(vec![CodeGen::CjsFacadeExports(CjsFacadeExportsCodeGen {
+                module: this.module,
+                names,
+                has_es_module,
+            })])
+            .to_resolved()
+            .await?;
+
+        Ok(EcmascriptModuleContentOptions {
+            parsed: None,
+            module: ResolvedVc::upcast(self),
+            specified_module_type: SpecifiedModuleType::CommonJs,
+            chunking_context,
+            references: self.references().to_resolved().await?,
+            part_references: vec![],
+            esm_references: EsmAssetReferences::empty().to_resolved().await?,
+            code_generation,
+            async_module: self.get_async_module().to_resolved().await?,
+            generate_source_map: false,
+            original_source_map: None,
+            exports: self.get_exports().to_resolved().await?,
+            async_module_info,
+        }
+        .cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for EcmascriptModuleCjsFacadeModule {
+    #[turbo_tasks::function]
+    fn get_exports(&self) -> Vc<EcmascriptExports> {
+        // Keep the original module's CommonJS exports so importer-side interop
+        // treats the facade like the original module.
+        self.module.get_exports()
+    }
+
+    // `get_async_module` uses the trait default (`None`) — CommonJS is never async.
+
+    #[turbo_tasks::function]
+    async fn chunk_item_content(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+        _estimated: bool,
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let content = self.module_content(chunking_context, async_module_info);
+        Ok(EcmascriptChunkItemContent::new(
+            content,
+            chunking_context,
+            self.get_async_module().module_options(async_module_info),
+        ))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModule for EcmascriptModuleCjsFacadeModule {
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        ecmascript_chunk_item(ResolvedVc::upcast(self), module_graph, chunking_context)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EvaluatableAsset for EcmascriptModuleCjsFacadeModule {}
+
+/// Emits the CommonJS facade body: import the evaluation part (side effects) and
+/// the exports part (values), then rebuild `module.exports` with native writes.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, ValueDebugFormat, NonLocalValue, Encode, Decode,
+)]
+pub struct CjsFacadeExportsCodeGen {
+    module: ResolvedVc<EcmascriptModuleAsset>,
+    names: Vec<RcStr>,
+    has_es_module: bool,
+}
+
+impl CjsFacadeExportsCodeGen {
+    /// Emits the facade body. For `names = ["foo", "bar"]` and
+    /// `has_es_module = true`:
+    ///
+    /// ```js
+    /// __turbopack_context__.i(<module evaluation part>);
+    /// var __TURBOPACK_cjs_facade_exports__ = __turbopack_context__.i(<exports part>);
+    /// exports.__esModule = true;
+    /// exports.foo = __TURBOPACK_cjs_facade_exports__.foo;
+    /// exports.bar = __TURBOPACK_cjs_facade_exports__.bar;
+    /// ```
+    pub async fn code_generation(
+        &self,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Result<CodeGeneration> {
+        let eval_id = EcmascriptModulePartAsset::new_with_resolved_part(
+            *self.module,
+            ModulePart::evaluation(),
+        )
+        .chunk_item_id(chunking_context)
+        .await?;
+        let exports_id =
+            EcmascriptModulePartAsset::new_with_resolved_part(*self.module, ModulePart::exports())
+                .chunk_item_id(chunking_context)
+                .await?;
+
+        // `var __TURBOPACK_cjs_facade_exports__ = __turbopack_context__.i(<exports part>);`
+        let ns = Ident::new(
+            "__TURBOPACK_cjs_facade_exports__".into(),
+            DUMMY_SP,
+            Default::default(),
+        );
+
+        let hoisted = vec![
+            // Run the module's side effects first, like `require()` would.
+            CodeGenerationHoistedStmt::new(
+                rcstr!("cjs facade evaluation"),
+                quote!(
+                    "$turbopack_import($id);" as Stmt,
+                    turbopack_import: Expr = TURBOPACK_IMPORT.into(),
+                    id: Expr = module_id_to_lit(&eval_id),
+                ),
+            ),
+            CodeGenerationHoistedStmt::new(
+                rcstr!("cjs facade exports"),
+                quote!(
+                    "var $name = $turbopack_import($id);" as Stmt,
+                    name = ns.clone(),
+                    turbopack_import: Expr = TURBOPACK_IMPORT.into(),
+                    id: Expr = module_id_to_lit(&exports_id),
+                ),
+            ),
+        ];
+
+        // `exports.NAME = <ns>.NAME` writes, plus the `__esModule` marker first.
+        let mut late = Vec::with_capacity(self.names.len() + self.has_es_module as usize);
+        if self.has_es_module {
+            late.push(CodeGenerationHoistedStmt::new(
+                rcstr!("cjs facade __esModule"),
+                exports_write("__esModule", quote!("true" as Expr)),
+            ));
+        }
+        for name in &self.names {
+            late.push(CodeGenerationHoistedStmt::new(
+                format!("cjs facade export {name}").into(),
+                exports_write(name, Expr::Member(member(ns.clone(), name))),
+            ));
+        }
+
+        Ok(CodeGeneration::new(vec![], hoisted, vec![], late, vec![]))
+    }
+}
+
+/// `exports.<prop> = <value>;`
+fn exports_write(prop: &str, value: Expr) -> Stmt {
+    let exports = Ident::new("exports".into(), DUMMY_SP, Default::default());
+    Stmt::Expr(ExprStmt {
+        span: DUMMY_SP,
+        expr: Box::new(Expr::Assign(AssignExpr {
+            span: DUMMY_SP,
+            op: AssignOp::Assign,
+            left: AssignTarget::Simple(SimpleAssignTarget::Member(member(exports, prop))),
+            right: Box::new(value),
+        })),
+    })
+}
+
+/// `<obj>.<prop>`
+fn member(obj: Ident, prop: &str) -> MemberExpr {
+    MemberExpr {
+        span: DUMMY_SP,
+        obj: Box::new(Expr::Ident(obj)),
+        prop: MemberProp::Ident(IdentName {
+            span: DUMMY_SP,
+            sym: prop.into(),
+        }),
+    }
+}
+
+impl From<CjsFacadeExportsCodeGen> for CodeGen {
+    fn from(val: CjsFacadeExportsCodeGen) -> Self {
+        CodeGen::CjsFacadeExports(val)
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     references::exports::cjs::{CjsExportFormat, analyze_cjs_exports},
 };
 
+pub mod cjs_facade;
 mod graph;
 pub mod merge;
 mod optimizations;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
@@ -25,8 +25,8 @@ use crate::{
     },
     rename::module::EcmascriptModuleRenameModule,
     tree_shake::{
-        Key, SplitResult, get_part_id, part_of_module, side_effects::module::SideEffectsModule,
-        split_module,
+        Key, SplitResult, cjs_facade::EcmascriptModuleCjsFacadeModule, get_part_id, part_of_module,
+        side_effects::module::SideEffectsModule, split_module,
     },
 };
 
@@ -142,9 +142,23 @@ impl EcmascriptModulePartAsset {
         module: Vc<EcmascriptModuleAsset>,
         part: ModulePart,
     ) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
-        let SplitResult::Ok { entrypoints, .. } = &*split_module(module).await? else {
+        let SplitResult::Ok {
+            entrypoints,
+            is_cjs,
+            ..
+        } = &*split_module(module).await?
+        else {
             return Ok(Vc::upcast(module));
         };
+
+        // A whole-module consumer of a split CommonJS module must observe the
+        // re-assembled, mutable `module.exports` — the dedicated CJS facade
+        // module — not an ESM re-export. This covers both `import * as ns`
+        // (`Exports`) and the part-less `require()` / `import()` case, which
+        // `apply_module_type` routes here as `Facade` in `ModuleFragments` mode.
+        if *is_cjs && matches!(part, ModulePart::Exports | ModulePart::Facade) {
+            return Ok(Vc::upcast(EcmascriptModuleCjsFacadeModule::new(module)));
+        }
 
         match part {
             ModulePart::Evaluation => {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -276,6 +276,8 @@ struct TestOptions {
     minify: bool,
     #[serde(default)]
     production_chunking: bool,
+    #[serde(default)]
+    cjs_tree_shaking: bool,
 }
 
 fn default_tree_shaking_mode() -> Option<TreeShakingMode> {
@@ -295,6 +297,7 @@ impl Default for TestOptions {
             scope_hoisting: default_true(),
             minify: false,
             production_chunking: false,
+            cjs_tree_shaking: false,
         }
     }
 }
@@ -445,6 +448,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
                 import_externals: true,
                 enable_exports_info_inlining: true,
                 infer_module_side_effects: true,
+                cjs_tree_shaking: options.cjs_tree_shaking,
                 ..Default::default()
             },
             environment: Some(env),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/input/a.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/input/a.js
@@ -1,0 +1,6 @@
+exports.early = 'a-early'
+
+const b = require('./b')
+
+exports.fromB = b.seen
+exports.late = 'a-late'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/input/b.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/input/b.js
@@ -1,0 +1,10 @@
+const a = require('./a')
+
+exports.seen = a.early
+exports.lateSeen = a.late
+exports.deferredEarly = function () {
+  return a.early
+}
+exports.deferredLate = function () {
+  return a.late
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/input/index.js
@@ -1,0 +1,21 @@
+// A `require()` cycle a -> b -> a between split CommonJS modules. The exports
+// object identity is shared like in Node.js, so the (very common) deferred
+// access pattern — reading the other module's exports inside a function called
+// after the cycle completed — observes the final values.
+//
+// Intentionally unsupported: *top-level* reads of the other module mid-cycle
+// observe an empty exports object instead of Node's partially-populated one,
+// because a split module's exports are written by its facade after evaluation
+// instead of interleaved with it.
+
+it('should share exports object identity so deferred reads see final values', () => {
+  const b = require('./b')
+  expect(b.deferredEarly()).toBe('a-early')
+  expect(b.deferredLate()).toBe('a-late')
+})
+
+it('should complete the cycle and expose post-cycle values', () => {
+  const a = require('./a')
+  expect(a.early).toBe('a-early')
+  expect(a.late).toBe('a-late')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports-cycle/options.json
@@ -1,0 +1,4 @@
+{
+  "treeShakingMode": "module-fragments",
+  "cjsTreeShaking": true
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/input/index.js
@@ -1,0 +1,28 @@
+import { pick } from './other'
+
+it('should require a split CommonJS module and get the full exports object', () => {
+  const lib = require('./lib')
+  expect(lib.used).toBe('used-value')
+  expect(lib.unused).toBe('unused-value')
+  expect(lib.impure).toBe('impure')
+  expect(lib.__esModule).toBeUndefined()
+  // module.exports must stay a plain mutable object (not sealed)
+  lib.added = 'added'
+  expect(lib.added).toBe('added')
+  delete lib.added
+})
+
+it('should preserve evaluation order of interleaved side effects', () => {
+  const lib = require('./lib')
+  expect(lib.order).toEqual(['start', 'impure', 'end'])
+})
+
+it('should support namespace imports of a split CommonJS module', async () => {
+  const ns = await import('./lib')
+  expect(ns.used).toBe('used-value')
+  expect(ns.unused).toBe('unused-value')
+})
+
+it('should support named imports from a split CommonJS module', () => {
+  expect(pick).toBe('picked')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/input/lib.js
@@ -1,0 +1,16 @@
+const order = []
+
+exports.order = order
+
+order.push('start')
+
+exports.used = 'used-value'
+exports.impure = pushAndReturn('impure')
+exports.unused = 'unused-value'
+
+order.push('end')
+
+function pushAndReturn(name) {
+  order.push(name)
+  return name
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/input/other.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/input/other.js
@@ -1,0 +1,2 @@
+exports.pick = 'picked'
+exports.skip = 'skipped'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-exports/options.json
@@ -1,0 +1,4 @@
+{
+  "treeShakingMode": "module-fragments",
+  "cjsTreeShaking": true
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-module-exports-object/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-module-exports-object/input/index.js
@@ -1,0 +1,27 @@
+import { a as importedA } from './lib'
+
+it('should require a split `module.exports = { ... }` object literal', () => {
+  const lib = require('./lib')
+  expect(lib.a).toBe('a-value')
+  expect(lib.b).toBe('b-value')
+  expect(lib.c).toBe('c-value')
+  expect(lib.d).toBe('d-value')
+  expect(typeof lib.greet).toBe('function')
+  expect(lib.greet()).toBe('hello')
+  expect(lib.__esModule).toBeUndefined()
+  // module.exports must stay a plain mutable object (not sealed)
+  lib.added = 'added'
+  expect(lib.added).toBe('added')
+  delete lib.added
+})
+
+it('should support a named import from an object-literal module', () => {
+  expect(importedA).toBe('a-value')
+})
+
+it('should support namespace imports of an object-literal module', async () => {
+  const ns = await import('./lib')
+  expect(ns.a).toBe('a-value')
+  expect(ns.c).toBe('c-value')
+  expect(ns.greet()).toBe('hello')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-module-exports-object/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-module-exports-object/input/lib.js
@@ -1,0 +1,15 @@
+const b = 'b-value'
+
+function makeD() {
+  return 'd-value'
+}
+
+module.exports = {
+  a: 'a-value',
+  b,
+  c: 'c-value',
+  d: makeD(),
+  greet() {
+    return 'hello'
+  },
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-module-exports-object/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/cjs-module-exports-object/options.json
@@ -1,0 +1,4 @@
+{
+  "treeShakingMode": "module-fragments",
+  "cjsTreeShaking": true
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -106,6 +106,8 @@ struct SnapshotOptions {
     chunk_loading_global: String,
     #[serde(default)]
     enable_rust_react_compiler: bool,
+    #[serde(default)]
+    cjs_tree_shaking: bool,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -141,6 +143,7 @@ impl Default for SnapshotOptions {
             source_map_source_type: SourceMapSourceType::default(),
             chunk_loading_global: default_chunk_loading_global(),
             enable_rust_react_compiler: false,
+            cjs_tree_shaking: false,
         }
     }
 }
@@ -411,6 +414,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 enable_rust_react_compiler: options
                     .enable_rust_react_compiler
                     .then_some(ReactCompilerCompilationMode::Infer),
+                cjs_tree_shaking: options.cjs_tree_shaking,
                 ..Default::default()
             },
             environment: Some(env),

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/index.js
@@ -1,0 +1,3 @@
+import { used } from './lib'
+
+console.log(used)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/lib.js
@@ -1,0 +1,2 @@
+exports.used = 'used_sentinel'
+exports.unused = 'unused_sentinel'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/options.json
@@ -1,0 +1,4 @@
+{
+  "treeShakingMode": "module-fragments",
+  "cjsTreeShaking": true
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_0ey5_na._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_0ey5_na._.js
@@ -1,0 +1,26 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_0ey5_na._.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$cjs$2d$exports$2d$dce$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/lib.js [test] (ecmascript) <internal part 0>");
+;
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$cjs$2d$exports$2d$dce$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__["used"]);
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/lib.js [test] (ecmascript) <internal part 0>", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "a",
+    ()=>__TURBOPACK_cjs_export__used,
+    (new___TURBOPACK_cjs_export__used)=>__TURBOPACK_cjs_export__used = new___TURBOPACK_cjs_export__used,
+    "used",
+    ()=>__TURBOPACK_cjs_export__used
+]);
+const __TURBOPACK_cjs_export__used = 'used_sentinel';
+;
+;
+}),
+]);
+
+//# sourceMappingURL=0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_0ey5_na._.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_0ey5_na._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_0ey5_na._.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/index.js"],"sourcesContent":["import { used } from './lib'\n\nconsole.log(used)\n"],"names":["console","log"],"mappings":";AAAA;;AAEAA,QAAQC,GAAG,CAAC,uPAAI"}},
+    {"offset": {"line": 12, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/lib.js"],"sourcesContent":["exports.used = 'used_sentinel'\nexports.unused = 'unused_sentinel'\n"],"names":[],"mappings":";;;;;;;qCAAe"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_index_0l047k0.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_index_0l047k0.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0rv8_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_index_0l047k0.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/output/0rv8_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_index_0l047k0.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/0rv8_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_index_0l047k0.js",
+    {"otherChunks":["output/0_9x_turbopack-tests_tests_snapshot_tree-shaking_cjs-exports-dce_input_0ey5_na._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/cjs-exports-dce/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -185,6 +185,11 @@ async fn apply_module_type(
             }
 
             let module = builder.build().to_resolved().await?;
+            // Use the module's own (path-scoped) tree shaking mode rather than the
+            // context-wide one: `ModuleOptions::new` may have switched to a different
+            // options context for this path (e.g. foreign code in node_modules), and
+            // part selection must match the mode the module is analyzed with.
+            let tree_shaking_mode = options.await?.tree_shaking_mode;
             if matches!(reference_type, ReferenceType::Runtime) {
                 ResolvedVc::upcast(module)
             } else {
@@ -227,6 +232,14 @@ async fn apply_module_type(
                                         )
                                         .await?
                                     }
+                                    // A ModuleFragments importer may request the exports of a
+                                    // module that itself uses reexports-only tree shaking (e.g.
+                                    // user code importing foreign code when the two use different
+                                    // modes). The module is not split into fragments, so its
+                                    // exports are the facade, like a part-less reference.
+                                    ModulePart::Exports => Vc::upcast(
+                                        EcmascriptModuleFacadeModule::new(Vc::upcast(*module)),
+                                    ),
                                     _ => bail!(
                                         "Invalid module part \"{}\" for reexports only tree \
                                          shaking mode",


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/95657 allows for tree-shaken CJS modules to be imported using the `import { foo } from './x'` syntax; however, you would not be able to `require('./x')` or `import * as bar from './x'`. 

To support these, this PR introduces a "facade" similar to `EcmascriptModuleFacadeModule` and the `ModulePart::Facade` that is built in `EcmascriptModulePartAsset`. The facade is empty at first but a codegen exists that will generate a module that looks like:

```javascript
__turbopack_context__.i(`<evaluation part id>`);
var __TURBOPACK_cjs_facade_exports__ = __turbopack_context__.i(`<exports part id>`);
exports.__esModule = true;
exports.foo = __TURBOPACK_cjs_facade_exports__.foo;
exports.bar = __TURBOPACK_cjs_facade_exports__.bar;
```

Now, when you import everything we will route you through this facade ^

The first import is the evaluation import - which runs all the side-effectful code and then the second is the exports part which has all of the things this module exports. These come from `split_module` in `graph.rs`, which is pre-existing.