### PR TITLE
Fix missing Pages Turbopack runtime in adapter outputs

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -2166,6 +2166,14 @@ async function getSharedNodeAssets({
     )
     currentDependencies.push(modulePath)
 
+    if (type === 'pages' && bundler === Bundler.Turbopack) {
+      currentDependencies.push(
+        require.resolve(
+          'next/dist/compiled/next-server/pages-turbo.runtime.prod.js'
+        )
+      )
+    }
+
     const contextDir = path.join(
       path.dirname(modulePath),
       'vendored',

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -4,7 +4,7 @@ import type { AdapterOutput, NextAdapter } from 'next'
 import { version as nextVersion } from 'next/package.json'
 
 describe('adapter-config', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
 
@@ -390,6 +390,23 @@ describe('adapter-config', () => {
     expect(appPageVendoredContexts.length).toBeGreaterThan(0)
     // pages should have vendored context files traced
     expect(pagesVendoredContexts.length).toBeGreaterThan(0)
+
+    if (isTurbopack) {
+      const pagesApiOutput = outputs.pagesApi.find(
+        (output) =>
+          output.pathname === '/docs/api/node-pages' &&
+          output.runtime === 'nodejs'
+      )
+
+      expect(pagesApiOutput).toBeDefined()
+      expect(
+        Object.keys(pagesApiOutput!.assets).some((asset) =>
+          /[\\/]next[\\/]dist[\\/]compiled[\\/]next-server[\\/]pages-turbo\.runtime\.prod\.js$/.test(
+            asset
+          )
+        )
+      ).toBe(true)
+    }
 
     for (const route of edgeOutputs) {
       try {


### PR DESCRIPTION
## What?

Include `pages-turbo.runtime.prod.js` in the shared assets for Node.js Pages Router outputs when building with Turbopack.

Add regression coverage confirming that a Pages Router API output contains the runtime in its adapter asset map.

## Why?

The Pages Router module wrapper selects this runtime for Node.js production Turbopack builds:

```js
require('next/dist/compiled/next-server/pages-turbo.runtime.prod.js')
```

Adapter outputs currently include `pages/module.compiled.js` and its vendored contexts, but they do not explicitly include the Turbopack production runtime required by that module.

When a deployment adapter packages a Pages API output independently, the resulting function can therefore contain `module.compiled.js` without the runtime it requires. The build completes successfully, but the function fails during startup with:

```text
Cannot find module 'next/dist/compiled/next-server/pages-turbo.runtime.prod.js'
```

This could previously be hidden when Pages API and SSR outputs were packaged together, because another output could incidentally supply the missing runtime.

## How?

When collecting shared Node assets:

- Detect the `pages` route-module type.
- Check that the active bundler is Turbopack.
- Resolve `pages-turbo.runtime.prod.js`.
- Add it to the existing shared asset and hash pipeline.

The runtime is added to Node.js Pages Router outputs only. App Router, Edge, static, and Webpack outputs are unchanged.

The regression test inspects `outputs.pagesApi` directly so that an SSR output cannot mask the missing API dependency.

## Testing

The new assertion was verified red-to-green: it failed before the production change because the runtime was absent, then passed after the change.

```bash
pnpm test-start-turbo test/production/adapter-config/adapter-config.test.ts \
  -t "should call onBuildComplete with correct context"

pnpm test-start test/production/adapter-config/adapter-config.test.ts \
  -t "should call onBuildComplete with correct context"

pnpm --filter=next types
pnpm --filter=next build
pnpm build-all
git diff --check
```

All passed.

## Risk

Low and limited to adapter-generated Node.js Pages Router outputs using Turbopack. The required runtime is approximately 122 KB and asset entries are deduplicated by destination path.

A future improvement could derive the transitive dependency closure automatically or share the runtime path with `module.compiled.js`, avoiding duplication of the hard-coded filename.