### PR TITLE
Add Server Action tracing to Request Insights

### DIFF
--- a/packages/next/src/cli/next-request-insights.ts
+++ b/packages/next/src/cli/next-request-insights.ts
@@ -82,6 +82,11 @@ export async function nextRequestInsights(
     console.log(
       `  request ${shortId(request.requestId)} page ${shortId(request.htmlRequestId)}`
     )
+    if (request.serverAction) {
+      console.log(
+        `  server action ${request.serverAction.name} ${formatDuration(request.serverAction.durationMs)}${request.serverAction.file ? ` ${request.serverAction.file}` : ''}`
+      )
+    }
 
     const visibleFetches = request.fetches.slice(0, DEFAULT_FETCH_LIMIT)
     if (visibleFetches.length < request.fetches.length) {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -77,16 +77,21 @@
   white-space: nowrap;
 }
 
-.request-insights-page-load {
+.request-insights-badge {
   flex-shrink: 0;
   border-radius: 999px;
   padding: 1px 5px;
-  background: var(--color-blue-100);
-  color: var(--color-blue-900);
+  background: var(--color-gray-200);
+  color: var(--color-gray-900);
   font-size: var(--size-10);
   font-weight: 600;
   line-height: 16px;
   white-space: nowrap;
+}
+
+.request-insights-badge[data-kind='page-load'] {
+  background: var(--color-blue-100);
+  color: var(--color-blue-900);
 }
 
 .request-insights-duration,

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -69,6 +69,10 @@ function RequestRow({
   selected: boolean
   onSelect: () => void
 }) {
+  const title = request.serverAction
+    ? `ƒ ${request.serverAction.name}`
+    : (request.route ?? request.url ?? 'Unknown route')
+
   return (
     <button
       className="request-insights-row"
@@ -79,11 +83,14 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
-        <span className="request-insights-route-label">
-          {request.route ?? request.url ?? 'Unknown route'}
-        </span>
+        <span className="request-insights-route-label">{title}</span>
+        {request.serverAction ? (
+          <span className="request-insights-badge">Server Action</span>
+        ) : null}
         {pageLoad ? (
-          <span className="request-insights-page-load">Page load</span>
+          <span className="request-insights-badge" data-kind="page-load">
+            Page load
+          </span>
         ) : null}
       </span>
       <span className="request-insights-duration">
@@ -109,15 +116,16 @@ function RequestDetails({ request }: { request: RequestInsight }) {
   )
   const overview = useMemo(() => getRequestOverview(request), [request])
   const diagnosis = getDiagnosis(request, traceItems)
+  const title = request.serverAction
+    ? `ƒ ${request.serverAction.name}`
+    : (request.route ?? request.url ?? request.requestId)
 
   return (
     <div className="request-insights-details">
       <div className="request-insights-summary">
         <div className="request-insights-heading">
           <div className="request-insights-title-row">
-            <div className="request-insights-title">
-              {request.route ?? request.url ?? request.requestId}
-            </div>
+            <div className="request-insights-title">{title}</div>
             <CopyButton
               actionLabel="Copy request JSON"
               className="request-insights-copy"
@@ -162,6 +170,8 @@ function RequestOverview({
       <span>Method {overview.method}</span>
       <span>Status {overview.statusLabel}</span>
       <span>{overview.kind}</span>
+      {overview.route ? <span>Route {overview.route}</span> : null}
+      {overview.source ? <span>Source {overview.source}</span> : null}
       <span>{overview.fetchSummary}</span>
       <span>{overview.cacheSummary}</span>
       <span>{overview.spanSummary}</span>
@@ -344,7 +354,13 @@ function getRequestOverview(request: RequestInsight) {
     method,
     statusCode,
     statusLabel: statusCode ?? request.status,
-    kind: isRsc ? 'RSC request' : 'HTML request',
+    kind: request.serverAction
+      ? 'Server Action'
+      : isRsc
+        ? 'RSC request'
+        : 'HTML request',
+    route: request.serverAction ? (request.route ?? request.url) : undefined,
+    source: request.serverAction?.file,
     fetchSummary: request.fetches.length
       ? `${request.fetches.length} fetch${request.fetches.length === 1 ? '' : 'es'}`
       : 'No fetches',

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -275,6 +275,49 @@ describe('request insights trace viewer', () => {
     ])
   })
 
+  it('shows Server Action execution in the default trace', () => {
+    const request = createRequest({
+      spans: [
+        {
+          name: 'POST /messages',
+          spanId: 'request',
+          startTime: 100,
+          durationMs: 250,
+          attributes: { 'next.span_type': 'BaseServer.handleRequest' },
+        },
+        {
+          name: 'run Server Action saveMessage',
+          spanId: 'action',
+          parentSpanId: 'request',
+          startTime: 110,
+          durationMs: 200,
+          attributes: {
+            'next.span.category': 'application',
+            'next.span_name': 'run Server Action saveMessage',
+            'next.span_type': 'AppRender.executeServerAction',
+            'next.server_action.name': 'saveMessage',
+            'next.server_action.file': 'app/actions.ts',
+          },
+        },
+      ],
+    })
+
+    expect(
+      getTraceItems(request, false).map(({ label, category, depth }) => ({
+        label,
+        category,
+        depth,
+      }))
+    ).toEqual([
+      { label: 'POST /messages', category: 'nextjs', depth: 0 },
+      {
+        label: 'run Server Action saveMessage',
+        category: 'application',
+        depth: 1,
+      },
+    ])
+  })
+
   it('gives every displayed span a human readable name', () => {
     const request = createRequest({
       spans: [

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -42,6 +42,7 @@ const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'AppRender.waitForRSC',
   'AppRender.renderToNodeFizzStream',
   'AppRender.waitForHTMLCompletion',
+  'AppRender.executeServerAction',
   FETCH_SPAN_TYPE,
   'NextNodeServer.waitForFirstResponseChunk',
   'NextNodeServer.startResponse',
@@ -343,6 +344,14 @@ function getSpanLabel(span: RequestInsightSpan): string {
     typeof explicitName === 'string' && explicitName.trim().length > 0
       ? explicitName
       : span.name
+
+  if (
+    span.attributes?.['next.span_type'] === 'AppRender.executeServerAction' &&
+    typeof explicitName === 'string'
+  ) {
+    return explicitName
+  }
+
   const displayName = name
     .replace(FIZZ_WORD, 'HTML')
     .replace(FLIGHT_WORD, 'RSC')

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -42,6 +42,13 @@ export type RequestInsightFetch = {
   index?: number
 }
 
+export type RequestInsightServerAction = {
+  name: string
+  file?: string
+  durationMs?: number
+  status: 'ok' | 'error'
+}
+
 export type RequestInsight = {
   requestId: string
   htmlRequestId: string
@@ -50,6 +57,7 @@ export type RequestInsight = {
   startTime: number
   durationMs?: number
   status: 'ok' | 'error' | 'pending'
+  serverAction?: RequestInsightServerAction
   spans: RequestInsightSpan[]
   fetches: RequestInsightFetch[]
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -74,8 +74,44 @@ import {
   ActionDidRevalidateStaticAndDynamic,
 } from '../../shared/lib/action-revalidation-kind'
 import { computeCacheBustingSearchParam } from '../../shared/lib/router/utils/cache-busting-search-param'
+import { getTracer } from '../lib/trace/tracer'
+import { AppRenderSpan } from '../lib/trace/constants'
 
 const INLINE_ACTION_PREFIX = '$$RSC_SERVER_ACTION_'
+
+type ServerActionInfo = {
+  name: string
+  file: string
+}
+
+function getServerActionInfo(
+  actionId: string,
+  ctx: AppRenderContext
+): ServerActionInfo | null {
+  const serverActionsManifest = getServerActionsManifest()
+  const runtime = process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
+  const actionInfo = serverActionsManifest[runtime]?.[actionId]
+
+  if (!actionInfo) {
+    return null
+  }
+
+  const projectDir =
+    ctx.renderOpts.dir ||
+    (process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd())
+  const file = normalizeFilePath(projectDir, actionInfo.filename)
+  const isInlineAction =
+    actionInfo.exportedName?.startsWith(INLINE_ACTION_PREFIX)
+
+  return {
+    name: isInlineAction
+      ? '<inline action>'
+      : actionInfo.exportedName === 'default'
+        ? 'default'
+        : actionInfo.exportedName || '<action>',
+    file,
+  }
+}
 
 /**
  * Checks if the app has any server actions defined in any runtime.
@@ -788,7 +824,13 @@ export async function handleAction({
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
+              const mpaActionId = process.env.__NEXT_DEV_SERVER
+                ? getValidatedMPAActionId(formData, serverModuleMap)
+                : null
+              const areActionIdsValid = process.env.__NEXT_DEV_SERVER
+                ? mpaActionId !== null
+                : areAllActionIdsValid(formData, serverModuleMap)
+              if (!areActionIdsValid) {
                 // TODO: This can be from skew or manipulated input. We should handle this case
                 // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
                 throw new Error(
@@ -808,7 +850,10 @@ export async function handleAction({
                   [],
                   workStore,
                   requestStore,
-                  actionWasForwarded
+                  actionWasForwarded,
+                  process.env.__NEXT_DEV_SERVER
+                    ? getServerActionInfo(mpaActionId!, ctx)
+                    : null
                 )
 
                 const formState = await decodeFormState(
@@ -994,7 +1039,13 @@ export async function handleAction({
                 throw err
               }
 
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
+              const mpaActionId = process.env.__NEXT_DEV_SERVER
+                ? getValidatedMPAActionId(formData, serverModuleMap)
+                : null
+              const areActionIdsValid = process.env.__NEXT_DEV_SERVER
+                ? mpaActionId !== null
+                : areAllActionIdsValid(formData, serverModuleMap)
+              if (!areActionIdsValid) {
                 // TODO: This can be from skew or manipulated input. We should handle this case
                 // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
                 throw new Error(
@@ -1016,7 +1067,10 @@ export async function handleAction({
                   [],
                   workStore,
                   requestStore,
-                  actionWasForwarded
+                  actionWasForwarded,
+                  process.env.__NEXT_DEV_SERVER
+                    ? getServerActionInfo(mpaActionId!, ctx)
+                    : null
                 )
 
                 const formState = await decodeFormState(
@@ -1101,40 +1155,26 @@ export async function handleAction({
             actionId!
           ]
 
+        const serverActionInfo = process.env.__NEXT_DEV_SERVER
+          ? getServerActionInfo(actionId!, ctx)
+          : null
+
         // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
         const { type: actionType } = extractInfoFromServerReferenceId(actionId!)
         if (
-          process.env.NODE_ENV === 'development' &&
+          process.env.__NEXT_DEV_SERVER &&
           ctx.renderOpts.logServerFunctions &&
           // TODO: For now, skip logging for 'use cache' Server Functions as the
           // output needs more work, or a different approach entirely.
           actionType !== 'use-cache'
         ) {
-          const serverActionsManifest = getServerActionsManifest()
-          const runtime = process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          const actionInfo = serverActionsManifest[runtime]?.[actionId!]
-
-          if (actionInfo) {
-            const isInlineAction =
-              actionInfo.exportedName?.startsWith(INLINE_ACTION_PREFIX)
-
-            const projectDir =
-              ctx.renderOpts.dir ||
-              (process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd())
-            const location = normalizeFilePath(projectDir, actionInfo.filename)
-
-            // Format function name for display
-            let functionName: string
-            if (isInlineAction) {
-              functionName = '<inline action>'
-            } else if (actionInfo.exportedName === 'default') {
-              functionName = 'default'
-            } else {
-              functionName = actionInfo.exportedName || '<action>'
+          if (serverActionInfo) {
+            logInfo = {
+              functionName: serverActionInfo.name,
+              args: boundActionArguments,
+              location: serverActionInfo.file,
             }
-
-            logInfo = { functionName, args: boundActionArguments, location }
           }
         }
 
@@ -1145,7 +1185,8 @@ export async function handleAction({
             boundActionArguments,
             workStore,
             requestStore,
-            actionWasForwarded
+            actionWasForwarded,
+            serverActionInfo
           ).finally(() => {
             addRevalidationHeader(res, { workStore, requestStore })
             if (logInfo) {
@@ -1306,7 +1347,8 @@ async function executeActionAndPrepareForRender<
   args: Parameters<TFn>,
   workStore: WorkStore,
   requestStore: RequestStore,
-  actionWasForwarded: boolean
+  actionWasForwarded: boolean,
+  serverAction: ServerActionInfo | null
 ): Promise<{
   actionResult: Awaited<ReturnType<TFn>>
   skipPageRendering: boolean
@@ -1321,9 +1363,40 @@ async function executeActionAndPrepareForRender<
   }
 
   try {
-    const actionResult = await workUnitAsyncStorage.run(requestStore, () =>
-      action.apply(null, args)
-    )
+    const executeAction = () =>
+      workUnitAsyncStorage.run(requestStore, () => action.apply(null, args))
+    let actionResult: Awaited<ReturnType<TFn>>
+
+    if (process.env.__NEXT_DEV_SERVER) {
+      const serverActionName = serverAction?.name ?? '<action>'
+      actionResult = await getTracer().trace(
+        AppRenderSpan.executeServerAction,
+        {
+          attributes: {
+            'next.span_name': `run Server Action ${serverActionName}`,
+            'next.span.category': 'application',
+            'next.server_action.name': serverActionName,
+            'next.server_action.file': serverAction?.file || undefined,
+          },
+        },
+        async (_span, done) => {
+          try {
+            const result = await executeAction()
+            done?.()
+            return result
+          } catch (err) {
+            done?.(
+              isRedirectError(err) || isHTTPAccessFallbackError(err)
+                ? undefined
+                : (err as Error)
+            )
+            throw err
+          }
+        }
+      )
+    } else {
+      actionResult = await executeAction()
+    }
 
     // If the page was not revalidated, or if the action was forwarded from
     // another worker, we can skip rendering the page.
@@ -1436,6 +1509,43 @@ function areAllActionIdsValid(
   return hasAtLeastOneAction
 }
 
+/**
+ * Returns the action ID for development-only tracing after validating the full
+ * form with the production validation path above.
+ */
+function getValidatedMPAActionId(
+  mpaFormData: FormData,
+  serverModuleMap: ServerModuleMap
+): string | null {
+  if (!areAllActionIdsValid(mpaFormData, serverModuleMap)) {
+    return null
+  }
+
+  let actionId: string | null = null
+  for (const key of mpaFormData.keys()) {
+    if (key.startsWith($ACTION_ID_)) {
+      actionId = key.slice($ACTION_ID_.length)
+    } else if (key.startsWith($ACTION_REF_)) {
+      const actionDescriptorField =
+        $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
+      const actionDescriptor = mpaFormData.get(actionDescriptorField)
+      if (typeof actionDescriptor !== 'string') {
+        return null
+      }
+
+      actionId = getActionIdFromStringDescriptor(
+        actionDescriptor,
+        serverModuleMap
+      )
+      if (actionId === null) {
+        return null
+      }
+    }
+  }
+
+  return actionId
+}
+
 const ACTION_DESCRIPTOR_ID_PREFIX = '{"id":"'
 function isInvalidStringActionDescriptor(
   actionDescriptor: string,
@@ -1464,6 +1574,20 @@ function isInvalidStringActionDescriptor(
   }
 
   return false
+}
+
+function getActionIdFromStringDescriptor(
+  actionDescriptor: string,
+  serverModuleMap: ServerModuleMap
+): string | null {
+  if (isInvalidStringActionDescriptor(actionDescriptor, serverModuleMap)) {
+    return null
+  }
+
+  return actionDescriptor.slice(
+    ACTION_DESCRIPTOR_ID_PREFIX.length,
+    ACTION_DESCRIPTOR_ID_PREFIX.length + ACTION_ID_EXPECTED_LENGTH
+  )
 }
 
 function isInvalidActionIdFieldName(

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -89,6 +89,7 @@ enum AppRenderSpan {
   fetch = 'AppRender.fetch',
   waitShellReady = 'AppRender.waitShellReady',
   renderToNodeFizzStream = 'AppRender.renderToNodeFizzStream',
+  executeServerAction = 'AppRender.executeServerAction',
 }
 
 enum RouterSpan {
@@ -134,6 +135,7 @@ export const NextVanillaSpanAllowlist = new Set([
   RenderSpan.getStaticProps,
   AppRenderSpan.fetch,
   AppRenderSpan.getBodyResult,
+  AppRenderSpan.executeServerAction,
   RenderSpan.renderDocument,
   NodeSpan.runHandler,
   AppRouteRouteHandlersSpan.runHandler,

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -184,6 +184,48 @@ describe('request insights', () => {
     })
   })
 
+  it('derives safe Server Action metadata from its execution span', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'run Server Action saveMessage',
+      startTime: 100,
+      durationMs: 250,
+      status: 'ok',
+      requestId: 'req_action',
+      htmlRequestId: 'html_action',
+      route: '/messages',
+      attributes: {
+        'next.span.category': 'application',
+        'next.span_type': 'AppRender.executeServerAction',
+        'next.server_action.name': 'saveMessage',
+        'next.server_action.file': 'app/actions.ts',
+        'next.server_action.args': 'secret value',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        serverAction: {
+          name: 'saveMessage',
+          file: 'app/actions.ts',
+          durationMs: 250,
+          status: 'ok',
+        },
+        spans: [
+          expect.objectContaining({
+            attributes: {
+              'next.span.category': 'application',
+              'next.span_type': 'AppRender.executeServerAction',
+              'next.server_action.name': 'saveMessage',
+              'next.server_action.file': 'app/actions.ts',
+            },
+          }),
+        ],
+      })
+    )
+  })
+
   it('redacts sensitive request insight payload fields', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -2,6 +2,7 @@ import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
 import type {
   RequestInsight,
   RequestInsightFetch,
+  RequestInsightServerAction,
   RequestInsightsSnapshot,
 } from '../../../next-devtools/shared/request-insights'
 import type { SpanStoreRecord } from './span-store'
@@ -31,7 +32,10 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.fetch.idx',
   'next.route',
   'next.rsc',
+  'next.server_action.file',
+  'next.server_action.name',
   'next.segment',
+  'next.span.category',
   'next.span_name',
   'next.span_type',
 ])
@@ -87,6 +91,11 @@ class InMemoryRequestInsightsStore {
       events: sanitizeSpanEvents(span.events),
       error: span.error,
     })
+
+    const serverAction = getServerActionInsight(span)
+    if (serverAction) {
+      insight.serverAction = serverAction
+    }
 
     const fetch = getFetchInsight(span)
     if (fetch) {
@@ -252,6 +261,31 @@ function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {
     cacheStatus: getStringAttribute(attributes['next.fetch.cache_status']),
     cacheReason: getStringAttribute(attributes['next.fetch.cache_reason']),
     index: getNumberAttribute(attributes['next.fetch.idx']),
+  }
+}
+
+function getServerActionInsight(
+  span: SpanStoreRecord
+): RequestInsightServerAction | null {
+  const attributes = span.attributes
+
+  if (
+    !attributes ||
+    attributes['next.span_type'] !== 'AppRender.executeServerAction'
+  ) {
+    return null
+  }
+
+  const name = getStringAttribute(attributes['next.server_action.name'])
+  if (!name) {
+    return null
+  }
+
+  return {
+    name,
+    file: getStringAttribute(attributes['next.server_action.file']),
+    durationMs: span.durationMs,
+    status: span.status === 'error' ? 'error' : 'ok',
   }
 }
 

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -185,8 +185,11 @@ type NextAttributeNames =
   | 'next.page'
   | 'next.rsc'
   | 'next.segment'
+  | 'next.span.category'
   | 'next.span_name'
   | 'next.span_type'
+  | 'next.server_action.name'
+  | 'next.server_action.file'
   | 'next.clientComponentLoadCount'
 type OTELAttributeNames = `http.${string}` | `net.${string}`
 type AttributeNames = NextAttributeNames | OTELAttributeNames

--- a/test/development/app-dir/request-insights/app/actions/action-buttons.tsx
+++ b/test/development/app-dir/request-insights/app/actions/action-buttons.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+
+export function ActionButtons({
+  delayedAction,
+  defaultAction,
+  inlineAction,
+  errorAction,
+}: {
+  delayedAction: (message: string) => Promise<number>
+  defaultAction: () => Promise<string>
+  inlineAction: () => Promise<string>
+  errorAction: () => Promise<void>
+}) {
+  const [result, setResult] = useState('')
+
+  return (
+    <>
+      <button
+        id="delayed-action"
+        onClick={async () => {
+          const length = await delayedAction('super-secret-action-argument')
+          setResult(`delayed:${length}`)
+        }}
+      >
+        Delayed action
+      </button>
+      <button
+        id="default-action"
+        onClick={async () => setResult(await defaultAction())}
+      >
+        Default action
+      </button>
+      <button
+        id="inline-action"
+        onClick={async () => setResult(await inlineAction())}
+      >
+        Inline action
+      </button>
+      <button
+        id="error-action"
+        onClick={async () => {
+          try {
+            await errorAction()
+          } catch {
+            setResult('action failed')
+          }
+        }}
+      >
+        Error action
+      </button>
+      <p id="action-result">{result}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/actions/actions.ts
+++ b/test/development/app-dir/request-insights/app/actions/actions.ts
@@ -1,0 +1,21 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+export async function delayedAction(message: string) {
+  await new Promise((resolve) => setTimeout(resolve, 200))
+  return message.length
+}
+
+export async function progressiveAction() {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  redirect('/actions?progressive=done')
+}
+
+export async function errorAction() {
+  throw new Error('request insights action failure')
+}
+
+export default async function defaultAction() {
+  return 'default action complete'
+}

--- a/test/development/app-dir/request-insights/app/actions/page.tsx
+++ b/test/development/app-dir/request-insights/app/actions/page.tsx
@@ -1,0 +1,29 @@
+import { ActionButtons } from './action-buttons'
+import defaultAction, {
+  delayedAction,
+  errorAction,
+  progressiveAction,
+} from './actions'
+
+export default function ActionsPage() {
+  async function inlineAction() {
+    'use server'
+    return 'inline action complete'
+  }
+
+  return (
+    <>
+      <ActionButtons
+        delayedAction={delayedAction}
+        defaultAction={defaultAction}
+        inlineAction={inlineAction}
+        errorAction={errorAction}
+      />
+      <form action={progressiveAction}>
+        <button id="progressive-action" type="submit">
+          Progressive action
+        </button>
+      </form>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/next.config.js
+++ b/test/development/app-dir/request-insights/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   distDir: 'build',
+  logging: {
+    serverFunctions: false,
+  },
   experimental: {
     requestInsights: true,
   },

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -1,14 +1,30 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createServer } from 'http'
 import type { AddressInfo } from 'net'
+import { retry } from 'next-test-utils'
 
 type RequestInsight = {
   requestId: string
   htmlRequestId: string
   route: string
   startTime: number
-  status: 'ok'
-  spans: []
+  status: 'ok' | 'error' | 'pending'
+  durationMs?: number
+  serverAction?: {
+    name: string
+    file?: string
+    durationMs?: number
+    status: 'ok' | 'error'
+  }
+  spans: Array<{
+    name: string
+    spanId?: string
+    parentSpanId?: string
+    startTime: number
+    durationMs?: number
+    status?: 'ok' | 'error'
+    attributes?: Record<string, string | number | boolean>
+  }>
   fetches: Array<{
     durationMs: number
     statusCode: number
@@ -77,6 +93,147 @@ describe('request insights', () => {
     }
     expect(result.cliOutput).toMatch(
       /No request insights captured yet|retained requests \(newest first\)/
+    )
+  })
+
+  it('identifies client-dispatched Server Actions without retaining arguments', async () => {
+    const browser = await next.browser('/actions')
+
+    await browser.elementById('delayed-action').click()
+    await retry(async () => {
+      expect(await browser.elementById('action-result').text()).toStartWith(
+        'delayed:'
+      )
+    })
+    const snapshot = (await next
+      .fetch('/_next/development/request-insights')
+      .then((response) => response.json())) as {
+      requests: RequestInsight[]
+    }
+    const request = snapshot.requests.findLast(
+      (insight) => insight.serverAction?.name === 'delayedAction'
+    )
+    const actionSpan = request?.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.executeServerAction'
+    )
+    expect(request).toBeDefined()
+    expect(request!.route).toBe('/actions')
+    expect(request!.serverAction).toEqual({
+      name: 'delayedAction',
+      file: 'app/actions/actions.ts',
+      durationMs: expect.any(Number),
+      status: 'ok',
+    })
+    expect(request!.serverAction!.durationMs).toBeGreaterThanOrEqual(180)
+    expect(actionSpan).toEqual(
+      expect.objectContaining({
+        name: 'AppRender.executeServerAction',
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span.category': 'application',
+          'next.span_name': 'run Server Action delayedAction',
+          'next.span_type': 'AppRender.executeServerAction',
+          'next.server_action.name': 'delayedAction',
+          'next.server_action.file': 'app/actions/actions.ts',
+        }),
+      })
+    )
+    const serializedRequest = JSON.stringify(request)
+    expect(serializedRequest).not.toContain('super-secret-action-argument')
+    expect(serializedRequest).not.toContain('actionId')
+    expect(request!.serverAction).not.toHaveProperty('args')
+
+    const command = await next.runCommand([
+      'experimental-request-insights',
+      '--limit',
+      '100',
+    ])
+    expect(command.code).toBe(0)
+    expect(command.stdout).toContain('server action delayedAction')
+    expect(command.stdout).toContain('app/actions/actions.ts')
+    expect(next.cliOutput).not.toContain('└─ ƒ delayedAction')
+  })
+
+  it('identifies default, inline, successful control-flow, and failed actions', async () => {
+    const browser = await next.browser('/actions')
+
+    await browser.elementById('default-action').click()
+    await retry(async () => {
+      expect(await browser.elementById('action-result').text()).toBe(
+        'default action complete'
+      )
+    })
+
+    await browser.elementById('inline-action').click()
+    await retry(async () => {
+      expect(await browser.elementById('action-result').text()).toBe(
+        'inline action complete'
+      )
+    })
+
+    await browser.elementById('error-action').click()
+    await retry(async () => {
+      expect(await browser.elementById('action-result').text()).toBe(
+        'action failed'
+      )
+    })
+
+    const progressiveBrowser = await next.browser('/actions', {
+      disableJavaScript: true,
+    })
+    await progressiveBrowser.elementById('progressive-action').click()
+    await retry(async () => {
+      expect(await progressiveBrowser.url()).toBe(
+        `${next.url}/actions?progressive=done`
+      )
+    })
+
+    const snapshot = (await next
+      .fetch('/_next/development/request-insights')
+      .then((response) => response.json())) as {
+      requests: RequestInsight[]
+    }
+    const defaultRequest = snapshot.requests.findLast(
+      (insight) => insight.serverAction?.name === 'default'
+    )
+    const inlineRequest = snapshot.requests.findLast(
+      (insight) => insight.serverAction?.name === '<inline action>'
+    )
+    const errorRequest = snapshot.requests.findLast(
+      (insight) => insight.serverAction?.name === 'errorAction'
+    )
+    const progressiveRequest = snapshot.requests.findLast(
+      (insight) => insight.serverAction?.name === 'progressiveAction'
+    )
+
+    expect(defaultRequest?.serverAction).toEqual(
+      expect.objectContaining({
+        name: 'default',
+        file: 'app/actions/actions.ts',
+        status: 'ok',
+      })
+    )
+    expect(inlineRequest?.serverAction).toEqual(
+      expect.objectContaining({
+        name: '<inline action>',
+        file: 'app/actions/page.tsx',
+        status: 'ok',
+      })
+    )
+    expect(errorRequest?.serverAction).toEqual(
+      expect.objectContaining({
+        name: 'errorAction',
+        file: 'app/actions/actions.ts',
+        status: 'error',
+      })
+    )
+    expect(progressiveRequest?.serverAction).toEqual(
+      expect.objectContaining({
+        name: 'progressiveAction',
+        file: 'app/actions/actions.ts',
+        status: 'ok',
+      })
     )
   })
 


### PR DESCRIPTION
> [!NOTE]
> Superseded by #95770. GitHub marked this PR as merged into its previous stacked base while the stack was being reordered; it was not merged into `canary`.

## What?

Adds development-only OpenTelemetry tracing and Request Insights metadata for Server Action execution.

Request Insights can now distinguish a Server Action POST from an ordinary POST request and show the action’s name, source file, duration, status, and execution span in the default trace. It supports client-dispatched actions, progressively enhanced form actions, default exports, inline actions, successful control-flow responses, and failures.

## Why?

Server Action execution is application work, but it previously appeared only as otherwise unexplained time inside a POST request. Without resolving the action, Request Insights could not tell reviewers which application function ran or attribute its execution time correctly.

The metadata must also be safe to retain: action arguments and action IDs can contain sensitive implementation or user data and should not be included in Request Insights snapshots.

## How?

- Resolves development-only action metadata from the Server Actions manifest after validating the action through the existing production validation path.
- Wraps the actual action invocation in an `AppRender.executeServerAction` Application span.
- Records a human-readable action label plus the normalized action name and source file.
- Treats redirects and HTTP access fallbacks as successful control flow while recording genuine failures as errors.
- Derives a safe `serverAction` summary for the Request Insights snapshot, CLI, and DevTools panel.
- Explicitly drops arguments, action IDs, and unapproved action attributes from retained data.
- Adds coverage for client actions, ordinary POST requests, progressive forms, default and inline actions, failures, hierarchy, and redaction.

All action resolution and tracing added by this PR is gated to the development server.

## Verification

- `pnpm --filter=next build`
- `pnpm exec jest packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts --runInBand`
- `pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts`

<!-- NEXT_JS_LLM -->
