### PR TITLE
Micro-optimization for string format

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -253,7 +253,7 @@ impl SourceMapGenConfig for InlineSourcesContentConfig {
         match f {
             FileName::Custom(s) => {
                 // format! here is suboptimal and allocates over and over again.
-                // On a random test next test project this one spot accounted for 
+                // On a random test next test project this one spot accounted for
                 // 10% of allocations, hence the more verbose approach.
                 let proto: &str = &SOURCE_URL_PROTOCOL;
                 let mut out = String::with_capacity(proto.len() + 3 + s.len());

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -252,7 +252,15 @@ impl SourceMapGenConfig for InlineSourcesContentConfig {
     fn file_name_to_source(&self, f: &FileName) -> String {
         match f {
             FileName::Custom(s) => {
-                format!("{SOURCE_URL_PROTOCOL}///{s}")
+                // format! here is suboptimal and allocates over and over again.
+                // On a random test next test project this one spot accounted for 
+                // 10% of allocations, hence the more verbose approach.
+                let proto: &str = &SOURCE_URL_PROTOCOL;
+                let mut out = String::with_capacity(proto.len() + 3 + s.len());
+                out.push_str(proto);
+                out.push_str("///");
+                out.push_str(s);
+                out
             }
             _ => f.to_string(),
         }

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -36,7 +36,7 @@ use turbo_tasks::{PrettyPrintError, ResolvedVc, ValueToString, Vc, turbofmt, uti
 use turbo_tasks_fs::{FileContent, FileSystemPath, rope::Rope};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
-    SOURCE_URL_PROTOCOL,
+    SOURCE_URL_PROTOCOL_STR,
     asset::{Asset, AssetContent},
     issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     source::Source,
@@ -255,9 +255,8 @@ impl SourceMapGenConfig for InlineSourcesContentConfig {
                 // format! here is suboptimal and allocates over and over again.
                 // On a random test next test project this one spot accounted for
                 // 10% of allocations, hence the more verbose approach.
-                let proto: &str = &SOURCE_URL_PROTOCOL;
-                let mut out = String::with_capacity(proto.len() + 3 + s.len());
-                out.push_str(proto);
+                let mut out = String::with_capacity(SOURCE_URL_PROTOCOL_STR.len() + 3 + s.len());
+                out.push_str(SOURCE_URL_PROTOCOL_STR);
                 out.push_str("///");
                 out.push_str(s);
                 out


### PR DESCRIPTION
I get this is a bit of a silly change in some ways. It isn't going to have some massive impact. But using dhat I got these stats on a smallish sample nextjs project

| metric                  | A (parse.rs change) | B (baseline) | delta              |
| ------------------------ | -------------------- | ------------ | ------------------- |
| total bytes allocated    | 438.4 MiB            | 442.6 MiB    | -4.3 MiB (-0.94%)   |
| total allocation count   | 1,672,688            | 1,872,347    | -199,659 (-10.66%)

Eliminating ~200k allocations from this small change just felt worth it.