### PR TITLE
[ci] Skip JS build when running all e2e deploy tests

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -11,6 +11,15 @@ on:
         required: false
         description: 'whether to skip pnpm install && pnpm build'
         type: string
+      hydrateNextDistVersion:
+        required: false
+        description: >
+          When set, skip `pnpm build` and populate packages/next/dist from the
+          published `next` tarball (version, dist-tag, or tarball URL) instead.
+          Only valid for jobs whose tests never run the local Next.js build
+          (e.g. deploy tests).
+        type: string
+        default: ''
       skipNativeBuild:
         required: false
         description: 'whether to skip building native modules'
@@ -363,7 +372,13 @@ jobs:
         run: pnpm install --recursive
 
       - run: ANALYZE=1 pnpm build
-        if: ${{ inputs.skipInstallBuild != 'yes' }}
+        if: ${{ inputs.skipInstallBuild != 'yes' && inputs.hydrateNextDistVersion == '' }}
+
+      - name: Hydrate next dist from published tarball
+        if: ${{ inputs.hydrateNextDistVersion != '' }}
+        env:
+          NEXT_DIST_VERSION: ${{ inputs.hydrateNextDistVersion }}
+        run: bash scripts/hydrate-next-dist.sh "$NEXT_DIST_VERSION"
 
       - name: Install Playwright browsers
         if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' }}

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -133,6 +133,7 @@ jobs:
         NEXT_TEST_CLEANUP_SCRIPT_PATH="${{ github.event.inputs.cleanupScriptPath || '' }}" \
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} -c 2 --type e2e
       testTimingsArtifact: 'test-timings'
+      hydrateNextDistVersion: ${{ github.event.inputs.nextVersion || needs.setup.outputs.next-version || 'canary' }}
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-webpack-${{ matrix.group }}'
@@ -179,6 +180,7 @@ jobs:
         NEXT_TEST_CLEANUP_SCRIPT_PATH="${{ github.event.inputs.cleanupScriptPath || '' }}" \
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} -c 2 --type e2e
       testTimingsArtifact: 'test-timings'
+      hydrateNextDistVersion: ${{ github.event.inputs.nextVersion || needs.setup.outputs.next-version || 'canary' }}
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-turbopack-${{ matrix.group }}'
@@ -222,6 +224,7 @@ jobs:
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} -c 2 --type e2e
       testTimingsArtifact: 'test-timings'
+      hydrateNextDistVersion: ${{ github.event.inputs.nextVersion || needs.setup.outputs.next-version || 'canary' }}
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-deploy-${{ matrix.group }}'

--- a/scripts/hydrate-next-dist.sh
+++ b/scripts/hydrate-next-dist.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Populates packages/next/dist (and packages/next-env/dist, which the
+# workspace `next` package resolves via its `@next/env` dependency) from
+# published tarballs instead of building locally. Used by deploy tests, which
+# deploy the published NEXT_TEST_VERSION anyway and only need dist for the
+# local test harness (e.g. `next/dist/trace` imports in test/lib).
+set -euo pipefail
+
+version="${1:?usage: hydrate-next-dist.sh <version|dist-tag|tarball-url>}"
+
+case "$version" in
+  http*) next_spec="$version" ;;
+  *) next_spec="next@$version" ;;
+esac
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Extracts the published tarball for $1 into a fresh directory, moves its
+# dist/ to $2, and leaves the extracted package dir path in $extracted_pkg.
+hydrate() {
+  local spec="$1"
+  local dest="$2"
+  local pkgdir tarball
+  pkgdir="$(mktemp -d "$tmpdir/pkg.XXXXXX")"
+  tarball="$(cd "$pkgdir" && npm pack "$spec" --silent | tail -n1)"
+  tar -xzf "$pkgdir/$tarball" -C "$pkgdir" package
+  rm -rf "$dest"
+  mv "$pkgdir/package/dist" "$dest"
+  extracted_pkg="$pkgdir/package"
+  echo "hydrated $dest from $spec"
+}
+
+hydrate "$next_spec" packages/next/dist
+
+# `@next/env` is a workspace dependency of `next`; resolve the exact version
+# from the packed `next` package so it also works for tarball URLs.
+next_env_version="$(node -e "console.log(require(process.argv[1]).dependencies['@next/env'])" "$extracted_pkg/package.json")"
+hydrate "@next/env@$next_env_version" packages/next-env/dist

--- a/scripts/hydrate-next-dist.sh
+++ b/scripts/hydrate-next-dist.sh
@@ -16,6 +16,19 @@ esac
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
+# When the preview-builds npm mirror is auth-protected, fetching its tarballs
+# needs credentials (see `writeMirrorNpmrcIfNecessary` in
+# test/lib/next-modes/next-deploy.ts, which does the same for the remote
+# install). Point npm at an npmrc with a read token scoped to the mirror so
+# `npm pack` can authenticate; registry fetches are unaffected.
+if [[ -n "${PREVIEW_BUILDS_READ_TOKEN:-}" ]]; then
+  base_url="${NEXT_TEST_PREVIEW_BUILDS_BASE_URL:-https://vercel-packages.vercel.app/next}"
+  registry_key="//${base_url#*://}"
+  registry_key="${registry_key%/}/"
+  echo "${registry_key}:_authToken=${PREVIEW_BUILDS_READ_TOKEN}" > "$tmpdir/npmrc"
+  export NPM_CONFIG_USERCONFIG="$tmpdir/npmrc"
+fi
+
 # Extracts the published tarball for $1 into a fresh directory, moves its
 # dist/ to $2, and leaves the extracted package dir path in $extracted_pkg.
 hydrate() {
@@ -33,7 +46,13 @@ hydrate() {
 
 hydrate "$next_spec" packages/next/dist
 
-# `@next/env` is a workspace dependency of `next`; resolve the exact version
-# from the packed `next` package so it also works for tarball URLs.
-next_env_version="$(node -e "console.log(require(process.argv[1]).dependencies['@next/env'])" "$extracted_pkg/package.json")"
-hydrate "@next/env@$next_env_version" packages/next-env/dist
+# `@next/env` is a workspace dependency of `next`; resolve it from the packed
+# `next` package. Published versions pin an exact version, while preview
+# tarballs (scripts/create-preview-tarballs.js) rewrite the dependency to a
+# tarball URL on the preview-builds mirror.
+next_env_dep="$(node -e "console.log(require(process.argv[1]).dependencies['@next/env'])" "$extracted_pkg/package.json")"
+case "$next_env_dep" in
+  http*) next_env_spec="$next_env_dep" ;;
+  *) next_env_spec="@next/env@$next_env_dep" ;;
+esac
+hydrate "$next_env_spec" packages/next-env/dist


### PR DESCRIPTION
The `test-e2e-deploy-release` workflow ran `pnpm build` in all jobs even though deploy tests install the published `NEXT_TEST_VERSION` remotely on Vercel, so nothing that gets deployed uses the local build. The only local consumer of build output is the Jest test harness, which has load-time value imports from `next/dist` (e.g. `test/lib/e2e-utils/index.ts`, `test/lib/next-test-utils.ts`) and, transitively via `next/dist/server/next`, from `@next/env`'s dist.

Instead, we're now manually creating `next/dist` and `next-env/dist` from the configured Next.js version we're testing with. So this not only a perf fix but also correctness because tests didn't necessarily get the same `next` the deployed app was using.

## Test plan

- [ ] [e2e deploy release job from this branch](https://github.com/vercel/next.js/actions/runs/29360224144)
