### PR TITLE
[turbopack] Simplify service worker e2e tests

### DIFF
--- a/test/e2e/app-dir/service-worker/app/page.js
+++ b/test/e2e/app-dir/service-worker/app/page.js
@@ -7,6 +7,7 @@ export default function Page() {
   const [script, setScript] = useState('default')
   const [fetchResult, setFetchResult] = useState('default')
   const [interceptPath, setInterceptPath] = useState('/sw-intercepted')
+  const [updateViaCache, setUpdateViaCache] = useState('default')
 
   useEffect(() => {
     if (!('serviceWorker' in navigator)) {
@@ -20,6 +21,11 @@ export default function Page() {
         { updateViaCache: 'none' }
       )
       setScope(registration.scope)
+
+      // `updateViaCache` reflects the option passed to `register()`. The codegen pins `{ scope }`
+      // but must merge it into the user's options, so this stays `'none'` (not the default
+      // `'imports'`) only if those options were preserved.
+      setUpdateViaCache(registration.updateViaCache)
 
       // Fetch a sentinel URL that lives inside the registration scope (e.g. `/sw-intercepted` or
       // `/base/sw-intercepted`), so the service worker actually controls the request.
@@ -52,6 +58,7 @@ export default function Page() {
       <p id="sw-scope">{scope}</p>
       <p id="sw-controller">{controller}</p>
       <p id="sw-script">{script}</p>
+      <p id="sw-update-via-cache">{updateViaCache}</p>
       <button
         onClick={async () => {
           const res = await fetch(interceptPath)

--- a/test/e2e/app-dir/service-worker/service-worker-register.test.ts
+++ b/test/e2e/app-dir/service-worker/service-worker-register.test.ts
@@ -66,6 +66,8 @@ function runTests(next: NextInstance, basePath: string) {
   it('preserves the options object passed to register()', async () => {
     // The codegen pins `{ scope }` but must merge it into the user's options rather than
     // replacing them, or options like `updateViaCache` / `type: 'module'` are silently dropped.
+    // `registration.updateViaCache` reflects the passed option, so it reads back `'none'` only if
+    // the user's options survived codegen (the default is `'imports'`).
     const browser = await next.browser(home)
     await retry(async () => {
       expect(await browser.elementByCss('#sw-controller').text()).toBe(
@@ -73,29 +75,9 @@ function runTests(next: NextInstance, basePath: string) {
       )
     })
 
-    const scripts: string[] = await browser.eval(`
-      Array.from(
-        new Set(
-          performance
-            .getEntriesByType('resource')
-            .map((r) => r.name)
-            .filter((n) => n.includes('/_next/static/') && n.endsWith('.js'))
-        )
-      )
-    `)
-    expect(scripts.length).toBeGreaterThan(0)
-
-    let preserved = false
-    for (const src of scripts) {
-      const res = await next.fetch(new URL(src).pathname)
-      if (res.status !== 200) continue
-      const text = await res.text()
-      if (/updateViaCache\s*:\s*["']none["']/.test(text)) {
-        preserved = true
-        break
-      }
-    }
-    expect(preserved).toBe(true)
+    expect(await browser.elementByCss('#sw-update-via-cache').text()).toBe(
+      'none'
+    )
   })
 
   it('intercepts fetches within scope', async () => {


### PR DESCRIPTION
This PR simplifies the way that we're preserving `registration.updateViaCache` after the code-gen that rewrites the options in the service worker registration