### PR TITLE
Add experimental.staticWorkerMaxOldSpaceSize to cap build worker heap

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -852,6 +852,7 @@ export function createStaticWorker(
     enableSourceMaps: config.enablePrerenderSourceMaps,
     // remove --max-old-space-size flag as it can cause memory issues.
     isolatedMemory: true,
+    maxOldSpaceSize: config.experimental.staticWorkerMaxOldSpaceSize,
     enableWorkerThreads: config.experimental.workerThreads,
     exposedMethods: staticWorkerExposedMethods,
     forkOptions: {

--- a/packages/next/src/lib/worker.test.ts
+++ b/packages/next/src/lib/worker.test.ts
@@ -125,3 +125,63 @@ describe('lib/worker color propagation', () => {
     expect(latestForkEnv?.FORCE_COLOR).toBeUndefined()
   })
 })
+
+describe('lib/worker memory options', () => {
+  const originalEnv = { ...process.env }
+
+  const restoreEnv = () => {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    Object.assign(process.env, originalEnv)
+  }
+
+  afterEach(() => {
+    restoreEnv()
+    jest.resetModules()
+    latestForkEnv = undefined
+  })
+
+  it('sets --max-old-space-size when maxOldSpaceSize is provided', () => {
+    const { Worker } = require('./worker') as typeof import('./worker')
+
+    const worker = new Worker(__filename, {
+      ...noopOptions,
+      isolatedMemory: true,
+      maxOldSpaceSize: 2048,
+    })
+    worker.close()
+
+    expect(latestForkEnv?.NODE_OPTIONS).toContain('--max-old-space-size=2048')
+  })
+
+  it('strips inherited --max-old-space-size with isolatedMemory', () => {
+    process.env.NODE_OPTIONS = '--max-old-space-size=4096'
+
+    const { Worker } = require('./worker') as typeof import('./worker')
+
+    const worker = new Worker(__filename, {
+      ...noopOptions,
+      isolatedMemory: true,
+    })
+    worker.close()
+
+    expect(latestForkEnv?.NODE_OPTIONS).not.toContain('max-old-space-size')
+  })
+
+  it('maxOldSpaceSize overrides an inherited NODE_OPTIONS value', () => {
+    process.env.NODE_OPTIONS = '--max-old-space-size=4096'
+
+    const { Worker } = require('./worker') as typeof import('./worker')
+
+    const worker = new Worker(__filename, {
+      ...noopOptions,
+      isolatedMemory: true,
+      maxOldSpaceSize: 1024,
+    })
+    worker.close()
+
+    expect(latestForkEnv?.NODE_OPTIONS).toContain('--max-old-space-size=1024')
+    expect(latestForkEnv?.NODE_OPTIONS).not.toContain('4096')
+  })
+})

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -52,6 +52,11 @@ export class Worker {
        * True if `--max-old-space-size` should not be forwarded to the worker.
        */
       isolatedMemory: boolean
+      /**
+       * If set, explicitly sets `--max-old-space-size` (in MB) for the
+       * worker, taking precedence over `isolatedMemory` stripping the flag.
+       */
+      maxOldSpaceSize?: number
       timeout?: number
       onActivity?: () => void
       onActivityAbort?: () => void
@@ -68,6 +73,7 @@ export class Worker {
       logger = console,
       debuggerPortOffset,
       isolatedMemory,
+      maxOldSpaceSize,
       onActivity,
       onActivityAbort,
       ...farmOptions
@@ -117,6 +123,11 @@ export class Worker {
     if (isolatedMemory) {
       delete nodeOptions['max-old-space-size']
       delete nodeOptions['max_old_space_size']
+    }
+
+    if (maxOldSpaceSize !== undefined) {
+      delete nodeOptions['max_old_space_size']
+      nodeOptions['max-old-space-size'] = String(maxOldSpaceSize)
     }
 
     const { nodeOptions: formattedNodeOptions, execArgv } =

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -218,6 +218,7 @@ export const experimentalSchema = {
   clientRouterFilterRedirects: z.boolean().optional(),
   clientRouterFilterAllowedRate: z.number().optional(),
   cpus: z.number().optional(),
+  staticWorkerMaxOldSpaceSize: z.number().int().positive().optional(),
   memoryBasedWorkersCount: z.boolean().optional(),
   craCompat: z.boolean().optional(),
   caseSensitiveRoutes: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -618,6 +618,12 @@ export interface ExperimentalConfig {
   disablePostcssPresetEnv?: boolean
   cpus?: number
   memoryBasedWorkersCount?: boolean
+  /**
+   * Sets `--max-old-space-size` (in MB) for each static generation worker
+   * spawned during `next build`. By default no explicit cap is set (any
+   * `--max-old-space-size` in `NODE_OPTIONS` is stripped for static workers).
+   */
+  staticWorkerMaxOldSpaceSize?: number
   proxyTimeout?: number
   isrFlushToDisk?: boolean
   workerThreads?: boolean


### PR DESCRIPTION
## Summary

`next build` static workers (page-data collection + static generation) are spawned with `isolatedMemory: true`, which strips `--max-old-space-size` from `NODE_OPTIONS`, and no other memory control is exposed — so nothing bounds build-worker memory and large module graphs OOM (SIGKILL). `experimental.cpus` can't compensate because static generation and page-data collection have opposing worker-count/memory constraints.

This adds an opt-in `experimental.staticWorkerMaxOldSpaceSize` (in MB) that explicitly sets `--max-old-space-size` on static workers, taking precedence over the `isolatedMemory` strip. Default behavior is unchanged.

Fixes #95745

## Verification

- `pnpm jest packages/next/src/lib/worker.test.ts` (3 new tests: flag set, strip regression guard, flag overrides inherited `NODE_OPTIONS`)
- Manual smoke test: minimal app logging `process.env.NODE_OPTIONS` in `getStaticProps`; with the flag the worker sees `--max-old-space-size=2048`, without it an inherited `--max-old-space-size=4096` is still stripped

<!-- NEXT_JS_LLM_PR -->