### PR TITLE
Add Request Insights OpenTelemetry span names

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -737,6 +737,7 @@ export async function handler(
           {
             startTime: appPagePreparationStart,
             attributes: {
+              'next.span_name': 'prepare app page response',
               'next.span_type': AppRenderSpan.prepareAppPageResponse,
             },
           }
@@ -791,13 +792,14 @@ export async function handler(
           'http.route': route,
           'next.span_name': name,
         })
-        span.updateName(name)
 
         // Propagate http.route to the parent span if one exists (e.g.
         // a platform-created HTTP span in adapter deployments).
         if (parentSpan && parentSpan !== span) {
-          parentSpan.setAttribute('http.route', route)
-          parentSpan.updateName(name)
+          parentSpan.setAttributes({
+            'http.route': route,
+            'next.span_name': name,
+          })
         }
       })
     }
@@ -2137,9 +2139,9 @@ export async function handler(
           tracer.trace(
             BaseServerSpan.handleRequest,
             {
-              spanName: `${method} ${srcPage}`,
               kind: SpanKind.SERVER,
               attributes: {
+                'next.span_name': `${method} ${srcPage}`,
                 'http.method': method,
                 'http.target': httpTarget,
               },

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -170,6 +170,7 @@ describe('request insights trace viewer', () => {
           durationMs: 1,
           attributes: {
             'next.span_type': 'LoadComponents.loadComponents',
+            'next.span_name': 'load components',
           },
         },
         {
@@ -318,7 +319,7 @@ describe('request insights trace viewer', () => {
     ])
   })
 
-  it('gives every displayed span a human readable name', () => {
+  it('uses the recorded human readable span name', () => {
     const request = createRequest({
       spans: [
         {
@@ -326,7 +327,7 @@ describe('request insights trace viewer', () => {
           startTime: 100,
           durationMs: 10,
           attributes: {
-            'next.span_name': 'AppRender.renderToNodeFizzStream',
+            'next.span_name': 'render HTML shell',
             'next.span_type': 'AppRender.renderToNodeFizzStream',
           },
         },
@@ -335,7 +336,7 @@ describe('request insights trace viewer', () => {
           startTime: 110,
           durationMs: 10,
           attributes: {
-            'next.span_name': 'wait for Fizz render task',
+            'next.span_name': 'wait for HTML render task',
             'next.span_type': 'AppRender.waitForFizzRenderTask',
           },
         },
@@ -344,7 +345,7 @@ describe('request insights trace viewer', () => {
           startTime: 120,
           durationMs: 10,
           attributes: {
-            'next.span_name': 'AppRender.renderToNodeFlightStream',
+            'next.span_name': 'render RSC response',
             'next.span_type': 'AppRender.renderToNodeFlightStream',
           },
         },
@@ -359,9 +360,9 @@ describe('request insights trace viewer', () => {
       ],
     })
     const expectedLabels = [
-      'render to HTML stream',
+      'render HTML shell',
       'wait for HTML render task',
-      'render to RSC stream',
+      'render RSC response',
       'render HTML stream',
     ]
 
@@ -389,6 +390,7 @@ describe('request insights trace viewer', () => {
           attributes: {
             'next.span_category': 'application',
             'next.span_type': 'ResolveMetadata.generateMetadata',
+            'next.span_name': 'generate metadata /',
           },
         },
         {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -54,20 +54,6 @@ const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'ResolveMetadata.generateMetadata',
   'ResolveMetadata.generateViewport',
 ])
-const FIZZ_WORD = /\bFizz\b/gi
-const FLIGHT_WORD = /\bFlight\b/gi
-const SPAN_WORD_CASE: Record<string, string> = {
-  api: 'API',
-  fizz: 'HTML',
-  flight: 'RSC',
-  html: 'HTML',
-  http: 'HTTP',
-  https: 'HTTPS',
-  id: 'ID',
-  node: 'Node',
-  rsc: 'RSC',
-  url: 'URL',
-}
 
 export function getTraceItems(
   request: RequestInsight,
@@ -340,55 +326,9 @@ function getSpanCategory(span: RequestInsightSpan): 'nextjs' | 'application' {
 
 function getSpanLabel(span: RequestInsightSpan): string {
   const explicitName = span.attributes?.['next.span_name']
-  const name =
-    typeof explicitName === 'string' && explicitName.trim().length > 0
-      ? explicitName
-      : span.name
-
-  if (
-    span.attributes?.['next.span_type'] === 'AppRender.executeServerAction' &&
-    typeof explicitName === 'string'
-  ) {
-    return explicitName
-  }
-
-  const displayName = name
-    .replace(FIZZ_WORD, 'HTML')
-    .replace(FLIGHT_WORD, 'RSC')
-
-  if (displayName === 'resolve segment modules') {
-    return 'resolve segment'
-  }
-
-  if (displayName === 'build component tree') {
-    return 'build component tree'
-  }
-
-  if (!displayName.includes('.') && !/[a-z][A-Z]|[_-]/.test(displayName)) {
-    return displayName
-  }
-
-  const identifier = displayName.slice(displayName.lastIndexOf('.') + 1)
-  const words = identifier
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-    .replace(/[_-]+/g, ' ')
-    .trim()
-    .split(/\s+/)
-    .map((word) => SPAN_WORD_CASE[word.toLowerCase()] ?? word.toLowerCase())
-    .filter(
-      (word, index, allWords) =>
-        !(
-          (word === 'Node' || word === 'web') &&
-          (allWords[index + 1] === 'HTML' || allWords[index + 1] === 'RSC')
-        )
-    )
-
-  if (words[0] === 'wait' && words[1] !== 'for') {
-    words.splice(1, 0, 'for')
-  }
-
-  return words.join(' ')
+  return typeof explicitName === 'string' && explicitName.trim().length > 0
+    ? explicitName
+    : span.name
 }
 
 function getUrlPath(url: string | undefined): string {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2221,6 +2221,7 @@ async function getRSCPayload(
       {
         startTime: finalizePayloadStart,
         attributes: {
+          'next.span_name': 'finalize RSC payload',
           'next.span_type': AppRenderSpan.finalizeRSCPayload,
         },
       }
@@ -3379,6 +3380,7 @@ async function renderToStream(
       {
         startTime: initializationStart,
         attributes: {
+          'next.span_name': 'initialize app render',
           'next.span_type': AppRenderSpan.initializeRender,
         },
       }
@@ -3389,16 +3391,13 @@ async function renderToStream(
   // Create the "render route (app)" span manually so we can keep it open during streaming.
   // This is necessary because errors inside Suspense boundaries are reported asynchronously
   // during stream consumption, after a typical wrapped function would have ended the span.
-  const renderSpan = getTracer().startSpan(
-    `render route (app) ${pagePath}` as any,
-    {
-      attributes: {
-        'next.span_name': `render route (app) ${pagePath}`,
-        'next.span_type': AppRenderSpan.getBodyResult,
-        'next.route': pagePath,
-      },
-    }
-  )
+  const renderSpan = getTracer().startSpan(AppRenderSpan.getBodyResult, {
+    attributes: {
+      'next.span_name': `render route (app) ${pagePath}`,
+      'next.span_type': AppRenderSpan.getBodyResult,
+      'next.route': pagePath,
+    },
+  })
 
   // Helper to end the span with error status (used when throwing from catch blocks)
   const endSpanWithError = (err: unknown) => {
@@ -3417,7 +3416,7 @@ async function renderToStream(
   const trackHTMLRenderCompletion = (allReady: Promise<void>) => {
     const completion = getTracer().trace(
       AppRenderSpan.waitForHTMLCompletion,
-      {},
+      { attributes: { 'next.span_name': 'wait for HTML completion' } },
       () => allReady
     )
 
@@ -3845,6 +3844,7 @@ async function renderToStream(
             {
               startTime: startRSCStreamTime,
               attributes: {
+                'next.span_name': 'start RSC stream',
                 'next.span_type': AppRenderSpan.startRSCStream,
               },
             }
@@ -3862,7 +3862,7 @@ async function renderToStream(
       ) {
         await getTracer().trace(
           AppRenderSpan.waitForRSC,
-          {},
+          { attributes: { 'next.span_name': 'wait for RSC render task' } },
           waitAtLeastOneReactRenderTask
         )
       } else {
@@ -3993,6 +3993,7 @@ async function renderToStream(
             {
               startTime: prepareHTMLRenderStart,
               attributes: {
+                'next.span_name': 'prepare HTML render',
                 'next.span_type': AppRenderSpan.prepareHTMLRender,
               },
             }
@@ -4002,7 +4003,7 @@ async function renderToStream(
 
         const { stream: htmlStream, allReady } = await getTracer().trace(
           AppRenderSpan.renderToNodeFizzStream,
-          {},
+          { attributes: { 'next.span_name': 'render HTML shell' } },
           () =>
             workUnitAsyncStorage.run(
               requestStore,

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -575,7 +575,7 @@ export function renderToNodeFlightStream(
 
   return getTracer().trace(
     AppRenderSpan.renderRSCResponse,
-    {},
+    { attributes: { 'next.span_name': 'render RSC response' } },
     (_span, done) => {
       if (!ComponentMod.renderToPipeableStream) {
         throw new Error('renderToPipeableStream is not implemented')
@@ -654,7 +654,7 @@ export async function renderToNodeFizzStream(
 
   const pipeable = getTracer().trace(
     AppRenderSpan.renderToReadableStream,
-    {},
+    { attributes: { 'next.span_name': 'start HTML render' } },
     () =>
       renderToPipeableStream(element, {
         ...streamOptions,
@@ -680,7 +680,7 @@ export async function renderToNodeFizzStream(
 
   await getTracer().trace(
     AppRenderSpan.waitShellReady,
-    {},
+    { attributes: { 'next.span_name': 'wait for HTML shell' } },
     () => shellReady.promise
   )
 
@@ -688,11 +688,13 @@ export async function renderToNodeFizzStream(
     if (getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1') {
       await getTracer().trace(
         AppRenderSpan.waitForFizzRenderTask,
-        {},
+        { attributes: { 'next.span_name': 'wait for HTML render task' } },
         waitAtLeastOneReactRenderTask
       )
-      getTracer().trace(AppRenderSpan.pipeFizzStream, {}, () =>
-        pipeable.pipe(pt)
+      getTracer().trace(
+        AppRenderSpan.pipeFizzStream,
+        { attributes: { 'next.span_name': 'pipe HTML stream' } },
+        () => pipeable.pipe(pt)
       )
     } else {
       await waitAtLeastOneReactRenderTask()
@@ -792,7 +794,7 @@ export async function continueFizzStream(
       if (shouldTraceDetailedRender) {
         await getTracer().trace(
           AppRenderSpan.waitForFizzFlush,
-          {},
+          { attributes: { 'next.span_name': 'wait for HTML flush' } },
           () => allReady
         )
       } else {
@@ -805,7 +807,7 @@ export async function continueFizzStream(
     if (shouldTraceDetailedRender) {
       await getTracer().trace(
         AppRenderSpan.waitForFizzFlush,
-        {},
+        { attributes: { 'next.span_name': 'wait for HTML flush' } },
         waitAtLeastOneReactRenderTask
       )
     } else {
@@ -877,6 +879,7 @@ export async function continueFizzStream(
       {
         startTime: createHTMLTransformsStart,
         attributes: {
+          'next.span_name': 'create HTML transforms',
           'next.span_type': AppRenderSpan.createHTMLTransforms,
         },
       }

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -261,7 +261,7 @@ export function renderToWebFlightStream(
 
   return getTracer().trace(
     AppRenderSpan.renderRSCResponse,
-    {},
+    { attributes: { 'next.span_name': 'render RSC response' } },
     (_span, done) => {
       const stream = ComponentMod.renderToReadableStream(
         payload,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -920,9 +920,9 @@ export default abstract class Server<
         return tracer.trace(
           BaseServerSpan.handleRequest,
           {
-            spanName: `${method}`,
             kind: SpanKind.SERVER,
             attributes: {
+              'next.span_name': method,
               'http.method': method,
               'http.target': req.url,
             },
@@ -931,8 +931,10 @@ export default abstract class Server<
             const request =
               isRequestInsightsEnabled() ||
               process.env.NEXT_OTEL_VERBOSE === '1'
-                ? tracer.trace(BaseServerSpan.handleRequestImpl, {}, () =>
-                    this.handleRequestImpl(req, res, parsedUrl)
+                ? tracer.trace(
+                    BaseServerSpan.handleRequestImpl,
+                    { attributes: { 'next.span_name': 'handle request' } },
+                    () => this.handleRequestImpl(req, res, parsedUrl)
                   )
                 : this.handleRequestImpl(req, res, parsedUrl)
 
@@ -982,7 +984,6 @@ export default abstract class Server<
                   'http.route': route,
                   'next.span_name': name,
                 })
-                span.updateName(name)
 
                 // Propagate http.route to the parent span if one exists and
                 // is different from the handleRequest span. This ensures APM
@@ -992,7 +993,10 @@ export default abstract class Server<
                   parentSpan.setAttribute('http.route', route)
                 }
               } else {
-                span.updateName(isRSCRequest ? `RSC ${method}` : `${method}`)
+                span.setAttribute(
+                  'next.span_name',
+                  isRSCRequest ? `RSC ${method}` : method
+                )
               }
             })
           }
@@ -1031,6 +1035,7 @@ export default abstract class Server<
     let requestSetupSpan = shouldTraceDetailedRequest
       ? getTracer().startSpan(BaseServerSpan.prepareRequest, {
           attributes: {
+            'next.span_name': 'prepare request',
             'next.span_type': BaseServerSpan.prepareRequest,
           },
         })
@@ -1629,8 +1634,11 @@ export default abstract class Server<
         const normalizedParsedUrl = parsedUrl
 
         if (shouldTraceDetailedRequest) {
-          await getTracer().trace(BaseServerSpan.dispatchRequest, {}, () =>
-            this.handleCatchallRenderRequest(req, res, normalizedParsedUrl)
+          await getTracer().trace(
+            BaseServerSpan.dispatchRequest,
+            { attributes: { 'next.span_name': 'dispatch request' } },
+            () =>
+              this.handleCatchallRenderRequest(req, res, normalizedParsedUrl)
           )
         } else {
           await this.handleCatchallRenderRequest(req, res, normalizedParsedUrl)
@@ -1845,8 +1853,10 @@ export default abstract class Server<
       'renderOpts'
     >
   ): Promise<void> {
-    return getTracer().trace(BaseServerSpan.pipe, async () =>
-      this.pipeImpl(fn, partialContext)
+    return getTracer().trace(
+      BaseServerSpan.pipe,
+      { attributes: { 'next.span_name': 'render and send response' } },
+      async () => this.pipeImpl(fn, partialContext)
     )
   }
 
@@ -1948,8 +1958,11 @@ export default abstract class Server<
     parsedUrl?: NextUrlWithParsedQuery,
     internalRender = false
   ): Promise<void> {
-    return getTracer().trace(BaseServerSpan.render, async () =>
-      this.renderImpl(req, res, pathname, query, parsedUrl, internalRender)
+    return getTracer().trace(
+      BaseServerSpan.render,
+      { attributes: { 'next.span_name': 'render request' } },
+      async () =>
+        this.renderImpl(req, res, pathname, query, parsedUrl, internalRender)
     )
   }
 
@@ -2077,6 +2090,7 @@ export default abstract class Server<
 
     return getTracer().trace(
       BaseServerSpan.renderToResponseWithComponents,
+      { attributes: { 'next.span_name': 'render response' } },
       async () => {
         try {
           return await this.renderToResponseWithComponentsImpl(
@@ -2148,6 +2162,7 @@ export default abstract class Server<
         BaseServerSpan.prepareResponseWithComponents,
         {
           attributes: {
+            'next.span_name': 'prepare response',
             'next.span_type': BaseServerSpan.prepareResponseWithComponents,
           },
         }
@@ -2471,6 +2486,7 @@ export default abstract class Server<
         BaseServerSpan.getIncrementalCache,
         {
           attributes: {
+            'next.span_name': 'get incremental cache',
             'next.span_type': BaseServerSpan.getIncrementalCache,
           },
         }
@@ -2488,6 +2504,7 @@ export default abstract class Server<
         BaseServerSpan.resolvePrerendering,
         {
           attributes: {
+            'next.span_name': 'resolve prerendering',
             'next.span_type': BaseServerSpan.resolvePrerendering,
           },
         }
@@ -2585,6 +2602,7 @@ export default abstract class Server<
         BaseServerSpan.prepareRouteHandler,
         {
           attributes: {
+            'next.span_name': 'prepare route handler',
             'next.span_type': BaseServerSpan.prepareRouteHandler,
           },
         }
@@ -2657,10 +2675,13 @@ export default abstract class Server<
     if (detailedPhase) {
       detailedPhase.span?.end()
       detailedPhase.span = undefined
-      await getTracer().trace(BaseServerSpan.executeRouteHandler, {}, () =>
-        components.ComponentMod.handler(handlerReq, handlerRes, {
-          waitUntil: this.getWaitUntil(),
-        })
+      await getTracer().trace(
+        BaseServerSpan.executeRouteHandler,
+        { attributes: { 'next.span_name': 'execute route handler' } },
+        () =>
+          components.ComponentMod.handler(handlerReq, handlerRes, {
+            waitUntil: this.getWaitUntil(),
+          })
       )
     } else {
       await components.ComponentMod.handler(handlerReq, handlerRes, {
@@ -2748,8 +2769,8 @@ export default abstract class Server<
     return getTracer().trace(
       BaseServerSpan.renderToResponse,
       {
-        spanName: `rendering page`,
         attributes: {
+          'next.span_name': 'rendering page',
           'next.route': ctx.pathname,
         },
       },

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -64,8 +64,10 @@ export class DevBundlerService {
   ) => {
     // TODO: remove after ensure is pulled out of server
     if (isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1') {
-      return await getTracer().trace(DevBundlerServiceSpan.ensurePage, {}, () =>
-        this.bundler.hotReloader.ensurePage(definition)
+      return await getTracer().trace(
+        DevBundlerServiceSpan.ensurePage,
+        { attributes: { 'next.span_name': 'compile route' } },
+        () => this.bundler.hotReloader.ensurePage(definition)
       )
     }
 

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -354,5 +354,6 @@ async function loadComponentsImpl<
 
 export const loadComponents = getTracer().wrap(
   LoadComponentsSpan.loadComponents,
+  { attributes: { 'next.span_name': 'load components' } },
   loadComponentsImpl
 )

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1089,6 +1089,7 @@ export default class NextNodeServer extends BaseServer<
     let routePreparationSpan = shouldTraceDetailedRequest
       ? getTracer().startSpan(NextNodeServerSpan.prepareRoute, {
           attributes: {
+            'next.span_name': 'prepare route',
             'next.span_type': NextNodeServerSpan.prepareRoute,
           },
         })
@@ -1143,14 +1144,17 @@ export default class NextNodeServer extends BaseServer<
     let routeResolutionSpan
     try {
       const match = shouldTraceDetailedRequest
-        ? await getTracer().trace(NextNodeServerSpan.matchRoute, {}, () =>
-            this.matchers.match(pathname, options)
+        ? await getTracer().trace(
+            NextNodeServerSpan.matchRoute,
+            { attributes: { 'next.span_name': 'match route' } },
+            () => this.matchers.match(pathname, options)
           )
         : await this.matchers.match(pathname, options)
 
       routeResolutionSpan = shouldTraceDetailedRequest
         ? getTracer().startSpan(NextNodeServerSpan.resolveRoute, {
             attributes: {
+              'next.span_name': 'resolve route',
               'next.span_type': NextNodeServerSpan.resolveRoute,
             },
           })
@@ -1200,6 +1204,7 @@ export default class NextNodeServer extends BaseServer<
           routeResolutionSpan = shouldTraceDetailedRequest
             ? getTracer().startSpan(NextNodeServerSpan.resolveRoute, {
                 attributes: {
+                  'next.span_name': 'resolve route',
                   'next.span_type': NextNodeServerSpan.resolveRoute,
                 },
               })
@@ -1241,6 +1246,7 @@ export default class NextNodeServer extends BaseServer<
         routeResolutionSpan = shouldTraceDetailedRequest
           ? getTracer().startSpan(NextNodeServerSpan.resolveRoute, {
               attributes: {
+                'next.span_name': 'resolve route',
                 'next.span_type': NextNodeServerSpan.resolveRoute,
               },
             })

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -159,6 +159,7 @@ export async function pipeNodeReadableToNodeResponse(
       getRequestInsightsIdentity() || process.env.NEXT_OTEL_VERBOSE === '1'
         ? getTracer().startSpan(NextNodeServerSpan.waitForFirstResponseChunk, {
             attributes: {
+              'next.span_name': 'wait for first response chunk',
               'next.span_type': NextNodeServerSpan.waitForFirstResponseChunk,
             },
           })

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -75,6 +75,7 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
           DevRouteMatcherManagerSpan.matchDevelopmentRoute,
           {
             attributes: {
+              'next.span_name': 'match development route',
               'next.span_type':
                 DevRouteMatcherManagerSpan.matchDevelopmentRoute,
             },
@@ -93,12 +94,14 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
         if (shouldTraceDetailedMatch) {
           await getTracer().trace(
             DevRouteMatcherManagerSpan.ensureRoute,
-            {},
+            {
+              attributes: { 'next.span_name': 'compile and prepare route' },
+            },
             () => this.ensurer.ensure(developmentMatch, pathname)
           )
           await getTracer().trace(
             DevRouteMatcherManagerSpan.reloadMatchers,
-            {},
+            { attributes: { 'next.span_name': 'reload route matchers' } },
             () => this.production.reload()
           )
         } else {
@@ -111,6 +114,7 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
               DevRouteMatcherManagerSpan.matchProductionRoute,
               {
                 attributes: {
+                  'next.span_name': 'match production route',
                   'next.span_type':
                     DevRouteMatcherManagerSpan.matchProductionRoute,
                 },
@@ -138,6 +142,7 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
               DevRouteMatcherManagerSpan.matchDevelopmentRoute,
               {
                 attributes: {
+                  'next.span_name': 'match development route',
                   'next.span_type':
                     DevRouteMatcherManagerSpan.matchDevelopmentRoute,
                 },

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -343,8 +343,10 @@ export function renderToInitialFizzStream({
   element: React.ReactElement
   streamOptions?: Parameters<typeof ReactDOMServer.renderToReadableStream>[1]
 }): Promise<ReactDOMServerReadableStream> {
-  return getTracer().trace(AppRenderSpan.renderToReadableStream, {}, async () =>
-    ReactDOMServer.renderToReadableStream(element, streamOptions)
+  return getTracer().trace(
+    AppRenderSpan.renderToReadableStream,
+    { attributes: { 'next.span_name': 'start HTML render' } },
+    async () => ReactDOMServer.renderToReadableStream(element, streamOptions)
   )
 }
 

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -122,9 +122,11 @@ describe('request insights', () => {
     const baseRenderSpan = request?.spans.find(
       (span) => span.attributes?.['next.span_type'] === 'BaseServer.render'
     )
+    const pipeSpan = request?.spans.find(
+      (span) => span.attributes?.['next.span_type'] === 'BaseServer.pipe'
+    )
     const renderSpan = request?.spans.find(
-      (span) =>
-        span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+      (span) => span.attributes?.['next.span_name'] === 'render route (app) /'
     )
     const renderWithComponentsSpan = request?.spans.find(
       (span) =>
@@ -290,13 +292,29 @@ describe('request insights', () => {
     expect(resolveRouteSpan).toBeDefined()
     expect(matchDevelopmentRouteSpan).toBeDefined()
     expect(ensureRouteSpan).toBeDefined()
+    expect(ensureRouteSpan!.attributes?.['next.span_name']).toBe(
+      'compile and prepare route'
+    )
     expect(compileRouteSpan).toBeDefined()
+    expect(compileRouteSpan!.attributes?.['next.span_name']).toBe(
+      'compile route'
+    )
     expect(compileRouteSpan!.parentSpanId).toBe(ensureRouteSpan!.spanId)
     expect(reloadMatchersSpan).toBeDefined()
     expect(matchProductionRouteSpan).toBeDefined()
     expect(baseRenderSpan).toBeDefined()
+    expect(baseRenderSpan!.attributes?.['next.span_name']).toBe(
+      'render request'
+    )
+    expect(pipeSpan).toBeDefined()
+    expect(pipeSpan!.attributes?.['next.span_name']).toBe(
+      'render and send response'
+    )
     expect(renderSpan).toBeDefined()
     expect(renderWithComponentsSpan).toBeDefined()
+    expect(renderWithComponentsSpan!.attributes?.['next.span_name']).toBe(
+      'render response'
+    )
     expect(prepareResponseSpan).toBeDefined()
     expect(getIncrementalCacheSpan).toBeDefined()
     expect(resolvePrerenderingSpan).toBeDefined()
@@ -329,8 +347,35 @@ describe('request insights', () => {
       })
     ).toBe(true)
     expect(requestSpan!.attributes?.['next.span.category']).toBe('nextjs')
+    expect(renderToNodeFizzStreamSpan!.attributes?.['next.span_name']).toBe(
+      'render HTML shell'
+    )
+    expect(renderRSCResponseSpan!.attributes?.['next.span_name']).toBe(
+      'render RSC response'
+    )
+    expect(waitForRSCSpan!.attributes?.['next.span_name']).toBe(
+      'wait for RSC render task'
+    )
+    expect(waitForHTMLCompletionSpan!.attributes?.['next.span_name']).toBe(
+      'wait for HTML completion'
+    )
     expect(renderRSCResponseSpan!.parentSpanId).toBe(renderSpan!.spanId)
     expect(waitForHTMLCompletionSpan!.parentSpanId).toBe(renderSpan!.spanId)
+    expect(renderToReadableStreamSpan!.attributes?.['next.span_name']).toBe(
+      'start HTML render'
+    )
+    expect(waitShellReadySpan!.attributes?.['next.span_name']).toBe(
+      'wait for HTML shell'
+    )
+    expect(waitForFizzRenderTaskSpan!.attributes?.['next.span_name']).toBe(
+      'wait for HTML render task'
+    )
+    expect(pipeFizzStreamSpan!.attributes?.['next.span_name']).toBe(
+      'pipe HTML stream'
+    )
+    expect(waitForFizzFlushSpan!.attributes?.['next.span_name']).toBe(
+      'wait for HTML flush'
+    )
     expect(request!.startTime).toBe(requestSpan!.startTime)
     expect(request!.durationMs).toBeCloseTo(requestSpan!.durationMs!, 3)
     expect(requestSpan!.startTime).toBeLessThanOrEqual(renderSpan!.startTime)


### PR DESCRIPTION
## What?

Adds explicit human-readable names for the OpenTelemetry spans displayed by Request Insights.

Framework instrumentation now records the UI label in `next.span_name`, while the OpenTelemetry operation name remains a stable internal identifier such as `AppRender.renderToNodeFizzStream`. The trace viewer uses the recorded label directly instead of deriving user-facing text from internal class and method names.

## Why?

Internal names such as `AppRender.renderToNodeFizzStream`, Fizz, and Flight are implementation details. Converting them in the UI required a growing set of heuristics and still produced labels that were difficult to understand.

Recording the intended label at the instrumentation site makes ownership explicit, keeps the trace viewer simple, and lets the framework use terminology developers recognize: HTML rendering and RSC rendering.

## How?

- Adds `next.span_name` to every framework span shown in the focused Request Insights trace.
- Uses stable internal operation names for OpenTelemetry instead of changing operation names to include routes or methods.
- Names Fizz operations in terms of HTML rendering and Flight operations in terms of RSC rendering.
- Adds readable labels for BaseServer rendering, component loading, route preparation/compilation, App Router initialization, RSC work, HTML work, and response streaming.
- Simplifies the trace viewer to prefer the recorded `next.span_name`, with the original span name as the fallback for application and custom spans.
- Extends unit and integration assertions to ensure displayed framework spans have the expected labels.

This PR changes names only; Server Action tracing is introduced by #95773, its Request Insights representation by #95770, and the timing boundaries by #95765.

## Stack

1. #95773 — Server Action OpenTelemetry span
2. #95770 — Server Action metadata in Request Insights
3. #95765 — Missing OpenTelemetry spans
4. **#95766 — Human-readable OpenTelemetry span names (this PR)**

## Verification

- `pnpm --filter=next build`
- `pnpm exec jest --runTestsByPath packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts packages/next/src/server/lib/trace/request-insights.test.ts`
- `pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts`

<!-- NEXT_JS_LLM -->
