### PR TITLE
fix: do not run onStage listeners for stages that were aborted

### DIFF
--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -115,8 +115,8 @@ export class StagedRenderingController {
     }
   }
 
-  onStage(stage: AdvanceableRenderStage, callback: () => void) {
-    addSyncTriggerListener(this.triggers[stage], callback)
+  onStage(stage: AdvanceableRenderStage, callback: () => void): boolean {
+    return addSyncTriggerListener(this.triggers[stage], callback)
   }
 
   shouldTrackSyncInterrupt(): boolean {
@@ -351,11 +351,28 @@ type StageTrigger = {
   _rejectPromise: (reason: unknown) => void
 }
 
-function addSyncTriggerListener(trigger: StageTrigger, listener: () => void) {
-  if (trigger.state === 'pending') {
-    trigger._listeners.push(listener)
-  } else {
-    listener()
+/**
+ * @returns Whether or not the listener was added (if the trigger is cancelled, we skip adding it)
+ * */
+function addSyncTriggerListener(
+  trigger: StageTrigger,
+  listener: () => void
+): boolean {
+  switch (trigger.state) {
+    case 'pending': {
+      // Queue the listener until the trigger fires.
+      trigger._listeners.push(listener)
+      return true
+    }
+    case 'triggered': {
+      // Trigger already fired, run listener immediately.
+      listener()
+      return true
+    }
+    case 'cancelled': {
+      // The trigger was cancelled and will never fire, so we ignore the listener.
+      return false
+    }
   }
 }
 


### PR DESCRIPTION
Small fix for `StageRenderingController.onStage` -- the `StageTrigger` implementation that `onStage` is based around would immediately fire the callback if the stage trigger was cancelled (i.e. if we aborted the render and won't reach the stage). The intention was to only fire it synchronously if the trigger was fired (i.e. we advanced to the stage)

Luckily it looks like we have literally one usage of `onStage` right now: in `countShellAndStaticStageBytes`, which is only used in full renders that don't abort, so this shouldn't be a factor, but still worth doing for future-proofing