### PR TITLE
fix(eslint): avoid crashing on valueless attributes in no-css-tags

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-css-tags.ts
+++ b/packages/eslint-plugin-next/src/rules/no-css-tags.ts
@@ -27,11 +27,14 @@ export default defineRule({
         if (
           attributes.find(
             (attr) =>
-              attr.name.name === 'rel' && attr.value.value === 'stylesheet'
+              attr.name.name === 'rel' &&
+              attr.value &&
+              attr.value.value === 'stylesheet'
           ) &&
           attributes.find(
             (attr) =>
               attr.name.name === 'href' &&
+              attr.value &&
               attr.value.type === 'Literal' &&
               !/^https?/.test(attr.value.value)
           )

--- a/test/unit/eslint-plugin-next/no-css-tags.test.ts
+++ b/test/unit/eslint-plugin-next/no-css-tags.test.ts
@@ -55,6 +55,18 @@ const tests = {
           );
         }
     }`,
+
+    // Valueless attributes have a null value; the rule should not crash.
+    `export class Blah extends Head {
+        render() {
+          return (
+            <div>
+              <link rel />
+              <link rel="stylesheet" href />
+            </div>
+          );
+        }
+    }`,
   ],
 
   invalid: [


### PR DESCRIPTION
The `no-css-tags` rule crashes on valid code when a `<link>` uses a valueless attribute.

To decide whether a `<link>` is a manual stylesheet, the rule reads `attr.value.value` (for `rel`) and `attr.value.type` / `attr.value.value` (for `href`) directly. A valueless JSX attribute — for example `<link rel>` or `<link rel="stylesheet" href>` — parses with `value: null`, so these accesses throw `Cannot read properties of null (reading 'value')` (or `reading 'type'`) and abort the lint run on otherwise valid source.

The fix checks that the attribute actually has a value before inspecting it. This mirrors the guard already used in `no-before-interactive-script-outside-document`, which does `!strategy.value` before reading `strategy.value.value`.

I verified both the crash and the fix with ESLint's `RuleTester`: `<link rel>` and `<link rel="stylesheet" href>` throw on current `canary` and no longer throw after the change, while the existing behavior is preserved — external stylesheets (`https://…`) stay allowed and local stylesheet links are still flagged. A regression test with valueless `rel` and `href` attributes is added.
