### PR TITLE
fix(next-codemod): handle CommonJS legacy ESLint configs in next-lint…

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/legacy-config-cjs/.eslintrc.cjs
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/legacy-config-cjs/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['next/core-web-vitals'],
+  rules: {
+    'no-console': 'error',
+  },
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/legacy-config-cjs/package.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/legacy-config-cjs/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "react": "^19",
+    "react-dom": "^19",
+    "next": "^16"
+  },
+  "devDependencies": {
+    "eslint": "^8",
+    "eslint-config-next": "^16"
+  }
+}

--- a/packages/next-codemod/transforms/__tests__/next-lint-to-eslint-cli.test.js
+++ b/packages/next-codemod/transforms/__tests__/next-lint-to-eslint-cli.test.js
@@ -598,4 +598,79 @@ describe('next-lint-to-eslint-cli', () => {
       `)
     })
   })
+
+  describe('legacy-config-cjs', () => {
+    it('should migrate a CommonJS legacy config to a CommonJS flat config', async () => {
+      const testDir = path.join(fixturesDir, 'legacy-config-cjs')
+      // Check BEFORE state
+      const beforeEslintrc = fs.readFileSync(
+        path.join(testDir, '.eslintrc.cjs'),
+        'utf8'
+      )
+
+      expect(beforeEslintrc).toMatchInlineSnapshot(`
+        "module.exports = {
+          extends: ['next/core-web-vitals'],
+          rules: {
+            'no-console': 'error',
+          },
+        }
+        "
+      `)
+
+      // Run transformer
+      await transformer([testDir], { skipInstall: true })
+
+      // The migration tool keeps the CommonJS format of the legacy config,
+      // so the generated flat config is eslint.config.cjs, not .mjs
+      expect(fs.existsSync(path.join(testDir, 'eslint.config.mjs'))).toBe(false)
+
+      // Check AFTER state - eslint.config.cjs was created and transformed
+      // without ESM import statements
+      const actualConfig = fs.readFileSync(
+        path.join(testDir, 'eslint.config.cjs'),
+        'utf8'
+      )
+      expect(actualConfig).not.toContain('import ')
+      expect(actualConfig).toMatchInlineSnapshot(`
+       "const {
+           defineConfig,
+       } = require("eslint/config");
+
+       const nextCoreWebVitals = require("eslint-config-next/core-web-vitals");
+
+       module.exports = defineConfig([{
+           extends: [...nextCoreWebVitals],
+
+           rules: {
+               "no-console": "error",
+           },
+       }]);
+       "
+      `)
+
+      // Check package.json transformed
+      const actualPackage = fs.readFileSync(
+        path.join(testDir, 'package.json'),
+        'utf8'
+      )
+      expect(actualPackage).toMatchInlineSnapshot(`
+       "{
+         "scripts": {
+           "lint": "eslint ."
+         },
+         "dependencies": {
+           "react": "^19",
+           "react-dom": "^19",
+           "next": "^16"
+         },
+         "devDependencies": {
+           "eslint": "^9",
+           "eslint-config-next": "^16"
+         }
+       }
+       "
+      `)
+    })
+  })
 })

--- a/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
+++ b/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
@@ -105,6 +105,56 @@ function findExistingEslintConfig(projectRoot: string): {
   return { exists: false, path: null, isLegacy: null }
 }
 
+function isRequireOf(node: any, moduleNames: string[]): boolean {
+  return (
+    node &&
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'require' &&
+    node.arguments.length === 1 &&
+    (node.arguments[0].type === 'Literal' ||
+      node.arguments[0].type === 'StringLiteral') &&
+    moduleNames.includes(node.arguments[0].value)
+  )
+}
+
+// Flat configs migrated from a legacy `.eslintrc.js`/`.eslintrc.cjs` are
+// CommonJS, so added declarations must use require() instead of import.
+function isCommonJsConfig(configPath: string, j: any, root: any): boolean {
+  const extension = path.extname(configPath)
+  if (extension === '.cjs' || extension === '.cts') {
+    return true
+  }
+  if (extension === '.mjs' || extension === '.mts') {
+    return false
+  }
+  return (
+    root.find(j.ImportDeclaration).size() === 0 &&
+    root.find(j.ExportDefaultDeclaration).size() === 0 &&
+    root.find(j.ExportNamedDeclaration).size() === 0
+  )
+}
+
+function createDefaultImport(
+  j: any,
+  localName: string,
+  source: string,
+  useRequire: boolean
+) {
+  if (useRequire) {
+    return j.variableDeclaration('const', [
+      j.variableDeclarator(
+        j.identifier(localName),
+        j.callExpression(j.identifier('require'), [j.literal(source)])
+      ),
+    ])
+  }
+  return j.importDeclaration(
+    [j.importDefaultSpecifier(j.identifier(localName))],
+    j.literal(source)
+  )
+}
+
 function replaceFlatCompatInConfig(configPath: string): boolean {
   let configContent: string
   try {
@@ -127,6 +177,8 @@ function replaceFlatCompatInConfig(configPath: string): boolean {
   // Parse the file using jscodeshift
   const j = createParserFromPath(configPath)
   const root = j(configContent)
+
+  const isCommonJs = isCommonJsConfig(configPath, j, root)
 
   // Track if we need to add imports and preserve other configs
   let needsNext = false
@@ -238,12 +290,18 @@ function replaceFlatCompatInConfig(configPath: string): boolean {
       // Leave path/url imports alone - they might be used elsewhere
     })
 
-    // Remove only the compat variable - keep __dirname and __filename
+    // Remove only the compat variable and FlatCompat-specific requires -
+    // keep __dirname and __filename
     root.find(j.VariableDeclaration).forEach((astPath) => {
       const node = astPath.value
       if (node.declarations) {
-        // Filter out only the compat variable
         const filteredDeclarations = node.declarations.filter((decl: any) => {
+          if (
+            decl &&
+            isRequireOf(decl.init, ['@eslint/eslintrc', '@eslint/js'])
+          ) {
+            return false
+          }
           if (decl && decl.id && decl.id.type === 'Identifier') {
             return decl.id.name !== 'compat'
           }
@@ -269,38 +327,52 @@ function replaceFlatCompatInConfig(configPath: string): boolean {
   // Add imports in correct order: next first, then core-web-vitals, then typescript
   if (needsNext) {
     imports.push(
-      j.importDeclaration(
-        [j.importDefaultSpecifier(j.identifier('next'))],
-        j.literal('eslint-config-next')
-      )
+      createDefaultImport(j, 'next', 'eslint-config-next', isCommonJs)
     )
   }
 
   if (needsNextVitals) {
     imports.push(
-      j.importDeclaration(
-        [j.importDefaultSpecifier(j.identifier('nextCoreWebVitals'))],
-        j.literal('eslint-config-next/core-web-vitals')
+      createDefaultImport(
+        j,
+        'nextCoreWebVitals',
+        'eslint-config-next/core-web-vitals',
+        isCommonJs
       )
     )
   }
 
   if (needsNextTs) {
     imports.push(
-      j.importDeclaration(
-        [j.importDefaultSpecifier(j.identifier('nextTypescript'))],
-        j.literal('eslint-config-next/typescript')
+      createDefaultImport(
+        j,
+        'nextTypescript',
+        'eslint-config-next/typescript',
+        isCommonJs
       )
     )
   }
 
-  // Find the eslint/config import and insert our imports after it
+  // Find the eslint/config import (or require) and insert our imports after it
   let eslintConfigImportPath = null
-  root.find(j.ImportDeclaration).forEach((astPath) => {
-    if (astPath.value.source.value === 'eslint/config') {
-      eslintConfigImportPath = astPath
-    }
-  })
+  if (isCommonJs) {
+    root.find(j.VariableDeclaration).forEach((astPath) => {
+      if (
+        !eslintConfigImportPath &&
+        astPath.value.declarations?.some((decl: any) =>
+          isRequireOf(decl?.init, ['eslint/config'])
+        )
+      ) {
+        eslintConfigImportPath = astPath
+      }
+    })
+  } else {
+    root.find(j.ImportDeclaration).forEach((astPath) => {
+      if (astPath.value.source.value === 'eslint/config') {
+        eslintConfigImportPath = astPath
+      }
+    })
+  }
 
   // Insert imports after eslint/config import (or at beginning if not found)
   if (eslintConfigImportPath) {
@@ -1105,11 +1177,22 @@ export default function transformer(
           stdio: 'pipe',
         })
 
-        // The migration tool creates eslint.config.mjs by default
-        const outputPath = path.join(projectRoot, 'eslint.config.mjs')
-        if (!existsSync(outputPath)) {
+        // The migration tool derives its output filename from the legacy
+        // config: JS configs keep their extension (`.eslintrc.cjs` becomes
+        // `eslint.config.cjs`), other formats become `eslint.config.mjs`.
+        // No flat config existed before the tool ran, so whichever of these
+        // exists now was generated by it.
+        const generatedConfigFilenames = [
+          'eslint.config.mjs',
+          'eslint.config.js',
+          'eslint.config.cjs',
+        ]
+        const outputPath = generatedConfigFilenames
+          .map((filename) => path.join(projectRoot, filename))
+          .find((generatedPath) => existsSync(generatedPath))
+        if (!outputPath) {
           throw new Error(
-            `Failed to find the expected output file "${outputPath}" generated by the migration tool.`
+            `Failed to find the flat config file generated by the migration tool (expected one of ${generatedConfigFilenames.join(', ')} in "${projectRoot}").`
           )
         }
 


### PR DESCRIPTION
## What?

The `next-lint-to-eslint-cli` codemod assumed that `@eslint/migrate-config` always generates `eslint.config.mjs`. In practice, the migration tool preserves the module format of JavaScript-based legacy configs:

- `.eslintrc.js` → `eslint.config.js`
- `.eslintrc.cjs` → `eslint.config.cjs`

Because of this assumption, the codemod failed with:

> Failed to find the expected output file

when migrating projects using CommonJS ESLint configs.

This change detects whichever flat config file was actually generated instead of hardcoding `eslint.config.mjs`. It also preserves the module system when updating CommonJS configs by generating `require()` declarations instead of ESM `import` statements.

## Why?

`next lint` has been removed in Next.js 16, making this codemod the recommended migration path. Projects using `.eslintrc.js` or `.eslintrc.cjs` currently cannot complete the migration because the codemod crashes before finishing.

Additionally, even if the generated file were found, the previous implementation would have inserted ESM imports into a CommonJS config, resulting in an invalid ESLint configuration.

## How?

- Detect the generated flat config (`.mjs`, `.js`, or `.cjs`) instead of assuming a fixed filename.
- Detect whether the generated config is CommonJS.
- Generate `require()` declarations for CommonJS configs while preserving the existing ESM behavior for `.mjs` configs.
- Update the FlatCompat replacement logic to work correctly for CommonJS output.
- Add a regression test covering migration from a `.eslintrc.cjs` configuration.

## Testing

- Added a regression test for `.eslintrc.cjs` migration.
- Verified the new test reproduces the reported failure before the fix and passes afterward.
- Ran the full `next-codemod` test suite successfully.
- Verified the generated `eslint.config.cjs` works with ESLint 9 in a real sample project.

Fixes #85679
