### PR TITLE
Turbopack: send the current HMR hash in sync messages

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1465,7 +1465,10 @@ export async function createHotReloaderTurbopack(
             type: HMR_MESSAGE_SENT_TO_BROWSER.SYNC,
             errors,
             warnings: [],
-            hash: '',
+            // Match the webpack hot reloader, whose sync carries the current
+            // compilation hash: report the server's latest HMR hash so a
+            // (re)connecting client can learn the current point instead of ''.
+            hash: String(hmrHash),
             versionInfo,
             debug: {
               devtoolsFrontendUrl,


### PR DESCRIPTION
### What?

The Turbopack hot reloader's `sync` message now carries the server's current HMR hash instead of an empty string, matching the webpack hot reloader's behavior.

### Why?

The `SyncMessage.hash` field exists because the webpack hot reloader fills it: `hot-middleware.ts` sends `hash: stats.hash!` (the current compilation hash) on every sync. The Turbopack hot reloader has sent `hash: ''` since the field appeared in its sync construction (visible as far back as early 2024).

The practical consequence: a client that connects — or reconnects after a network interruption — cannot learn the server's current point until the next hash-bearing message (`built`, `serverComponentChanges`) happens to arrive. For the built-in client this is masked, but external HMR consumers observing the socket (dev tooling that ingests build settlements to correlate browser state with server rebuilds) are left blind after every reconnect, with no recovery if no further build occurs.

### How?

Send `String(hmrHash)` — the server's latest HMR hash — in the sync message, without incrementing (the same "current state" semantics as webpack's `stats.hash`). The only client reader gated on `message.hash` stores it for `isUpdateAvailable`, whose Turbopack branch compares against an undefined `__webpack_hash__` and is unaffected; no test pins the empty value.
