### PR TITLE
Turbopack tests: remove assertions that duplicate webpack results

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -36,15 +36,9 @@ describe('ReactRefreshLogBox app', () => {
     )
     await browser.elementByCss('a').click()
 
-    if (isTurbopack) {
-      await expect(browser).toDisplayRedbox(
-        `"Expected Redbox but found no visible one."`
-      )
-    } else {
-      await expect(browser).toDisplayRedbox(
-        `"Expected Redbox but found no visible one."`
-      )
-    }
+    await expect(browser).toDisplayRedbox(
+      `"Expected Redbox but found no visible one."`
+    )
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554137807
@@ -215,15 +209,9 @@ describe('ReactRefreshLogBox app', () => {
       `export default function FunctionDefault() { throw new Error('no'); }`
     )
 
-    if (isTurbopack) {
-      await expect(browser).toDisplayRedbox(
-        `"Expected Redbox but found no visible one."`
-      )
-    } else {
-      await expect(browser).toDisplayRedbox(
-        `"Expected Redbox but found no visible one."`
-      )
-    }
+    await expect(browser).toDisplayRedbox(
+      `"Expected Redbox but found no visible one."`
+    )
   })
 
   // TODO: investigate why this fails when running outside of the Next.js
@@ -615,42 +603,22 @@ describe('ReactRefreshLogBox app', () => {
 
     await browser.elementByCss('button').click()
 
-    // TODO(veil): Why Owner Stack location different?
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "description": "end https://nextjs.org",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('end https://nextjs.org')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "description": "end https://nextjs.org",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('end https://nextjs.org')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "description": "end https://nextjs.org",
+       "environmentLabel": null,
+       "label": "Runtime Error",
+       "source": "index.js (5:11) @ Index.useCallback[boom]
+     > 5 |     throw new Error('end https://nextjs.org')
+         |           ^",
+       "stack": [
+         "Index.useCallback[boom] index.js (5:11)",
+         "button <anonymous>",
+         "Index index.js (9:7)",
+         "Page app/page.js (4:10)",
+       ],
+     }
+    `)
 
     expect(
       await session.evaluate(
@@ -694,42 +662,22 @@ describe('ReactRefreshLogBox app', () => {
 
     await browser.elementByCss('button').click()
 
-    // TODO(veil): Why Owner Stack location different?
-    if (isTurbopack) {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "https://nextjs.org start",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('https://nextjs.org start')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "https://nextjs.org start",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('https://nextjs.org start')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayRedbox(`
+     {
+       "description": "https://nextjs.org start",
+       "environmentLabel": null,
+       "label": "Runtime Error",
+       "source": "index.js (5:11) @ Index.useCallback[boom]
+     > 5 |     throw new Error('https://nextjs.org start')
+         |           ^",
+       "stack": [
+         "Index.useCallback[boom] index.js (5:11)",
+         "button <anonymous>",
+         "Index index.js (9:7)",
+         "Page app/page.js (4:10)",
+       ],
+     }
+    `)
     expect(
       await session.evaluate(
         () =>
@@ -772,42 +720,22 @@ describe('ReactRefreshLogBox app', () => {
 
     await browser.elementByCss('button').click()
 
-    // TODO(veil): Why Owner Stack location different?
-    if (isTurbopack) {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "middle https://nextjs.org end",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('middle https://nextjs.org end')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "middle https://nextjs.org end",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('middle https://nextjs.org end')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayRedbox(`
+     {
+       "description": "middle https://nextjs.org end",
+       "environmentLabel": null,
+       "label": "Runtime Error",
+       "source": "index.js (5:11) @ Index.useCallback[boom]
+     > 5 |     throw new Error('middle https://nextjs.org end')
+         |           ^",
+       "stack": [
+         "Index.useCallback[boom] index.js (5:11)",
+         "button <anonymous>",
+         "Index index.js (9:7)",
+         "Page app/page.js (4:10)",
+       ],
+     }
+    `)
     expect(
       await session.evaluate(
         () =>
@@ -850,42 +778,22 @@ describe('ReactRefreshLogBox app', () => {
 
     await browser.elementByCss('button').click()
 
-    // TODO(veil): Why Owner Stack location different?
-    if (isTurbopack) {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "multiple https://nextjs.org links http://example.com",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('multiple https://nextjs.org links http://example.com')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "multiple https://nextjs.org links http://example.com",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ Index.useCallback[boom]
-       > 5 |     throw new Error('multiple https://nextjs.org links http://example.com')
-           |           ^",
-         "stack": [
-           "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayRedbox(`
+     {
+       "description": "multiple https://nextjs.org links http://example.com",
+       "environmentLabel": null,
+       "label": "Runtime Error",
+       "source": "index.js (5:11) @ Index.useCallback[boom]
+     > 5 |     throw new Error('multiple https://nextjs.org links http://example.com')
+         |           ^",
+       "stack": [
+         "Index.useCallback[boom] index.js (5:11)",
+         "button <anonymous>",
+         "Index index.js (9:7)",
+         "Page app/page.js (4:10)",
+       ],
+     }
+    `)
     expect(
       await session.evaluate(
         () =>
@@ -1152,38 +1060,20 @@ describe('ReactRefreshLogBox app', () => {
     )
 
     // Render error should "win" and show up in fullscreen
-    // TODO(veil): Why Owner Stack location different?
-    if (isTurbopack) {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "Component error",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (2:44) @ Index
-       > 2 |   if (typeof window !== 'undefined') throw new Error('Component error')
-           |                                            ^",
-         "stack": [
-           "Index index.js (2:44)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "description": "Component error",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (2:44) @ Index
-       > 2 |   if (typeof window !== 'undefined') throw new Error('Component error')
-           |                                            ^",
-         "stack": [
-           "Index index.js (2:44)",
-           "Page app/page.js (4:10)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayRedbox(`
+     {
+       "description": "Component error",
+       "environmentLabel": null,
+       "label": "Runtime Error",
+       "source": "index.js (2:44) @ Index
+     > 2 |   if (typeof window !== 'undefined') throw new Error('Component error')
+         |                                            ^",
+       "stack": [
+         "Index index.js (2:44)",
+         "Page app/page.js (4:10)",
+       ],
+     }
+    `)
   })
 
   test('Call stack for client error', async () => {

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -339,21 +339,7 @@ describe('ReactRefreshLogBox', () => {
        ]
       `)
     } else {
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "no",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "FunctionDefault.js (1:51) @ FunctionDefault
-         > 1 | export default function FunctionDefault() { throw new Error('no'); }
-             |                                                   ^",
-           "stack": [
-             "FunctionDefault FunctionDefault.js (1:51)",
-           ],
-         }
-        `)
-      } else if (isRspack) {
+      if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
            "description": "no",
@@ -633,20 +619,6 @@ describe('ReactRefreshLogBox', () => {
              "ClickCount.render Child.js (4:11)",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",
-           ],
-         }
-        `)
-      } else if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "Child.js (4:11) @ ClickCount.render
-         > 4 |     throw new Error()
-             |           ^",
-           "stack": [
-             "ClickCount.render Child.js (4:11)",
            ],
          }
         `)
@@ -1289,83 +1261,43 @@ describe('ReactRefreshLogBox', () => {
     const { browser } = sandbox
 
     if (isReact18) {
-      if (isTurbopack) {
-        // Wait for the error to reach the correct count
-        await retry(async () => {
-          expect(await getRedboxTotalErrorCount(browser)).toBe(3)
-        })
-        await expect(browser).toDisplayRedbox(`
-         [
-           {
-             "description": "Client error",
-             "environmentLabel": null,
-             "label": "Runtime Error",
-             "source": "pages/index.js (3:11) @ Page
-         > 3 |     throw new Error('Client error')
-             |           ^",
-             "stack": [
-               "Page pages/index.js (3:11)",
-             ],
-           },
-           {
-             "description": "Client error",
-             "environmentLabel": null,
-             "label": "Runtime Error",
-             "source": "pages/index.js (3:11) @ Page
-         > 3 |     throw new Error('Client error')
-             |           ^",
-             "stack": [
-               "Page pages/index.js (3:11)",
-             ],
-           },
-           {
-             "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
-             "environmentLabel": null,
-             "label": "Recoverable Error",
-             "source": null,
-             "stack": [],
-           },
-         ]
-        `)
-      } else {
-        // Wait for the error to reach the correct count
-        await retry(async () => {
-          expect(await getRedboxTotalErrorCount(browser)).toBe(3)
-        })
-        await expect(browser).toDisplayRedbox(`
-         [
-           {
-             "description": "Client error",
-             "environmentLabel": null,
-             "label": "Runtime Error",
-             "source": "pages/index.js (3:11) @ Page
-         > 3 |     throw new Error('Client error')
-             |           ^",
-             "stack": [
-               "Page pages/index.js (3:11)",
-             ],
-           },
-           {
-             "description": "Client error",
-             "environmentLabel": null,
-             "label": "Runtime Error",
-             "source": "pages/index.js (3:11) @ Page
-         > 3 |     throw new Error('Client error')
-             |           ^",
-             "stack": [
-               "Page pages/index.js (3:11)",
-             ],
-           },
-           {
-             "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
-             "environmentLabel": null,
-             "label": "Recoverable Error",
-             "source": null,
-             "stack": [],
-           },
-         ]
-        `)
-      }
+      // Wait for the error to reach the correct count
+      await retry(async () => {
+        expect(await getRedboxTotalErrorCount(browser)).toBe(3)
+      })
+      await expect(browser).toDisplayRedbox(`
+       [
+         {
+           "description": "Client error",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/index.js (3:11) @ Page
+       > 3 |     throw new Error('Client error')
+           |           ^",
+           "stack": [
+             "Page pages/index.js (3:11)",
+           ],
+         },
+         {
+           "description": "Client error",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/index.js (3:11) @ Page
+       > 3 |     throw new Error('Client error')
+           |           ^",
+           "stack": [
+             "Page pages/index.js (3:11)",
+           ],
+         },
+         {
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "environmentLabel": null,
+           "label": "Recoverable Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
+      `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -311,20 +311,6 @@ describe('pages/ error recovery', () => {
            ],
          }
         `)
-      } else if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "oops",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "child.js (3:9) @ Child
-         > 3 |   throw new Error('oops')
-             |         ^",
-           "stack": [
-             "Child child.js (3:9)",
-           ],
-         }
-        `)
       } else {
         await expect(browser).toDisplayRedbox(`
          {

--- a/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
 describe('Cache Components Fallback Validation', () => {
-  const { isTurbopack, next } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -49,304 +49,151 @@ describe('Cache Components Fallback Validation', () => {
     await browser.loadPage(
       `${next.url}/partial/prerendered/unwrapped/prerendered`
     )
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
-       > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
-           |                          ^",
-         "stack": [
-           "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
-       > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
-           |                          ^",
-         "stack": [
-           "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
+     > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
+         |                          ^",
+       "stack": [
+         "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
+       ],
+     }
+    `)
 
     await browser.loadPage(`${next.url}/partial/prerendered/unwrapped/novel`)
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
-       > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
-           |                          ^",
-         "stack": [
-           "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
-       > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
-           |                          ^",
-         "stack": [
-           "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
+     > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
+         |                          ^",
+       "stack": [
+         "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
+       ],
+     }
+    `)
 
     await browser.loadPage(`${next.url}/partial/novel/unwrapped/novel`)
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/partial/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/partial/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/partial/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/partial/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/partial/[top]/unwrapped/layout.tsx (8:3) @ Layout
+     >  8 |   await params
+          |   ^",
+       "stack": [
+         "Layout app/partial/[top]/unwrapped/layout.tsx (8:3)",
+       ],
+     }
+    `)
   })
 
   it('should warn about missing Suspense when accessing params if static params are entirely missing at build time', async () => {
     // when the params are partially complete we don't expect to see any errors awaiting the params that are known
     // but do expect errors awaiting the params that are not known if not inside a Suspense boundary.
     const browser = await next.browser('/none/prerendered/wrapped/prerendered')
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
-       > 10 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
-       > 10 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
+     > 10 |   await params
+          |   ^",
+       "stack": [
+         "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
+       ],
+     }
+    `)
 
     await browser.loadPage(`${next.url}/none/prerendered/wrapped/novel`)
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
-       > 10 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
-       > 10 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
+     > 10 |   await params
+          |   ^",
+       "stack": [
+         "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
+       ],
+     }
+    `)
 
     await browser.loadPage(`${next.url}/none/novel/wrapped/novel`)
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
-       > 10 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
-       > 10 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
+     > 10 |   await params
+          |   ^",
+       "stack": [
+         "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
+       ],
+     }
+    `)
 
     await browser.loadPage(`${next.url}/none/prerendered/unwrapped/prerendered`)
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
+     >  8 |   await params
+          |   ^",
+       "stack": [
+         "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
+       ],
+     }
+    `)
 
     await browser.loadPage(`${next.url}/none/prerendered/unwrapped/novel`)
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
+     >  8 |   await params
+          |   ^",
+       "stack": [
+         "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
+       ],
+     }
+    `)
 
     await browser.loadPage(`${next.url}/none/novel/unwrapped/novel`)
-    if (isTurbopack) {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1400",
-         "description": "Next.js encountered runtime data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
-       >  8 |   await params
-            |   ^",
-         "stack": [
-           "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1400",
+       "description": "Next.js encountered runtime data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
+     >  8 |   await params
+          |   ^",
+       "stack": [
+         "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
+       ],
+     }
+    `)
   })
 })

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -39,66 +39,36 @@ describe('react-dom/server in React Server environment', () => {
     )
 
     await waitForNoRedbox(browser)
-    if (isTurbopack) {
-      expect(await browser.elementByCss('main').text()).toMatchInlineSnapshot(`
-        "{
-          "default": [
-            "renderToReadableStream",
-            "renderToStaticMarkup",
-            "renderToString",
-            "resume",
-            "version"
-          ],
-          "named": [
-            "default",
-            "renderToReadableStream",
-            "renderToStaticMarkup",
-            "renderToString",
-            "resume",
-            "version"
-          ]
-        }"
-      `)
-    } else {
-      expect(await browser.elementByCss('main').text()).toMatchInlineSnapshot(`
-        "{
-          "default": [
-            "renderToReadableStream",
-            "renderToStaticMarkup",
-            "renderToString",
-            "resume",
-            "version"
-          ],
-          "named": [
-            "default",
-            "renderToReadableStream",
-            "renderToStaticMarkup",
-            "renderToString",
-            "resume",
-            "version"
-          ]
-        }"
-      `)
-    }
+    expect(await browser.elementByCss('main').text()).toMatchInlineSnapshot(`
+      "{
+        "default": [
+          "renderToReadableStream",
+          "renderToStaticMarkup",
+          "renderToString",
+          "resume",
+          "version"
+        ],
+        "named": [
+          "default",
+          "renderToReadableStream",
+          "renderToStaticMarkup",
+          "renderToString",
+          "resume",
+          "version"
+        ]
+      }"
+    `)
+
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
     }
-    if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    }
+    expect(redbox).toMatchInlineSnapshot(`
+      {
+        "description": null,
+        "source": null,
+      }
+    `)
   })
 
   it('explicit react-dom/server.edge usage in app code', async () => {
@@ -156,21 +126,12 @@ describe('react-dom/server in React Server environment', () => {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
     }
-    if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    }
+    expect(redbox).toMatchInlineSnapshot(`
+      {
+        "description": null,
+        "source": null,
+      }
+    `)
   })
 
   it('implicit react-dom/server.edge usage in app code', async () => {
@@ -510,21 +471,12 @@ describe('react-dom/server in React Server environment', () => {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
     }
-    if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    }
+    expect(redbox).toMatchInlineSnapshot(`
+      {
+        "description": null,
+        "source": null,
+      }
+    `)
   })
 
   it('implicit react-dom/server.edge usage in library code', async () => {
@@ -533,70 +485,38 @@ describe('react-dom/server in React Server environment', () => {
     )
 
     await waitForNoRedbox(browser)
-    if (isTurbopack) {
-      expect(await browser.elementByCss('main').text()).toMatchInlineSnapshot(`
-        "{
-          "default": {
-            "default": [
-              "renderToReadableStream",
-              "renderToStaticMarkup",
-              "renderToString",
-              "resume",
-              "version"
-            ],
-            "named": [
-              "default",
-              "renderToReadableStream",
-              "renderToStaticMarkup",
-              "renderToString",
-              "resume",
-              "version"
-            ]
-          }
-        }"
-      `)
-    } else {
-      expect(await browser.elementByCss('main').text()).toMatchInlineSnapshot(`
-        "{
-          "default": {
-            "default": [
-              "renderToReadableStream",
-              "renderToStaticMarkup",
-              "renderToString",
-              "resume",
-              "version"
-            ],
-            "named": [
-              "default",
-              "renderToReadableStream",
-              "renderToStaticMarkup",
-              "renderToString",
-              "resume",
-              "version"
-            ]
-          }
-        }"
-      `)
-    }
+    expect(await browser.elementByCss('main').text()).toMatchInlineSnapshot(`
+      "{
+        "default": {
+          "default": [
+            "renderToReadableStream",
+            "renderToStaticMarkup",
+            "renderToString",
+            "resume",
+            "version"
+          ],
+          "named": [
+            "default",
+            "renderToReadableStream",
+            "renderToStaticMarkup",
+            "renderToString",
+            "resume",
+            "version"
+          ]
+        }
+      }"
+    `)
+
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
     }
-    if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
-      `)
-    }
+    expect(redbox).toMatchInlineSnapshot(`
+      {
+        "description": null,
+        "source": null,
+      }
+    `)
   })
 
   it('explicit react-dom/server.node usage in library code', async () => {

--- a/test/development/next-image-new/invalid-image-import/invalid-image-import.test.ts
+++ b/test/development/next-image-new/invalid-image-import/invalid-image-import.test.ts
@@ -16,10 +16,6 @@ describe('Invalid Image Import (dev)', () => {
     const description = await getRedboxDescription(browser)
     if (isTurbopack) {
       expect(description).toContain('Processing image failed')
-    } else if (process.env.NEXT_RSPACK) {
-      expect(description).toContain(
-        'Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format.'
-      )
     } else {
       expect(description).toContain(
         'Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format.'
@@ -33,11 +29,6 @@ describe('Invalid Image Import (dev)', () => {
       )
       expect(source).toContain(
         'Source code does not contain a <svg> root element'
-      )
-    } else if (process.env.NEXT_RSPACK) {
-      expect(source).toContain('./pages/index.js')
-      expect(source).toContain(
-        'Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format.'
       )
     } else {
       expect(source).toContain('./pages/index.js')

--- a/test/e2e/dynamic-routing/shared.ts
+++ b/test/e2e/dynamic-routing/shared.ts
@@ -13,7 +13,7 @@ export function runTests(ctx: {
   isTurbopack: boolean
   middlewareEnabled: boolean
 }) {
-  const { next, isNextDev, isTurbopack, middlewareEnabled } = ctx
+  const { next, isNextDev, middlewareEnabled } = ctx
 
   if (isNextStart) {
     it('should have correct cache entries on prefetch', async () => {
@@ -1615,63 +1615,33 @@ export function runTests(ctx: {
         await next.readFile('.next/server/pages-manifest.json')
       )
 
-      if (isTurbopack) {
-        expect(manifest).toMatchInlineSnapshot(`
-         {
-           "/": "pages/index.html",
-           "/404": "pages/404.html",
-           "/[name]": "pages/[name].js",
-           "/[name]/[comment]": "pages/[name]/[comment].js",
-           "/[name]/[comment]/[...rest]": "pages/[name]/[comment]/[...rest].js",
-           "/[name]/comments": "pages/[name]/comments.js",
-           "/[name]/on-mount-redir": "pages/[name]/on-mount-redir.html",
-           "/_app": "pages/_app.js",
-           "/_document": "pages/_document.js",
-           "/_error": "pages/_error.js",
-           "/another": "pages/another.html",
-           "/b/[123]": "pages/b/[123].js",
-           "/blog/[name]/comment/[id]": "pages/blog/[name]/comment/[id].js",
-           "/c/[alongparamnameshouldbeallowedeventhoughweird]": "pages/c/[alongparamnameshouldbeallowedeventhoughweird].js",
-           "/catchall-dash/[...hello-world]": "pages/catchall-dash/[...hello-world].html",
-           "/d/[id]": "pages/d/[id].html",
-           "/dash/[hello-world]": "pages/dash/[hello-world].html",
-           "/index/[...slug]": "pages/index/[...slug].html",
-           "/on-mount/[post]": "pages/on-mount/[post].html",
-           "/p1/p2/all-ssg/[...rest]": "pages/p1/p2/all-ssg/[...rest].js",
-           "/p1/p2/all-ssr/[...rest]": "pages/p1/p2/all-ssr/[...rest].js",
-           "/p1/p2/nested-all-ssg/[...rest]": "pages/p1/p2/nested-all-ssg/[...rest].js",
-           "/p1/p2/predefined-ssg/[...rest]": "pages/p1/p2/predefined-ssg/[...rest].js",
-         }
-        `)
-      } else {
-        expect(manifest).toMatchInlineSnapshot(`
-         {
-           "/": "pages/index.html",
-           "/404": "pages/404.html",
-           "/[name]": "pages/[name].js",
-           "/[name]/[comment]": "pages/[name]/[comment].js",
-           "/[name]/[comment]/[...rest]": "pages/[name]/[comment]/[...rest].js",
-           "/[name]/comments": "pages/[name]/comments.js",
-           "/[name]/on-mount-redir": "pages/[name]/on-mount-redir.html",
-           "/_app": "pages/_app.js",
-           "/_document": "pages/_document.js",
-           "/_error": "pages/_error.js",
-           "/another": "pages/another.html",
-           "/b/[123]": "pages/b/[123].js",
-           "/blog/[name]/comment/[id]": "pages/blog/[name]/comment/[id].js",
-           "/c/[alongparamnameshouldbeallowedeventhoughweird]": "pages/c/[alongparamnameshouldbeallowedeventhoughweird].js",
-           "/catchall-dash/[...hello-world]": "pages/catchall-dash/[...hello-world].html",
-           "/d/[id]": "pages/d/[id].html",
-           "/dash/[hello-world]": "pages/dash/[hello-world].html",
-           "/index/[...slug]": "pages/index/[...slug].html",
-           "/on-mount/[post]": "pages/on-mount/[post].html",
-           "/p1/p2/all-ssg/[...rest]": "pages/p1/p2/all-ssg/[...rest].js",
-           "/p1/p2/all-ssr/[...rest]": "pages/p1/p2/all-ssr/[...rest].js",
-           "/p1/p2/nested-all-ssg/[...rest]": "pages/p1/p2/nested-all-ssg/[...rest].js",
-           "/p1/p2/predefined-ssg/[...rest]": "pages/p1/p2/predefined-ssg/[...rest].js",
-         }
-        `)
-      }
+      expect(manifest).toMatchInlineSnapshot(`
+       {
+         "/": "pages/index.html",
+         "/404": "pages/404.html",
+         "/[name]": "pages/[name].js",
+         "/[name]/[comment]": "pages/[name]/[comment].js",
+         "/[name]/[comment]/[...rest]": "pages/[name]/[comment]/[...rest].js",
+         "/[name]/comments": "pages/[name]/comments.js",
+         "/[name]/on-mount-redir": "pages/[name]/on-mount-redir.html",
+         "/_app": "pages/_app.js",
+         "/_document": "pages/_document.js",
+         "/_error": "pages/_error.js",
+         "/another": "pages/another.html",
+         "/b/[123]": "pages/b/[123].js",
+         "/blog/[name]/comment/[id]": "pages/blog/[name]/comment/[id].js",
+         "/c/[alongparamnameshouldbeallowedeventhoughweird]": "pages/c/[alongparamnameshouldbeallowedeventhoughweird].js",
+         "/catchall-dash/[...hello-world]": "pages/catchall-dash/[...hello-world].html",
+         "/d/[id]": "pages/d/[id].html",
+         "/dash/[hello-world]": "pages/dash/[hello-world].html",
+         "/index/[...slug]": "pages/index/[...slug].html",
+         "/on-mount/[post]": "pages/on-mount/[post].html",
+         "/p1/p2/all-ssg/[...rest]": "pages/p1/p2/all-ssg/[...rest].js",
+         "/p1/p2/all-ssr/[...rest]": "pages/p1/p2/all-ssr/[...rest].js",
+         "/p1/p2/nested-all-ssg/[...rest]": "pages/p1/p2/nested-all-ssg/[...rest].js",
+         "/p1/p2/predefined-ssg/[...rest]": "pages/p1/p2/predefined-ssg/[...rest].js",
+       }
+      `)
     })
   }
 }

--- a/test/e2e/import-meta/import-meta.test.ts
+++ b/test/e2e/import-meta/import-meta.test.ts
@@ -11,13 +11,8 @@ describe('import-meta', () => {
       const testData = $('#test-data').text()
       const data = JSON.parse(testData)
 
-      if (isTurbopack) {
-        expect(data.url).toStartWith('file:///')
-        expect(data.url).toEndWith('/pages/index.tsx')
-      } else {
-        expect(data.url).toStartWith('file:///')
-        expect(data.url).toEndWith('/pages/index.tsx')
-      }
+      expect(data.url).toStartWith('file:///')
+      expect(data.url).toEndWith('/pages/index.tsx')
     })
 
     it('should work in browser', async () => {

--- a/test/e2e/next-image-legacy/default/default-static.test.ts
+++ b/test/e2e/next-image-legacy/default/default-static.test.ts
@@ -115,11 +115,7 @@ describe('Static Image Component Tests', () => {
   it('Should add a blur placeholder to statically imported jpg', async () => {
     const $ = cheerio.load(html)
     const style = $('#basic-static').attr('style')
-    if (isTurbopack) {
-      expect(replaceDataUrl(style)).toMatchInlineSnapshot(
-        `"position:absolute;top:0;left:0;bottom:0;right:0;box-sizing:border-box;padding:0;border:none;margin:auto;display:block;width:0;height:0;min-width:100%;max-width:100%;min-height:100%;max-height:100%;background-size:cover;background-position:0% 0%;filter:blur(20px);background-image:url("data:<REPLACED>")"`
-      )
-    } else if (isNextDev) {
+    if (isNextDev && !isTurbopack) {
       // In webpack dev, `next/legacy/image` emits a dynamic blur URL via the
       // image optimizer route instead of an inlined base64 data URL, to avoid
       // slowing down the dev server (see

--- a/test/production/css-features/css-features.test.ts
+++ b/test/production/css-features/css-features.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
 describe('Custom Properties: Pass-Through IE11', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'cp-ie-11'),
   })
 
@@ -17,20 +17,14 @@ describe('Custom Properties: Pass-Through IE11', () => {
       .replace(/\/\*.*?\*\//g, '')
       .trim()
 
-    if (isTurbopack) {
-      expect(
-        cssContent.replace(/\/\*.*?\*\//g, '').trim()
-      ).toMatchInlineSnapshot(`":root{--color:red}h1{color:var(--color)}"`)
-    } else {
-      expect(
-        cssContent.replace(/\/\*.*?\*\//g, '').trim()
-      ).toMatchInlineSnapshot(`":root{--color:red}h1{color:var(--color)}"`)
-    }
+    expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatchInlineSnapshot(
+      `":root{--color:red}h1{color:var(--color)}"`
+    )
   })
 })
 
 describe('Custom Properties: Pass-Through Modern', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'cp-modern'),
   })
 
@@ -45,15 +39,9 @@ describe('Custom Properties: Pass-Through Modern', () => {
       .replace(/\/\*.*?\*\//g, '')
       .trim()
 
-    if (isTurbopack) {
-      expect(
-        cssContent.replace(/\/\*.*?\*\//g, '').trim()
-      ).toMatchInlineSnapshot(`":root{--color:red}h1{color:var(--color)}"`)
-    } else {
-      expect(
-        cssContent.replace(/\/\*.*?\*\//g, '').trim()
-      ).toMatchInlineSnapshot(`":root{--color:red}h1{color:var(--color)}"`)
-    }
+    expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatchInlineSnapshot(
+      `":root{--color:red}h1{color:var(--color)}"`
+    )
   })
 })
 


### PR DESCRIPTION
We forked test assertions in places in the early days of merging Turbopack. Now that we more closely align, a bunch of these had the exact same assertions. Fold them into one.
