### PR TITLE
Add missing Request Insights OpenTelemetry spans

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1419,5 +1419,8 @@
   "1418": "TypeScript %s does not provide the compiler API required by Next.js. Enable %s in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1419": "TypeScript CLI interrupted by %s",
   "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s",
-  "1421": "The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed."
+  "1421": "The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed.",
+  "1422": "RSC render stream cancelled",
+  "1423": "RSC render stream closed before completion",
+  "1424": "RSC render aborted"
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -22,7 +22,10 @@ import {
   getRequestMeta,
   setRequestMeta,
 } from '../../server/request-meta' with { 'turbopack-transition': 'next-server-utility' }
-import { BaseServerSpan } from '../../server/lib/trace/constants' with { 'turbopack-transition': 'next-server-utility' }
+import {
+  AppRenderSpan,
+  BaseServerSpan,
+} from '../../server/lib/trace/constants' with { 'turbopack-transition': 'next-server-utility' }
 import { interopDefault } from '../../server/app-render/interop-default' with { 'turbopack-transition': 'next-server-utility' }
 import { stripFlightHeaders } from '../../server/app-render/strip-flight-headers' with { 'turbopack-transition': 'next-server-utility' }
 import {
@@ -212,6 +215,11 @@ export async function handler(
     requestMeta?: RequestMeta
   }
 ) {
+  let appPagePreparationStart =
+    process.env.__NEXT_REQUEST_INSIGHTS || process.env.NEXT_OTEL_VERBOSE === '1'
+      ? performance.timeOrigin + performance.now()
+      : undefined
+
   if (ctx.requestMeta) {
     setRequestMeta(req, ctx.requestMeta)
   }
@@ -721,6 +729,21 @@ export async function handler(
     ) => {
       const nextReq = new NodeNextRequest(req)
       const nextRes = new NodeNextResponse(res)
+
+      if (appPagePreparationStart !== undefined) {
+        const preparationEnd = performance.timeOrigin + performance.now()
+        const preparationSpan = tracer.startSpan(
+          AppRenderSpan.prepareAppPageResponse,
+          {
+            startTime: appPagePreparationStart,
+            attributes: {
+              'next.span_type': AppRenderSpan.prepareAppPageResponse,
+            },
+          }
+        )
+        preparationSpan.end(preparationEnd)
+        appPagePreparationStart = undefined
+      }
 
       return routeModule.render(nextReq, nextRes, context).finally(() => {
         if (!span) return

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -508,6 +508,7 @@ function getDefinedViewport(
           {
             spanName: `generateViewport ${route}`,
             attributes: {
+              'next.span.category': 'application',
               'next.page': route,
             },
           },
@@ -535,6 +536,7 @@ function getDefinedMetadata(
           {
             spanName: `generateMetadata ${route}`,
             attributes: {
+              'next.span.category': 'application',
               'next.page': route,
             },
           },

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -30,6 +30,9 @@ export function wrapApiHandler<T extends (...args: any[]) => any>(
       NodeSpan.runHandler,
       {
         spanName: `executing api route (pages) ${page}`,
+        attributes: {
+          'next.span.category': 'application',
+        },
       },
       () => handler(...args)
     )

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -94,6 +94,7 @@ import {
 import { isRedirectError } from '../../client/components/redirect-error'
 import { getImplicitTags, type ImplicitTags } from '../lib/implicit-tags'
 import { AppRenderSpan, NextNodeServerSpan } from '../lib/trace/constants'
+import { getRequestInsightsIdentity } from '../lib/trace/request-insights-identity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
 import { FlightRenderResult } from './flight-render-result'
 import {
@@ -249,7 +250,11 @@ import {
 import { isReactLargeShellError } from './react-large-shell-error'
 import type { GlobalErrorComponent } from '../../client/components/builtin/global-error'
 import { normalizeConventionFilePath } from './segment-explorer-path'
-import { getRequestMeta } from '../request-meta'
+import {
+  addRequestMeta,
+  getRequestMeta,
+  removeRequestMeta,
+} from '../request-meta'
 import {
   getDynamicParam,
   interpolateParallelRouteParams,
@@ -2118,6 +2123,11 @@ async function getRSCPayload(
     MetadataOutlet,
   })
 
+  const finalizePayloadStart =
+    getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1'
+      ? performance.timeOrigin + performance.now()
+      : undefined
+
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
   // it could respond differently if there's an interception route. We provide this information
   // to `AppRouter` so that it can properly seed the prefetch cache with a prefix, if needed.
@@ -2165,7 +2175,7 @@ async function getRSCPayload(
     workStore.isStaticGeneration &&
     ctx.renderOpts.experimental.isRoutePPREnabled === true
 
-  return maybeAppendBuildIdToRSCPayload(ctx, {
+  const payload = maybeAppendBuildIdToRSCPayload(ctx, {
     // See the comment above the `Preloads` component (below) for why this is part of the payload
     P: createElement(Preloads, {
       preloadCallbacks: preloadCallbacks,
@@ -2203,6 +2213,22 @@ async function getRSCPayload(
       ? ((await getDynamicStaleTime(tree)) ?? undefined)
       : undefined,
   } satisfies InitialRSCPayload & { P: ReactNode })
+
+  if (finalizePayloadStart !== undefined) {
+    const finalizePayloadEnd = performance.timeOrigin + performance.now()
+    const finalizePayloadSpan = getTracer().startSpan(
+      AppRenderSpan.finalizeRSCPayload,
+      {
+        startTime: finalizePayloadStart,
+        attributes: {
+          'next.span_type': AppRenderSpan.finalizeRSCPayload,
+        },
+      }
+    )
+    finalizePayloadSpan.end(finalizePayloadEnd)
+  }
+
+  return payload
 }
 
 /**
@@ -2630,10 +2656,7 @@ async function renderToHTMLOrFlightImpl(
                 'next.span_type': NextNodeServerSpan.clientComponentLoading,
               },
             })
-            .end(
-              metrics.clientComponentLoadStart +
-                metrics.clientComponentLoadTimes
-            )
+            .end(metrics.clientComponentLoadEnd)
         }
       }
     })
@@ -2672,6 +2695,9 @@ async function renderToHTMLOrFlightImpl(
 
   let requestId: string
   let htmlRequestId: string
+  const requestInsightsIdentity = process.env.__NEXT_REQUEST_INSIGHTS
+    ? getRequestInsightsIdentity()
+    : undefined
 
   const {
     flightRouterState,
@@ -2686,6 +2712,10 @@ async function renderToHTMLOrFlightImpl(
   if (parsedRequestHeaders.requestId) {
     // If the client has provided a request ID (in development mode), we use it.
     requestId = parsedRequestHeaders.requestId
+  } else if (requestInsightsIdentity) {
+    // Request Insights starts recording before the work store exists. Reuse
+    // the identity from that outer request scope so all spans stay together.
+    requestId = requestInsightsIdentity.requestId
   } else {
     // Otherwise we generate a new request ID.
     if (isStaticGeneration) {
@@ -2706,7 +2736,10 @@ async function renderToHTMLOrFlightImpl(
   // send debug information to the associated WebSocket client. Otherwise, this
   // is the request for the HTML document, so we use the request ID also as the
   // HTML request ID.
-  htmlRequestId = parsedRequestHeaders.htmlRequestId || requestId
+  htmlRequestId =
+    parsedRequestHeaders.htmlRequestId ||
+    requestInsightsIdentity?.htmlRequestId ||
+    requestId
   workStore.requestId = requestId
   workStore.htmlRequestId = htmlRequestId
 
@@ -3084,6 +3117,14 @@ export const renderToHTMLOrFlight: AppPageRender = (
     throw new Error('Invalid URL')
   }
 
+  if (getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1') {
+    addRequestMeta(
+      req,
+      'appRenderInitializationStart',
+      performance.timeOrigin + performance.now()
+    )
+  }
+
   const url = parseRelativeUrl(req.url, undefined, false)
 
   // We read these values from the request object as, in certain cases,
@@ -3326,10 +3367,28 @@ async function renderToStream(
       (await getInstantTestBootstrapScriptContent())
   }
 
+  const initializationStart = getRequestMeta(
+    req,
+    'appRenderInitializationStart'
+  )
+  if (initializationStart !== undefined) {
+    removeRequestMeta(req, 'appRenderInitializationStart')
+    const initializationEnd = performance.timeOrigin + performance.now()
+    const initializationSpan = getTracer().startSpan(
+      AppRenderSpan.initializeRender,
+      {
+        startTime: initializationStart,
+        attributes: {
+          'next.span_type': AppRenderSpan.initializeRender,
+        },
+      }
+    )
+    initializationSpan.end(initializationEnd)
+  }
+
   // Create the "render route (app)" span manually so we can keep it open during streaming.
   // This is necessary because errors inside Suspense boundaries are reported asynchronously
   // during stream consumption, after a typical wrapped function would have ended the span.
-  // Note: We pass the full span name as the first argument since startSpan uses it directly.
   const renderSpan = getTracer().startSpan(
     `render route (app) ${pagePath}` as any,
     {
@@ -3353,6 +3412,21 @@ async function renderToStream(
       message: err instanceof Error ? err.message : undefined,
     })
     renderSpan.end()
+  }
+
+  const trackHTMLRenderCompletion = (allReady: Promise<void>) => {
+    const completion = getTracer().trace(
+      AppRenderSpan.waitForHTMLCompletion,
+      {},
+      () => allReady
+    )
+
+    void completion.then(
+      () => {
+        if (renderSpan.isRecording()) renderSpan.end()
+      },
+      (err) => endSpanWithError(err)
+    )
   }
 
   // Run the rest of the function within the span's context so child spans
@@ -3674,6 +3748,11 @@ async function renderToStream(
         reactServerResult = new ReactServerResult(flightStream)
       } else {
         // MARK: nodeStreams RSC
+        const startRSCStreamTime =
+          getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1'
+            ? performance.timeOrigin + performance.now()
+            : undefined
+
         if (process.env.__NEXT_USE_NODE_STREAMS) {
           // This is a dynamic render. We don't do dynamic tracking because we're not prerendering
           const RSCPayload: RSCPayload & RSCPayloadDevProperties =
@@ -3758,12 +3837,42 @@ async function renderToStream(
             )
           )
         }
+
+        if (startRSCStreamTime !== undefined) {
+          const startRSCStreamEnd = performance.timeOrigin + performance.now()
+          const startRSCStreamSpan = getTracer().startSpan(
+            AppRenderSpan.startRSCStream,
+            {
+              startTime: startRSCStreamTime,
+              attributes: {
+                'next.span_type': AppRenderSpan.startRSCStream,
+              },
+            }
+          )
+          startRSCStreamSpan.end(startRSCStreamEnd)
+        }
       }
 
       // React doesn't start rendering synchronously but we want the RSC render to have a chance to start
       // before we begin SSR rendering because we want to capture any available preload headers so we tick
       // one task before continuing
-      await waitAtLeastOneReactRenderTask()
+      if (
+        getRequestInsightsIdentity() ||
+        process.env.NEXT_OTEL_VERBOSE === '1'
+      ) {
+        await getTracer().trace(
+          AppRenderSpan.waitForRSC,
+          {},
+          waitAtLeastOneReactRenderTask
+        )
+      } else {
+        await waitAtLeastOneReactRenderTask()
+      }
+
+      const prepareHTMLRenderStart =
+        getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1'
+          ? performance.timeOrigin + performance.now()
+          : undefined
 
       // MARK: nodeStreams HTML
       if (process.env.__NEXT_USE_NODE_STREAMS) {
@@ -3820,10 +3929,7 @@ async function renderToStream(
                 { onError: htmlRendererErrorHandler, nonce }
               )
 
-            // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-            allReady.finally(() => {
-              if (renderSpan.isRecording()) renderSpan.end()
-            })
+            trackHTMLRenderCompletion(allReady)
 
             return await continueDynamicHTMLResumeNode(htmlStream, {
               delayDataUntilFirstHtmlChunk:
@@ -3879,8 +3985,24 @@ async function renderToStream(
           formState,
         }
 
+        if (prepareHTMLRenderStart !== undefined) {
+          const prepareHTMLRenderEnd =
+            performance.timeOrigin + performance.now()
+          const prepareHTMLRenderSpan = getTracer().startSpan(
+            AppRenderSpan.prepareHTMLRender,
+            {
+              startTime: prepareHTMLRenderStart,
+              attributes: {
+                'next.span_type': AppRenderSpan.prepareHTMLRender,
+              },
+            }
+          )
+          prepareHTMLRenderSpan.end(prepareHTMLRenderEnd)
+        }
+
         const { stream: htmlStream, allReady } = await getTracer().trace(
           AppRenderSpan.renderToNodeFizzStream,
+          {},
           () =>
             workUnitAsyncStorage.run(
               requestStore,
@@ -3891,10 +4013,7 @@ async function renderToStream(
             )
         )
 
-        // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-        allReady.finally(() => {
-          if (renderSpan.isRecording()) renderSpan.end()
-        })
+        trackHTMLRenderCompletion(allReady)
 
         return await continueFizzStream(htmlStream, {
           inlinedDataStream: createNodeInlinedDataStream(
@@ -3964,10 +4083,7 @@ async function renderToStream(
                 { onError: htmlRendererErrorHandler, nonce }
               )
 
-            // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-            allReady.finally(() => {
-              if (renderSpan.isRecording()) renderSpan.end()
-            })
+            trackHTMLRenderCompletion(allReady)
 
             return await continueDynamicHTMLResumeWeb(htmlStream, {
               delayDataUntilFirstHtmlChunk:
@@ -4029,10 +4145,7 @@ async function renderToStream(
           fizzOptions
         )
 
-        // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-        allReady.finally(() => {
-          if (renderSpan.isRecording()) renderSpan.end()
-        })
+        trackHTMLRenderCompletion(allReady)
 
         return await continueFizzStream(htmlStream, {
           inlinedDataStream: createWebInlinedDataStream(
@@ -4180,9 +4293,7 @@ async function renderToStream(
               { waitForAllReady: generateStaticHTML }
             )
 
-          errorAllReady.finally(() => {
-            if (renderSpan.isRecording()) renderSpan.end()
-          })
+          trackHTMLRenderCompletion(errorAllReady)
 
           return await continueFizzStream(errorHtmlStream, {
             inlinedDataStream: createNodeInlinedDataStream(
@@ -4278,9 +4389,7 @@ async function renderToStream(
               }
             )
 
-          errorAllReady.finally(() => {
-            if (renderSpan.isRecording()) renderSpan.end()
-          })
+          trackHTMLRenderCompletion(errorAllReady)
 
           return await continueFizzStream(errorHtmlStream, {
             inlinedDataStream: createWebInlinedDataStream(

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -44,6 +44,7 @@ import {
 import { DetachedPromise } from '../../lib/detached-promise'
 import { getTracer } from '../lib/trace/tracer'
 import { AppRenderSpan } from '../lib/trace/constants'
+import { getRequestInsightsIdentity } from '../lib/trace/request-insights-identity'
 import {
   atLeastOneTask,
   waitAtLeastOneReactRenderTask,
@@ -545,36 +546,98 @@ export function renderToNodeFlightStream(
   clientModules: FlightClientModules,
   opts: FlightRenderOptions
 ): AnyStream {
-  if (!ComponentMod.renderToPipeableStream) {
-    throw new Error('renderToPipeableStream is not implemented')
-  }
-
-  // `renderToPipeableStream` has no `signal` option (unlike the Web
-  // `renderToReadableStream`), so pull `signal` out of the options and abort
-  // the returned pipeable ourselves when it fires. We drop the listener when
-  // the passthrough closes so a finished render's `pipeable` isn't retained by
-  // the request signal, which can outlive it.
-  const { signal, ...renderOptions } = opts ?? {}
-
-  const pt = new PassThrough()
-  const pipeable = ComponentMod.renderToPipeableStream!(
-    payload,
-    clientModules,
-    renderOptions
-  )
-  pipeable.pipe(pt)
-
-  if (signal) {
-    if (signal.aborted) {
-      pipeable.abort(signal.reason)
-    } else {
-      const onAbort = () => pipeable.abort(signal.reason)
-      signal.addEventListener('abort', onAbort, { once: true })
-      pt.on('close', () => signal.removeEventListener('abort', onAbort))
+  if (!getRequestInsightsIdentity() && process.env.NEXT_OTEL_VERBOSE !== '1') {
+    if (!ComponentMod.renderToPipeableStream) {
+      throw new Error('renderToPipeableStream is not implemented')
     }
+
+    const { signal, ...renderOptions } = opts ?? {}
+    const pt = new PassThrough()
+    const pipeable = ComponentMod.renderToPipeableStream(
+      payload,
+      clientModules,
+      renderOptions
+    )
+    pipeable.pipe(pt)
+
+    if (signal) {
+      if (signal.aborted) {
+        pipeable.abort(signal.reason)
+      } else {
+        const onAbort = () => pipeable.abort(signal.reason)
+        signal.addEventListener('abort', onAbort, { once: true })
+        pt.on('close', () => signal.removeEventListener('abort', onAbort))
+      }
+    }
+
+    return pt
   }
 
-  return pt
+  return getTracer().trace(
+    AppRenderSpan.renderRSCResponse,
+    {},
+    (_span, done) => {
+      if (!ComponentMod.renderToPipeableStream) {
+        throw new Error('renderToPipeableStream is not implemented')
+      }
+
+      // `renderToPipeableStream` has no `signal` option (unlike the Web
+      // `renderToReadableStream`), so pull `signal` out of the options and abort
+      // the returned pipeable ourselves when it fires. We drop the listener when
+      // rendering finishes so a finished render's `pipeable` isn't retained by
+      // the request signal, which can outlive it.
+      const { signal, ...renderOptions } = opts ?? {}
+
+      const pt = new PassThrough()
+      const pipeable = ComponentMod.renderToPipeableStream(
+        payload,
+        clientModules,
+        renderOptions
+      )
+      let finished = false
+      let onAbort: (() => void) | undefined
+
+      const finish = (error?: Error) => {
+        if (finished) return
+        finished = true
+        if (onAbort) signal?.removeEventListener('abort', onAbort)
+        done?.(error)
+      }
+
+      pt.once('finish', () => finish())
+      pt.once('error', (error) => finish(error))
+      pt.once('close', () => {
+        if (!pt.writableFinished) {
+          finish(new Error('RSC render stream closed before completion'))
+        }
+      })
+
+      pipeable.pipe(pt)
+
+      if (signal) {
+        if (signal.aborted) {
+          pipeable.abort(signal.reason)
+          finish(
+            signal.reason instanceof Error
+              ? signal.reason
+              : new Error('RSC render aborted')
+          )
+        } else {
+          onAbort = () => {
+            pipeable.abort(signal.reason)
+            finish(
+              signal.reason instanceof Error
+                ? signal.reason
+                : new Error('RSC render aborted')
+            )
+          }
+          signal.addEventListener('abort', onAbort, { once: true })
+        }
+      }
+
+      return pt
+    }
+  )
 }
 
 export { renderToWebFizzStream } from './stream-ops.web'
@@ -589,37 +652,52 @@ export async function renderToNodeFizzStream(
   const allReady = new DetachedPromise<void>()
   const deferPipe = options?.waitForAllReady === true
 
-  const pipeable = getTracer().trace(AppRenderSpan.renderToReadableStream, () =>
-    renderToPipeableStream(element, {
-      ...streamOptions,
-      onHeaders: streamOptions?.onHeaders,
-      onShellReady() {
-        streamOptions?.onShellReady?.()
-        shellReady.resolve()
-      },
-      onShellError(error: unknown) {
-        streamOptions?.onShellError?.(error)
-        shellReady.reject(error)
-      },
-      onAllReady() {
-        streamOptions?.onAllReady?.()
-        if (deferPipe) {
-          pipeable.pipe(pt)
-        }
-        allReady.resolve()
-      },
-      onError: streamOptions?.onError,
-    })
+  const pipeable = getTracer().trace(
+    AppRenderSpan.renderToReadableStream,
+    {},
+    () =>
+      renderToPipeableStream(element, {
+        ...streamOptions,
+        onHeaders: streamOptions?.onHeaders,
+        onShellReady() {
+          streamOptions?.onShellReady?.()
+          shellReady.resolve()
+        },
+        onShellError(error: unknown) {
+          streamOptions?.onShellError?.(error)
+          shellReady.reject(error)
+        },
+        onAllReady() {
+          streamOptions?.onAllReady?.()
+          if (deferPipe) {
+            pipeable.pipe(pt)
+          }
+          allReady.resolve()
+        },
+        onError: streamOptions?.onError,
+      })
   )
 
   await getTracer().trace(
     AppRenderSpan.waitShellReady,
+    {},
     () => shellReady.promise
   )
 
   if (!deferPipe) {
-    await waitAtLeastOneReactRenderTask()
-    pipeable.pipe(pt)
+    if (getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1') {
+      await getTracer().trace(
+        AppRenderSpan.waitForFizzRenderTask,
+        {},
+        waitAtLeastOneReactRenderTask
+      )
+      getTracer().trace(AppRenderSpan.pipeFizzStream, {}, () =>
+        pipeable.pipe(pt)
+      )
+    } else {
+      await waitAtLeastOneReactRenderTask()
+      pipeable.pipe(pt)
+    }
   }
 
   return {
@@ -703,18 +781,41 @@ export async function continueFizzStream(
     validateRootLayout,
   }: import('./stream-ops.web').ContinueFizzStreamOptions
 ): Promise<Readable> {
+  const shouldTraceDetailedRender =
+    getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1'
+
   // Suffix itself might contain close tags at the end, so we need to split it.
   const suffixUnclosed = suffix ? suffix.split(CLOSE_TAG, 1)[0] : null
 
   if (isStaticGeneration) {
     if (allReady) {
-      await allReady
+      if (shouldTraceDetailedRender) {
+        await getTracer().trace(
+          AppRenderSpan.waitForFizzFlush,
+          {},
+          () => allReady
+        )
+      } else {
+        await allReady
+      }
     }
   } else {
     // Otherwise, we want to make sure Fizz is done with all microtasky work
     // before we start pulling the stream and cause a flush.
-    await waitAtLeastOneReactRenderTask()
+    if (shouldTraceDetailedRender) {
+      await getTracer().trace(
+        AppRenderSpan.waitForFizzFlush,
+        {},
+        waitAtLeastOneReactRenderTask
+      )
+    } else {
+      await waitAtLeastOneReactRenderTask()
+    }
   }
+
+  const createHTMLTransformsStart = shouldTraceDetailedRender
+    ? performance.timeOrigin + performance.now()
+    : undefined
 
   // Pipe the render stream through Node.js Transforms:
   // 1. Buffer – coalesces chunks written in the same microtask into one Uint8Array
@@ -768,6 +869,20 @@ export async function continueFizzStream(
   const headInsertion = createHeadInsertionTransform(getServerInsertedHTML)
   source.pipe(headInsertion)
   source = headInsertion
+
+  if (createHTMLTransformsStart !== undefined) {
+    const createHTMLTransformsEnd = performance.timeOrigin + performance.now()
+    const createHTMLTransformsSpan = getTracer().startSpan(
+      AppRenderSpan.createHTMLTransforms,
+      {
+        startTime: createHTMLTransformsStart,
+        attributes: {
+          'next.span_type': AppRenderSpan.createHTMLTransforms,
+        },
+      }
+    )
+    createHTMLTransformsSpan.end(createHTMLTransformsEnd)
+  }
 
   return source
 }

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -28,6 +28,9 @@ import {
 import { createInlinedDataReadableStream } from './use-flight-response'
 import { processPrelude as webProcessPrelude } from './app-render-prerender-utils'
 import type { AnyStream as AnyStreamType } from './app-render-prerender-utils'
+import { getTracer } from '../lib/trace/tracer'
+import { AppRenderSpan } from '../lib/trace/constants'
+import { getRequestInsightsIdentity } from '../lib/trace/request-insights-identity'
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -252,7 +255,42 @@ export function renderToWebFlightStream(
   clientModules: FlightClientModules,
   opts: FlightRenderOptions
 ): AnyStream {
-  return ComponentMod.renderToReadableStream(payload, clientModules, opts)
+  if (!getRequestInsightsIdentity() && process.env.NEXT_OTEL_VERBOSE !== '1') {
+    return ComponentMod.renderToReadableStream(payload, clientModules, opts)
+  }
+
+  return getTracer().trace(
+    AppRenderSpan.renderRSCResponse,
+    {},
+    (_span, done) => {
+      const stream = ComponentMod.renderToReadableStream(
+        payload,
+        clientModules,
+        opts
+      )
+      const tracked = new TransformStream<Uint8Array, Uint8Array>()
+      let finished = false
+
+      const finish = (reason?: unknown) => {
+        if (finished) return
+        finished = true
+        done?.(
+          reason === undefined
+            ? undefined
+            : reason instanceof Error
+              ? reason
+              : new Error('RSC render stream cancelled')
+        )
+      }
+
+      stream.pipeTo(tracked.writable).then(
+        () => finish(),
+        (reason) => finish(reason)
+      )
+
+      return tracked.readable
+    }
+  )
 }
 
 export async function streamToString(stream: AnyStream): Promise<string> {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -44,6 +44,7 @@ import type { ProxyMatcher } from '../build/analysis/get-page-static-info'
 import type { TLSSocket } from 'tls'
 import type { PathnameNormalizer } from './normalizers/request/pathname-normalizer'
 import type { InstrumentationModule } from './instrumentation/types'
+import type { Span } from 'next/dist/compiled/@opentelemetry/api'
 
 import * as path from 'path'
 import { format as formatUrl } from 'url'
@@ -84,6 +85,8 @@ import {
 import { getNextPathnameInfo } from '../shared/lib/router/utils/get-next-pathname-info'
 import {
   RSC_HEADER,
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
   NEXT_RSC_UNION_QUERY,
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
@@ -92,6 +95,7 @@ import {
   NEXT_INSTANT_TEST_COOKIE,
   NEXT_HMR_REFRESH_HEADER,
 } from '../client/components/app-router-headers'
+import { nanoid } from 'next/dist/compiled/nanoid'
 import type {
   MatchOptions,
   RouteMatcherManager,
@@ -110,6 +114,8 @@ import {
   SpanStatusCode,
 } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
+import { runWithRequestInsightsIdentity } from './lib/trace/request-insights-identity'
+import { isRequestInsightsEnabled } from './lib/trace/span-store'
 import { I18NProvider } from './lib/i18n-provider'
 import { sendResponse } from './send-response'
 import { normalizeNextQueryParam } from './web/utils'
@@ -902,86 +908,117 @@ export default abstract class Server<
     const method = req.method.toUpperCase()
     const tracer = getTracer()
 
-    return tracer.withPropagatedContext(req.headers, () => {
-      // Capture the parent span before creating the handleRequest span.
-      // When deployed with an adapter, the platform's runtime may create its
-      // own OTEL HTTP server span before Next.js runs. We propagate http.route
-      // to this parent span so APM tools (e.g. Datadog) can derive the
-      // resource name correctly.
-      const parentSpan = tracer.getActiveScopeSpan()
+    const handleRequest = () =>
+      tracer.withPropagatedContext(req.headers, () => {
+        // Capture the parent span before creating the handleRequest span.
+        // When deployed with an adapter, the platform's runtime may create its
+        // own OTEL HTTP server span before Next.js runs. We propagate http.route
+        // to this parent span so APM tools (e.g. Datadog) can derive the
+        // resource name correctly.
+        const parentSpan = tracer.getActiveScopeSpan()
 
-      return tracer.trace(
-        BaseServerSpan.handleRequest,
-        {
-          spanName: `${method}`,
-          kind: SpanKind.SERVER,
-          attributes: {
-            'http.method': method,
-            'http.target': req.url,
+        return tracer.trace(
+          BaseServerSpan.handleRequest,
+          {
+            spanName: `${method}`,
+            kind: SpanKind.SERVER,
+            attributes: {
+              'http.method': method,
+              'http.target': req.url,
+            },
           },
-        },
-        async (span) =>
-          this.handleRequestImpl(req, res, parsedUrl).finally(() => {
-            if (!span) return
+          async (span) => {
+            const request =
+              isRequestInsightsEnabled() ||
+              process.env.NEXT_OTEL_VERBOSE === '1'
+                ? tracer.trace(BaseServerSpan.handleRequestImpl, {}, () =>
+                    this.handleRequestImpl(req, res, parsedUrl)
+                  )
+                : this.handleRequestImpl(req, res, parsedUrl)
 
-            const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
-            span.setAttributes({
-              'http.status_code': res.statusCode,
-              'next.rsc': isRSCRequest,
-            })
+            return request.finally(() => {
+              if (!span) return
 
-            if (res.statusCode && res.statusCode >= 500) {
-              // For 5xx status codes: SHOULD be set to 'Error' span status.
-              // x-ref: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
-              span.setStatus({
-                code: SpanStatusCode.ERROR,
-              })
-              // For span status 'Error', SHOULD set 'error.type' attribute.
-              span.setAttribute('error.type', res.statusCode.toString())
-            }
-
-            const rootSpanAttributes = tracer.getRootSpanAttributes()
-            // We were unable to get attributes, probably OTEL is not enabled
-            if (!rootSpanAttributes) return
-
-            if (
-              rootSpanAttributes.get('next.span_type') !==
-              BaseServerSpan.handleRequest
-            ) {
-              console.warn(
-                `Unexpected root span type '${rootSpanAttributes.get(
-                  'next.span_type'
-                )}'. Please report this Next.js issue https://github.com/vercel/next.js`
-              )
-              return
-            }
-
-            const route = rootSpanAttributes.get('next.route')
-            if (route) {
-              const name = isRSCRequest
-                ? `RSC ${method} ${route}`
-                : `${method} ${route}`
-
+              const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
               span.setAttributes({
-                'next.route': route,
-                'http.route': route,
-                'next.span_name': name,
+                'http.status_code': res.statusCode,
+                'next.rsc': isRSCRequest,
               })
-              span.updateName(name)
 
-              // Propagate http.route to the parent span if one exists and
-              // is different from the handleRequest span. This ensures APM
-              // tools that read attributes from the outermost span (e.g.
-              // a platform-created HTTP span) can derive the resource name.
-              if (parentSpan && parentSpan !== span) {
-                parentSpan.setAttribute('http.route', route)
+              if (res.statusCode && res.statusCode >= 500) {
+                // For 5xx status codes: SHOULD be set to 'Error' span status.
+                // x-ref: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                })
+                // For span status 'Error', SHOULD set 'error.type' attribute.
+                span.setAttribute('error.type', res.statusCode.toString())
               }
-            } else {
-              span.updateName(isRSCRequest ? `RSC ${method}` : `${method}`)
-            }
-          })
-      )
-    })
+
+              const rootSpanAttributes = tracer.getRootSpanAttributes()
+              // We were unable to get attributes, probably OTEL is not enabled
+              if (!rootSpanAttributes) return
+
+              if (
+                rootSpanAttributes.get('next.span_type') !==
+                BaseServerSpan.handleRequest
+              ) {
+                console.warn(
+                  `Unexpected root span type '${rootSpanAttributes.get(
+                    'next.span_type'
+                  )}'. Please report this Next.js issue https://github.com/vercel/next.js`
+                )
+                return
+              }
+
+              const route = rootSpanAttributes.get('next.route')
+              if (route) {
+                const name = isRSCRequest
+                  ? `RSC ${method} ${route}`
+                  : `${method} ${route}`
+
+                span.setAttributes({
+                  'next.route': route,
+                  'http.route': route,
+                  'next.span_name': name,
+                })
+                span.updateName(name)
+
+                // Propagate http.route to the parent span if one exists and
+                // is different from the handleRequest span. This ensures APM
+                // tools that read attributes from the outermost span (e.g.
+                // a platform-created HTTP span) can derive the resource name.
+                if (parentSpan && parentSpan !== span) {
+                  parentSpan.setAttribute('http.route', route)
+                }
+              } else {
+                span.updateName(isRSCRequest ? `RSC ${method}` : `${method}`)
+              }
+            })
+          }
+        )
+      })
+
+    if (!isRequestInsightsEnabled()) {
+      return handleRequest()
+    }
+
+    const requestIdHeader = req.headers[NEXT_REQUEST_ID_HEADER]
+    const requestId =
+      typeof requestIdHeader === 'string' ? requestIdHeader : nanoid()
+    const htmlRequestIdHeader = req.headers[NEXT_HTML_REQUEST_ID_HEADER]
+
+    return runWithRequestInsightsIdentity(
+      {
+        requestId,
+        htmlRequestId:
+          typeof htmlRequestIdHeader === 'string'
+            ? htmlRequestIdHeader
+            : requestId,
+        url: req.url,
+      },
+      handleRequest
+    )
   }
 
   private async handleRequestImpl(
@@ -989,6 +1026,15 @@ export default abstract class Server<
     res: ServerResponse,
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
+    const shouldTraceDetailedRequest =
+      isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1'
+    let requestSetupSpan = shouldTraceDetailedRequest
+      ? getTracer().startSpan(BaseServerSpan.prepareRequest, {
+          attributes: {
+            'next.span_type': BaseServerSpan.prepareRequest,
+          },
+        })
+      : undefined
     try {
       // Wait for the matchers to be ready.
       await this.matchers.waitTillReady()
@@ -1578,7 +1624,17 @@ export default abstract class Server<
         finished = await this.normalizeAndAttachMetadata(req, res, parsedUrl)
         if (finished) return
 
-        await this.handleCatchallRenderRequest(req, res, parsedUrl)
+        requestSetupSpan?.end()
+        requestSetupSpan = undefined
+        const normalizedParsedUrl = parsedUrl
+
+        if (shouldTraceDetailedRequest) {
+          await getTracer().trace(BaseServerSpan.dispatchRequest, {}, () =>
+            this.handleCatchallRenderRequest(req, res, normalizedParsedUrl)
+          )
+        } else {
+          await this.handleCatchallRenderRequest(req, res, normalizedParsedUrl)
+        }
         return
       }
 
@@ -1617,6 +1673,8 @@ export default abstract class Server<
       }
 
       res.statusCode = 200
+      requestSetupSpan?.end()
+      requestSetupSpan = undefined
       return await this.run(req, res, parsedUrl)
     } catch (err: any) {
       if (err instanceof NoFallbackError) {
@@ -1638,6 +1696,8 @@ export default abstract class Server<
       this.logError(getProperError(err))
       res.statusCode = 500
       res.body('Internal Server Error').send()
+    } finally {
+      requestSetupSpan?.end()
     }
   }
 
@@ -2006,13 +2066,28 @@ export default abstract class Server<
     requestContext: RequestContext<ServerRequest, ServerResponse>,
     findComponentsResult: FindComponentsResult
   ): Promise<ResponsePayload | null> {
+    const detailedPhase:
+      | {
+          span: Span | undefined
+        }
+      | undefined =
+      isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1'
+        ? { span: undefined }
+        : undefined
+
     return getTracer().trace(
       BaseServerSpan.renderToResponseWithComponents,
-      async () =>
-        this.renderToResponseWithComponentsImpl(
-          requestContext,
-          findComponentsResult
-        )
+      async () => {
+        try {
+          return await this.renderToResponseWithComponentsImpl(
+            requestContext,
+            findComponentsResult,
+            detailedPhase
+          )
+        } finally {
+          detailedPhase?.span?.end()
+        }
+      }
     )
   }
 
@@ -2061,8 +2136,24 @@ export default abstract class Server<
       pathname,
       renderOpts: opts,
     }: RequestContext<ServerRequest, ServerResponse>,
-    { components, query }: FindComponentsResult
+    { components, query }: FindComponentsResult,
+    detailedPhase:
+      | {
+          span: Span | undefined
+        }
+      | undefined
   ): Promise<ResponsePayload | null> {
+    if (detailedPhase) {
+      detailedPhase.span = getTracer().startSpan(
+        BaseServerSpan.prepareResponseWithComponents,
+        {
+          attributes: {
+            'next.span_type': BaseServerSpan.prepareResponseWithComponents,
+          },
+        }
+      )
+    }
+
     if (pathname === UNDERSCORE_NOT_FOUND_ROUTE) {
       pathname = '/404'
     }
@@ -2374,10 +2465,34 @@ export default abstract class Server<
     }
 
     // use existing incrementalCache instance if available
+    if (detailedPhase) {
+      detailedPhase.span?.end()
+      detailedPhase.span = getTracer().startSpan(
+        BaseServerSpan.getIncrementalCache,
+        {
+          attributes: {
+            'next.span_type': BaseServerSpan.getIncrementalCache,
+          },
+        }
+      )
+    }
+
     const incrementalCache: import('./lib/incremental-cache').IncrementalCache =
       await this.getIncrementalCache({
         requestHeaders: Object.assign({}, req.headers),
       })
+
+    if (detailedPhase) {
+      detailedPhase.span?.end()
+      detailedPhase.span = getTracer().startSpan(
+        BaseServerSpan.resolvePrerendering,
+        {
+          attributes: {
+            'next.span_type': BaseServerSpan.resolvePrerendering,
+          },
+        }
+      )
+    }
 
     // TODO: investigate, this is not safe across multiple concurrent requests
     incrementalCache.resetRequestCache()
@@ -2464,6 +2579,18 @@ export default abstract class Server<
       return null
     }
 
+    if (detailedPhase) {
+      detailedPhase.span?.end()
+      detailedPhase.span = getTracer().startSpan(
+        BaseServerSpan.prepareRouteHandler,
+        {
+          attributes: {
+            'next.span_type': BaseServerSpan.prepareRouteHandler,
+          },
+        }
+      )
+    }
+
     const request = isNodeNextRequest(req) ? req.originalRequest : req
     const response = isNodeNextResponse(res) ? res.originalResponse : res
 
@@ -2527,9 +2654,19 @@ export default abstract class Server<
     // generic anyway.
     let handlerRes: HTTPServerResponse = response
 
-    await components.ComponentMod.handler(handlerReq, handlerRes, {
-      waitUntil: this.getWaitUntil(),
-    })
+    if (detailedPhase) {
+      detailedPhase.span?.end()
+      detailedPhase.span = undefined
+      await getTracer().trace(BaseServerSpan.executeRouteHandler, {}, () =>
+        components.ComponentMod.handler(handlerReq, handlerRes, {
+          waitUntil: this.getWaitUntil(),
+        })
+      )
+    } else {
+      await components.ComponentMod.handler(handlerReq, handlerRes, {
+        waitUntil: this.getWaitUntil(),
+      })
+    }
 
     // response is handled fully in handler
     return null

--- a/packages/next/src/server/client-component-renderer-logger.ts
+++ b/packages/next/src/server/client-component-renderer-logger.ts
@@ -2,6 +2,7 @@ import type { AppPageModule } from './route-modules/app-page/module'
 
 // Combined load times for loading client components
 let clientComponentLoadStart = 0
+let clientComponentLoadEnd = 0
 let clientComponentLoadTimes = 0
 let clientComponentLoadCount = 0
 
@@ -28,16 +29,25 @@ export function wrapClientComponentLoader(
         clientComponentLoadCount += 1
         return ComponentMod.__next_app__.require(...args)
       } finally {
-        clientComponentLoadTimes += performance.now() - startTime
+        const endTime = performance.now()
+        clientComponentLoadEnd = endTime
+        clientComponentLoadTimes += endTime - startTime
       }
     },
     loadChunk: (...args) => {
       const startTime = performance.now()
+
+      if (clientComponentLoadStart === 0) {
+        clientComponentLoadStart = startTime
+      }
+
       const result = ComponentMod.__next_app__.loadChunk(...args)
       // Avoid wrapping `loadChunk`'s result in an extra promise in case something like React depends on its identity.
       // We only need to know when it's settled.
       result.finally(() => {
-        clientComponentLoadTimes += performance.now() - startTime
+        const endTime = performance.now()
+        clientComponentLoadEnd = endTime
+        clientComponentLoadTimes += endTime - startTime
       })
       return result
     },
@@ -52,12 +62,14 @@ export function getClientComponentLoaderMetrics(
       ? undefined
       : {
           clientComponentLoadStart,
+          clientComponentLoadEnd,
           clientComponentLoadTimes,
           clientComponentLoadCount,
         }
 
   if (options.reset) {
     clientComponentLoadStart = 0
+    clientComponentLoadEnd = 0
     clientComponentLoadTimes = 0
     clientComponentLoadCount = 0
   }

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -10,6 +10,8 @@ import {
   type NextJsHotReloaderInterface,
 } from '../dev/hot-reloader-types'
 import { subscribeRequestInsights } from './trace/request-insights'
+import { DevBundlerServiceSpan } from './trace/constants'
+import { getTracer } from './trace/tracer'
 
 /**
  * The DevBundlerService provides an interface to perform tasks with the
@@ -61,6 +63,12 @@ export class DevBundlerService {
     definition
   ) => {
     // TODO: remove after ensure is pulled out of server
+    if (isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1') {
+      return await getTracer().trace(DevBundlerServiceSpan.ensurePage, {}, () =>
+        this.bundler.hotReloader.ensurePage(definition)
+      )
+    }
+
     return await this.bundler.hotReloader.ensurePage(definition)
   }
 

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -344,6 +344,7 @@ export function createPatchedFetcher(
         kind: SpanKind.CLIENT,
         spanName: ['fetch', method, fetchUrl].filter(Boolean).join(' '),
         attributes: {
+          'next.span.category': isInternal ? 'nextjs' : 'application',
           'http.url': fetchUrl,
           'http.method': method,
           'net.peer.name': url?.hostname,

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -9,11 +9,19 @@
 
 enum BaseServerSpan {
   handleRequest = 'BaseServer.handleRequest',
+  handleRequestImpl = 'BaseServer.handleRequestImpl',
+  prepareRequest = 'BaseServer.prepareRequest',
+  dispatchRequest = 'BaseServer.dispatchRequest',
   run = 'BaseServer.run',
   pipe = 'BaseServer.pipe',
   getStaticHTML = 'BaseServer.getStaticHTML',
   render = 'BaseServer.render',
   renderToResponseWithComponents = 'BaseServer.renderToResponseWithComponents',
+  prepareResponseWithComponents = 'BaseServer.prepareResponseWithComponents',
+  getIncrementalCache = 'BaseServer.getIncrementalCache',
+  resolvePrerendering = 'BaseServer.resolvePrerendering',
+  prepareRouteHandler = 'BaseServer.prepareRouteHandler',
+  executeRouteHandler = 'BaseServer.executeRouteHandler',
   renderToResponse = 'BaseServer.renderToResponse',
   renderToHTML = 'BaseServer.renderToHTML',
   renderError = 'BaseServer.renderError',
@@ -37,6 +45,9 @@ enum NextServerSpan {
 
 enum NextNodeServerSpan {
   compression = 'NextNodeServer.compression',
+  prepareRoute = 'NextNodeServer.prepareRoute',
+  matchRoute = 'NextNodeServer.matchRoute',
+  resolveRoute = 'NextNodeServer.resolveRoute',
   getBuildId = 'NextNodeServer.getBuildId',
   createComponentTree = 'NextNodeServer.createComponentTree',
   clientComponentLoading = 'NextNodeServer.clientComponentLoading',
@@ -61,6 +72,7 @@ enum NextNodeServerSpan {
   renderError = 'NextNodeServer.renderError',
   renderErrorToHTML = 'NextNodeServer.renderErrorToHTML',
   render404 = 'NextNodeServer.render404',
+  waitForFirstResponseChunk = 'NextNodeServer.waitForFirstResponseChunk',
   startResponse = 'NextNodeServer.startResponse',
 
   // nested inner span, does not require parent scope name
@@ -83,17 +95,40 @@ enum RenderSpan {
 }
 
 enum AppRenderSpan {
+  prepareAppPageResponse = 'AppRender.prepareAppPageResponse',
+  initializeRender = 'AppRender.initializeRender',
+  finalizeRSCPayload = 'AppRender.finalizeRSCPayload',
+  startRSCStream = 'AppRender.startRSCStream',
+  renderRSCResponse = 'AppRender.renderRSCResponse',
+  waitForRSC = 'AppRender.waitForRSC',
+  prepareHTMLRender = 'AppRender.prepareHTMLRender',
   renderToString = 'AppRender.renderToString',
   renderToReadableStream = 'AppRender.renderToReadableStream',
   getBodyResult = 'AppRender.getBodyResult',
   fetch = 'AppRender.fetch',
   waitShellReady = 'AppRender.waitShellReady',
+  waitForFizzRenderTask = 'AppRender.waitForFizzRenderTask',
+  pipeFizzStream = 'AppRender.pipeFizzStream',
+  waitForFizzFlush = 'AppRender.waitForFizzFlush',
+  createHTMLTransforms = 'AppRender.createHTMLTransforms',
   renderToNodeFizzStream = 'AppRender.renderToNodeFizzStream',
   executeServerAction = 'AppRender.executeServerAction',
+  waitForHTMLCompletion = 'AppRender.waitForHTMLCompletion',
 }
 
 enum RouterSpan {
   executeRoute = 'Router.executeRoute',
+}
+
+enum DevRouteMatcherManagerSpan {
+  matchDevelopmentRoute = 'DevRouteMatcherManager.matchDevelopmentRoute',
+  ensureRoute = 'DevRouteMatcherManager.ensureRoute',
+  reloadMatchers = 'DevRouteMatcherManager.reloadMatchers',
+  matchProductionRoute = 'DevRouteMatcherManager.matchProductionRoute',
+}
+
+enum DevBundlerServiceSpan {
+  ensurePage = 'DevBundlerService.ensurePage',
 }
 
 enum NodeSpan {
@@ -121,6 +156,8 @@ type SpanTypes =
   | `${NextNodeServerSpan}`
   | `${RenderSpan}`
   | `${RouterSpan}`
+  | `${DevRouteMatcherManagerSpan}`
+  | `${DevBundlerServiceSpan}`
   | `${AppRenderSpan}`
   | `${NodeSpan}`
   | `${AppRouteRouteHandlersSpan}`
@@ -164,6 +201,8 @@ export {
   StartServerSpan,
   RenderSpan,
   RouterSpan,
+  DevRouteMatcherManagerSpan,
+  DevBundlerServiceSpan,
   AppRenderSpan,
   NodeSpan,
   AppRouteRouteHandlersSpan,

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -6,6 +6,7 @@ import { runInNewContext } from 'node:vm'
 import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
 import { createLocalSpan } from './local-span-recorder'
+import { runWithRequestInsightsIdentity } from './request-insights-identity'
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 
 const originalDevServer = process.env.__NEXT_DEV_SERVER
@@ -115,6 +116,47 @@ describe('local recording span', () => {
             },
           }),
         ],
+      }),
+    ])
+  })
+
+  it('uses the request insights identity before the work store exists', () => {
+    runWithRequestInsightsIdentity(
+      {
+        requestId: 'request-1',
+        htmlRequestId: 'html-1',
+        url: '/dashboard?tab=overview',
+      },
+      () => {
+        const span = createLocalSpan({ name: 'test.request-root' })
+        span.end()
+      }
+    )
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        name: 'test.request-root',
+        requestId: 'request-1',
+        htmlRequestId: 'html-1',
+        url: '/dashboard?tab=overview',
+      }),
+    ])
+  })
+
+  it('records explicit performance timestamps', () => {
+    const startTime = performance.now() - 10
+    const span = createLocalSpan({
+      name: 'test.local-span.explicit-time',
+      startTime,
+    })
+
+    span.end(startTime + 0.2)
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        name: 'test.local-span.explicit-time',
+        startTime: performance.timeOrigin + startTime,
+        durationMs: expect.closeTo(0.2, 3),
       }),
     ])
   })

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -7,6 +7,7 @@ import type { AsyncLocalStorage } from 'async_hooks'
 import { SpanStatusCode } from 'next/dist/compiled/@opentelemetry/api'
 import {
   isLocalSpanRecordingEnabled,
+  isRequestInsightsEnabled,
   recordSpan,
   type SpanStoreAttributes,
   type SpanStoreEvent,
@@ -34,6 +35,7 @@ export function createLocalSpan({
   name,
   attributes,
   links,
+  startTime,
   traceId,
   spanId,
   parentSpanId,
@@ -42,6 +44,7 @@ export function createLocalSpan({
   name: string
   attributes?: LocalSpanAttributes
   links?: SpanOptions['links']
+  startTime?: SpanOptions['startTime']
   traceId?: string
   spanId?: string
   parentSpanId?: string
@@ -51,6 +54,7 @@ export function createLocalSpan({
     name,
     attributes,
     links,
+    startTime,
     delegateSpan,
     traceId: traceId ?? getLocalTraceId(),
     spanId: spanId ?? getLocalSpanId(),
@@ -76,6 +80,7 @@ export type LocalSpanRecorder = {
   getActiveLocalSpan: typeof getActiveLocalSpan
   isLocalRecordingSpan: typeof isLocalRecordingSpan
   isLocalSpanRecordingEnabled: typeof isLocalSpanRecordingEnabled
+  isRequestInsightsEnabled: typeof isRequestInsightsEnabled
   withLocalSpan: typeof withLocalSpan
 }
 
@@ -90,6 +95,7 @@ export function registerLocalSpanRecorder(): void {
     getActiveLocalSpan,
     isLocalRecordingSpan,
     isLocalSpanRecordingEnabled,
+    isRequestInsightsEnabled,
     withLocalSpan,
   }
 }
@@ -122,7 +128,6 @@ class LocalRecordingSpan implements Span {
   private readonly parentSpanId?: string
   private requestIdentity: RequestIdentity
   private readonly startTime: number
-  private readonly startTimeMs: number
   private statusCode: number | undefined
   private statusMessage: string | undefined
   private exception:
@@ -137,6 +142,7 @@ class LocalRecordingSpan implements Span {
     name,
     attributes,
     links,
+    startTime,
     delegateSpan,
     traceId,
     spanId,
@@ -146,6 +152,7 @@ class LocalRecordingSpan implements Span {
     name: string
     attributes?: LocalSpanAttributes
     links?: SpanOptions['links']
+    startTime?: SpanOptions['startTime']
     delegateSpan?: Span
     traceId: string
     spanId: string
@@ -164,8 +171,7 @@ class LocalRecordingSpan implements Span {
     this.links = getSpanStoreLinks(links)
     this.parentSpanId = parentSpanId
     this.requestIdentity = requestIdentity
-    this.startTime = Date.now()
-    this.startTimeMs = getCurrentTimeMs()
+    this.startTime = getTimestamp(startTime)
     this.statusCode = undefined
     this.statusMessage = undefined
     this.exception = undefined
@@ -254,7 +260,7 @@ class LocalRecordingSpan implements Span {
       this.delegateSpan?.end(endTime)
     } finally {
       try {
-        this.record()
+        this.record(endTime)
       } finally {
         this.releaseReferences()
       }
@@ -282,14 +288,14 @@ class LocalRecordingSpan implements Span {
     this.delegateSpan?.recordException(exception, time)
   }
 
-  private record(): void {
+  private record(endTime: Parameters<Span['end']>[0]): void {
     const recordAttributes =
       Object.keys(this.attributes).length > 0 ? this.attributes : undefined
 
     recordSpan({
       name: this.name,
       startTime: this.startTime,
-      durationMs: getCurrentTimeMs() - this.startTimeMs,
+      durationMs: Math.max(0, getTimestamp(endTime) - this.startTime),
       status: this.statusCode === SpanStatusCode.ERROR ? 'error' : 'ok',
       traceId: this.spanContextValue.traceId,
       spanId: this.spanContextValue.spanId,
@@ -374,8 +380,31 @@ function cleanSpanStoreAttributes(
   return cleanedAttributes
 }
 
-function getCurrentTimeMs(): number {
-  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+function getTimestamp(time?: SpanOptions['startTime']): number {
+  if (time instanceof Date) {
+    return time.getTime()
+  }
+
+  if (Array.isArray(time)) {
+    return time[0] * 1000 + time[1] / 1_000_000
+  }
+
+  if (typeof time === 'number') {
+    const timeOrigin = getPerformanceTimeOrigin()
+    return timeOrigin !== undefined && time < timeOrigin
+      ? timeOrigin + time
+      : time
+  }
+
+  const timeOrigin = getPerformanceTimeOrigin()
+  return timeOrigin === undefined ? Date.now() : timeOrigin + performance.now()
+}
+
+function getPerformanceTimeOrigin(): number | undefined {
+  return typeof performance !== 'undefined' &&
+    typeof performance.timeOrigin === 'number'
+    ? performance.timeOrigin
+    : undefined
 }
 
 function getStringAttribute(
@@ -452,20 +481,24 @@ function getSpanStoreExceptionAttributes(
 
 function getCurrentRequestIdentity(): RequestIdentity {
   try {
+    const { getRequestInsightsIdentity } =
+      require('./request-insights-identity') as typeof import('./request-insights-identity')
     const { workAsyncStorage } =
       require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
     const { workUnitAsyncStorage } =
       require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
     const workStore = workAsyncStorage.getStore()
     const workUnitStore = workUnitAsyncStorage.getStore()
+    const requestInsightsIdentity = getRequestInsightsIdentity()
     const url =
       workUnitStore && 'url' in workUnitStore ? workUnitStore.url : undefined
 
     return {
-      requestId: workStore?.requestId,
-      htmlRequestId: workStore?.htmlRequestId,
+      requestId: workStore?.requestId ?? requestInsightsIdentity?.requestId,
+      htmlRequestId:
+        workStore?.htmlRequestId ?? requestInsightsIdentity?.htmlRequestId,
       route: workStore?.route,
-      url: url ? `${url.pathname}${url.search}` : undefined,
+      url: url ? `${url.pathname}${url.search}` : requestInsightsIdentity?.url,
     }
   } catch {
     return {}

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -1,0 +1,34 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+import { createAsyncLocalStorage } from '../../app-render/async-local-storage'
+
+export type RequestInsightsIdentity = {
+  requestId: string
+  htmlRequestId: string
+  url: string | undefined
+}
+
+const REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY = Symbol.for(
+  '@next/request-insights-identity-storage'
+)
+
+function getRequestInsightsIdentityStorage(): AsyncLocalStorage<RequestInsightsIdentity> {
+  const globalStore = globalThis as typeof globalThis & {
+    [REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY]?: AsyncLocalStorage<RequestInsightsIdentity>
+  }
+
+  return (globalStore[REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY] ??=
+    createAsyncLocalStorage())
+}
+
+export function runWithRequestInsightsIdentity<T>(
+  identity: RequestInsightsIdentity,
+  fn: () => T
+): T {
+  return getRequestInsightsIdentityStorage().run(identity, fn)
+}
+
+export function getRequestInsightsIdentity():
+  | RequestInsightsIdentity
+  | undefined {
+  return getRequestInsightsIdentityStorage().getStore()
+}

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -42,6 +42,7 @@ describe('request insights', () => {
       htmlRequestId: 'html_1',
       route: '/products/[id]',
       attributes: {
+        'next.span.category': 'nextjs',
         'next.span_type': 'AppRender.getBodyResult',
       },
       events: [
@@ -67,6 +68,7 @@ describe('request insights', () => {
       htmlRequestId: 'html_1',
       route: '/products/[id]',
       attributes: {
+        'next.span.category': 'application',
         'next.span_type': 'AppRender.fetch',
         'http.url': 'https://example.vercel.sh/',
         'http.method': 'GET',
@@ -88,10 +90,16 @@ describe('request insights', () => {
           spans: expect.arrayContaining([
             expect.objectContaining({
               name: 'fetch GET https://example.vercel.sh/',
+              attributes: expect.objectContaining({
+                'next.span.category': 'application',
+              }),
             }),
             expect.objectContaining({
               traceId: 'trace_1',
               spanId: 'span_1',
+              attributes: expect.objectContaining({
+                'next.span.category': 'nextjs',
+              }),
               events: [
                 {
                   name: 'metadata ready',
@@ -144,6 +152,53 @@ describe('request insights', () => {
     )
 
     unsubscribe()
+  })
+
+  it('uses the HTTP request span as the end-to-end request timing', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'render route (app) /dashboard',
+      requestId: 'req_timing',
+      startTime: 100,
+      durationMs: 60,
+    })
+    recordSpan({
+      name: 'GET /dashboard',
+      requestId: 'req_timing',
+      startTime: 100,
+      durationMs: 50,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    recordRequestInsightFetch(
+      { requestId: 'req_timing' },
+      { url: 'https://example.com/late', startTime: 145, durationMs: 20 }
+    )
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        startTime: 100,
+        durationMs: 50,
+      })
+    )
+  })
+
+  it('does not treat aggregate client component loading as a trace span', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'NextNodeServer.clientComponentLoading',
+      requestId: 'req_client_loading',
+      startTime: 100,
+      durationMs: 50,
+      attributes: {
+        'next.span_type': 'NextNodeServer.clientComponentLoading',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([])
   })
 
   it('records request fetch metrics when the OTel fetch span does not complete locally', () => {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -10,6 +10,8 @@ export { isRequestInsightsEnabled } from './span-store'
 
 const MAX_REQUEST_INSIGHTS = 100
 const REQUEST_INSIGHTS_STORE_KEY = Symbol.for('@next/request-insights-store')
+const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
+  'NextNodeServer.clientComponentLoading'
 
 type RequestInsightsListener = (insight: RequestInsight) => void
 type RequestInsightIdentity = {
@@ -44,6 +46,10 @@ const SENSITIVE_PARAM_NAME_RE =
 
 class InMemoryRequestInsightsStore {
   private readonly requests = new Map<string, RequestInsight>()
+  private readonly requestTimings = new Map<
+    string,
+    { startTime: number; durationMs: number }
+  >()
   private readonly requestOrder: string[] = []
   private readonly listeners = new Set<RequestInsightsListener>()
 
@@ -58,19 +64,15 @@ class InMemoryRequestInsightsStore {
     )
 
     const spanStartTime = span.startTime ?? span.timestamp
-    const spanEndTime = span.durationMs
-      ? spanStartTime + span.durationMs
-      : spanStartTime
-    const requestEndTime = insight.durationMs
-      ? insight.startTime + insight.durationMs
-      : insight.startTime
-
     insight.htmlRequestId = span.htmlRequestId ?? insight.htmlRequestId
     insight.route = insight.route ?? span.route
     insight.url = insight.url ?? sanitizeUrl(span.url)
-    insight.startTime = Math.min(insight.startTime, spanStartTime)
-    insight.durationMs =
-      Math.max(requestEndTime, spanEndTime) - insight.startTime
+    this.updateTiming(
+      insight,
+      spanStartTime,
+      span.durationMs,
+      span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+    )
     insight.status =
       insight.status === 'error' || span.status === 'error'
         ? 'error'
@@ -112,15 +114,7 @@ class InMemoryRequestInsightsStore {
 
     const fetchStartTime = fetch.startTime ?? Date.now()
     const insight = this.getOrCreateRequest(identity, fetchStartTime)
-    const fetchEndTime = fetch.durationMs
-      ? fetchStartTime + fetch.durationMs
-      : fetchStartTime
-    const requestEndTime = insight.durationMs
-      ? insight.startTime + insight.durationMs
-      : insight.startTime
-
-    insight.durationMs =
-      Math.max(requestEndTime, fetchEndTime) - insight.startTime
+    this.updateTiming(insight, fetchStartTime, fetch.durationMs, false)
     this.recordFetchForInsight(insight, sanitizeFetchInsight(fetch))
     this.notify(insight)
   }
@@ -142,7 +136,35 @@ class InMemoryRequestInsightsStore {
 
   clear(): void {
     this.requests.clear()
+    this.requestTimings.clear()
     this.requestOrder.length = 0
+  }
+
+  private updateTiming(
+    insight: RequestInsight,
+    startTime: number,
+    durationMs: number | undefined,
+    isRequestSpan: boolean
+  ): void {
+    if (isRequestSpan && durationMs !== undefined) {
+      const requestTiming = { startTime, durationMs }
+      this.requestTimings.set(insight.requestId, requestTiming)
+      insight.startTime = requestTiming.startTime
+      insight.durationMs = requestTiming.durationMs
+      return
+    }
+
+    const requestTiming = this.requestTimings.get(insight.requestId)
+    if (requestTiming) {
+      insight.startTime = requestTiming.startTime
+      insight.durationMs = requestTiming.durationMs
+      return
+    }
+
+    const endTime = startTime + (durationMs ?? 0)
+    const requestEndTime = insight.startTime + (insight.durationMs ?? 0)
+    insight.startTime = Math.min(insight.startTime, startTime)
+    insight.durationMs = Math.max(requestEndTime, endTime) - insight.startTime
   }
 
   private notify(insight: RequestInsight): void {
@@ -206,12 +228,19 @@ class InMemoryRequestInsightsStore {
       const requestId = this.requestOrder.shift()
       if (requestId) {
         this.requests.delete(requestId)
+        this.requestTimings.delete(requestId)
       }
     }
   }
 }
 
 export function recordRequestInsightSpan(span: SpanStoreRecord): void {
+  if (
+    span.attributes?.['next.span_type'] === CLIENT_COMPONENT_LOADING_SPAN_TYPE
+  ) {
+    return
+  }
+
   getRequestInsightsStore().recordSpan(span)
 }
 

--- a/packages/next/src/server/lib/trace/span-store.test.ts
+++ b/packages/next/src/server/lib/trace/span-store.test.ts
@@ -96,6 +96,7 @@ describe('span recording', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     setSpanRecorderForTest(recorder)
 
+    expect(isRequestInsightsEnabled()).toBe(false)
     expect(isLocalSpanRecordingEnabled()).toBe(false)
 
     recordSpan({ name: 'test.production', requestId: 'req_2' })

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -74,6 +74,10 @@ export function isLocalSpanRecordingEnabled(): boolean {
 }
 
 export function isRequestInsightsEnabled(): boolean {
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return false
+  }
+
   const value = process.env.__NEXT_REQUEST_INSIGHTS
   return isEnabledEnvValue(value)
 }

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -20,7 +20,12 @@ import {
 
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 import { registerLocalSpanRecorder } from './local-span-recorder'
-import { AppRenderSpan, NodeSpan } from './constants'
+import {
+  AppRenderSpan,
+  BaseServerSpan,
+  LoadComponentsSpan,
+  NodeSpan,
+} from './constants'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
@@ -184,6 +189,22 @@ describe('local span recording', () => {
     expect(getSpanRecords()).toEqual([])
   })
 
+  it('records verbose spans locally for request insights', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    getTracer().trace(BaseServerSpan.render, () => undefined)
+    const wrappedLoadComponents = getTracer().wrap(
+      LoadComponentsSpan.loadComponents,
+      () => undefined
+    )
+    wrappedLoadComponents()
+
+    expect(getSpanRecords()).toEqual([
+      expect.objectContaining({ name: BaseServerSpan.render }),
+      expect.objectContaining({ name: LoadComponentsSpan.loadComponents }),
+    ])
+  })
+
   it('bypasses local span handling outside the dev server', () => {
     delete process.env.__NEXT_DEV_SERVER
     let receivedSpan: unknown = 'not-called'
@@ -221,6 +242,7 @@ describe('local span recording', () => {
         durationMs: expect.any(Number),
         attributes: expect.objectContaining({
           'next.route': '/products/[id]',
+          'next.span.category': 'nextjs',
           'next.span_name': 'test.sync',
           'next.span_type': NodeSpan.runHandler,
         }),
@@ -235,6 +257,7 @@ describe('local span recording', () => {
         kind: SpanKind.CLIENT,
         spanName: 'fetch GET https://example.vercel.sh/',
         attributes: {
+          'next.span.category': 'application',
           'http.url': 'https://example.vercel.sh/',
           'http.method': 'GET',
           'net.peer.name': 'example.vercel.sh',
@@ -253,6 +276,7 @@ describe('local span recording', () => {
         attributes: expect.objectContaining({
           'next.span_name': 'fetch GET https://example.vercel.sh/',
           'next.span_type': AppRenderSpan.fetch,
+          'next.span.category': 'application',
           'http.url': 'https://example.vercel.sh/',
           'http.method': 'GET',
           'net.peer.name': 'example.vercel.sh',
@@ -415,7 +439,10 @@ describe('local span recording', () => {
       expect(getTracer().getActiveScopeSpan()).toBe(parentSpan)
 
       const childSpan = getTracer().startSpan(AppRenderSpan.fetch, {
-        attributes: { 'next.page': 'child' },
+        attributes: {
+          'next.page': 'child',
+          'next.span.category': 'application',
+        },
       })
       childSpanId = childSpan.spanContext().spanId
       childSpan.end()
@@ -434,6 +461,9 @@ describe('local span recording', () => {
       expect.objectContaining({
         name: NodeSpan.runHandler,
         parentSpanId: undefined,
+        attributes: expect.objectContaining({
+          'next.span.category': 'nextjs',
+        }),
       })
     )
     expect(childRecord).toEqual(
@@ -442,6 +472,9 @@ describe('local span recording', () => {
         spanId: childSpanId,
         traceId: parentRecord?.traceId,
         parentSpanId: parentRecord?.spanId,
+        attributes: expect.objectContaining({
+          'next.span.category': 'application',
+        }),
       })
     )
   })

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -340,8 +340,9 @@ class NextTracerImpl implements NextTracer {
     const [type, fnOrOptions, fnOrEmpty] = args
     const tracingEnabled =
       Boolean(NEXT_OTEL_PERFORMANCE_PREFIX) || this.isOpenTelemetryEnabled()
+    const localSpanRecorder = getLocalSpanRecorder()
     const localSpanRecordingEnabled =
-      getLocalSpanRecorder()?.isLocalSpanRecordingEnabled() ?? false
+      localSpanRecorder?.isLocalSpanRecordingEnabled() ?? false
 
     if (!tracingEnabled && !localSpanRecordingEnabled) {
       return typeof fnOrOptions === 'function' ? fnOrOptions() : fnOrEmpty()
@@ -366,12 +367,15 @@ class NextTracerImpl implements NextTracer {
           }
 
     const spanName = options.spanName ?? type
+    const isVanillaSpan =
+      NextVanillaSpanAllowlist.has(type) ||
+      process.env.NEXT_OTEL_VERBOSE === '1'
+    const shouldRecordLocalSpan =
+      localSpanRecordingEnabled &&
+      (isVanillaSpan ||
+        (localSpanRecorder?.isRequestInsightsEnabled() ?? false))
 
-    if (
-      (!NextVanillaSpanAllowlist.has(type) &&
-        process.env.NEXT_OTEL_VERBOSE !== '1') ||
-      options.hideSpan
-    ) {
+    if ((!isVanillaSpan && !shouldRecordLocalSpan) || options.hideSpan) {
       return fn()
     }
 
@@ -395,6 +399,7 @@ class NextTracerImpl implements NextTracer {
     const spanId = getSpanId()
 
     options.attributes = {
+      'next.span.category': 'nextjs',
       'next.span_name': spanName,
       'next.span_type': type,
       ...options.attributes,
@@ -405,8 +410,8 @@ class NextTracerImpl implements NextTracer {
         spanName,
         options,
         spanContext,
-        tracingEnabled,
-        localSpanRecordingEnabled,
+        tracingEnabled && isVanillaSpan,
+        shouldRecordLocalSpan,
         (span: Span) => {
           let startTime: number | undefined
           if (
@@ -548,6 +553,7 @@ class NextTracerImpl implements NextTracer {
       name,
       attributes: options.attributes,
       links: options.links,
+      startTime: options.startTime,
       delegateSpan,
       traceId: delegateSpanContext?.traceId ?? parentSpanContext?.traceId,
       spanId: delegateSpanContext?.spanId,
@@ -573,7 +579,8 @@ class NextTracerImpl implements NextTracer {
 
     if (
       !NextVanillaSpanAllowlist.has(name) &&
-      process.env.NEXT_OTEL_VERBOSE !== '1'
+      process.env.NEXT_OTEL_VERBOSE !== '1' &&
+      !process.env.__NEXT_DEV_SERVER
     ) {
       return fn
     }
@@ -606,7 +613,17 @@ class NextTracerImpl implements NextTracer {
   public startSpan(type: SpanTypes): Span
   public startSpan(type: SpanTypes, options: TracerSpanOptions): Span
   public startSpan(...args: Array<any>): Span {
-    const [type, options]: [string, TracerSpanOptions | undefined] = args as any
+    const [type, passedOptions]: [string, TracerSpanOptions | undefined] =
+      args as any
+    const options: TracerSpanOptions = passedOptions
+      ? {
+          ...passedOptions,
+          attributes: {
+            'next.span.category': 'nextjs',
+            ...passedOptions.attributes,
+          },
+        }
+      : { attributes: { 'next.span.category': 'nextjs' } }
 
     const parentContext =
       this.getSpanContext(options?.parentSpan ?? this.getActiveScopeSpan()) ??

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -98,6 +98,7 @@ import type { PagesAPIRouteMatch } from './route-matches/pages-api-route-match'
 import type { MatchOptions } from './route-matcher-managers/route-matcher-manager'
 import { BubbledError, getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
+import { isRequestInsightsEnabled } from './lib/trace/span-store'
 import { nodeFs } from './lib/node-fs-methods'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { pipeToNodeResponse } from './pipe-readable'
@@ -1083,46 +1084,81 @@ export default class NextNodeServer extends BaseServer<
     parsedUrl
   ) => {
     let { pathname, query } = parsedUrl
+    const shouldTraceDetailedRequest =
+      isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1'
+    let routePreparationSpan = shouldTraceDetailedRequest
+      ? getTracer().startSpan(NextNodeServerSpan.prepareRoute, {
+          attributes: {
+            'next.span_type': NextNodeServerSpan.prepareRoute,
+          },
+        })
+      : undefined
     if (!pathname) {
+      routePreparationSpan?.end()
       throw new Error('Invariant: pathname is undefined')
     }
 
-    // When in minimal mode we do not bubble the fallback as the
-    // router-server is not present to handle the error
-    addRequestMeta(req, 'bubbleNoFallback', this.minimalMode ? undefined : true)
-
-    // This is needed to expose render404 and nextConfig
-    // for environments without router-server
-    if (!routerServerGlobal[RouterServerContextSymbol]) {
-      routerServerGlobal[RouterServerContextSymbol] = {}
-    }
-    const relativeProjectDir = relative(process.cwd(), this.dir)
-    const existingServerContext =
-      routerServerGlobal[RouterServerContextSymbol][relativeProjectDir]
-
-    if (!existingServerContext) {
-      routerServerGlobal[RouterServerContextSymbol][relativeProjectDir] = {
-        render404: this.render404.bind(this),
-      }
-    }
-    routerServerGlobal[RouterServerContextSymbol][
-      relativeProjectDir
-    ].nextConfig = this.nextConfig
-    routerServerGlobal[RouterServerContextSymbol][
-      relativeProjectDir
-    ].isWrappedByNextServer = true
-
+    let options: MatchOptions
     try {
+      // When in minimal mode we do not bubble the fallback as the
+      // router-server is not present to handle the error
+      addRequestMeta(
+        req,
+        'bubbleNoFallback',
+        this.minimalMode ? undefined : true
+      )
+
+      // This is needed to expose render404 and nextConfig
+      // for environments without router-server
+      if (!routerServerGlobal[RouterServerContextSymbol]) {
+        routerServerGlobal[RouterServerContextSymbol] = {}
+      }
+      const relativeProjectDir = relative(process.cwd(), this.dir)
+      const existingServerContext =
+        routerServerGlobal[RouterServerContextSymbol][relativeProjectDir]
+
+      if (!existingServerContext) {
+        routerServerGlobal[RouterServerContextSymbol][relativeProjectDir] = {
+          render404: this.render404.bind(this),
+        }
+      }
+      routerServerGlobal[RouterServerContextSymbol][
+        relativeProjectDir
+      ].nextConfig = this.nextConfig
+      routerServerGlobal[RouterServerContextSymbol][
+        relativeProjectDir
+      ].isWrappedByNextServer = true
+
       // next.js core assumes page path without trailing slash
       pathname = removeTrailingSlash(pathname)
 
-      const options: MatchOptions = {
+      options = {
         i18n: this.i18nProvider?.fromRequest(req, pathname),
       }
-      const match = await this.matchers.match(pathname, options)
+    } finally {
+      routePreparationSpan?.end()
+      routePreparationSpan = undefined
+    }
 
+    let routeResolutionSpan
+    try {
+      const match = shouldTraceDetailedRequest
+        ? await getTracer().trace(NextNodeServerSpan.matchRoute, {}, () =>
+            this.matchers.match(pathname, options)
+          )
+        : await this.matchers.match(pathname, options)
+
+      routeResolutionSpan = shouldTraceDetailedRequest
+        ? getTracer().startSpan(NextNodeServerSpan.resolveRoute, {
+            attributes: {
+              'next.span_type': NextNodeServerSpan.resolveRoute,
+            },
+          })
+        : undefined
       // If we don't have a match, try to render it anyways.
       if (!match) {
+        routeResolutionSpan?.end()
+        routeResolutionSpan = undefined
         await this.render(req, res, pathname, query, parsedUrl, true)
 
         return true
@@ -1139,6 +1175,8 @@ export default class NextNodeServer extends BaseServer<
         if (edgeFunctionsPage !== match.definition.page) continue
 
         if (this.nextConfig.output === 'export') {
+          routeResolutionSpan?.end()
+          routeResolutionSpan = undefined
           await this.render404(req, res, parsedUrl)
           return true
         }
@@ -1147,6 +1185,8 @@ export default class NextNodeServer extends BaseServer<
         // If we handled the request, we can return early.
         // For api routes edge runtime
         try {
+          routeResolutionSpan?.end()
+          routeResolutionSpan = undefined
           const handled = await this.runEdgeFunction({
             req,
             res,
@@ -1157,6 +1197,13 @@ export default class NextNodeServer extends BaseServer<
             appPaths: null,
           })
           if (handled) return true
+          routeResolutionSpan = shouldTraceDetailedRequest
+            ? getTracer().startSpan(NextNodeServerSpan.resolveRoute, {
+                attributes: {
+                  'next.span_type': NextNodeServerSpan.resolveRoute,
+                },
+              })
+            : undefined
         } catch (apiError) {
           const silenceLog = false
           await this.instrumentationOnRequestError(
@@ -1180,18 +1227,34 @@ export default class NextNodeServer extends BaseServer<
       // TODO: move this behavior into a route handler.
       if (isPagesAPIRouteMatch(match)) {
         if (this.nextConfig.output === 'export') {
+          routeResolutionSpan?.end()
+          routeResolutionSpan = undefined
           await this.render404(req, res, parsedUrl)
           return true
         }
 
+        routeResolutionSpan?.end()
+        routeResolutionSpan = undefined
         const handled = await this.handleApiRequest(req, res, query, match)
         if (handled) return true
+
+        routeResolutionSpan = shouldTraceDetailedRequest
+          ? getTracer().startSpan(NextNodeServerSpan.resolveRoute, {
+              attributes: {
+                'next.span_type': NextNodeServerSpan.resolveRoute,
+              },
+            })
+          : undefined
       }
 
+      routeResolutionSpan?.end()
+      routeResolutionSpan = undefined
       await this.render(req, res, pathname, query, parsedUrl, true)
 
       return true
     } catch (err: any) {
+      routeResolutionSpan?.end()
+      routeResolutionSpan = undefined
       if (err instanceof NoFallbackError) {
         throw err
       }

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -8,6 +8,7 @@ import {
 import { DetachedPromise } from '../lib/detached-promise'
 import { getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
+import { getRequestInsightsIdentity } from './lib/trace/request-insights-identity'
 import { getClientComponentLoaderMetrics } from './client-component-renderer-logger'
 
 export function isAbortError(e: any): e is Error & { name: 'AbortError' } {
@@ -61,9 +62,7 @@ function createWriterFromResponse(
               `${process.env.NEXT_OTEL_PERFORMANCE_PREFIX}:next-client-component-loading`,
               {
                 start: metrics.clientComponentLoadStart,
-                end:
-                  metrics.clientComponentLoadStart +
-                  metrics.clientComponentLoadTimes,
+                end: metrics.clientComponentLoadEnd,
               }
             )
           }
@@ -156,10 +155,19 @@ export async function pipeNodeReadableToNodeResponse(
     if (errored || destroyed) return
 
     let started = false
-
+    let waitForFirstResponseChunkSpan =
+      getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1'
+        ? getTracer().startSpan(NextNodeServerSpan.waitForFirstResponseChunk, {
+            attributes: {
+              'next.span_type': NextNodeServerSpan.waitForFirstResponseChunk,
+            },
+          })
+        : undefined
     const finished = new DetachedPromise<void>()
 
     res.once('close', () => {
+      waitForFirstResponseChunkSpan?.end()
+      waitForFirstResponseChunkSpan = undefined
       readable.destroy()
       finished.resolve()
     })
@@ -167,6 +175,8 @@ export async function pipeNodeReadableToNodeResponse(
     readable.on('data', (chunk: Buffer) => {
       if (!started) {
         started = true
+        waitForFirstResponseChunkSpan?.end()
+        waitForFirstResponseChunkSpan = undefined
 
         if (
           'performance' in globalThis &&
@@ -178,9 +188,7 @@ export async function pipeNodeReadableToNodeResponse(
               `${process.env.NEXT_OTEL_PERFORMANCE_PREFIX}:next-client-component-loading`,
               {
                 start: metrics.clientComponentLoadStart,
-                end:
-                  metrics.clientComponentLoadStart +
-                  metrics.clientComponentLoadTimes,
+                end: metrics.clientComponentLoadEnd,
               }
             )
           }
@@ -211,6 +219,8 @@ export async function pipeNodeReadableToNodeResponse(
     })
 
     readable.on('end', async () => {
+      waitForFirstResponseChunkSpan?.end()
+      waitForFirstResponseChunkSpan = undefined
       if (waitUntilForEnd) {
         await waitUntilForEnd
       }
@@ -223,6 +233,8 @@ export async function pipeNodeReadableToNodeResponse(
     })
 
     readable.on('error', (err) => {
+      waitForFirstResponseChunkSpan?.end()
+      waitForFirstResponseChunkSpan = undefined
       if (isAbortError(err)) {
         finished.resolve()
         return

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -881,6 +881,7 @@ export async function renderToHTMLImpl(
         {
           spanName: `getStaticProps ${pathname}`,
           attributes: {
+            'next.span.category': 'application',
             'next.route': pathname,
           },
         },
@@ -1101,6 +1102,7 @@ export async function renderToHTMLImpl(
         {
           spanName: `getServerSideProps ${pathname}`,
           attributes: {
+            'next.span.category': 'application',
             'next.route': pathname,
           },
         },

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -322,6 +322,11 @@ export interface RequestMeta {
   devRequestTimingInternalsEnd?: bigint
 
   /**
+   * DEV only: The epoch timestamp when App Render initialization started.
+   */
+  appRenderInitializationStart?: number
+
+  /**
    * DEV only: The duration of getStaticPaths/generateStaticParams in process.hrtime.bigint()
    */
   devGenerateStaticParamsDuration?: bigint

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -7,6 +7,9 @@ import path from '../../shared/lib/isomorphic/path'
 import * as Log from '../../build/output/log'
 import { cyan } from '../../lib/picocolors'
 import type { RouteMatcher } from '../route-matchers/route-matcher'
+import { DevRouteMatcherManagerSpan } from '../lib/trace/constants'
+import { getTracer } from '../lib/trace/tracer'
+import { isRequestInsightsEnabled } from '../lib/trace/span-store'
 
 export interface RouteEnsurer {
   ensure(match: RouteMatch, pathname: string): Promise<void>
@@ -65,22 +68,85 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
     pathname: string,
     options: MatchOptions
   ): AsyncGenerator<RouteMatch<RouteDefinition<RouteKind>>, null, undefined> {
+    const shouldTraceDetailedMatch =
+      isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1'
+    let matchDevelopmentRouteSpan = shouldTraceDetailedMatch
+      ? getTracer().startSpan(
+          DevRouteMatcherManagerSpan.matchDevelopmentRoute,
+          {
+            attributes: {
+              'next.span_type':
+                DevRouteMatcherManagerSpan.matchDevelopmentRoute,
+            },
+          }
+        )
+      : undefined
     // Iterate over the development matches to see if one of them match the
     // request path.
-    for await (const developmentMatch of super.matchAll(pathname, options)) {
-      // We're here, which means that we haven't seen this match yet, so we
-      // should try to ensure it and recompile the production matcher.
-      await this.ensurer.ensure(developmentMatch, pathname)
-      await this.production.reload()
+    try {
+      for await (const developmentMatch of super.matchAll(pathname, options)) {
+        matchDevelopmentRouteSpan?.end()
+        matchDevelopmentRouteSpan = undefined
 
-      // Iterate over the production matches again, this time we should be able
-      // to match it against the production matcher unless there's an error.
-      for await (const productionMatch of this.production.matchAll(
-        pathname,
-        options
-      )) {
-        yield productionMatch
+        // We're here, which means that we haven't seen this match yet, so we
+        // should try to ensure it and recompile the production matcher.
+        if (shouldTraceDetailedMatch) {
+          await getTracer().trace(
+            DevRouteMatcherManagerSpan.ensureRoute,
+            {},
+            () => this.ensurer.ensure(developmentMatch, pathname)
+          )
+          await getTracer().trace(
+            DevRouteMatcherManagerSpan.reloadMatchers,
+            {},
+            () => this.production.reload()
+          )
+        } else {
+          await this.ensurer.ensure(developmentMatch, pathname)
+          await this.production.reload()
+        }
+
+        let matchProductionRouteSpan = shouldTraceDetailedMatch
+          ? getTracer().startSpan(
+              DevRouteMatcherManagerSpan.matchProductionRoute,
+              {
+                attributes: {
+                  'next.span_type':
+                    DevRouteMatcherManagerSpan.matchProductionRoute,
+                },
+              }
+            )
+          : undefined
+        try {
+          // Iterate over the production matches again, this time we should be
+          // able to match it against the production matcher unless there's an
+          // error.
+          for await (const productionMatch of this.production.matchAll(
+            pathname,
+            options
+          )) {
+            matchProductionRouteSpan?.end()
+            matchProductionRouteSpan = undefined
+            yield productionMatch
+          }
+        } finally {
+          matchProductionRouteSpan?.end()
+        }
+
+        matchDevelopmentRouteSpan = shouldTraceDetailedMatch
+          ? getTracer().startSpan(
+              DevRouteMatcherManagerSpan.matchDevelopmentRoute,
+              {
+                attributes: {
+                  'next.span_type':
+                    DevRouteMatcherManagerSpan.matchDevelopmentRoute,
+                },
+              }
+            )
+          : undefined
       }
+    } finally {
+      matchDevelopmentRouteSpan?.end()
     }
 
     // We tried direct matching against the pathname and against all the dynamic

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -894,6 +894,7 @@ export class AppRouteRouteModule extends RouteModule<
               {
                 spanName: `executing api route (app) ${pathname}`,
                 attributes: {
+                  'next.span.category': 'application',
                   'next.route': pathname,
                 },
               },

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -343,7 +343,7 @@ export function renderToInitialFizzStream({
   element: React.ReactElement
   streamOptions?: Parameters<typeof ReactDOMServer.renderToReadableStream>[1]
 }): Promise<ReactDOMServerReadableStream> {
-  return getTracer().trace(AppRenderSpan.renderToReadableStream, async () =>
+  return getTracer().trace(AppRenderSpan.renderToReadableStream, {}, async () =>
     ReactDOMServer.renderToReadableStream(element, streamOptions)
   )
 }

--- a/test/development/app-dir/request-insights/app/delayed/page.tsx
+++ b/test/development/app-dir/request-insights/app/delayed/page.tsx
@@ -1,0 +1,4 @@
+export default async function DelayedPage() {
+  await new Promise((resolve) => setTimeout(resolve, 200))
+  return <p>loaded</p>
+}

--- a/test/development/app-dir/request-insights/app/suspense/layout.tsx
+++ b/test/development/app-dir/request-insights/app/suspense/layout.tsx
@@ -1,0 +1,5 @@
+import { Suspense, type ReactNode } from 'react'
+
+export default function SuspenseLayout({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<p>loading</p>}>{children}</Suspense>
+}

--- a/test/development/app-dir/request-insights/app/suspense/page.tsx
+++ b/test/development/app-dir/request-insights/app/suspense/page.tsx
@@ -1,0 +1,4 @@
+export default async function SuspendedPage() {
+  await new Promise((resolve) => setTimeout(resolve, 200))
+  return <p>loaded</p>
+}

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -3,6 +3,8 @@ import { createServer } from 'http'
 import type { AddressInfo } from 'net'
 import { retry } from 'next-test-utils'
 
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
 type RequestInsight = {
   requestId: string
   htmlRequestId: string
@@ -96,6 +98,520 @@ describe('request insights', () => {
     )
   })
 
+  it('captures the full request through the response pipeline', async () => {
+    const maxSpanBoundaryGapMs = 5
+    await next.render('/')
+
+    const snapshot = (await next
+      .fetch('/_next/development/request-insights')
+      .then((response) => response.json())) as {
+      requests: RequestInsight[]
+    }
+    const request = snapshot.requests.findLast(
+      (insight) =>
+        insight.route === '/' &&
+        insight.spans.some(
+          (span) =>
+            span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+        )
+    )
+    const requestSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+    )
+    const baseRenderSpan = request?.spans.find(
+      (span) => span.attributes?.['next.span_type'] === 'BaseServer.render'
+    )
+    const renderSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+    )
+    const renderWithComponentsSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'BaseServer.renderToResponseWithComponents'
+    )
+    const prepareResponseSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'BaseServer.prepareResponseWithComponents'
+    )
+    const getIncrementalCacheSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.getIncrementalCache'
+    )
+    const resolvePrerenderingSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.resolvePrerendering'
+    )
+    const prepareRouteHandlerSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.prepareRouteHandler'
+    )
+    const executeRouteHandlerSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.executeRouteHandler'
+    )
+    const prepareAppPageResponseSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'AppRender.prepareAppPageResponse'
+    )
+    const initializeAppRenderSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.initializeRender'
+    )
+    const buildComponentTreeSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'NextNodeServer.createComponentTree'
+    )
+    const finalizeRSCPayloadSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.finalizeRSCPayload'
+    )
+    const startRSCStreamSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.startRSCStream'
+    )
+    const renderRSCResponseSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.renderRSCResponse'
+    )
+    const waitForRSCSpan = request?.spans.find(
+      (span) => span.attributes?.['next.span_type'] === 'AppRender.waitForRSC'
+    )
+    const prepareHTMLRenderSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.prepareHTMLRender'
+    )
+    const renderToNodeFizzStreamSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'AppRender.renderToNodeFizzStream'
+    )
+    const waitForHTMLCompletionSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'AppRender.waitForHTMLCompletion'
+    )
+    const renderToReadableStreamSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'AppRender.renderToReadableStream'
+    )
+    const waitShellReadySpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.waitShellReady'
+    )
+    const waitForFizzRenderTaskSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'AppRender.waitForFizzRenderTask'
+    )
+    const pipeFizzStreamSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.pipeFizzStream'
+    )
+    const waitForFizzFlushSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.waitForFizzFlush'
+    )
+    const createHTMLTransformsSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.createHTMLTransforms'
+    )
+    const waitForFirstResponseChunkSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'NextNodeServer.waitForFirstResponseChunk'
+    )
+    const startResponseSpan = request?.spans.findLast(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'NextNodeServer.startResponse'
+    )
+    const handlerSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.handleRequestImpl'
+    )
+    const prepareSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.prepareRequest'
+    )
+    const dispatchSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.dispatchRequest'
+    )
+    const prepareRouteSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'NextNodeServer.prepareRoute'
+    )
+    const matchRouteSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'NextNodeServer.matchRoute'
+    )
+    const resolveRouteSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'NextNodeServer.resolveRoute'
+    )
+    const matchDevelopmentRouteSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'DevRouteMatcherManager.matchDevelopmentRoute'
+    )
+    const ensureRouteSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'DevRouteMatcherManager.ensureRoute'
+    )
+    const compileRouteSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+          'DevBundlerService.ensurePage' &&
+        span.parentSpanId === ensureRouteSpan?.spanId
+    )
+    const reloadMatchersSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'DevRouteMatcherManager.reloadMatchers'
+    )
+    const matchProductionRouteSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+        'DevRouteMatcherManager.matchProductionRoute'
+    )
+    expect(request).toBeDefined()
+    expect(requestSpan).toBeDefined()
+    expect(handlerSpan).toBeDefined()
+    expect(prepareSpan).toBeDefined()
+    expect(dispatchSpan).toBeDefined()
+    expect(prepareRouteSpan).toBeDefined()
+    expect(matchRouteSpan).toBeDefined()
+    expect(resolveRouteSpan).toBeDefined()
+    expect(matchDevelopmentRouteSpan).toBeDefined()
+    expect(ensureRouteSpan).toBeDefined()
+    expect(compileRouteSpan).toBeDefined()
+    expect(compileRouteSpan!.parentSpanId).toBe(ensureRouteSpan!.spanId)
+    expect(reloadMatchersSpan).toBeDefined()
+    expect(matchProductionRouteSpan).toBeDefined()
+    expect(baseRenderSpan).toBeDefined()
+    expect(renderSpan).toBeDefined()
+    expect(renderWithComponentsSpan).toBeDefined()
+    expect(prepareResponseSpan).toBeDefined()
+    expect(getIncrementalCacheSpan).toBeDefined()
+    expect(resolvePrerenderingSpan).toBeDefined()
+    expect(prepareRouteHandlerSpan).toBeDefined()
+    expect(executeRouteHandlerSpan).toBeDefined()
+    expect(prepareAppPageResponseSpan).toBeDefined()
+    expect(initializeAppRenderSpan).toBeDefined()
+    expect(buildComponentTreeSpan).toBeDefined()
+    expect(finalizeRSCPayloadSpan).toBeDefined()
+    if (!isCacheComponentsEnabled) {
+      expect(startRSCStreamSpan).toBeDefined()
+    }
+    expect(renderRSCResponseSpan).toBeDefined()
+    expect(waitForRSCSpan).toBeDefined()
+    expect(prepareHTMLRenderSpan).toBeDefined()
+    expect(renderToNodeFizzStreamSpan).toBeDefined()
+    expect(waitForHTMLCompletionSpan).toBeDefined()
+    expect(renderToReadableStreamSpan).toBeDefined()
+    expect(waitShellReadySpan).toBeDefined()
+    expect(waitForFizzRenderTaskSpan).toBeDefined()
+    expect(pipeFizzStreamSpan).toBeDefined()
+    expect(waitForFizzFlushSpan).toBeDefined()
+    expect(createHTMLTransformsSpan).toBeDefined()
+    expect(waitForFirstResponseChunkSpan).toBeDefined()
+    expect(startResponseSpan).toBeDefined()
+    expect(
+      request!.spans.every((span) => {
+        const category = span.attributes?.['next.span.category']
+        return category === 'nextjs' || category === 'application'
+      })
+    ).toBe(true)
+    expect(requestSpan!.attributes?.['next.span.category']).toBe('nextjs')
+    expect(renderRSCResponseSpan!.parentSpanId).toBe(renderSpan!.spanId)
+    expect(waitForHTMLCompletionSpan!.parentSpanId).toBe(renderSpan!.spanId)
+    expect(request!.startTime).toBe(requestSpan!.startTime)
+    expect(request!.durationMs).toBeCloseTo(requestSpan!.durationMs!, 3)
+    expect(requestSpan!.startTime).toBeLessThanOrEqual(renderSpan!.startTime)
+    expect(handlerSpan!.startTime).toBeLessThanOrEqual(renderSpan!.startTime)
+    expect(
+      handlerSpan!.startTime + handlerSpan!.durationMs!
+    ).toBeGreaterThanOrEqual(renderSpan!.startTime + renderSpan!.durationMs!)
+    expect(prepareSpan!.startTime - handlerSpan!.startTime).toBeLessThan(
+      maxSpanBoundaryGapMs
+    )
+    expect(prepareSpan!.startTime).toBeLessThanOrEqual(dispatchSpan!.startTime)
+    expect(
+      dispatchSpan!.startTime -
+        (prepareSpan!.startTime + prepareSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(dispatchSpan!.startTime).toBeLessThanOrEqual(renderSpan!.startTime)
+    expect(prepareRouteSpan!.startTime - dispatchSpan!.startTime).toBeLessThan(
+      maxSpanBoundaryGapMs
+    )
+    expect(
+      matchRouteSpan!.startTime -
+        (prepareRouteSpan!.startTime + prepareRouteSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      resolveRouteSpan!.startTime -
+        (matchRouteSpan!.startTime + matchRouteSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      matchDevelopmentRouteSpan!.startTime - matchRouteSpan!.startTime
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      ensureRouteSpan!.startTime -
+        (matchDevelopmentRouteSpan!.startTime +
+          matchDevelopmentRouteSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      reloadMatchersSpan!.startTime -
+        (ensureRouteSpan!.startTime + ensureRouteSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      matchProductionRouteSpan!.startTime -
+        (reloadMatchersSpan!.startTime + reloadMatchersSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      baseRenderSpan!.startTime -
+        (resolveRouteSpan!.startTime + resolveRouteSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      prepareResponseSpan!.startTime - renderWithComponentsSpan!.startTime
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      getIncrementalCacheSpan!.startTime -
+        (prepareResponseSpan!.startTime + prepareResponseSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      resolvePrerenderingSpan!.startTime -
+        (getIncrementalCacheSpan!.startTime +
+          getIncrementalCacheSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      prepareRouteHandlerSpan!.startTime -
+        (resolvePrerenderingSpan!.startTime +
+          resolvePrerenderingSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      executeRouteHandlerSpan!.startTime -
+        (prepareRouteHandlerSpan!.startTime +
+          prepareRouteHandlerSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(executeRouteHandlerSpan!.startTime).toBeLessThanOrEqual(
+      renderSpan!.startTime
+    )
+    expect(
+      prepareAppPageResponseSpan!.startTime - executeRouteHandlerSpan!.startTime
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      initializeAppRenderSpan!.startTime -
+        (prepareAppPageResponseSpan!.startTime +
+          prepareAppPageResponseSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      renderSpan!.startTime -
+        (initializeAppRenderSpan!.startTime +
+          initializeAppRenderSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      finalizeRSCPayloadSpan!.startTime -
+        (buildComponentTreeSpan!.startTime +
+          buildComponentTreeSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    if (startRSCStreamSpan) {
+      expect(
+        startRSCStreamSpan.startTime -
+          (finalizeRSCPayloadSpan!.startTime +
+            finalizeRSCPayloadSpan!.durationMs!)
+      ).toBeLessThan(maxSpanBoundaryGapMs)
+      expect(
+        waitForRSCSpan!.startTime -
+          (startRSCStreamSpan.startTime + startRSCStreamSpan.durationMs!)
+      ).toBeLessThan(maxSpanBoundaryGapMs)
+    }
+    expect(
+      prepareHTMLRenderSpan!.startTime -
+        (waitForRSCSpan!.startTime + waitForRSCSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      renderToNodeFizzStreamSpan!.startTime -
+        (prepareHTMLRenderSpan!.startTime + prepareHTMLRenderSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      waitForFizzRenderTaskSpan!.startTime -
+        (waitShellReadySpan!.startTime + waitShellReadySpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      pipeFizzStreamSpan!.startTime -
+        (waitForFizzRenderTaskSpan!.startTime +
+          waitForFizzRenderTaskSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      waitForFizzFlushSpan!.startTime -
+        (pipeFizzStreamSpan!.startTime + pipeFizzStreamSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      createHTMLTransformsSpan!.startTime -
+        (waitForFizzFlushSpan!.startTime + waitForFizzFlushSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      waitForFirstResponseChunkSpan!.startTime -
+        (createHTMLTransformsSpan!.startTime +
+          createHTMLTransformsSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      startResponseSpan!.startTime -
+        (waitForFirstResponseChunkSpan!.startTime +
+          waitForFirstResponseChunkSpan!.durationMs!)
+    ).toBeLessThan(maxSpanBoundaryGapMs)
+    expect(
+      executeRouteHandlerSpan!.startTime + executeRouteHandlerSpan!.durationMs!
+    ).toBeGreaterThanOrEqual(renderSpan!.startTime + renderSpan!.durationMs!)
+    expect(
+      dispatchSpan!.startTime + dispatchSpan!.durationMs!
+    ).toBeGreaterThanOrEqual(renderSpan!.startTime + renderSpan!.durationMs!)
+    expect(
+      requestSpan!.startTime + requestSpan!.durationMs!
+    ).toBeGreaterThanOrEqual(renderSpan!.startTime + renderSpan!.durationMs!)
+    expect(
+      request!.spans.map((span) => span.attributes?.['next.span_type'])
+    ).toEqual(
+      expect.arrayContaining([
+        'BaseServer.handleRequestImpl',
+        'BaseServer.prepareRequest',
+        'BaseServer.dispatchRequest',
+        'NextNodeServer.prepareRoute',
+        'NextNodeServer.matchRoute',
+        'NextNodeServer.resolveRoute',
+        'DevRouteMatcherManager.matchDevelopmentRoute',
+        'DevRouteMatcherManager.ensureRoute',
+        'DevBundlerService.ensurePage',
+        'DevRouteMatcherManager.reloadMatchers',
+        'DevRouteMatcherManager.matchProductionRoute',
+        'BaseServer.render',
+        'BaseServer.pipe',
+        'BaseServer.renderToResponse',
+        'BaseServer.renderToResponseWithComponents',
+        'BaseServer.prepareResponseWithComponents',
+        'BaseServer.getIncrementalCache',
+        'BaseServer.resolvePrerendering',
+        'BaseServer.prepareRouteHandler',
+        'BaseServer.executeRouteHandler',
+        'AppRender.prepareAppPageResponse',
+        'AppRender.initializeRender',
+        'AppRender.finalizeRSCPayload',
+        ...(isCacheComponentsEnabled ? [] : ['AppRender.startRSCStream']),
+        'AppRender.renderRSCResponse',
+        'AppRender.waitForRSC',
+        'AppRender.prepareHTMLRender',
+        'AppRender.renderToNodeFizzStream',
+        'AppRender.waitForHTMLCompletion',
+        'AppRender.waitShellReady',
+        'AppRender.waitForFizzRenderTask',
+        'AppRender.pipeFizzStream',
+        'AppRender.waitForFizzFlush',
+        'AppRender.createHTMLTransforms',
+        'NextNodeServer.waitForFirstResponseChunk',
+        'NextNodeServer.startResponse',
+        'LoadComponents.loadComponents',
+      ])
+    )
+    expect(
+      request!.spans.some(
+        (span) =>
+          span.attributes?.['next.span_type'] ===
+          'NextNodeServer.clientComponentLoading'
+      )
+    ).toBe(false)
+  })
+
+  it('tracks RSC rendering and HTML completion across Suspense', async () => {
+    await next.render('/suspense')
+
+    const snapshot = (await next
+      .fetch('/_next/development/request-insights')
+      .then((response) => response.json())) as {
+      requests: RequestInsight[]
+    }
+    const request = snapshot.requests.findLast(
+      (insight) => insight.route === '/suspense'
+    )
+    const renderSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+    )
+    const renderRSCResponseSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.renderRSCResponse' &&
+        span.parentSpanId === renderSpan?.spanId
+    )
+    const renderHTMLShellSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+          'AppRender.renderToNodeFizzStream' &&
+        span.parentSpanId === renderSpan?.spanId
+    )
+    const waitForHTMLCompletionSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+          'AppRender.waitForHTMLCompletion' &&
+        span.parentSpanId === renderSpan?.spanId
+    )
+
+    expect(renderSpan).toBeDefined()
+    expect(renderRSCResponseSpan).toBeDefined()
+    expect(renderHTMLShellSpan).toBeDefined()
+    expect(waitForHTMLCompletionSpan).toBeDefined()
+    expect(renderRSCResponseSpan!.durationMs).toBeGreaterThanOrEqual(150)
+    expect(waitForHTMLCompletionSpan!.durationMs).toBeGreaterThanOrEqual(150)
+    expect(renderHTMLShellSpan!.durationMs).toBeLessThan(
+      renderRSCResponseSpan!.durationMs!
+    )
+    expect(
+      Math.abs(
+        waitForHTMLCompletionSpan!.startTime +
+          waitForHTMLCompletionSpan!.durationMs! -
+          (renderSpan!.startTime + renderSpan!.durationMs!)
+      )
+    ).toBeLessThan(5)
+  })
+
+  it('attributes delayed server component work to RSC rendering', async () => {
+    await next.render('/delayed')
+
+    const snapshot = (await next
+      .fetch('/_next/development/request-insights')
+      .then((response) => response.json())) as {
+      requests: RequestInsight[]
+    }
+    const request = snapshot.requests.findLast(
+      (insight) => insight.route === '/delayed'
+    )
+    const renderSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+    )
+    const renderRSCResponseSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.renderRSCResponse' &&
+        span.parentSpanId === renderSpan?.spanId
+    )
+    const renderHTMLShellSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] ===
+          'AppRender.renderToNodeFizzStream' &&
+        span.parentSpanId === renderSpan?.spanId
+    )
+
+    expect(renderRSCResponseSpan).toBeDefined()
+    expect(renderHTMLShellSpan).toBeDefined()
+    expect(renderRSCResponseSpan!.durationMs).toBeGreaterThanOrEqual(150)
+    expect(renderHTMLShellSpan!.durationMs).toBeGreaterThanOrEqual(150)
+  })
+
   it('identifies client-dispatched Server Actions without retaining arguments', async () => {
     const browser = await next.browser('/actions')
 
@@ -105,6 +621,12 @@ describe('request insights', () => {
         'delayed:'
       )
     })
+    await next.fetch('/actions', {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: 'ordinary POST body',
+    })
+
     const snapshot = (await next
       .fetch('/_next/development/request-insights')
       .then((response) => response.json())) as {
@@ -117,7 +639,17 @@ describe('request insights', () => {
       (span) =>
         span.attributes?.['next.span_type'] === 'AppRender.executeServerAction'
     )
+    const ordinaryPostRequest = snapshot.requests.findLast(
+      (insight) =>
+        insight.route === '/actions' &&
+        insight.serverAction === undefined &&
+        insight.spans.some(
+          (span) => span.attributes?.['http.method'] === 'POST'
+        )
+    )
+
     expect(request).toBeDefined()
+    expect(ordinaryPostRequest).toBeDefined()
     expect(request!.route).toBe('/actions')
     expect(request!.serverAction).toEqual({
       name: 'delayedAction',
@@ -139,6 +671,10 @@ describe('request insights', () => {
         }),
       })
     )
+    expect(
+      request!.spans.some((span) => span.spanId === actionSpan?.parentSpanId)
+    ).toBe(true)
+
     const serializedRequest = JSON.stringify(request)
     expect(serializedRequest).not.toContain('super-secret-action-argument')
     expect(serializedRequest).not.toContain('actionId')

--- a/test/e2e/app-dir/hello-world/next.config.js
+++ b/test/e2e/app-dir/hello-world/next.config.js
@@ -1,6 +1,10 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    requestInsights: true,
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
## What?

Adds the missing OpenTelemetry timing boundaries needed for Request Insights to show an end-to-end request trace without unexplained gaps.

The additional coverage includes request preparation and dispatch, development route matching and compilation, component loading, response preparation, App Router initialization, RSC and HTML rendering phases, route-handler execution, and response streaming through the first chunk.

This PR focuses only on span coverage and timing. Server Action tracing and resolution are provided by the preceding PRs, while human-readable display names are handled by the dependent PR.

## Why?

The existing spans covered important rendering operations, but substantial request time could fall between them. Async rendering also made some spans end before Suspense work or response streaming had completed. This produced dead time in the trace and made it unclear where a slow request was spending time.

Request Insights needs boundaries around the actual asynchronous work so the trace represents the complete lifecycle from request ingress to the first response chunk.

## How?

- Carries a request-scoped Request Insights identity through framework work so related spans are recorded under the correct request.
- Adds detailed spans around request setup, dispatch, route matching, route preparation, and bundler compilation.
- Separates component loading, response preparation, cache/prerender resolution, and route-handler execution.
- Tracks RSC stream setup, RSC scheduling, HTML render preparation, HTML completion, and response streaming.
- Keeps the route render span open until asynchronous React rendering, including Suspense work, completes.
- Records the actual end of client component loading instead of deriving it from accumulated timings.
- Adds delayed and Suspense fixtures that assert the trace covers the work without large boundary gaps.

## Stack

1. #95773 — Server Action OpenTelemetry span
2. #95770 — Server Action metadata in Request Insights
3. **#95765 — Missing OpenTelemetry spans (this PR)**
4. #95766 — Human-readable OpenTelemetry span names

## Verification

- `pnpm --filter=next build`
- `pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts`

<!-- NEXT_JS_LLM -->
