### PR TITLE
Fix cache warming and static params for metadata images with top-level await

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -192,17 +192,8 @@ impl AppPageLoaderTreeBuilder {
                 let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
                 let inner_module_id = format!("METADATA_{i}");
 
-                // This should use the same importing mechanism as create_module_tuple_code, so that
-                // the relative order of items is retained (which isn't the case
-                // when mixing ESM imports and requires).
-                self.base.imports.push((
-                    depth,
-                    format!(
-                        "const {identifier} = () => require(/*turbopackChunkingType: \
-                         shared*/\"{inner_module_id}\");"
-                    )
-                    .into(),
-                ));
+                self.base
+                    .create_module_getter_declaration(depth, &identifier, &inner_module_id);
 
                 let source = dynamic_image_metadata_source(
                     *ResolvedVc::upcast(self.base.module_asset_context),
@@ -240,17 +231,8 @@ impl AppPageLoaderTreeBuilder {
         let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
         let inner_module_id = format!("METADATA_{i}");
 
-        // This should use the same importing mechanism as create_module_tuple_code, so that the
-        // relative order of items is retained (which isn't the case when mixing ESM imports and
-        // requires).
-        self.base.imports.push((
-            depth,
-            format!(
-                "const {identifier} = () => require(/*turbopackChunkingType: \
-                 shared*/\"{inner_module_id}\");"
-            )
-            .into(),
-        ));
+        self.base
+            .create_module_getter_declaration(depth, &identifier, &inner_module_id);
         let module = StructuredImageModuleType::create_module(
             Vc::upcast(FileSource::new(path.clone())),
             BlurPlaceholderMode::None,
@@ -265,17 +247,8 @@ impl AppPageLoaderTreeBuilder {
             let identifier = magic_identifier::mangle(&format!("{name} alt text #{i}"));
             let inner_module_id = format!("METADATA_ALT_{i}");
 
-            // This should use the same importing mechanism as create_module_tuple_code, so that the
-            // relative order of items is retained (which isn't the case when mixing ESM imports and
-            // requires).
-            self.base.imports.push((
-                depth,
-                format!(
-                    "const {identifier} = () => require(/*turbopackChunkingType: \
-                     shared*/\"{inner_module_id}\");"
-                )
-                .into(),
-            ));
+            self.base
+                .create_module_getter_declaration(depth, &identifier, &inner_module_id);
 
             let module = self
                 .base
@@ -483,7 +456,13 @@ impl AppPageLoaderTreeBuilder {
         let mut imports = self.base.imports;
         imports.sort_by_key(|(position, _)| *position);
         Ok(AppPageLoaderTreeModule {
-            imports: imports.into_iter().map(|(_, import)| import).collect(),
+            imports: std::iter::once(
+                "import { instrumentModuleGetter } from \
+                 \"next/dist/server/app-render/module-loading/instrument-module-getter\";"
+                    .into(),
+            )
+            .chain(imports.into_iter().map(|(_, import)| import))
+            .collect(),
             loader_tree_code: self.loader_tree_code.into(),
             inner_assets: self.base.inner_assets,
         })

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use indoc::formatdoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToStringRef, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -87,6 +86,26 @@ impl BaseLoaderTreeBuilder {
             .process_module(module, *self.module_asset_context)
     }
 
+    /// The getters use `require()` instead of ESM imports so that the relative
+    /// order of items is retained (which isn't the case when mixing ESM
+    /// imports and requires).
+    pub fn create_module_getter_declaration(
+        &mut self,
+        position: u32,
+        identifier: &str,
+        inner_module_id: &str,
+    ) {
+        self.imports.push((
+            position,
+            format!(
+                "const {identifier} = instrumentModuleGetter(() => \
+                 require(/*turbopackChunkingType: shared*/{inner_module_id}));",
+                inner_module_id = StringifyJs(inner_module_id)
+            )
+            .into(),
+        ));
+    }
+
     pub async fn create_module_tuple_code(
         &mut self,
         module_type: AppDirModuleType,
@@ -97,17 +116,7 @@ impl BaseLoaderTreeBuilder {
         let i = self.unique_number();
         let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
 
-        self.imports.push((
-            position,
-            formatdoc!(
-                r#"
-                const {} = () => require(/*turbopackChunkingType: shared*/"MODULE_{}");
-                "#,
-                identifier,
-                i
-            )
-            .into(),
-        ));
+        self.create_module_getter_declaration(position, &identifier, &format!("MODULE_{i}"));
 
         let module = self
             .process_source(Vc::upcast(FileSource::new(path.clone())))

--- a/packages/next/src/build/segment-config/app/app-segments.ts
+++ b/packages/next/src/build/segment-config/app/app-segments.ts
@@ -141,9 +141,13 @@ async function collectAppPageSegments(routeModule: AppPageRouteModule) {
  * @param routeModule the app route module
  * @returns the segments for the app route module
  */
-function collectAppRouteSegments(
+async function collectAppRouteSegments(
   routeModule: AppRouteRouteModule
-): AppSegment[] {
+): Promise<AppSegment[]> {
+  // The route file may be an async module (top-level await), so the userland
+  // module must be resolved before its exports can be inspected.
+  await routeModule.ensureUserland()
+
   // Get the pathname parts, slice off the first element (which is empty).
   const parts = routeModule.definition.pathname.split('/').slice(1)
   if (parts.length === 0) {

--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -114,9 +114,9 @@ export async function createStaticMetadataFromRoute(
           // WEBPACK_RESOURCE_QUERIES.metadata query here only for filtering out applying to image loader
         )}!${filepath}?${WEBPACK_RESOURCE_QUERIES.metadata}`
 
-        const imageModule = `(async (props) => (await import(/* webpackMode: "eager" */ ${JSON.stringify(
+        const imageModule = `(async (props) => (await instrumentModuleGetter(() => import(/* webpackMode: "eager" */ ${JSON.stringify(
           imageModuleImportSource
-        )})).default(props))`
+        )}))()).default(props))`
         hasStaticMetadataFiles = true
         if (type === 'favicon') {
           staticImagesMetadata.icon.unshift(imageModule)

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -1108,13 +1108,15 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
   )
 
   // Lazily evaluate the imported modules in the generated code
-  const header = collectedDeclarations
-    .map(([varName, modulePath]) => {
-      return `const ${varName} = () => import(/* webpackMode: "eager" */ ${JSON.stringify(
-        modulePath
-      )});\n`
-    })
-    .join('')
+  const header =
+    `import { instrumentModuleGetter } from 'next/dist/server/app-render/module-loading/instrument-module-getter'\n` +
+    collectedDeclarations
+      .map(([varName, modulePath]) => {
+        return `const ${varName} = instrumentModuleGetter(() => import(/* webpackMode: "eager" */ ${JSON.stringify(
+          modulePath
+        )}));\n`
+      })
+      .join('')
 
   return header + code
 }

--- a/packages/next/src/server/app-render/module-loading/instrument-module-getter.ts
+++ b/packages/next/src/server/app-render/module-loading/instrument-module-getter.ts
@@ -1,0 +1,28 @@
+/**
+ * Wraps a module getter from the generated loader tree code so that the
+ * result of an async module (e.g. due to a top-level await) is tracked as a
+ * pending import, which the cache warming phase of a prerender waits for.
+ * Both bundlers emit this around every module getter in the loader tree.
+ */
+export function instrumentModuleGetter<TModule>(
+  getter: () => TModule
+): () => TModule {
+  if (
+    process.env.NEXT_RUNTIME === 'edge' ||
+    !process.env.__NEXT_CACHE_COMPONENTS
+  ) {
+    // The tracking is only consumed when prerendering with Cache Components,
+    // which is not supported in the edge runtime (and the tracking relies on
+    // Node.js APIs).
+    return getter
+  } else {
+    return () => {
+      const { trackPendingImport } =
+        require('./track-module-loading.external') as typeof import('./track-module-loading.external')
+
+      const exportsOrPromise = getter()
+      trackPendingImport(exportsOrPromise)
+      return exportsOrPromise
+    }
+  }
+}

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/app/[slug]/opengraph-image.tsx
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/app/[slug]/opengraph-image.tsx
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises'
+import { generateImage, size, contentType } from '../../og/generate-image'
+
+export const alt = 'Blog post'
+export { size, contentType }
+
+async function getTitle(slug: string) {
+  'use cache'
+  const file = await readFile('./posts/' + slug + '.txt', 'utf8')
+  return file.trim()
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const title = await getTitle(slug)
+  return generateImage(title)
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'first-post' }, { slug: 'second-post' }]
+}

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/app/[slug]/page.tsx
@@ -1,0 +1,35 @@
+import { readFile } from 'fs/promises'
+
+async function getPostFile(slug: string) {
+  'use cache'
+  return readFile('./posts/' + slug + '.txt', 'utf8')
+}
+
+async function PostContent({ slug }: { slug: string }) {
+  'use cache'
+  const file = await getPostFile(slug)
+  return <article>{file.trim()}</article>
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <PostContent slug={slug} />
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const file = await getPostFile(slug)
+  return { title: file.trim() }
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'first-post' }, { slug: 'second-post' }]
+}

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/og/generate-image.tsx
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/og/generate-image.tsx
@@ -1,0 +1,33 @@
+import { ImageResponse } from 'next/og'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// The top-level await makes this an async module that's also evaluated during
+// the page's prerender, via the metadata image route's exports.
+const font = await readFile(join(process.cwd(), 'assets/typewr__.ttf'))
+
+export async function generateImage(text: string) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 88,
+          fontFamily: 'Typewriter',
+          background: '#fff',
+          color: '#000',
+        }}
+      >
+        {text}
+      </div>
+    ),
+    { ...size, fonts: [{ name: 'Typewriter', data: font, style: 'normal' }] }
+  )
+}

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/posts/first-post.txt
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/posts/first-post.txt
@@ -1,0 +1,1 @@
+First Post

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/posts/second-post.txt
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/posts/second-post.txt
@@ -1,0 +1,1 @@
+Second Post

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
@@ -31,6 +31,27 @@ describe('use-cache-metadata-route-handler', () => {
     }
   })
 
+  it('should prerender a page that shares a segment with an opengraph image that uses a custom font', async () => {
+    const res = await next.fetch('/first-post')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('First Post')
+
+    const imageRes = await next.fetch('/first-post/opengraph-image')
+    expect(imageRes.status).toBe(200)
+    expect(imageRes.headers.get('content-type')).toBe('image/png')
+
+    expect(next.cliOutput).not.toContain(
+      'Unexpected cache miss after cache warming phase'
+    )
+
+    if (isNextStart) {
+      // The image route uses generateStaticParams, so the build is expected
+      // to prerender it for each param.
+      expect(next.cliOutput).toMatch(/● \/first-post\/opengraph-image/)
+      expect(next.cliOutput).toMatch(/● \/second-post\/opengraph-image/)
+    }
+  })
+
   it('should generate an icon image with a metadata route handler that uses "use cache"', async () => {
     const res = await next.fetch('/icon')
     expect(res.status).toBe(200)

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/app/[slug]/opengraph-image.tsx
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/app/[slug]/opengraph-image.tsx
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises'
+import { generateImage, size, contentType } from '../../og/generate-image'
+
+export const alt = 'Blog post'
+export { size, contentType }
+
+async function getTitle(slug: string) {
+  'use cache'
+  const file = await readFile('./posts/' + slug + '.txt', 'utf8')
+  return file.trim()
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const title = await getTitle(slug)
+  return generateImage(title)
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'first-post' }, { slug: 'second-post' }]
+}

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/app/[slug]/page.tsx
@@ -1,0 +1,35 @@
+import { readFile } from 'fs/promises'
+
+async function getPostFile(slug: string) {
+  'use cache'
+  return readFile('./posts/' + slug + '.txt', 'utf8')
+}
+
+async function PostContent({ slug }: { slug: string }) {
+  'use cache'
+  const file = await getPostFile(slug)
+  return <article>{file.trim()}</article>
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <PostContent slug={slug} />
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const file = await getPostFile(slug)
+  return { title: file.trim() }
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'first-post' }, { slug: 'second-post' }]
+}

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/next.config.js
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/og/generate-image.tsx
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/og/generate-image.tsx
@@ -1,0 +1,32 @@
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// The top-level await makes this an async module that's also evaluated during
+// the page's prerender, via the metadata image route's exports. Real-world
+// equivalent: loading font files with `await readFile(...)`. The delay must
+// outlast the prerender's cache reads.
+await new Promise((resolve) => setTimeout(resolve, 5000))
+
+export async function generateImage(text: string) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 88,
+          background: '#fff',
+          color: '#000',
+        }}
+      >
+        {text}
+      </div>
+    ),
+    size
+  )
+}

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/posts/first-post.txt
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/posts/first-post.txt
@@ -1,0 +1,1 @@
+First Post

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/posts/second-post.txt
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/posts/second-post.txt
@@ -1,0 +1,1 @@
+Second Post

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
@@ -1,0 +1,58 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('use-cache-og-image-top-level-await', () => {
+  const { next, isNextStart, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    // The prerendered output can't be observed in a deployment, and without
+    // it nothing distinguishes broken from fixed behavior.
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextStart) {
+    beforeAll(async () => {
+      await next.build({ args: ['--experimental-build-mode', 'compile'] })
+    })
+
+    it('should prerender a page whose opengraph image uses a top-level await', async () => {
+      const { exitCode, cliOutput } = await next.build({
+        args: [
+          '--experimental-build-mode',
+          'generate',
+          '--debug-build-paths',
+          'app/[slug]/page.tsx,app/[slug]/opengraph-image.tsx',
+        ],
+      })
+
+      expect(cliOutput).not.toContain(
+        'Unexpected cache miss after cache warming phase'
+      )
+      expect(cliOutput).not.toContain(
+        'Next.js encountered uncached or runtime data in `generateMetadata()`'
+      )
+      expect(exitCode).toBe(0)
+
+      // The image route uses generateStaticParams, so the build is expected
+      // to prerender it for each param.
+      expect(cliOutput).toMatch(/● \/first-post\/opengraph-image/)
+      expect(cliOutput).toMatch(/● \/second-post\/opengraph-image/)
+    })
+  } else {
+    beforeAll(async () => {
+      await next.start()
+    })
+
+    it('should render a page whose opengraph image uses a top-level await', async () => {
+      const $ = await next.render$('/first-post')
+      expect($('article').text()).toBe('First Post')
+
+      const res = await next.fetch('/first-post/opengraph-image')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('image/png')
+    })
+  }
+})


### PR DESCRIPTION
Extracted from https://github.com/vercel/next.js/pull/95468 and arguably the main fix there.

We need to add code to wait for top-level awaits in two cases:

- If a metadata module (like `opengraph-image.tsx`) is slow to evaluate, cache warming wouldn't "wait" for it, and then the actual build would fail with `Unexpected cache miss after cache warming phase`. This is fixed with placing `instrumentModuleGetter` around them.
- If the evaluation is fast but still async (e.g. `await readFile` on a large font), the build passes but the segment collector reads the module too early, doesn't see `generateStaticParams`, and so the image becomes dynamic instead of prerendered. The fix is `await ensureUserland` before looking at exports.

Remaining callsites are wrapped so we don't add more bugs like this, but it's not strictly required now because they are already being awaited elsewhere. I've done this for consistency.

New tests fail before the fix.