### PR TITLE
fix(config): make compiler.relay.src optional for Relay multi-project configs

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -539,7 +539,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
           .optional(),
         relay: z
           .object({
-            src: z.string(),
+            src: z.string().optional(),
             artifactDirectory: z.string().optional(),
             language: z.enum(['javascript', 'typescript', 'flow']).optional(),
             eagerEsModules: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1763,7 +1763,7 @@ export interface NextConfig {
           properties?: string[]
         }
     relay?: {
-      src: string
+      src?: string
       artifactDirectory?: string
       language?: 'typescript' | 'javascript' | 'flow'
       eagerEsModules?: boolean

--- a/test/e2e/relay-graphql-swc-multi-project/project-a/next.config.js
+++ b/test/e2e/relay-graphql-swc-multi-project/project-a/next.config.js
@@ -3,7 +3,8 @@ const relay = require('../relay.config')
 module.exports = {
   compiler: {
     relay: {
-      src: './pages',
+      // Intentionally omitted: Relay's multi-project config format
+      // (used via `relay.config.js` -> `projects`) has no single `src`.
       artifactDirectory: './__generated__',
       language: relay.projects['project-b'].language,
     },

--- a/test/e2e/relay-graphql-swc-multi-project/project-b/next.config.js
+++ b/test/e2e/relay-graphql-swc-multi-project/project-b/next.config.js
@@ -3,7 +3,8 @@ const relay = require('../relay.config')
 module.exports = {
   compiler: {
     relay: {
-      src: './pages',
+      // Intentionally omitted: Relay's multi-project config format
+      // (used via `relay.config.js` -> `projects`) has no single `src`.
       artifactDirectory: './__generated__',
       language: relay.projects['project-b'].language,
     },

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
@@ -15,7 +15,7 @@ use turbopack_ecmascript::{CustomTransformer, TransformContext};
 )]
 #[serde(rename_all = "camelCase")]
 pub struct RelayConfig {
-    pub src: String,
+    pub src: Option<String>,
     pub artifact_directory: Option<String>,
     pub language: Option<RelayLanguage>,
 }


### PR DESCRIPTION
### What?

`compiler.relay.src` is currently required by Next.js's config schema, but
it's never actually consumed by the SWC/webpack relay transform or the
Turbopack relay transform — only `artifactDirectory`, `language`, and
`eagerEsModules` are used. This made it impossible to use Relay's official
multi-project config format (`relay.config.js` with a `projects` map),
which has no single top-level `src`, without adding an unused dummy value
just to satisfy validation.

### Why?

Fixes #73097. Relay's multi-project mode is a supported, documented Relay
configuration shape (https://relay.dev/docs/guides/compiler-multi-project/),
so Next.js's config validation shouldn't require a field that the compiler
integration doesn't need.

### How?

- Made `src` optional in the `compiler.relay` Zod schema
  (`packages/next/src/server/config-schema.ts`) and the corresponding
  TypeScript type (`packages/next/src/server/config-shared.ts`).
- Made the matching Rust struct field optional in the Turbopack relay
  transform (`turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs`),
  confirming `src` has no other read sites in that crate.
- Updated the existing `test/e2e/relay-graphql-swc-multi-project` fixture
  to drop the now-unnecessary dummy `src` values, demonstrating the
  multi-project shape validates and builds without it.

Fixes #73097