### PR TITLE
Fix termination handling

### DIFF
--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -37,14 +37,14 @@ function verifyAndRunTypeScript(
   let impl: typeof import('../lib/verify-typescript-setup').verifyAndRunTypeScript
   let typeCheckWorker:
     | (Worker & {
-        verifyAndRunTypeScript: typeof impl
+        verifyAndRunTypeScriptInWorker: typeof impl
       })
     | undefined
   if (shouldRunTypeCheck && !useTypeScriptCli) {
     typeCheckWorker = new Worker(
       require.resolve('../lib/verify-typescript-setup'),
       {
-        exposedMethods: ['verifyAndRunTypeScript'],
+        exposedMethods: ['verifyAndRunTypeScriptInWorker'],
         debuggerPortOffset: -1,
         isolatedMemory: false,
         numWorkers: 1,
@@ -52,7 +52,7 @@ function verifyAndRunTypeScript(
         maxRetries: 0,
       }
     ) as typeof typeCheckWorker
-    impl = typeCheckWorker!.verifyAndRunTypeScript
+    impl = typeCheckWorker!.verifyAndRunTypeScriptInWorker
   } else {
     // No worker: either we are not type-checking (just writing setup files), or
     // the CLI checker runs `tsc` in-process. Avoid the worker overhead.

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -40,7 +40,7 @@ function verifyAndRunTypeScript(
         verifyAndRunTypeScript: typeof impl
       })
     | undefined
-  if (shouldRunTypeCheck) {
+  if (shouldRunTypeCheck && !useTypeScriptCli) {
     typeCheckWorker = new Worker(
       require.resolve('../lib/verify-typescript-setup'),
       {
@@ -48,16 +48,14 @@ function verifyAndRunTypeScript(
         debuggerPortOffset: -1,
         isolatedMemory: false,
         numWorkers: 1,
-        // CLI mode must use a child-process worker so terminating the worker
-        // produces a process lifecycle event that can be forwarded to `tsc`.
-        enableWorkerThreads: useTypeScriptCli ? false : enableWorkerThreads,
+        enableWorkerThreads,
         maxRetries: 0,
       }
     ) as typeof typeCheckWorker
     impl = typeCheckWorker!.verifyAndRunTypeScript
   } else {
-    // When not running typecheck, just run the implementation in-process without spawning a worker,
-    // to avoid the overhead of the worker.
+    // No worker: either we are not type-checking (just writing setup files), or
+    // the CLI checker runs `tsc` in-process. Avoid the worker overhead.
     impl = (
       require('../lib/verify-typescript-setup') as typeof import('../lib/verify-typescript-setup')
     ).verifyAndRunTypeScript
@@ -84,8 +82,10 @@ function verifyAndRunTypeScript(
       return result
     })
     .catch(() => {
-      // The error is already logged in the worker, we simply exit the main thread to prevent the
-      // `Jest worker encountered 1 child process exceptions, exceeding retry limit` from showing up
+      // The error is already logged (in the worker for the API checker, or
+      // directly for the in-process CLI checker); we simply exit to prevent the
+      // `Jest worker encountered 1 child process exceptions, exceeding retry
+      // limit` message from showing up.
       process.exit(1)
     })
 }

--- a/packages/next/src/lib/typescript/runTypeScriptCli.test.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.test.ts
@@ -22,6 +22,7 @@ function getProcessListeners(event: ProcessEvent): ProcessListener[] {
 }
 
 class MockChildProcess extends EventEmitter {
+  pid = 4321
   killed = false
   kill = jest.fn(() => true)
   stdout = new PassThrough()
@@ -70,7 +71,7 @@ describe('runTypeScriptCli', () => {
     }
   }
 
-  it('forwards SIGTERM to the child and cleans up all listeners on close', async () => {
+  it('spawns tsc detached with inherited stdio and resolves with the exit code', async () => {
     const resultPromise = runTypeScriptCli({
       cwd: '/project',
       tscPath: '/project/node_modules/typescript/bin/tsc',
@@ -87,15 +88,91 @@ describe('runTypeScriptCli', () => {
         stdio: 'inherit',
       })
     )
-    getAddedListener('SIGTERM')()
-    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
 
     child.emit('close', 0, null)
 
-    await expect(resultPromise).rejects.toThrow(
-      'TypeScript CLI interrupted by SIGTERM'
-    )
-    expect(processKill).toHaveBeenCalledWith(process.pid, 'SIGTERM')
+    await expect(resultPromise).resolves.toMatchObject({
+      exitCode: 0,
+      signal: null,
+    })
+    expectListenersRestored()
+  })
+
+  it('SIGKILLs the whole process group on process exit', async () => {
+    // The native compiler ignores catchable signals, so teardown must SIGKILL
+    // the process group (negative pid) to reap it.
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const resultPromise = runTypeScriptCli({
+      cwd: '/project',
+      tscPath: '/project/node_modules/typescript/bin/tsc',
+      args: ['--noEmit'],
+    })
+
+    getAddedListener('exit')()
+    expect(processKill).toHaveBeenCalledWith(-child.pid, 'SIGKILL')
+
+    child.emit('close', null, 'SIGKILL')
+
+    await expect(resultPromise).resolves.toMatchObject({
+      exitCode: 1,
+      signal: 'SIGKILL',
+    })
+    expectListenersRestored()
+  })
+
+  it('terminates the child only once', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const resultPromise = runTypeScriptCli({
+      cwd: '/project',
+      tscPath: '/project/node_modules/typescript/bin/tsc',
+      args: ['--noEmit'],
+    })
+
+    const terminate = getAddedListener('exit')
+    terminate()
+    terminate()
+
+    expect(processKill).toHaveBeenCalledTimes(1)
+
+    child.emit('close', null, 'SIGKILL')
+    await resultPromise
+    expectListenersRestored()
+  })
+
+  it('reaps the child and exits on a termination signal', async () => {
+    // Node.js does not fire `exit` on signal termination, so SIGINT/SIGTERM/
+    // SIGHUP must be handled explicitly or the native compiler would be left
+    // running.
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const processExit = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+
+    try {
+      const resultPromise = runTypeScriptCli({
+        cwd: '/project',
+        tscPath: '/project/node_modules/typescript/bin/tsc',
+        args: ['--noEmit'],
+      })
+
+      getAddedListener('SIGINT')()
+      expect(processKill).toHaveBeenCalledWith(-child.pid, 'SIGKILL')
+      expect(processExit).toHaveBeenCalledWith(1)
+
+      child.emit('close', null, 'SIGKILL')
+      await resultPromise
+    } finally {
+      processExit.mockRestore()
+    }
     expectListenersRestored()
   })
 

--- a/packages/next/src/lib/typescript/runTypeScriptCli.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.ts
@@ -127,45 +127,43 @@ export function runTypeScriptCli({
     }
 
     let terminationRequested = false
-    const terminateChild = (signal: NodeJS.Signals = 'SIGTERM') => {
-      if (terminationRequested || child.killed) {
+    const terminateChild = () => {
+      if (terminationRequested || child.killed || child.pid === undefined) {
         return
       }
       terminationRequested = true
 
-      if (process.platform === 'win32' && child.pid) {
+      // The native compiler ignores SIGTERM and SIGINT, so send a kill signal.
+      // Target the whole process group so the signal reaches the native compiler whether
+      // it is a grandchild or a direct child.
+      if (process.platform === 'win32') {
         spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
           stdio: 'ignore',
           windowsHide: true,
         })
-      } else if (child.pid) {
+      } else {
         try {
-          process.kill(-child.pid, signal)
+          // https://www.youtube.com/watch?v=Fow7iUaKrq4
+          process.kill(-child.pid, 'SIGKILL')
         } catch {
           // The process may have exited between the lifecycle event and kill.
         }
-      } else {
-        child.kill(signal)
       }
     }
     const terminateOnExit = () => terminateChild()
     process.once('exit', terminateOnExit)
 
-    let receivedSignal: NodeJS.Signals | undefined
-    const signalHandlers = new Map<NodeJS.Signals, () => void>()
-    const createSignalHandler = (signal: NodeJS.Signals) => () => {
-      receivedSignal ??= signal
-      terminateChild(signal)
+    const handler = () => {
+      terminateChild()
+      process.exit(1)
     }
     for (const signal of terminationSignals) {
-      const handler = createSignalHandler(signal)
-      signalHandlers.set(signal, handler)
       process.once(signal, handler)
     }
 
     const cleanup = () => {
       process.off('exit', terminateOnExit)
-      for (const [signal, handler] of signalHandlers) {
+      for (const signal of terminationSignals) {
         process.off(signal, handler)
       }
     }
@@ -177,28 +175,6 @@ export function runTypeScriptCli({
       }
       settled = true
       cleanup()
-
-      if (receivedSignal) {
-        const signal = receivedSignal
-        try {
-          // Installing a signal handler replaces Node.js' default termination.
-          // Re-send the signal after the child exits so this process preserves
-          // the original exit semantics instead of treating cancellation as a
-          // successful type check.
-          process.kill(process.pid, signal)
-        } catch (error) {
-          reject(error)
-          return
-        }
-
-        // If another listener consumes the re-sent signal, still fail instead
-        // of leaving the type-check promise pending indefinitely.
-        setImmediate(() => {
-          reject(new Error(`TypeScript CLI interrupted by ${signal}`))
-        })
-        return
-      }
-
       settle()
     }
 

--- a/packages/next/src/lib/typescript/runTypeScriptCli.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.ts
@@ -136,6 +136,7 @@ export function runTypeScriptCli({
       // The native compiler ignores SIGTERM and SIGINT, so send a kill signal.
       // Target the whole process group so the signal reaches the native compiler whether
       // it is a grandchild or a direct child.
+      // https://github.com/microsoft/typescript-go/pull/4592 should improve this in the long run
       if (process.platform === 'win32') {
         spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
           stdio: 'ignore',

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -286,31 +286,43 @@ export async function verifyAndRunTypeScript({
     }
     return { result, version: typescriptVersion, typeCheckMode }
   } catch (err) {
-    // These are special errors that should not show a stack trace:
+    // Print the user-facing message here and rethrow. This function runs both
+    // in-process (next dev / next test / next typegen, and the CLI type-check
+    // during build) and inside a jest worker (the TypeScript-API type-check
+    // during build). A thrown error does not survive the worker boundary — the
+    // parent only sees `Call retries were exceeded` — so the message must be
+    // printed on this side. The caller decides what to do with the throw (exit,
+    // or tolerate it as `next dev` does on re-verification).
     if (err instanceof CompileError) {
+      // The checker already printed its diagnostics.
       console.error(red('Failed to type check.\n'))
       if (err.message) {
         console.error(err.message)
       }
-      process.exit(1)
+    } else if (err instanceof Error) {
+      console.error(err.message)
+    } else {
+      console.error(err)
     }
-
-    /**
-     * verifyAndRunTypeScript can be either invoked directly in the main thread (during next dev / next lint)
-     * or run in a worker (during next build). In the latter case, we need to print the error message, as the
-     * parent process will only receive an `Jest worker encountered 1 child process exceptions, exceeding retry limit`.
-     */
-
-    // we are in a worker, print the error message and exit the process
-    if (process.env.IS_NEXT_WORKER) {
-      if (err instanceof Error) {
-        console.error(err.message)
-      } else {
-        console.error(err)
-      }
-      process.exit(1)
-    }
-    // we are in the main thread, throw the error and it will be handled by the caller
     throw err
+  }
+}
+
+/**
+ * Worker entrypoint used by `next build` for the TypeScript-API type-check.
+ * `verifyAndRunTypeScript` has already printed any error, so on failure we exit
+ * the worker directly rather than rethrowing: a thrown error would be retried by
+ * jest-worker and surface in the parent as the unhelpful
+ * `Jest worker encountered 1 child process exceptions, exceeding retry limit`.
+ */
+export async function verifyAndRunTypeScriptInWorker(
+  options: Parameters<typeof verifyAndRunTypeScript>[0]
+): ReturnType<typeof verifyAndRunTypeScript> {
+  try {
+    return await verifyAndRunTypeScript(options)
+  } catch {
+    // The error was already printed by `verifyAndRunTypeScript`.
+    // Kill the worker with a non-zero exit code.
+    process.exit(1)
   }
 }


### PR DESCRIPTION
## Follow-ups for the experimental TypeScript CLI checker

Two independent improvements to the `experimental.useTypeScriptCli` build path.

### 1. Make `tsc` responsive to interruption

When `next build` is interrupted (Ctrl-C / `SIGTERM`), the TypeScript 7 native compiler could keep running to completion instead of stopping — leaving a CPU-heavy process alive after the build was abandoned.

The teardown already handled termination signals and killed the whole process group; the problem was the signal it sent. The native compiler ignores `SIGTERM`/`SIGINT`, so the graceful signal never stopped it. We now escalate to `SIGKILL` (Windows: `taskkill /T /F`), which reaps the compiler on interrupt (measured ~200ms vs. running to completion).

The compiler's signal handling may be improved upstream — see [microsoft/typescript-go#4592](https://github.com/microsoft/typescript-go/pull/4592), in the mean time we should just send a kill signal
### 2. Skip the jest worker for the CLI checker

The type-check runs in a jest worker to isolate the TypeScript compiler-API heap so it can be freed after checking. In CLI mode the compiler runs in a separate `tsc` process, so there is no heap to isolate.  Just spawn tsc from the parent process.

### Testing

- Unit tests for `runTypeScriptCli` (spawn options, group-SIGKILL teardown, signal handling, listener cleanup, captured-output decoding).
- Existing `test/production/app-dir/typescript-cli` integration suite passes (TS 6, TS 7, opt-in-required, `ignoreBuildErrors`, `--debug-build-paths`).
- Manually verified against a TypeScript 7 project large enough to distinguish a real kill from natural completion: the native compiler is reaped ~200ms after interrupt.

<!-- NEXT_JS_LLM_PR -->
