### PR TITLE
fix: cache miss in App Shell for cached pages with gSP

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1446,5 +1446,6 @@
   "1445": "Invariant: Missing `__NEXT_PRIVATE_ORIGIN` environment variable.",
   "1446": "Missing initURL",
   "1447": "Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server.",
-  "1448": "Error in the \"%s\" app-route HMR subscription"
+  "1448": "Error in the \"%s\" app-route HMR subscription",
+  "1449": "Accessed `searchParams` during prerendering."
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1513,6 +1513,7 @@ async function generateRuntimePrefetchResult(
 
   await prospectiveRuntimeServerPrerender(
     ctx,
+    isShellPrefetch,
     generateDynamicRSCPayload.bind(null, ctx),
     prerenderResumeDataCache,
     rootParams,
@@ -1568,6 +1569,7 @@ async function generateRuntimePrefetchResult(
 
 async function prospectiveRuntimeServerPrerender(
   ctx: AppRenderContext,
+  isShellPrefetch: boolean,
   getPayload: () => Promise<RSCPayload>,
   resumeDataCache: PrerenderResumeDataCache | null,
   rootParams: Params,
@@ -1618,6 +1620,7 @@ async function prospectiveRuntimeServerPrerender(
     varyParamsAccumulator: null,
     // No stage sequencing needed for prospective renders.
     stagedRendering: null,
+    isSessionShell: isShellPrefetch,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
     headers,
     cookies,
@@ -1792,8 +1795,8 @@ async function finalRuntimeServerPrerender(
     resumeDataCache,
     hmrRefreshHash: undefined,
     varyParamsAccumulator,
-    // Used to separate the stages in the 5-task pipeline.
     stagedRendering: finalStageController,
+    isSessionShell: mode.type === 'session-shell-only',
     // These are not present in regular prerenders, but allowed in a runtime prerender.
     headers,
     cookies,

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -164,6 +164,7 @@ export interface PrerenderStoreModernRuntime
    * renders where all stages run without sequencing.
    */
   readonly stagedRendering: StagedRenderingController | null
+  readonly isSessionShell: boolean
 
   readonly headers: RequestStore['headers']
   readonly cookies: RequestStore['cookies']

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -244,6 +244,7 @@ export function createServerParamsForServerSegment(
         return createRuntimePrerenderParams(
           underlyingParams,
           optionalCatchAllParamName,
+          workStore,
           workUnitStore,
           varyParamsAccumulator
         )
@@ -431,6 +432,7 @@ function createStaticPrerenderParams(
 function createRuntimePrerenderParams(
   underlyingParams: Params,
   optionalCatchAllParamName: string | null,
+  workStore: WorkStore,
   workUnitStore: PrerenderStoreModernRuntime,
   varyParamsAccumulator: VaryParamsAccumulator | null
 ): Promise<Params> {
@@ -450,9 +452,14 @@ function createRuntimePrerenderParams(
 
   const { stagedRendering } = workUnitStore
   if (!stagedRendering) {
-    // If there's no staging, we're in a prospective runtime prerender,
-    // and it doesn't matter when params resolve.
-    return makeUntrackedParams(userspaceParams)
+    // If there's no staging, we're in a prospective runtime prerender.
+    if (workUnitStore.isSessionShell) {
+      // If we're warming up for a session shell, params should be hanging,
+      // because they'll be a hanging input in the final prerender.
+      return makeHangingParams(underlyingParams, workStore, workUnitStore)
+    } else {
+      return makeUntrackedParams(userspaceParams)
+    }
   }
 
   // We don't have fallbackParams in runtime prerenders, so we don't know
@@ -709,7 +716,7 @@ const fallbackParamsProxyHandler: ProxyHandler<Promise<Params>> = {
 function makeHangingParams(
   underlyingParams: Params,
   workStore: WorkStore,
-  prerenderStore: StaticPrerenderStoreModern
+  prerenderStore: StaticPrerenderStoreModern | PrerenderStoreModernRuntime
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -71,7 +71,15 @@ export function createServerPathnameForMetadata(
             underlyingPathname
           )
         } else {
-          return createRenderPathname(underlyingPathname)
+          if (workUnitStore.isSessionShell) {
+            return makeHangingPromise<string>(
+              workUnitStore.renderSignal,
+              workStore.route,
+              '`pathname`'
+            )
+          } else {
+            return createRenderPathname(underlyingPathname)
+          }
         }
       }
       case 'request':

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -14,6 +14,7 @@ import {
   postponeWithTracking,
   annotateDynamicAccess,
 } from '../app-render/dynamic-rendering'
+import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-storage.external'
 
 import {
   workUnitAsyncStorage,
@@ -387,9 +388,9 @@ function makeHangingSearchParams(
     '`searchParams`'
   )
 
-  const proxiedPromise = new Proxy(promise, {
+  const proxyHandler: ProxyHandler<Promise<SearchParams>> = {
     get(target, prop, receiver) {
-      if (Object.hasOwn(promise, prop)) {
+      if (Object.hasOwn(target, prop)) {
         // The promise has this property directly. we must return it.
         // We know it isn't a dynamic access because it can only be something
         // that was previously written to the promise and thus not an underlying searchParam value
@@ -397,11 +398,32 @@ function makeHangingSearchParams(
       }
 
       switch (prop) {
-        case 'then': {
-          const expression =
-            '`await searchParams`, `searchParams.then`, or similar'
-          annotateDynamicAccess(expression, prerenderStore)
-          return ReflectAdapter.get(target, prop, receiver)
+        case 'then':
+        case 'catch':
+        case 'finally': {
+          const originalMethod = ReflectAdapter.get(target, prop, receiver)
+          return {
+            [prop]: (...args: unknown[]) => {
+              const expression =
+                '`await searchParams`, `searchParams.then`, or similar'
+              annotateDynamicAccess(expression, prerenderStore)
+              // Mirror `makeHangingParams`: when this never-resolving promise
+              // is awaited while a `use cache` key is being encoded
+              // (dynamicAccessAsyncStorage is set), abort so the surrounding
+              // cache bails out to a dynamic hole instead of hanging on it.
+              // Without this, a private cache that reads `searchParams` would
+              // stall the App Shell cache-warming render. Re-wrapping the
+              // result propagates the same behavior to promises derived via
+              // `.then`/`.catch`/`.finally` that are then passed into a cache.
+              const dynamicAccessStore = dynamicAccessAsyncStorage.getStore()
+              if (dynamicAccessStore) {
+                dynamicAccessStore.abortController.abort(
+                  new Error('Accessed `searchParams` during prerendering.')
+                )
+              }
+              return new Proxy(originalMethod.apply(target, args), proxyHandler)
+            },
+          }[prop]
         }
         case 'status': {
           const expression =
@@ -415,7 +437,9 @@ function makeHangingSearchParams(
         }
       }
     },
-  })
+  }
+
+  const proxiedPromise = new Proxy(promise, proxyHandler)
 
   CachedSearchParams.set(prerenderStore, proxiedPromise)
   return proxiedPromise

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -247,23 +247,28 @@ function createRuntimePrerenderSearchParams(
       ? createVaryingSearchParams(varyParamsAccumulator, underlyingSearchParams)
       : underlyingSearchParams
 
+  const result = makeUntrackedSearchParams(userspaceSearchParams)
   const { stagedRendering } = workUnitStore
   if (!stagedRendering) {
     // If there's no staging, we're in a prospective runtime prerender.
     if (workUnitStore.isSessionShell) {
-      // If we're warming up for a session shell, params should hang, because
-      // they'll be a hanging input in the final prerender.
+      // If we're warming up for a session shell, search params should hang,
+      // because they'll be a hanging input in the final prerender.
       return makeHangingSearchParams(workStore, workUnitStore)
-    } else {
-      return makeUntrackedSearchParams(userspaceSearchParams)
     }
+    return result
   }
+  // Unlike `createRuntimePrerenderParams`, which uses `delayUntilStage`, we
+  // resolve with `waitForStage(...).then(...)` here. Switching search params to
+  // `delayUntilStage` drops the source code frame from the instant-validation
+  // "URL data outside of Suspense" error when a page awaits `searchParams` at
+  // the top level (params, read via a nested component, is unaffected). See the
+  // `missing suspense around search params` cases in the instant-validation
+  // `suspense-boundaries` tests. The underlying reason in React's async I/O
+  // await tracking isn't understood yet. TODO: align search params with params
+  // on `delayUntilStage` once resolved.
   const searchParamsStage = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
-  return stagedRendering.delayUntilStage(
-    searchParamsStage,
-    'searchParams',
-    userspaceSearchParams
-  )
+  return stagedRendering.waitForStage(searchParamsStage).then(() => result)
 }
 
 function createRenderSearchParams(

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -142,6 +142,7 @@ export function createServerSearchParamsForServerPage(
       case 'prerender-runtime':
         return createRuntimePrerenderSearchParams(
           underlyingSearchParams,
+          workStore,
           workUnitStore,
           varyParamsAccumulator
         )
@@ -237,21 +238,32 @@ function createStaticPrerenderSearchParams(
 
 function createRuntimePrerenderSearchParams(
   underlyingSearchParams: SearchParams,
+  workStore: WorkStore,
   workUnitStore: PrerenderStoreModernRuntime,
   varyParamsAccumulator: VaryParamsAccumulator | null
 ): Promise<SearchParams> {
-  const underlyingSearchParamsWithVarying =
+  const userspaceSearchParams =
     varyParamsAccumulator !== null
       ? createVaryingSearchParams(varyParamsAccumulator, underlyingSearchParams)
       : underlyingSearchParams
 
-  const result = makeUntrackedSearchParams(underlyingSearchParamsWithVarying)
   const { stagedRendering } = workUnitStore
   if (!stagedRendering) {
-    return result
+    // If there's no staging, we're in a prospective runtime prerender.
+    if (workUnitStore.isSessionShell) {
+      // If we're warming up for a session shell, params should hang, because
+      // they'll be a hanging input in the final prerender.
+      return makeHangingSearchParams(workStore, workUnitStore)
+    } else {
+      return makeUntrackedSearchParams(userspaceSearchParams)
+    }
   }
   const searchParamsStage = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
-  return stagedRendering.waitForStage(searchParamsStage).then(() => result)
+  return stagedRendering.delayUntilStage(
+    searchParamsStage,
+    'searchParams',
+    userspaceSearchParams
+  )
 }
 
 function createRenderSearchParams(
@@ -357,7 +369,7 @@ const CachedSearchParamsForUseCache = new WeakMap<
 
 function makeHangingSearchParams(
   workStore: WorkStore,
-  prerenderStore: PrerenderStoreModern
+  prerenderStore: PrerenderStoreModern | PrerenderStoreModernRuntime
 ): Promise<SearchParams> {
   const cachedSearchParams = CachedSearchParams.get(prerenderStore)
   if (cachedSearchParams) {

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/layout.tsx
@@ -1,0 +1,7 @@
+export default async function Layout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/layout.tsx
@@ -1,7 +1,24 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// Reading a cookie makes the shell depend on session data, so a prefetch
+// renders a runtime App Shell. This is what exercises the prospective/final
+// runtime prerender where params are a hanging input in a cached page.
+async function SessionData() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="cookie-value">{`Cookie: ${value}`}</p>
+}
+
 export default async function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <Suspense fallback={<p id="cookie-loading">Loading cookie...</p>}>
+          <SessionData />
+        </Suspense>
+        {children}
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/page.tsx
@@ -1,0 +1,20 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <ul>
+        <li>
+          <LinkAccordion href="/slug/prerendered">
+            prerendered from gSP - /slug/prerendered
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/slug/not-prerendered">
+            not prerendered - /slug/not-prerendered
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/slug/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/app/slug/[slug]/page.tsx
@@ -1,0 +1,18 @@
+export async function generateStaticParams() {
+  return [{ slug: 'prerendered' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  'use cache'
+  const { slug } = await params
+  return (
+    <main>
+      <h1>Cached page with params</h1>
+      <p id="slug">{`Slug: ${slug}`}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  partialPrefetching: true,
 }
 
 export default nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/prefetch-app-shell-cached-gsp.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-cached-gsp/prefetch-app-shell-cached-gsp.test.ts
@@ -1,0 +1,70 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+import { retry } from 'next-test-utils'
+
+const CACHE_MISS_WARNING = 'Unexpected cache miss after cache warming phase'
+
+// The App Shell prefetch (next-router-prefetch: '3') renders the runtime shell
+// of the /slug/[slug] route. Because the page is a `'use cache'` page that
+// awaits static params, params are a hanging input in the final prerender. If
+// the prospective (cache-warming) prerender resolved those params instead of
+// leaving them hanging, the cached page's key would differ between the two
+// prerenders and the final prerender would log an "Unexpected cache miss"
+// warning and degrade the cached segment to a dynamic hole.
+describe('App Shell prefetching - cached page with generateStaticParams', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('is skipped', () => {})
+    return
+  }
+
+  it('does not report a cache miss when prefetching the shell of a cached page that reads static params', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Revealing the link prefetches the App Shell for /slug/[slug]. Because the
+    // shell is param-independent, this single request drives the runtime shell
+    // prerender of the cached page whose params are a hanging input.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/slug/prerendered"]')
+        .click()
+    })
+
+    expect(next.cliOutput).not.toContain(CACHE_MISS_WARNING)
+  })
+
+  it('renders the cached page content after navigating to a prefetched shell', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/slug/prerendered"]')
+        .click()
+    })
+
+    await browser.elementByCss('a[href="/slug/prerendered"]').click()
+
+    await retry(async () => {
+      expect(await browser.elementById('slug').text()).toEqual(
+        'Slug: prerendered'
+      )
+    })
+
+    expect(next.cliOutput).not.toContain(CACHE_MISS_WARNING)
+  })
+})


### PR DESCRIPTION
If we're prerendering an App Shell, then url data is excluded (i.e. we don't advance beyond the `ShellRuntime` stage). however the prospective prerender was still letting params/searchParams resolve, so if those ended up being inputs to a page, they wouldn't be hanging inputs, and we'd get a cache miss for them in the final prerender.

closes NAR-883