### PR TITLE
Model async userland loading in app routes as a state machine

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1418,5 +1418,6 @@
   "1417": "Could not parse output from TypeScript's --showConfig.",
   "1418": "TypeScript %s does not provide the compiler API required by Next.js. Enable %s in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1419": "TypeScript CLI interrupted by %s",
-  "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s"
+  "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s",
+  "1421": "The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed."
 }

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -62,15 +62,13 @@ const routeModule = new AppRouteRouteModule({
   relativeProjectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
   resolvedPagePath: 'VAR_RESOLVED_PAGE_PATH',
   nextConfigOutput,
-  // Always use a lazy require factory so that:
+  // The lazy require factory ensures that:
   // - In dev: devRequestTimingInternalsEnd is set before userland executes,
   //   correctly attributing module load time to application-code rather than
   //   framework internals.
   // - In all modes: async modules (route files with top-level await) are
   //   handled correctly — require() returns a Promise for such modules, which
-  //   ensureUserland() awaits before the first request is handled. Eagerly
-  //   calling require() would pass that Promise directly to the constructor
-  //   and break _initFromUserland().
+  //   ensureUserland() awaits before the first request is handled.
   userland: () => require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
   // In Turbopack dev mode, also provide a synchronous per-request getter so
   // server HMR updates are picked up without re-executing the entry chunk.

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -94,10 +94,8 @@ export async function exportAppRoute(
   }
 
   try {
-    // Ensure the userland module is fully loaded before accessing it. This is
-    // required for route files that use top-level await: require() returns a
-    // Promise for async modules, so module.userland would be undefined until
-    // the Promise resolves.
+    // The route file may be an async module (top-level await), so the
+    // userland module must be resolved before its exports can be inspected.
     await module.ensureUserland()
     const userland = module.userland
     // we don't bail from the static optimization for

--- a/packages/next/src/server/lib/lazy-module.ts
+++ b/packages/next/src/server/lib/lazy-module.ts
@@ -1,0 +1,91 @@
+import { InvariantError } from '../../shared/lib/invariant-error'
+
+type PendingLazyModule<TModule> = {
+  status: 'pending'
+  /** Resolves to the settled state, and never rejects. */
+  promise: Promise<SettledLazyModule<TModule>>
+}
+
+type SettledLazyModule<TModule> =
+  | { status: 'resolved'; module: TModule }
+  | { status: 'rejected'; reason: unknown }
+
+export class LazyModule<TModule> {
+  private state:
+    | { status: 'uninitialized' }
+    | PendingLazyModule<TModule>
+    | SettledLazyModule<TModule> = { status: 'uninitialized' }
+
+  constructor(
+    private readonly load: () => TModule | Promise<TModule>,
+    private readonly onLoad: (module: TModule) => void
+  ) {}
+
+  loadIfNeeded(): void {
+    if (this.state.status !== 'uninitialized') {
+      return
+    }
+
+    const result = this.load()
+
+    if (!(result instanceof Promise)) {
+      this.onLoad(result)
+      this.state = { status: 'resolved', module: result }
+      return
+    }
+
+    this.state = {
+      status: 'pending',
+      promise: result
+        .then((module) => {
+          this.onLoad(module)
+          const resolved: SettledLazyModule<TModule> = {
+            status: 'resolved',
+            module,
+          }
+          this.state = resolved
+          return resolved
+        })
+        .catch((reason) => {
+          const rejected: SettledLazyModule<TModule> = {
+            status: 'rejected',
+            reason,
+          }
+          this.state = rejected
+          return rejected
+        }),
+    }
+  }
+
+  async waitUntilLoaded(): Promise<void> {
+    this.loadIfNeeded()
+
+    let state = this.state
+
+    if (state.status === 'pending') {
+      state = await state.promise
+    }
+
+    if (state.status === 'rejected') {
+      throw state.reason
+    }
+  }
+
+  assertLoaded(): TModule {
+    this.loadIfNeeded()
+
+    const state = this.state
+
+    if (state.status === 'resolved') {
+      return state.module
+    }
+
+    if (state.status === 'rejected') {
+      throw state.reason
+    }
+
+    throw new InvariantError(
+      'The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed.'
+    )
+  }
+}

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -87,6 +87,7 @@ import { INFINITE_CACHE } from '../../../lib/constants'
 import { executeRevalidates } from '../../revalidation-utils'
 import { trackPendingModules } from '../../app-render/module-loading/track-module-loading.external'
 import { InvariantError } from '../../../shared/lib/invariant-error'
+import { LazyModule } from '../../lib/lazy-module'
 import { createPrerenderResumeDataCache } from '../../resume-data-cache/resume-data-cache'
 
 export class WrappedNextRouterError {
@@ -178,9 +179,9 @@ export interface AppRouteRouteModuleOptions
     RouteModuleOptions<AppRouteRouteDefinition, AppRouteUserlandModule>,
     'userland'
   > {
-  readonly userland:
+  readonly userland: () =>
     | AppRouteUserlandModule
-    | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
+    | Promise<AppRouteUserlandModule>
   readonly resolvedPagePath: string
   readonly nextConfigOutput: NextConfig['output']
   /**
@@ -227,17 +228,9 @@ export class AppRouteRouteModule extends RouteModule<
   public readonly resolvedPagePath: string
   public readonly nextConfigOutput: NextConfig['output'] | undefined
 
-  // Set in the constructor when userland is provided as a factory. Cleared
-  // after the first access so userland is only loaded once.
-  private _userlandFactory:
-    | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
-    | null
-  // Non-null while an async userland module (top-level await) is loading.
-  // ensureUserland() awaits this before the first request is handled.
-  private _pendingUserland: Promise<void> | null = null
-  // Init error from an async userland module, rethrown by ensureUserland().
-  private _initError: unknown = null
-  private _hasInitError = false
+  // Loaded lazily since the route file may be an async module (top-level
+  // await).
+  private readonly _lazyUserland: LazyModule<AppRouteUserlandModule>
   // Synchronous per-request userland getter for Turbopack dev mode.
   // Called on every request to pick up server HMR updates.
   private readonly _getUserland?: () => AppRouteUserlandModule
@@ -246,46 +239,18 @@ export class AppRouteRouteModule extends RouteModule<
   private _dynamic!: AppRouteUserlandModule['dynamic']
 
   override get userland(): AppRouteUserlandModule {
-    if (this._userlandFactory) {
-      const result = this._userlandFactory()
-      this._userlandFactory = null
-      if (result instanceof Promise) {
-        // The route file uses top-level await (async module). Store the
-        // promise so ensureUserland() can await it before the first request.
-        this._pendingUserland = result.then((mod) => {
-          this._userland = mod
-          this._pendingUserland = null
-          try {
-            this._initFromUserland()
-          } catch (err) {
-            this._initError = err
-            this._hasInitError = true
-          }
-        })
-      } else {
-        this._userland = result
-        this._initFromUserland()
-      }
-    }
-    return this._userland as AppRouteUserlandModule
+    return this._lazyUserland.assertLoaded()
   }
 
   /**
-   * Ensures the userland module is fully loaded before a request is handled.
-   * Required for route files that use top-level await, where require() returns
-   * a Promise instead of the module directly. Must be called before accessing
-   * `userland` in contexts where the module may not yet be resolved (e.g. the
-   * export/static-generation worker).
+   * Ensures the userland module is fully loaded before it's accessed via
+   * `userland`. Required for route files that use top-level await, where
+   * require() returns a promise instead of the module directly. Must be called
+   * before accessing `userland` in contexts where the module may not yet be
+   * resolved (e.g. the export/static-generation worker).
    */
   async ensureUserland(): Promise<void> {
-    // Trigger lazy loading if not yet started.
-    void this.userland
-    if (this._pendingUserland) {
-      await this._pendingUserland
-    }
-    if (this._hasInitError) {
-      throw this._initError
-    }
+    await this._lazyUserland.waitUntilLoaded()
   }
 
   constructor({
@@ -297,9 +262,8 @@ export class AppRouteRouteModule extends RouteModule<
     resolvedPagePath,
     nextConfigOutput,
   }: AppRouteRouteModuleOptions) {
-    const isLazy = typeof userland === 'function'
     super({
-      userland: (isLazy ? undefined! : userland) as AppRouteUserlandModule,
+      userland: undefined! as AppRouteUserlandModule,
       definition,
       distDir,
       relativeProjectDir,
@@ -308,40 +272,18 @@ export class AppRouteRouteModule extends RouteModule<
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
     this._getUserland = getUserland
+    this._lazyUserland = new LazyModule(userland, (module) =>
+      this._onUserlandLoaded(module)
+    )
 
-    if (!isLazy) {
-      this._userlandFactory = null
-      this._initFromUserland()
-    } else if (nextConfigOutput === 'export') {
-      // For output:export routes, validate constraints eagerly at module load
-      // time so that the error surfaces as a Redbox in dev (module load error)
-      // rather than being silently swallowed as a 500 response at request time.
-      this._userlandFactory = null
-      const result = userland()
-      if (result instanceof Promise) {
-        // Async module (top-level await) — defer via pending promise.
-        this._pendingUserland = result.then((mod) => {
-          this._userland = mod
-          this._pendingUserland = null
-          try {
-            this._initFromUserland()
-          } catch (err) {
-            this._initError = err
-            this._hasInitError = true
-          }
-        })
-      } else {
-        this._userland = result
-        this._initFromUserland() // throws for invalid output:export routes
-      }
-    } else {
-      this._userlandFactory = userland
+    // output:export routes load eagerly, so that errors surface at module
+    // load time (as a Redbox in dev) rather than at request time.
+    if (nextConfigOutput === 'export') {
+      this._lazyUserland.loadIfNeeded()
     }
   }
 
-  private _initFromUserland(): void {
-    const userland = this._userland as AppRouteUserlandModule
-
+  private _onUserlandLoaded(userland: AppRouteUserlandModule): void {
     // Automatically implement some methods if they aren't implemented by the
     // userland module.
     this._methods = autoImplementMethods(userland)
@@ -819,7 +761,7 @@ export class AppRouteRouteModule extends RouteModule<
     // immediately. This is cheap — it is just a devModuleCache lookup.
     // For routes with top-level await, require() may still return a Promise
     // (async module); in that case fall back to the already-resolved
-    // _userland from ensureUserland() above.
+    // userland module resolved by ensureUserland() above.
     const rawLiveUserland = this._getUserland?.()
     const liveUserland =
       rawLiveUserland instanceof Promise
@@ -841,7 +783,7 @@ export class AppRouteRouteModule extends RouteModule<
 
     // Use the live userland (if available) for per-request values so HMR
     // changes to fetchCache, dynamic, etc. are also picked up.
-    const userland = liveUserland ?? (this._userland as AppRouteUserlandModule)
+    const userland = liveUserland ?? this.userland
 
     // Add the fetchCache option to the renderOpts.
     staticGenerationContext.renderOpts.fetchCache = userland.fetchCache

--- a/test/production/app-dir/app-route-async-module-error/app-route-async-module-error.test.ts
+++ b/test/production/app-dir/app-route-async-module-error/app-route-async-module-error.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-route-async-module-error', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  // The route module uses top-level await, so the error rejects the module
+  // promise instead of throwing during require(). It must still fail the
+  // build.
+  it('fails the build when an async route module rejects', async () => {
+    const { exitCode, cliOutput } = await next.build()
+    expect(cliOutput).toContain('Kaboom')
+    expect(exitCode).toBe(1)
+  })
+})

--- a/test/production/app-dir/app-route-async-module-error/app/api/data/route.ts
+++ b/test/production/app-dir/app-route-async-module-error/app/api/data/route.ts
@@ -1,0 +1,5 @@
+await Promise.reject(new Error('Kaboom'))
+
+export async function GET() {
+  return Response.json({ ok: true })
+}

--- a/test/production/app-dir/app-route-async-module-error/app/layout.tsx
+++ b/test/production/app-dir/app-route-async-module-error/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/app-route-async-module-error/app/page.tsx
+++ b/test/production/app-dir/app-route-async-module-error/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/app-route-async-module-error/next.config.js
+++ b/test/production/app-dir/app-route-async-module-error/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/app-route-then-export/app-route-then-export.test.ts
+++ b/test/production/app-dir/app-route-then-export/app-route-then-export.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-route-then-export', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // A module that exports a function named `then` is not an async module,
+  // even though the exports object is thenable.
+  it('builds and serves a route handler that exports `then`', async () => {
+    const res = await next.fetch('/api/thenable')
+    expect(await res.json()).toEqual({ ok: true })
+  })
+})

--- a/test/production/app-dir/app-route-then-export/app/api/thenable/route.js
+++ b/test/production/app-dir/app-route-then-export/app/api/thenable/route.js
@@ -1,0 +1,5 @@
+export function then() {}
+
+export function GET() {
+  return Response.json({ ok: true })
+}

--- a/test/production/app-dir/app-route-then-export/app/layout.js
+++ b/test/production/app-dir/app-route-then-export/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/app-route-then-export/app/page.js
+++ b/test/production/app-dir/app-route-then-export/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/app-route-then-export/next.config.js
+++ b/test/production/app-dir/app-route-then-export/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Extracted from https://github.com/vercel/next.js/pull/95468, tries to address @lubieowoce feedback.

This should be a pure refactor with no publicly observable behavior changes. We want to simplify the state of how we're loading and tracking modules, and simplify signatures:

- Extract a state machine into `LazyModule` that hides per-module state. You can kick it (`loadIfNeeded`), wait for completion with `waitUntilLoaded`, or peek-or-throw with `assertLoaded`.
- Reading `.userland` while pending now throws with an invariant so we don't do it accidentally again. Should be unreachable from current callsites.
- Remove the non-thunk overload from `userland` factory.

Added tests to cover the cases that the refactor had a risk of breaking.