### PR TITLE
Only track pending imports for real promises

### DIFF
--- a/packages/next/src/server/app-render/module-loading/track-module-loading.instance.ts
+++ b/packages/next/src/server/app-render/module-loading/track-module-loading.instance.ts
@@ -1,5 +1,4 @@
 import { CacheSignal } from '../cache-signal'
-import { isThenable } from '../../../shared/lib/is-thenable'
 
 /**
  * Tracks all in-flight async imports and chunk loads.
@@ -23,11 +22,8 @@ export function trackPendingImport(exportsOrPromise: unknown) {
 
   // requiring an async module returns a promise.
   // if it's sync, there's nothing to track.
-  if (isThenable(exportsOrPromise)) {
-    // A client reference proxy might look like a promise, but we can only call `.then()` on it, not e.g. `.finally()`.
-    // Turn it into a real promise to avoid issues elsewhere.
-    const promise = Promise.resolve(exportsOrPromise)
-    moduleLoadingSignal.trackRead(promise)
+  if (exportsOrPromise instanceof Promise) {
+    moduleLoadingSignal.trackRead(exportsOrPromise)
   }
 }
 

--- a/test/production/app-dir/client-module-then-export/app/client.tsx
+++ b/test/production/app-dir/client-module-then-export/app/client.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import './promise-exports'
+
+export function then() {}
+
+export function Widget() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/client-module-then-export/app/layout.tsx
+++ b/test/production/app-dir/client-module-then-export/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/client-module-then-export/app/page.tsx
+++ b/test/production/app-dir/client-module-then-export/app/page.tsx
@@ -1,0 +1,5 @@
+import { Widget } from './client'
+
+export default function Page() {
+  return <Widget />
+}

--- a/test/production/app-dir/client-module-then-export/app/promise-exports.js
+++ b/test/production/app-dir/client-module-then-export/app/promise-exports.js
@@ -1,0 +1,3 @@
+'use client'
+
+module.exports = new Promise(() => {})

--- a/test/production/app-dir/client-module-then-export/client-module-then-export.test.ts
+++ b/test/production/app-dir/client-module-then-export/client-module-then-export.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('client-module-then-export', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  // A client module that exports a function named `then` has thenable
+  // exports, even though it is not an async module. If module tracking
+  // mistakes it for a pending async module, awaiting it calls the `then`
+  // export instead of settling, and the build hangs in the cache warming
+  // phase. A module whose exports object literally is a promise
+  // (promise-exports.js) must not hang the build either, even though the
+  // promise never settles.
+  it('builds pages that render client modules that export `then`', async () => {
+    const { exitCode } = await next.build()
+    expect(exitCode).toBe(0)
+  })
+})

--- a/test/production/app-dir/client-module-then-export/next.config.js
+++ b/test/production/app-dir/client-module-then-export/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Extracted from https://github.com/vercel/next.js/pull/95468.

Fixes a module with `then` export hanging the module tracking during the build.

---

`trackPendingImport` needs to track actually async modules (top-level await).

Before this change, this codepath was happy to adopt any thenable. But since thenables may not be Promises, this could break things downstream, hence why we had `Promise.resolve` there.

However, we don't *want* to adopt arbitrary thenables here. **Tracking is for top-level awaited modules.** For example, `module.exports = new Promise(() => {})` has a `.then` but we don't want to track that. It's not TLA.

This is why, to catch real top-level await modules, we narrow the check to `instanceof Promise`.

We add tests for:

- A client module with a `then` function export (**hangs** on Turbopack before this PR with CC on)
- Exporting a literal Promise (works before and after, but worth testing for future regressions)
