### PR TITLE
Add OpenTelemetry span for Server Action execution

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -335,7 +335,7 @@ describe('request insights trace viewer', () => {
           startTime: 100,
           durationMs: 10,
           attributes: {
-            'next.span.category': 'nextjs',
+            'next.span_category': 'nextjs',
             'next.span_type': 'BaseServer.render',
           },
         },
@@ -344,7 +344,7 @@ describe('request insights trace viewer', () => {
           startTime: 110,
           durationMs: 10,
           attributes: {
-            'next.span.category': 'application',
+            'next.span_category': 'application',
             'next.span_type': 'ResolveMetadata.generateMetadata',
           },
         },
@@ -384,7 +384,7 @@ describe('request insights trace viewer', () => {
           startTime: 120,
           durationMs: 30,
           attributes: {
-            'next.span.category': 'application',
+            'next.span_category': 'application',
             'next.span_type': 'AppRender.fetch',
             'next.fetch.idx': 1,
           },
@@ -396,7 +396,7 @@ describe('request insights trace viewer', () => {
           startTime: 155,
           durationMs: 10,
           attributes: {
-            'next.span.category': 'nextjs',
+            'next.span_category': 'nextjs',
             'next.span_type': 'AppRender.fetch',
             'next.fetch.idx': 2,
           },

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -323,7 +323,7 @@ function getFetchIndex(span: RequestInsightSpan): number | undefined {
 }
 
 function getSpanCategory(span: RequestInsightSpan): 'nextjs' | 'application' {
-  const category = span.attributes?.['next.span.category']
+  const category = span.attributes?.['next.span_category']
   if (category === 'nextjs' || category === 'application') {
     return category
   }

--- a/packages/next/src/server/app-render/action-handler.test.ts
+++ b/packages/next/src/server/app-render/action-handler.test.ts
@@ -45,6 +45,30 @@ describe('getValidatedMPAActionId', () => {
     expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_A)
   })
 
+  it('uses the last duplicate descriptor ID to match React decodeAction', () => {
+    const formData = new FormData()
+    formData.append('$ACTION_REF_0', '')
+    formData.append(
+      '$ACTION_0:0',
+      `{"id":"${ACTION_ID_A}","bound":"$@1","id":"${ACTION_ID_B}"}`
+    )
+    formData.append('$ACTION_0:1', '["A"]')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_B)
+  })
+
+  it('rejects an unknown last duplicate descriptor ID', () => {
+    const formData = new FormData()
+    formData.append('$ACTION_REF_0', '')
+    formData.append(
+      '$ACTION_0:0',
+      `{"id":"${ACTION_ID_A}","bound":"$@1","id":"${UNKNOWN_ACTION_ID}"}`
+    )
+    formData.append('$ACTION_0:1', '["A"]')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBeNull()
+  })
+
   it('returns the last valid action ID to match React decodeAction', () => {
     const formData = new FormData()
     formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
@@ -115,6 +139,10 @@ describe('getValidatedMPAActionId', () => {
     ['a missing descriptor', undefined],
     ['a non-string descriptor', new Blob()],
     ['a malformed descriptor', '{}'],
+    [
+      'a truncated descriptor after a valid action ID',
+      `{"id":"${ACTION_ID_A}"`,
+    ],
     [
       'a descriptor with a too-short action ID',
       createBoundActionDescriptor(ACTION_ID_A.slice(1)),

--- a/packages/next/src/server/app-render/action-handler.test.ts
+++ b/packages/next/src/server/app-render/action-handler.test.ts
@@ -1,4 +1,206 @@
-import { parseHostHeader } from './action-handler'
+import type { ServerModuleMap } from './manifests-singleton'
+import { getValidatedMPAActionId, parseHostHeader } from './action-handler'
+
+const ACTION_ID_A = 'a'.repeat(42)
+const ACTION_ID_B = 'b'.repeat(42)
+const UNKNOWN_ACTION_ID = 'c'.repeat(42)
+
+const serverModuleMap: ServerModuleMap = {
+  [ACTION_ID_A]: {
+    id: 'module-a',
+    name: ACTION_ID_A,
+    chunks: [],
+  },
+  [ACTION_ID_B]: {
+    id: 'module-b',
+    name: ACTION_ID_B,
+    chunks: [],
+  },
+}
+
+function createBoundActionDescriptor(actionId: string): string {
+  return JSON.stringify({ id: actionId, bound: null })
+}
+
+describe('getValidatedMPAActionId', () => {
+  it('returns null when the form does not contain an action', () => {
+    const formData = new FormData()
+    formData.append('name', 'value')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBeNull()
+  })
+
+  it('returns a valid unbound action ID', () => {
+    const formData = new FormData()
+    formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_A)
+  })
+
+  it('returns a valid bound action ID', () => {
+    const formData = new FormData()
+    formData.append('$ACTION_REF_0', '')
+    formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_A))
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_A)
+  })
+
+  it('returns the last valid action ID to match React decodeAction', () => {
+    const formData = new FormData()
+    formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+    formData.append(`$ACTION_ID_${ACTION_ID_B}`, '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_B)
+  })
+
+  it.each([
+    ['an unbound action followed by a bound action', 'unbound-bound'],
+    ['a bound action followed by an unbound action', 'bound-unbound'],
+  ])('returns the last action for %s', (_description, order) => {
+    const formData = new FormData()
+    if (order === 'unbound-bound') {
+      formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+      formData.append('$ACTION_REF_0', '')
+      formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_B))
+    } else {
+      formData.append('$ACTION_REF_0', '')
+      formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_A))
+      formData.append(`$ACTION_ID_${ACTION_ID_B}`, '')
+    }
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_B)
+  })
+
+  it('returns the last of multiple bound actions', () => {
+    const formData = new FormData()
+    formData.append('$ACTION_REF_0', '')
+    formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_A))
+    formData.append('$ACTION_REF_1', '')
+    formData.append('$ACTION_1:0', createBoundActionDescriptor(ACTION_ID_B))
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_B)
+  })
+
+  it('ignores duplicate action markers to match React decodeAction', () => {
+    const formData = new FormData()
+    formData.append('$ACTION_REF_0', '')
+    formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_A))
+    formData.append(`$ACTION_ID_${ACTION_ID_B}`, '')
+    formData.append('$ACTION_REF_0', '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_B)
+  })
+
+  it('ignores duplicate unbound action markers', () => {
+    const formData = new FormData()
+    formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+    formData.append(`$ACTION_ID_${ACTION_ID_B}`, '')
+    formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_B)
+  })
+
+  it.each([
+    ['a too-short action ID', `$ACTION_ID_${ACTION_ID_A.slice(1)}`],
+    ['a too-long action ID', `$ACTION_ID_${ACTION_ID_A}extra`],
+    ['an unknown action ID', `$ACTION_ID_${UNKNOWN_ACTION_ID}`],
+  ])('rejects %s', (_description, actionField) => {
+    const formData = new FormData()
+    formData.append(actionField, '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBeNull()
+  })
+
+  it.each([
+    ['a missing descriptor', undefined],
+    ['a non-string descriptor', new Blob()],
+    ['a malformed descriptor', '{}'],
+    [
+      'a descriptor with a too-short action ID',
+      createBoundActionDescriptor(ACTION_ID_A.slice(1)),
+    ],
+    [
+      'a descriptor with a too-long action ID',
+      createBoundActionDescriptor(`${ACTION_ID_A}extra`),
+    ],
+    [
+      'a descriptor without a quote after the action ID',
+      `{"id":"${ACTION_ID_A}x}`,
+    ],
+    [
+      'a descriptor with an unknown action ID',
+      createBoundActionDescriptor(UNKNOWN_ACTION_ID),
+    ],
+  ])('rejects %s for a bound action', (_description, descriptor) => {
+    const formData = new FormData()
+    formData.append('$ACTION_REF_0', '')
+    if (descriptor !== undefined) {
+      formData.append('$ACTION_0:0', descriptor)
+    }
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBeNull()
+  })
+
+  it('accepts a bound descriptor that appears before its action marker', () => {
+    const formData = new FormData()
+    formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_A))
+    formData.append('$ACTION_REF_0', '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_A)
+  })
+
+  it('ignores unreferenced descriptors and unrelated action fields', () => {
+    const formData = new FormData()
+    formData.append(
+      '$ACTION_unused:0',
+      createBoundActionDescriptor(ACTION_ID_B)
+    )
+    formData.append('$ACTION_unrelated', '')
+    formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_A)
+  })
+
+  it('rejects duplicate bound action descriptors', () => {
+    const formData = new FormData()
+    formData.append('$ACTION_REF_0', '')
+    formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_A))
+    formData.append('$ACTION_0:0', createBoundActionDescriptor(ACTION_ID_A))
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBeNull()
+  })
+
+  it('rejects the full form if any action ID is invalid', () => {
+    const formData = new FormData()
+    formData.append(`$ACTION_ID_${UNKNOWN_ACTION_ID}`, '')
+    formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBeNull()
+  })
+
+  it('rejects a valid action followed by an invalid action', () => {
+    const formData = new FormData()
+    formData.append(`$ACTION_ID_${ACTION_ID_A}`, '')
+    formData.append(`$ACTION_ID_${UNKNOWN_ACTION_ID}`, '')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBeNull()
+  })
+
+  it('does not rescan the form data for each bound action reference', () => {
+    const formData = new FormData()
+    for (let index = 0; index < 100; index++) {
+      formData.append(`$ACTION_REF_${index}`, '')
+      formData.append(
+        `$ACTION_${index}:0`,
+        createBoundActionDescriptor(ACTION_ID_A)
+      )
+    }
+    const getAll = jest.spyOn(formData, 'getAll')
+
+    expect(getValidatedMPAActionId(formData, serverModuleMap)).toBe(ACTION_ID_A)
+    expect(getAll).not.toHaveBeenCalled()
+  })
+})
 
 describe('parseHostHeader', () => {
   it('should return correct host', () => {

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1522,48 +1522,33 @@ export function getValidatedMPAActionId(
   return actionId
 }
 
-const ACTION_DESCRIPTOR_ID_PREFIX = '{"id":"'
-function isInvalidStringActionDescriptor(
-  actionDescriptor: string,
-  serverModuleMap: ServerModuleMap
-): unknown {
-  if (actionDescriptor.startsWith(ACTION_DESCRIPTOR_ID_PREFIX) === false) {
-    return true
-  }
-
-  const from = ACTION_DESCRIPTOR_ID_PREFIX.length
-  const to = from + ACTION_ID_EXPECTED_LENGTH
-
-  // We expect actionDescriptor to be '{"id":"<actionId>",...}'
-  const actionId = actionDescriptor.slice(from, to)
-  if (
-    actionId.length !== ACTION_ID_EXPECTED_LENGTH ||
-    actionDescriptor[to] !== '"'
-  ) {
-    return true
-  }
-
-  const entry = serverModuleMap[actionId]
-
-  if (entry == null) {
-    return true
-  }
-
-  return false
-}
-
 function getActionIdFromStringDescriptor(
   actionDescriptor: string,
   serverModuleMap: ServerModuleMap
 ): string | null {
-  if (isInvalidStringActionDescriptor(actionDescriptor, serverModuleMap)) {
+  let parsedActionDescriptor: unknown
+  try {
+    // React also parses this descriptor as JSON before reading its `id`. In
+    // particular, this makes the last of any duplicate `id` properties win.
+    parsedActionDescriptor = JSON.parse(actionDescriptor)
+  } catch {
     return null
   }
 
-  return actionDescriptor.slice(
-    ACTION_DESCRIPTOR_ID_PREFIX.length,
-    ACTION_DESCRIPTOR_ID_PREFIX.length + ACTION_ID_EXPECTED_LENGTH
-  )
+  if (typeof parsedActionDescriptor !== 'object' || !parsedActionDescriptor) {
+    return null
+  }
+
+  const actionId = (parsedActionDescriptor as { id?: unknown }).id
+  if (
+    typeof actionId !== 'string' ||
+    actionId.length !== ACTION_ID_EXPECTED_LENGTH ||
+    serverModuleMap[actionId] == null
+  ) {
+    return null
+  }
+
+  return actionId
 }
 
 function isInvalidActionIdFieldName(

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1457,14 +1457,30 @@ const ACTION_ID_EXPECTED_LENGTH = 42
  * It pre-parses the FormData to ensure that any action IDs referred to are actual action IDs for
  * this Next.js application.
  */
-function getValidatedMPAActionId(
+export function getValidatedMPAActionId(
   mpaFormData: FormData,
   serverModuleMap: ServerModuleMap
 ): string | null {
+  const actionDescriptors = new Map<string, FormDataEntryValue | null>()
+  for (const [key, value] of mpaFormData) {
+    if (
+      key.startsWith($ACTION_) &&
+      !key.startsWith($ACTION_ID_) &&
+      !key.startsWith($ACTION_REF_) &&
+      key.endsWith(':0')
+    ) {
+      // A descriptor must have exactly one root row. Use null as a duplicate
+      // sentinel so descriptor lookup stays O(1) for adversarial forms with
+      // many action references.
+      actionDescriptors.set(key, actionDescriptors.has(key) ? null : value)
+    }
+  }
+
   let actionId: string | null = null
+  const seenActions = new Set<string>()
   // Before we attempt to decode the payload for a possible MPA action, assert that all
   // action IDs are valid IDs. If not we should disregard the payload
-  for (let key of mpaFormData.keys()) {
+  for (const key of mpaFormData.keys()) {
     if (!key.startsWith($ACTION_)) {
       // not a relevant field
       continue
@@ -1472,6 +1488,11 @@ function getValidatedMPAActionId(
 
     if (key.startsWith($ACTION_ID_)) {
       // No Bound args case
+      if (seenActions.has(key)) {
+        continue
+      }
+      seenActions.add(key)
+
       if (isInvalidActionIdFieldName(key, serverModuleMap)) {
         return null
       }
@@ -1479,13 +1500,14 @@ function getValidatedMPAActionId(
       actionId = key.slice($ACTION_ID_.length)
     } else if (key.startsWith($ACTION_REF_)) {
       // Bound args case
+      if (seenActions.has(key)) {
+        continue
+      }
+      seenActions.add(key)
+
       const actionDescriptorField =
         $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
-      const actionFields = mpaFormData.getAll(actionDescriptorField)
-      if (actionFields.length !== 1) {
-        return null
-      }
-      const actionField = actionFields[0]
+      const actionField = actionDescriptors.get(actionDescriptorField)
       if (typeof actionField !== 'string') {
         return null
       }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -96,12 +96,18 @@ function getServerActionInfo(
     return null
   }
 
-  const projectDir =
-    ctx.renderOpts.dir ||
-    (process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd())
-  const file = normalizeFilePath(projectDir, actionInfo.filename)
   const isInlineAction =
     actionInfo.exportedName?.startsWith(INLINE_ACTION_PREFIX)
+  let file = ''
+
+  // Resolving the source location is only needed for development logging and
+  // tracing. Avoid path normalization on every Server Action in production.
+  if (process.env.__NEXT_DEV_SERVER) {
+    const projectDir =
+      ctx.renderOpts.dir ||
+      (process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd())
+    file = normalizeFilePath(projectDir, actionInfo.filename)
+  }
 
   return {
     name: isInlineAction
@@ -824,13 +830,11 @@ export async function handleAction({
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
-              const mpaActionId = process.env.__NEXT_DEV_SERVER
-                ? getValidatedMPAActionId(formData, serverModuleMap)
-                : null
-              const areActionIdsValid = process.env.__NEXT_DEV_SERVER
-                ? mpaActionId !== null
-                : areAllActionIdsValid(formData, serverModuleMap)
-              if (!areActionIdsValid) {
+              const mpaActionId = getValidatedMPAActionId(
+                formData,
+                serverModuleMap
+              )
+              if (mpaActionId === null) {
                 // TODO: This can be from skew or manipulated input. We should handle this case
                 // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
                 throw new Error(
@@ -851,9 +855,7 @@ export async function handleAction({
                   workStore,
                   requestStore,
                   actionWasForwarded,
-                  process.env.__NEXT_DEV_SERVER
-                    ? getServerActionInfo(mpaActionId!, ctx)
-                    : null
+                  getServerActionInfo(mpaActionId, ctx)
                 )
 
                 const formState = await decodeFormState(
@@ -1039,13 +1041,11 @@ export async function handleAction({
                 throw err
               }
 
-              const mpaActionId = process.env.__NEXT_DEV_SERVER
-                ? getValidatedMPAActionId(formData, serverModuleMap)
-                : null
-              const areActionIdsValid = process.env.__NEXT_DEV_SERVER
-                ? mpaActionId !== null
-                : areAllActionIdsValid(formData, serverModuleMap)
-              if (!areActionIdsValid) {
+              const mpaActionId = getValidatedMPAActionId(
+                formData,
+                serverModuleMap
+              )
+              if (mpaActionId === null) {
                 // TODO: This can be from skew or manipulated input. We should handle this case
                 // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
                 throw new Error(
@@ -1068,9 +1068,7 @@ export async function handleAction({
                   workStore,
                   requestStore,
                   actionWasForwarded,
-                  process.env.__NEXT_DEV_SERVER
-                    ? getServerActionInfo(mpaActionId!, ctx)
-                    : null
+                  getServerActionInfo(mpaActionId, ctx)
                 )
 
                 const formState = await decodeFormState(
@@ -1155,9 +1153,7 @@ export async function handleAction({
             actionId!
           ]
 
-        const serverActionInfo = process.env.__NEXT_DEV_SERVER
-          ? getServerActionInfo(actionId!, ctx)
-          : null
+        const serverActionInfo = getServerActionInfo(actionId!, ctx)
 
         // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
@@ -1368,16 +1364,14 @@ async function executeActionAndPrepareForRender<
     const serverActionName = serverAction?.name ?? '<action>'
     const actionResult = await getTracer().trace(
       AppRenderSpan.executeServerAction,
-      process.env.__NEXT_DEV_SERVER
-        ? {
-            attributes: {
-              'next.span_name': `run Server Action ${serverActionName}`,
-              'next.span.category': 'application',
-              'next.server_action.name': serverActionName,
-              'next.server_action.file': serverAction?.file || undefined,
-            },
-          }
-        : {},
+      {
+        attributes: {
+          'next.span_name': `run Server Action ${serverActionName}`,
+          'next.span.category': 'application',
+          'next.server_action.name': serverActionName,
+          'next.server_action.file': serverAction?.file || undefined,
+        },
+      },
       async (_span, done) => {
         try {
           const result = await executeAction()
@@ -1463,11 +1457,11 @@ const ACTION_ID_EXPECTED_LENGTH = 42
  * It pre-parses the FormData to ensure that any action IDs referred to are actual action IDs for
  * this Next.js application.
  */
-function areAllActionIdsValid(
+function getValidatedMPAActionId(
   mpaFormData: FormData,
   serverModuleMap: ServerModuleMap
-): boolean {
-  let hasAtLeastOneAction = false
+): string | null {
+  let actionId: string | null = null
   // Before we attempt to decode the payload for a possible MPA action, assert that all
   // action IDs are valid IDs. If not we should disregard the payload
   for (let key of mpaFormData.keys()) {
@@ -1479,60 +1473,24 @@ function areAllActionIdsValid(
     if (key.startsWith($ACTION_ID_)) {
       // No Bound args case
       if (isInvalidActionIdFieldName(key, serverModuleMap)) {
-        return false
+        return null
       }
 
-      hasAtLeastOneAction = true
+      actionId = key.slice($ACTION_ID_.length)
     } else if (key.startsWith($ACTION_REF_)) {
       // Bound args case
       const actionDescriptorField =
         $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
       const actionFields = mpaFormData.getAll(actionDescriptorField)
       if (actionFields.length !== 1) {
-        return false
+        return null
       }
       const actionField = actionFields[0]
       if (typeof actionField !== 'string') {
-        return false
-      }
-
-      if (isInvalidStringActionDescriptor(actionField, serverModuleMap)) {
-        return false
-      }
-      hasAtLeastOneAction = true
-    }
-  }
-  return hasAtLeastOneAction
-}
-
-/**
- * Returns the action ID for development-only tracing after validating the full
- * form with the production validation path above.
- */
-function getValidatedMPAActionId(
-  mpaFormData: FormData,
-  serverModuleMap: ServerModuleMap
-): string | null {
-  if (!areAllActionIdsValid(mpaFormData, serverModuleMap)) {
-    return null
-  }
-
-  let actionId: string | null = null
-  for (const key of mpaFormData.keys()) {
-    if (key.startsWith($ACTION_ID_)) {
-      actionId = key.slice($ACTION_ID_.length)
-    } else if (key.startsWith($ACTION_REF_)) {
-      const actionDescriptorField =
-        $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
-      const actionDescriptor = mpaFormData.get(actionDescriptorField)
-      if (typeof actionDescriptor !== 'string') {
         return null
       }
 
-      actionId = getActionIdFromStringDescriptor(
-        actionDescriptor,
-        serverModuleMap
-      )
+      actionId = getActionIdFromStringDescriptor(actionField, serverModuleMap)
       if (actionId === null) {
         return null
       }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1367,7 +1367,7 @@ async function executeActionAndPrepareForRender<
       {
         attributes: {
           'next.span_name': `run Server Action ${serverActionName}`,
-          'next.span.category': 'application',
+          'next.span_category': 'application',
           'next.server_action.name': serverActionName,
           'next.server_action.file': serverAction?.file || undefined,
         },

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -74,8 +74,44 @@ import {
   ActionDidRevalidateStaticAndDynamic,
 } from '../../shared/lib/action-revalidation-kind'
 import { computeCacheBustingSearchParam } from '../../shared/lib/router/utils/cache-busting-search-param'
+import { getTracer } from '../lib/trace/tracer'
+import { AppRenderSpan } from '../lib/trace/constants'
 
 const INLINE_ACTION_PREFIX = '$$RSC_SERVER_ACTION_'
+
+type ServerActionInfo = {
+  name: string
+  file: string
+}
+
+function getServerActionInfo(
+  actionId: string,
+  ctx: AppRenderContext
+): ServerActionInfo | null {
+  const serverActionsManifest = getServerActionsManifest()
+  const runtime = process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
+  const actionInfo = serverActionsManifest[runtime]?.[actionId]
+
+  if (!actionInfo) {
+    return null
+  }
+
+  const projectDir =
+    ctx.renderOpts.dir ||
+    (process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd())
+  const file = normalizeFilePath(projectDir, actionInfo.filename)
+  const isInlineAction =
+    actionInfo.exportedName?.startsWith(INLINE_ACTION_PREFIX)
+
+  return {
+    name: isInlineAction
+      ? '<inline action>'
+      : actionInfo.exportedName === 'default'
+        ? 'default'
+        : actionInfo.exportedName || '<action>',
+    file,
+  }
+}
 
 /**
  * Checks if the app has any server actions defined in any runtime.
@@ -788,7 +824,13 @@ export async function handleAction({
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
+              const mpaActionId = process.env.__NEXT_DEV_SERVER
+                ? getValidatedMPAActionId(formData, serverModuleMap)
+                : null
+              const areActionIdsValid = process.env.__NEXT_DEV_SERVER
+                ? mpaActionId !== null
+                : areAllActionIdsValid(formData, serverModuleMap)
+              if (!areActionIdsValid) {
                 // TODO: This can be from skew or manipulated input. We should handle this case
                 // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
                 throw new Error(
@@ -808,7 +850,10 @@ export async function handleAction({
                   [],
                   workStore,
                   requestStore,
-                  actionWasForwarded
+                  actionWasForwarded,
+                  process.env.__NEXT_DEV_SERVER
+                    ? getServerActionInfo(mpaActionId!, ctx)
+                    : null
                 )
 
                 const formState = await decodeFormState(
@@ -994,7 +1039,13 @@ export async function handleAction({
                 throw err
               }
 
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
+              const mpaActionId = process.env.__NEXT_DEV_SERVER
+                ? getValidatedMPAActionId(formData, serverModuleMap)
+                : null
+              const areActionIdsValid = process.env.__NEXT_DEV_SERVER
+                ? mpaActionId !== null
+                : areAllActionIdsValid(formData, serverModuleMap)
+              if (!areActionIdsValid) {
                 // TODO: This can be from skew or manipulated input. We should handle this case
                 // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
                 throw new Error(
@@ -1016,7 +1067,10 @@ export async function handleAction({
                   [],
                   workStore,
                   requestStore,
-                  actionWasForwarded
+                  actionWasForwarded,
+                  process.env.__NEXT_DEV_SERVER
+                    ? getServerActionInfo(mpaActionId!, ctx)
+                    : null
                 )
 
                 const formState = await decodeFormState(
@@ -1101,40 +1155,26 @@ export async function handleAction({
             actionId!
           ]
 
+        const serverActionInfo = process.env.__NEXT_DEV_SERVER
+          ? getServerActionInfo(actionId!, ctx)
+          : null
+
         // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
         const { type: actionType } = extractInfoFromServerReferenceId(actionId!)
         if (
-          process.env.NODE_ENV === 'development' &&
+          process.env.__NEXT_DEV_SERVER &&
           ctx.renderOpts.logServerFunctions &&
           // TODO: For now, skip logging for 'use cache' Server Functions as the
           // output needs more work, or a different approach entirely.
           actionType !== 'use-cache'
         ) {
-          const serverActionsManifest = getServerActionsManifest()
-          const runtime = process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          const actionInfo = serverActionsManifest[runtime]?.[actionId!]
-
-          if (actionInfo) {
-            const isInlineAction =
-              actionInfo.exportedName?.startsWith(INLINE_ACTION_PREFIX)
-
-            const projectDir =
-              ctx.renderOpts.dir ||
-              (process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd())
-            const location = normalizeFilePath(projectDir, actionInfo.filename)
-
-            // Format function name for display
-            let functionName: string
-            if (isInlineAction) {
-              functionName = '<inline action>'
-            } else if (actionInfo.exportedName === 'default') {
-              functionName = 'default'
-            } else {
-              functionName = actionInfo.exportedName || '<action>'
+          if (serverActionInfo) {
+            logInfo = {
+              functionName: serverActionInfo.name,
+              args: boundActionArguments,
+              location: serverActionInfo.file,
             }
-
-            logInfo = { functionName, args: boundActionArguments, location }
           }
         }
 
@@ -1145,7 +1185,8 @@ export async function handleAction({
             boundActionArguments,
             workStore,
             requestStore,
-            actionWasForwarded
+            actionWasForwarded,
+            serverActionInfo
           ).finally(() => {
             addRevalidationHeader(res, { workStore, requestStore })
             if (logInfo) {
@@ -1306,7 +1347,8 @@ async function executeActionAndPrepareForRender<
   args: Parameters<TFn>,
   workStore: WorkStore,
   requestStore: RequestStore,
-  actionWasForwarded: boolean
+  actionWasForwarded: boolean,
+  serverAction: ServerActionInfo | null
 ): Promise<{
   actionResult: Awaited<ReturnType<TFn>>
   skipPageRendering: boolean
@@ -1321,8 +1363,35 @@ async function executeActionAndPrepareForRender<
   }
 
   try {
-    const actionResult = await workUnitAsyncStorage.run(requestStore, () =>
-      action.apply(null, args)
+    const executeAction = () =>
+      workUnitAsyncStorage.run(requestStore, () => action.apply(null, args))
+    const serverActionName = serverAction?.name ?? '<action>'
+    const actionResult = await getTracer().trace(
+      AppRenderSpan.executeServerAction,
+      process.env.__NEXT_DEV_SERVER
+        ? {
+            attributes: {
+              'next.span_name': `run Server Action ${serverActionName}`,
+              'next.span.category': 'application',
+              'next.server_action.name': serverActionName,
+              'next.server_action.file': serverAction?.file || undefined,
+            },
+          }
+        : {},
+      async (_span, done) => {
+        try {
+          const result = await executeAction()
+          done?.()
+          return result
+        } catch (err) {
+          done?.(
+            isRedirectError(err) || isHTTPAccessFallbackError(err)
+              ? undefined
+              : (err as Error)
+          )
+          throw err
+        }
+      }
     )
 
     // If the page was not revalidated, or if the action was forwarded from
@@ -1436,6 +1505,43 @@ function areAllActionIdsValid(
   return hasAtLeastOneAction
 }
 
+/**
+ * Returns the action ID for development-only tracing after validating the full
+ * form with the production validation path above.
+ */
+function getValidatedMPAActionId(
+  mpaFormData: FormData,
+  serverModuleMap: ServerModuleMap
+): string | null {
+  if (!areAllActionIdsValid(mpaFormData, serverModuleMap)) {
+    return null
+  }
+
+  let actionId: string | null = null
+  for (const key of mpaFormData.keys()) {
+    if (key.startsWith($ACTION_ID_)) {
+      actionId = key.slice($ACTION_ID_.length)
+    } else if (key.startsWith($ACTION_REF_)) {
+      const actionDescriptorField =
+        $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
+      const actionDescriptor = mpaFormData.get(actionDescriptorField)
+      if (typeof actionDescriptor !== 'string') {
+        return null
+      }
+
+      actionId = getActionIdFromStringDescriptor(
+        actionDescriptor,
+        serverModuleMap
+      )
+      if (actionId === null) {
+        return null
+      }
+    }
+  }
+
+  return actionId
+}
+
 const ACTION_DESCRIPTOR_ID_PREFIX = '{"id":"'
 function isInvalidStringActionDescriptor(
   actionDescriptor: string,
@@ -1464,6 +1570,20 @@ function isInvalidStringActionDescriptor(
   }
 
   return false
+}
+
+function getActionIdFromStringDescriptor(
+  actionDescriptor: string,
+  serverModuleMap: ServerModuleMap
+): string | null {
+  if (isInvalidStringActionDescriptor(actionDescriptor, serverModuleMap)) {
+    return null
+  }
+
+  return actionDescriptor.slice(
+    ACTION_DESCRIPTOR_ID_PREFIX.length,
+    ACTION_DESCRIPTOR_ID_PREFIX.length + ACTION_ID_EXPECTED_LENGTH
+  )
 }
 
 function isInvalidActionIdFieldName(

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -89,6 +89,7 @@ enum AppRenderSpan {
   fetch = 'AppRender.fetch',
   waitShellReady = 'AppRender.waitShellReady',
   renderToNodeFizzStream = 'AppRender.renderToNodeFizzStream',
+  executeServerAction = 'AppRender.executeServerAction',
 }
 
 enum RouterSpan {
@@ -134,6 +135,7 @@ export const NextVanillaSpanAllowlist = new Set([
   RenderSpan.getStaticProps,
   AppRenderSpan.fetch,
   AppRenderSpan.getBodyResult,
+  AppRenderSpan.executeServerAction,
   RenderSpan.renderDocument,
   NodeSpan.runHandler,
   AppRouteRouteHandlersSpan.runHandler,

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -185,7 +185,7 @@ type NextAttributeNames =
   | 'next.page'
   | 'next.rsc'
   | 'next.segment'
-  | 'next.span.category'
+  | 'next.span_category'
   | 'next.span_name'
   | 'next.span_type'
   | 'next.server_action.name'

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -185,8 +185,11 @@ type NextAttributeNames =
   | 'next.page'
   | 'next.rsc'
   | 'next.segment'
+  | 'next.span.category'
   | 'next.span_name'
   | 'next.span_type'
+  | 'next.server_action.name'
+  | 'next.server_action.file'
   | 'next.clientComponentLoadCount'
 type OTELAttributeNames = `http.${string}` | `net.${string}`
 type AttributeNames = NextAttributeNames | OTELAttributeNames

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/server-action/actions.ts
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/server-action/actions.ts
@@ -1,0 +1,3 @@
+'use server'
+
+export async function exportedServerAction() {}

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/server-action/page.tsx
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/server-action/page.tsx
@@ -1,11 +1,20 @@
+import { exportedServerAction } from './actions'
+
 export default function Page() {
-  async function serverAction() {
+  async function inlineServerAction() {
     'use server'
   }
 
   return (
-    <form action={serverAction}>
-      <button id="run-server-action">Run Server Action</button>
-    </form>
+    <>
+      <form action={inlineServerAction}>
+        <button id="run-inline-server-action">Run inline Server Action</button>
+      </form>
+      <form action={exportedServerAction}>
+        <button id="run-exported-server-action">
+          Run exported Server Action
+        </button>
+      </form>
+    </>
   )
 }

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/server-action/page.tsx
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/server-action/page.tsx
@@ -1,0 +1,11 @@
+export default function Page() {
+  async function serverAction() {
+    'use server'
+  }
+
+  return (
+    <form action={serverAction}>
+      <button id="run-server-action">Run Server Action</button>
+    </form>
+  )
+}

--- a/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
+++ b/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
@@ -50,6 +50,7 @@ async function main() {
     [/^\/app\/param\/loading\/page1$/, 'app/app/[param]/loading/page1/page.js'],
     [/^\/app\/param\/loading\/page2$/, 'app/app/[param]/loading/page2/page.js'],
     [/^\/app\/param\/rsc-fetch$/, 'app/app/[param]/rsc-fetch/page.js'],
+    [/^\/app\/param\/server-action$/, 'app/app/[param]/server-action/page.js'],
     [
       /^\/app\/param\/rsc-fetch\/error$/,
       'app/app/[param]/rsc-fetch/error/page.js',

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -137,7 +137,7 @@ describe.each(
                     attributes: expect.objectContaining({
                       'next.span_name': 'run Server Action <inline action>',
                       'next.span_type': 'AppRender.executeServerAction',
-                      'next.span.category': 'application',
+                      'next.span_category': 'application',
                       'next.server_action.name': '<inline action>',
                       ...(isNextDev
                         ? {
@@ -172,7 +172,7 @@ describe.each(
                       'next.span_name':
                         'run Server Action exportedServerAction',
                       'next.span_type': 'AppRender.executeServerAction',
-                      'next.span.category': 'application',
+                      'next.span_category': 'application',
                       'next.server_action.name': 'exportedServerAction',
                       ...(isNextDev
                         ? {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -88,6 +88,8 @@ describe.each(
 
   // Edge runtime is currently not implemented in custom-entrypoint-server.ts
   const itEdge = useDirectEntrypointHandler ? it.skip : it
+  // This fixture is not wired into custom-entrypoint-server.ts.
+  const itServerAction = useDirectEntrypointHandler ? it.skip : it
 
   for (const env of [
     {
@@ -115,6 +117,45 @@ describe.each(
       env.name,
       () => {
         describe('app router', () => {
+          if (env.name === 'root context') {
+            itServerAction('should trace Server Action execution', async () => {
+              const browser = await next.browser('/app/param/server-action')
+              await browser.elementById('run-server-action').click()
+
+              await retry(async () => {
+                const spanName = isNextDev
+                  ? 'run Server Action <inline action>'
+                  : 'AppRender.executeServerAction'
+                const span = getCollector()
+                  .getSpans()
+                  .find(
+                    (candidate) =>
+                      candidate.attributes?.['next.span_type'] ===
+                      'AppRender.executeServerAction'
+                  )
+
+                expect(span).toEqual(
+                  expect.objectContaining({
+                    name: 'AppRender.executeServerAction',
+                    attributes: expect.objectContaining({
+                      'next.span_name': spanName,
+                      'next.span_type': 'AppRender.executeServerAction',
+                      ...(isNextDev
+                        ? {
+                            'next.span.category': 'application',
+                            'next.server_action.name': '<inline action>',
+                            'next.server_action.file':
+                              'app/app/[param]/server-action/page.tsx',
+                          }
+                        : {}),
+                    }),
+                    status: { code: 0 },
+                  })
+                )
+              })
+            })
+          }
+
           it('should handle RSC with fetch', async () => {
             await next.fetch('/app/param/rsc-fetch', env.fetchInit)
 

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -123,9 +123,6 @@ describe.each(
               await browser.elementById('run-server-action').click()
 
               await retry(async () => {
-                const spanName = isNextDev
-                  ? 'run Server Action <inline action>'
-                  : 'AppRender.executeServerAction'
                 const span = getCollector()
                   .getSpans()
                   .find(
@@ -138,12 +135,12 @@ describe.each(
                   expect.objectContaining({
                     name: 'AppRender.executeServerAction',
                     attributes: expect.objectContaining({
-                      'next.span_name': spanName,
+                      'next.span_name': 'run Server Action <inline action>',
                       'next.span_type': 'AppRender.executeServerAction',
+                      'next.span.category': 'application',
+                      'next.server_action.name': '<inline action>',
                       ...(isNextDev
                         ? {
-                            'next.span.category': 'application',
-                            'next.server_action.name': '<inline action>',
                             'next.server_action.file':
                               'app/app/[param]/server-action/page.tsx',
                           }

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -88,8 +88,6 @@ describe.each(
 
   // Edge runtime is currently not implemented in custom-entrypoint-server.ts
   const itEdge = useDirectEntrypointHandler ? it.skip : it
-  // This fixture is not wired into custom-entrypoint-server.ts.
-  const itServerAction = useDirectEntrypointHandler ? it.skip : it
 
   for (const env of [
     {
@@ -118,7 +116,7 @@ describe.each(
       () => {
         describe('app router', () => {
           if (env.name === 'root context') {
-            itServerAction('should trace inline Server Action', async () => {
+            it('should trace inline Server Action', async () => {
               const browser = await next.browser('/app/param/server-action')
               await browser.elementById('run-inline-server-action').click()
 
@@ -152,7 +150,7 @@ describe.each(
               })
             })
 
-            itServerAction('should trace exported Server Action', async () => {
+            it('should trace exported Server Action', async () => {
               const browser = await next.browser('/app/param/server-action')
               await browser.elementById('run-exported-server-action').click()
 

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -118,9 +118,9 @@ describe.each(
       () => {
         describe('app router', () => {
           if (env.name === 'root context') {
-            itServerAction('should trace Server Action execution', async () => {
+            itServerAction('should trace inline Server Action', async () => {
               const browser = await next.browser('/app/param/server-action')
-              await browser.elementById('run-server-action').click()
+              await browser.elementById('run-inline-server-action').click()
 
               await retry(async () => {
                 const span = getCollector()
@@ -143,6 +143,41 @@ describe.each(
                         ? {
                             'next.server_action.file':
                               'app/app/[param]/server-action/page.tsx',
+                          }
+                        : {}),
+                    }),
+                    status: { code: 0 },
+                  })
+                )
+              })
+            })
+
+            itServerAction('should trace exported Server Action', async () => {
+              const browser = await next.browser('/app/param/server-action')
+              await browser.elementById('run-exported-server-action').click()
+
+              await retry(async () => {
+                const span = getCollector()
+                  .getSpans()
+                  .find(
+                    (candidate) =>
+                      candidate.attributes?.['next.server_action.name'] ===
+                      'exportedServerAction'
+                  )
+
+                expect(span).toEqual(
+                  expect.objectContaining({
+                    name: 'AppRender.executeServerAction',
+                    attributes: expect.objectContaining({
+                      'next.span_name':
+                        'run Server Action exportedServerAction',
+                      'next.span_type': 'AppRender.executeServerAction',
+                      'next.span.category': 'application',
+                      'next.server_action.name': 'exportedServerAction',
+                      ...(isNextDev
+                        ? {
+                            'next.server_action.file':
+                              'app/app/[param]/server-action/actions.ts',
                           }
                         : {}),
                     }),


### PR DESCRIPTION
## What?

Adds an OpenTelemetry span around Server Action execution, including the resolved function name and source filename in development.

The new `AppRender.executeServerAction` span measures only the application function invocation. It is emitted through the standard Next.js tracer and is available anywhere OpenTelemetry tracing is enabled, independently of Request Insights. In development it resolves the action through the Server Actions manifest and records a readable function name and normalized source filename.

## Why?

Server Action execution was previously uninstrumented application work inside an action request. This made action latency invisible to OpenTelemetry users and made the span difficult to investigate without knowing which application function ran.

Keeping the complete span instrumentation in its own PR separates OpenTelemetry concerns from the Request Insights snapshot and UI handling added by the next PR in the stack.

## How?

- Adds `AppRender.executeServerAction` to the framework span constants and vanilla OpenTelemetry allowlist.
- Resolves development-only action metadata from the Server Actions manifest after validating the action through the existing production validation path.
- Wraps the actual `action.apply()` invocation while preserving the existing request async-storage context.
- Records a human-readable action label, application category, normalized action name, and source filename in development.
- Records genuine action failures as errors while treating redirects and HTTP access fallbacks as successful control flow.
- Adds development coverage for the resolved inline function and filename, plus production coverage for the generic span.

## Stack

1. **#95773 — Server Action OpenTelemetry span (this PR)**
2. #95770 — Server Action metadata in Request Insights
3. #95765 — Missing OpenTelemetry spans
4. #95766 — Human-readable OpenTelemetry span names

## Verification

- `pnpm --filter=next build`
- `pnpm test-dev-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t "should trace Server Action execution"`
- `pnpm test-start-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t "should trace Server Action execution"`

<!-- NEXT_JS_LLM -->
