### PR TITLE
Fix webpack build failure when pageExtensions has a single value

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -289,7 +289,7 @@ export function getAppEntry(opts: Readonly<AppLoaderOptions>) {
     ;(opts as any).projectRoot = normalize(join(__dirname, '../../..'))
   }
   return {
-    import: `${getAppLoader()}?${stringify(opts)}!`,
+    import: `${getAppLoader()}?${JSON.stringify(opts)}!`,
     layer: WEBPACK_LAYERS.reactServerComponents,
   }
 }

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -719,10 +719,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     relatedModules: [],
   }
 
-  const extensions =
-    typeof pageExtensions === 'string'
-      ? [pageExtensions]
-      : pageExtensions.map((extension) => `.${extension}`)
+  const extensions = pageExtensions.map((extension) => `.${extension}`)
 
   const normalizedAppPaths =
     typeof appPaths === 'string' ? [appPaths] : appPaths || []

--- a/test/production/app-dir/page-extensions-single-value-app/app/layout.tsx
+++ b/test/production/app-dir/page-extensions-single-value-app/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/page-extensions-single-value-app/app/page.tsx
+++ b/test/production/app-dir/page-extensions-single-value-app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/page-extensions-single-value-app/next.config.js
+++ b/test/production/app-dir/page-extensions-single-value-app/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  pageExtensions: ['tsx'],
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/page-extensions-single-value-app/page-extensions-single-value-app.test.ts
+++ b/test/production/app-dir/page-extensions-single-value-app/page-extensions-single-value-app.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression test for https://github.com/vercel/next.js/issues/95517
+// A single-element `pageExtensions` array (e.g. `['tsx']`) failed to
+// resolve any app dir route when building with webpack, because the
+// loader options were serialized with `querystring.stringify`, which
+// collapses a one-element array into a bare string.
+describe('page-extensions-single-value-app', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should resolve app dir routes when pageExtensions has a single value', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})


### PR DESCRIPTION
### What?

Fixes app dir route resolution failing with `Can't resolve private-next-app-dir/page` when `pageExtensions` is configured with
exactly one extension (e.g. `['tsx']`).

### Why?

`getAppEntry()` in `packages/next/src/build/entries.ts` serializes the `next-app-loader` options (including `pageExtensions`)
using Node's `querystring.stringify()`. That function collapses a single-element array into a bare string rather than preserving
it as an array, so on the loader side the original array shape can't be recovered.

`next-app-loader` did have a fallback for this case (`typeof pageExtensions === 'string'`), but it forgot to prepend the
extension's leading dot. This made it check for a file named `pagetsx` instead of `page.tsx`, so resolution always failed.

### How?

- Switched the loader options serialization from `querystring.stringify()` to `JSON.stringify()`, matching the pattern already
used by `next-edge-ssr-loader` in the same file. Webpack's loader-utils parses `?{...}`-style queries as JSON5, so the original
array is correctly restored regardless of how many elements it has.
- Removed the now-unreachable string/array fallback branch in `next-app-loader`, since the query is always parsed back into an
array.

### Testing

- Added a regression test at `test/production/app-dir/page-extensions-single-value-app/` (confirmed failing before the fix,
passing after).
- Verified the existing `test/production/page-extensions/page-extensions.test.ts` (4 tests) still passes.
- Verified the new regression test passes under both webpack and Turbopack (Turbopack was never affected by this bug).

Fixes #95517