### PR TITLE
Fix OpenTelemetry API singleton in server bundles

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
@@ -31,6 +31,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@mikro-orm/knex`
 - `@node-rs/argon2`
 - `@node-rs/bcrypt`
+- `@opentelemetry/api`
 - `@prisma/client`
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
@@ -31,6 +31,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@mikro-orm/knex`
 - `@node-rs/argon2`
 - `@node-rs/bcrypt`
+- `@opentelemetry/api`
 - `@prisma/client`
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`

--- a/packages/next/src/lib/server-external-packages.jsonc
+++ b/packages/next/src/lib/server-external-packages.jsonc
@@ -13,6 +13,7 @@
   "@mikro-orm/knex",
   "@node-rs/argon2",
   "@node-rs/bcrypt",
+  "@opentelemetry/api",
   "@prisma/client",
   "@react-pdf/renderer",
   // Native Node.js addons

--- a/test/e2e/opentelemetry/instrumentation/app/api/app/[param]/module-scope-tracer/route.ts
+++ b/test/e2e/opentelemetry/instrumentation/app/api/app/[param]/module-scope-tracer/route.ts
@@ -1,0 +1,21 @@
+import { trace } from '@opentelemetry/api'
+
+const tracer = trace.getTracer('module-scope-tracer-route')
+
+export async function GET() {
+  const externalTraceApi = (
+    globalThis as typeof globalThis & { __nextTestTraceApi?: typeof trace }
+  ).__nextTestTraceApi
+  if (externalTraceApi !== trace) {
+    return new Response('route bundled a private OpenTelemetry API instance', {
+      status: 500,
+    })
+  }
+
+  return tracer.startActiveSpan('module-scope-tracer', (span) => {
+    span.end()
+    return new Response('ok')
+  })
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
+++ b/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
@@ -8,9 +8,9 @@ import { register } from './instrumentation-custom-server'
 
 const withoutParentSpan = process.argv.includes('--without-parent-span')
 
-if (!withoutParentSpan) {
-  register()
-}
+;(globalThis as typeof globalThis & { __nextTestTraceApi?: typeof trace })[
+  '__nextTestTraceApi'
+] = trace
 
 type EntrypointHandler = (
   req: IncomingMessage,
@@ -36,11 +36,22 @@ function loadEntrypointHandler<T>(handler: string): T {
   return mod.handler
 }
 
+require('next/dist/server/node-environment')
+
+// Load one route before registration to cover modules that acquire a tracer at
+// module scope. The tracer must become live when the provider is registered.
+const preloadedModuleScopeTracerHandler =
+  loadEntrypointHandler<EntrypointHandler>(
+    'app/api/app/[param]/module-scope-tracer/route.js'
+  )
+
+if (!withoutParentSpan) {
+  register()
+}
+
 async function main() {
   const port = await getPort()
   const hostname = 'localhost'
-
-  require('next/dist/server/node-environment')
 
   const handlers: [RegExp, string][] = [
     [/^\/api\/app\/param\/data$/, 'app/api/app/[param]/data/route.js'],
@@ -99,7 +110,10 @@ async function main() {
   createServer((req, res) => {
     const method = req.method || 'GET'
     const pathname = parse(req.url || '/', false).pathname || '/'
-    const handler = resolveHandler<EntrypointHandler>(handlers, pathname)
+    const handler =
+      pathname === '/api/app/param/module-scope-tracer'
+        ? preloadedModuleScopeTracerHandler
+        : resolveHandler<EntrypointHandler>(handlers, pathname)
     const middlewareHandler = resolveHandler<MiddlewareHandler>(
       middlewareHandlers,
       pathname

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1919,6 +1919,19 @@ if (isNextStart) {
       await collector.shutdown()
     })
 
+    it('records spans from a tracer acquired before instrumentation registration', async () => {
+      const response = await next.fetch('/api/app/param/module-scope-tracer')
+      expect(response.status).toBe(200)
+
+      await retry(async () => {
+        expect(
+          collector
+            .getSpans()
+            .some((span) => span.name === 'module-scope-tracer')
+        ).toBe(true)
+      })
+    })
+
     const directEntrypointCases = [
       { pathname: '/app/param/rsc-fetch', route: '/app/[param]/rsc-fetch' },
       { pathname: '/api/app/param/data', route: '/api/app/[param]/data' },


### PR DESCRIPTION
## Summary

- Externalize `@opentelemetry/api` from server bundles so route code and instrumentation use the same process-wide singleton.
- Add production direct-entrypoint coverage for a tracer acquired at module scope before instrumentation registration.
- Sync the documented default `serverExternalPackages` list.

## Problem

A production route can acquire its tracer when the route module is evaluated:

```ts
// route.ts — evaluated first
import { trace } from '@opentelemetry/api'

const tracer = trace.getTracer('route')
```

Instrumentation registers the provider later:

```ts
// instrumentation.ts
import { trace } from '@opentelemetry/api'

trace.setGlobalTracerProvider(provider)
```

This ordering is supported by OpenTelemetry's proxy API. It broke when the route bundle contained API copy A while instrumentation loaded API copy B: registering the provider on B never activated the tracer from A, so custom spans stayed no-op.

Externalizing `@opentelemetry/api` makes both imports resolve to the same singleton, allowing an early tracer to delegate to the provider after registration.

## Reproduction

The E2E fixture reproduces the production sequence: preload the generated route, acquire its module-scope tracer, register OpenTelemetry, then invoke the route.

```bash
pnpm test-start-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts \
  -t "records spans from a tracer acquired before instrumentation registration"
```

- Without the new external-package entry: the route and loader receive different API objects, the request returns 500, and no custom span is exported.
- With the entry: the API objects match, the request returns 200, and the collector receives `module-scope-tracer`.

## Observed versions

| Next.js | Production observation |
| --- | --- |
| `16.1.6` | Known good: 223 sampled application turn spans alongside 3,979 AI SDK spans |
| `16.2.10` | Affected: 0 application turn spans while 342 AI SDK spans confirmed traffic and OTel ingestion continued |

These sampled counts establish presence versus absence, not exact traffic volume. The application upgrade also changed its instrumentation integration, so the production comparison identifies the observed boundary but does not isolate Next.js by itself; the E2E negative control above isolates the server bundling behavior.

Target: canary, with a backport to the maintained `16.2.x` line.

## Testing

- Production Turbopack direct-entrypoint OpenTelemetry tests: 9 passed
- `pnpm --filter=next types`
- `pnpm validate-externals-doc`

<!-- NEXT_JS_LLM -->
