### PR TITLE
[turbopack] Fix a potential deadlock in scope_and_block

### DIFF
--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(async_fn_traits)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(const_type_name)]
+#![feature(mpmc_channel)]
 
 pub mod backend;
 mod capture_future;

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -6,7 +6,7 @@ use std::{
     marker::PhantomData,
     panic::{self, AssertUnwindSafe, catch_unwind},
     sync::{
-        Arc, LazyLock,
+        Arc,
         atomic::{AtomicUsize, Ordering},
     },
     thread::{self, Thread},
@@ -17,14 +17,7 @@ use parking_lot::{Condvar, Mutex};
 use tokio::{runtime::Handle, task::block_in_place};
 use tracing::{Span, info_span};
 
-use crate::{
-    TurboTasksApi, manager::try_turbo_tasks, parallel::available_parallelism, turbo_tasks_scope,
-};
-
-/// Number of worker tasks to spawn that process jobs. It's 1 less than the number of cpus as we
-/// also use the current task as worker.
-static WORKER_TASKS: LazyLock<usize> =
-    LazyLock::new(|| available_parallelism().map_or(0, |n| n.get() - 1));
+use crate::{TurboTasksApi, manager::try_turbo_tasks, turbo_tasks_scope};
 
 enum WorkQueueJob {
     Job(usize, Box<dyn FnOnce() + Send + 'static>),
@@ -95,18 +88,16 @@ impl ScopeInner {
         }
     }
 
-    fn worker(&self, first_job_index: usize, first_job: Box<dyn FnOnce() + Send + 'static>) {
-        let mut current_job_index = first_job_index;
-        let mut current_job = first_job;
-        loop {
-            let result = catch_unwind(AssertUnwindSafe(current_job));
-            let panic = result.err().map(|e| (e, current_job_index));
+    /// Pulls jobs from the shared work queue and runs them until the `End` sentinel, recording any
+    /// panic. Both the opportunistic helper worker tasks and the calling thread (via
+    /// `end_and_help_complete`) run this. Helpers are a pure optimization: whether zero or all of
+    /// them ever get scheduled, the calling thread drains the whole queue by itself, so liveness
+    /// never depends on a helper being scheduled.
+    fn run_jobs(&self) {
+        while let Some((index, job)) = self.pick_job_from_work_queue() {
+            let result = catch_unwind(AssertUnwindSafe(job));
+            let panic = result.err().map(|e| (e, index));
             self.on_task_finished(panic);
-            let Some((index, job)) = self.pick_job_from_work_queue() else {
-                return;
-            };
-            current_job_index = index;
-            current_job = job;
         }
     }
 
@@ -121,10 +112,18 @@ impl ScopeInner {
         };
         match job {
             WorkQueueJob::Job(index, job) => {
+                // If work remains, wake another helper. `parking_lot` notifications are not
+                // latched, so a `notify_one` at enqueue time is lost if no helper was parked yet
+                // (e.g. it was busy running a previous job). Handing off the surplus wakeup here
+                // ensures idle helpers still get pulled in, preserving parallelism.
+                if !work_queue.is_empty() {
+                    self.work_queue_condition_var.notify_one();
+                }
                 drop(work_queue);
                 Some((index, job))
             }
             WorkQueueJob::End => {
+                // Reinsert so other workers can find it
                 work_queue.push_front(WorkQueueJob::End);
                 drop(work_queue);
                 self.work_queue_condition_var.notify_all();
@@ -134,16 +133,13 @@ impl ScopeInner {
     }
 
     fn end_and_help_complete(&self) {
-        let job;
-        {
-            let mut work_queue = self.work_queue.lock();
-            job = work_queue.pop_front();
-            work_queue.push_back(WorkQueueJob::End);
-        }
-        self.work_queue_condition_var.notify_all();
-        if let Some(WorkQueueJob::Job(index, job)) = job {
-            self.worker(index, job);
-        }
+        // Mark the end of work, then drain whatever remains inline. Pushing `End` first guarantees
+        // `help` never blocks on the condvar (the queue is non-empty), and the `End` handling in
+        // `pick_job_from_work_queue` wakes any parked helpers. This is what makes the calling
+        // thread able to complete the whole scope by itself, regardless of whether any
+        // helper ran.
+        self.work_queue.lock().push_back(WorkQueueJob::End);
+        self.run_jobs();
     }
 }
 
@@ -155,6 +151,13 @@ pub struct Scope<'scope, 'env: 'scope, R: Send + 'env> {
     index: AtomicUsize,
     inner: Arc<ScopeInner>,
     handle: Handle,
+    /// Max number of opportunistic helper worker tasks to spawn: the tokio runtime's worker count
+    /// minus the main thread. Helper workers run synchronous code and hold their tokio core
+    /// without yielding, so spawning more than there are worker threads would be pointless
+    /// (they can't run concurrently) and, historically, deadlock-prone. Helpers are now a pure
+    /// optimization — the main thread can drain the whole queue by itself — so this only sizes
+    /// the parallelism, never correctness.
+    worker_tasks: usize,
     turbo_tasks: Option<Arc<dyn TurboTasksApi>>,
     span: Span,
     /// Invariance over 'env, to make sure 'env cannot shrink, which is necessary for soundness.
@@ -171,6 +174,15 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
     ///
     /// The caller must ensure `Scope` is dropped and not forgotten.
     unsafe fn new(results: &'scope [Mutex<Option<R>>]) -> Self {
+        let handle = Handle::current();
+        // Size helpers to the actual runtime worker count minus the main thread. A helper runs
+        // synchronous code and holds its tokio core without yielding, so spawning more than there
+        // are worker threads can never add concurrency. This is the true ceiling: the
+        // `TURBO_TASKS_AVAILABLE_PARALLELISM` override already flows in through `num_workers()`
+        // because the runtime's worker thread count is derived from it. `num_workers()` is O(1) and
+        // returns 1 for a current-thread runtime (=> 0 helpers => everything drains inline on the
+        // main thread). Liveness never depends on this value — it only sizes the parallelism.
+        let worker_tasks = handle.metrics().num_workers().saturating_sub(1);
         Self {
             results,
             index: AtomicUsize::new(0),
@@ -181,7 +193,8 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
                 work_queue: Mutex::new(VecDeque::new()),
                 work_queue_condition_var: Condvar::new(),
             }),
-            handle: Handle::current(),
+            handle,
+            worker_tasks,
             turbo_tasks: try_turbo_tasks(),
             span: Span::current(),
             env: PhantomData,
@@ -228,23 +241,26 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 
         self.inner.remaining_tasks.fetch_add(1, Ordering::Relaxed);
 
-        // The first job always goes to the work_queue to be worked on by the main thread.
-        // After that we spawn a new worker for every job until we reach WORKER_TASKS.
-        // After that we queue up jobs in the work_queue again.
-        if (1..=*WORKER_TASKS).contains(&index) {
+        // Every job goes on the shared work queue. The main thread (in Drop via
+        // `end_and_help_complete`) drains the entire queue by itself if no helper ever runs, so
+        // liveness never depends on a spawned helper being scheduled — this is what makes the
+        // primitive robust on thread-limited or otherwise-contended runtimes.
+        self.inner
+            .work_queue
+            .lock()
+            .push_back(WorkQueueJob::Job(index, f));
+        self.inner.work_queue_condition_var.notify_one();
+
+        // Opportunistically spawn a helper worker task to add parallelism, up to `worker_tasks`.
+        // Helpers pull from the same shared queue; they are never assigned a specific job (that
+        // would double-run it). Index 0 is the main thread's share, so helpers cover indices
+        // `1..=worker_tasks`.
+        if (1..=self.worker_tasks).contains(&index) {
             let inner = self.inner.clone();
-            // Spawn a worker task that will process that tasks and potentially more.
             self.handle.spawn(async move {
                 let _span = span.entered();
-                inner.worker(index, f);
+                inner.run_jobs();
             });
-        } else {
-            // Queue the task to be processed by a worker task.
-            self.inner
-                .work_queue
-                .lock()
-                .push_back(WorkQueueJob::Job(index, f));
-            self.inner.work_queue_condition_var.notify_one();
         }
     }
 }
@@ -258,6 +274,13 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Drop for Scope<'scope, 'env, R> {
 
 /// Helper method to spawn tasks in parallel, ensuring that all tasks are awaited and errors are
 /// handled. Also ensures turbo tasks and tracing context are maintained across the tasks.
+///
+/// Jobs are added to a shared work queue and processed by up to `runtime worker threads - 1`
+/// opportunistic helper worker tasks plus the calling thread. The helpers are a pure optimization:
+/// the calling thread drains the whole queue by itself if no helper ever runs, so this does not
+/// deadlock even on a thread-limited runtime or when the worker threads are otherwise occupied.
+/// Jobs must be independent (they must not block waiting on each other), since the degree of real
+/// concurrency is bounded by the runtime's worker threads.
 ///
 /// Be aware that although this function avoids starving other independently spawned tasks, any
 /// other code running concurrently in the same task will be suspended during the call to
@@ -293,6 +316,136 @@ mod tests {
     use std::panic::{AssertUnwindSafe, catch_unwind};
 
     use super::*;
+
+    /// Regression test for the deadlock this primitive hit when adopted for parallel consumption of
+    /// a shared worklist (e.g. `gc_collect`) on a thread-limited runtime.
+    ///
+    /// Previously `scope_and_block` sized its worker count from the host cpu count
+    /// (`available_parallelism() - 1`) and handed job indices `1..=WORKER_TASKS` *exclusively* to
+    /// spawned worker tasks — those jobs were never placed on the shared work queue, so *only* a
+    /// spawned worker could run them. A spawned worker runs synchronous code and, once scheduled,
+    /// holds its tokio core without ever yielding it back. When the runtime's worker threads are
+    /// already occupied by other synchronous/blocking work (as happens under GC, which holds a
+    /// global operation lock while other tasks block), the scope's spawned workers can never be
+    /// scheduled onto a core. The jobs assigned to them never run, `remaining_tasks` never reaches
+    /// zero, and the caller blocks forever.
+    ///
+    /// This reproduces it deterministically without risking a hung test process. Every runtime
+    /// worker thread is pinned by a task that blocks synchronously (holding its core, *not* via
+    /// `block_in_place`, so tokio cannot hand the core off), and those tasks are released only
+    /// after a fixed delay. The scope runs on a separate `spawn_blocking` thread. Pre-fix: the jobs
+    /// assigned to spawned workers cannot run until a core frees up, so the scope cannot finish
+    /// before the release delay. Post-fix: every job lives on the shared work queue and the
+    /// caller's own thread drains all of them immediately, so the scope finishes well before the
+    /// release. We assert the scope finished quickly — which fails cleanly (no hang) on the old
+    /// code because the scope thread is still blocked when we check, but the release timer
+    /// guarantees the process still makes progress and exits.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_scope_worker_threads_occupied() {
+        const WORKER_THREADS: usize = 2;
+        const JOBS: usize = 64;
+        const RELEASE_AFTER: Duration = Duration::from_secs(4);
+
+        // Pin every runtime worker thread with a task that blocks synchronously (holding its core,
+        // no block_in_place hand-off) until the release deadline. Models threads stuck on other
+        // work while GC runs.
+        let ready = Arc::new(AtomicUsize::new(0));
+        let mut occupiers = Vec::with_capacity(WORKER_THREADS);
+        for _ in 0..WORKER_THREADS {
+            let ready = ready.clone();
+            occupiers.push(tokio::spawn(async move {
+                ready.fetch_add(1, Ordering::SeqCst);
+                // Synchronous sleep: holds the core for the whole duration.
+                thread::sleep(RELEASE_AFTER);
+            }));
+        }
+        // Wait until both occupiers are actually running (and thus holding both cores).
+        while ready.load(Ordering::SeqCst) < WORKER_THREADS {
+            tokio::task::yield_now().await;
+        }
+
+        let started = Instant::now();
+        let results = tokio::task::spawn_blocking(move || {
+            scope_and_block(JOBS, |scope| {
+                for i in 0..JOBS {
+                    scope.spawn(move || i);
+                }
+            })
+            .collect::<Vec<_>>()
+        })
+        .await
+        .unwrap();
+        let elapsed = started.elapsed();
+
+        assert_eq!(results.len(), JOBS);
+        results.iter().enumerate().for_each(|(i, &result)| {
+            assert_eq!(result, i);
+        });
+        // The scope must complete on its own thread without waiting for an occupied core to free
+        // up. On the old code the jobs assigned to spawned workers could not run until an occupier
+        // released its core, so this would take ~RELEASE_AFTER.
+        assert!(
+            elapsed < RELEASE_AFTER / 2,
+            "scope_and_block took {elapsed:?}; it should not depend on an occupied worker thread \
+             freeing up"
+        );
+
+        for occupier in occupiers {
+            occupier.await.unwrap();
+        }
+    }
+
+    /// On a `current_thread` runtime there are no worker threads to spawn helpers onto, and
+    /// `block_in_place` is not even allowed. `num_workers()` reports 1, so `worker_tasks` is 0 and
+    /// the main thread drains the entire queue inline — reaching `remaining_tasks == 0` before
+    /// `wait()` would ever call `block_in_place`. This must complete rather than panic or hang.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_scope_current_thread_runtime() {
+        let results = tokio::task::spawn_blocking(|| {
+            scope_and_block(16, |scope| {
+                for i in 0..16 {
+                    scope.spawn(move || i);
+                }
+            })
+            .collect::<Vec<_>>()
+        })
+        .await
+        .unwrap();
+        assert_eq!(results.len(), 16);
+        results.iter().enumerate().for_each(|(i, &result)| {
+            assert_eq!(result, i);
+        });
+    }
+
+    /// Sanity check that helpers actually add parallelism when threads are available: with a pool
+    /// larger than 1, many jobs that each block briefly complete in far less than their serial sum.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_scope_runs_in_parallel() {
+        const JOBS: usize = 16;
+        const PER_JOB: Duration = Duration::from_millis(50);
+        let started = Instant::now();
+        let results = tokio::task::spawn_blocking(|| {
+            scope_and_block(JOBS, |scope| {
+                for i in 0..JOBS {
+                    scope.spawn(move || {
+                        thread::sleep(PER_JOB);
+                        i
+                    });
+                }
+            })
+            .collect::<Vec<_>>()
+        })
+        .await
+        .unwrap();
+        let elapsed = started.elapsed();
+        assert_eq!(results.len(), JOBS);
+        // Serial would be JOBS * PER_JOB = 800ms. With 4 worker threads we expect a meaningful
+        // speedup; assert well under half the serial time to avoid flakiness.
+        assert!(
+            elapsed < (JOBS as u32 * PER_JOB) / 2,
+            "scope_and_block took {elapsed:?}; expected parallel speedup across worker threads"
+        );
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_scope() {

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -19,9 +19,16 @@ use tracing::{Span, info_span};
 
 use crate::{TurboTasksApi, manager::try_turbo_tasks, turbo_tasks_scope};
 
-enum WorkQueueJob {
-    Job(usize, Box<dyn FnOnce() + Send + 'static>),
-    End,
+/// A job placed on the work queue: its result-slot index and the closure to run.
+type WorkQueueJob = (usize, Box<dyn FnOnce() + Send + 'static>);
+
+struct WorkQueue {
+    /// Jobs that have not yet been picked up by a drainer.
+    jobs: VecDeque<WorkQueueJob>,
+    /// Set once no more jobs will be enqueued. A drainer that finds the queue empty exits when
+    /// this is set, or parks otherwise. Guarded by the same lock as `jobs`, so the "empty + not
+    /// closed → park" and "close + notify" sequences are serialized and cannot lose a wakeup.
+    closed: bool,
 }
 
 struct ScopeInner {
@@ -31,7 +38,7 @@ struct ScopeInner {
     /// The usize value is the index of the task.
     panic: Mutex<Option<(Box<dyn Any + Send + 'static>, usize)>>,
     /// The work queue for spawned jobs that have not yet been picked up by a worker task.
-    work_queue: Mutex<VecDeque<WorkQueueJob>>,
+    work_queue: Mutex<WorkQueue>,
     /// A condition variable to notify worker tasks of new work or end of work.
     work_queue_condition_var: Condvar,
 }
@@ -88,8 +95,8 @@ impl ScopeInner {
         }
     }
 
-    /// Pulls jobs from the shared work queue and runs them until the `End` sentinel, recording any
-    /// panic. Both the opportunistic helper worker tasks and the calling thread (via
+    /// Pulls jobs from the shared work queue and runs them until the queue is closed and drained,
+    /// recording any panic. Both the opportunistic helper worker tasks and the calling thread (via
     /// `end_and_help_complete`) run this. Helpers are a pure optimization: whether zero or all of
     /// them ever get scheduled, the calling thread drains the whole queue by itself, so liveness
     /// never depends on a helper being scheduled.
@@ -101,40 +108,38 @@ impl ScopeInner {
         }
     }
 
-    fn pick_job_from_work_queue(&self) -> Option<(usize, Box<dyn FnOnce() + Send + 'static>)> {
+    fn pick_job_from_work_queue(&self) -> Option<WorkQueueJob> {
         let mut work_queue = self.work_queue.lock();
-        let job = loop {
-            if let Some(job) = work_queue.pop_front() {
-                break job;
-            } else {
-                self.work_queue_condition_var.wait(&mut work_queue);
-            };
-        };
-        match job {
-            WorkQueueJob::Job(index, job) => {
+        loop {
+            if let Some(job) = work_queue.jobs.pop_front() {
                 // If work remains, wake another helper. `parking_lot` notifications are not
                 // latched, so a `notify_one` at enqueue time is lost if no helper was parked yet
                 // (e.g. it was busy running a previous job). Handing off the surplus wakeup here
                 // ensures idle helpers still get pulled in, preserving parallelism.
-                if !work_queue.is_empty() {
+                if !work_queue.jobs.is_empty() {
                     self.work_queue_condition_var.notify_one();
                 }
-                drop(work_queue);
-                Some((index, job))
-            }
-            WorkQueueJob::End => {
-                // Reinsert so other workers can find it
-                work_queue.push_front(WorkQueueJob::End);
-                drop(work_queue);
-                self.work_queue_condition_var.notify_all();
-                None
+                return Some(job);
+            } else if work_queue.closed {
+                // No more jobs will ever be enqueued: this drainer is done.
+                return None;
+            } else {
+                // Empty but not closed: wait for a job to arrive or for the queue to be closed.
+                self.work_queue_condition_var.wait(&mut work_queue);
             }
         }
     }
 
     fn end_and_help_complete(&self) {
-        // Mark the end of work, then drain whatever remains inline.
-        self.work_queue.lock().push_back(WorkQueueJob::End);
+        // Close the queue and wake every parked drainer once; each will drain any remaining jobs
+        // and then observe `closed` and exit. Closing under the queue lock (paired with `wait`
+        // releasing it atomically) means a drainer cannot park after we close without seeing it.
+        {
+            let mut work_queue = self.work_queue.lock();
+            work_queue.closed = true;
+        }
+        self.work_queue_condition_var.notify_all();
+        // Drain whatever remains inline.
         self.run_jobs();
     }
 }
@@ -180,7 +185,12 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
                 main_thread: thread::current(),
                 remaining_tasks: AtomicUsize::new(0),
                 panic: Mutex::new(None),
-                work_queue: Mutex::new(VecDeque::with_capacity(results.len())),
+                work_queue: Mutex::new(WorkQueue {
+                    // Presize to the job count so `push_back` never reallocates while holding the
+                    // queue lock during the enqueue loop.
+                    jobs: VecDeque::with_capacity(results.len()),
+                    closed: false,
+                }),
                 work_queue_condition_var: Condvar::new(),
             }),
             handle,
@@ -227,24 +237,24 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
         // SAFETY: We just called `Box::into_raw`.
         let f = unsafe { Box::from_raw(f) };
 
-        let span = self.span.clone();
-
         self.inner.remaining_tasks.fetch_add(1, Ordering::Relaxed);
 
         // Every job goes on the shared work queue, this way work is never assigned to a task that
         // might never run.  Because we block synchronously on the main thread it is possible that
         // our spawned tasks cannot find threads to run on this ensures all the work is available to
         // all threads including the main_thread.
-        self.inner
-            .work_queue
-            .lock()
-            .push_back(WorkQueueJob::Job(index, f));
+        self.inner.work_queue.lock().jobs.push_back((index, f));
+        // This isn't needed for liveness, but optimizes behavior when we have limited threads
+        // available.
         self.inner.work_queue_condition_var.notify_one();
 
         // Spawn a tokio worker for each task (except the last spawn call which will be handled by
-        // this thread)
+        // this thread). Helpers all run the identical `run_jobs` loop pulling from the shared
+        // queue, so nothing here is job-specific; we only clone the span for the workers we
+        // actually spawn.
         if index < self.worker_tasks {
             let inner = self.inner.clone();
+            let span = self.span.clone();
             self.handle.spawn(async move {
                 let _span = span.entered();
                 inner.run_jobs();

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -133,11 +133,7 @@ impl ScopeInner {
     }
 
     fn end_and_help_complete(&self) {
-        // Mark the end of work, then drain whatever remains inline. Pushing `End` first guarantees
-        // `help` never blocks on the condvar (the queue is non-empty), and the `End` handling in
-        // `pick_job_from_work_queue` wakes any parked helpers. This is what makes the calling
-        // thread able to complete the whole scope by itself, regardless of whether any
-        // helper ran.
+        // Mark the end of work, then drain whatever remains inline.
         self.work_queue.lock().push_back(WorkQueueJob::End);
         self.run_jobs();
     }
@@ -151,12 +147,7 @@ pub struct Scope<'scope, 'env: 'scope, R: Send + 'env> {
     index: AtomicUsize,
     inner: Arc<ScopeInner>,
     handle: Handle,
-    /// Max number of opportunistic helper worker tasks to spawn: the tokio runtime's worker count
-    /// minus the main thread. Helper workers run synchronous code and hold their tokio core
-    /// without yielding, so spawning more than there are worker threads would be pointless
-    /// (they can't run concurrently) and, historically, deadlock-prone. Helpers are now a pure
-    /// optimization — the main thread can drain the whole queue by itself — so this only sizes
-    /// the parallelism, never correctness.
+    /// Max number of opportunistic helper worker tasks to spawn
     worker_tasks: usize,
     turbo_tasks: Option<Arc<dyn TurboTasksApi>>,
     span: Span,
@@ -175,14 +166,13 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
     /// The caller must ensure `Scope` is dropped and not forgotten.
     unsafe fn new(results: &'scope [Mutex<Option<R>>]) -> Self {
         let handle = Handle::current();
-        // Size helpers to the actual runtime worker count minus the main thread. A helper runs
-        // synchronous code and holds its tokio core without yielding, so spawning more than there
-        // are worker threads can never add concurrency. This is the true ceiling: the
-        // `TURBO_TASKS_AVAILABLE_PARALLELISM` override already flows in through `num_workers()`
-        // because the runtime's worker thread count is derived from it. `num_workers()` is O(1) and
-        // returns 1 for a current-thread runtime (=> 0 helpers => everything drains inline on the
-        // main thread). Liveness never depends on this value — it only sizes the parallelism.
-        let worker_tasks = handle.metrics().num_workers().saturating_sub(1);
+        // The calling thread is itself a drainer, so we only need helpers to cover the remaining
+        // work.
+        let worker_tasks = handle
+            .metrics()
+            .num_workers()
+            .min(results.len())
+            .saturating_sub(1);
         Self {
             results,
             index: AtomicUsize::new(0),
@@ -190,7 +180,7 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
                 main_thread: thread::current(),
                 remaining_tasks: AtomicUsize::new(0),
                 panic: Mutex::new(None),
-                work_queue: Mutex::new(VecDeque::new()),
+                work_queue: Mutex::new(VecDeque::with_capacity(results.len())),
                 work_queue_condition_var: Condvar::new(),
             }),
             handle,
@@ -241,21 +231,19 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 
         self.inner.remaining_tasks.fetch_add(1, Ordering::Relaxed);
 
-        // Every job goes on the shared work queue. The main thread (in Drop via
-        // `end_and_help_complete`) drains the entire queue by itself if no helper ever runs, so
-        // liveness never depends on a spawned helper being scheduled — this is what makes the
-        // primitive robust on thread-limited or otherwise-contended runtimes.
+        // Every job goes on the shared work queue, this way work is never assigned to a task that
+        // might never run.  Because we block synchronously on the main thread it is possible that
+        // our spawned tasks cannot find threads to run on this ensures all the work is available to
+        // all threads including the main_thread.
         self.inner
             .work_queue
             .lock()
             .push_back(WorkQueueJob::Job(index, f));
         self.inner.work_queue_condition_var.notify_one();
 
-        // Opportunistically spawn a helper worker task to add parallelism, up to `worker_tasks`.
-        // Helpers pull from the same shared queue; they are never assigned a specific job (that
-        // would double-run it). Index 0 is the main thread's share, so helpers cover indices
-        // `1..=worker_tasks`.
-        if (1..=self.worker_tasks).contains(&index) {
+        // Spawn a tokio worker for each task (except the last spawn call which will be handled by
+        // this thread)
+        if index < self.worker_tasks {
             let inner = self.inner.clone();
             self.handle.spawn(async move {
                 let _span = span.entered();

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -29,9 +29,8 @@ struct ScopeInner {
     /// The first panic that occurred in the tasks, by task index.
     /// The usize value is the index of the task.
     panic: Mutex<Option<(Box<dyn Any + Send + 'static>, usize)>>,
-    /// Receiving end of the work queue. Every drainer pulls from this; `recv` blocks while the
-    /// queue is empty and fails once the `Scope`'s sender is dropped, which is what tells drainers
-    /// no more jobs are coming.
+    /// Receiving end of the work queue, shared by every drainer. Dropping the `Scope`'s sender is
+    /// what signals that no more jobs are coming.
     work_queue: Receiver<WorkQueueJob>,
 }
 
@@ -91,8 +90,6 @@ impl ScopeInner {
     /// recording any panic. Both the opportunistic helper worker tasks and the calling thread (via
     /// `Scope::drop`) run this.
     fn run_jobs(&self) {
-        // `recv` blocks while the queue is empty and returns `Err` once the sender is dropped and
-        // the queue is drained, so this ends exactly when there is no more work.
         while let Ok((index, job)) = self.work_queue.recv() {
             let result = catch_unwind(AssertUnwindSafe(job));
             let panic = result.err().map(|e| (e, index));
@@ -108,8 +105,7 @@ pub struct Scope<'scope, 'env: 'scope, R: Send + 'env> {
     results: &'scope [Mutex<Option<R>>],
     index: AtomicUsize,
     inner: Arc<ScopeInner>,
-    /// Sending end of the work queue. This is the only sender, and it is dropped in `Drop` to
-    /// signal the drainers that no more jobs are coming.
+    /// Sending end of the work queue. The only sender; `Drop` takes it to close the queue.
     work_queue: Option<Sender<WorkQueueJob>>,
     handle: Handle,
     /// Max number of threads to use, threads are only spawned when needed. The calling thread
@@ -132,8 +128,7 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
     /// The caller must ensure `Scope` is dropped and not forgotten.
     unsafe fn new(results: &'scope [Mutex<Option<R>>]) -> Self {
         let handle = Handle::current();
-        // Never use more threads than there are jobs, and never more than the runtime has workers.
-        // The calling thread always participates, so this is at least 1.
+        // Never use more threads than there are jobs, or than the runtime has workers.
         let worker_tasks = NonZeroUsize::new(handle.metrics().num_workers().min(results.len()))
             .unwrap_or(NonZeroUsize::MIN);
         let (sender, receiver) = mpmc::channel();
@@ -193,17 +188,16 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 
         self.inner.remaining_tasks.fetch_add(1, Ordering::Relaxed);
 
-        // Add to the shared work queue, all threads read from this. `inner` holds the receiver and
-        // outlives every drainer, so neither the `expect` nor the `send` can fail; if a job were
-        // ever dropped here `remaining_tasks` would never reach zero and the scope would hang.
+        // Add to the shared work queue, all threads read from this. Neither failure is reachable,
+        // but a job silently dropped here would leave `remaining_tasks` above zero and hang the
+        // scope, so panic instead.
         self.work_queue
             .as_ref()
             .expect("sender is only taken in Drop")
             .send((index, f))
             .expect("receiver is owned by inner and outlives the scope");
 
-        // Spawn a tokio worker for each job until we hit the max `worker_tasks`. The calling thread
-        // covers one slot of the budget, so we spawn at most `worker_tasks - 1` helpers.
+        // Spawn a tokio worker for each job until we hit the max `worker_tasks`.
         if index < self.worker_tasks.get() - 1 {
             let inner = self.inner.clone();
             let span = self.span.clone();
@@ -217,8 +211,7 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 
 impl<'scope, 'env: 'scope, R: Send + 'env> Drop for Scope<'scope, 'env, R> {
     fn drop(&mut self) {
-        // Dropping the only sender closes the queue: each drainer finishes the jobs still in it
-        // and then sees `recv` fail and exits. This must happen *before* we drain below —
+        // Close the queue by dropping the only sender. This must happen before draining below:
         // `run_jobs` blocks in `recv` until the queue is closed, so a live sender here would hang
         // the scope.
         drop(
@@ -226,8 +219,7 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Drop for Scope<'scope, 'env, R> {
                 .take()
                 .expect("sender is taken exactly once, here in Drop"),
         );
-        // Help drain whatever remains inline, so completion never depends on a helper being
-        // scheduled.
+        // Drain inline so completion never depends on a helper being scheduled.
         self.inner.run_jobs();
         self.inner.wait_and_rethrow_panic();
     }
@@ -236,12 +228,12 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Drop for Scope<'scope, 'env, R> {
 /// Helper method to spawn tasks in parallel, ensuring that all tasks are awaited and errors are
 /// handled. Also ensures turbo tasks and tracing context are maintained across the tasks.
 ///
-/// Jobs are added to a shared work queue and processed by up to `runtime worker threads - 1`
-/// opportunistic helper worker tasks plus the calling thread. The helpers are a pure optimization:
-/// the calling thread drains the whole queue by itself if no helper ever runs, so this does not
-/// deadlock even on a thread-limited runtime or when the worker threads are otherwise occupied.
-/// Jobs must be independent (they must not block waiting on each other), since the degree of real
-/// concurrency is bounded by the runtime's worker threads.
+/// Jobs are added to a shared work queue and processed by the calling thread plus up to
+/// `runtime worker threads - 1` opportunistic helpers. The helpers are a pure optimization — the
+/// calling thread drains the whole queue by itself if none ever runs — so this does not deadlock on
+/// a thread-limited runtime or when the worker threads are otherwise occupied. Jobs must be
+/// independent (they must not block waiting on each other), since the degree of real concurrency is
+/// bounded by the runtime's worker threads.
 ///
 /// Be aware that although this function avoids starving other independently spawned tasks, any
 /// other code running concurrently in the same task will be suspended during the call to
@@ -291,15 +283,13 @@ mod tests {
         const RELEASE_AFTER: Duration = Duration::from_secs(4);
 
         // Pin every runtime worker thread with a task that blocks synchronously (holding its core,
-        // no block_in_place hand-off) until the release deadline. Models threads stuck on other
-        // work while GC runs.
+        // no block_in_place hand-off) until the release deadline.
         let ready = Arc::new(AtomicUsize::new(0));
         let mut occupiers = Vec::with_capacity(WORKER_THREADS);
         for _ in 0..WORKER_THREADS {
             let ready = ready.clone();
             occupiers.push(tokio::spawn(async move {
                 ready.fetch_add(1, Ordering::SeqCst);
-                // Synchronous sleep: holds the core for the whole duration.
                 thread::sleep(RELEASE_AFTER);
             }));
         }
@@ -325,9 +315,6 @@ mod tests {
         results.iter().enumerate().for_each(|(i, &result)| {
             assert_eq!(result, i);
         });
-        // The scope must complete on its own thread without waiting for an occupied core to free
-        // up. On the old code the jobs assigned to spawned workers could not run until an occupier
-        // released its core, so this would take ~RELEASE_AFTER.
         assert!(
             elapsed < RELEASE_AFTER / 2,
             "scope_and_block took {elapsed:?}; it should not depend on an occupied worker thread \
@@ -339,10 +326,8 @@ mod tests {
         }
     }
 
-    /// On a `current_thread` runtime there are no worker threads to spawn helpers onto, and
-    /// `block_in_place` is not even allowed. `num_workers()` reports 1, so no helpers are spawned
-    /// and the main thread drains the entire queue inline — reaching `remaining_tasks == 0` before
-    /// `wait()` would ever call `block_in_place`. This must complete rather than panic or hang.
+    /// On a `current_thread` runtime no helpers can be spawned and `block_in_place` is not allowed,
+    /// so the calling thread must drain the queue inline rather than panicking or hanging.
     #[tokio::test(flavor = "current_thread")]
     async fn test_scope_current_thread_runtime() {
         let results = tokio::task::spawn_blocking(|| {
@@ -361,8 +346,8 @@ mod tests {
         });
     }
 
-    /// Sanity check that helpers actually add parallelism when threads are available: with a pool
-    /// larger than 1, many jobs that each block briefly complete in far less than their serial sum.
+    /// Helpers must actually add parallelism when threads are available: jobs that each block
+    /// briefly should complete in far less than their serial sum.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_scope_runs_in_parallel() {
         const JOBS: usize = 16;
@@ -383,8 +368,8 @@ mod tests {
         .unwrap();
         let elapsed = started.elapsed();
         assert_eq!(results.len(), JOBS);
-        // Serial would be JOBS * PER_JOB = 800ms. With 4 worker threads we expect a meaningful
-        // speedup; assert well under half the serial time to avoid flakiness.
+        // Half the serial time is a loose bound on purpose: 4 threads should beat it comfortably,
+        // so a slow machine won't make this flaky.
         assert!(
             elapsed < (JOBS as u32 * PER_JOB) / 2,
             "scope_and_block took {elapsed:?}; expected parallel speedup across worker threads"

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -2,19 +2,19 @@
 
 use std::{
     any::Any,
-    collections::VecDeque,
     marker::PhantomData,
     num::NonZeroUsize,
     panic::{self, AssertUnwindSafe, catch_unwind},
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
+        mpmc::{self, Receiver, Sender},
     },
     thread::{self, Thread},
     time::{Duration, Instant},
 };
 
-use parking_lot::{Condvar, Mutex};
+use parking_lot::Mutex;
 use tokio::{runtime::Handle, task::block_in_place};
 use tracing::{Span, info_span};
 
@@ -23,25 +23,16 @@ use crate::{TurboTasksApi, manager::try_turbo_tasks, turbo_tasks_scope};
 /// A job placed on the work queue: its result-slot index and the closure to run.
 type WorkQueueJob = (usize, Box<dyn FnOnce() + Send + 'static>);
 
-struct WorkQueue {
-    /// Jobs that have not yet been picked up by a drainer.
-    jobs: VecDeque<WorkQueueJob>,
-    /// Set once no more jobs will be enqueued. A drainer that finds the queue empty exits when
-    /// this is set, or parks otherwise. Guarded by the same lock as `jobs`, so the "empty + not
-    /// closed → park" and "close + notify" sequences are serialized and cannot lose a wakeup.
-    closed: bool,
-}
-
 struct ScopeInner {
     main_thread: Thread,
     remaining_tasks: AtomicUsize,
     /// The first panic that occurred in the tasks, by task index.
     /// The usize value is the index of the task.
     panic: Mutex<Option<(Box<dyn Any + Send + 'static>, usize)>>,
-    /// The work queue for spawned jobs that have not yet been picked up by a worker task.
-    work_queue: Mutex<WorkQueue>,
-    /// A condition variable to notify worker tasks of new work or end of work.
-    work_queue_condition_var: Condvar,
+    /// Receiving end of the work queue. Every drainer pulls from this; `recv` blocks while the
+    /// queue is empty and fails once the `Scope`'s sender is dropped, which is what tells drainers
+    /// no more jobs are coming.
+    work_queue: Receiver<WorkQueueJob>,
 }
 
 impl ScopeInner {
@@ -98,44 +89,15 @@ impl ScopeInner {
 
     /// Pulls jobs from the shared work queue and runs them until the queue is closed and drained,
     /// recording any panic. Both the opportunistic helper worker tasks and the calling thread (via
-    /// `end_and_help_complete`) run this.
+    /// `Scope::drop`) run this.
     fn run_jobs(&self) {
-        while let Some((index, job)) = self.pick_job_from_work_queue() {
+        // `recv` blocks while the queue is empty and returns `Err` once the sender is dropped and
+        // the queue is drained, so this ends exactly when there is no more work.
+        while let Ok((index, job)) = self.work_queue.recv() {
             let result = catch_unwind(AssertUnwindSafe(job));
             let panic = result.err().map(|e| (e, index));
             self.on_task_finished(panic);
         }
-    }
-
-    fn pick_job_from_work_queue(&self) -> Option<WorkQueueJob> {
-        let mut work_queue = self.work_queue.lock();
-        loop {
-            if let Some(job) = work_queue.jobs.pop_front() {
-                // If work remains, let other threads try to handle it in parallel
-                if !work_queue.jobs.is_empty() {
-                    self.work_queue_condition_var.notify_one();
-                }
-                return Some(job);
-            } else if work_queue.closed {
-                // No more jobs will ever be enqueued: this drainer is done.
-                return None;
-            } else {
-                // Empty but not closed: wait for a job to arrive or for the queue to be closed.
-                self.work_queue_condition_var.wait(&mut work_queue);
-            }
-        }
-    }
-
-    fn end_and_help_complete(&self) {
-        // Close the queue and wake every parked drainer once; each will drain any remaining jobs
-        // and then observe `closed` and exit.
-        {
-            let mut work_queue = self.work_queue.lock();
-            work_queue.closed = true;
-        }
-        self.work_queue_condition_var.notify_all();
-        // Drain whatever remains inline.
-        self.run_jobs();
     }
 }
 
@@ -146,6 +108,9 @@ pub struct Scope<'scope, 'env: 'scope, R: Send + 'env> {
     results: &'scope [Mutex<Option<R>>],
     index: AtomicUsize,
     inner: Arc<ScopeInner>,
+    /// Sending end of the work queue. This is the only sender, and it is dropped in `Drop` to
+    /// signal the drainers that no more jobs are coming.
+    work_queue: Option<Sender<WorkQueueJob>>,
     handle: Handle,
     /// Max number of threads to use, threads are only spawned when needed. The calling thread
     /// counts towards this budget, so we spawn at most `worker_tasks - 1` helpers.
@@ -171,6 +136,7 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
         // The calling thread always participates, so this is at least 1.
         let worker_tasks = NonZeroUsize::new(handle.metrics().num_workers().min(results.len()))
             .unwrap_or(NonZeroUsize::MIN);
+        let (sender, receiver) = mpmc::channel();
         Self {
             results,
             index: AtomicUsize::new(0),
@@ -178,14 +144,9 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
                 main_thread: thread::current(),
                 remaining_tasks: AtomicUsize::new(0),
                 panic: Mutex::new(None),
-                work_queue: Mutex::new(WorkQueue {
-                    // Presize to the job count so `push_back` never reallocates while holding the
-                    // queue lock during the enqueue loop.
-                    jobs: VecDeque::with_capacity(results.len()),
-                    closed: false,
-                }),
-                work_queue_condition_var: Condvar::new(),
+                work_queue: receiver,
             }),
+            work_queue: Some(sender),
             handle,
             worker_tasks,
             turbo_tasks: try_turbo_tasks(),
@@ -232,10 +193,14 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 
         self.inner.remaining_tasks.fetch_add(1, Ordering::Relaxed);
 
-        // Add to the shared work queue, all threads read from this
-        self.inner.work_queue.lock().jobs.push_back((index, f));
-        // If there's currently an idle worker, wake it up
-        self.inner.work_queue_condition_var.notify_one();
+        // Add to the shared work queue, all threads read from this. `inner` holds the receiver and
+        // outlives every drainer, so neither the `expect` nor the `send` can fail; if a job were
+        // ever dropped here `remaining_tasks` would never reach zero and the scope would hang.
+        self.work_queue
+            .as_ref()
+            .expect("sender is only taken in Drop")
+            .send((index, f))
+            .expect("receiver is owned by inner and outlives the scope");
 
         // Spawn a tokio worker for each job until we hit the max `worker_tasks`. The calling thread
         // covers one slot of the budget, so we spawn at most `worker_tasks - 1` helpers.
@@ -252,7 +217,12 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 
 impl<'scope, 'env: 'scope, R: Send + 'env> Drop for Scope<'scope, 'env, R> {
     fn drop(&mut self) {
-        self.inner.end_and_help_complete();
+        // Dropping the only sender closes the queue: each drainer finishes the jobs still in it
+        // and then sees `recv` fail and exits.
+        self.work_queue.take();
+        // Help drain whatever remains inline, so completion never depends on a helper being
+        // scheduled.
+        self.inner.run_jobs();
         self.inner.wait_and_rethrow_panic();
     }
 }

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -4,6 +4,7 @@ use std::{
     any::Any,
     collections::VecDeque,
     marker::PhantomData,
+    num::NonZeroUsize,
     panic::{self, AssertUnwindSafe, catch_unwind},
     sync::{
         Arc,
@@ -97,9 +98,7 @@ impl ScopeInner {
 
     /// Pulls jobs from the shared work queue and runs them until the queue is closed and drained,
     /// recording any panic. Both the opportunistic helper worker tasks and the calling thread (via
-    /// `end_and_help_complete`) run this. Helpers are a pure optimization: whether zero or all of
-    /// them ever get scheduled, the calling thread drains the whole queue by itself, so liveness
-    /// never depends on a helper being scheduled.
+    /// `end_and_help_complete`) run this.
     fn run_jobs(&self) {
         while let Some((index, job)) = self.pick_job_from_work_queue() {
             let result = catch_unwind(AssertUnwindSafe(job));
@@ -112,10 +111,7 @@ impl ScopeInner {
         let mut work_queue = self.work_queue.lock();
         loop {
             if let Some(job) = work_queue.jobs.pop_front() {
-                // If work remains, wake another helper. `parking_lot` notifications are not
-                // latched, so a `notify_one` at enqueue time is lost if no helper was parked yet
-                // (e.g. it was busy running a previous job). Handing off the surplus wakeup here
-                // ensures idle helpers still get pulled in, preserving parallelism.
+                // If work remains, let other threads try to handle it in parallel
                 if !work_queue.jobs.is_empty() {
                     self.work_queue_condition_var.notify_one();
                 }
@@ -132,8 +128,7 @@ impl ScopeInner {
 
     fn end_and_help_complete(&self) {
         // Close the queue and wake every parked drainer once; each will drain any remaining jobs
-        // and then observe `closed` and exit. Closing under the queue lock (paired with `wait`
-        // releasing it atomically) means a drainer cannot park after we close without seeing it.
+        // and then observe `closed` and exit.
         {
             let mut work_queue = self.work_queue.lock();
             work_queue.closed = true;
@@ -152,8 +147,9 @@ pub struct Scope<'scope, 'env: 'scope, R: Send + 'env> {
     index: AtomicUsize,
     inner: Arc<ScopeInner>,
     handle: Handle,
-    /// Max number of opportunistic helper worker tasks to spawn
-    worker_tasks: usize,
+    /// Max number of threads to use, threads are only spawned when needed. The calling thread
+    /// counts towards this budget, so we spawn at most `worker_tasks - 1` helpers.
+    worker_tasks: NonZeroUsize,
     turbo_tasks: Option<Arc<dyn TurboTasksApi>>,
     span: Span,
     /// Invariance over 'env, to make sure 'env cannot shrink, which is necessary for soundness.
@@ -171,13 +167,10 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
     /// The caller must ensure `Scope` is dropped and not forgotten.
     unsafe fn new(results: &'scope [Mutex<Option<R>>]) -> Self {
         let handle = Handle::current();
-        // The calling thread is itself a drainer, so we only need helpers to cover the remaining
-        // work.
-        let worker_tasks = handle
-            .metrics()
-            .num_workers()
-            .min(results.len())
-            .saturating_sub(1);
+        // Never use more threads than there are jobs, and never more than the runtime has workers.
+        // The calling thread always participates, so this is at least 1.
+        let worker_tasks = NonZeroUsize::new(handle.metrics().num_workers().min(results.len()))
+            .unwrap_or(NonZeroUsize::MIN);
         Self {
             results,
             index: AtomicUsize::new(0),
@@ -239,20 +232,14 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 
         self.inner.remaining_tasks.fetch_add(1, Ordering::Relaxed);
 
-        // Every job goes on the shared work queue, this way work is never assigned to a task that
-        // might never run.  Because we block synchronously on the main thread it is possible that
-        // our spawned tasks cannot find threads to run on this ensures all the work is available to
-        // all threads including the main_thread.
+        // Add to the shared work queue, all threads read from this
         self.inner.work_queue.lock().jobs.push_back((index, f));
-        // This isn't needed for liveness, but optimizes behavior when we have limited threads
-        // available.
+        // If there's currently an idle worker, wake it up
         self.inner.work_queue_condition_var.notify_one();
 
-        // Spawn a tokio worker for each task (except the last spawn call which will be handled by
-        // this thread). Helpers all run the identical `run_jobs` loop pulling from the shared
-        // queue, so nothing here is job-specific; we only clone the span for the workers we
-        // actually spawn.
-        if index < self.worker_tasks {
+        // Spawn a tokio worker for each job until we hit the max `worker_tasks`. The calling thread
+        // covers one slot of the budget, so we spawn at most `worker_tasks - 1` helpers.
+        if index < self.worker_tasks.get() - 1 {
             let inner = self.inner.clone();
             let span = self.span.clone();
             self.handle.spawn(async move {
@@ -315,29 +302,12 @@ mod tests {
 
     use super::*;
 
-    /// Regression test for the deadlock this primitive hit when adopted for parallel consumption of
-    /// a shared worklist (e.g. `gc_collect`) on a thread-limited runtime.
+    /// A scope must make progress even when every runtime worker thread is busy, since the calling
+    /// thread can always drain the shared queue itself.
     ///
-    /// Previously `scope_and_block` sized its worker count from the host cpu count
-    /// (`available_parallelism() - 1`) and handed job indices `1..=WORKER_TASKS` *exclusively* to
-    /// spawned worker tasks — those jobs were never placed on the shared work queue, so *only* a
-    /// spawned worker could run them. A spawned worker runs synchronous code and, once scheduled,
-    /// holds its tokio core without ever yielding it back. When the runtime's worker threads are
-    /// already occupied by other synchronous/blocking work (as happens under GC, which holds a
-    /// global operation lock while other tasks block), the scope's spawned workers can never be
-    /// scheduled onto a core. The jobs assigned to them never run, `remaining_tasks` never reaches
-    /// zero, and the caller blocks forever.
-    ///
-    /// This reproduces it deterministically without risking a hung test process. Every runtime
-    /// worker thread is pinned by a task that blocks synchronously (holding its core, *not* via
-    /// `block_in_place`, so tokio cannot hand the core off), and those tasks are released only
-    /// after a fixed delay. The scope runs on a separate `spawn_blocking` thread. Pre-fix: the jobs
-    /// assigned to spawned workers cannot run until a core frees up, so the scope cannot finish
-    /// before the release delay. Post-fix: every job lives on the shared work queue and the
-    /// caller's own thread drains all of them immediately, so the scope finishes well before the
-    /// release. We assert the scope finished quickly — which fails cleanly (no hang) on the old
-    /// code because the scope thread is still blocked when we check, but the release timer
-    /// guarantees the process still makes progress and exits.
+    /// Every worker thread is pinned by a task blocking synchronously until a release deadline, so
+    /// no helper can be scheduled; we assert the scope still finishes well before that deadline.
+    /// The deadline also guarantees the test fails cleanly instead of hanging.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_scope_worker_threads_occupied() {
         const WORKER_THREADS: usize = 2;
@@ -394,8 +364,8 @@ mod tests {
     }
 
     /// On a `current_thread` runtime there are no worker threads to spawn helpers onto, and
-    /// `block_in_place` is not even allowed. `num_workers()` reports 1, so `worker_tasks` is 0 and
-    /// the main thread drains the entire queue inline — reaching `remaining_tasks == 0` before
+    /// `block_in_place` is not even allowed. `num_workers()` reports 1, so no helpers are spawned
+    /// and the main thread drains the entire queue inline — reaching `remaining_tasks == 0` before
     /// `wait()` would ever call `block_in_place`. This must complete rather than panic or hang.
     #[tokio::test(flavor = "current_thread")]
     async fn test_scope_current_thread_runtime() {

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -218,8 +218,14 @@ impl<'scope, 'env: 'scope, R: Send + 'env> Scope<'scope, 'env, R> {
 impl<'scope, 'env: 'scope, R: Send + 'env> Drop for Scope<'scope, 'env, R> {
     fn drop(&mut self) {
         // Dropping the only sender closes the queue: each drainer finishes the jobs still in it
-        // and then sees `recv` fail and exits.
-        self.work_queue.take();
+        // and then sees `recv` fail and exits. This must happen *before* we drain below —
+        // `run_jobs` blocks in `recv` until the queue is closed, so a live sender here would hang
+        // the scope.
+        drop(
+            self.work_queue
+                .take()
+                .expect("sender is taken exactly once, here in Drop"),
+        );
         // Help drain whatever remains inline, so completion never depends on a helper being
         // scheduled.
         self.inner.run_jobs();


### PR DESCRIPTION
### What?

Fix a potential deadlock in `scope_and_block` (the CPU fan-out primitive in `turbopack/crates/turbo-tasks/src/scope.rs`) by routing every job through a single shared work queue, so completion never depends on a spawned worker being scheduled.

### Why?

`scope_and_block` runs a batch of jobs across the tokio runtime's worker threads while the calling thread blocks. Previously, jobs at indices `1..=WORKER_TASKS` were handed *exclusively* to freshly `handle.spawn`ed worker tasks and never placed on the shared queue — but the calling thread only drains the queue, so it could not run those jobs itself.

Each spawned worker runs synchronous code and parks on a `parking_lot::Condvar` (no `.await`, no `block_in_place`), so once scheduled it holds its runtime core for the whole scope. When the runtime has fewer worker threads than host CPUs, or they are already occupied, those workers may never get a core. Their exclusively-assigned jobs then never run, `remaining_tasks` never reaches 0, and the caller blocks forever. 

### How?

- **Every job goes on one shared queue.** Spawned helpers are now a pure optimization that pull from the same queue; they are never assigned a dedicated job. The calling thread drains the whole queue itself in `end_and_help_complete`, so liveness never depends on a helper being scheduled.
- **Runtime-accurate helper cap.** The helper count is `num_workers().min(number_of_tasks) - 1` (per-scope, from `Handle::current().metrics()`) instead of a process-global host-CPU constant.
- **Close via a flag, not a sentinel.** The queue carries a `closed` bit guarded by the same lock as the jobs. `end_and_help_complete` sets it and `notify_all`s once; a drainer that finds the queue empty exits when closed or parks otherwise. This replaces the previous `End` token that had to be ping-ponged across drainers.
- **Wakeup correctness/perf.** `pick_job_from_work_queue` hands off a surplus `notify_one` when work remains (parking_lot notifications are not latched), and the enqueue-time `notify_one` re-wakes a parked helper — the bootstrap wakeup the hand-off cannot provide from a fully-parked state, which matters most on thread-limited runtimes.
- The `VecDeque` is presized to the job count so `push_back` never reallocates under the queue lock.

Added a deterministic regression test (`test_scope_worker_threads_occupied`): it pins every runtime worker thread with a synchronous sleep, runs the scope on `spawn_blocking`, and asserts it completes well before the sleep releases. This fails (cleanly, via timeout) before the fix and passes after.

Closes NEXT-
