### PR TITLE
fix: do not delay pathnameForMetadata unnecessarily in runtime prenders

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -55,7 +55,10 @@ export function createMetadataComponents({
   MetadataOutlet: React.ComponentType
 } {
   const searchParams = createServerSearchParamsForMetadata(parsedQuery)
-  const pathnameForMetadata = createServerPathnameForMetadata(pathname)
+  const pathnameForMetadata = createServerPathnameForMetadata(
+    pathname,
+    interpolatedParams
+  )
 
   async function Viewport() {
     const tags = await getResolvedViewport(

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -12,6 +12,7 @@ import {
   throwInvariantForMissingStore,
   workUnitAsyncStorage,
   type PrerenderStoreLegacy,
+  type PrerenderStoreModernRuntime,
   type PrerenderStoreModernServer,
   type PrerenderStorePPR,
 } from '../app-render/work-unit-async-storage.external'
@@ -20,9 +21,12 @@ import {
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
+import type { Params } from './params'
+import { allParamsAreRootParams, isEmptyParams } from '../lib/params-utils'
 
 export function createServerPathnameForMetadata(
-  underlyingPathname: string
+  underlyingPathname: string,
+  params: Params
 ): Promise<string> {
   const workStore = workAsyncStorage.getStore()
   if (!workStore) {
@@ -56,31 +60,12 @@ export function createServerPathnameForMetadata(
           'createServerPathnameForMetadata should not be called inside generateStaticParams.'
         )
       case 'prerender-runtime': {
-        // TODO(app-shells): whether or not this is included in the shell
-        // should depend on whether this route has params.
-        // if there's no params, it can be included.
-        // for now, we defensively exclude it to match the earlier pessimistic
-        // behavior of always resolving in the runtime stage
-        // (i.e. assuming that we have non-static params in the pathname)
-        const { stagedRendering } = workUnitStore
-        if (stagedRendering) {
-          const pathnameStage = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
-          return stagedRendering.delayUntilStage(
-            pathnameStage,
-            undefined,
-            underlyingPathname
-          )
-        } else {
-          if (workUnitStore.isSessionShell) {
-            return makeHangingPromise<string>(
-              workUnitStore.renderSignal,
-              workStore.route,
-              '`pathname`'
-            )
-          } else {
-            return createRenderPathname(underlyingPathname)
-          }
-        }
+        return createRuntimePrerenderPathname(
+          underlyingPathname,
+          params,
+          workStore,
+          workUnitStore
+        )
       }
       case 'request':
         // TODO(app-shells): this should be delayed if there's non-static params
@@ -127,6 +112,44 @@ function createPrerenderPathname(
 
   // We don't have any fallback params so we have an entirely static safe params object
   return Promise.resolve(underlyingPathname)
+}
+
+function createRuntimePrerenderPathname(
+  underlyingPathname: string,
+  params: Params,
+  workStore: WorkStore,
+  workUnitStore: PrerenderStoreModernRuntime
+): Promise<string> {
+  const { stagedRendering, rootParams } = workUnitStore
+
+  // If there's no params or they're all root params, then this is not link data
+  // (i.e. is allowed in the shell stage) and we don't need to delay it.
+  if (isEmptyParams(params) || allParamsAreRootParams(params, rootParams)) {
+    return createRenderPathname(underlyingPathname)
+  }
+
+  if (stagedRendering) {
+    // Final prerender.
+    const pathnameStage = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
+    return stagedRendering.delayUntilStage(
+      pathnameStage,
+      undefined,
+      underlyingPathname
+    )
+  }
+
+  // Prospective prerender.
+  if (workUnitStore.isSessionShell) {
+    // These will be hanging in the final prerender.
+    return makeHangingPromise<string>(
+      workUnitStore.renderSignal,
+      workStore.route,
+      '`pathname`'
+    )
+  } else {
+    // These will resolve in the Runtime stage of the final prerender.
+    return createRenderPathname(underlyingPathname)
+  }
 }
 
 function makeErroringPathname<T>(


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->