### PR TITLE
Turbopack: skip trimmed side-effect imports in SideEffectsModule

### DIFF
--- a/test/e2e/app-dir/treeshake-mw/app/layout.tsx
+++ b/test/e2e/app-dir/treeshake-mw/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/treeshake-mw/app/page.tsx
+++ b/test/e2e/app-dir/treeshake-mw/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>home</h1>
+}

--- a/test/e2e/app-dir/treeshake-mw/lib/barrel.ts
+++ b/test/e2e/app-dir/treeshake-mw/lib/barrel.ts
@@ -1,0 +1,6 @@
+// Star re-export barrel. Because `getKey` is not a static named entrypoint of
+// this module, resolving `import { getKey } from './lib/barrel'` goes through
+// `follow_reexports_with_side_effects`, which builds a `SideEffectsModule`.
+// This barrel has an import but no top-level side effects, so it is classified
+// `ModuleEvaluationIsSideEffectFree` — the status that triggers the desync.
+export * from './keys'

--- a/test/e2e/app-dir/treeshake-mw/lib/keys.ts
+++ b/test/e2e/app-dir/treeshake-mw/lib/keys.ts
@@ -1,0 +1,3 @@
+export function getKey() {
+  return 'k'
+}

--- a/test/e2e/app-dir/treeshake-mw/middleware.ts
+++ b/test/e2e/app-dir/treeshake-mw/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+import { getKey } from './lib/barrel'
+
+export function middleware() {
+  const k = getKey()
+  const res = NextResponse.next()
+  res.headers.set('x-key', k)
+  return res
+}
+
+export const config = {
+  runtime: 'nodejs',
+  matcher: '/((?!_next/static|_next/image|favicon.ico).*)',
+}

--- a/test/e2e/app-dir/treeshake-mw/mw.test.ts
+++ b/test/e2e/app-dir/treeshake-mw/mw.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression test for `experimental.turbopackTreeShaking` + Node.js-runtime
+// middleware that imports a binding through a star re-export barrel.
+//
+// The build used to panic during middleware chunking with:
+//   ModuleId not found for ident: .../lib/barrel.ts [middleware] (ecmascript) <internal part N>
+//   - Execution of <SideEffectsModule as EcmascriptChunkPlaceable>::chunk_item_content failed
+//
+// Cause: a re-export module with imports but no top-level side effects is
+// classified `ModuleEvaluationIsSideEffectFree`. `follow_reexports` treats that
+// as side-effectful (`!= SideEffectFree`) and builds a `SideEffectsModule` that
+// emits `TURBOPACK_IMPORT(<eval part id>)`, but `compute_side_effect_free_module_info`
+// classifies the same module as side-effect-free, so binding-usage prunes the
+// `Evaluation` edge and the eval part never gets a module id.
+//
+// The build completing and the middleware running is the assertion.
+describe('treeshake-mw', () => {
+  const { next } = nextTestSetup({ files: __dirname })
+
+  it('builds and runs Node.js middleware importing via a star re-export', async () => {
+    const res = await next.fetch('/')
+    expect(res.headers.get('x-key')).toBe('k')
+  })
+})

--- a/test/e2e/app-dir/treeshake-mw/mw.test.ts
+++ b/test/e2e/app-dir/treeshake-mw/mw.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression test for `experimental.turbopackModuleFragments` + Node.js-runtime
+// middleware that imports a binding through a star re-export barrel.
+//
+// The build used to panic during middleware chunking with:
+//   ModuleId not found for ident: .../lib/barrel.ts [middleware] (ecmascript) <internal part N>
+//   - Execution of <SideEffectsModule as EcmascriptChunkPlaceable>::chunk_item_content failed
+//
+// Cause: a re-export module with imports but no top-level side effects is
+// classified `ModuleEvaluationIsSideEffectFree`. `follow_reexports` treats that
+// as side-effectful (`!= SideEffectFree`) and builds a `SideEffectsModule` that
+// emits `TURBOPACK_IMPORT(<eval part id>)`, but `compute_side_effect_free_module_info`
+// classifies the same module as side-effect-free, so binding-usage prunes the
+// `Evaluation` edge and the eval part never gets a module id.
+//
+// The build completing and the middleware running is the assertion.
+describe('treeshake-mw', () => {
+  const { next } = nextTestSetup({ files: __dirname })
+
+  it('builds and runs Node.js middleware importing via a star re-export', async () => {
+    const res = await next.fetch('/')
+    expect(res.headers.get('x-key')).toBe('k')
+  })
+})

--- a/test/e2e/app-dir/treeshake-mw/next.config.js
+++ b/test/e2e/app-dir/treeshake-mw/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import("next").NextConfig} */
+module.exports = {
+  typescript: { ignoreBuildErrors: true },
+  experimental: { turbopackTreeShaking: true },
+}

--- a/test/e2e/app-dir/treeshake-mw/next.config.js
+++ b/test/e2e/app-dir/treeshake-mw/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import("next").NextConfig} */
+module.exports = {
+  typescript: { ignoreBuildErrors: true },
+  experimental: { turbopackModuleFragments: true },
+}

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_id_strategy.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_id_strategy.rs
@@ -40,11 +40,38 @@ impl ModuleIdStrategy {
         self.get_id_from_ident(ident).await
     }
 
+    /// Looks `ident` up in the explicit module id map. Returns `None` when there is no map, or the
+    /// map has no entry for `ident`. Applies no fallback: callers decide what a miss means.
+    async fn lookup_in_map(&self, ident: ResolvedVc<AssetIdent>) -> Result<Option<ModuleId>> {
+        let Some(module_id_map) = self.module_id_map else {
+            return Ok(None);
+        };
+        Ok(module_id_map.get(&ident).await?.as_deref().cloned())
+    }
+
+    /// like get_id_from_ident but doesn't use the fallback strategy.
+    /// This was created because our side-effect analysis can be conserverative
+    /// at points, and then later tree shake away something once we discover it doesn't
+    /// actually have side effects. This lets us skip these rather than error
+    /// like the fallback strategy might be.
+    pub async fn try_get_id_from_module(
+        &self,
+        module: Vc<Box<dyn Module>>,
+    ) -> Result<Option<ModuleId>> {
+        let ident = module.ident().to_resolved().await?;
+        if self.module_id_map.is_some() {
+            // With an explicit map, presence is authoritative: a missing entry means the module was
+            // not included by the traversal, so it has no id.
+            return self.lookup_in_map(ident).await;
+        }
+
+        // Without a map the strategy synthesizes an id from the ident, so an id always exists.
+        Ok(Some(self.get_id_from_ident(*ident).await?))
+    }
+
     pub async fn get_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<ModuleId> {
         let ident = ident.to_resolved().await?;
-        if let Some(module_id_map) = self.module_id_map
-            && let Some(module_id) = module_id_map.get(&ident).await?.as_deref().cloned()
-        {
+        if let Some(module_id) = self.lookup_in_map(ident).await? {
             return Ok(module_id);
         }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_id_strategy.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_id_strategy.rs
@@ -40,38 +40,11 @@ impl ModuleIdStrategy {
         self.get_id_from_ident(ident).await
     }
 
-    /// Looks `ident` up in the explicit module id map. Returns `None` when there is no map, or the
-    /// map has no entry for `ident`. Applies no fallback: callers decide what a miss means.
-    async fn lookup_in_map(&self, ident: ResolvedVc<AssetIdent>) -> Result<Option<ModuleId>> {
-        let Some(module_id_map) = self.module_id_map else {
-            return Ok(None);
-        };
-        Ok(module_id_map.get(&ident).await?.as_deref().cloned())
-    }
-
-    /// like get_id_from_ident but doesn't use the fallback strategy.
-    /// This was created because our side-effect analysis can be conserverative
-    /// at points, and then later tree shake away something once we discover it doesn't
-    /// actually have side effects. This lets us skip these rather than error
-    /// like the fallback strategy might be.
-    pub async fn try_get_id_from_module(
-        &self,
-        module: Vc<Box<dyn Module>>,
-    ) -> Result<Option<ModuleId>> {
-        let ident = module.ident().to_resolved().await?;
-        if self.module_id_map.is_some() {
-            // With an explicit map, presence is authoritative: a missing entry means the module was
-            // not included by the traversal, so it has no id.
-            return self.lookup_in_map(ident).await;
-        }
-
-        // Without a map the strategy synthesizes an id from the ident, so an id always exists.
-        Ok(Some(self.get_id_from_ident(*ident).await?))
-    }
-
     pub async fn get_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<ModuleId> {
         let ident = ident.to_resolved().await?;
-        if let Some(module_id) = self.lookup_in_map(ident).await? {
+        if let Some(module_id_map) = self.module_id_map
+            && let Some(module_id) = module_id_map.get(&ident).await?.as_deref().cloned()
+        {
             return Ok(module_id);
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/side_effects/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/side_effects/module.rs
@@ -55,6 +55,16 @@ impl SideEffectsModule {
     }
 }
 
+fn side_effect_reference(
+    side_effect: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+) -> Vc<SingleChunkableModuleReference> {
+    SingleChunkableModuleReference::new(
+        *ResolvedVc::upcast(side_effect),
+        rcstr!("side effect"),
+        ExportUsage::evaluation(),
+    )
+}
+
 #[turbo_tasks::value_impl]
 impl Module for SideEffectsModule {
     #[turbo_tasks::function]
@@ -95,13 +105,7 @@ impl Module for SideEffectsModule {
                 .iter()
                 .map(|side_effect| async move {
                     Ok(ResolvedVc::upcast(
-                        SingleChunkableModuleReference::new(
-                            *ResolvedVc::upcast(*side_effect),
-                            rcstr!("side effect"),
-                            ExportUsage::evaluation(),
-                        )
-                        .to_resolved()
-                        .await?,
+                        side_effect_reference(*side_effect).to_resolved().await?,
                     ))
                 })
                 .try_join()
@@ -149,20 +153,16 @@ impl EcmascriptChunkPlaceable for SideEffectsModule {
         let mut code = RopeBuilder::default();
         let mut has_top_level_await = false;
 
-        let id_strategy = chunking_context.chunk_item_id_strategy().await?;
+        let unused_references = chunking_context.unused_references();
 
         for &side_effect in module.side_effects.iter() {
-            // These side effects were collected conservatively (see
-            // `follow_reexports_with_side_effects`). Inner-graph tree shaking may have
-            // since determined a "side effect" to be side-effect-free and pruned its
-            // evaluation edge, in which case it has no chunk item id.
-            // So we are going to skip it.
-            let Some(id) = id_strategy
-                .try_get_id_from_module(Vc::upcast(*side_effect))
+            let reference = side_effect_reference(side_effect).to_resolved().await?;
+            if unused_references
+                .contains_key(&ResolvedVc::upcast(reference))
                 .await?
-            else {
+            {
                 continue;
-            };
+            }
 
             let need_await = 'need_await: {
                 let async_module = *side_effect.get_async_module().await?;
@@ -182,7 +182,7 @@ impl EcmascriptChunkPlaceable for SideEffectsModule {
                 format!(
                     "{}{TURBOPACK_IMPORT}({});\n",
                     if need_await { "await " } else { "" },
-                    StringifyModuleId(&id)
+                    StringifyModuleId(&side_effect.chunk_item_id(chunking_context).await?)
                 )
                 .as_bytes(),
             );

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/side_effects/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/side_effects/module.rs
@@ -149,7 +149,21 @@ impl EcmascriptChunkPlaceable for SideEffectsModule {
         let mut code = RopeBuilder::default();
         let mut has_top_level_await = false;
 
+        let id_strategy = chunking_context.chunk_item_id_strategy().await?;
+
         for &side_effect in module.side_effects.iter() {
+            // These side effects were collected conservatively (see
+            // `follow_reexports_with_side_effects`). Inner-graph tree shaking may have
+            // since determined a "side effect" to be side-effect-free and pruned its
+            // evaluation edge, in which case it has no chunk item id.
+            // So we are going to skip it.
+            let Some(id) = id_strategy
+                .try_get_id_from_module(Vc::upcast(*side_effect))
+                .await?
+            else {
+                continue;
+            };
+
             let need_await = 'need_await: {
                 let async_module = *side_effect.get_async_module().await?;
                 if let Some(async_module) = async_module
@@ -168,7 +182,7 @@ impl EcmascriptChunkPlaceable for SideEffectsModule {
                 format!(
                     "{}{TURBOPACK_IMPORT}({});\n",
                     if need_await { "await " } else { "" },
-                    StringifyModuleId(&side_effect.chunk_item_id(chunking_context).await?)
+                    StringifyModuleId(&id)
                 )
                 .as_bytes(),
             );


### PR DESCRIPTION
A star re-export barrel with imports but no top-level side effects is
classified ModuleEvaluationIsSideEffectFree. follow_reexports_with_side_effects
treats that as effectful and builds a SideEffectsModule that emits
TURBOPACK_IMPORT(<eval part id>), but compute_side_effect_free_module_info
classifies the same module as side-effect-free, so binding-usage prunes the
Evaluation edge and the eval part never gets a module id. The build then
panicked with 'ModuleId not found for ident: .../barrel.ts <internal part 0>'
during middleware chunking.

SideEffectsModule is designed so graph tree-shaking may trim these imports, so
the consumer must tolerate a trimmed side effect. Add
ModuleIdStrategy::try_get_id_from_module (returns None instead of erroring when
an explicit id map lacks the module) and have chunk_item_content skip side
effects with no id -- a pruned side-effect-free module has nothing to evaluate.

Adds an e2e regression test (treeshake-mw).
