### PR TITLE
Fix Request Insights subscription initialization

### DIFF
--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -25,7 +25,8 @@ export class DevBundlerService {
 
   constructor(
     private readonly bundler: DevBundler,
-    private readonly handler: WorkerRequestHandler
+    private readonly handler: WorkerRequestHandler,
+    requestInsightsEnabled: boolean
   ) {
     this.appIsrManifestInner = new LRUCache(
       8_000,
@@ -42,7 +43,7 @@ export class DevBundlerService {
       hotReloader.setReactDebugChannel.bind(hotReloader)
     this.sendErrorsToBrowser = hotReloader.sendErrorsToBrowser.bind(hotReloader)
 
-    if (isRequestInsightsEnabled()) {
+    if (requestInsightsEnabled || isRequestInsightsEnabled()) {
       this.unsubscribeRequestInsights = subscribeRequestInsights((insight) => {
         hotReloader.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_INSIGHTS_UPDATE,

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -9,7 +9,6 @@ import {
   type HmrMessageSentToBrowser,
   type NextJsHotReloaderInterface,
 } from '../dev/hot-reloader-types'
-import { isRequestInsightsEnabled } from './trace/span-store'
 import { subscribeRequestInsights } from './trace/request-insights'
 
 /**
@@ -43,7 +42,7 @@ export class DevBundlerService {
       hotReloader.setReactDebugChannel.bind(hotReloader)
     this.sendErrorsToBrowser = hotReloader.sendErrorsToBrowser.bind(hotReloader)
 
-    if (requestInsightsEnabled || isRequestInsightsEnabled()) {
+    if (requestInsightsEnabled) {
       this.unsubscribeRequestInsights = subscribeRequestInsights((insight) => {
         hotReloader.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_INSIGHTS_UPDATE,

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -223,7 +223,8 @@ export async function initialize(opts: {
       // reference to it.
       (req, res) => {
         return requestHandlers[opts.dir](req, res)
-      }
+      },
+      Boolean(developmentConfig.experimental.requestInsights)
     )
 
     development = {


### PR DESCRIPTION
## Summary

Pass the configured Request Insights state into the dev bundler service so it subscribes to insight updates during initialization. The service is constructed outside request-local tracing state, so checking only `isRequestInsightsEnabled()` can incorrectly skip the subscription even when Request Insights is enabled in configuration.

## Verification

- `pnpm build-all`
- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write packages/next/src/server/lib/dev-bundler-service.ts packages/next/src/server/lib/router-server.ts`
- `npx eslint --config eslint.config.mjs --fix packages/next/src/server/lib/dev-bundler-service.ts packages/next/src/server/lib/router-server.ts`

<!-- NEXT_JS_LLM -->