### PR TITLE
[test] Add instant() shell test for a Client Component reading search params

### DIFF
--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/use-search-params-page/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/use-search-params-page/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+
+export default function UseSearchParamsPage() {
+  return (
+    <div>
+      <h1 data-testid="use-search-params-title">Use Search Params Page</h1>
+      <Suspense
+        fallback={
+          <div data-testid="use-search-params-fallback">
+            Loading search params...
+          </div>
+        }
+      >
+        <SearchParamsReader />
+      </Suspense>
+    </div>
+  )
+}
+
+function SearchParamsReader() {
+  const searchParams = useSearchParams()
+  return (
+    <div data-testid="use-search-params-content">
+      foo: {searchParams.get('foo') ?? 'not set'}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -643,6 +643,32 @@ describe('instant-navigation-testing-api', () => {
     })
   })
 
+  // A Client Component reading useSearchParams() suspends the prerender (the
+  // static shell contains the Suspense fallback), but the value resolves
+  // client-side from the URL. So unlike server `searchParams`, the value
+  // becomes visible without releasing the instant lock.
+  describe('client component useSearchParams is visible in instant shell', () => {
+    it('renders search param values on initial visit without releasing the lock', async () => {
+      const page = await openPage(next, '/')
+
+      await instant(page, async () => {
+        await page.goto(
+          new URL('/use-search-params-page?foo=bar', next.url).href
+        )
+
+        const title = page.locator('[data-testid="use-search-params-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // The value renders client-side while the instant lock is held
+        const content = page.locator(
+          '[data-testid="use-search-params-content"]'
+        )
+        await content.waitFor({ state: 'visible' })
+        expect(await content.textContent()).toContain('foo: bar')
+      })
+    })
+  })
+
   describe('statically generated params are included in instant shell', () => {
     it('includes statically generated param values in instant shell during client navigation', async () => {
       const page = await openPage(next, '/')


### PR DESCRIPTION
## Summary

Adds e2e coverage to the `instant-navigation-testing-api` suite for a Client Component page that reads search params via `useSearchParams()`. The suite already covered a server page reading `await searchParams`, asserting the value is excluded from the instant shell; the Client Component counterpart was untested.

The new fixture is a `'use client'` page rendering a `useSearchParams()` reader inside a Suspense boundary. The test performs an initial document visit inside an `instant()` scope and asserts the search param value becomes visible without releasing the instant lock: unlike server `searchParams`, the hook resolves client-side from the known URL, so only the prerendered HTML contains the Suspense fallback while streamed dynamic data stays withheld.

## Verification

- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts` (full suite, 36 passed / 1 skipped)
- `HEADLESS=true pnpm test-dev-turbo test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts -t "renders search param values on initial visit"`

<!-- NEXT_JS_LLM -->