### PR TITLE
Avoid a `tsc --showConfig` spawn in the CLI type-checker

### DIFF
--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -151,10 +151,10 @@ export async function startTypeChecking({
           pagesDir,
           debugBuildPaths,
           useTypeScriptCli,
-          // Stop the spinner before the CLI checker writes its diagnostics
-          // (which it does directly to stdout/stderr, bypassing the console
-          // hooks that would otherwise pause the spinner).
-          () => typeCheckingSpinner?.stop()
+          // Stop the spinner before as soon as the subprocess reports output.
+          useTypeScriptCli && typeCheckingSpinner
+            ? () => typeCheckingSpinner.stop()
+            : undefined
         ).then((resolved) => {
           const checkEnd = process.hrtime(typeCheckAndLintStart)
           return [resolved, checkEnd] as const

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -32,7 +32,8 @@ function verifyAndRunTypeScript(
   appDir: string | undefined,
   pagesDir: string | undefined,
   debugBuildPaths: { app: string[]; pages: string[] } | undefined,
-  useTypeScriptCli: boolean
+  useTypeScriptCli: boolean,
+  onFirstCliOutput?: () => void
 ) {
   let impl: typeof import('../lib/verify-typescript-setup').verifyAndRunTypeScript
   let typeCheckWorker:
@@ -76,6 +77,7 @@ function verifyAndRunTypeScript(
     pagesDir,
     debugBuildPaths,
     useTypeScriptCli,
+    onFirstCliOutput,
   })
     .then((result) => {
       typeCheckWorker?.end()
@@ -124,14 +126,7 @@ export async function startTypeChecking({
   }
 
   if (typeCheckingSpinnerPrefixText) {
-    if (useTypeScriptCli) {
-      // The CLI writes directly to stdout/stderr, bypassing the console hooks
-      // that pause an active spinner. Keep its diagnostics byte-for-byte and
-      // on their own lines by logging a static status line instead.
-      Log.info(`${typeCheckingSpinnerPrefixText} ...`)
-    } else {
-      typeCheckingSpinner = createSpinner(typeCheckingSpinnerPrefixText)
-    }
+    typeCheckingSpinner = createSpinner(typeCheckingSpinnerPrefixText)
   }
 
   const typeCheckAndLintStart = process.hrtime()
@@ -155,7 +150,11 @@ export async function startTypeChecking({
           appDir,
           pagesDir,
           debugBuildPaths,
-          useTypeScriptCli
+          useTypeScriptCli,
+          // Stop the spinner before the CLI checker writes its diagnostics
+          // (which it does directly to stdout/stderr, bypassing the console
+          // hooks that would otherwise pause the spinner).
+          () => typeCheckingSpinner?.stop()
         ).then((resolved) => {
           const checkEnd = process.hrtime(typeCheckAndLintStart)
           return [resolved, checkEnd] as const

--- a/packages/next/src/lib/typescript/loadTsConfig.ts
+++ b/packages/next/src/lib/typescript/loadTsConfig.ts
@@ -9,6 +9,8 @@ export type RelevantCompilerOptions = {
   baseUrl?: string
   /** Absolute directory containing an inherited paths option without baseUrl. */
   pathsBasePath?: string
+  incremental?: boolean
+  composite?: boolean
 }
 
 function resolveConfigDirValue(
@@ -149,6 +151,16 @@ function loadTsConfigOptionsRecursive(
   }
 
   const currentOptions = config.compilerOptions ?? {}
+
+  // Carry `incremental`/`composite` through the extends chain. Assign whenever
+  // the key is present (not just when truthy) so an explicit `false` in a child
+  // config correctly overrides an inherited `true`.
+  if (Object.hasOwn(currentOptions, 'incremental')) {
+    mergedOptions.incremental = Boolean(currentOptions.incremental)
+  }
+  if (Object.hasOwn(currentOptions, 'composite')) {
+    mergedOptions.composite = Boolean(currentOptions.composite)
+  }
 
   if (Object.hasOwn(currentOptions, 'paths')) {
     mergedOptions.paths = currentOptions.paths

--- a/packages/next/src/lib/typescript/runTypeCheckCli.ts
+++ b/packages/next/src/lib/typescript/runTypeCheckCli.ts
@@ -12,11 +12,17 @@ export async function runTypeCheckCli({
   tsConfigPath,
   tscPath,
   cacheDir,
+  onFirstOutput,
 }: {
   baseDir: string
   tsConfigPath: string
   tscPath: string
   cacheDir?: string
+  /**
+   * Called once when `tsc` first produces output. Used to stop the build
+   * spinner so it does not sit above the diagnostics.
+   */
+  onFirstOutput?: () => void
 }): Promise<TypeCheckResult> {
   const configuration = await getTypeScriptConfigurationCli({
     baseDir,
@@ -45,6 +51,7 @@ export async function runTypeCheckCli({
     cwd: baseDir,
     tscPath,
     args,
+    onFirstOutput,
   })
 
   if (result.exitCode !== 0) {

--- a/packages/next/src/lib/typescript/runTypeCheckCli.ts
+++ b/packages/next/src/lib/typescript/runTypeCheckCli.ts
@@ -2,10 +2,8 @@ import path from 'node:path'
 
 import { CompileError } from '../compile-error'
 import type { TypeCheckResult } from './runTypeCheck'
-import {
-  getTypeScriptConfigurationCli,
-  runTypeScriptCli,
-} from './runTypeScriptCli'
+import { runTypeScriptCli } from './runTypeScriptCli'
+import { loadTsConfigOptions } from './loadTsConfig'
 
 export async function runTypeCheckCli({
   baseDir,
@@ -24,14 +22,10 @@ export async function runTypeCheckCli({
    */
   onFirstOutput?: () => void
 }): Promise<TypeCheckResult> {
-  const configuration = await getTypeScriptConfigurationCli({
-    baseDir,
-    tsConfigPath,
-    tscPath,
-  })
+  // Read from the tsconfig directly to avoid the overhead of launching a subprocess.
+  const compilerOptions = loadTsConfigOptions(tsConfigPath)
   const incremental = Boolean(
-    configuration.compilerOptions.incremental ||
-      configuration.compilerOptions.composite
+    compilerOptions.incremental || compilerOptions.composite
   )
   const args = [
     '--project',

--- a/packages/next/src/lib/typescript/runTypeScriptCli.test.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.test.ts
@@ -71,7 +71,7 @@ describe('runTypeScriptCli', () => {
     }
   }
 
-  it('spawns tsc detached with inherited stdio and resolves with the exit code', async () => {
+  it('spawns tsc detached with piped stdio and resolves with the exit code', async () => {
     const resultPromise = runTypeScriptCli({
       cwd: '/project',
       tscPath: '/project/node_modules/typescript/bin/tsc',
@@ -85,7 +85,7 @@ describe('runTypeScriptCli', () => {
         cwd: '/project',
         detached: process.platform !== 'win32',
         shell: false,
-        stdio: 'inherit',
+        stdio: ['ignore', 'pipe', 'pipe'],
       })
     )
 
@@ -95,6 +95,41 @@ describe('runTypeScriptCli', () => {
       exitCode: 0,
       signal: null,
     })
+    expectListenersRestored()
+  })
+
+  it('forwards output as it arrives, preserving stdout/stderr interleaving, and stops the spinner on the first byte', async () => {
+    const stdoutWrite = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true)
+    const stderrWrite = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true)
+    const onFirstOutput = jest.fn()
+
+    try {
+      const resultPromise = runTypeScriptCli({
+        cwd: '/project',
+        tscPath: '/project/node_modules/typescript/bin/tsc',
+        args: ['--noEmit'],
+        onFirstOutput,
+      })
+
+      child.stdout.write('checking a\n')
+      child.stderr.write('warning b\n')
+      child.stdout.write('checking c\n')
+      child.emit('close', 0, null)
+
+      await expect(resultPromise).resolves.toMatchObject({ exitCode: 0 })
+
+      expect(onFirstOutput).toHaveBeenCalledTimes(1)
+      expect(stdoutWrite).toHaveBeenNthCalledWith(1, 'checking a\n')
+      expect(stderrWrite).toHaveBeenNthCalledWith(1, 'warning b\n')
+      expect(stdoutWrite).toHaveBeenNthCalledWith(2, 'checking c\n')
+    } finally {
+      stdoutWrite.mockRestore()
+      stderrWrite.mockRestore()
+    }
     expectListenersRestored()
   })
 

--- a/packages/next/src/lib/typescript/runTypeScriptCli.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.ts
@@ -142,12 +142,9 @@ export function runTypeScriptCli({
         stderr += chunk
       })
     } else {
-      let sawOutput = false
       const forward = (dest: NodeJS.WriteStream, chunk: string) => {
-        if (!sawOutput) {
-          sawOutput = true
-          onFirstOutput?.()
-        }
+        onFirstOutput?.()
+        onFirstOutput = undefined // ensure we don't call it again
         dest.write(chunk)
       }
 

--- a/packages/next/src/lib/typescript/runTypeScriptCli.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.ts
@@ -92,11 +92,21 @@ export function runTypeScriptCli({
   tscPath,
   args,
   captureOutput = false,
+  onFirstOutput,
 }: {
   cwd: string
   tscPath: string
   args: string[]
+  /**
+   * Accumulate stdout/stderr into the resolved result instead of forwarding it
+   * to this process's stdout/stderr (for e.g. parsing `--showConfig` output).
+   */
   captureOutput?: boolean
+  /**
+   * Called once, on the first chunk of forwarded output. Used to stop the build
+   * spinner before `tsc`'s diagnostics appear. Not called when capturing.
+   */
+  onFirstOutput?: () => void
 }): Promise<TypeScriptCliResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [tscPath, ...args], {
@@ -106,23 +116,46 @@ export function runTypeScriptCli({
       // reach both processes instead of orphaning the native compiler.
       detached: process.platform !== 'win32',
       shell: false,
-      stdio: captureOutput ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+      stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        // Piping stdio makes `tsc` disable colored/pretty diagnostics. Restore
+        // them when we are forwarding output to a TTY (not capturing it for
+        // parsing, e.g. `--showConfig`).
+        ...(!captureOutput && process.stdout.isTTY
+          ? { FORCE_COLOR: '1' }
+          : undefined),
       },
     })
 
     let stdout = ''
     let stderr = ''
 
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+
     if (captureOutput) {
-      child.stdout?.setEncoding('utf8')
-      child.stderr?.setEncoding('utf8')
-      child.stdout?.on('data', (chunk) => {
+      child.stdout?.on('data', (chunk: string) => {
         stdout += chunk
       })
-      child.stderr?.on('data', (chunk) => {
+      child.stderr?.on('data', (chunk: string) => {
         stderr += chunk
+      })
+    } else {
+      let sawOutput = false
+      const forward = (dest: NodeJS.WriteStream, chunk: string) => {
+        if (!sawOutput) {
+          sawOutput = true
+          onFirstOutput?.()
+        }
+        dest.write(chunk)
+      }
+
+      child.stdout?.on('data', (chunk: string) => {
+        forward(process.stdout, chunk)
+      })
+      child.stderr?.on('data', (chunk: string) => {
+        forward(process.stderr, chunk)
       })
     }
 

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -64,6 +64,7 @@ export async function verifyAndRunTypeScript({
   pagesDir,
   debugBuildPaths,
   useTypeScriptCli = false,
+  onFirstCliOutput,
 }: {
   dir: string
   distDir: string
@@ -79,6 +80,11 @@ export async function verifyAndRunTypeScript({
   pagesDir?: string
   debugBuildPaths?: { app?: string[]; pages?: string[] }
   useTypeScriptCli?: boolean
+  /**
+   * Called once when the CLI checker first produces output, so the caller can
+   * stop the build spinner. Only used on the in-process CLI path.
+   */
+  onFirstCliOutput?: () => void
 }): Promise<{
   result?: TypeCheckResult
   version: string | null
@@ -258,6 +264,7 @@ export async function verifyAndRunTypeScript({
           tsConfigPath: resolvedTsConfigPath,
           tscPath: typeScriptPath,
           cacheDir,
+          onFirstOutput: onFirstCliOutput,
         })
       } else {
         const { runTypeCheck } =

--- a/test/unit/typescript-cli-config-origin/index.test.ts
+++ b/test/unit/typescript-cli-config-origin/index.test.ts
@@ -1,4 +1,11 @@
-import { cpSync, mkdtempSync, mkdirSync, realpathSync, rmSync } from 'node:fs'
+import {
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -89,5 +96,39 @@ describe('TypeScript CLI config metadata', () => {
         path.join(testDir, 'node_modules/typescript/lib/tsc.js')
       ),
     })
+  })
+
+  it('reads incremental and composite from the config', () => {
+    const configPath = path.join(testDir, 'incremental.json')
+    writeFileSync(
+      configPath,
+      JSON.stringify({ compilerOptions: { incremental: true } })
+    )
+    expect(loadTsConfigOptions(configPath).incremental).toBe(true)
+
+    const compositePath = path.join(testDir, 'composite.json')
+    writeFileSync(
+      compositePath,
+      JSON.stringify({ compilerOptions: { composite: true } })
+    )
+    expect(loadTsConfigOptions(compositePath).composite).toBe(true)
+  })
+
+  it('lets a child config disable incremental inherited from a base', () => {
+    const basePath = path.join(testDir, 'tsconfig.base.json')
+    writeFileSync(
+      basePath,
+      JSON.stringify({ compilerOptions: { incremental: true } })
+    )
+    const childPath = path.join(testDir, 'tsconfig.child.json')
+    writeFileSync(
+      childPath,
+      JSON.stringify({
+        extends: './tsconfig.base.json',
+        compilerOptions: { incremental: false },
+      })
+    )
+
+    expect(loadTsConfigOptions(childPath).incremental).toBe(false)
   })
 })


### PR DESCRIPTION
The `experimental.useTypeScriptCli` type-check runs `tsc --showConfig` as a separate `tsc` process purely to read `incremental`/`composite` bits before the actual `--noEmit` check. 

This resolves those options in-process instead via a small enhancement to `loadTsConfigOptions`

This drops one `tsc` spawn from every CLI-mode build.  This shouldn't be very expensive but in the base case is ~30ms and in my case (due to sentineld!!!) is 300ms

> Note: a `tsc --showConfig` call still runs elsewhere (`load-jsconfig`, used for the webpack/next-jest config path). That one is out of scope here and can be addressed separately.

### Testing
- Unit tests added for `incremental`/`composite` resolution, including a child config disabling `incremental` inherited from a base.
- Existing `typescript-cli` production suite passes (including the incremental-on and incremental-disabled cases).

<!-- NEXT_JS_LLM_PR -->
