### PR TITLE
Turbopack(napi v3): address review feedback on #95412

### DIFF
--- a/crates/next-napi-bindings/src/css/mod.rs
+++ b/crates/next-napi-bindings/src/css/mod.rs
@@ -1,13 +1,10 @@
-use napi::{Env, bindgen_prelude::Object};
+use napi::{Env, Unknown, bindgen_prelude::Object};
 use napi_derive::napi;
 use next_core::next_config::lightningcss_feature_names_to_mask;
 
 #[napi(js_name = "lightningCssTransform")]
 #[allow(dead_code)]
-pub fn transform<'env>(
-    env: &'env Env,
-    opts: Object<'_>,
-) -> napi::Result<napi::bindgen_prelude::Unknown<'env>> {
+pub fn transform<'env>(env: &'env Env, opts: Object<'_>) -> napi::Result<Unknown<'env>> {
     turbopack_lightningcss_napi::transform(env, opts)
 }
 
@@ -16,7 +13,7 @@ pub fn transform<'env>(
 pub fn transform_style_attribute<'env>(
     env: &'env Env,
     opts: Object<'_>,
-) -> napi::Result<napi::bindgen_prelude::Unknown<'env>> {
+) -> napi::Result<Unknown<'env>> {
     turbopack_lightningcss_napi::transform_style_attribute(env, opts)
 }
 

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -3,8 +3,8 @@ use std::{ops::Deref, sync::Arc};
 use anyhow::Result;
 use futures_util::TryFutureExt;
 use napi::{
-    Env, Unknown as JsUnknown,
-    bindgen_prelude::{External, ExternalRef, PromiseRaw},
+    Env,
+    bindgen_prelude::{External, FunctionRef},
 };
 use napi_derive::napi;
 use next_api::{
@@ -148,55 +148,47 @@ async fn get_written_endpoint_with_issues_operation(
     .cell())
 }
 
+#[tracing::instrument(level = "info", name = "write endpoint to disk", skip_all)]
 #[napi]
-pub fn endpoint_write_to_disk<'env>(
-    env: &'env Env,
+pub async fn endpoint_write_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,
-) -> napi::Result<PromiseRaw<'env, TurbopackResult<NapiWrittenEndpoint>>> {
+) -> napi::Result<TurbopackResult<NapiWrittenEndpoint>> {
     let ctx = endpoint.turbopack_ctx().clone();
     let endpoint_op = ****endpoint;
-    env.spawn_future(
-        async move {
-            let (written, issues) = ctx
-                .turbo_tasks()
-                .run(async move {
-                    let written_entrypoint_with_issues_op =
-                        get_written_endpoint_with_issues_operation(endpoint_op);
-                    let read = read_strongly_consistent_and_apply_effects(
-                        written_entrypoint_with_issues_op,
-                        |v| &v.effects,
-                    )
-                    .await?;
-                    let WrittenEndpointWithIssues {
-                        written, issues, ..
-                    } = &*read;
+    let (written, issues) = ctx
+        .turbo_tasks()
+        .run(async move {
+            let written_entrypoint_with_issues_op =
+                get_written_endpoint_with_issues_operation(endpoint_op);
+            let read = read_strongly_consistent_and_apply_effects(
+                written_entrypoint_with_issues_op,
+                |v| &v.effects,
+            )
+            .await?;
+            let WrittenEndpointWithIssues {
+                written, issues, ..
+            } = &*read;
 
-                    Ok((written.clone(), issues.clone()))
-                })
-                .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
-                .await?;
-            Ok(TurbopackResult {
-                result: NapiWrittenEndpoint::from(written.map(ReadRef::into_owned)),
-                issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
-            })
-        }
-        .instrument(tracing::info_span!("write endpoint to disk")),
-    )
+            Ok((written.clone(), issues.clone()))
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+    Ok(TurbopackResult {
+        result: NapiWrittenEndpoint::from(written.map(ReadRef::into_owned)),
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+    })
 }
 
 #[tracing::instrument(level = "info", name = "get server-side endpoint changes", skip_all)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_server_changed_subscribe(
     env: Env,
-    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: ExternalRef<ExternalEndpoint>,
+    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,
     issues: bool,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: napi::bindgen_prelude::FunctionRef<
-        JsUnknown<'static>,
-        (),
-    >,
+    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<TurbopackResult<()>, ()>,
 ) -> napi::Result<External<RootTask>> {
     let turbopack_ctx = endpoint.turbopack_ctx().clone();
-    let endpoint = ***endpoint;
+    let endpoint = ****endpoint;
     subscribe(
         turbopack_ctx,
         &env,
@@ -276,14 +268,11 @@ async fn subscribe_issues_and_diags_operation(
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_client_changed_subscribe(
     env: Env,
-    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: ExternalRef<ExternalEndpoint>,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: napi::bindgen_prelude::FunctionRef<
-        JsUnknown<'static>,
-        (),
-    >,
+    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,
+    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<TurbopackResult<()>, ()>,
 ) -> napi::Result<External<RootTask>> {
     let turbopack_ctx = endpoint.turbopack_ctx().clone();
-    let endpoint_op = ***endpoint;
+    let endpoint_op = ****endpoint;
     subscribe(
         turbopack_ctx,
         &env,

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -12,8 +12,8 @@ use bincode::{Decode, Encode};
 use flate2::write::GzEncoder;
 use futures_util::TryFutureExt;
 use napi::{
-    Env, Status, Unknown as JsUnknown,
-    bindgen_prelude::{External, PromiseRaw, within_runtime_if_available},
+    Env, Status, Unknown,
+    bindgen_prelude::{External, FunctionRef, PromiseRaw, within_runtime_if_available},
     threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 use napi_derive::napi;
@@ -422,7 +422,7 @@ pub fn project_new<'env>(
     options: NapiProjectOptions,
     turbo_engine_options: NapiTurboEngineOptions,
     napi_callbacks: NapiNextTurbopackCallbacksJsObject,
-) -> napi::Result<napi::bindgen_prelude::PromiseRaw<'env, External<ProjectInstance>>> {
+) -> napi::Result<PromiseRaw<'env, External<ProjectInstance>>> {
     let napi_callbacks = NapiNextTurbopackCallbacks::from_js(env, napi_callbacks)?;
     let (exit, exit_receiver) = ExitHandler::new_receiver();
 
@@ -727,46 +727,38 @@ async fn benchmark_file_io(turbo_tasks: &NextTurboTasks, dir: &Path) -> Result<(
     Ok(())
 }
 
+#[tracing::instrument(level = "info", name = "update project", skip_all)]
 #[napi]
-pub fn project_update<'env>(
-    env: &'env Env,
+pub async fn project_update(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     options: NapiPartialProjectOptions,
-) -> napi::Result<PromiseRaw<'env, ()>> {
+) -> napi::Result<()> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
     let options = options.into();
-    env.spawn_future(
-        async move {
-            ctx.turbo_tasks()
-                .run(async move { container.update(options).await })
-                .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
-                .await
-        }
-        .instrument(tracing::info_span!("update project")),
-    )
+    ctx.turbo_tasks()
+        .run(async move { container.update(options).await })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
 }
 
 /// Invalidates the filesystem cache so that it will be deleted next time that a turbopack project
 /// is created with filesystem cache enabled.
 #[napi]
-pub fn project_invalidate_file_system_cache<'env>(
-    env: &'env Env,
+pub async fn project_invalidate_file_system_cache(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-) -> napi::Result<PromiseRaw<'env, ()>> {
+) -> napi::Result<()> {
     let ctx = project.turbopack_ctx.clone();
-    env.spawn_future(async move {
-        tokio::task::spawn_blocking(move || {
-            // TODO: Let the JS caller specify a reason? We need to limit the reasons to ones we
-            // know how to generate a message for on the Rust side of the FFI.
-            ctx.turbo_tasks()
-                .backend()
-                .invalidate_storage(invalidation_reasons::USER_REQUEST)
-        })
-        .await
-        .context("panicked while invalidating filesystem cache")??;
-        Ok::<_, napi::Error>(())
+    tokio::task::spawn_blocking(move || {
+        // TODO: Let the JS caller specify a reason? We need to limit the reasons to ones we
+        // know how to generate a message for on the Rust side of the FFI.
+        ctx.turbo_tasks()
+            .backend()
+            .invalidate_storage(invalidation_reasons::USER_REQUEST)
     })
+    .await
+    .context("panicked while invalidating filesystem cache")??;
+    Ok::<_, napi::Error>(())
 }
 
 /// Runs exit handlers for the project registered using the [`ExitHandler`] API.
@@ -774,15 +766,12 @@ pub fn project_invalidate_file_system_cache<'env>(
 /// This is called by `project_shutdown`, so if you're calling that API, you shouldn't call this
 /// one.
 #[napi]
-pub fn project_on_exit<'env>(
-    env: &'env Env,
+pub async fn project_on_exit(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-) -> napi::Result<PromiseRaw<'env, ()>> {
+) -> napi::Result<()> {
     let exit_receiver = project.exit_receiver.clone();
-    env.spawn_future(async move {
-        run_exit_handlers(exit_receiver).await;
-        Ok::<_, napi::Error>(())
-    })
+    run_exit_handlers(exit_receiver).await;
+    Ok::<_, napi::Error>(())
 }
 
 /// Takes the [`ExitReceiver`] out of the shared slot and runs the registered exit handlers.
@@ -806,21 +795,16 @@ async fn run_exit_handlers(exit_receiver: Arc<std::sync::Mutex<Option<ExitReceiv
 /// This is used in builds where it's important that we completely persist turbo-tasks to disk, but
 /// it's skipped in the development server (`project_on_exit` is used instead with a short timeout),
 /// where we prioritize fast exit and user responsiveness over all else.
+#[tracing::instrument(level = "info", name = "shutdown project", skip_all)]
 #[napi]
-pub fn project_shutdown<'env>(
-    env: &'env Env,
+pub async fn project_shutdown(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-) -> napi::Result<PromiseRaw<'env, ()>> {
+) -> napi::Result<()> {
     let tt = project.turbopack_ctx.turbo_tasks().clone();
     let exit_receiver = project.exit_receiver.clone();
-    env.spawn_future(
-        async move {
-            tt.stop_and_wait().await;
-            run_exit_handlers(exit_receiver).await;
-            Ok::<_, napi::Error>(())
-        }
-        .instrument(tracing::info_span!("shutdown project")),
-    )
+    tt.stop_and_wait().await;
+    run_exit_handlers(exit_receiver).await;
+    Ok::<_, napi::Error>(())
 }
 
 #[napi(object, object_from_js = false)]
@@ -1330,18 +1314,15 @@ async fn app_route_filter_for_write_phase(
     ))
 }
 
+#[tracing::instrument(level = "info", name = "write all entrypoints to disk", skip_all)]
 #[napi(ts_return_type = "Promise<TurbopackResult<Partial<NapiEntrypoints>>>")]
-pub fn project_write_all_entrypoints_to_disk<'env>(
-    env: &'env Env,
+pub async fn project_write_all_entrypoints_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     app_dir_only: bool,
-) -> napi::Result<PromiseRaw<'env, TurbopackResult<Option<NapiEntrypoints>>>> {
+) -> napi::Result<TurbopackResult<Option<NapiEntrypoints>>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(
-        async move { project_write_all_entrypoints_to_disk_inner(ctx, container, app_dir_only).await }
-            .instrument(tracing::info_span!("write all entrypoints to disk")),
-    )
+    project_write_all_entrypoints_to_disk_inner(ctx, container, app_dir_only).await
 }
 
 async fn project_write_all_entrypoints_to_disk_inner(
@@ -1729,49 +1710,41 @@ async fn output_assets_operation(
     ))
 }
 
+#[tracing::instrument(level = "info", name = "get entrypoints", skip_all)]
 #[napi(ts_return_type = "Promise<TurbopackResult<Partial<NapiEntrypoints>>>")]
-pub fn project_entrypoints<'env>(
-    env: &'env Env,
+pub async fn project_entrypoints(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-) -> napi::Result<PromiseRaw<'env, TurbopackResult<Option<NapiEntrypoints>>>> {
+) -> napi::Result<TurbopackResult<Option<NapiEntrypoints>>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(
-        async move {
-            let (entrypoints, issues) = ctx
-                .turbo_tasks()
-                .run_once(async move {
-                    let entrypoints_with_issues_op =
-                        get_entrypoints_with_issues_operation(container);
+    let (entrypoints, issues) = ctx
+        .turbo_tasks()
+        .run_once(async move {
+            let entrypoints_with_issues_op = get_entrypoints_with_issues_operation(container);
 
-                    // Read and compile the files
-                    let EntrypointsWithIssues {
-                        entrypoints,
-                        issues,
-                        effects: _,
-                    } = &*entrypoints_with_issues_op
-                        .read_strongly_consistent()
-                        .await?;
+            // Read and compile the files
+            let EntrypointsWithIssues {
+                entrypoints,
+                issues,
+                effects: _,
+            } = &*entrypoints_with_issues_op
+                .read_strongly_consistent()
+                .await?;
 
-                    Ok((entrypoints.clone(), issues.clone()))
-                })
-                .await
-                .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+            Ok((entrypoints.clone(), issues.clone()))
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
 
-            let result = match entrypoints {
-                Some(entrypoints) => {
-                    Some(NapiEntrypoints::from_entrypoints_op(&entrypoints, &ctx)?)
-                }
-                None => None,
-            };
+    let result = match entrypoints {
+        Some(entrypoints) => Some(NapiEntrypoints::from_entrypoints_op(&entrypoints, &ctx)?),
+        None => None,
+    };
 
-            Ok(TurbopackResult {
-                result,
-                issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
-            })
-        }
-        .instrument(tracing::info_span!("get entrypoints")),
-    )
+    Ok(TurbopackResult {
+        result,
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+    })
 }
 
 #[tracing::instrument(level = "info", name = "subscribe to entrypoints", skip_all)]
@@ -1779,8 +1752,8 @@ pub fn project_entrypoints<'env>(
 pub fn project_entrypoints_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: napi::bindgen_prelude::FunctionRef<
-        JsUnknown<'static>,
+    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<
+        TurbopackResult<Option<NapiEntrypoints>>,
         (),
     >,
 ) -> napi::Result<External<RootTask>> {
@@ -1883,8 +1856,8 @@ pub fn project_hmr_events(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     chunk_name: RcStr,
     target: String,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: napi::bindgen_prelude::FunctionRef<
-        JsUnknown<'static>,
+    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<
+        TurbopackResult<Unknown<'static>>,
         (),
     >,
 ) -> napi::Result<External<RootTask>> {
@@ -1977,7 +1950,7 @@ pub fn project_hmr_events(
 }
 
 #[napi(object, object_from_js = false)]
-struct HmrChunkNames {
+pub struct HmrChunkNames {
     pub chunk_names: Vec<RcStr>,
 }
 
@@ -2026,8 +1999,8 @@ pub fn project_hmr_chunk_names_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     target: String,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: napi::bindgen_prelude::FunctionRef<
-        JsUnknown<'static>,
+    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<
+        TurbopackResult<HmrChunkNames>,
         (),
     >,
 ) -> napi::Result<External<RootTask>> {
@@ -2129,10 +2102,7 @@ pub fn project_update_info_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     aggregation_ms: u32,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: napi::bindgen_prelude::FunctionRef<
-        JsUnknown<'static>,
-        (),
-    >,
+    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<Unknown<'static>, ()>,
 ) -> napi::Result<()> {
     let func: ThreadsafeFunction<UpdateMessage, (), NapiUpdateMessage, Status, true> = func
         .borrow_back(&env)?
@@ -2143,8 +2113,6 @@ pub fn project_update_info_subscribe(
             Ok(NapiUpdateMessage::from(message))
         })?;
     let tt = project.turbopack_ctx.turbo_tasks().clone();
-    // Unlike napi v2, v3 does not enter the tokio runtime context on the JS thread, so
-    // `tokio::spawn` from a sync `#[napi]` fn panics without this wrapper.
     within_runtime_if_available(|| {
         tokio::spawn(async move {
             loop {
@@ -2210,10 +2178,7 @@ impl From<Arc<dyn CompilationEvent>> for NapiCompilationEvent {
 pub fn project_compilation_events_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: napi::bindgen_prelude::FunctionRef<
-        JsUnknown<'static>,
-        (),
-    >,
+    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<Unknown<'static>, ()>,
     event_types: Option<Vec<String>>,
 ) -> napi::Result<()> {
     let tsfn: ThreadsafeFunction<
@@ -2229,8 +2194,6 @@ pub fn project_compilation_events_subscribe(
         .build_callback(|ctx| Ok(NapiCompilationEvent::from(ctx.value)))?;
 
     let tt = project.turbopack_ctx.turbo_tasks().clone();
-    // Unlike napi v2, v3 does not enter the tokio runtime context on the JS thread, so
-    // `tokio::spawn` from a sync `#[napi]` fn panics without this wrapper.
     within_runtime_if_available(|| {
         tokio::spawn(async move {
             let mut receiver = tt.subscribe_to_compilation_events(event_types);
@@ -2439,77 +2402,67 @@ pub async fn project_trace_source_operation(
     })))
 }
 
+#[tracing::instrument(level = "info", name = "apply SourceMap to stack frame", skip_all)]
 #[napi(ts_return_type = "Promise<StackFrame | null>")]
-pub fn project_trace_source<'env>(
-    env: &'env Env,
+pub async fn project_trace_source(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     frame: StackFrame,
     current_directory_file_url: String,
-) -> napi::Result<PromiseRaw<'env, Option<StackFrame>>> {
+) -> napi::Result<Option<StackFrame>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(
-        async move {
-            ctx.turbo_tasks()
-                .run(async move {
-                    let traced_frame = project_trace_source_operation(
-                        container,
-                        frame,
-                        RcStr::from(current_directory_file_url),
-                    )
-                    .read_strongly_consistent()
-                    .await?;
-                    Ok(ReadRef::into_owned(traced_frame))
-                })
-                // HACK: Don't use `TurbopackInternalError`, this function is race-condition prone
-                // (the source files may have changed or been deleted), so these probably aren't
-                // internal errors? Ideally we should differentiate.
-                .await
-                .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
-        }
-        .instrument(tracing::info_span!("apply SourceMap to stack frame")),
-    )
+    ctx.turbo_tasks()
+        .run(async move {
+            let traced_frame = project_trace_source_operation(
+                container,
+                frame,
+                RcStr::from(current_directory_file_url),
+            )
+            .read_strongly_consistent()
+            .await?;
+            Ok(ReadRef::into_owned(traced_frame))
+        })
+        // HACK: Don't use `TurbopackInternalError`, this function is race-condition prone
+        // (the source files may have changed or been deleted), so these probably aren't
+        // internal errors? Ideally we should differentiate.
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
+#[tracing::instrument(level = "info", name = "get source content for asset", skip_all)]
 #[napi(ts_return_type = "Promise<string | null>")]
-pub fn project_get_source_for_asset<'env>(
-    env: &'env Env,
+pub async fn project_get_source_for_asset(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     file_path: RcStr,
-) -> napi::Result<PromiseRaw<'env, Option<String>>> {
+) -> napi::Result<Option<String>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(
-        async move {
-            ctx.turbo_tasks()
-                .run(async move {
-                    #[turbo_tasks::function(operation, root)]
-                    async fn source_content_operation(
-                        container: ResolvedVc<ProjectContainer>,
-                        file_path: RcStr,
-                    ) -> Result<Vc<FileContent>> {
-                        let project_path = container.project().project_path().await?;
-                        Ok(project_path.fs().root().await?.join(&file_path)?.read())
-                    }
+    ctx.turbo_tasks()
+        .run(async move {
+            #[turbo_tasks::function(operation, root)]
+            async fn source_content_operation(
+                container: ResolvedVc<ProjectContainer>,
+                file_path: RcStr,
+            ) -> Result<Vc<FileContent>> {
+                let project_path = container.project().project_path().await?;
+                Ok(project_path.fs().root().await?.join(&file_path)?.read())
+            }
 
-                    let source_content = &*source_content_operation(container, file_path.clone())
-                        .read_strongly_consistent()
-                        .await?;
+            let source_content = &*source_content_operation(container, file_path.clone())
+                .read_strongly_consistent()
+                .await?;
 
-                    let FileContent::Content(source_content) = source_content else {
-                        bail!("Cannot find source for asset {}", file_path);
-                    };
+            let FileContent::Content(source_content) = source_content else {
+                bail!("Cannot find source for asset {}", file_path);
+            };
 
-                    Ok(Some(source_content.content().to_str()?.into_owned()))
-                })
-                // HACK: Don't use `TurbopackInternalError`, this function is race-condition prone
-                // (the source files may have changed or been deleted), so these probably aren't
-                // internal errors? Ideally we should differentiate.
-                .await
-                .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
-        }
-        .instrument(tracing::info_span!("get source content for asset")),
-    )
+            Ok(Some(source_content.content().to_str()?.into_owned()))
+        })
+        // HACK: Don't use `TurbopackInternalError`, this function is race-condition prone
+        // (the source files may have changed or been deleted), so these probably aren't
+        // internal errors? Ideally we should differentiate.
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
 async fn project_get_source_map_inner(
@@ -2534,18 +2487,15 @@ async fn project_get_source_map_inner(
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
+#[tracing::instrument(level = "info", name = "get SourceMap for asset", skip_all)]
 #[napi(ts_return_type = "Promise<string | null>")]
-pub fn project_get_source_map<'env>(
-    env: &'env Env,
+pub async fn project_get_source_map(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     file_path: RcStr,
-) -> napi::Result<PromiseRaw<'env, Option<String>>> {
+) -> napi::Result<Option<String>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(
-        async move { project_get_source_map_inner(ctx, container, file_path).await }
-            .instrument(tracing::info_span!("get SourceMap for asset")),
-    )
+    project_get_source_map_inner(ctx, container, file_path).await
 }
 
 #[napi]
@@ -2562,33 +2512,28 @@ pub fn project_get_source_map_sync(
 }
 
 #[napi]
-pub fn project_write_analyze_data<'env>(
-    env: &'env Env,
+pub async fn project_write_analyze_data(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     app_dir_only: bool,
-) -> napi::Result<PromiseRaw<'env, TurbopackResult<()>>> {
+) -> napi::Result<TurbopackResult<()>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(async move {
-        let issues = ctx
-            .turbo_tasks()
-            .run_once(async move {
-                let analyze_data_op =
-                    write_analyze_data_with_issues_operation(container, app_dir_only);
-                // Write the files to disk
-                let read =
-                    read_strongly_consistent_and_apply_effects(analyze_data_op, |v| &v.effects)
-                        .await?;
-                let WriteAnalyzeResult { issues, .. } = &*read;
-                Ok(issues.clone())
-            })
-            .await
-            .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
-
-        Ok(TurbopackResult {
-            result: (),
-            issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+    let issues = ctx
+        .turbo_tasks()
+        .run_once(async move {
+            let analyze_data_op = write_analyze_data_with_issues_operation(container, app_dir_only);
+            // Write the files to disk
+            let read =
+                read_strongly_consistent_and_apply_effects(analyze_data_op, |v| &v.effects).await?;
+            let WriteAnalyzeResult { issues, .. } = &*read;
+            Ok(issues.clone())
         })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+
+    Ok(TurbopackResult {
+        result: (),
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
     })
 }
 
@@ -2625,68 +2570,57 @@ async fn get_all_compilation_issues_operation(
 /// Intended to be called once at the end of a build, after `writeAllEntrypointsToDisk`. The
 /// summary is computed by walking the whole-app module graph and is cached by turbo-tasks, so the
 /// call is cheap when the graph is already materialized.
+#[tracing::instrument(level = "info", name = "get project feature usage", skip_all)]
 #[napi]
-pub fn project_feature_usage<'env>(
-    env: &'env Env,
+pub async fn project_feature_usage(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-) -> napi::Result<PromiseRaw<'env, Vec<NapiUsedFeature>>> {
+) -> napi::Result<Vec<NapiUsedFeature>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(
-        async move {
-            let summary = ctx
-                .turbo_tasks()
-                .run_once(async move {
-                    #[turbo_tasks::function(operation, root)]
-                    async fn project_feature_usage_operation(
-                        container: ResolvedVc<ProjectContainer>,
-                    ) -> Result<Vc<ProjectFeatureUsageSummary>> {
-                        Ok(container.project().project_feature_usage())
-                    }
-                    project_feature_usage_operation(container)
-                        .read_strongly_consistent()
-                        .await
-                })
+    let summary = ctx
+        .turbo_tasks()
+        .run_once(async move {
+            #[turbo_tasks::function(operation, root)]
+            async fn project_feature_usage_operation(
+                container: ResolvedVc<ProjectContainer>,
+            ) -> Result<Vc<ProjectFeatureUsageSummary>> {
+                Ok(container.project().project_feature_usage())
+            }
+            project_feature_usage_operation(container)
+                .read_strongly_consistent()
                 .await
-                .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
 
-            Ok(summary
-                .features
-                .iter()
-                .map(|(name, count)| NapiUsedFeature::new(name.clone(), *count))
-                .collect())
-        }
-        .instrument(tracing::info_span!("get project feature usage")),
-    )
+    Ok(summary
+        .features
+        .iter()
+        .map(|(name, count)| NapiUsedFeature::new(name.clone(), *count))
+        .collect())
 }
 
+#[tracing::instrument(level = "info", name = "get all compilation issues", skip_all)]
 #[napi]
-pub fn project_get_all_compilation_issues<'env>(
-    env: &'env Env,
+pub async fn project_get_all_compilation_issues(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-) -> napi::Result<PromiseRaw<'env, TurbopackResult<()>>> {
+) -> napi::Result<TurbopackResult<()>> {
     let ctx = project.turbopack_ctx.clone();
     let container = project.container;
-    env.spawn_future(
-        async move {
-            let issues = ctx
-                .turbo_tasks()
-                .run_once(async move {
-                    let op = get_all_compilation_issues_operation(container);
-                    let OperationResult { issues, effects: _ } =
-                        &*op.read_strongly_consistent().await?;
-                    Ok(issues.clone())
-                })
-                .await
-                .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+    let issues = ctx
+        .turbo_tasks()
+        .run_once(async move {
+            let op = get_all_compilation_issues_operation(container);
+            let OperationResult { issues, effects: _ } = &*op.read_strongly_consistent().await?;
+            Ok(issues.clone())
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
 
-            Ok(TurbopackResult {
-                result: (),
-                issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
-            })
-        }
-        .instrument(tracing::info_span!("get all compilation issues")),
-    )
+    Ok(TurbopackResult {
+        result: (),
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+    })
 }
 
 /// Opens the Turbopack persistent cache database at the given path and performs a full compaction.

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::Result;
 use napi::{
-    Env, Status, Unknown as JsUnknown,
+    Env, Status, Unknown,
     bindgen_prelude::{FunctionRef, Promise},
     threadsafe_function::ThreadsafeFunction,
 };
@@ -151,7 +151,7 @@ pub struct NapiNextTurbopackCallbacksJsObject {
     /// there's a runtime conversion error. This should never happen, but if it does, the function
     /// can throw it instead.
     #[napi(ts_type = "(conversionError: Error | null, opts: TurbopackInternalErrorOpts) => never")]
-    pub throw_turbopack_internal_error: FunctionRef<JsUnknown<'static>, ()>,
+    pub throw_turbopack_internal_error: FunctionRef<Unknown<'static>, ()>,
 
     /// Called before deferred entries are processed in a production build.
     #[napi(ts_type = "() => Promise<void>")]

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use futures_util::TryFutureExt;
 use napi::{
-    Env, Status, Unknown as JsUnknown,
+    Env, Status, Unknown,
     bindgen_prelude::{
         Buffer, External, ExternalRef, Function, FunctionRef, JsObjectValue, JsValue, Object,
         ToNapiValue,
@@ -412,7 +412,7 @@ impl<T: ToNapiValue> ToNapiValue for TurbopackResult<T> {
         let env_wrapper = Env::from_raw(env);
 
         let result_raw = unsafe { T::to_napi_value(env, val.result)? };
-        let result = unsafe { JsUnknown::from_raw_unchecked(env, result_raw) };
+        let result = unsafe { Unknown::from_raw_unchecked(env, result_raw) };
 
         // When the result is an object, extend it in place with the `issues`
         // property. Otherwise, produce a fresh object holding only `issues`.
@@ -435,11 +435,11 @@ pub fn subscribe<
 >(
     ctx: NextTurbopackContext,
     env: &Env,
-    func: &FunctionRef<JsUnknown<'static>, ()>,
+    func: &FunctionRef<V, ()>,
     handler: impl 'static + Sync + Send + Clone + Fn() -> F,
     mapper: impl 'static + Sync + Send + FnMut(ThreadsafeCallContext<T>) -> napi::Result<V>,
 ) -> napi::Result<External<RootTask>> {
-    let js_func: Function<'_, JsUnknown<'static>, ()> = func.borrow_back(env)?;
+    let js_func: Function<'_, V, ()> = func.borrow_back(env)?;
     let func: ThreadsafeFunction<T, (), V, Status, true> = js_func
         .build_threadsafe_function::<T>()
         .callee_handled::<true>()

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -5,8 +5,7 @@ import type { TurbopackResult } from './types'
 export type TurboTasks = { readonly __tag: unique symbol }
 export type ExternalEndpoint = { readonly __tag: unique symbol }
 export type NextTurboTasks = { readonly __tag: unique symbol }
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type RefCell<T = unknown> = { readonly __tag: unique symbol }
+export type RefCell<_T = unknown> = { readonly __tag: unique symbol }
 export type FlushGuard = { readonly __tag: unique symbol }
 export type NapiRouteHas = {
   type: string


### PR DESCRIPTION
Stacked on #95412 to address @bgw's review feedback. Each commit maps to a review comment (grouped per file where changes were interleaved).

- **RefCell type** — keep `RefCell` (it's used by `initCustomTraceSubscriber`/`teardownTraceSubscriber`); the only lint issue was its unused phantom type param, now marked `_T` instead of an `eslint-disable`.
- **`napi::Unknown`** — dropped the `Unknown as JsUnknown` alias everywhere; use the plain re-exported `napi::Unknown` (incl. importing it in the lightningcss bindings).
- **Revert `spawn_future`** — `External<T>` is `Send` (only `ExternalRef<T>` is `!Send`), so the 13 affected endpoint/project entrypoints go back to plain `async fn` taking `&External<T>`; no `env.spawn_future`, no unsafe `SendableExternalRef`, less nesting. Restored `#[tracing::instrument]` attributes.
- **`ExternalRef` → `&External`** on the endpoint subscribe entrypoints.
- **`FunctionRef`** imported instead of the fully-qualified path.
- **`subscribe()` generic** — threads the concrete napi value type `V` through instead of erasing callbacks to `Unknown`; callsites updated to concrete result types.
- **`PromiseRaw`** — use the already-imported type in `project_new`.
- **Deleted migration meta-comments.**

Not included: the `@napi-rs/cli` version pinning question (left as-is pending the Slack discussion). The TS callback `any` types are also left for now — typing them precisely risks the generated `.d.ts` check.