### PR TITLE
[Navigation Inspector] Fix inspector UI looking stuck on Back button

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -2322,3 +2322,15 @@ async function waitForNavigationLock(lock: NavigationLock): Promise<void> {
     await waitForNavigationLockIfActive(lock)
   }
 }
+
+/**
+ * Ends a captured lock scope and re-arms a fresh pending one after a history
+ * restore. No-op when the testing API is disabled or no capture is active.
+ */
+export function rearmNavigationLockAfterTraversal(): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    const { rearmNavigationLockAfterTraversal: rearm } =
+      require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
+    rearm()
+  }
+}

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -7,6 +7,7 @@ import { extractPathFromFlightRouterState } from '../compute-changed-path'
 import {
   FreshnessPolicy,
   getCurrentNavigationLock,
+  rearmNavigationLockAfterTraversal,
   spawnDynamicRequests,
   startPPRNavigation,
   type NavigationRequestAccumulation,
@@ -98,6 +99,9 @@ export function restoreReducer(
     // Not an HMR refresh, so there's no request generation to cancel.
     undefined
   )
+  // After spawnDynamicRequests so the requests spawned above hold the
+  // released scope's lock and their gated writes flush immediately.
+  rearmNavigationLockAfterTraversal()
   return completeTraverseNavigation(
     state,
     restoredUrl,

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
@@ -61,6 +61,8 @@ export function getCurrentNavigationLock(): NavigationLockState | null {
   return null
 }
 
+export function rearmNavigationLockAfterTraversal(): void {}
+
 export function shouldRestrictNavigationToShell(
   _rootPrefetchHints: number,
   _linkFetchStrategy: FetchStrategy

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -451,6 +451,38 @@ export function getCurrentNavigationLock(): NavigationLockState | null {
 }
 
 /**
+ * Called when the router applies a history restore (back/forward traversal,
+ * external pushState/replaceState, bfcache document restore) while a capture
+ * is active. The captured navigation is no longer what's on screen, so end
+ * its scope and immediately start a fresh pending one: dynamic writes gated
+ * on the old scope flush, and the next navigation is captured. Pending
+ * scopes are left alone.
+ *
+ * The cookie transitions from captured back to pending without ever being
+ * absent. Deleting it would disarm shell rendering for any document request
+ * that races the re-arm, and would trigger the unlock refresh, which the
+ * restored page doesn't need.
+ */
+export function rearmNavigationLockAfterTraversal(): void {
+  if (lockState === null || typeof document === 'undefined') {
+    return
+  }
+  const target = NEXT_INSTANT_TEST_COOKIE + '='
+  for (const segment of document.cookie.split(';')) {
+    const trimmed = segment.trim()
+    if (trimmed.startsWith(target)) {
+      const state = parseCookieValue(trimmed.slice(target.length))
+      if (state === 'mpa' || state === 'spa') {
+        releaseLock()
+        acquireLock()
+        writeCookieValue([0, `c${Math.random()}`])
+      }
+      return
+    }
+  }
+}
+
+/**
  * Decides whether segment reads during a navigation should be restricted to
  * shell entries (every param substituted with Fallback) rather than matching
  * entries that vary on concrete route params.

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -729,6 +729,88 @@ describe('instant-nav-panel', () => {
     })
   })
 
+  describe('history traversals', () => {
+    it('re-arms the capture when navigating back from a captured SPA navigation', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+      await expectTargetPageSpaShell(browser)
+
+      // The SPA capture is recorded as soon as the prefetch resolves, which
+      // can be before the navigation commits the new URL. Wait for the URL to
+      // change before traversing so back() returns to home.
+      await retry(async () => {
+        expect(await browser.url()).toContain('/target-page/my-post')
+      }, 10000)
+
+      await browser.back()
+
+      // The traversal restores home with its real content.
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await retry(async () => {
+        expect(await browser.url()).not.toContain('/target-page')
+      })
+
+      // The capture no longer corresponds to what's on screen, so the panel
+      // returns to awaiting the next navigation, with the cookie still set.
+      await expectPendingPanel(browser)
+      await waitForInstantModeCookie(browser)
+
+      // The next navigation is captured again. (The revisited route renders
+      // from the navigation cache rather than showing the shell — same as a
+      // recapture after Resume.)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+    })
+
+    it('shows real content on forward after back while awaiting navigation', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+      await expectTargetPageSpaShell(browser)
+      await retry(async () => {
+        expect(await browser.url()).toContain('/target-page/my-post')
+      }, 10000)
+
+      await browser.back()
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await expectPendingPanel(browser)
+
+      // The re-arm released the captured scope, so the target page's dynamic
+      // data finished streaming in. Forward restores it with real content and
+      // does not start a new capture.
+      await browser.forward()
+      await expectTargetPageRendered(browser)
+      await expectPendingPanel(browser)
+    })
+
+    it('captures a page load when reloading after back', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+      await retry(async () => {
+        expect(await browser.url()).toContain('/target-page/my-post')
+      }, 10000)
+
+      await browser.back()
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await expectPendingPanel(browser)
+
+      await browser.refresh()
+      await getInstantNavPanel(browser)
+      await expectMpaPanel(browser)
+    })
+  })
+
   describe('capture lifecycle', () => {
     it('ends the capture when opening the menu via the logo', async () => {
       const browser = await next.browser('/')


### PR DESCRIPTION
Claude says this should fix the Back button getting stuck in Navigation Inspector. Tests were failing before the fix.

The fix is to release the old lock and acquire a fresh one on Back/Forward. We then rewrite the cookie to pending, which the navigation UI picks up. We're not deleting the cookie because we want hard reloads to still capture.