### PR TITLE
[instant] Let dev-server requests bypass the fetch lock

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -365,6 +365,32 @@ export function resetNavigationLockToPending(): void {
 }
 
 /**
+ * Returns true if the request targets a dev-server endpoint — one of the
+ * hot-reloader middleware routes (error overlay, source maps, launch-editor,
+ * devtools). They all share the `/__nextjs_` path prefix and are always
+ * requested root-relative on the same origin.
+ */
+function isDevServerRequest(input: RequestInfo | URL): boolean {
+  let url: URL
+  try {
+    url = new URL(
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input
+          : input.url,
+      window.location.href
+    )
+  } catch {
+    return false
+  }
+  return (
+    url.origin === window.location.origin &&
+    url.pathname.startsWith('/__nextjs_')
+  )
+}
+
+/**
  * Global fetch override
  *
  * While the navigation lock is active, we install this as `window.fetch` so
@@ -385,6 +411,15 @@ function globalFetchOverride(
     // only if a caller captured a reference to this function during a lock
     // scope and invoked it after release.
     return fetch(input, init)
+  }
+  if (process.env.__NEXT_DEV_SERVER && isDevServerRequest(input)) {
+    // Dev-server requests must not be gated on the testing lock — blocking
+    // them would break the error overlay, source maps, and devtools for the
+    // whole scope. Dispatch immediately through the pre-lock fetch. Copy to a
+    // local so the call doesn't bind `this` to the lock state object (native
+    // fetch throws "Illegal invocation" for a foreign receiver).
+    const preLockFetch = lockState.fetch
+    return preLockFetch(input, init)
   }
   // Block user-initiated fetches until the lock is released, then dispatch
   // through the fetch captured at acquire time. Reading from `lockState`

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -1100,6 +1100,33 @@ describe('instant-navigation-testing-api', () => {
     expect(await fetchedData.textContent()).toContain('api response')
   })
 
+  if (isNextDev) {
+    it('lets dev-server requests through during instant scope', async () => {
+      const page = await openPage(next, '/')
+
+      await instant(page, async () => {
+        await page.click('#link-to-client-fetch')
+
+        // The out-of-band fetch to /api/data is blocked by the lock
+        const loading = page.locator('[data-testid="fetched-data-loading"]')
+        await loading.waitFor({ state: 'visible' })
+
+        // But dev-server requests (hot-reloader middleware endpoints like the
+        // error overlay and source maps) bypass the lock and resolve while the
+        // scope is still active. Without the bypass this evaluate would hang
+        // until the scope ends.
+        const status = await page.evaluate(() =>
+          fetch('/__nextjs_server_status').then((res) => res.status)
+        )
+        expect(status).toBe(200)
+
+        // The blocked fetch still hasn't resolved
+        const fetchedData = page.locator('[data-testid="fetched-data"]')
+        expect(await fetchedData.count()).toBe(0)
+      })
+    })
+  }
+
   it('clears cookie even when callback throws', async () => {
     const page = await openPage(next, '/')
 


### PR DESCRIPTION


While an `instant()` testing scope is active, the navigation testing lock replaces `window.fetch` and queues every request until the scope ends. This also blocked the dev server's own client-side requests, i.e. everything served by the hot-reloader middlewares: the error overlay could not resolve stack frames via `/__nextjs_original-stack-frames`, source maps could not load via `/__nextjs_source-map`, and devtools actions like launch-editor hung for the whole scope.

The fix lets same-origin requests to `/__nextjs_`-prefixed paths (the shared prefix of all hot-reloader middleware endpoints) through the lock immediately.

Before:


https://github.com/user-attachments/assets/b87eda29-8973-4161-a94c-ee316473ea59


