### PR TITLE
Support metadata routes in --debug-build-paths

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -10,6 +10,7 @@ import type { CacheControl, Revalidate } from '../server/lib/cache-control'
 import type { PrefetchHints } from '../shared/lib/app-router-types'
 
 import '../lib/setup-exception-listeners'
+import { resolveBuildPaths } from '../lib/resolve-build-paths'
 
 import { loadEnvConfig, type LoadedEnvFiles } from '@next/env'
 import { bold, yellow } from '../lib/picocolors'
@@ -937,7 +938,7 @@ export default async function build(
   bundler = Bundler.Turbopack,
   experimentalBuildMode: 'default' | 'compile' | 'generate' | 'generate-env',
   traceUploadUrl: string | undefined,
-  debugBuildPaths: { app: string[]; pages: string[] } | undefined,
+  debugBuildPathsPatterns: string[] | undefined,
   enabledFeatures: Record<string, unknown> = {}
 ): Promise<void> {
   const isCompileMode = experimentalBuildMode === 'compile'
@@ -977,7 +978,6 @@ export default async function build(
     NextBuildContext.reactProductionProfiling = reactProductionProfiling
     NextBuildContext.noMangling = noMangling
     NextBuildContext.debugPrerender = debugPrerender
-    NextBuildContext.debugBuildPaths = debugBuildPaths
 
     await nextBuildSpan.traceAsyncFn(async () => {
       // attempt to load global env values so they are available in next.config.js
@@ -1017,6 +1017,19 @@ export default async function build(
           )
         )
       loadedConfig = config
+
+      // Resolve selective build paths now that the page extensions are known.
+      const debugBuildPaths = debugBuildPathsPatterns
+        ? await (async () => {
+            const resolved = await resolveBuildPaths(
+              debugBuildPathsPatterns,
+              dir,
+              config.pageExtensions
+            )
+            return { app: resolved.appPaths, pages: resolved.pagePaths }
+          })()
+        : undefined
+      NextBuildContext.debugBuildPaths = debugBuildPaths
 
       // Validate deploymentId if provided
       if (config.deploymentId !== undefined) {

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -11,10 +11,7 @@ import { getProjectDir } from '../lib/get-project-dir'
 import { enableMemoryDebuggingMode } from '../lib/memory/startup'
 import { disableMemoryDebuggingMode } from '../lib/memory/shutdown'
 import { Bundler, parseBundlerArgs } from '../lib/bundler'
-import {
-  resolveBuildPaths,
-  parseBuildPathsInput,
-} from '../lib/resolve-build-paths'
+import { parseBuildPathsInput } from '../lib/resolve-build-paths'
 
 export type NextBuildOptions = {
   experimentalAnalyze?: boolean
@@ -104,24 +101,13 @@ const nextBuild = async (options: NextBuildOptions, directory?: string) => {
     printAndExit(`> No such directory exists as the project root: ${dir}`)
   }
 
-  // Resolve selective build paths
-  let resolvedBuildPaths: { app: string[]; pages: string[] } | undefined
+  let debugBuildPathsPatterns: string[] | undefined
 
   if (debugBuildPaths) {
-    try {
-      const patterns = parseBuildPathsInput(debugBuildPaths)
+    const patterns = parseBuildPathsInput(debugBuildPaths)
 
-      if (patterns.length > 0) {
-        const resolved = await resolveBuildPaths(patterns, dir)
-        resolvedBuildPaths = {
-          app: resolved.appPaths,
-          pages: resolved.pagePaths,
-        }
-      }
-    } catch (err) {
-      printAndExit(
-        `Failed to resolve build paths: ${isError(err) ? err.message : String(err)}`
-      )
+    if (patterns.length > 0) {
+      debugBuildPathsPatterns = patterns
     }
   }
 
@@ -145,7 +131,7 @@ const nextBuild = async (options: NextBuildOptions, directory?: string) => {
     bundler,
     experimentalBuildMode,
     traceUploadUrl,
-    resolvedBuildPaths,
+    debugBuildPathsPatterns,
     enabledFeatures
   )
     .catch((err) => {

--- a/packages/next/src/lib/resolve-build-paths.ts
+++ b/packages/next/src/lib/resolve-build-paths.ts
@@ -4,6 +4,8 @@ import * as Log from '../build/output/log'
 import path from 'path'
 import fs from 'fs'
 import isError from './is-error'
+import { createValidFileMatcher } from '../server/lib/find-page-file'
+import type { PageExtensions } from '../build/page-extensions-type'
 
 const glob = promisify(globOriginal)
 
@@ -35,10 +37,12 @@ function escapeBrackets(pattern: string): string {
  */
 export async function resolveBuildPaths(
   patterns: string[],
-  projectDir: string
+  projectDir: string,
+  pageExtensions: PageExtensions
 ): Promise<ResolvedBuildPaths> {
   const appPaths: Set<string> = new Set()
   const pagePaths: Set<string> = new Set()
+  const validFileMatcher = createValidFileMatcher(pageExtensions, undefined)
 
   // Detect whether the project keeps its routes under `src/` so we can accept
   // patterns written with or without that prefix (e.g. both `app/foo/page.tsx`
@@ -89,7 +93,7 @@ export async function resolveBuildPaths(
 
     for (const file of matches) {
       if (!fs.statSync(path.join(projectDir, file)).isDirectory()) {
-        categorizeAndAddPath(file, appPaths, pagePaths)
+        categorizeAndAddPath(file, appPaths, pagePaths, validFileMatcher)
       }
     }
   } catch (error) {
@@ -128,7 +132,7 @@ function addSrcPrefixIfNeeded(
 
 /**
  * Categorizes a file path to either app or pages router based on its prefix.
- * For app router, only route-defining files (page.*, route.*) are included.
+ * For app router, only route-defining files are included.
  *
  * Accepts both top-level (`app/...`, `pages/...`) and src-prefixed
  * (`src/app/...`, `src/pages/...`) project structures.
@@ -142,7 +146,8 @@ function addSrcPrefixIfNeeded(
 function categorizeAndAddPath(
   filePath: string,
   appPaths: Set<string>,
-  pagePaths: Set<string>
+  pagePaths: Set<string>,
+  validFileMatcher: ReturnType<typeof createValidFileMatcher>
 ): void {
   let normalized = filePath.replace(/\\/g, '/')
 
@@ -151,9 +156,9 @@ function categorizeAndAddPath(
   }
 
   if (normalized.startsWith('app/')) {
-    // Only include route-defining files (page.* or route.*)
-    if (/\/(page|route)\.[^/]+$/.test(normalized)) {
-      appPaths.add('/' + normalized.slice(4))
+    const appRelativePath = '/' + normalized.slice(4)
+    if (validFileMatcher.isAppRouterPage(appRelativePath)) {
+      appPaths.add(appRelativePath)
     }
   } else if (normalized.startsWith('pages/')) {
     pagePaths.add('/' + normalized.slice(6))


### PR DESCRIPTION
Extracted from https://github.com/vercel/next.js/pull/95468.

@lubieowoce asked me to use `--debug-build-paths` in a test, but it didn't work for route handlers because this flag was using a homecooked regex that doesn't match App Router's actual mechanism.

Making it use the actual App Router matching involves moving some resolution around and threading things through.

This is for a debug-only (test-only?) helper.