### PR TITLE
test: skip redbox check in "static prefetch - missing suspense around search params"

### DIFF
--- a/test/e2e/app-dir/instant-validation/suspense-boundaries.util.ts
+++ b/test/e2e/app-dir/instant-validation/suspense-boundaries.util.ts
@@ -513,8 +513,80 @@ export function registerSuspenseBoundariesTests(
       const browser = await navigateTo(
         '/suspense-in-root/static/missing-suspense-around-search-params?foo=bar'
       )
-      if (partialPrefetching) {
-        await expect(browser).toDisplayCollapsedRedbox(`
+      if (isClientNav) {
+        // TODO(app-shells): redbox is flaky and sometimes doesn't appear even though validation runs.
+        // as a stopgap, we assert on CLI output instead
+        // await expect(browser).toDisplayCollapsedRedbox(`...`)
+        if (partialPrefetching) {
+          expect(
+            await getDevCliValidationOutput(
+              await browser.url(),
+              getCliOutputSinceMark
+            )
+          ).toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/static/missing-suspense-around-search-params": Next.js encountered URL data during prerendering or a navigation.
+
+           \`params\` or \`searchParams\` accessed outside of \`<Suspense>\` may prevent the navigation from being instant, leading to a slower user experience.
+
+           Ways to fix this:
+             - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               https://nextjs.org/docs/messages/instant-shell-url-data#wrap-in-or-move-into-suspense
+             - [block] Set \`export const instant = false\` to allow a blocking route
+               https://nextjs.org/docs/messages/instant-shell-url-data#allow-blocking-route
+               at Page (app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx:7:18)
+              5 |
+              6 | export default async function Page({ searchParams }) {
+           >  7 |   const search = await searchParams
+                |                  ^
+              8 |   return (
+              9 |     <main>
+             10 |       <p> {
+             [cause]: Instant Validation:  
+                 at instant (app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx:1:24)
+             > 1 | export const instant = {
+                 |                        ^
+               2 |   level: 'experimental-error',
+               3 |   unstable_samples: [{ searchParams: { foo: 'bar' } }],
+               4 | }
+           }"
+          `)
+        } else {
+          expect(
+            await getDevCliValidationOutput(
+              await browser.url(),
+              getCliOutputSinceMark
+            )
+          ).toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/static/missing-suspense-around-search-params": Next.js encountered runtime data during prerendering or a navigation.
+
+           \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.
+
+           Ways to fix this:
+             - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#wrap-in-or-move-into-suspense
+             - [block] Set \`export const instant = false\` to allow a blocking route
+               https://nextjs.org/docs/messages/blocking-prerender-runtime#allow-blocking-route
+               at Page (app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx:7:18)
+              5 |
+              6 | export default async function Page({ searchParams }) {
+           >  7 |   const search = await searchParams
+                |                  ^
+              8 |   return (
+              9 |     <main>
+             10 |       <p> {
+             [cause]: Instant Validation:  
+                 at instant (app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx:1:24)
+             > 1 | export const instant = {
+                 |                        ^
+               2 |   level: 'experimental-error',
+               3 |   unstable_samples: [{ searchParams: { foo: 'bar' } }],
+               4 | }
+           }"
+          `)
+        }
+      } else {
+        if (partialPrefetching) {
+          await expect(browser).toDisplayCollapsedRedbox(`
            {
              "cause": [
                {
@@ -540,8 +612,8 @@ export function registerSuspenseBoundariesTests(
              ],
            }
           `)
-      } else {
-        await expect(browser).toDisplayCollapsedRedbox(`
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
            {
              "cause": [
                {
@@ -567,6 +639,7 @@ export function registerSuspenseBoundariesTests(
              ],
            }
           `)
+        }
       }
     } else {
       const result = await prerender(


### PR DESCRIPTION
this has been very flaky recently, see [datadog](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22instant%20validation%20dev%20-%20client%20navigation%20invalid%20-%20static%20prefetch%20-%20missing%20suspense%20around%20search%20params%22%20%40test.type%3A%22turbopack%22%20%40test.status%3A%22fail%22&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1783042724737&end=1783647524737&paused=true)

we had similar problems with the `runtime prefetch - missing suspense around search params` test from the same suite. still unsure about the cause, but redbox seems to not appear sometimes during client navigations. this does not seem to be a problem with instant validation itself, because it runs and forwards the errors to the browser as expected, so i suspect this is a bug with the redbox. as a workaround we assert on the instant validation CLI output instead.