### PR TITLE
fix(examples): support https and gravatar in cms-wordpress remotePatterns

### DIFF
--- a/examples/cms-wordpress/next.config.js
+++ b/examples/cms-wordpress/next.config.js
@@ -8,6 +8,16 @@ const nextConfig = {
         hostname: process.env.NEXT_PUBLIC_WORDPRESS_API_HOSTNAME,
         port: "",
       },
+      {
+        protocol: "https",
+        hostname: process.env.NEXT_PUBLIC_WORDPRESS_API_HOSTNAME,
+        port: "",
+      },
+      {
+        protocol: "https",
+        hostname: "secure.gravatar.com",
+        port: "",
+      },
     ],
   },
 };


### PR DESCRIPTION
### What?
Allows optimized WordPress featured images and author avatars to load successfully in the `cms-wordpress` example.

### Why?
The current `next.config.js` only configures `http` protocol for the WordPress API hostname, which blocks images requested via `https` (such as on Vercel deployments and modern WordPress sites). Author avatars from `secure.gravatar.com` are also blocked.

### How?
Added a remote pattern for the `https` protocol of the WordPress API hostname and added `secure.gravatar.com` to the allowed `remotePatterns` in `next.config.js`.

Fixes #94807