### PR TITLE
Turbopack(napi v3): a second round of fixes on #95412

### DIFF
--- a/crates/next-napi-bindings/src/css/mod.rs
+++ b/crates/next-napi-bindings/src/css/mod.rs
@@ -3,13 +3,11 @@ use napi_derive::napi;
 use next_core::next_config::lightningcss_feature_names_to_mask;
 
 #[napi(js_name = "lightningCssTransform")]
-#[allow(dead_code)]
 pub fn transform<'env>(env: &'env Env, opts: Object<'_>) -> napi::Result<Unknown<'env>> {
     turbopack_lightningcss_napi::transform(env, opts)
 }
 
 #[napi(js_name = "lightningCssTransformStyleAttribute")]
-#[allow(dead_code)]
 pub fn transform_style_attribute<'env>(
     env: &'env Env,
     opts: Object<'_>,
@@ -23,6 +21,5 @@ pub fn transform_style_attribute<'env>(
 #[napi]
 #[allow(dead_code)]
 fn lightningcss_feature_names_to_mask_napi(names: Vec<String>) -> napi::Result<u32> {
-    lightningcss_feature_names_to_mask(&names)
-        .map_err(|e| napi::Error::from_reason(format!("{}", e)))
+    lightningcss_feature_names_to_mask(&names).map_err(|e| napi::Error::from_reason(e.to_string()))
 }

--- a/crates/next-napi-bindings/src/lib.rs
+++ b/crates/next-napi-bindings/src/lib.rs
@@ -34,11 +34,9 @@ DEALINGS IN THE SOFTWARE.
 
 use std::sync::Arc;
 
-use napi::bindgen_prelude::*;
-use rustc_hash::{FxHashMap, FxHashSet};
+use napi::bindgen_prelude::create_custom_tokio_runtime;
 use swc_core::{
-    atoms::Atom,
-    base::{Compiler, TransformOutput},
+    base::Compiler,
     common::{FilePathMapping, SourceMap},
 };
 
@@ -59,6 +57,8 @@ pub mod turbo_trace_server;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod turbopack;
 pub mod util;
+
+pub use transform::TransformOutputResult;
 
 #[cfg(not(any(feature = "__internal_dhat-heap", feature = "__internal_dhat-ad-hoc")))]
 #[global_allocator]
@@ -131,46 +131,4 @@ fn get_compiler() -> Compiler {
     let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
 
     Compiler::new(cm)
-}
-
-/// The JS-facing result of a SWC transform.
-///
-/// Optional fields are omitted from the resulting object when `None`, matching
-/// the previous manual object construction.
-#[napi_derive::napi(object)]
-pub struct TransformOutputResult {
-    pub code: String,
-    pub map: Option<String>,
-    pub eliminated_packages: Option<String>,
-    pub use_cache_telemetry_tracker: Option<String>,
-}
-
-pub fn complete_output(
-    _env: &Env,
-    output: TransformOutput,
-    eliminated_packages: FxHashSet<Atom>,
-    use_cache_telemetry_tracker: FxHashMap<String, usize>,
-) -> napi::Result<TransformOutputResult> {
-    let eliminated_packages = if eliminated_packages.is_empty() {
-        None
-    } else {
-        Some(serde_json::to_string(&eliminated_packages)?)
-    };
-    let use_cache_telemetry_tracker = if use_cache_telemetry_tracker.is_empty() {
-        None
-    } else {
-        Some(serde_json::to_string(
-            &use_cache_telemetry_tracker
-                .iter()
-                .map(|(k, v)| (k.clone(), *v))
-                .collect::<Vec<_>>(),
-        )?)
-    };
-
-    Ok(TransformOutputResult {
-        code: output.code,
-        map: output.map,
-        eliminated_packages,
-        use_cache_telemetry_tracker,
-    })
 }

--- a/crates/next-napi-bindings/src/lockfile.rs
+++ b/crates/next-napi-bindings/src/lockfile.rs
@@ -152,7 +152,7 @@ pub fn lockfile_unlock<'env>(
 fn take_lockfile_inner(lockfile: &JsLockfile) -> Option<LockfileInner> {
     lockfile
         .lock()
-        .expect("poisoned: another thread panicked during `lockfile_unlock_sync`?")
+        .expect("poisoned: another thread panicked while unlocking this lockfile")
         .take()
 }
 

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -153,7 +153,7 @@ async fn get_written_endpoint_with_issues_operation(
 pub async fn endpoint_write_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,
 ) -> napi::Result<TurbopackResult<NapiWrittenEndpoint>> {
-    let ctx = endpoint.turbopack_ctx().clone();
+    let ctx = endpoint.turbopack_ctx();
     let endpoint_op = ****endpoint;
     let (written, issues) = ctx
         .turbo_tasks()

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -410,10 +410,8 @@ impl From<NapiDefineEnv> for DefineEnv {
 pub struct ProjectInstance {
     turbopack_ctx: NextTurbopackContext,
     container: ResolvedVc<ProjectContainer>,
-    // `Arc` so the `'static` futures spawned by `project_on_exit`/`project_shutdown` can own a
-    // handle to it (the `External<ProjectInstance>` itself is `!Send`). Never locked across an
-    // await point.
-    exit_receiver: Arc<std::sync::Mutex<Option<ExitReceiver>>>,
+    // Never locked across an await point.
+    exit_receiver: std::sync::Mutex<Option<ExitReceiver>>,
 }
 
 #[napi(ts_return_type = "Promise<{ __napiType: \"Project\" }>")]
@@ -644,7 +642,7 @@ pub fn project_new<'env>(
             Ok(External::new(ProjectInstance {
                 turbopack_ctx,
                 container,
-                exit_receiver: Arc::new(std::sync::Mutex::new(Some(exit_receiver))),
+                exit_receiver: std::sync::Mutex::new(Some(exit_receiver)),
             }))
         }
         .instrument(tracing::info_span!("create project")),
@@ -733,9 +731,9 @@ pub async fn project_update(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     options: NapiPartialProjectOptions,
 ) -> napi::Result<()> {
-    let ctx = project.turbopack_ctx.clone();
-    let container = project.container;
+    let ctx = &project.turbopack_ctx;
     let options = options.into();
+    let container = project.container;
     ctx.turbo_tasks()
         .run(async move { container.update(options).await })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
@@ -758,7 +756,7 @@ pub async fn project_invalidate_file_system_cache(
     })
     .await
     .context("panicked while invalidating filesystem cache")??;
-    Ok::<_, napi::Error>(())
+    Ok(())
 }
 
 /// Runs exit handlers for the project registered using the [`ExitHandler`] API.
@@ -769,9 +767,8 @@ pub async fn project_invalidate_file_system_cache(
 pub async fn project_on_exit(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
 ) -> napi::Result<()> {
-    let exit_receiver = project.exit_receiver.clone();
-    run_exit_handlers(exit_receiver).await;
-    Ok::<_, napi::Error>(())
+    run_exit_handlers(&project.exit_receiver).await;
+    Ok(())
 }
 
 /// Takes the [`ExitReceiver`] out of the shared slot and runs the registered exit handlers.
@@ -779,7 +776,7 @@ pub async fn project_on_exit(
 /// The receiver is taken only once the caller is ready to run the handlers, so an earlier failure
 /// (e.g. a panic in `stop_and_wait` during `project_shutdown`) leaves it in place for a fallback
 /// `project_on_exit` call.
-async fn run_exit_handlers(exit_receiver: Arc<std::sync::Mutex<Option<ExitReceiver>>>) {
+async fn run_exit_handlers(exit_receiver: &std::sync::Mutex<Option<ExitReceiver>>) {
     let exit_receiver = exit_receiver
         .lock()
         .expect("panicked while holding the exit receiver")
@@ -800,11 +797,10 @@ async fn run_exit_handlers(exit_receiver: Arc<std::sync::Mutex<Option<ExitReceiv
 pub async fn project_shutdown(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
 ) -> napi::Result<()> {
-    let tt = project.turbopack_ctx.turbo_tasks().clone();
-    let exit_receiver = project.exit_receiver.clone();
+    let tt = project.turbopack_ctx.turbo_tasks();
     tt.stop_and_wait().await;
-    run_exit_handlers(exit_receiver).await;
-    Ok::<_, napi::Error>(())
+    run_exit_handlers(&project.exit_receiver).await;
+    Ok(())
 }
 
 #[napi(object, object_from_js = false)]
@@ -1320,17 +1316,8 @@ pub async fn project_write_all_entrypoints_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     app_dir_only: bool,
 ) -> napi::Result<TurbopackResult<Option<NapiEntrypoints>>> {
-    let ctx = project.turbopack_ctx.clone();
+    let ctx = &project.turbopack_ctx;
     let container = project.container;
-    project_write_all_entrypoints_to_disk_inner(ctx, container, app_dir_only).await
-}
-
-async fn project_write_all_entrypoints_to_disk_inner(
-    ctx: NextTurbopackContext,
-    container: ResolvedVc<ProjectContainer>,
-    app_dir_only: bool,
-) -> napi::Result<TurbopackResult<Option<NapiEntrypoints>>> {
-    let ctx = &ctx;
     let tt = ctx.turbo_tasks();
 
     #[turbo_tasks::function(operation, root)]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     io::Write,
     path::{Path, PathBuf},
-    sync::{Arc, LazyLock},
+    sync::{Arc, LazyLock, Mutex},
     thread,
     time::Duration,
 };
@@ -411,7 +411,7 @@ pub struct ProjectInstance {
     turbopack_ctx: NextTurbopackContext,
     container: ResolvedVc<ProjectContainer>,
     // Never locked across an await point.
-    exit_receiver: std::sync::Mutex<Option<ExitReceiver>>,
+    exit_receiver: Mutex<Option<ExitReceiver>>,
 }
 
 #[napi(ts_return_type = "Promise<{ __napiType: \"Project\" }>")]
@@ -642,7 +642,7 @@ pub fn project_new<'env>(
             Ok(External::new(ProjectInstance {
                 turbopack_ctx,
                 container,
-                exit_receiver: std::sync::Mutex::new(Some(exit_receiver)),
+                exit_receiver: Mutex::new(Some(exit_receiver)),
             }))
         }
         .instrument(tracing::info_span!("create project")),
@@ -776,7 +776,7 @@ pub async fn project_on_exit(
 /// The receiver is taken only once the caller is ready to run the handlers, so an earlier failure
 /// (e.g. a panic in `stop_and_wait` during `project_shutdown`) leaves it in place for a fallback
 /// `project_on_exit` call.
-async fn run_exit_handlers(exit_receiver: &std::sync::Mutex<Option<ExitReceiver>>) {
+async fn run_exit_handlers(exit_receiver: &Mutex<Option<ExitReceiver>>) {
     let exit_receiver = exit_receiver
         .lock()
         .expect("panicked while holding the exit receiver")

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2192,7 +2192,7 @@ pub fn project_compilation_events_subscribe(
                 }
             }
             // Signal the JS side that the subscription has ended (e.g. after
-            // project shutdown drops all senders).  This allows the async
+            // project shutdown drops all senders). This allows the async
             // iterator to exit promptly instead of hanging forever.
             let _ = tsfn.call(
                 Err(napi::Error::new(

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -106,7 +106,7 @@ impl NextTurbopackContext {
                 }))
                 .await
             {
-                Ok(_) => panic!("throwTurbopackInternalError must throw an error"),
+                Ok(()) => panic!("throwTurbopackInternalError must throw an error"),
                 Err(err) => err,
             }
         }

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -222,7 +222,7 @@ impl NapiNextTurbopackCallbacks {
                     .build_threadsafe_function::<()>()
                     .callee_handled::<true>()
                     .weak::<true>()
-                    .build_callback(|_| Ok::<(), _>(()))?;
+                    .build_callback(|_| Ok(()))?;
                 Ok::<_, napi::Error>(f)
             })
             .transpose()?;
@@ -303,7 +303,7 @@ pub fn create_turbo_tasks(
         )?;
         let tt = TurboTasks::new(TurboTasksBackend::new(
             BackendOptions {
-                storage_mode: Some(if std::env::var("TURBO_ENGINE_READ_ONLY").is_ok() {
+                storage_mode: Some(if env::var("TURBO_ENGINE_READ_ONLY").is_ok() {
                     turbo_tasks_backend::StorageMode::ReadOnly
                 } else if is_ci || is_short_session {
                     turbo_tasks_backend::StorageMode::ReadWriteOnShutdown
@@ -449,7 +449,7 @@ pub fn log_internal_error_and_inform(internal_error: &anyhow::Error) {
         .open(PANIC_LOG.as_path())
         .unwrap_or_else(|_| panic!("Failed to open {}", PANIC_LOG.to_string_lossy()));
 
-    let internal_error_str: String = PrettyPrintError(internal_error).to_string();
+    let internal_error_str = PrettyPrintError(internal_error).to_string();
     writeln!(log_file, "{}\n{}", LOG_DIVIDER, internal_error_str).unwrap();
 
     let title = format!(

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -408,8 +408,6 @@ impl<T: ToNapiValue> ToNapiValue for TurbopackResult<T> {
         env: napi::sys::napi_env,
         val: Self,
     ) -> napi::Result<napi::sys::napi_value> {
-        let env_wrapper = Env::from_raw(env);
-
         let result_raw = unsafe { T::to_napi_value(env, val.result)? };
         let result = unsafe { Unknown::from_raw_unchecked(env, result_raw) };
 
@@ -418,7 +416,7 @@ impl<T: ToNapiValue> ToNapiValue for TurbopackResult<T> {
         let mut obj = if matches!(result.get_type()?, napi::ValueType::Object) {
             Object::from_raw(env, result_raw)
         } else {
-            Object::new(&env_wrapper)?
+            Object::new(&Env::from_raw(env))?
         };
 
         obj.set_named_property("issues", val.issues)?;

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -9,8 +9,7 @@ use futures_util::TryFutureExt;
 use napi::{
     Env, Status, Unknown,
     bindgen_prelude::{
-        Buffer, External, ExternalRef, Function, FunctionRef, JsObjectValue, JsValue, Object,
-        ToNapiValue,
+        Buffer, External, ExternalRef, FunctionRef, JsObjectValue, JsValue, Object, ToNapiValue,
     },
     threadsafe_function::{ThreadsafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
@@ -439,7 +438,7 @@ pub fn subscribe<
     handler: impl 'static + Sync + Send + Clone + Fn() -> F,
     mapper: impl 'static + Sync + Send + FnMut(ThreadsafeCallContext<T>) -> napi::Result<V>,
 ) -> napi::Result<External<RootTask>> {
-    let js_func: Function<'_, V, ()> = func.borrow_back(env)?;
+    let js_func = func.borrow_back(env)?;
     let func: ThreadsafeFunction<T, (), V, Status, true> = js_func
         .build_threadsafe_function::<T>()
         .callee_handled::<true>()

--- a/crates/next-napi-bindings/src/rspack.rs
+++ b/crates/next-napi-bindings/src/rspack.rs
@@ -155,8 +155,7 @@ impl Task for FinderTask {
         })
     }
 
-    fn resolve(&mut self, env: Env, result: Self::Output) -> napi::Result<Self::JsValue> {
-        let _ = env;
+    fn resolve(&mut self, _env: Env, result: Self::Output) -> napi::Result<Self::JsValue> {
         Ok(result.into_iter().map(|name| name.to_string()).collect())
     }
 }

--- a/crates/next-napi-bindings/src/transform.rs
+++ b/crates/next-napi-bindings/src/transform.rs
@@ -51,8 +51,7 @@ use crate::{get_compiler, util::MapErr};
 
 /// The JS-facing result of a SWC transform.
 ///
-/// Optional fields are omitted from the resulting object when `None`, matching
-/// the previous manual object construction.
+/// Optional fields are omitted from the resulting object when `None`.
 #[napi(object)]
 pub struct TransformOutputResult {
     pub code: String,

--- a/crates/next-napi-bindings/src/transform.rs
+++ b/crates/next-napi-bindings/src/transform.rs
@@ -47,7 +47,48 @@ use swc_core::{
 };
 use swc_plugin_backend_wasmtime::WasmtimeRuntime;
 
-use crate::{complete_output, get_compiler, util::MapErr};
+use crate::{get_compiler, util::MapErr};
+
+/// The JS-facing result of a SWC transform.
+///
+/// Optional fields are omitted from the resulting object when `None`, matching
+/// the previous manual object construction.
+#[napi(object)]
+pub struct TransformOutputResult {
+    pub code: String,
+    pub map: Option<String>,
+    pub eliminated_packages: Option<String>,
+    pub use_cache_telemetry_tracker: Option<String>,
+}
+
+fn complete_output(
+    output: TransformOutput,
+    eliminated_packages: FxHashSet<Atom>,
+    use_cache_telemetry_tracker: FxHashMap<String, usize>,
+) -> napi::Result<TransformOutputResult> {
+    let eliminated_packages = if eliminated_packages.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&eliminated_packages)?)
+    };
+    let use_cache_telemetry_tracker = if use_cache_telemetry_tracker.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(
+            &use_cache_telemetry_tracker
+                .iter()
+                .map(|(k, v)| (k.clone(), *v))
+                .collect::<Vec<_>>(),
+        )?)
+    };
+
+    Ok(TransformOutputResult {
+        code: output.code,
+        map: output.map,
+        eliminated_packages,
+        use_cache_telemetry_tracker,
+    })
+}
 
 /// Input to transform
 #[derive(Debug)]
@@ -84,7 +125,7 @@ fn skip_filename() -> bool {
 
 impl Task for TransformTask {
     type Output = (TransformOutput, FxHashSet<Atom>, FxHashMap<String, usize>);
-    type JsValue = crate::TransformOutputResult;
+    type JsValue = TransformOutputResult;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         GLOBALS.set(&Default::default(), || {
@@ -190,15 +231,10 @@ impl Task for TransformTask {
 
     fn resolve(
         &mut self,
-        env: Env,
+        _env: Env,
         (output, eliminated_packages, use_cache_telemetry_tracker): Self::Output,
     ) -> napi::Result<Self::JsValue> {
-        complete_output(
-            &env,
-            output,
-            eliminated_packages,
-            use_cache_telemetry_tracker,
-        )
+        complete_output(output, eliminated_packages, use_cache_telemetry_tracker)
     }
 }
 
@@ -229,7 +265,7 @@ pub fn transform_sync(
     src: Either3<String, Buffer, Undefined>,
     _is_module: bool,
     options: Buffer,
-) -> napi::Result<crate::TransformOutputResult> {
+) -> napi::Result<TransformOutputResult> {
     let c = get_compiler();
 
     let input = match src {


### PR DESCRIPTION
## Summary

Stacked on #95412 (via the now-merged #95740). This is a second, smaller round of
cleanup: a few of bgw's review comments that were still outstanding, plus a handful
of additional cosmetic/structural nits (redundant clones, redundant type
annotations, a single-caller helper with no abstraction value, a stale doc comment,
an inaccurate panic message) found by independently re-reviewing the diff. Every
nit was individually verified against the actual code (several plausible-looking
"simplifications" turned out to be wrong on inspection or on compiling and were
left alone) before being applied.

Notable non-cosmetic-but-still-small fix: `ProjectInstance::exit_receiver` no
longer needs to be wrapped in an `Arc` — that wrapper was only there to support an
abandoned `spawn_future`-based refactor that #95740 already reverted, so once the
last two clones of it were removed, the `Arc` had no reason to exist either.

## Verification

- `cargo check --workspace`
- `cargo clippy -p next-napi-bindings --all-targets`
- `cargo fmt -p next-napi-bindings` (no-op)