### PR TITLE
docs: clarify layout.js nesting behavior in route groups

### DIFF
--- a/docs/01-app/01-getting-started/02-project-structure.mdx
+++ b/docs/01-app/01-getting-started/02-project-structure.mdx
@@ -368,7 +368,7 @@ To organize routes without affecting the URL, create a group to keep related rou
   height="930"
 />
 
-Even though routes inside `(marketing)` and `(shop)` share the same URL hierarchy, you can create a different layout for each group by adding a `layout.js` file inside their folders. This `layout.js` nests inside the top-level `app/layout.js` like any other layout, it does not replace it. To remove the top-level layout entirely and give each group its own root layout instead, see [Creating multiple root layouts](#creating-multiple-root-layouts) below.
+Even though routes inside `(marketing)` and `(shop)` share the same URL hierarchy, you can create a different layout for each group by adding a `layout.js` file inside their folders. These layouts nest within the existing app layout.
 
 <Image
   alt="Route Groups with Multiple Layouts"

--- a/docs/01-app/01-getting-started/02-project-structure.mdx
+++ b/docs/01-app/01-getting-started/02-project-structure.mdx
@@ -368,7 +368,7 @@ To organize routes without affecting the URL, create a group to keep related rou
   height="930"
 />
 
-Even though routes inside `(marketing)` and `(shop)` share the same URL hierarchy, you can create a different layout for each group by adding a `layout.js` file inside their folders.
+Even though routes inside `(marketing)` and `(shop)` share the same URL hierarchy, you can create a different layout for each group by adding a `layout.js` file inside their folders. This `layout.js` nests inside the top-level `app/layout.js` like any other layout, it does not replace it. To remove the top-level layout entirely and give each group its own root layout instead, see [Creating multiple root layouts](#creating-multiple-root-layouts) below.
 
 <Image
   alt="Route Groups with Multiple Layouts"


### PR DESCRIPTION
### What?

- Adds one clarifying sentence (plus a link) to the "Organize routes without affecting the URL path" section in docs/01-app/01-getting-started/02-project-structure.mdx. No behavior change, docs text only.
---
### Why?

- The existing sentence says you can add a layout.js inside a route group folder to give it a different layout, but it doesn't say whether that layout.js nests inside the top-level app/layout.js or replaces it. Read in order, a reader hits this line before the page ever mentions removing the top-level layout, so it's genuinely ambiguous at that point in the page. The nesting behavior is only clarified later, in the "Creating multiple root layouts" section — and even then, it's explained for a different, more specific case (removing the top-level layout entirely to give each route group its own root layout).
---
### How?

- Added one sentence stating that this layout.js nests inside the top-level app/layout.js like any other layout by default, and linked to "Creating multiple root layouts" for readers who want the root-layout behavior instead.
