### PR TITLE
fix(turbopack): correct tree-shaking for re-exports (fixes #95698)

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -156,6 +156,7 @@ pub async fn compute_binding_usage_info(
                     return Ok(GraphTraversalAction::Continue);
                 };
 
+                let mut propagated_export_usage = ref_data.binding_usage.export.clone();
                 if remove_unused_imports {
                     // If this is an evaluation reference and the target has no side effects
                     // then we can drop it. NOTE: many `imports` create parallel Evaluation
@@ -220,12 +221,56 @@ pub async fn compute_binding_usage_info(
                             unused_references.remove(&ref_data.reference);
                             // Continue, has to always be included
                         }
+                        ImportUsage::StarReexport => {
+                            let source_used_exports = used_exports
+                                .get(&parent)
+                                .context("parent module must have usage info")?;
+                            match source_used_exports {
+                                ModuleExportUsageInfo::Evaluation => {
+                                    // parent has no exports used, skip
+                                    #[cfg(debug_assertions)]
+                                    debug_unused_references_name.insert((
+                                        parent,
+                                        ref_data.binding_usage.export.clone(),
+                                        target,
+                                    ));
+                                    unused_references_edges.insert(edge);
+                                    unused_references.insert(ref_data.reference);
+
+                                    return Ok(GraphTraversalAction::Skip);
+                                }
+                                ModuleExportUsageInfo::Exports(exports) => {
+                                    // Propagate the specific exports used by the parent
+                                    propagated_export_usage = ExportUsage::PartialNamespaceObject(
+                                        exports.iter().cloned().collect(),
+                                    );
+                                    #[cfg(debug_assertions)]
+                                    debug_unused_references_name.remove(&(
+                                        parent,
+                                        ref_data.binding_usage.export.clone(),
+                                        target,
+                                    ));
+                                    unused_references_edges.remove(&edge);
+                                    unused_references.remove(&ref_data.reference);
+                                }
+                                ModuleExportUsageInfo::All => {
+                                    #[cfg(debug_assertions)]
+                                    debug_unused_references_name.remove(&(
+                                        parent,
+                                        ref_data.binding_usage.export.clone(),
+                                        target,
+                                    ));
+                                    unused_references_edges.remove(&edge);
+                                    unused_references.remove(&ref_data.reference);
+                                }
+                            }
+                        }
                     }
                 }
 
                 let entry = used_exports.entry(target);
                 let is_first_visit = matches!(entry, Entry::Vacant(_));
-                if entry.or_default().add(&ref_data.binding_usage.export) || is_first_visit {
+                if entry.or_default().add(&propagated_export_usage) || is_first_visit {
                     // First visit, or the used exports changed. This can cause more imports to get
                     // used downstream.
                     Ok(GraphTraversalAction::Continue)

--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::Entry;
+use std::{borrow::Cow, collections::hash_map::Entry};
 
 use anyhow::{Context, Result, bail};
 use auto_hash_map::AutoSet;
@@ -16,6 +16,10 @@ use crate::{
     },
     resolve::{ExportUsage, ImportUsage},
 };
+
+/// Static constant for `ExportUsage::Evaluation`, used to borrow via `Cow` in the traversal
+/// without allocating.
+const EVALUATION_USAGE: ExportUsage = ExportUsage::Evaluation;
 
 #[turbo_tasks::value(transparent, cell = "keyed")]
 pub struct UsedExportsMap(FxHashMap<ResolvedVc<Box<dyn Module>>, ModuleExportUsageInfo>);
@@ -156,7 +160,7 @@ pub async fn compute_binding_usage_info(
                     return Ok(GraphTraversalAction::Continue);
                 };
 
-                let mut propagated_export_usage = ref_data.binding_usage.export.clone();
+                let mut propagated_export_usage = Cow::Borrowed(&ref_data.binding_usage.export);
                 if remove_unused_imports {
                     // If this is an evaluation reference and the target has no side effects
                     // then we can drop it. NOTE: many `imports` create parallel Evaluation
@@ -227,23 +231,52 @@ pub async fn compute_binding_usage_info(
                                 .context("parent module must have usage info")?;
                             match source_used_exports {
                                 ModuleExportUsageInfo::Evaluation => {
-                                    // parent has no exports used, skip
-                                    #[cfg(debug_assertions)]
-                                    debug_unused_references_name.insert((
-                                        parent,
-                                        ref_data.binding_usage.export.clone(),
-                                        target,
-                                    ));
-                                    unused_references_edges.insert(edge);
-                                    unused_references.insert(ref_data.reference);
+                                    // Parent has no exports used. No export names need to
+                                    // be forwarded, but `export * from '...'` still causes
+                                    // the target to be evaluated at runtime. Only skip the
+                                    // edge if the target is side-effect-free; otherwise we
+                                    // must keep it so the target's side effects are preserved.
+                                    if side_effect_free_modules
+                                        .as_ref()
+                                        .expect(
+                                            "this must be present if `remove_unused_imports` is \
+                                             true",
+                                        )
+                                        .contains(&target)
+                                    {
+                                        #[cfg(debug_assertions)]
+                                        debug_unused_references_name.insert((
+                                            parent,
+                                            ref_data.binding_usage.export.clone(),
+                                            target,
+                                        ));
+                                        unused_references_edges.insert(edge);
+                                        unused_references.insert(ref_data.reference);
 
-                                    return Ok(GraphTraversalAction::Skip);
+                                        return Ok(GraphTraversalAction::Skip);
+                                    }
+                                    // Target has side effects, keep the edge but propagate
+                                    // only evaluation usage (no export names needed).
+                                    propagated_export_usage = Cow::Borrowed(&EVALUATION_USAGE);
                                 }
                                 ModuleExportUsageInfo::Exports(exports) => {
-                                    // Propagate the specific exports used by the parent
-                                    propagated_export_usage = ExportUsage::PartialNamespaceObject(
-                                        exports.iter().cloned().collect(),
-                                    );
+                                    // Propagate the specific exports used by the parent.
+                                    //
+                                    // TODO: This over-approximates by propagating *all* of the
+                                    // parent's used exports to the target, including exports that
+                                    // are locally defined in the parent and not actually forwarded
+                                    // by this `export * from '...'`. Ideally we would intersect
+                                    // with the set of export names the target module actually
+                                    // provides, but that information is behind async Vc calls
+                                    // (EcmascriptChunkPlaceable::get_exports), may require
+                                    // recursive star-export expansion, and lives in the
+                                    // turbopack-ecmascript crate (cross-crate boundary). The
+                                    // over-approximation is sound (conservative) but can keep
+                                    // star re-export edges alive unnecessarily.
+                                    propagated_export_usage =
+                                        Cow::Owned(ExportUsage::PartialNamespaceObject(
+                                            exports.iter().cloned().collect(),
+                                        ));
                                     #[cfg(debug_assertions)]
                                     debug_unused_references_name.remove(&(
                                         parent,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -162,6 +162,11 @@ pub enum ImportUsage {
     /// (This is only ever set on `ModulePart::Export` references. Side effects are handled via
     /// `ModulePart::Evaluation` references, which always have `ImportUsage::TopLevel`.)
     Exports(FrozenSet<RcStr>),
+    /// This import is a star re-export (`export * from '...'`). It contributes to a dynamic set
+    /// of the parent module's exports. During binding-usage analysis, instead of propagating
+    /// `ExportUsage::All` to the target, only the parent's actually-used exports are propagated.
+    /// If the parent has no used exports (only evaluation), the reference can be skipped.
+    StarReexport,
 }
 
 /// Defines what parts of a module are used by another module

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -165,7 +165,9 @@ pub enum ImportUsage {
     /// This import is a star re-export (`export * from '...'`). It contributes to a dynamic set
     /// of the parent module's exports. During binding-usage analysis, instead of propagating
     /// `ExportUsage::All` to the target, only the parent's actually-used exports are propagated.
-    /// If the parent has no used exports (only evaluation), the reference can be skipped.
+    /// If the parent has no used exports (only evaluation), the reference can be skipped only
+    /// when the target is side-effect-free; otherwise an `Evaluation` usage must still be
+    /// propagated to preserve the target's side effects.
     StarReexport,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -765,7 +765,47 @@ impl ImportMap {
 
         m.visit_with(&mut analyzer);
 
-        data.import_usage = analyzer.program_decl_usage.compute_import_usage();
+        let mut import_usage = analyzer.program_decl_usage.compute_import_usage();
+
+        let mut extra_import_usages: rustc_hash::FxHashMap<
+            usize,
+            rustc_hash::FxHashSet<turbo_rcstr::RcStr>,
+        > = rustc_hash::FxHashMap::default();
+        for (export_name, export) in &data.exports {
+            match export {
+                Export::ImportedBinding(i, _, _) | Export::ImportedNamespace(i) => {
+                    extra_import_usages
+                        .entry(*i)
+                        .or_default()
+                        .insert(export_name.clone());
+                }
+                _ => {}
+            }
+        }
+
+        for (i, extra_exports) in extra_import_usages {
+            import_usage
+                .entry(i)
+                .and_modify(|usage| {
+                    if let turbopack_core::resolve::ImportUsage::Exports(exports) = usage {
+                        let mut new_exports = exports
+                            .iter()
+                            .cloned()
+                            .collect::<rustc_hash::FxHashSet<_>>();
+                        new_exports.extend(extra_exports.clone());
+                        *usage = turbopack_core::resolve::ImportUsage::Exports(
+                            new_exports.into_iter().collect(),
+                        );
+                    }
+                })
+                .or_insert_with(|| {
+                    turbopack_core::resolve::ImportUsage::Exports(
+                        extra_exports.into_iter().collect(),
+                    )
+                });
+        }
+
+        data.import_usage = import_usage;
 
         data
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/exports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/exports.rs
@@ -85,6 +85,9 @@ pub async fn compute_ecmascript_module_exports(
     let span = tracing::trace_span!("esm import references");
     let import_references = async {
         let mut import_references = Vec::with_capacity(eval_context.imports.references().len());
+        let reexport_namespace_idxs: rustc_hash::FxHashSet<usize> =
+            eval_context.imports.reexport_namespaces().collect();
+
         for (i, r) in eval_context.imports.references().enumerate() {
             let mut should_add_evaluation = false;
 
@@ -95,6 +98,17 @@ pub async fn compute_ecmascript_module_exports(
                 Some(*a)
             } else {
                 None
+            };
+
+            let import_usage = if reexport_namespace_idxs.contains(&i) {
+                turbopack_core::resolve::ImportUsage::StarReexport
+            } else {
+                eval_context
+                    .imports
+                    .import_usage
+                    .get(&i)
+                    .cloned()
+                    .unwrap_or_default()
             };
 
             let reference = EsmAssetReference::new(
@@ -132,12 +146,7 @@ pub async fn compute_ecmascript_module_exports(
                     )
                     .then(ModulePart::exports),
                 },
-                eval_context
-                    .imports
-                    .import_usage
-                    .get(&i)
-                    .cloned()
-                    .unwrap_or_default(),
+                import_usage,
                 import_externals,
                 options.tree_shaking_mode,
                 resolve_override,


### PR DESCRIPTION
Closes #95698

This PR resolves an issue where Turbopack failed to properly tree-shake libraries that heavily rely on star re-exports and named re-exports (such as `viem` and `wagmi`), resulting in severe bundle bloat (e.g., bundling all 712 chains instead of just the 1 used chain).

### Root Cause
There were two main issues in how Turbopack assigned `ImportUsage` for re-exports during binding-usage analysis:
1. **Star re-exports** (`export * from '...'`) were defaulting to `ImportUsage::TopLevel`, which tells the optimizer that the target module must be unconditionally evaluated, effectively opting the whole branch out of tree-shaking.
2. **Named re-exports** (`export { named } from './module.js'`) were being modeled exclusively as export bindings rather than local declarations. Because `ProgramDeclUsage` only tracks local identifier bindings, these re-exports lacked `ImportUsage` metadata entirely and consequently fell back to `ImportUsage::TopLevel` as well.

### Changes Made
- **`turbopack_core`**: Added a new `ImportUsage::StarReexport` variant.
- **`binding_usage_info.rs`**: Added logic to handle `ImportUsage::StarReexport` during graph traversal. It now correctly propagates only the specifically-used exports (via `ExportUsage::PartialNamespaceObject`) to the target module, or skips the edge entirely if the parent has no used exports.
- **`references/exports.rs`**: Updated reference generation to identify star re-export namespaces and assign them `ImportUsage::StarReexport`.
- **`analyzer/imports.rs`**: Modified the import analyzer to explicitly collect `Export::ImportedBinding` and `Export::ImportedNamespace` names and map them as `ImportUsage::Exports` for their respective import references.

### Testing
- Validated via `cargo test -p turbopack-tests -- tree-shaking` (all 30 execution and snapshot tree-shaking tests pass successfully).
- Verified `next-swc` native build integrity.