### PR TITLE
Turbopack: resolve loader source map sources against the compilation root

### DIFF
--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -102,7 +102,13 @@ async function batchedTraceSource(
         currentSourcesByFile.delete(originalFile!)
       }, 100)
     }
-    source = await sourcePromise
+    try {
+      source = await sourcePromise
+    } catch {
+      // The frame was successfully traced; a failed source read only costs
+      // the code frame, it must not reject the mapped frame itself.
+      source = null
+    }
   }
 
   const ignorableFrame: IgnorableStackFrame = {

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -70,7 +70,7 @@ impl GenerateSourceMap for SourceMapReference {
 
         let content = file.read().await?;
         let content = content.as_content().map(|file| file.content());
-        if let Some(source_map) = resolve_source_map_sources(content, &self.from).await? {
+        if let Some(source_map) = resolve_source_map_sources(content, &self.from, None).await? {
             Ok(FileContent::Content(File::from(source_map)).cell())
         } else {
             Ok(FileContent::NotFound.cell())

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -83,6 +83,12 @@ struct SourceMapJson {
 pub async fn resolve_source_map_sources(
     map: Option<&Rope>,
     origin: &FileSystemPath,
+    // The directory relative `sources` resolve against. `None` applies the
+    // source map spec's default (the map's location, i.e. `origin`'s
+    // directory). Webpack loaders instead emit `sources` relative to the
+    // compilation root (`rootContext`) they were handed, so the loader
+    // transform passes that root here explicitly.
+    relative_source_base: Option<&FileSystemPath>,
 ) -> Result<Option<Rope>> {
     let fs_vc = origin.fs().to_resolved().await?;
     let fs_str = &*turbofmt!("[{fs_vc}]").await?;
@@ -127,9 +133,11 @@ pub async fn resolve_source_map_sources(
             } else {
                 // assume it's a relative URL, and just remove any percent encoding from path
                 // segments. Our internal path format is POSIX-like, without percent encoding.
-                origin
-                    .parent()
-                    .try_join(&urlencoding::decode(source_url).unwrap_or(Cow::Borrowed(source_url)))
+                let decoded = urlencoding::decode(source_url).unwrap_or(Cow::Borrowed(source_url));
+                match relative_source_base {
+                    Some(base) => base.try_join(&decoded),
+                    None => origin.parent().try_join(&decoded),
+                }
             };
 
             if let Some(fs_path) = fs_path {
@@ -361,6 +369,7 @@ mod tests {
             struct SourceMapSourcesOutput {
                 resolved_sources: Vec<Option<String>>,
                 rooted_sources: Vec<Option<String>>,
+                loader_sources: Vec<Option<String>>,
             }
 
             #[turbo_tasks::function(operation, root)]
@@ -406,6 +415,7 @@ mod tests {
                         // NOTE: the percent encoding here should NOT be decoded, as this is not
                         // part of a `file://` URL
                         &fs_root_path.join("app/source%20mapped/page.js").unwrap(),
+                        None,
                     )
                     .await?
                     .unwrap()
@@ -421,6 +431,25 @@ mod tests {
                             ["page.js"],
                         )),
                         &fs_root_path.join("app/page.js").unwrap(),
+                        None,
+                    )
+                    .await?
+                    .unwrap()
+                    .to_str()?,
+                )?;
+
+                // A webpack loader emits `sources` relative to the compilation
+                // root it was handed (its `rootContext`), NOT the resource's
+                // directory. Resolving against the resource's directory would
+                // double the path ("apps/web/src/i18n/src/i18n/toggle.tsx").
+                let loader_source_map: SourceMapJson = serde_json::from_str(
+                    &resolve_source_map_sources(
+                        Some(&source_map_rope(
+                            /* source_root */ None,
+                            ["src/i18n/toggle.tsx"],
+                        )),
+                        &fs_root_path.join("apps/web/src/i18n/toggle.tsx").unwrap(),
+                        Some(&fs_root_path.join("apps/web").unwrap()),
                     )
                     .await?
                     .unwrap()
@@ -430,6 +459,7 @@ mod tests {
                 Ok(SourceMapSourcesOutput {
                     resolved_sources: resolved_source_map.sources.unwrap_or_default(),
                     rooted_sources: rooted_source_map.sources.unwrap_or_default(),
+                    loader_sources: loader_source_map.sources.unwrap_or_default(),
                 }
                 .cell())
             }
@@ -455,6 +485,11 @@ mod tests {
             assert_eq!(
                 resolved_source_maps.rooted_sources,
                 vec![Some(format!("{prefix}/source root page.js"))]
+            );
+
+            assert_eq!(
+                resolved_source_maps.loader_sources,
+                vec![Some(format!("{prefix}/apps/web/src/i18n/toggle.tsx"))]
             );
 
             anyhow::Ok(())

--- a/turbopack/crates/turbopack-ecmascript/src/source_map.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/source_map.rs
@@ -27,7 +27,7 @@ impl GenerateSourceMap for InlineSourceMap {
     pub async fn generate_source_map(&self) -> Result<Vc<FileContent>> {
         let source_map = maybe_decode_data_url(&self.source_map);
         if let Some(source_map) =
-            resolve_source_map_sources(source_map.as_ref(), &self.origin_path).await?
+            resolve_source_map_sources(source_map.as_ref(), &self.origin_path, None).await?
         {
             Ok(FileContent::Content(File::from(source_map)).cell())
         } else {

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -349,8 +349,15 @@ impl WebpackLoadersProcessedAsset {
                     .map
                     .map(|source_map| Rope::from(source_map.into_owned()))
             };
-            let source_map =
-                resolve_source_map_sources(source_map.as_ref(), resource_fs_path).await?;
+            // Loaders emit relative `sources` against the compilation root we
+            // hand them (`cwd`, exposed as the loader's `rootContext`), not
+            // against the resource's own directory.
+            let source_map = resolve_source_map_sources(
+                source_map.as_ref(),
+                resource_fs_path,
+                Some(&project_path),
+            )
+            .await?;
 
             let file = match processed.source {
                 Either::Left(str) => File::from(str),


### PR DESCRIPTION
### What?

Two dev-time symbolication fixes for Turbopack + webpack-style loaders:

- Relative `sources` in a source map returned by a webpack loader are now resolved against the compilation root the loader was handed (`rootContext`), instead of against the transformed file's own directory.
- `/__nextjs_original-stack-frames` no longer rejects a successfully traced frame when reading the original source content fails — the mapped frame is returned without a code frame instead.

### Why?

Motivating case: **next-intl's message extractor** in a pnpm monorepo. A Next 16 app lives at `apps/web` with `turbopack.root` set to the workspace root. next-intl (4.13, `experimental.extract`) registers a webpack-style loader rule under Turbopack (`next-intl/extractor/extractionLoader`, content condition `useExtracted|getExtracted`). For each matching file the loader runs swc with `sourceFileName: path.relative(rootContext, resourcePath)` — e.g. `src/components/i18n/language-toggle.tsx`, relative to the `rootContext` Turbopack handed it (`apps/web`) — so the returned map's `sources` are rootContext-relative, the convention webpack itself uses (`NormalModule` contextifies loader-returned map sources against `options.context`).

Turbopack then resolves those sources against a different base — the transformed file's own directory — in `resolve_source_map_sources`, so the served chunk map carries a doubled path:

```
file:///…/apps/web/src/components/i18n/src/components/i18n/language-toggle.tsx
```

Every dev-time consumer of that map degrades, but only for the loader-transformed files — sibling files in the same chunk map correctly, which makes it look flaky. A browser exception thrown in `language-toggle.tsx` traces correctly, then `/__nextjs_original-stack-frames` fails the whole frame with

```
Cannot find source for asset apps/web/src/components/i18n/src/components/i18n/language-toggle.tsx
```

because the code-frame read failure rejects a frame whose mapping had already succeeded. Overlay code frames and external dev symbolication consumers (e.g. Sentry's dev symbolication processor, which falls back silently to minified frames on rejection) lose original locations for exactly the files the loader touched.

Turbopack defines both sides of the contract here: it passes the loader runner `cwd` = the project path (exposed to loaders as `rootContext`, `turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts`), then interprets the returned map against the resource directory (`turbopack/crates/turbopack-node/src/transforms/webpack.rs`).

Generalized reproduction (no next-intl needed): `next dev --turbopack` in a workspace where `turbopack.root` is above the app dir, with any loader rule returning a map with rootContext-relative `sources`; fetch the chunk's `.map` and observe the doubled entry, or POST the frame to `/__nextjs_original-stack-frames` and observe the rejection.

### How?

- `resolve_source_map_sources` takes an explicit base for relative sources; `None` keeps the source-map-spec default (the map's location, i.e. the origin's directory), used by the inline-map and `.map`-file callers. The webpack-loader transform passes the same `project_path` it hands the loader runner.
- `batchedTraceSource` catches `getSourceForAsset` failures and returns the traced frame with `source = null`.
- Unit test added to `test_resolve_source_map_sources` covering the loader-shaped case (rootContext-relative source + explicit base).

Test plan: `cargo test -p turbopack-core --lib source_map` (new case + existing cases green); `cargo check` clean on `turbopack-node` and `turbopack-ecmascript`; rustfmt clean. The defect itself is reproduced live against `v16.3.0-canary.82` (these files are identical at the canary tip); the fixed binary has not been exercised against that live setup end to end.
