### PR TITLE
fix(eslint): respect pageExtensions in no-html-link-for-pages

### DIFF
--- a/docs/01-app/03-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/03-api-reference/05-config/03-eslint.mdx
@@ -154,6 +154,33 @@ export default eslintConfig
 
 `rootDir` can be a path (relative or absolute), a glob (i.e. `"packages/*/"`), or an array of paths and/or globs.
 
+### Using custom page extensions
+
+If you've configured a custom [`pageExtensions`](/docs/pages/api-reference/config/next-config-js/pageExtensions) in `next.config.js` (for example to use the `.page.tsx` convention or MDX pages), tell `@next/eslint-plugin-next` about it through the same `settings` property so rules such as `no-html-link-for-pages` can locate your pages:
+
+```js filename="eslint.config.mjs"
+import { defineConfig } from 'eslint/config'
+import eslintNextPlugin from '@next/eslint-plugin-next'
+
+const eslintConfig = defineConfig([
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    plugins: {
+      next: eslintNextPlugin,
+    },
+    settings: {
+      next: {
+        pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+      },
+    },
+  },
+])
+
+export default eslintConfig
+```
+
+`pageExtensions` should match the value in your `next.config.js`. When it's not set, it defaults to `['tsx', 'ts', 'jsx', 'js']`.
+
 ### Disabling rules
 
 If you would like to modify or disable any rules provided by the supported plugins (`react`, `react-hooks`, `next`), you can directly change them using the `rules` property in your `eslint.config.mjs`:

--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -8,6 +8,7 @@ import {
   normalizeURL,
   execOnce,
   getUrlFromAppDirectory,
+  DEFAULT_PAGE_EXTENSIONS,
 } from '../utils/url'
 
 const pagesDirWarning = execOnce((pagesDirs) => {
@@ -74,6 +75,14 @@ export default defineRule({
 
     const rootDirs = getRootDirs(context)
 
+    const nextSettings: { pageExtensions?: string[] } =
+      context.settings.next || {}
+    const pageExtensions =
+      Array.isArray(nextSettings.pageExtensions) &&
+      nextSettings.pageExtensions.length > 0
+        ? nextSettings.pageExtensions
+        : DEFAULT_PAGE_EXTENSIONS
+
     const pagesDirs = (
       customPagesDirectory
         ? [customPagesDirectory]
@@ -107,8 +116,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,59 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+// Matches the default `pageExtensions` used by Next.js when no custom value is
+// configured. Kept in sync with the default in `config-shared.ts`.
+export const DEFAULT_PAGE_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js']
+
+/**
+ * Escapes a string for safe use inside a RegExp.
+ */
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Builds a RegExp that matches a page file extension (e.g. `.tsx`, `.mdx`),
+ * derived from the project's `pageExtensions`. The leading portion is captured
+ * so it can be stripped from a filename to produce a URL segment.
+ */
+function getExtensionRegExp(pageExtensions: string[]) {
+  const alternation = pageExtensions
+    .map((ext) => escapeRegExp(ext.replace(/^\./, '')))
+    .join('|')
+  return new RegExp(`(\\.(?:${alternation}))$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extensionRegex = getExtensionRegExp(pageExtensions)
+  const indexRegex = new RegExp(`^index${extensionRegex.source}`)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extensionRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +67,35 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extensionRegex = getExtensionRegExp(pageExtensions)
+  const pageRegex = new RegExp(`^page${extensionRegex.source}`)
+  const layoutRegex = new RegExp(`^layout${extensionRegex.source}`)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extensionRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +178,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +201,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,7 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withPageExtensionsDir = path.join(__dirname, 'with-page-extensions-dir')
 
 const linters = {
   withoutPages: new Linter({
@@ -26,6 +27,10 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withPageExtensions: new Linter({
+    cwd: withPageExtensionsDir,
     configType: 'eslintrc',
   }),
 }
@@ -69,6 +74,15 @@ const linterConfigWithNestedContentRootDirDirectory = {
   settings: {
     next: {
       rootDir: path.join(withNestedPagesDir, 'demos/with-nextjs'),
+    },
+  },
+}
+
+const linterConfigWithPageExtensions = {
+  ...linterConfig,
+  settings: {
+    next: {
+      pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
     },
   },
 }
@@ -494,5 +508,57 @@ describe('no-html-link-for-pages', function () {
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
+  })
+  it('invalid static route with custom pageExtensions', function () {
+    const [report] = linters.withPageExtensions.verify(
+      invalidStaticCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid route with custom pageExtensions', function () {
+    const invalidAboutCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/about'>About</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+    const [report] = linters.withPageExtensions.verify(
+      invalidAboutCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/about/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('does not detect pages with custom extensions when pageExtensions is not configured', function () {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
+    const report = linters.withPageExtensions.verify(
+      invalidStaticCode,
+      linterConfig,
+      {
+        filename: 'foo.js',
+      }
+    )
+    // Without the `pageExtensions` setting the `.page.tsx` files are invisible
+    // to the rule, so nothing is reported and the default behavior is unchanged.
+    assert.deepEqual(report, [])
+    consoleSpy.mockRestore()
   })
 })

--- a/test/unit/eslint-plugin-next/with-page-extensions-dir/pages/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions-dir/pages/about.page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return null
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions-dir/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions-dir/pages/index.page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return null
+}


### PR DESCRIPTION
### What?

The `no-html-link-for-pages` rule now looks at the project's `pageExtensions` when it scans the `pages`/`app` directories, instead of assuming files always end in `.js`, `.jsx`, `.ts`, or `.tsx`.

You can set it through the same `settings.next` object that already handles `rootDir`:

```js
// eslint.config.mjs
settings: {
  next: {
    pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
  },
}
```

If the setting isn't provided, it defaults to `['tsx', 'ts', 'jsx', 'js']`, so nothing changes for projects that don't use a custom `pageExtensions`.

### Why?

If you configure a custom `pageExtensions` in `next.config.js` (a common one is the `.page.tsx` convention, or `.mdx` pages), the rule never found those files. The extension list was hardcoded as a regex (`/(\.(j|t)sx?)$/`) in `packages/eslint-plugin-next/src/utils/url.ts`, with two `TODO` comments already pointing this out. A link like `<a href="/about">` to an `about.page.tsx` page was silently ignored, so the rule effectively did nothing on these projects.

### How?

- Pass a `pageExtensions` array into `parseUrlForPages` / `parseUrlForAppDir` and build the match regex from it, replacing the hardcoded one. It defaults to the same extensions as before.
- Read `settings.next.pageExtensions` in the rule and pass it down. This mirrors how `rootDir` is already read via `getRootDirs`.
- Extensions are escaped before going into the regex.
- Added a `with-page-extensions-dir` fixture and unit tests: a link is now flagged when `pageExtensions` is set, and — as a guard against regressions — the same page is *not* detected when the setting is absent, confirming the default path is unchanged.
- Documented the setting next to `rootDir` in the ESLint config reference.

Fixes #53473
