### PR TITLE
docs: note default error/not-found UI follows OS color scheme, not app theme

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/error.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/error.mdx
@@ -162,6 +162,8 @@ In most cases, you should use [`retry()`](#retry) instead. However, if you have 
 
 While less common, you can handle errors in the root layout or template using `global-error.jsx`, located in the root app directory, even when leveraging [internationalization](/docs/app/guides/internationalization). Global error UI must define its own `<html>` and `<body>` tags, global styles, fonts, or other dependencies that your error page requires. This file replaces the root layout or template when active.
 
+> **Good to know**: `global-error` and the built-in 500 page render their own document and do **not** include your global styles, so an app-level theme toggle (a class or `data-theme` attribute) won't reach them. The default UI follows the OS color scheme; to match your app's theme, apply it inside your own `global-error` component.
+
 > **Good to know**: Error boundaries must be [Client Components](/docs/app/getting-started/server-and-client-components#using-client-components), which means that [`metadata` and `generateMetadata`](/docs/app/getting-started/metadata-and-og-images) exports are not supported in `global-error.jsx`. As an alternative, you can use the React [`<title>`](https://react.dev/reference/react-dom/components/title) component.
 
 ```tsx filename="app/global-error.tsx" switcher

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -42,11 +42,13 @@ export default function NotFound() {
 
 In the [component hierarchy](/docs/app/getting-started/project-structure#component-hierarchy), `not-found.js` renders between `loading.js` and `page.js`. It is wrapped by the `<Suspense>` boundary from `loading.js` and the error boundary from `error.js` in the same segment.
 
+> **Good to know**: The default not found UI follows the operating system's color scheme via `prefers-color-scheme` and does not read an app-level theme (such as a class or `data-theme` attribute on `<html>`). Because it renders inside your root layout, the quickest way to match an explicit theme is to add a higher-specificity rule pair in your global stylesheet, scoped to your theme selector — for example `html[data-theme='light'] body` and `html[data-theme='dark'] body`. For full control over the markup, provide your own `not-found.js`.
+
 ## `global-not-found.js` (experimental)
 
 The `global-not-found.js` file lets you define a 404 page for your entire application. Unlike `not-found.js`, which works at the route level, this is used when a requested URL doesn't match any route at all. Next.js **skips rendering** and directly returns this global page.
 
-The `global-not-found.js` file bypasses your app's normal rendering, which means you'll need to import any global styles, fonts, or other dependencies that your 404 page requires.
+The `global-not-found.js` file bypasses your app's normal rendering, which means you'll need to import any global styles, fonts, or other dependencies that your 404 page requires. This includes your theme: because `global-not-found.js` bypasses your layout, the OS color scheme is the only signal the default UI sees, so apply your theme (class or attribute) inside this file.
 
 > **Good to know**: A smaller version of your global styles, and a simpler font family could improve performance of this page.
 

--- a/docs/02-pages/03-building-your-application/01-routing/08-custom-error.mdx
+++ b/docs/02-pages/03-building-your-application/01-routing/08-custom-error.mdx
@@ -9,6 +9,8 @@ A 404 page may be accessed very often. Server-rendering an error page for every 
 
 To avoid the above pitfalls, Next.js provides a static 404 page by default without having to add any additional files.
 
+> **Good to know**: The default 404 and 500 pages follow the operating system's color scheme via `prefers-color-scheme` and do not read an app-level theme. Because `pages/404.js` and `pages/500.js` render inside your custom `App`, providing your own files lets your global styles and theme apply.
+
 ### Customizing The 404 Page
 
 To create a custom 404 page you can create a `pages/404.js` file. This file is statically generated at build time.


### PR DESCRIPTION
Guidance for those who don't customize their own not-found page, pages router's 404, etc, because the defaults honor the system style, not any app-level theme settings. 